### PR TITLE
feat(mcp): add SSE transport support for MCP servers

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1201,6 +1201,129 @@ class TestHTTPConfig:
         asyncio.run(_test())
 
 
+class TestSSEConfig:
+    """Tests for SSE transport detection and handling."""
+
+    def test_is_sse_with_transport_config(self):
+        """Explicit transport: sse config is detected."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("sse-srv")
+        server._config = {"url": "https://example.com/mcp/sse", "transport": "sse"}
+        assert server._is_sse() is True
+
+    def test_is_sse_from_url_path(self):
+        """URL ending in /sse is auto-detected as SSE."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("auto-sse")
+        server._config = {"url": "https://example.com/mcp/sse"}
+        assert server._is_sse() is True
+
+    def test_is_sse_from_url_with_trailing_slash(self):
+        """URL ending in /sse/ (trailing slash) is still detected as SSE."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("trailing")
+        server._config = {"url": "https://example.com/mcp/sse/"}
+        assert server._is_sse() is True
+
+    def test_is_sse_from_url_with_query_params(self):
+        """URL with /sse path and query params is detected as SSE."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("query")
+        server._config = {"url": "https://example.com/mcp/sse?key=abc123"}
+        assert server._is_sse() is True
+
+    def test_not_sse_for_plain_http_url(self):
+        """Regular /mcp URL is NOT SSE."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("http-srv")
+        server._config = {"url": "https://example.com/mcp"}
+        assert server._is_sse() is False
+
+    def test_not_sse_for_stdio_config(self):
+        """Stdio config (no url) is not SSE."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("stdio-srv")
+        server._config = {"command": "npx", "args": []}
+        assert server._is_sse() is False
+
+    def test_sse_unavailable_raises(self):
+        """_run_sse raises ImportError when SSE client is not available."""
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("sse-srv")
+        config = {"url": "https://example.com/mcp/sse"}
+
+        async def _test():
+            with patch("tools.mcp_tool._MCP_SSE_AVAILABLE", False):
+                with pytest.raises(ImportError, match="SSE transport"):
+                    await server._run_sse(config)
+
+        asyncio.run(_test())
+
+    def test_sse_and_http_both_true_for_sse_url(self):
+        """An SSE URL satisfies both _is_http() and _is_sse()."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("sse-srv")
+        server._config = {"url": "https://example.com/mcp/sse"}
+        assert server._is_http() is True
+        assert server._is_sse() is True
+
+    def test_http_only_for_non_sse_url(self):
+        """A non-SSE HTTP URL satisfies _is_http() but not _is_sse()."""
+        from tools.mcp_tool import MCPServerTask
+        server = MCPServerTask("http-srv")
+        server._config = {"url": "https://example.com/mcp"}
+        assert server._is_http() is True
+        assert server._is_sse() is False
+
+
+class TestGetMcpStatusTransport:
+    """Tests for transport field in get_mcp_status()."""
+
+    def test_sse_transport_detected_in_status(self):
+        """SSE URL shows transport='sse' in status output."""
+        from tools.mcp_tool import get_mcp_status, _servers
+
+        config = {"mcp_servers": {
+            "my-sse": {"url": "https://example.com/mcp/sse"},
+        }}
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch.dict(_servers, {}, clear=True):
+            status = get_mcp_status()
+
+        assert len(status) == 1
+        assert status[0]["name"] == "my-sse"
+        assert status[0]["transport"] == "sse"
+
+    def test_http_transport_in_status(self):
+        """Regular HTTP URL shows transport='http' in status output."""
+        from tools.mcp_tool import get_mcp_status, _servers
+
+        config = {"mcp_servers": {
+            "my-http": {"url": "https://example.com/mcp"},
+        }}
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch.dict(_servers, {}, clear=True):
+            status = get_mcp_status()
+
+        assert len(status) == 1
+        assert status[0]["transport"] == "http"
+
+    def test_stdio_transport_in_status(self):
+        """Stdio server shows transport='stdio' in status output."""
+        from tools.mcp_tool import get_mcp_status, _servers
+
+        config = {"mcp_servers": {
+            "my-stdio": {"command": "npx", "args": ["-y", "test"]},
+        }}
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch.dict(_servers, {}, clear=True):
+            status = get_mcp_status()
+
+        assert len(status) == 1
+        assert status[0]["transport"] == "stdio"
+
+
 # ---------------------------------------------------------------------------
 # Reconnection logic
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -102,6 +102,11 @@ try:
         _MCP_HTTP_AVAILABLE = True
     except ImportError:
         _MCP_HTTP_AVAILABLE = False
+    try:
+        from mcp.client.sse import sse_client
+        _MCP_SSE_AVAILABLE = True
+    except ImportError:
+        _MCP_SSE_AVAILABLE = False
     # Prefer the non-deprecated API (mcp >= 1.24.0); fall back to the
     # deprecated wrapper for older SDK versions.
     try:
@@ -778,7 +783,8 @@ class MCPServerTask:
     runs inside one asyncio Task so that anyio cancel-scopes created by
     the transport client are entered and exited in the same Task context.
 
-    Supports both stdio and HTTP/StreamableHTTP transports.
+    Supports both stdio and HTTP/StreamableHTTP transports,
+    as well as legacy SSE (Server-Sent Events) transport.
     """
 
     __slots__ = (
@@ -812,6 +818,21 @@ class MCPServerTask:
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
+
+    def _is_sse(self) -> bool:
+        """Check if this server should use SSE transport.
+
+        Explicitly opted in via ``transport: sse`` in config, or
+        auto-detected when the URL path ends with ``/sse``.
+        """
+        if self._config.get("transport", "").lower() == "sse":
+            return True
+        url = self._config.get("url", "")
+        if not url:
+            return False
+        from urllib.parse import urlparse
+        path = urlparse(url).path
+        return path.rstrip("/").endswith("/sse")
 
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
@@ -1075,6 +1096,42 @@ class MCPServerTask:
                             "tearing down legacy HTTP session", self.name,
                         )
 
