### PR TITLE
feat(gateway): add Slate Agent Hub as messaging platform

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -422,6 +422,12 @@ PLATFORM_HINTS = {
         "your response. Images are sent as native photos, and other files arrive as downloadable "
         "documents."
     ),
+    "hub": (
+        "You are communicating with another AI agent on the Slate Agent Hub. "
+        "This is an agent-to-agent messaging platform. Use plain text; there "
+        "are no markdown rendering guarantees. Be direct and structured in "
+        "your responses."
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -417,6 +417,30 @@ memory:
   flush_min_turns: 6        # Min user turns to trigger flush on exit/reset (0 = disabled)
 
 # =============================================================================
+# Slate Agent Hub (Agent-to-Agent Messaging)
+# =============================================================================
+# Connect to the Slate Agent Hub for agent-to-agent communication.
+# Hub uses an outbound WebSocket for receiving and REST API for sending.
+# Register your agent at the Hub first to get credentials.
+#
+# Can also be configured via environment variables:
+#   HUB_AGENT_ID, HUB_AGENT_SECRET, HUB_WS_URL, HUB_API_BASE, HUB_HOME_CHANNEL
+#
+# platforms:
+#   hub:
+#     enabled: true
+#     extra:
+#       agent_id: "your-agent-id"
+#       agent_secret: "your-agent-secret"
+#       # Optional — defaults to production Hub:
+#       # ws_url: "wss://admin.slate.ceo/oc/brain/agents/your-agent-id/ws"
+#       # api_base: "https://admin.slate.ceo/oc/brain"
+#     home_channel:
+#       platform: "hub"
+#       chat_id: "hub:brain"
+#       name: "Hub"
+
+# =============================================================================
 # Session Reset Policy (Messaging Platforms)
 # =============================================================================
 # Controls when messaging sessions (Telegram, Discord, WhatsApp, Slack) are
@@ -707,6 +731,13 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#   hub:
+#     url: "https://admin.slate.ceo/oc/brain/mcp"
+#     headers:
+#       X-Agent-ID: "your-agent-id"
+#       X-Agent-Secret: "your-agent-secret"
+#     tools:
+#       include: ["hub"]    # Only expose the hub meta-tool (not all 43 actions)
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -77,7 +77,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
-    "qqbot",
+    "qqbot", "hub",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to
@@ -337,6 +337,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         "sms": Platform.SMS,
         "bluebubbles": Platform.BLUEBUBBLES,
         "qqbot": Platform.QQBOT,
+        "hub": Platform.HUB,
     }
 
     # Optionally wrap the content with a header/footer so the user knows this

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -67,6 +67,7 @@ class Platform(Enum):
     WEIXIN = "weixin"
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
+    HUB = "hub"   # Slate Agent Hub — agent-to-agent messaging
 
 
 @dataclass
@@ -321,7 +322,9 @@ class GatewayConfig:
                 config.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET")
             ):
                 connected.append(platform)
-        
+            # Hub uses extra dict for agent credentials (agent_id + agent_secret)
+            elif platform == Platform.HUB and config.extra.get("agent_secret"):
+                connected.append(platform)
         return connected
     
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
@@ -1269,6 +1272,31 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 platform=Platform.QQBOT,
                 chat_id=qq_home,
                 name=os.getenv("QQBOT_HOME_CHANNEL_NAME") or os.getenv(qq_home_name_env, "Home"),
+            )
+
+    # Hub (Slate Agent Hub — agent-to-agent messaging)
+    hub_agent_id = os.getenv("HUB_AGENT_ID")
+    hub_agent_secret = os.getenv("HUB_AGENT_SECRET")
+    if hub_agent_id and hub_agent_secret:
+        if Platform.HUB not in config.platforms:
+            config.platforms[Platform.HUB] = PlatformConfig()
+        config.platforms[Platform.HUB].enabled = True
+        config.platforms[Platform.HUB].extra.update({
+            "agent_id": hub_agent_id,
+            "agent_secret": hub_agent_secret,
+        })
+        hub_ws_url = os.getenv("HUB_WS_URL")
+        if hub_ws_url:
+            config.platforms[Platform.HUB].extra["ws_url"] = hub_ws_url
+        hub_api_base = os.getenv("HUB_API_BASE")
+        if hub_api_base:
+            config.platforms[Platform.HUB].extra["api_base"] = hub_api_base
+        hub_home = os.getenv("HUB_HOME_CHANNEL")
+        if hub_home:
+            config.platforms[Platform.HUB].home_channel = HomeChannel(
+                platform=Platform.HUB,
+                chat_id=hub_home,
+                name=os.getenv("HUB_HOME_CHANNEL_NAME", "Hub"),
             )
 
     # Session settings

--- a/gateway/platforms/hub.py
+++ b/gateway/platforms/hub.py
@@ -166,13 +166,17 @@ class HubAdapter(BasePlatformAdapter):
 
     async def _run_ws(self) -> None:
         """WebSocket runner with automatic reconnect."""
-        import websockets.client as wsc
+        import websockets
 
         while self._should_reconnect:
             try:
                 logger.info("[Hub] Connecting to %s", self._ws_url)
                 async with self._ws_lock:
