### PR TITLE
fix(hindsight): import get_hermes_home in _start_daemon closure

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -291,6 +291,7 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._mode == "local":
             def _start_daemon():
                 import traceback
+                from hermes_constants import get_hermes_home
                 log_dir = get_hermes_home() / "logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"


### PR DESCRIPTION
## Summary

`HindsightMemoryProvider._start_daemon` (in `plugins/memory/hindsight/__init__.py`, line 294 on current `main`) references `get_hermes_home()` but the symbol is never imported into that scope. Every other call site in the same file uses a local `from hermes_constants import get_hermes_home` — see line 144 in the same module — but the `_start_daemon` inner function was missed.

As a result, **local-mode Hindsight is completely broken**: the moment the background daemon thread is started, it raises `NameError: name 'get_hermes_home' is not defined` and the embedded daemon never comes up. Cloud mode is unaffected because the `_start_daemon` branch is only entered when `self._mode == \"local\"`.

## Reproduction

On a fresh Hermes install with no Hindsight config (cloud mode still works), then switch to local mode:

```bash
mkdir -p ~/.hermes/hindsight
cat > ~/.hermes/hindsight/config.json <<'JSON'
{
  \"mode\": \"local\",
  \"llm_provider\": \"groq\",
  \"llm_model\": \"openai/gpt-oss-120b\",
  \"bank_id\": \"hermes\",
  \"budget\": \"mid\",
  \"memory_mode\": \"hybrid\",
  \"prefetch_method\": \"recall\"
}
JSON
export HINDSIGHT_LLM_API_KEY=gsk_xxx
hermes chat -q \"hello\" -Q --max-turns 2
```

Observed output (before this fix):

```
Initializing agent...
Exception in thread hindsight-daemon-start:
Traceback (most recent call last):
  File \".../threading.py\", line 1045, in _bootstrap_inner
    self.run()
  File \".../threading.py\", line 982, in run
    self._target(*self._args, **self._kwargs)
  File \".../plugins/memory/hindsight/__init__.py\", line 293, in _start_daemon
    log_dir = get_hermes_home() / \"logs\"
              ^^^^^^^^^^^^^^^
NameError: name 'get_hermes_home' is not defined
```

After this fix, the embedded daemon starts normally and the rest of `_start_daemon` executes as intended:

```
╭───────────────────── ✓ Daemon Started (hermes @ :9177) ──────────────────────╮
│  Uvicorn running on http://127.0.0.1:9177                                     │
│  hindsight_api.worker.poller - Worker zoidberg starting polling loop          │
│  ✓ Daemon started successfully!                                               │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Root cause

`get_hermes_home` is imported locally in two places within this file (around lines 144 and 147 on current `main`), following what looks like a deliberate pattern throughout the repo of doing local imports of helpers from `hermes_constants` inside functions. When `_start_daemon` was added, it kept the same pattern everywhere else (`from pathlib import Path as _Path` a few lines later, etc.) but simply forgot to import `get_hermes_home` even though it uses it on the very next line.

## The fix

One-line local import at the top of the `_start_daemon` closure, mirroring the pattern used in the rest of the file:

```python
def _start_daemon():
    import traceback
    from hermes_constants import get_hermes_home   # <-- added
    log_dir = get_hermes_home() / \"logs\"
    ...
```

## Context & authorship disclosure

I want to be transparent with the maintainers about how this PR was produced:

- The bug was identified, root-caused, and the fix was written by **Claude Opus 4.6** (Anthropic) running as my coding agent inside Claude Code, during a session where I was setting up Hindsight local mode on my own box. The agent traced the `NameError`, grepped the repo for every existing `get_hermes_home` call site to confirm the local-import pattern, verified the bug is still present on `main` at tag `v2026.4.3`, and confirmed that no existing issue or PR covers it.
- **I (@mbac) do not have the Python/Hermes internals expertise to meaningfully review or revise this patch myself.** I can confirm it makes my local-mode Hindsight go from broken → working on my machine (aarch64, Hermes v0.7.0), but I cannot independently judge whether there's a more idiomatic fix the Hermes team would prefer (e.g. hoisting `get_hermes_home` to a module-level import instead of another local one).
- **Maintainer review/revision is explicitly welcome.** If you'd rather promote the import to module scope, change the pattern across the file, or take a different approach entirely, please feel free to rewrite or close-and-replace this PR. I'm opening it primarily to surface the bug with a minimal reproduction and a fix that's been verified to work end-to-end — not because I'm attached to this particular one-line change.

## Test plan

- [x] Confirmed `NameError` reproduces on unpatched `main` at `v2026.4.3` by reading `plugins/memory/hindsight/__init__.py` via the GitHub contents API.
- [x] Applied the fix locally on Hermes v0.7.0 installed via the official `uv`-based installer.
- [x] Ran `hermes chat -q \"pong\" -Q --max-turns 2` — agent returns \"pong\" and `~/.hermes/logs/hindsight-embed.log` is created with a successful `✓ Daemon started successfully!` message.
- [x] Verified `hindsight_embed` daemon is listening on `127.0.0.1:9177` and the per-profile DB is provisioned at `~/.pg0/instances/hindsight-embed-hermes`.
- [ ] Automated tests: I don't know the Hindsight test layout well enough to add a regression test here — happy to follow guidance if the maintainers want one.