+    async def _run_sse(self, config: dict):
+        """Run the server using SSE transport (legacy MCP Server-Sent Events)."""
+        if not _MCP_SSE_AVAILABLE:
+            raise ImportError(
+                f"MCP server '{self.name}' requires SSE transport but "
+                "mcp.client.sse is not available. Upgrade the mcp package "
+                "to get SSE support."
+            )
+
+        url = config["url"]
+        headers = dict(config.get("headers") or {})
+        connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+
+        sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
+        if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
+            sampling_kwargs["message_handler"] = self._make_message_handler()
+
+        # sse_client accepts the same (read_stream, write_stream) pattern
+        # as streamable_http_client.
+        _sse_kwargs: dict = {
+            "headers": headers or None,
+            "timeout": float(connect_timeout),
+            "sse_read_timeout": float(tool_timeout),
+        }
+
+        async with sse_client(url, **_sse_kwargs) as (
+            read_stream, write_stream,
+        ):
+            async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                await session.initialize()
+                self.session = session
+                await self._discover_tools()
+                self._ready.set()
+                await self._shutdown_event.wait()
+
     async def _discover_tools(self):
         """Discover tools from the connected session."""
         if self.session is None:
@@ -1118,7 +1175,10 @@ class MCPServerTask:
         while True:
             try:
                 if self._is_http():
-                    await self._run_http(config)
+                    if self._is_sse():
+                        await self._run_sse(config)
+                    else:
+                        await self._run_http(config)
                 else:
                     await self._run_stdio(config)
                 # Transport returned cleanly. Two cases:
@@ -2568,7 +2628,15 @@ def get_mcp_status() -> List[dict]:
         active_servers = dict(_servers)
 
     for name, cfg in configured.items():
-        transport = "http" if "url" in cfg else "stdio"
+        url = cfg.get("url", "")
+        from urllib.parse import urlparse
+        path = urlparse(url).path if url else ""
+        if cfg.get("transport", "").lower() == "sse" or path.rstrip("/").endswith("/sse"):
+            transport = "sse"
+        elif "url" in cfg:
+            transport = "http"
+        else:
+            transport = "stdio"
         server = active_servers.get(name)
         if server and server.session is not None:
             entry = {

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1096,8 +1096,40 @@ class MCPServerTask:
                             "tearing down legacy HTTP session", self.name,
                         )
 
+    async def _sse_keepalive(self, session, interval: float = 60.0):
+        """Send periodic pings to keep the SSE connection alive.
+
+        Some SSE MCP servers (e.g. Router Teamwork, Supermemory on
+        Cloudflare Workers) close idle connections after a few minutes
+        of silence.  This coroutine sends a lightweight MCP ping every
+        *interval* seconds so the server sees the client as active.
+        On failure the loop exits silently -- the main ``_run_sse``
+        coroutine will notice the dead session on the next tool call
+        or when the SSE stream raises.
+        """
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    await session.send_ping()
+                except Exception:
+                    logger.debug(
+                        "MCP server '%s': SSE keepalive ping failed",
+                        self.name,
+                    )
+                    break
+        except asyncio.CancelledError:
+            pass
+
     async def _run_sse(self, config: dict):