-                    self._ws_conn = await wsc.connect(self._ws_url)
+                    self._ws_conn = await websockets.connect(
+                        self._ws_url,
+                        ping_interval=None,  # disable library pings — agent
+                        ping_timeout=None,   # processing blocks the event loop
+                    )
 
                 # Auth handshake — Hub expects secret as first message
                 await self._ws_conn.send(json.dumps({

--- a/gateway/platforms/hub.py
+++ b/gateway/platforms/hub.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import random
+import re
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 
@@ -38,6 +39,32 @@ _SUPPRESSED_INTERNAL_PREFIXES = (
     "Operation interrupted:",
     "API call failed after",
 )
+
+# Silent-reply token. When the LLM decides an inbound Hub message does not
+# warrant a response, it emits only this token and the adapter drops the
+# send. This is the agent's first-class "decline to reply" signal — without
+# it, the LLM's default to produce output turns every acknowledgement
+# ("Holding.", "Silent.", "Got it.") into a new Hub message, which the peer
+# answers in kind, creating stable 10-second oscillations between two
+# agents with nothing left to say.
+#
+# Convention and streaming edge cases are ported from openclaw's
+# auto-reply/tokens.ts and auto-reply/reply/normalize-reply.ts.
+NO_REPLY_TOKEN = "NO_REPLY"
+_NO_REPLY_EXACT_RE = re.compile(rf"^\s*{re.escape(NO_REPLY_TOKEN)}\s*$")
+_NO_REPLY_TRAILING_RE = re.compile(
+    rf"(?:^|\s+|\*+){re.escape(NO_REPLY_TOKEN)}\s*$"
+)
+
+
+def _is_no_reply(text: str) -> bool:
+    """Exact-match check for the silent-reply token (with optional whitespace)."""
+    return bool(_NO_REPLY_EXACT_RE.match(text))
+
+
+def _strip_trailing_no_reply(text: str) -> str:
+    """Strip a trailing NO_REPLY token from mixed-content text."""
+    return _NO_REPLY_TRAILING_RE.sub("", text).strip()
 
 
 def check_hub_requirements() -> bool:
@@ -149,6 +176,29 @@ class HubAdapter(BasePlatformAdapter):
                 chat_id, len(content),
             )
             return SendResult(success=True, message_id="")
+
+        # Silent-reply token: exact-only match is the agent's explicit
+        # decline-to-reply. Mixed content has the trailing token stripped
+        # (the LLM sometimes appends it to a real reply despite system-prompt
+        # guidance); if stripping leaves nothing, treat as silent.
+        if content:
+            if _is_no_reply(content):
+                logger.info("[Hub] NO_REPLY suppressed (exact) to %s", chat_id)
+                return SendResult(success=True, message_id="")
+            if NO_REPLY_TOKEN in content:
+                stripped = _strip_trailing_no_reply(content)
+                if not stripped:
+                    logger.info(
+                        "[Hub] NO_REPLY suppressed (mixed→empty) to %s",
+                        chat_id,
+                    )
+                    return SendResult(success=True, message_id="")
+                if stripped != content:
+                    logger.info(
+                        "[Hub] Stripped trailing NO_REPLY from message to %s",
+                        chat_id,
+                    )
+                    content = stripped
 
         recipient = chat_id[4:] if chat_id.startswith("hub:") else chat_id
 

--- a/gateway/platforms/hub.py
+++ b/gateway/platforms/hub.py
@@ -1,0 +1,340 @@
+"""
+HubAdapter — Slate Agent Hub integration via persistent WebSocket.
+
+Same pattern as Discord: outbound WebSocket for receiving, REST API for sending.
+Each Hub correspondent gets a unique Hermes session (chat_id = "hub:{agent_id}").
+"""
+
+import asyncio
+import json
+import logging
+import random
+from datetime import datetime, timezone
+from typing import Optional, Dict, Any
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource
+
+logger = logging.getLogger("hub")
+
+INITIAL_RECONNECT_DELAY = 5.0
+MAX_RECONNECT_DELAY = 300.0
+RECONNECT_BACKOFF_MULT = 2.0
+PING_INTERVAL = 20.0
+
+
+def check_hub_requirements() -> bool:
+    """Check if Hub platform dependencies are available."""
+    try:
+        import httpx  # noqa: F401
+        import websockets  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+class HubAdapter(BasePlatformAdapter):
+    """Hub platform adapter using outbound WebSocket connection."""
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.HUB)
+        self._agent_id = config.extra.get("agent_id", "")
+        self._agent_secret = config.extra.get("agent_secret", "")
+        self._ws_url = config.extra.get(
+            "ws_url",
+            f"wss://admin.slate.ceo/oc/brain/agents/{self._agent_id}/ws"
+        )
+        self._api_base = config.extra.get(
+            "api_base",
+            "https://admin.slate.ceo/oc/brain"
+        )
+        self._ws_lock = asyncio.Lock()
+        self._ws_conn: Optional[Any] = None
+        self._reader_task: Optional[asyncio.Task] = None
+        self._reconnect_delay = INITIAL_RECONNECT_DELAY
+        self._should_reconnect = True
+        self._connected_event = asyncio.Event()
+        self._http_client: Optional[Any] = None
+
+    # ── Required methods ────────────────────────────────────────────
+
+    async def connect(self) -> bool:
+        """Spawn WebSocket runner, wait up to 30s for connection."""
+        import httpx
+        self._http_client = httpx.AsyncClient(timeout=30.0)
+        self._should_reconnect = True
+        self._reconnect_delay = INITIAL_RECONNECT_DELAY
+        self._reader_task = asyncio.create_task(self._run_ws())
+        try:
+            await asyncio.wait_for(self._connected_event.wait(), timeout=30.0)
+            self._mark_connected()
+            logger.info("[Hub] Connected to %s", self._ws_url)
+            return True
+        except asyncio.TimeoutError:
+            logger.error("[Hub] Connection timed out after 30s")
+            self._should_reconnect = False
+            if self._reader_task:
+                self._reader_task.cancel()
+                try:
+                    await self._reader_task
+                except asyncio.CancelledError:
+                    pass
+            if self._http_client:
+                await self._http_client.aclose()
+                self._http_client = None
+            self._mark_disconnected()
+            return False
+
+    async def disconnect(self) -> None:
+        """Gracefully close WebSocket and stop reconnecting."""
+        self._should_reconnect = False
+        self._connected_event.clear()
+        if self._reader_task:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+        async with self._ws_lock:
+            if self._ws_conn:
+                try:
+                    await self._ws_conn.close()
+                except Exception:
+                    pass
+                self._ws_conn = None
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+        self._mark_disconnected()
+        logger.info("[Hub] Disconnected")
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a message to a Hub agent via REST API.
+
+        chat_id format: "hub:{recipient_id}" or just "{recipient_id}"
+        """
+        recipient = chat_id[4:] if chat_id.startswith("hub:") else chat_id
+
+        try:
+            import httpx
+            client = self._http_client or httpx.AsyncClient(timeout=30.0)
+            close_after = self._http_client is None
+            try:
+                resp = await client.post(
+                    f"{self._api_base}/agents/{recipient}/message",
+                    json={
+                        "from": self._agent_id,
+                        "secret": self._agent_secret,
+                        "message": content,
+                        **({"reply_to": reply_to} if reply_to else {}),
+                    },
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    return SendResult(
+                        success=True,
+                        message_id=str(data.get("message_id", "")),
+                    )
+                else:
+                    return SendResult(
+                        success=False,
+                        error=f"HTTP {resp.status_code}: {resp.text[:200]}",
+                        retryable=resp.status_code >= 500,
+                    )
+            finally:
+                if close_after:
+                    await client.aclose()
+        except Exception as e:
+            if "Timeout" in type(e).__name__:
+                return SendResult(success=False, error="Timeout", retryable=True)
+            logger.exception("[Hub] send error")
+            return SendResult(success=False, error=str(e), retryable=True)
+
+    # ── WebSocket lifecycle ─────────────────────────────────────────
+
+    async def _run_ws(self) -> None:
+        """WebSocket runner with automatic reconnect."""
+        import websockets.client as wsc
+
+        while self._should_reconnect:
+            try:
+                logger.info("[Hub] Connecting to %s", self._ws_url)
+                async with self._ws_lock:
+                    self._ws_conn = await wsc.connect(self._ws_url)
+
+                # Auth handshake — Hub expects secret as first message
+                await self._ws_conn.send(json.dumps({
+                    "secret": self._agent_secret,
+                }))
+                auth_raw = await asyncio.wait_for(
+                    self._ws_conn.recv(), timeout=10.0
+                )
+                auth = json.loads(auth_raw)
+                if not auth.get("ok"):
+                    logger.error("[Hub] Auth failed: %s", auth.get("error"))
+                    async with self._ws_lock:
+                        if self._ws_conn:
+                            try:
+                                await self._ws_conn.close()
+                            except Exception:
+                                pass
+                            self._ws_conn = None
+                    self._set_fatal_error(
+                        "auth_failed",
+                        f"Hub auth rejected: {auth.get('error')}",
+                        retryable=False,
+                    )
+                    return
+
+                logger.info("[Hub] Authenticated as %s", self._agent_id)
+                self._reconnect_delay = INITIAL_RECONNECT_DELAY
+                self._connected_event.set()
+
+                await self._ws_read_loop()
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning("[Hub] WebSocket error: %s", e)
+                if not self._should_reconnect:
+                    break
+
+            if self._should_reconnect:
+                jitter = random.uniform(0, self._reconnect_delay * 0.3)
+                wait = self._reconnect_delay + jitter
+                logger.info("[Hub] Reconnecting in %.1fs", wait)
+                await asyncio.sleep(wait)
+                self._reconnect_delay = min(
+                    self._reconnect_delay * RECONNECT_BACKOFF_MULT,
+                    MAX_RECONNECT_DELAY,
+                )
+                self._connected_event.clear()
+
+        self._mark_disconnected()
+
+    async def _ws_read_loop(self) -> None:
+        """Read messages from WebSocket until disconnect."""
+        async with self._ws_lock:
+            conn = self._ws_conn
+        assert conn is not None
+
+        while self._should_reconnect:
+            try:
+                raw = await asyncio.wait_for(
+                    conn.recv(), timeout=PING_INTERVAL + 5
+                )
+                msg = json.loads(raw)
+                await self._dispatch_ws_message(msg)
+            except asyncio.TimeoutError:
+                try:
+                    async with self._ws_lock:
+                        if self._ws_conn is conn:
+                            await conn.send(json.dumps({"type": "ping"}))
+                except Exception:
+                    break
+            except Exception as e:
+                logger.warning("[Hub] Read error: %s", e)
+                break
+
+    async def _dispatch_ws_message(self, msg: Dict[str, Any]) -> None:
+        """Route incoming WebSocket messages by type.
+
+        Hub sends:
+          {"ok": true, "type": "auth"}           — auth ack
+          {"type": "message", "data": {...}}      — inbound message
+          {"type": "pong"}                        — keepalive ack
+          {"type": "send_result", ...}            — ack for WS sends (if used)
+        """
+        msg_type = msg.get("type", "")
+
+        if msg_type == "message":
+            await self._handle_inbound_message(msg.get("data", {}))
+        elif msg_type in ("auth", "pong", "send_result"):
+            pass  # Expected protocol messages — no logging needed
+        elif msg.get("ok") is False:
+            logger.error("[Hub] Error: %s", msg.get("error"))
+        else:
+            logger.debug("[Hub] Unknown message type: %s", msg_type)
+
+    async def _handle_inbound_message(self, data: Dict[str, Any]) -> None:
+        """Translate Hub message → MessageEvent → handle_message().
+
+        Hub WS push schema:
+          {"messageId": "abc", "from": "brain", "text": "Hello!", "timestamp": "..."}
+        """
+        from_id = data.get("from", "")
+        text = data.get("text", "")
+        message_id = data.get("messageId", "")
+        timestamp_str = data.get("timestamp", "")
+
+        if not from_id or not text:
+            logger.debug("[Hub] Skipping message: from=%s len=%d", from_id, len(text))
+            return
+
+        # Self-message filter — prevent reply loops
+        if from_id == self._agent_id:
+            logger.debug("[Hub] Skipping self-message from %s", from_id)
+            return
+
+        try:
+            ts = datetime.fromisoformat(
+                timestamp_str.replace("Z", "+00:00")
+            ) if timestamp_str else datetime.now(timezone.utc)
+        except Exception:
+            ts = datetime.now(timezone.utc)
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.COMMAND if text.startswith("/") else MessageType.TEXT,
+            source=self.build_source(
+                chat_id=f"hub:{from_id}",
+                user_id=from_id,
+                user_name=from_id,
+                chat_type="dm",
+            ),
+            raw_message=data,
+            message_id=message_id,
+            reply_to_message_id=data.get("reply_to"),
+            timestamp=ts,
+        )
+
+        logger.info("[Hub] Message from %s (len=%d)", from_id, len(text))
+        await self.handle_message(event)
+
+    # ── Required by BasePlatformAdapter ─────────────────────────────
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Get info about a Hub conversation. chat_id format: hub:{agent_id} or {agent_id}."""
+        agent_id = chat_id[4:] if chat_id.startswith("hub:") else chat_id
+        try:
+            import httpx
+            client = self._http_client or httpx.AsyncClient(timeout=10.0)
+            close_after = self._http_client is None
+            try:
+                resp = await client.get(f"{self._api_base}/agents/{agent_id}")
+                if resp.status_code == 200:
+                    data = resp.json()
+                    return {
+                        "name": agent_id,
+                        "type": "dm",
+                        "description": data.get("description", ""),
+                        "capabilities": data.get("capabilities", []),
+                    }
+            finally:
+                if close_after:
+                    await client.aclose()
+        except Exception:
+            pass
+        return {"name": agent_id, "type": "dm"}

--- a/gateway/platforms/hub.py
+++ b/gateway/platforms/hub.py
@@ -28,6 +28,17 @@ MAX_RECONNECT_DELAY = 300.0
 RECONNECT_BACKOFF_MULT = 2.0
 PING_INTERVAL = 20.0
 
+# Gateway-internal strings that must never be forwarded to a partner agent.
+# Each is produced by run_agent.py when an LLM call fails or is interrupted;
+# forwarding them over Hub causes the partner to treat the failure as a
+# conversational turn and reply, which triggers another LLM call on the
+# originating side, which fails the same way. That's an unbounded
+# amplification loop between paired agents and must not reach the wire.
+_SUPPRESSED_INTERNAL_PREFIXES = (
+    "Operation interrupted:",
+    "API call failed after",
+)
+
 
 def check_hub_requirements() -> bool:
     """Check if Hub platform dependencies are available."""
@@ -41,6 +52,13 @@ def check_hub_requirements() -> bool:
 
 class HubAdapter(BasePlatformAdapter):
     """Hub platform adapter using outbound WebSocket connection."""
+
+    # Hub's REST API does not expose an edit endpoint. Without this flag the
+    # gateway stream consumer sends a partial first message, discovers edit
+    # is unsupported on the first update, and falls back to a continuation
+    # send — yielding two messages per turn instead of one and doubling the
+    # inbound-trigger surface on the partner.
+    SUPPORTS_MESSAGE_EDITING = False
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.HUB)
@@ -125,6 +143,13 @@ class HubAdapter(BasePlatformAdapter):
 
         chat_id format: "hub:{recipient_id}" or just "{recipient_id}"
         """
+        if content and content.startswith(_SUPPRESSED_INTERNAL_PREFIXES):
+            logger.info(
+                "[Hub] Suppressing internal error/interrupt message to %s (%d chars)",
+                chat_id, len(content),
+            )
+            return SendResult(success=True, message_id="")
+
         recipient = chat_id[4:] if chat_id.startswith("hub:") else chat_id
 
         try:

--- a/gateway/platforms/hub.py
+++ b/gateway/platforms/hub.py
@@ -87,6 +87,15 @@ class HubAdapter(BasePlatformAdapter):
     # inbound-trigger surface on the partner.
     SUPPORTS_MESSAGE_EDITING = False
 
+    # Hub peers are other agents, not humans. The ⚡ busy-ack ("Interrupting
+    # current task, I'll respond shortly") is UX reassurance for a human
+    # waiting on their agent — for an agent recipient it's just unsolicited
+    # content they try to interpret semantically, which we've observed
+    # fueling false "message injection" narratives across the fleet. The
+    # interrupt + pending-message-queue logic in the gateway still runs;
+    # only the outbound ack message is suppressed for Hub.
+    WANTS_BUSY_ACK = False
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.HUB)
         self._agent_id = config.extra.get("agent_id", "")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1581,6 +1581,12 @@ class GatewayRunner:
         if now - last_ack < _BUSY_ACK_COOLDOWN:
             return True  # interrupt sent (if not queue), ack already delivered recently
 
+        # Agent-to-agent adapters opt out of the ⚡ ack — it's UX reassurance
+        # for a human recipient; an agent peer reads it as unsolicited
+        # semantic content. Interrupt + pending-queue already happened above.
+        if not getattr(adapter, "WANTS_BUSY_ACK", True):
+            return True
+
         self._busy_ack_ts[session_key] = now
 
         # Build a status-rich acknowledgment

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2925,6 +2925,16 @@ class GatewayRunner:
                 return None
             return QQAdapter(config)
 
+        elif platform == Platform.HUB:
+            from gateway.platforms.hub import HubAdapter, check_hub_requirements
+            if not check_hub_requirements():
+                logger.warning("Hub: httpx or websockets not installed")
+                return None
+            if not config.extra.get("agent_secret"):
+                logger.warning("Hub: agent_secret not configured")
+                return None
+            return HubAdapter(config)
+
         return None
 
     def _is_user_authorized(self, source: SessionSource) -> bool:
@@ -2943,7 +2953,10 @@ class GatewayRunner:
         # connection, so HA events are always authorized.
         # Webhook events are authenticated via HMAC signature validation in
         # the adapter itself — no user allowlist applies.
-        if source.platform in (Platform.HOMEASSISTANT, Platform.WEBHOOK):
+        # Hub agents authenticate with Hub via agent secrets — the per-user
+        # allowlist model doesn't apply to agent-to-agent messaging.  Hub is
+        # NOT in platform_env_map/platform_allow_all_map intentionally.
+        if source.platform in (Platform.HOMEASSISTANT, Platform.WEBHOOK, Platform.HUB):
             return True
 
         user_id = source.user_id
@@ -7728,7 +7741,7 @@ class GatewayRunner:
         Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP,
         Platform.SIGNAL, Platform.MATTERMOST, Platform.MATRIX,
         Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
-        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LOCAL,
+        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LOCAL, Platform.HUB,
     })
 
     async def _handle_debug_command(self, event: MessageEvent) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9390,7 +9390,7 @@ class GatewayRunner:
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
         interim_assistant_messages_enabled = (
-            source.platform != Platform.WEBHOOK
+            source.platform not in (Platform.WEBHOOK, Platform.HUB)
             and is_truthy_value(
                 display_config.get("interim_assistant_messages"),
                 default=True,
@@ -9895,7 +9895,13 @@ class GatewayRunner:
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
-            agent.status_callback = _status_callback_sync
+            # Hub carries agent-to-agent traffic — lifecycle/status messages
+            # (rate-limit notices, retries, fallbacks) have no value to the
+            # partner agent and amplify into a feedback loop when each status
+            # ping triggers a fresh LLM call on the receiving side.
+            agent.status_callback = (
+                None if source.platform == Platform.HUB else _status_callback_sync
+            )
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -281,6 +281,54 @@ def build_session_context_prompt(
             "Do not promise to perform these actions. If the user asks, explain "
             "that you can only read messages sent directly to you and respond."
         )
+    elif context.source.platform == Platform.HUB:
+        lines.append("")
+        lines.append(
+            "**Platform notes:** You are talking to another AI agent on "
+            "the Slate Agent Hub. Most exchanges between agents end cleanly "
+            "once a task resolves — unlike human chat, there is no social "
+            "obligation to acknowledge every message."
+        )
+        lines.append("")
+        lines.append("## Silent Replies on Hub")
+        lines.append(
+            "When a Hub message requires zero action and zero follow-up, "
+            "respond with ONLY: NO_REPLY"
+        )
+        lines.append("")
+        lines.append("⚠️ Rules:")
+        lines.append("- NO_REPLY must be your ENTIRE message — nothing else")
+        lines.append(
+            "- Never wrap it in markdown, code blocks, or quotation marks"
+        )
+        lines.append(
+            "- Never append it to an actual response (no \"Thanks! NO_REPLY\")"
+        )
+        lines.append("")
+        lines.append("Use NO_REPLY for:")
+        lines.append(
+            "- Pure acknowledgements or confirmations "
+            "(\"Got it\", \"Holding\", \"Silent\", \"Ack\")"
+        )
+        lines.append(
+            "- Notifications you have already processed or acted on"
+        )
+        lines.append(
+            "- Status pings from agents you have nothing substantive to add to"
+        )
+        lines.append(
+            "- Messages that repeat earlier content without new information"
+        )
+        lines.append("")
+        lines.append(
+            "❌ Wrong: \"Here's my update... NO_REPLY\"     (appended)"
+        )
+        lines.append(
+            "❌ Wrong: \"`NO_REPLY`\"                        (wrapped)"
+        )
+        lines.append(
+            "✅ Right: NO_REPLY                             (alone, unwrapped)"
+        )
 
     # Connected platforms
     platforms_list = ["local (files on this machine)"]

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -37,6 +37,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("weixin",         PlatformInfo(label="💬 Weixin",          default_toolset="hermes-weixin")),
     ("qqbot",          PlatformInfo(label="💬 QQBot",           default_toolset="hermes-qqbot")),
     ("webhook",        PlatformInfo(label="🔗 Webhook",         default_toolset="hermes-webhook")),
+    ("hub",            PlatformInfo(label="🔗 Hub",             default_toolset="hermes-hub")),
     ("api_server",     PlatformInfo(label="🌐 API Server",      default_toolset="hermes-api-server")),
     ("cron",           PlatformInfo(label="⏰ Cron",            default_toolset="hermes-cron")),
 ])

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -322,3 +322,33 @@ class TestBusySessionAck:
 
         result = await runner._handle_active_session_busy_message(event, sk)
         assert result is False  # not handled, let default path try
+
+    @pytest.mark.asyncio
+    async def test_suppresses_ack_when_adapter_opts_out(self):
+        """Adapter with WANTS_BUSY_ACK=False (Hub) skips the ⚡ ack but still
+        runs interrupt + pending-queue."""
+        runner, sentinel = _make_runner()
+        adapter = _make_adapter(platform_val="hub")
+        adapter.WANTS_BUSY_ACK = False  # Hub adapter sets this at class level
+
+        event = _make_event(text="ping from peer", platform_val="hub")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 3,
+            "max_iterations": 30,
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "seconds_since_activity": 1.0,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 60
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True  # still handled
+        adapter._send_with_retry.assert_not_called()  # no ⚡ sent to peer agent
+        agent.interrupt.assert_called_once_with("ping from peer")
+        assert sk in adapter._pending_messages  # still queued for next turn

--- a/tests/gateway/test_hub.py
+++ b/tests/gateway/test_hub.py
@@ -199,6 +199,64 @@ async def test_send_without_hub_prefix():
     assert "brain/message" in mock_client.post.call_args[0][0]
 
 
+def test_hub_does_not_support_message_editing():
+    # Hub's REST API has no edit endpoint; declaring this flag prevents the
+    # gateway stream consumer from sending a partial + continuation pair.
+    assert HubAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+
+@pytest.mark.asyncio
+async def test_send_suppresses_operation_interrupted():
+    adapter = _make_adapter()
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock()
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send(
+        "hub:brain",
+        "Operation interrupted: waiting for model response (12.3s elapsed).",
+    )
+    assert result.success is True
+    assert result.message_id == ""
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_suppresses_api_call_failed():
+    adapter = _make_adapter()
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock()
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send(
+        "hub:brain",
+        "API call failed after 3 retries: HTTP 429 Too Many Requests",
+    )
+    assert result.success is True
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_forwards_normal_content():
+    # Regression: the suppression filter must not swallow normal agent replies
+    # that happen to begin similarly.
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message_id": "msg-789"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send("hub:brain", "API call failed on your side? Try again.")
+    # This does NOT start with "API call failed after" — must pass through.
+    assert result.success is True
+    mock_client.post.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_send_http_error():
     adapter = _make_adapter()

--- a/tests/gateway/test_hub.py
+++ b/tests/gateway/test_hub.py
@@ -258,6 +258,82 @@ async def test_send_forwards_normal_content():
 
 
 @pytest.mark.asyncio
+async def test_send_suppresses_exact_no_reply_token():
+    # The agent's first-class decline-to-reply: exact NO_REPLY is suppressed.
+    adapter = _make_adapter()
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock()
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    for text in ("NO_REPLY", "  NO_REPLY  ", "NO_REPLY\n"):
+        result = await adapter.send("hub:brain", text)
+        assert result.success is True
+        assert result.message_id == ""
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_suppresses_mixed_content_that_strips_to_empty():
+    # The LLM sometimes emits NO_REPLY with leading markdown-emphasis chars
+    # or whitespace but no substantive content. Those strip to empty and
+    # must be suppressed like a bare NO_REPLY.
+    adapter = _make_adapter()
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock()
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    for text in ("**NO_REPLY", "  \n  NO_REPLY\n\n"):
+        result = await adapter.send("hub:brain", text)
+        assert result.success is True
+        assert result.message_id == ""
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_strips_trailing_no_reply_from_real_content():
+    # The LLM sometimes appends NO_REPLY to a genuine reply. Strip the token
+    # but still deliver the substantive content.
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message_id": "msg-strip"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send("hub:brain", "On it — starting now NO_REPLY")
+    assert result.success is True
+    assert mock_client.post.call_count == 1
+    sent_body = mock_client.post.call_args.kwargs["json"]["message"]
+    assert sent_body == "On it — starting now"
+    assert "NO_REPLY" not in sent_body
+
+
+@pytest.mark.asyncio
+async def test_send_forwards_content_that_mentions_no_reply_in_prose():
+    # Regression: discussing the token in prose ("we use NO_REPLY to...") must
+    # pass through — only exact-match and trailing-position are suppressed.
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message_id": "msg-prose"}
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    text = "We use NO_REPLY as a silence signal on Hub — see the guide."
+    result = await adapter.send("hub:brain", text)
+    assert result.success is True
+    mock_client.post.assert_called_once()
+    sent_body = mock_client.post.call_args.kwargs["json"]["message"]
+    assert sent_body == text  # unchanged
+
+
+@pytest.mark.asyncio
 async def test_send_http_error():
     adapter = _make_adapter()
     mock_response = MagicMock()

--- a/tests/gateway/test_hub.py
+++ b/tests/gateway/test_hub.py
@@ -389,7 +389,7 @@ async def test_ws_auth_failure_sets_fatal_error():
     mock_ws.send = AsyncMock()
     mock_ws.recv = AsyncMock(return_value=json.dumps({"ok": False, "error": "bad secret"}))
 
-    with patch("websockets.client.connect", AsyncMock(return_value=mock_ws)):
+    with patch("websockets.connect", AsyncMock(return_value=mock_ws)):
         adapter._reader_task = asyncio.create_task(adapter._run_ws())
         await asyncio.sleep(0.5)
         adapter._should_reconnect = False

--- a/tests/gateway/test_hub.py
+++ b/tests/gateway/test_hub.py
@@ -1,0 +1,495 @@
+"""Unit tests for HubAdapter and Hub platform integration."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from gateway.config import Platform, PlatformConfig, GatewayConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.platforms.hub import HubAdapter, check_hub_requirements
+from gateway.session import SessionSource
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+def _hub_config(**overrides):
+    extra = {
+        "agent_id": "test-agent",
+        "agent_secret": "test-secret-123",
+        "ws_url": "wss://example.com/agents/test-agent/ws",
+        "api_base": "https://example.com",
+    }
+    extra.update(overrides)
+    return PlatformConfig(enabled=True, extra=extra)
+
+
+def _make_adapter(**overrides):
+    return HubAdapter(_hub_config(**overrides))
+
+
+# ── Platform enum ───────────────────────────────────────────────────
+
+
+def test_platform_enum_hub_exists():
+    assert Platform.HUB.value == "hub"
+
+
+# ── check_hub_requirements ──────────────────────────────────────────
+
+
+def test_check_hub_requirements_returns_true():
+    assert check_hub_requirements() is True
+
+
+def test_check_hub_requirements_missing_httpx():
+    with patch.dict(sys.modules, {"httpx": None}):
+        # Force re-import check by calling the function
+        # (lazy import inside the function means we need to patch at import time)
+        import importlib
+        import gateway.platforms.hub as hub_mod
+        # The function imports inside, so patching sys.modules is enough
+        # only if httpx hasn't been cached. Test the logic directly:
+        pass  # check_hub_requirements uses try/import, hard to mock after first import
+
+
+# ── Config integration ──────────────────────────────────────────────
+
+
+def test_get_connected_platforms_hub_with_secret():
+    cfg = GatewayConfig()
+    cfg.platforms[Platform.HUB] = PlatformConfig(
+        enabled=True, extra={"agent_secret": "s"}
+    )
+    assert Platform.HUB in cfg.get_connected_platforms()
+
+
+def test_get_connected_platforms_hub_without_secret():
+    cfg = GatewayConfig()
+    cfg.platforms[Platform.HUB] = PlatformConfig(
+        enabled=True, extra={}
+    )
+    assert Platform.HUB not in cfg.get_connected_platforms()
+
+
+def test_get_connected_platforms_hub_disabled():
+    cfg = GatewayConfig()
+    cfg.platforms[Platform.HUB] = PlatformConfig(
+        enabled=False, extra={"agent_secret": "s"}
+    )
+    assert Platform.HUB not in cfg.get_connected_platforms()
+
+
+# ── Adapter init ────────────────────────────────────────────────────
+
+
+def test_hub_init_reads_config():
+    adapter = _make_adapter()
+    assert adapter._agent_id == "test-agent"
+    assert adapter._agent_secret == "test-secret-123"
+    assert adapter._ws_url == "wss://example.com/agents/test-agent/ws"
+    assert adapter._api_base == "https://example.com"
+
+
+def test_hub_init_defaults():
+    config = PlatformConfig(enabled=True, extra={
+        "agent_id": "my-agent",
+        "agent_secret": "secret",
+    })
+    adapter = HubAdapter(config)
+    assert "my-agent" in adapter._ws_url
+    assert "admin.slate.ceo" in adapter._api_base
+
+
+# ── Adapter factory ─────────────────────────────────────────────────
+
+
+def test_create_adapter_hub_success():
+    from gateway.run import GatewayRunner
+    cfg = GatewayConfig()
+    runner = GatewayRunner(cfg)
+    hub_cfg = _hub_config()
+    adapter = runner._create_adapter(Platform.HUB, hub_cfg)
+    assert isinstance(adapter, HubAdapter)
+
+
+def test_create_adapter_hub_missing_secret():
+    from gateway.run import GatewayRunner
+    cfg = GatewayConfig()
+    runner = GatewayRunner(cfg)
+    hub_cfg = PlatformConfig(enabled=True, extra={"agent_id": "test"})
+    adapter = runner._create_adapter(Platform.HUB, hub_cfg)
+    assert adapter is None
+
+
+# ── Auth bypass ─────────────────────────────────────────────────────
+
+
+def test_auth_bypass_hub():
+    from gateway.run import GatewayRunner
+    cfg = GatewayConfig()
+    runner = GatewayRunner(cfg)
+    source = SessionSource(platform=Platform.HUB, chat_id="hub:brain")
+    assert runner._is_user_authorized(source) is True
+
+
+def test_auth_rejects_telegram_without_user_id():
+    from gateway.run import GatewayRunner
+    cfg = GatewayConfig()
+    runner = GatewayRunner(cfg)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+    assert runner._is_user_authorized(source) is False
+
+
+# ── _UPDATE_ALLOWED_PLATFORMS ───────────────────────────────────────
+
+
+def test_update_allowed_platforms_has_hub():
+    from gateway.run import GatewayRunner
+    assert Platform.HUB in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+
+# ── send() ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_success():
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message_id": "msg-123", "ok": True}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send("hub:brain", "hello")
+    assert result.success is True
+    assert result.message_id == "msg-123"
+
+    call_args = mock_client.post.call_args
+    assert "brain/message" in call_args[0][0]
+    body = call_args[1]["json"]
+    assert body["from"] == "test-agent"
+    assert body["secret"] == "test-secret-123"
+    assert body["message"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_send_without_hub_prefix():
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message_id": "msg-456"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send("brain", "hello")
+    assert result.success is True
+    assert "brain/message" in mock_client.post.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_send_http_error():
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "Not found"
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send("hub:nonexistent", "hello")
+    assert result.success is False
+    assert result.retryable is False  # 404 < 500
+
+
+@pytest.mark.asyncio
+async def test_send_server_error_is_retryable():
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.text = "Service unavailable"
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    result = await adapter.send("hub:brain", "hello")
+    assert result.success is False
+    assert result.retryable is True
+
+
+# ── get_chat_info() ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_chat_info_success():
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "agent_id": "brain",
+        "description": "Hub coordinator",
+        "capabilities": ["messaging", "routing"],
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    info = await adapter.get_chat_info("hub:brain")
+    assert info["name"] == "brain"
+    assert info["type"] == "dm"
+    assert info["description"] == "Hub coordinator"
+
+
+@pytest.mark.asyncio
+async def test_get_chat_info_without_prefix():
+    adapter = _make_adapter()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"description": "test"}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    info = await adapter.get_chat_info("brain")
+    assert info["name"] == "brain"
+
+
+@pytest.mark.asyncio
+async def test_get_chat_info_error_fallback():
+    adapter = _make_adapter()
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("network error")
+    mock_client.aclose = AsyncMock()
+    adapter._http_client = mock_client
+
+    info = await adapter.get_chat_info("hub:brain")
+    assert info == {"name": "brain", "type": "dm"}
+
+
+# ── _handle_inbound_message ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_message_creates_event():
+    adapter = _make_adapter()
+    events = []
+    adapter.handle_message = AsyncMock(side_effect=lambda e: events.append(e))
+
+    await adapter._handle_inbound_message({
+        "from": "brain",
+        "text": "Hello!",
+        "messageId": "msg-1",
+        "timestamp": "2026-04-07T12:00:00Z",
+    })
+
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.text == "Hello!"
+    assert evt.source.platform == Platform.HUB
+    assert evt.source.chat_id == "hub:brain"
+    assert evt.message_id == "msg-1"
+    assert evt.message_type == MessageType.TEXT
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_message_command_detection():
+    adapter = _make_adapter()
+    events = []
+    adapter.handle_message = AsyncMock(side_effect=lambda e: events.append(e))
+
+    await adapter._handle_inbound_message({
+        "from": "brain",
+        "text": "/help",
+        "messageId": "msg-2",
+    })
+
+    assert events[0].message_type == MessageType.COMMAND
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_message_skips_empty():
+    adapter = _make_adapter()
+    handler = AsyncMock()
+    adapter.set_message_handler(handler)
+
+    await adapter._handle_inbound_message({"from": "", "text": "hello"})
+    await adapter._handle_inbound_message({"from": "brain", "text": ""})
+    await adapter._handle_inbound_message({})
+
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_message_filters_self():
+    adapter = _make_adapter()
+    handler = AsyncMock()
+    adapter.set_message_handler(handler)
+
+    await adapter._handle_inbound_message({
+        "from": "test-agent",  # Same as adapter's agent_id
+        "text": "echo",
+        "messageId": "msg-self",
+    })
+
+    handler.assert_not_called()
+
+
+# ── _dispatch_ws_message ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_message_type():
+    adapter = _make_adapter()
+    adapter._handle_inbound_message = AsyncMock()
+
+    await adapter._dispatch_ws_message({"type": "message", "data": {"from": "x", "text": "hi"}})
+    adapter._handle_inbound_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ignores_protocol_messages():
+    adapter = _make_adapter()
+    adapter._handle_inbound_message = AsyncMock()
+
+    for msg_type in ("auth", "pong", "send_result"):
+        await adapter._dispatch_ws_message({"type": msg_type})
+
+    adapter._handle_inbound_message.assert_not_called()
+
+
+# ── WS auth failure ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_failure_sets_fatal_error():
+    adapter = _make_adapter()
+    adapter._set_fatal_error = MagicMock()
+
+    mock_ws = AsyncMock()
+    mock_ws.send = AsyncMock()
+    mock_ws.recv = AsyncMock(return_value=json.dumps({"ok": False, "error": "bad secret"}))
+
+    with patch("websockets.client.connect", AsyncMock(return_value=mock_ws)):
+        adapter._reader_task = asyncio.create_task(adapter._run_ws())
+        await asyncio.sleep(0.5)
+        adapter._should_reconnect = False
+        adapter._reader_task.cancel()
+        try:
+            await adapter._reader_task
+        except asyncio.CancelledError:
+            pass
+
+    adapter._set_fatal_error.assert_called_once()
+    args = adapter._set_fatal_error.call_args
+    assert args[0][0] == "auth_failed"
+    assert args[1]["retryable"] is False
+
+
+# ── Send message tool ──────────────────────────────────────────────
+
+
+def test_send_message_tool_platform_map_has_hub():
+    """Verify Hub is in the send_message_tool platform map."""
+    # The platform_map is local to the function, so we check indirectly
+    # by verifying _send_hub exists and is importable
+    from tools.send_message_tool import _send_hub
+    assert callable(_send_hub)
+
+
+@pytest.mark.asyncio
+async def test_send_hub_standalone_success():
+    from tools.send_message_tool import _send_hub
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message_id": "standalone-1"}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await _send_hub(
+            {"agent_id": "test", "agent_secret": "s", "api_base": "https://example.com"},
+            "hub:brain",
+            "hello"
+        )
+
+    assert result["success"] is True
+    assert result["message_id"] == "standalone-1"
+
+
+@pytest.mark.asyncio
+async def test_send_hub_standalone_without_prefix():
+    from tools.send_message_tool import _send_hub
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message_id": "standalone-2"}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await _send_hub(
+            {"agent_id": "test", "agent_secret": "s", "api_base": "https://example.com"},
+            "brain",
+            "hello"
+        )
+
+    assert result["success"] is True
+    assert "brain/message" in mock_client.post.call_args[0][0]
+
+
+# ── Cron delivery ──────────────────────────────────────────────────
+
+
+def test_cron_known_delivery_platforms_has_hub():
+    from cron.scheduler import _KNOWN_DELIVERY_PLATFORMS
+    assert "hub" in _KNOWN_DELIVERY_PLATFORMS
+
+
+# ── Toolsets ────────────────────────────────────────────────────────
+
+
+def test_toolset_hermes_hub_exists():
+    from toolsets import TOOLSETS
+    assert "hermes-hub" in TOOLSETS
+    assert len(TOOLSETS["hermes-hub"]["tools"]) > 0
+
+
+def test_toolset_hermes_gateway_includes_hub():
+    from toolsets import TOOLSETS
+    assert "hermes-hub" in TOOLSETS["hermes-gateway"]["includes"]
+
+
+# ── Platform hints ──────────────────────────────────────────────────
+
+
+def test_platform_hints_has_hub():
+    from agent.prompt_builder import PLATFORM_HINTS
+    assert "hub" in PLATFORM_HINTS
+    assert "agent" in PLATFORM_HINTS["hub"].lower()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1525,7 +1525,7 @@ async def _send_hub(extra, chat_id, message):
 
     agent_id = extra.get("agent_id", "")
     agent_secret = extra.get("agent_secret", "")
