### PR TITLE
fix: classify builtin skills by bundled directory name

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -507,6 +507,11 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
     lock = HubLockFile()
     hub_installed = {e["name"]: e for e in lock.list_installed()}
     builtin_names = set(_read_manifest())
+    builtin_dir_names = {
+        path.parent.name
+        for path in (Path(__file__).resolve().parent.parent / "skills").rglob("SKILL.md")
+        if not any(part in {".git", ".github", ".hub"} for part in path.parts)
+    }
 
     all_skills = _find_all_skills()
 
@@ -530,7 +535,7 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
             source_display = hub_entry.get("source", "hub")
             trust = hub_entry.get("trust_level", "community")
             hub_count += 1
-        elif name in builtin_names:
+        elif name in builtin_names or name in builtin_dir_names:
             source_type = "builtin"
             source_display = "builtin"
             trust = "builtin"

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -152,6 +152,37 @@ def test_do_list_filter_builtin(three_source_env):
     assert "local-skill" not in output
 
 
+def test_do_list_treats_bundled_directory_name_as_builtin(monkeypatch, hub_env):
+    import tools.skills_hub as hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+    import hermes_cli.skills_hub as cli_hub
+
+    monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile([]))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {"serving-llms-vllm": "abc123"})
+    monkeypatch.setattr(
+        skills_tool,
+        "_find_all_skills",
+        lambda: [{"name": "vllm", "category": "mlops", "description": "builtin alias"}],
+    )
+
+    fake_pkg_dir = hub_env.parent.parent / "fake_pkg"
+    repo_skills_dir = fake_pkg_dir.parent / "skills"
+    bundled_skill_dir = repo_skills_dir / "mlops" / "vllm"
+    bundled_skill_dir.mkdir(parents=True)
+    (bundled_skill_dir / "SKILL.md").write_text(
+        "---\nname: serving-llms-vllm\ndescription: Test skill\n---\n"
+    )
+    fake_pkg_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cli_hub, "__file__", str(fake_pkg_dir / "skills_hub.py"))
+
+    output = _capture()
+
+    assert "vllm" in output
+    assert "builtin" in output
+    assert "0 hub-installed, 1 builtin, 0 local" in output
+
+
 def test_do_check_reports_available_updates(monkeypatch):
     output = _capture_check(monkeypatch, [
         {"name": "hub-skill", "source": "skills.sh", "status": "update_available"},


### PR DESCRIPTION
## Résumé
- corrige `hermes skills list` pour reconnaître comme builtin les skills bundled dont le nom de dossier diffère du `name:` en frontmatter
- conserve le comportement existant pour les skills identifiés via le manifeste
- ajoute un test de non-régression pour le cas `vllm` / `serving-llms-vllm`

## Validation
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_skills_hub.py tests/tools/test_skills_sync.py tests/tools/test_skills_tool.py -q`

Closes #5433
