### PR TITLE
fix(compaction): show status message + re-emit context pressure bar at 95%

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -706,7 +706,10 @@ class AIAgent:
         # Context pressure warnings: notify the USER (not the LLM) as context
         # fills up.  Purely informational — displayed in CLI output and sent via
         # status_callback for gateway platforms.  Does NOT inject into messages.
-        self._context_pressure_warned = False
+        # Tracks the highest threshold level (0.85 or 0.95) at which the bar
+        # has been shown; 0.0 = not yet shown.  Float lets us re-emit at 0.95
+        # even after the 0.85 warning fired.
+        self._context_pressure_warned_at: float = 0.0
 
         # Activity tracking — updated on each API call, tool execution, and
         # stream chunk.  Used by the gateway timeout handler to report what the
@@ -5927,7 +5930,7 @@ class AIAgent:
         if self.context_compressor.threshold_tokens > 0:
             _post_progress = _compressed_est / self.context_compressor.threshold_tokens
             if _post_progress < 0.85:
-                self._context_pressure_warned = False
+                self._context_pressure_warned_at = 0.0
 
         # Clear the file-read dedup cache.  After compression the original
         # read content is summarised away — if the model re-reads the same
@@ -8810,11 +8813,17 @@ class AIAgent:
                     # and fires status_callback for gateway platforms.
                     if _compressor.threshold_tokens > 0:
                         _compaction_progress = _real_tokens / _compressor.threshold_tokens
-                        if _compaction_progress >= 0.85 and not self._context_pressure_warned:
-                            self._context_pressure_warned = True
+                        _warn_level = (
+                            0.95 if _compaction_progress >= 0.95 else
+                            0.85 if _compaction_progress >= 0.85 else
+                            0.0
+                        )
+                        if _warn_level > self._context_pressure_warned_at:
+                            self._context_pressure_warned_at = _warn_level
                             self._emit_context_pressure(_compaction_progress, _compressor)
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
+                        self._safe_print("  ⟳ compacting context…")
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message,
                             approx_tokens=self.context_compressor.last_prompt_tokens,

--- a/tests/test_context_pressure.py
+++ b/tests/test_context_pressure.py
@@ -235,6 +235,36 @@ class TestContextPressureFlags:
 
         assert agent._context_pressure_warned_at == 0.0
 
+    def test_flag_not_reset_when_compression_insufficient(self, agent):
+        """Flag must NOT reset if post-compression tokens are still >= 85% of threshold."""
+        agent._context_pressure_warned_at = 0.95
+        agent.compression_enabled = True
+
+        # Compressed output is large — simulate a fat system prompt dominating
+        # the token budget so _post_progress stays above 0.85.
+        agent.context_compressor = MagicMock()
+        agent.context_compressor.compress.return_value = [
+            {"role": "user", "content": "summary"}
+        ]
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        agent._todo_store = MagicMock()
+        agent._todo_store.format_for_injection.return_value = None
+
+        # Make _build_system_prompt return a very large string so the rough
+        # token estimate keeps _post_progress >= 0.85.
+        # estimate_tokens_rough uses len//4, threshold=100k → need >340k chars.
+        agent._build_system_prompt = MagicMock(return_value="x " * 200_000)
+        agent._cached_system_prompt = "old"
+        agent._session_db = None
+
+        messages = [{"role": "user", "content": "hello"}]
+        agent._compress_context(messages, "system prompt")
+
+        # Still above threshold — flag must be preserved
+        assert agent._context_pressure_warned_at == 0.95
+
     def test_flag_reemits_at_95(self, agent):
         """Warning should fire again at 95% even after firing at 85%."""
         agent._context_pressure_warned_at = 0.85  # already warned at 85%

--- a/tests/test_context_pressure.py
+++ b/tests/test_context_pressure.py
@@ -151,7 +151,7 @@ class TestContextPressureFlags:
     """Context pressure warning flag tracking on AIAgent."""
 
     def test_flag_initialized_false(self, agent):
-        assert agent._context_pressure_warned is False
+        assert agent._context_pressure_warned_at == 0.0
 
     def test_emit_calls_status_callback(self, agent):
         """status_callback should be invoked with event type and message."""
@@ -210,7 +210,7 @@ class TestContextPressureFlags:
 
     def test_flag_reset_on_compression(self, agent):
         """After _compress_context, context pressure flag should reset."""
-        agent._context_pressure_warned = True
+        agent._context_pressure_warned_at = 0.95
         agent.compression_enabled = True
 
         agent.context_compressor = MagicMock()
@@ -233,7 +233,26 @@ class TestContextPressureFlags:
         ]
         agent._compress_context(messages, "system prompt")
 
-        assert agent._context_pressure_warned is False
+        assert agent._context_pressure_warned_at == 0.0
+
+    def test_flag_reemits_at_95(self, agent):
+        """Warning should fire again at 95% even after firing at 85%."""
+        agent._context_pressure_warned_at = 0.85  # already warned at 85%
+
+        # Simulate 95% — warn_level (0.95) > warned_at (0.85), so should emit
+        _warn_level = 0.95 if 0.97 >= 0.95 else 0.85 if 0.97 >= 0.85 else 0.0
+        assert _warn_level > agent._context_pressure_warned_at
+
+        # Confirm below-85 produces warn_level 0.0 (no re-emit)
+        _warn_level_low = 0.95 if 0.70 >= 0.95 else 0.85 if 0.70 >= 0.85 else 0.0
+        assert _warn_level_low == 0.0
+
+    def test_flag_no_double_emit_same_level(self, agent):
+        """Warning should NOT re-emit at 85% if already warned at 85%."""
+        agent._context_pressure_warned_at = 0.85
+        _warn_level = 0.95 if 0.88 >= 0.95 else 0.85 if 0.88 >= 0.85 else 0.0
+        assert _warn_level == 0.85
+        assert not (_warn_level > agent._context_pressure_warned_at)
 
     def test_emit_callback_error_handled(self, agent):
         """If status_callback raises, it should be caught gracefully."""


### PR DESCRIPTION
## What does this PR do?

Two small UX fixes for context compaction feedback:

1. **Missing status message during compression**: When auto-compaction fired, the agent went silent for 10–30 s while the context summarisation LLM call ran — no spinner, no message. A `⟳ compacting context…` line is now printed before `_compress_context()` so the user knows what's happening.

2. **Context pressure bar only showed once**: The progress bar was gated on a boolean `_context_pressure_warned` that latched `True` at 85% and never re-fired. Users climbing from 88% → 97% never saw the bar update or change colour (orange → red). The bool is replaced with a float `_context_pressure_warned_at` that tracks the highest threshold already shown (0.85 or 0.95), allowing a second emit at the critical 95% tier.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: replace `_context_pressure_warned: bool` with `_context_pressure_warned_at: float`; add two-tier warning logic (0.85, 0.95); print `⟳ compacting context…` before compression fires
- `tests/test_context_pressure.py`: update two existing tests for renamed field; add `test_flag_reemits_at_95` and `test_flag_no_double_emit_same_level`

## How to Test

1. Run a long session until context reaches ~85% of the compaction threshold — verify the orange pressure bar appears
2. Continue until ~95% — verify the bar re-emits in red
3. Continue until compaction fires — verify `⟳ compacting context…` is printed before the next prompt appears
4. `pytest tests/test_context_pressure.py -q` — all 25 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A