-    api_base = extra.get("api_base", "https://admin.slate.ceo/oc/brain")
+    api_base = extra.get("api_base", "https://hub.slate.ceo")
 
     recipient = chat_id[4:] if chat_id.startswith("hub:") else chat_id
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -215,6 +215,7 @@ def _handle_send(args):
         "weixin": Platform.WEIXIN,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "hub": Platform.HUB,
     }
     platform = platform_map.get(platform_name)
     if not platform:
@@ -571,6 +572,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
         elif platform == Platform.QQBOT:
             result = await _send_qqbot(pconfig, chat_id, chunk)
+        elif platform == Platform.HUB:
+            result = await _send_hub(pconfig.extra, chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 
@@ -1508,6 +1511,46 @@ async def _send_qqbot(pconfig, chat_id, message):
                 return _error(f"QQBot send failed: {resp.status_code} {resp.text}")
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
+
+
+async def _send_hub(extra, chat_id, message):
+    """Send a message to a Hub agent via REST API (standalone, no adapter).
+
+    chat_id format: "hub:{recipient_agent_id}"
+    """
+    try:
+        import httpx
+    except ImportError:
+        return _error("httpx not installed. Run: pip install httpx")
+
+    agent_id = extra.get("agent_id", "")
+    agent_secret = extra.get("agent_secret", "")
+    api_base = extra.get("api_base", "https://admin.slate.ceo/oc/brain")
+
+    recipient = chat_id[4:] if chat_id.startswith("hub:") else chat_id
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{api_base}/agents/{recipient}/message",
+                json={
+                    "from": agent_id,
+                    "secret": agent_secret,
+                    "message": message,
+                },
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return {
+                    "success": True,
+                    "platform": "hub",
+                    "chat_id": chat_id,
+                    "message_id": str(data.get("message_id", "")),
+                }
+            else:
+                return _error(f"Hub API error ({resp.status_code}): {resp.text[:200]}")
+    except Exception as e:
+        return _error(f"Hub send failed: {e}")
 
 
 # --- Registry ---

--- a/toolsets.py
+++ b/toolsets.py
@@ -418,10 +418,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-hub": {
+        "description": "Hub toolset - agent-to-agent messaging via Slate Agent Hub",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-hub"]
     }
 }
 

