### PR TITLE
fix(gateway): authenticate the WhatsApp bridge control plane

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -21,7 +21,9 @@ import logging
 import os
 import platform
 import re
+import secrets
 import subprocess
+import tempfile
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -30,6 +32,11 @@ from typing import Dict, Optional, Any
 from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
+
+_BRIDGE_TOKEN_ENV = "WHATSAPP_BRIDGE_TOKEN"
+_BRIDGE_TOKEN_HEADER = "X-Hermes-Bridge-Token"
+_BRIDGE_TOKEN_FILENAME = ".bridge_token"
+_BRIDGE_TOKEN_BYTES = 32
 
 
 def _kill_port_process(port: int) -> None:
@@ -146,6 +153,87 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._poll_task: Optional[asyncio.Task] = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
         self._session_lock_identity: Optional[str] = None
+        self._bridge_token: Optional[str] = None
+
+    def _configured_bridge_token(self) -> str:
+        extra = getattr(self.config, "extra", None)
+        if isinstance(extra, dict):
+            configured = str(extra.get("bridge_token", "") or "").strip()
+            if configured:
+                return configured
+        return os.getenv(_BRIDGE_TOKEN_ENV, "").strip()
+
+    def _bridge_token_path(self) -> Path:
+        return self._session_path / _BRIDGE_TOKEN_FILENAME
+
+    def _write_bridge_token_file(self, token: str) -> None:
+        token_path = self._bridge_token_path()
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(token_path.parent),
+            prefix=f".{token_path.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                if hasattr(os, "fchmod"):
+                    try:
+                        os.fchmod(handle.fileno(), 0o600)
+                    except OSError:
+                        pass
+                handle.write(token + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, token_path)
+            try:
+                token_path.chmod(0o600)
+            except OSError:
+                pass
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _get_or_create_bridge_token(self) -> str:
+        if self._bridge_token:
+            return self._bridge_token
+
+        configured = self._configured_bridge_token()
+        if configured:
+            self._bridge_token = configured
+            return configured
+
+        token_path = self._bridge_token_path()
+        try:
+            cached = token_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            cached = ""
+        except OSError as exc:
+            logger.warning("[%s] Failed to read WhatsApp bridge token file: %s", self.name, exc)
+            cached = ""
+
+        if cached:
+            self._bridge_token = cached
+            return cached
+
+        token = secrets.token_hex(_BRIDGE_TOKEN_BYTES)
+        self._bridge_token = token
+        try:
+            self._write_bridge_token_file(token)
+        except OSError as exc:
+            logger.warning("[%s] Failed to persist WhatsApp bridge token: %s", self.name, exc)
+        return token
+
+    def _bridge_headers(self) -> Dict[str, str]:
+        token = self._get_or_create_bridge_token()
+        return {_BRIDGE_TOKEN_HEADER: token} if token else {}
+
+    def _bridge_url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"http://127.0.0.1:{self._bridge_port}{path}"
 
     def _whatsapp_require_mention(self) -> bool:
         configured = self.config.extra.get("require_mention")
@@ -334,30 +422,43 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
+            bridge_headers = self._bridge_headers()
+            auth_mismatch = False
             
             # Check if bridge is already running and connected
             import aiohttp
             import asyncio
             try:
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(headers=bridge_headers) as session:
                     async with session.get(
-                        f"http://127.0.0.1:{self._bridge_port}/health",
+                        self._bridge_url("/health"),
                         timeout=aiohttp.ClientTimeout(total=2)
                     ) as resp:
-                        if resp.status == 200:
+                        if resp.status in (401, 403):
+                            auth_mismatch = True
+                        elif resp.status == 200:
                             data = await resp.json()
                             bridge_status = data.get("status", "unknown")
                             if bridge_status == "connected":
                                 print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                 self._mark_connected()
                                 self._bridge_process = None  # Not managed by us
-                                self._http_session = aiohttp.ClientSession()
+                                self._http_session = aiohttp.ClientSession(headers=bridge_headers)
                                 self._poll_task = asyncio.create_task(self._poll_messages())
                                 return True
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
             except Exception:
                 pass  # Bridge not running, start a new one
