### PR TITLE
fix(api): API server streaming fix + conversation history support (PRs #5918, #5805, #5837)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -818,9 +818,29 @@ class APIServerAdapter(BasePlatformAdapter):
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
 
-        # Reconstruct conversation history from previous_response_id
+        # Accept explicit conversation_history from the request body.
+        # This lets stateless clients supply their own history instead of
+        # relying on server-side response chaining via previous_response_id.
+        # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, str]] = []
-        if previous_response_id:
+        raw_history = body.get("conversation_history")
+        if raw_history:
+            if not isinstance(raw_history, list):
+                return web.json_response(
+                    _openai_error("'conversation_history' must be an array of message objects"),
+                    status=400,
+                )
+            for i, entry in enumerate(raw_history):
+                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                    return web.json_response(
+                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                        status=400,
+                    )
+                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+            if previous_response_id:
+                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+
+        if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
                 return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
@@ -1406,8 +1426,28 @@ class APIServerAdapter(BasePlatformAdapter):
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
+
+        # Accept explicit conversation_history from the request body.
+        # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, str]] = []
-        if previous_response_id:
+        raw_history = body.get("conversation_history")
+        if raw_history:
+            if not isinstance(raw_history, list):
+                return web.json_response(
+                    _openai_error("'conversation_history' must be an array of message objects"),
+                    status=400,
+                )
+            for i, entry in enumerate(raw_history):
+                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                    return web.json_response(
+                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                        status=400,
+                    )
+                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+            if previous_response_id:
+                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+
+        if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1454,6 +1454,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 if instructions is None:
                     instructions = stored.get("instructions")
 
+        # When input is a multi-message array, extract all but the last
+        # message as conversation history (the last becomes user_message).
+        # Only fires when no explicit history was provided.
+        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
+            for msg in raw_input[:-1]:
+                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
+                    content = msg["content"]
+                    if isinstance(content, list):
+                        # Flatten multi-part content blocks to text
+                        content = " ".join(
+                            part.get("text", "") for part in content
+                            if isinstance(part, dict) and part.get("type") == "text"
+                        )
+                    conversation_history.append({"role": msg["role"], "content": str(content)})
+
         session_id = body.get("session_id") or run_id
         ephemeral_system_prompt = instructions
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -564,8 +564,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
-            def _on_tool_progress(name, preview, args):
+            def _on_tool_progress(event_type, name, preview, args, **kwargs):
                 """Inject tool progress into the SSE stream for Open WebUI."""
+                if event_type != "tool.started":
+                    return  # Only show tool start events in chat stream
                 if name.startswith("_"):
                     return  # Skip internal events (_thinking)
                 from agent.display import get_tool_emoji

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -439,7 +439,7 @@ class TestChatCompletionsEndpoint:
                 tp_cb = kwargs.get("tool_progress_callback")
                 # Simulate tool progress before streaming content
                 if tp_cb:
-                    tp_cb("terminal", "ls -la", {"command": "ls -la"})
+                    tp_cb("tool.started", "terminal", "ls -la", {"command": "ls -la"})
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Here are the files.")
@@ -476,8 +476,8 @@ class TestChatCompletionsEndpoint:
                 cb = kwargs.get("stream_delta_callback")
                 tp_cb = kwargs.get("tool_progress_callback")
                 if tp_cb:
-                    tp_cb("_thinking", "some internal state", {})
-                    tp_cb("web_search", "Python docs", {"query": "Python docs"})
+                    tp_cb("tool.started", "_thinking", "some internal state", {})
+                    tp_cb("tool.started", "web_search", "Python docs", {"query": "Python docs"})
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Found it.")


### PR DESCRIPTION
## Summary

Salvages three API server PRs into a single tested change.

### PR #5918 (sroecker) — tool_progress_callback signature regression fix
A prior commit changed the callback from `(name, preview, args)` to `(event_type, name, preview, args, **kwargs)` but the API server's streaming path wasn't updated. This broke tool-call display in Open WebUI.

### PR #5805 (VanBladee) — conversation_history in request body
Allows clients to pass explicit `conversation_history` in `/v1/responses` and `/v1/runs` request bodies, instead of relying on server-side response chaining via `previous_response_id`. Solves problems with stateless deployments where the in-memory ResponseStore is lost on restart.

**Added (not in original PR):** Input validation — rejects non-list values and entries missing `role`/`content` fields with specific error messages. Clear precedence: explicit conversation_history > previous_response_id. Empty `[]` correctly falls through.

### PR #5837 (pradeep7127) — preserve history from message arrays
When `/v1/runs` receives a multi-message array as input, all messages except the last are now extracted as conversation history. Previously multi-turn context was silently discarded.

### Follow-up: test signature updates
Updated two existing tool_progress tests to use the new 4-arg callback signature.

**Note:** Both #5805 and #5837 bundled an unrelated `hmac.compare_digest` → `==` change for API key auth (timing attack regression). That was excluded from this salvage.

## Test plan
- 129 existing API server tests pass (94 main + 35 jobs)
- 15 E2E tests covering: valid history, validation (non-list, missing fields, specific index), precedence (explicit > previous_response_id), fallthrough (empty [] → previous_response_id), array extraction, multi-part content flattening, stringification
- 2148 gateway tests pass (9 pre-existing failures in approve_deny + signal unrelated to this PR)

## Commits (4, preserving contributor authorship)
1. **Steffen Röcker** — callback signature fix
2. **VanBladee** — conversation_history support with validation
3. **pradeep7127** — input array history extraction
4. **Us** — test updates for new callback signature

Closes #5918, closes #5805, closes #5837.