### PR TITLE
fix(auxiliary): guard extract_content_or_reasoning when choices are missing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7001,6 +7001,9 @@ def extract_content_or_reasoning(response) -> str:
     """
     import re
 
+    if not getattr(response, "choices", None):
+        return ""
+
     msg = response.choices[0].message
     content = (msg.content or "").strip()
 

--- a/tests/tools/test_llm_content_none_guard.py
+++ b/tests/tools/test_llm_content_none_guard.py
@@ -163,6 +163,18 @@ class TestExtractContentOrReasoning:
         response = _make_response("")
         assert extract_content_or_reasoning(response) == ""
 
+    def test_choices_none_returns_empty(self):
+        response = types.SimpleNamespace(choices=None)
+        assert extract_content_or_reasoning(response) == ""
+
+    def test_choices_missing_attribute_returns_empty(self):
+        response = types.SimpleNamespace()
+        assert extract_content_or_reasoning(response) == ""
+
+    def test_choices_empty_list_returns_empty(self):
+        response = types.SimpleNamespace(choices=[])
+        assert extract_content_or_reasoning(response) == ""
+
     def test_think_blocks_stripped_with_remaining_content(self):
         response = _make_response("<think>internal reasoning</think>The answer is 42.")
         assert extract_content_or_reasoning(response) == "The answer is 42."


### PR DESCRIPTION
## What does this PR do?

Guards `extract_content_or_reasoning()` against responses where `response.choices` is missing, `None`, or empty.

The helper currently assumes an auxiliary response always has a non-empty `choices` list:

```python
msg = response.choices[0].message
```

That raises on malformed or partial responses:

- `choices=None` → `TypeError: 'NoneType' object is not subscriptable`
- missing `choices` → `AttributeError`

The fix adds an early guard that returns `""` instead of raising, so callers (e.g. the compressor summary path added in #4603) can fall back cleanly:

```python
if not getattr(response, "choices", None):
    return ""
```

This keeps the helper defensive and consistent with its existing behavior of returning `""` when no usable content is available.

## Related Issue

Fixes #5968

This complements #4603, which routes compressor summaries through `extract_content_or_reasoning()`. This PR hardens the helper itself.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added early guard in `extract_content_or_reasoning()` for missing/None/empty `choices`.
- Added regression tests covering `choices=None`, missing `choices`, and `choices=[]` in `tests/tools/test_llm_content_none_guard.py`.

## How to Test

1. `pytest tests/tools/test_llm_content_none_guard.py -q` → `34 passed in 36.29s`
2. `pytest tests/tools/test_llm_content_none_guard.py -q -k 'choices_none or choices_missing or choices_empty' -vv` → `3 passed in 31.07s`
3. Direct repro after the fix returns `''` for:
   - `types.SimpleNamespace(choices=None)`
   - `types.SimpleNamespace()`
   - `types.SimpleNamespace(choices=[])`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_llm_content_none_guard.py -q
34 passed in 36.29s

$ pytest tests/tools/test_llm_content_none_guard.py -q -k 'choices_none or choices_missing or choices_empty' -vv
3 passed in 31.07s
```