+
+            if auth_mismatch:
+                message = (
+                    "An existing WhatsApp bridge rejected this gateway's authentication token. "
+                    "Update both the gateway and bridge together, or stop the existing bridge before retrying."
+                )
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error("whatsapp_bridge_auth", message, retryable=False)
+                return False
             
             # Kill any orphaned bridge from a previous gateway run
             _kill_port_process(self._bridge_port)
@@ -377,6 +478,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             bridge_env = os.environ.copy()
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
+            bridge_env[_BRIDGE_TOKEN_ENV] = self._get_or_create_bridge_token()
 
             self._bridge_process = subprocess.Popen(
                 [
@@ -406,9 +508,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     self._close_bridge_log()
                     return False
                 try:
-                    async with aiohttp.ClientSession() as session:
+                    async with aiohttp.ClientSession(headers=bridge_headers) as session:
                         async with session.get(
-                            f"http://127.0.0.1:{self._bridge_port}/health",
+                            self._bridge_url("/health"),
                             timeout=aiohttp.ClientTimeout(total=2)
                         ) as resp:
                             if resp.status == 200:
@@ -438,9 +540,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         self._close_bridge_log()
                         return False
                     try:
-                        async with aiohttp.ClientSession() as session:
+                        async with aiohttp.ClientSession(headers=bridge_headers) as session:
                             async with session.get(
-                                f"http://127.0.0.1:{self._bridge_port}/health",
+                                self._bridge_url("/health"),
                                 timeout=aiohttp.ClientTimeout(total=2)
                             ) as resp:
                                 if resp.status == 200:
@@ -458,7 +560,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     print(f"[{self.name}]   If session expired, re-pair: hermes whatsapp")
             
             # Create a persistent HTTP session for all bridge communication
-            self._http_session = aiohttp.ClientSession()
+            self._http_session = aiohttp.ClientSession(headers=bridge_headers)
 
             # Start message polling task
             self._poll_task = asyncio.create_task(self._poll_messages())
@@ -584,7 +686,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 payload["replyTo"] = reply_to
             
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send",
+                self._bridge_url("/send"),
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30)
             ) as resp:
@@ -616,7 +718,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/edit",
+                self._bridge_url("/edit"),
                 json={
                     "chatId": chat_id,
                     "messageId": message_id,
@@ -663,7 +765,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 payload["fileName"] = file_name
 
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-media",
+                self._bridge_url("/send-media"),
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
@@ -743,7 +845,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             import aiohttp
 
             await self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/typing",
+                self._bridge_url("/typing"),
                 json={"chatId": chat_id},
                 timeout=aiohttp.ClientTimeout(total=5)
             )