-        """Run the server using SSE transport (legacy MCP Server-Sent Events)."""
+        """Run the server using SSE transport (legacy MCP Server-Sent Events).
+
+        Uses a long read timeout (300s) and a background keepalive task
+        that pings every 60s to prevent servers from closing idle SSE
+        connections.  Without keepalive, many SSE servers drop the
+        connection after ~60-120s of silence, causing ClosedResourceError
+        on the next tool call.
+        """
         if not _MCP_SSE_AVAILABLE:
             raise ImportError(
                 f"MCP server '{self.name}' requires SSE transport but "
@@ -1108,19 +1140,30 @@ class MCPServerTask:
         url = config["url"]
         headers = dict(config.get("headers") or {})
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
-        tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+
+        # OAuth 2.1 PKCE support (same as _run_http).
+        _oauth_auth = None
+        if self._auth_type == "oauth":
+            try:
+                from tools.mcp_oauth import build_oauth_auth
+                _oauth_auth = build_oauth_auth(
+                    self.name, url, config.get("oauth")
+                )
+            except Exception as exc:
+                logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
+                raise
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
             sampling_kwargs["message_handler"] = self._make_message_handler()
 
-        # sse_client accepts the same (read_stream, write_stream) pattern
-        # as streamable_http_client.
         _sse_kwargs: dict = {
             "headers": headers or None,
             "timeout": float(connect_timeout),
-            "sse_read_timeout": float(tool_timeout),
+            "sse_read_timeout": 300.0,  # 5 min — server keepalive is 60s
         }
+        if _oauth_auth is not None:
+            _sse_kwargs["auth"] = _oauth_auth
 
         async with sse_client(url, **_sse_kwargs) as (
             read_stream, write_stream,
@@ -1130,7 +1173,19 @@ class MCPServerTask:
                 self.session = session
                 await self._discover_tools()
                 self._ready.set()
-                await self._shutdown_event.wait()
+
+                # Start keepalive to prevent idle disconnect
+                keepalive = asyncio.ensure_future(
+                    self._sse_keepalive(session)
+                )
+                try:
+                    await self._shutdown_event.wait()
+                finally:
+                    keepalive.cancel()
+                    try:
+                        await keepalive
+                    except (asyncio.CancelledError, Exception):
+                        pass
 
     async def _discover_tools(self):
         """Discover tools from the connected session."""
@@ -2472,7 +2527,11 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
 
-    transport_type = "HTTP" if "url" in config else "stdio"
+    transport_type = (
+        "SSE" if server._is_sse()
+        else "HTTP" if "url" in config
+        else "stdio"
+    )
     logger.info(
         "MCP server '%s' (%s): registered %d tool(s): %s",
         name, transport_type, len(registered_names),


### PR DESCRIPTION
## Summary

Adds support for MCP servers that use the legacy **Server-Sent Events (SSE)** transport, alongside the existing stdio and HTTP/StreamableHTTP transports.

SSE was the standard MCP transport in protocol version 2024-11-05 (replaced by StreamableHTTP in 2025-03-26). Many servers still use it — especially those deployed on platforms that cannot support long-lived HTTP POST streams (e.g., Cloudflare Workers).

### Related work

- **#3976** by @airouz takes a different approach — automatic SSE fallback when StreamableHTTP fails, plus keepalive pings. Our PR uses explicit detection (no failed HTTP round-trip) but their keepalive idea is worth incorporating on top.

## Why auto-detect /sse URL paths?

The /sse path suffix is a **de facto convention** across the MCP ecosystem, not a protocol guarantee, but it is well-grounded:

1. **Official MCP Python SDK** — SseServerTransport in [src/mcp/server/sse.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/sse.py) uses Route("/sse", ...) as the canonical example in its docstring. The SDK continues to ship both server and client SSE modules.

2. **FastMCP** (powers ~70% of Python MCP servers, 23k stars) — hardcodes the default as sse_path: str = "/sse" in its [settings](https://github.com/PrefectHQ/fastmcp/blob/main/src/fastmcp/settings.py#L262). Every FastMCP server using SSE transport serves at /sse unless explicitly overridden.

3. **Real-world servers** using /sse endpoints:
   - Any FastMCP server with transport="sse" (thousands deployed)
   - Supermemory V4 on Cloudflare Workers (uses SSE because CF Workers cannot handle long-lived POST streams for StreamableHTTP) — see #3976
   - Router Teamwork (router.feedling.app/mcp/sse)

The auto-detection is a **heuristic convenience**, not the primary mechanism. The authoritative override is the explicit transport: sse config key.

## Changes

**tools/mcp_tool.py** (71 insertions, 3 deletions):
- Import mcp.client.sse.sse_client with _MCP_SSE_AVAILABLE flag
- Add _is_sse() — auto-detects SSE from transport: sse config or URL ending in /sse
- Add _run_sse() — SSE transport runner using the same ClientSession lifecycle as _run_http()
- Update run() routing: check _is_sse() before _run_http() for HTTP servers
- Update get_mcp_status() to distinguish "sse" vs "http" vs "stdio" transport

**tests/tools/test_mcp_tool.py** (123 insertions):
- TestSSEConfig — 9 tests: detection from config, URL path, trailing slash, query params, negative cases, ImportError guard
- TestGetMcpStatusTransport — 3 tests: transport field labeling for sse/http/stdio

## Testing

175 passed, 1 warning — all 12 new SSE tests pass alongside the existing 163 MCP tests.

## Configuration

SSE servers are auto-detected from the URL — no config change needed for most users:

```yaml
mcp_servers:
  router-teamwork:
    url: "https://router.feedling.app/mcp/sse?key=YOUR_KEY"
    timeout: 60
    connect_timeout: 30
```

Or explicitly with transport: sse:

```yaml
mcp_servers:
  my-server:
    url: "https://example.com/events"
    transport: sse
```