### PR TITLE
fix security prevent session log path traversal from session ids

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -405,6 +405,27 @@ def _strip_budget_warnings_from_history(messages: list) -> None:
             msg["content"] = cleaned
 
 
+def _safe_session_filename_component(session_id: str) -> str:
+    """Return a stable, path-safe filename component for a session ID."""
+    raw = str(session_id or "").strip()
+    sanitized = re.sub(r"[^\w-]", "_", raw).strip("._")
+    sanitized = sanitized[:96] or "session"
+    if raw and sanitized == raw:
+        return sanitized
+    digest = hashlib.sha256(
+        raw.encode("utf-8", errors="surrogatepass")
+    ).hexdigest()[:12]
+    return f"{sanitized}_{digest}"
+
+
+def _session_artifact_path(
+    logs_dir: Path, session_id: str, prefix: str, suffix: str = ".json"
+) -> Path:
+    """Build a session-scoped artifact path without allowing path traversal."""
+    safe_session_id = _safe_session_filename_component(session_id)
+    return logs_dir / f"{prefix}_{safe_session_id}{suffix}"
+
+
 # =========================================================================
 # Large tool result handler — save oversized output to temp file
 # =========================================================================
@@ -965,7 +986,9 @@ class AIAgent:
         hermes_home = get_hermes_home()
         self.logs_dir = hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
-        self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
+        self.session_log_file = _session_artifact_path(
+            self.logs_dir, self.session_id, "session"
+        )
         
         # Track conversation messages for session logging
         self._session_messages: List[Dict[str, Any]] = []
@@ -2382,7 +2405,11 @@ class AIAgent:
                 dump_payload["error"] = error_info
 
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-            dump_file = self.logs_dir / f"request_dump_{self.session_id}_{timestamp}.json"
+            dump_file = _session_artifact_path(
+                self.logs_dir,
+                f"{self.session_id}_{timestamp}",
+                "request_dump",
+            )
             dump_file.write_text(
                 json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str),
                 encoding="utf-8",
@@ -5890,7 +5917,9 @@ class AIAgent:
                 old_session_id = self.session_id
                 self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
                 # Update session_log_file to point to the new session's JSON file
-                self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
+                self.session_log_file = _session_artifact_path(
+                    self.logs_dir, self.session_id, "session"
+                )
                 self._session_db.create_session(
                     session_id=self.session_id,
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2482,6 +2482,35 @@ class TestSaveSessionLogAtomicWrite:
         assert call_args.kwargs["indent"] == 2
         assert call_args.kwargs["default"] is str
 
+    def test_session_id_cannot_escape_sessions_dir(self):
+        """Traversal-shaped session IDs must not redirect session logs."""
+        malicious_session_id = "../../../../outside_dir/pwned"
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_id=malicious_session_id,
+            )
+
+        messages = [{"role": "user", "content": "hello"}]
+        agent._save_session_log(messages)
+
+        sessions_dir = agent.logs_dir.resolve()
+        written_path = agent.session_log_file.resolve()
+
+        assert sessions_dir in written_path.parents
+        assert written_path.exists()
+        assert not (sessions_dir.parent.parent / "outside_dir").exists()
+
 
 # ===================================================================
 # Anthropic adapter integration fixes


### PR DESCRIPTION
The Problem:
The AIAgent class incorporates raw session_id values directly into session log and request dump filenames. Untrusted input from the X-Hermes-Session-Id header and API body is passed to these filesystem paths without sanitization. This vulnerability allows path traversal via sequences such as ../, leading to arbitrary file writes outside the intended sessions/ directory.

The Fix:
A sanitization function, _safe_session_filename_component, is implemented to process session_id strings using character filtering and SHA-256 hashing. All filesystem operations involving session IDs now utilize the _session_artifact_path helper to ensure path safety. Existing logic in run_agent.py is updated to utilize these sanitization helpers for all session-derived artifacts.

Testing:
Regression tests in tests/test_run_agent.py verify that traversal-based session IDs remain confined within the designated logs directory. The tests confirm that malicious inputs fail to create or overwrite files in parent directories.