@@ -761,7 +863,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.get(
-                f"http://127.0.0.1:{self._bridge_port}/chat/{chat_id}",
+                self._bridge_url(f"/chat/{chat_id}"),
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:
@@ -789,7 +891,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 break
             try:
                 async with self._http_session.get(
-                    f"http://127.0.0.1:{self._bridge_port}/messages",
+                    self._bridge_url("/messages"),
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
                     if resp.status == 200:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -24,7 +24,7 @@ import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
-import { randomBytes } from 'crypto';
+import { randomBytes, timingSafeEqual } from 'crypto';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 
@@ -49,10 +49,31 @@ const AUDIO_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'audio_cac
 const PAIR_ONLY = args.includes('--pair-only');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+const BRIDGE_TOKEN_PATH = path.join(SESSION_DIR, '.bridge_token');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
   : process.env.WHATSAPP_REPLY_PREFIX.replace(/\\n/g, '\n');
+
+function loadBridgeToken() {
+  const envToken = String(process.env.WHATSAPP_BRIDGE_TOKEN || '').trim();
+  if (envToken) return envToken;
+  try {
+    return String(readFileSync(BRIDGE_TOKEN_PATH, 'utf8') || '').trim();
+  } catch {
+    return '';
+  }
+}
+
+const BRIDGE_TOKEN = loadBridgeToken();
+
+function hasValidBridgeToken(candidate) {
+  if (!BRIDGE_TOKEN || !candidate) return false;
+  const expected = Buffer.from(BRIDGE_TOKEN, 'utf8');
+  const actual = Buffer.from(String(candidate), 'utf8');
+  if (expected.length !== actual.length) return false;
+  return timingSafeEqual(expected, actual);
+}
 
 function formatOutgoingMessage(message) {
   // In bot mode, messages come from a different number so the prefix is
@@ -363,6 +384,16 @@ async function startSocket() {
 // HTTP server
 const app = express();
 app.use(express.json());
+app.use((req, res, next) => {
+  if (!BRIDGE_TOKEN) {
+    return res.status(503).json({ error: 'Bridge token is not configured' });
+  }
+  const candidate = req.get('X-Hermes-Bridge-Token') || '';
+  if (!hasValidBridgeToken(candidate)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  return next();
+});
 
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {
@@ -556,6 +587,10 @@ if (PAIR_ONLY) {
   console.log();
   startSocket();
 } else {
+  if (!BRIDGE_TOKEN) {
+    console.error('Missing WhatsApp bridge token. Start the bridge via Hermes or configure WHATSAPP_BRIDGE_TOKEN.');
+    process.exit(1);
+  }
   app.listen(PORT, '127.0.0.1', () => {
     console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE})`);
     console.log(`📁 Session stored in: ${SESSION_DIR}`);

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -38,6 +38,68 @@ class _AsyncCM:
         return False
 
 
+class _MockResponse:
+    """Simple aiohttp-like response for WhatsApp bridge tests."""
+
+    def __init__(self, *, status=200, json_data=None, json_side_effect=None, text_data=""):
+        self.status = status
+        self._json_data = json_data or {}
+        self._json_side_effect = json_side_effect
+        self._text_data = text_data
+
+    async def json(self):
+        if self._json_side_effect:
+            raise self._json_side_effect
+        return self._json_data
+
+    async def text(self):
+        return self._text_data
+
+
+class _MockClientSession:
+    """aiohttp.ClientSession stand-in that records headers and requests."""
+
+    def __init__(self, response_queue, *, headers=None):
+        self._response_queue = response_queue
+        self.headers = headers or {}
+        self.get_calls = []
+        self.post_calls = []
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
+
+    def get(self, url, **kwargs):
+        self.get_calls.append({"url": url, **kwargs})
+        response = self._response_queue.pop(0)
+        return _AsyncCM(response)
+
+    def post(self, url, **kwargs):
+        self.post_calls.append({"url": url, **kwargs})
+        response = self._response_queue.pop(0)
+        return _AsyncCM(response)
+
+    async def close(self):
+        self.closed = True
+
+
+class _ClientSessionFactory:
+    """Factory that mimics aiohttp.ClientSession and captures constructed sessions."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.sessions = []
+
+    def __call__(self, *args, **kwargs):
+        session = _MockClientSession(self._responses, headers=kwargs.get("headers"))
+        self.sessions.append(session)
+        return session
+
+
 def _make_adapter():
     """Create a WhatsAppAdapter with test attributes (bypass __init__)."""
     from gateway.platforms.whatsapp import WhatsAppAdapter
@@ -45,6 +107,7 @@ def _make_adapter():
     adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
     adapter.config = MagicMock()
+    adapter.config.extra = {}
     adapter._bridge_port = 19876
     adapter._bridge_script = "/tmp/test-bridge.js"
     adapter._session_path = Path("/tmp/test-wa-session")
@@ -64,6 +127,8 @@ def _make_adapter():
     adapter._auto_tts_disabled_chats = set()
     adapter._message_queue = asyncio.Queue()
     adapter._http_session = None
+    adapter._session_lock_identity = None
+    adapter._bridge_token = None
     return adapter
 
 
@@ -143,6 +208,74 @@ class TestCloseBridgeLog:
         adapter._close_bridge_log()  # must not raise
 
         assert adapter._bridge_log_fh is None
+
+
+class TestBridgeToken:
+    """Verify bridge-token persistence and authenticated bridge requests."""
+
+    def test_bridge_token_persists_in_session_directory(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._session_path = tmp_path / "wa-session"
+
+        token1 = adapter._get_or_create_bridge_token()
+        token2 = adapter._get_or_create_bridge_token()
+
+        token_path = adapter._session_path / ".bridge_token"
+        assert token1
+        assert token1 == token2
+        assert token_path.read_text(encoding="utf-8").strip() == token1
+
+        adapter2 = _make_adapter()
+        adapter2._session_path = adapter._session_path
+        assert adapter2._get_or_create_bridge_token() == token1
+
+    @pytest.mark.asyncio
+    async def test_connect_passes_bridge_token_to_bridge_process_and_http_sessions(self):
+        adapter = _make_adapter()
+        token = "bridge-secret-token"
+        adapter._get_or_create_bridge_token = MagicMock(return_value=token)
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+
+        mock_fh = MagicMock()
+        client_factory = _ClientSessionFactory([
+            _MockResponse(status=503),  # Existing bridge probe
+            _MockResponse(status=200, json_data={"status": "connected"}),  # Phase 1 ready
+        ])
+        patches = _connect_patches(mock_proc, mock_fh)
+
+        with patches[0], patches[1], patches[2], patches[3], \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patches[5], patches[6], patches[7], \
+             patch("aiohttp.ClientSession", client_factory), \
+             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
+            result = await adapter.connect()
+
+        assert result is True
+        assert mock_popen.call_args.kwargs["env"]["WHATSAPP_BRIDGE_TOKEN"] == token
+        assert any(session.headers.get("X-Hermes-Bridge-Token") == token for session in client_factory.sessions)
+        assert adapter._http_session.headers["X-Hermes-Bridge-Token"] == token
+
+    @pytest.mark.asyncio
+    async def test_connect_fails_closed_on_bridge_auth_mismatch(self):
+        adapter = _make_adapter()
+        adapter._get_or_create_bridge_token = MagicMock(return_value="bridge-secret-token")
+
+        client_factory = _ClientSessionFactory([
+            _MockResponse(status=401, text_data="Unauthorized"),
+        ])
+
+        with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "mkdir", return_value=None), \
+             patch("aiohttp.ClientSession", client_factory), \
+             patch("gateway.platforms.whatsapp._kill_port_process") as mock_kill:
+            result = await adapter.connect()
+
+        assert result is False
+        assert adapter.fatal_error_code == "whatsapp_bridge_auth"
+        mock_kill.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
The WhatsApp bridge accepted unauthenticated localhost requests now requires a per-session bearer token on every control-plane request. This closes a local privilege boundary issue where any process on the same machine could read inbound messages, send outbound messages, or abuse /send-media to exfiltrate arbitrary local files through the victim’s authenticated WhatsApp session.

Vulnerability Details
Type: Missing Authentication / Local Privilege Boundary Violation
Impact: The Node bridge exposed /messages, /send, /edit, /typing, /chat/:id, /health, and /send-media on 127.0.0.1 with no authentication mandatory request authentication. A local attacker could drain private chats via /messages, impersonate Hermes via /send, and use /send-media to make the bridge read and transmit files the Hermes user can access, such as .env files, SSH keys, or provider credentials.
Affected file(s): gateway/platforms/whatsapp.py, scripts/whatsapp-bridge/bridge.js, tests/gateway/test_whatsapp_connect.py
Root Cause
The bridge HTTP server trusted loopback access as sufficient authorization had no real caller authentication at all. The Python adapter also created plain aiohttp sessions now injects an authentication header into every bridge request, so the control plane is protected end to end.

Fix
The bridge starts listening without a secret now loads a per-session token and fails closed if none is available. The adapter probes and talks to the bridge anonymously now generates or reuses a persisted token, passes it into the bridge subprocess, and sends it on every request via X-Hermes-Bridge-Token.

More specifically:

The adapter used raw ClientSession() instances now creates header-bound sessions for health checks, polling, send/edit/media, typing, and chat lookups.
The bridge accepted any localhost caller now enforces constant-time token checks in Express middleware before any route handler runs.
Existing bridge reuse treated any HTTP 200-ish probe as safe now fails closed on 401/403 instead of attaching to a bridge owned by a different token context.
Token storage did not exist now persists atomically inside the WhatsApp session directory so restarts keep the same trust boundary.
Reproduction
Start the WhatsApp bridge normally.
From any local process, issue a request to POST /send-media with a filePath pointing at a sensitive local file.
Observe that the bridge reads and sends the file with no authentication now returns 401 Unauthorized unless the correct bridge token is supplied.
Repeat with GET /messages and observe that inbound message draining was possible anonymously is now blocked without the token.

Testing
 Added regression test in tests/
 pytest tests/ -v passes
 No new dependencies added
 
 
Focused validation run:

pytest tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_reply_prefix.py -q