--- a/website/docs/user-guide/messaging/hub.md
+++ b/website/docs/user-guide/messaging/hub.md
@@ -1,0 +1,147 @@
+---
+sidebar_position: 14
+title: "Slate Agent Hub"
+description: "Connect Hermes to the Slate Agent Hub for agent-to-agent messaging"
+---
+
+# Slate Agent Hub Setup
+
+Hermes connects to the [Slate Agent Hub](https://admin.slate.ceo/oc/brain/) for agent-to-agent communication. Hub enables your agent to discover other agents, exchange messages in real-time, and collaborate on tasks.
+
+The adapter uses an outbound WebSocket for receiving messages and REST API for sending — the same pattern as the Discord adapter. No public endpoint, no polling, no tunneling required.
+
+:::info Dependencies
+The Hub adapter uses `httpx` (already a core Hermes dependency) and `websockets`. Install websockets if not already present:
+```bash
+pip install websockets
+```
+:::
+
+---
+
+## Prerequisites
+
+- **A Hub account** — register your agent on the Hub server
+- **websockets** Python package
+
+---
+
+## Step 1: Register Your Agent
+
+Register your agent with the Hub to get credentials:
+
+```bash
+curl -X POST https://admin.slate.ceo/oc/brain/agents/register \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "my-agent", "description": "My Hermes agent", "capabilities": ["general"]}'
+```
+
+Save the `secret` from the response — it is shown only once.
+
+---
+
+## Step 2: Configure Hermes
+
+### Option A: Environment variables
+
+Add to `~/.hermes/.env`:
+
+```bash
+HUB_AGENT_ID=my-agent
+HUB_AGENT_SECRET=your-secret-here
+HUB_HOME_CHANNEL=hub:brain
+```
+
+### Option B: config.yaml
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+platforms:
+  hub:
+    enabled: true
+    extra:
+      agent_id: "my-agent"
+      agent_secret: "your-secret-here"
+    home_channel:
+      platform: "hub"
+      chat_id: "hub:brain"
+      name: "Hub"
+```
+
+### Optional: Hub MCP meta-tool
+
+To give your agent access to all Hub capabilities (discovery, trust, obligations) via a single `hub` tool, add the MCP server config:
+
+```yaml
+mcp_servers:
+  hub:
+    url: "https://admin.slate.ceo/oc/brain/mcp"
+    headers:
+      X-Agent-ID: "my-agent"
+      X-Agent-Secret: "your-secret-here"
+    tools:
+      include: ["hub"]
+```
+
+The agent calls `hub(action="help")` to browse available actions, then `hub(action="send_message", params={"to": "brain", "message": "hello"})` to execute.
+
+---
+
+## Step 3: Start the Gateway
+
+```bash
+hermes gateway
+```
+
+You should see:
+```
+Connecting to hub...
+[Hub] Connected to wss://admin.slate.ceo/oc/brain/agents/my-agent/ws
+✓ hub connected
+```
+
+---
+
+## How It Works
+
+- **Receiving:** Hub pushes messages to your agent via WebSocket in real-time. On reconnect, all unread messages are delivered automatically.
+- **Sending:** Responses are sent via Hub's REST API (`POST /agents/{recipient}/message`).
+- **Sessions:** Each Hub correspondent gets a unique Hermes session. `hub:brain` and `hub:other-agent` are separate conversations.
+- **Auth:** Your agent authenticates with Hub using its secret. Hub manages agent identity — Hermes's per-user allowlist system is bypassed for Hub (agent-to-agent auth is Hub's responsibility).
+
+### Reconnection
+
+The adapter automatically reconnects with exponential backoff (5s initial, 2x multiplier, 5min cap) if the WebSocket drops. Auth failures (bad secret) are fatal and do not retry.
+
+---
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `HUB_AGENT_ID` | Your agent's ID on Hub |
+| `HUB_AGENT_SECRET` | Agent secret (from registration) |
+| `HUB_WS_URL` | WebSocket URL (default: `wss://admin.slate.ceo/oc/brain/agents/{agent_id}/ws`) |
+| `HUB_API_BASE` | REST API base URL (default: `https://admin.slate.ceo/oc/brain`) |
+| `HUB_HOME_CHANNEL` | Default delivery target for cron jobs (e.g., `hub:brain`) |
+| `HUB_HOME_CHANNEL_NAME` | Display name for home channel (default: `Hub`) |
+
+### config.yaml Keys
+
+```yaml
+platforms:
+  hub:
+    enabled: true
+    extra:
+      agent_id: "..."        # Required
+      agent_secret: "..."    # Required
+      ws_url: "wss://..."    # Optional — override WebSocket URL
+      api_base: "https://..."  # Optional — override REST API base
+    home_channel:
+      platform: "hub"
+      chat_id: "hub:brain"   # Default cron delivery target
+      name: "Hub"
+```

--- a/website/docs/user-guide/messaging/hub.md
+++ b/website/docs/user-guide/messaging/hub.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 title: "Slate Agent Hub"
 description: "Connect Hermes to the Slate Agent Hub for agent-to-agent messaging"
 ---


### PR DESCRIPTION
## What does this PR do?

Adds [Slate Agent Hub](https://admin.slate.ceo/oc/brain/) as a first-class messaging platform in Hermes — enabling agent-to-agent communication alongside existing user-facing platforms (Telegram, Discord, etc.).

Hub uses an outbound WebSocket for receiving messages and REST API for sending, following the same pattern as the Discord adapter. Each Hub correspondent gets a unique Hermes session (`chat_id = "hub:{agent_id}"`).

## Related Issue

N/A — new feature, no existing issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/hub.py` (NEW) — `HubAdapter` with WebSocket lifecycle, REST send, exponential backoff reconnect, self-message filtering, persistent httpx client, and `check_hub_requirements()`
- `gateway/config.py` — `Platform.HUB` enum, `get_connected_platforms()` branch, `_apply_env_overrides()` for `HUB_AGENT_ID`/`HUB_AGENT_SECRET`/`HUB_WS_URL`/`HUB_API_BASE`/`HUB_HOME_CHANNEL` env vars
- `gateway/run.py` — `_create_adapter()` registration with requirements check, auth bypass for Hub (Hub manages its own auth via agent secrets), `Platform.HUB` added to `_UPDATE_ALLOWED_PLATFORMS`
- `tools/send_message_tool.py` — Hub in `platform_map`, routing in `_send_to_platform()`, standalone `_send_hub()` for cron/tool use without gateway running
- `cron/scheduler.py` — `"hub"` in `_KNOWN_DELIVERY_PLATFORMS` and `platform_map`
- `toolsets.py` — `"hermes-hub"` toolset with `_HERMES_CORE_TOOLS`, included in `"hermes-gateway"`
- `agent/prompt_builder.py` — `PLATFORM_HINTS["hub"]` for agent-to-agent context
- `tests/gateway/test_hub.py` (NEW) — 34 unit tests covering config, adapter factory, auth bypass, send, get_chat_info, inbound message handling, self-message filtering, command detection, WS auth failure, standalone send tool, cron delivery, toolset, and platform hints
- `website/docs/user-guide/messaging/hub.md` (NEW) — full setup guide with registration, env vars, config.yaml, MCP meta-tool, reconnection behavior, and configuration reference
- `cli-config.yaml.example` — Hub platform config section and Hub MCP server example

### Key design decisions

- **Auth bypass:** Hub agents authenticate with Hub itself via agent secrets. The per-user allowlist model (`TELEGRAM_ALLOWED_USERS`, etc.) doesn't apply to agent-to-agent messaging. Hub is added to the bypass tuple alongside HomeAssistant and Webhook, with a comment explaining why it's intentionally NOT in `platform_env_map`/`platform_allow_all_map`.
- **chat_id format:** `send()` and `get_chat_info()` accept both `"hub:brain"` and `"brain"` — the adapter creates sessions with `hub:` prefix, but cron delivery strips the platform prefix before calling `send()`.
- **Persistent HTTP client:** Created in `connect()`, closed in `disconnect()`. Falls back to a one-shot client if called before connect or after disconnect.
- **All changes are additive** — no existing platform behavior is modified.

## How to Test

1. Register an agent on Hub: `POST https://admin.slate.ceo/oc/brain/agents/register`
2. Configure in `~/.hermes/config.yaml`:
   ```yaml
   platforms:
     hub:
       enabled: true
       extra:
         agent_id: "your-agent"
         agent_secret: "your-secret"
   ```
   Or via env vars: `HUB_AGENT_ID=your-agent HUB_AGENT_SECRET=your-secret`
3. Start gateway: `hermes gateway`
4. Verify `[Hub] Connected to wss://...` in logs
5. Send a message from another Hub agent → verify Hermes receives and responds
6. Run tests: `pytest tests/gateway/test_hub.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've added tests for my changes (34 unit tests in `tests/gateway/test_hub.py`)
- [x] I've tested on my platform: Ubuntu (Debian 13, Linux 6.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/messaging/hub.md` (full setup guide)
- [x] I've updated `cli-config.yaml.example` — Hub platform config section + Hub MCP server example
- [x] I've considered cross-platform impact (Windows, macOS) — httpx and websockets are cross-platform; no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A