### PR TITLE
fix(gateway): preserve reasoning-only assistant turns on reload

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6721,14 +6721,23 @@ class GatewayRunner:
                     clean_msg = {k: v for k, v in msg.items() if k != "timestamp"}
                     agent_history.append(clean_msg)
                 else:
-                    # Simple text message - just need role and content
+                    # Simple text message - just need role and content.
+                    # Assistant turns with reasoning replay state must survive
+                    # even when they have no visible content.
                     content = msg.get("content")
-                    if content:
+                    keep_assistant_replay = (
+                        role == "assistant"
+                        and any(
+                            msg.get(_rkey)
+                            for _rkey in ("reasoning", "reasoning_details", "codex_reasoning_items")
+                        )
+                    )
+                    if content or keep_assistant_replay:
                         # Tag cross-platform mirror messages so the agent knows their origin
-                        if msg.get("mirror"):
+                        if content and msg.get("mirror"):
                             mirror_src = msg.get("mirror_source", "another session")
                             content = f"[Delivered from {mirror_src}] {content}"
-                        entry = {"role": role, "content": content}
+                        entry = {"role": role, "content": content or ""}
                         # Preserve reasoning fields on assistant messages so
                         # multi-turn reasoning context survives session reload.
                         # The agent's _build_api_kwargs converts these to the

--- a/tests/gateway/test_transcript_offset.py
+++ b/tests/gateway/test_transcript_offset.py
@@ -43,8 +43,21 @@ def _filter_history(history: list) -> list:
             agent_history.append(clean_msg)
         else:
             content = msg.get("content")
-            if content:
-                agent_history.append({"role": role, "content": content})
+            keep_assistant_replay = (
+                role == "assistant"
+                and any(
+                    msg.get(key)
+                    for key in ("reasoning", "reasoning_details", "codex_reasoning_items")
+                )
+            )
+            if content or keep_assistant_replay:
+                entry = {"role": role, "content": content or ""}
+                if role == "assistant":
+                    for key in ("reasoning", "reasoning_details", "codex_reasoning_items"):
+                        value = msg.get(key)
+                        if value:
+                            entry[key] = value
+                agent_history.append(entry)
     return agent_history
 
 
@@ -265,3 +278,117 @@ class TestTranscriptHistoryOffset:
         assert len(fixed_new) == 2
         assert fixed_new[0]["content"] == "Now search for dogs"
         assert fixed_new[1]["content"] == "Dog results here."
+
+    def test_reasoning_only_assistant_survives_filter(self):
+        """Reasoning-only assistant turns must survive gateway reload."""
+        history = [
+            {"role": "user", "content": "Think hard", "timestamp": "t0"},
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning": "step by step",
+                "timestamp": "t1",
+            },
+        ]
+
+        agent_history = _filter_history(history)
+
+        assert len(agent_history) == 2
+        assert agent_history[1] == {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "step by step",
+        }
+
+    def test_reasoning_details_only_assistant_survives_filter(self):
+        """Structured reasoning continuity must survive even without content."""
+        history = [
+            {"role": "user", "content": "Think hard", "timestamp": "t0"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_details": [{"type": "summary", "text": "step by step"}],
+                "timestamp": "t1",
+            },
+        ]
+
+        agent_history = _filter_history(history)
+
+        assert len(agent_history) == 2
+        assert agent_history[1] == {
+            "role": "assistant",
+            "content": "",
+            "reasoning_details": [{"type": "summary", "text": "step by step"}],
+        }
+
+    def test_codex_reasoning_only_assistant_survives_filter(self):
+        """Encrypted Codex reasoning items must survive gateway reload."""
+        history = [
+            {"role": "user", "content": "Think hard", "timestamp": "t0"},
+            {
+                "role": "assistant",
+                "content": "",
+                "codex_reasoning_items": [
+                    {"id": "rs_1", "type": "reasoning", "encrypted_content": "enc_blob"}
+                ],
+                "timestamp": "t1",
+            },
+        ]
+
+        agent_history = _filter_history(history)
+
+        assert len(agent_history) == 2
+        assert agent_history[1] == {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"id": "rs_1", "type": "reasoning", "encrypted_content": "enc_blob"}
+            ],
+        }
+
+    def test_empty_assistant_without_replay_fields_still_dropped(self):
+        """Truly empty assistant shells should not be replayed."""
+        history = [
+            {"role": "user", "content": "Hi", "timestamp": "t0"},
+            {"role": "assistant", "content": "", "timestamp": "t1"},
+        ]
+
+        agent_history = _filter_history(history)
+
+        assert agent_history == [{"role": "user", "content": "Hi"}]
+
+    def test_reasoning_only_assistant_counts_toward_history_offset(self):
+        """Preserved reasoning-only turns must contribute to the offset."""
+        history = [
+            {"role": "session_meta", "tools": [], "timestamp": "t0"},
+            {"role": "user", "content": "Think hard", "timestamp": "t1"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_details": [{"type": "summary", "text": "step by step"}],
+                "timestamp": "t1",
+            },
+        ]
+
+        agent_history = _filter_history(history)
+        assert len(agent_history) == 2
+
+        agent_messages = [
+            {"role": "user", "content": "Think hard"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_details": [{"type": "summary", "text": "step by step"}],
+            },
+            {"role": "user", "content": "What next?"},
+            {"role": "assistant", "content": "Here is the next step."},
+        ]
+
+        fixed_new = (
+            agent_messages[len(agent_history):]
+            if len(agent_messages) > len(agent_history)
+            else []
+        )
+        assert len(fixed_new) == 2
+        assert fixed_new[0]["content"] == "What next?"
+        assert fixed_new[1]["content"] == "Here is the next step."


### PR DESCRIPTION
## Summary

Gateway reload currently drops assistant turns that have empty visible content but do carry replay-relevant reasoning state (`reasoning`, `reasoning_details`, `codex_reasoning_items`). That means Hermes persists those fields, but a fresh gateway turn silently discards them before the next API call.

This patch keeps those assistant turns in replay history while still dropping truly empty assistant shells.

## Motivation

Hermes already preserves reasoning continuity state for multi-turn providers. Gateway sessions create a fresh `AIAgent` per message, so transcript replay is the continuity boundary for every follow-up turn. If the reload path filters out reasoning-only assistant turns, users can lose continuity exactly in the scenarios where these fields matter most:

- reasoning-capable OpenRouter / Anthropic-compatible providers
- Codex reasoning-only interim turns
- longer gateway conversations where follow-up quality depends on replay fidelity

This tackles one narrow instance of the broader live-loop vs. session-reload drift tracked in #4555.

## What Changed

- preserve assistant messages during gateway history filtering when they carry:
  - `reasoning`
  - `reasoning_details`
  - `codex_reasoning_items`
- replay those turns with `content: ""` when there is no visible assistant text
- keep existing behavior for:
  - `session_meta` and `system` filtering
  - tool-call and tool-result replay
  - dropping truly empty assistant shells
  - `history_offset`-based transcript slicing

## Why This Scope

I intentionally kept this gateway-only and avoided a broader replay refactor. The goal here is to fix one real continuity bug with the smallest safe diff and the clearest review surface.

## Testing

- `venv/bin/python -m pytest -o addopts='' tests/gateway/test_transcript_offset.py`
- `venv/bin/python -m pytest -o addopts='' tests/gateway/test_session.py`
- `venv/bin/python -m pytest -o addopts='' tests/test_anthropic_adapter.py`
- `venv/bin/python -m pytest -o addopts='' tests/test_provider_parity.py`

Refs #4555
