### PR TITLE
feat(agent): add jittered retry backoff and harden retry-after parsing

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -1,0 +1,158 @@
+"""Retry utilities — jittered backoff, retryable error classification.
+
+Inspired by claw-code's Rust retry architecture (splitmix64 jitter,
+centralized is_retryable_status, structured failure classification).
+"""
+
+import hashlib
+import os
+import random
+import threading
+import time
+from typing import Optional
+
+# HTTP status codes that warrant a retry attempt.
+# Transient server errors + rate limits.  Client errors (4xx except 429/408/413)
+# are intentionally excluded — they indicate a problem with the request itself.
+RETRYABLE_STATUS_CODES = frozenset({408, 413, 429, 500, 502, 503, 504, 529})
+
+# Error message phrases that indicate a transient transport failure
+# (connection drop, timeout, pool exhaustion).  These are worth retrying
+# with a fresh connection even when no HTTP status code is available.
+TRANSIENT_TRANSPORT_PHRASES = frozenset({
+    "readtimeout", "connecttimeout", "pooltimeout",
+    "connecterror", "remoteprotocolerror",
+    "connection lost", "connection reset", "connection closed",
+    "connection terminated", "network error", "network connection",
+    "peer closed", "broken pipe", "upstream connect error",
+})
+
+# Monotonic counter for jitter seed uniqueness within the same process.
+# Protected by a lock to avoid race conditions in concurrent retry paths
+# (e.g. multiple sessions retrying simultaneously via the gateway).
+_jitter_counter = 0
+_jitter_lock = threading.Lock()
+
+
+def is_retryable_status(status_code: Optional[int]) -> bool:
+    """Return True if the HTTP status code indicates a retryable failure.
+
+    Centralized classification — use this instead of scattered status code
+    checks to keep retry policy consistent across the codebase.
+    """
+    if status_code is None:
+        return False
+    return status_code in RETRYABLE_STATUS_CODES
+
+
+def is_transient_transport_error(error: Exception) -> bool:
+    """Return True if the exception looks like a transient network failure.
+
+    These are worth retrying with a fresh connection (rebuild client, clear
+    connection pool) rather than backing off on the same dead connection.
+    """
+    error_str = str(error).lower()
+    return any(phrase in error_str for phrase in TRANSIENT_TRANSPORT_PHRASES)
+
+
+def jittered_backoff(
+    attempt: int,
+    *,
+    base_delay: float = 5.0,
+    max_delay: float = 120.0,
+    jitter_ratio: float = 0.5,
+) -> float:
+    """Compute a jittered exponential backoff delay.
+
+    Args:
+        attempt: 1-based retry attempt number.
+        base_delay: Base delay in seconds for attempt 1.
+        max_delay: Maximum delay cap in seconds.
+        jitter_ratio: Fraction of base delay to use as random jitter range.
+            0.5 means jitter is uniform in [0, 0.5 * computed_delay].
+
+    Returns:
+        Delay in seconds: min(base * 2^(attempt-1), max_delay) + random jitter.
+
+    The jitter decorrelates concurrent retries (e.g. multiple sessions hitting
+    the same rate-limited provider).  Modeled after claw-code's splitmix64
+    approach but adapted for Python's random module.
+    """
+    global _jitter_counter
+    with _jitter_lock:
+        _jitter_counter += 1
+        tick = _jitter_counter
+
+    # Exponential backoff: base, base*2, base*4, ... capped at max_delay.
+    # Guard against overflow for extreme attempt values by short-circuiting
+    # when the exponent alone would exceed what we need.
+    exponent = max(0, attempt - 1)
+    if exponent >= 63 or base_delay <= 0:
+        # 2^63 overflows or base_delay=0 means infinite tight loop — just cap
+        delay = max_delay
+    else:
+        computed = base_delay * (2 ** exponent)
+        delay = min(computed, max_delay)
+
+    # Additive jitter: uniform in [0, jitter_ratio * delay]
+    # Seed from time + counter for decorrelation even with coarse clocks
+    seed = (time.time_ns() ^ (_jitter_counter * 0x9E3779B9)) & 0xFFFFFFFF
+    rng = random.Random(seed)
+    jitter = rng.uniform(0, jitter_ratio * delay)
+
+    return delay + jitter
+
+
+def extract_retry_after(error: Exception) -> Optional[float]:
+    """Extract Retry-After delay (seconds) from an exception, if present.
+
+    Checks:
+    1. error.response.headers['Retry-After'] (HTTP header)
+    2. error.body JSON field 'retry_after' (some providers)
+    3. Error message text ('retry after N seconds')
+
+    Returns seconds to wait, or None if no Retry-After hint found.
+    """
+    # Check HTTP response headers
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None) if response else None
+    if headers:
+        for key in ("retry-after", "Retry-After"):
+            val = headers.get(key)
+            if val:
+                try:
+                    return float(val)
+                except (TypeError, ValueError):
+                    pass
+        # Some providers use x-ratelimit-reset (epoch timestamp)
+        reset = headers.get("x-ratelimit-reset")
+        if reset:
+            try:
+                remaining = float(reset) - time.time()
+                if remaining > 0:
+                    return remaining
+            except (TypeError, ValueError):
+                pass
+
+    # Check error body JSON
+    body = getattr(error, "body", None)
+    if isinstance(body, dict):
+        retry_after = body.get("retry_after")
+        if retry_after is not None:
+            try:
+                return float(retry_after)
+            except (TypeError, ValueError):
+                pass
+
+    # Parse from error message text
+    import re
+    msg = str(error)
+    match = re.search(
+        r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+        msg,
+        re.IGNORECASE,
+    )
+    if match:
+        return float(match.group(1))
+
+    return None

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -30,7 +30,7 @@ TRANSIENT_TRANSPORT_PHRASES = frozenset({
 })
 
 _RETRY_AFTER_TEXT_RE = re.compile(
-    r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+    r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:seconds?|secs?\b|s\b)",
     re.IGNORECASE,
 )
 
@@ -176,13 +176,17 @@ def extract_retry_after(error: Exception) -> Optional[float]:
     response = getattr(error, "response", None)
     headers = getattr(response, "headers", None) if response else None
     if headers and hasattr(headers, "get"):
-        for key in ("retry-after", "Retry-After"):
-            val = headers.get(key)
-            if val:
-                try:
-                    return float(val)
-                except (TypeError, ValueError):
-                    logger.debug("Could not parse %s header value as float: %r", key, val)
+        val = headers.get("retry-after") or headers.get("Retry-After")
+        if val is None and isinstance(headers, dict):
+            for key, candidate in headers.items():
+                if isinstance(key, str) and key.lower() == "retry-after":
+                    val = candidate
+                    break
+        if val:
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                logger.debug("Could not parse Retry-After header value as float: %r", val)
         # Some providers use x-ratelimit-reset (epoch timestamp)
         reset = headers.get("x-ratelimit-reset")
         if reset:

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -4,12 +4,14 @@ Inspired by claw-code's Rust retry architecture (splitmix64 jitter,
 centralized is_retryable_status, structured failure classification).
 """
 
-import hashlib
-import os
+import logging
 import random
+import re
 import threading
 import time
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # HTTP status codes that warrant a retry attempt.
 # Transient server errors + rate limits.  Client errors (4xx except 429/408/413)
@@ -27,11 +29,59 @@ TRANSIENT_TRANSPORT_PHRASES = frozenset({
     "peer closed", "broken pipe", "upstream connect error",
 })
 
+_RETRY_AFTER_TEXT_RE = re.compile(
+    r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+    re.IGNORECASE,
+)
+
 # Monotonic counter for jitter seed uniqueness within the same process.
 # Protected by a lock to avoid race conditions in concurrent retry paths
 # (e.g. multiple sessions retrying simultaneously via the gateway).
 _jitter_counter = 0
 _jitter_lock = threading.Lock()
+
+
+def _transient_exception_types() -> tuple[type[BaseException], ...]:
+    """Best-effort import of common transient transport exception classes."""
+    exc_types: list[type[BaseException]] = []
+
+    try:
+        import httpx
+
+        exc_types.extend(
+            [
+                httpx.ConnectError,
+                httpx.ConnectTimeout,
+                httpx.PoolTimeout,
+                httpx.ReadError,
+                httpx.ReadTimeout,
+                httpx.RemoteProtocolError,
+                httpx.WriteError,
+            ]
+        )
+    except Exception:
+        pass
+
+    try:
+        import requests
+
+        exc_types.extend(
+            [
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ConnectTimeout,
+                requests.exceptions.ReadTimeout,
+                requests.exceptions.Timeout,
+                requests.exceptions.ChunkedEncodingError,
+            ]
+        )
+    except Exception:
+        pass
+
+    # Deduplicate while preserving deterministic order.
+    return tuple(dict.fromkeys(exc_types))
+
+
+_TRANSIENT_EXCEPTION_TYPES = _transient_exception_types()
 
 
 def is_retryable_status(status_code: Optional[int]) -> bool:
@@ -51,7 +101,16 @@ def is_transient_transport_error(error: Exception) -> bool:
     These are worth retrying with a fresh connection (rebuild client, clear
     connection pool) rather than backing off on the same dead connection.
     """
-    error_str = str(error).lower()
+    if _TRANSIENT_EXCEPTION_TYPES and isinstance(error, _TRANSIENT_EXCEPTION_TYPES):
+        return True
+
+    # Prefer the first argument as the message payload; str(error) can include
+    # wrapper/context text in some exception implementations.
+    if error.args:
+        error_str = str(error.args[0]).lower()
+    else:
+        error_str = str(error).lower()
+
     return any(phrase in error_str for phrase in TRANSIENT_TRANSPORT_PHRASES)
 
 
@@ -96,7 +155,7 @@ def jittered_backoff(
 
     # Additive jitter: uniform in [0, jitter_ratio * delay]
     # Seed from time + counter for decorrelation even with coarse clocks
-    seed = (time.time_ns() ^ (_jitter_counter * 0x9E3779B9)) & 0xFFFFFFFF
+    seed = (time.time_ns() ^ (tick * 0x9E3779B9)) & 0xFFFFFFFF
     rng = random.Random(seed)
     jitter = rng.uniform(0, jitter_ratio * delay)
 
@@ -116,23 +175,22 @@ def extract_retry_after(error: Exception) -> Optional[float]:
     # Check HTTP response headers
     response = getattr(error, "response", None)
     headers = getattr(response, "headers", None) if response else None
-    if headers:
+    if headers and hasattr(headers, "get"):
         for key in ("retry-after", "Retry-After"):
             val = headers.get(key)
             if val:
                 try:
                     return float(val)
                 except (TypeError, ValueError):
-                    pass
+                    logger.debug("Could not parse %s header value as float: %r", key, val)
         # Some providers use x-ratelimit-reset (epoch timestamp)
         reset = headers.get("x-ratelimit-reset")
         if reset:
             try:
                 remaining = float(reset) - time.time()
-                if remaining > 0:
-                    return remaining
+                return max(0.0, remaining)
             except (TypeError, ValueError):
-                pass
+                logger.debug("Could not parse x-ratelimit-reset header value as float: %r", reset)
 
     # Check error body JSON
     body = getattr(error, "body", None)
@@ -142,16 +200,11 @@ def extract_retry_after(error: Exception) -> Optional[float]:
             try:
                 return float(retry_after)
             except (TypeError, ValueError):
-                pass
+                logger.debug("Could not parse body retry_after as float: %r", retry_after)
 
     # Parse from error message text
-    import re
     msg = str(error)
-    match = re.search(
-        r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
-        msg,
-        re.IGNORECASE,
-    )
+    match = _RETRY_AFTER_TEXT_RE.search(msg)
     if match:
         return float(match.group(1))
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -75,6 +75,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block
+from agent.retry_utils import jittered_backoff, extract_retry_after, is_retryable_status
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
@@ -7494,7 +7495,8 @@ class AIAgent:
                             }
                         
                         # Longer backoff for rate limiting (likely cause of None choices)
-                        wait_time = min(5 * (2 ** (retry_count - 1)), 120)  # 5s, 10s, 20s, 40s, 80s, 120s
+                        # Jittered exponential: 5s base, 120s cap + random jitter
+                        wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
                         self._vprint(f"{self.log_prefix}⏳ Retrying in {wait_time}s (extended backoff for possible rate limit)...", force=True)
                         logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                         
@@ -8351,7 +8353,7 @@ class AIAgent:
                                     _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
                                 except (TypeError, ValueError):
                                     pass
-                    wait_time = _retry_after if _retry_after else min(2 ** retry_count, 60)
+                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                     if is_rate_limited:
                         self._emit_status(f"⏱️ Rate limit reached. Waiting {wait_time}s before retry (attempt {retry_count + 1}/{max_retries})...")
                     else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -75,7 +75,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block
-from agent.retry_utils import jittered_backoff, extract_retry_after, is_retryable_status
+from agent.retry_utils import jittered_backoff
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -1,0 +1,197 @@
+"""Tests for agent.retry_utils — jittered backoff, retryable classification, Retry-After extraction."""
+
+import time
+from types import SimpleNamespace
+
+from agent.retry_utils import (
+    jittered_backoff,
+    is_retryable_status,
+    is_transient_transport_error,
+    extract_retry_after,
+    RETRYABLE_STATUS_CODES,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_retryable_status
+# ---------------------------------------------------------------------------
+
+
+def test_retryable_status_codes():
+    """All standard transient codes should be retryable."""
+    for code in (408, 413, 429, 500, 502, 503, 504, 529):
+        assert is_retryable_status(code), f"{code} should be retryable"
+
+
+def test_non_retryable_status_codes():
+    """Client errors (except 408/413/429) should NOT be retryable."""
+    for code in (400, 401, 403, 404, 422):
+        assert not is_retryable_status(code), f"{code} should not be retryable"
+
+
+def test_none_status_is_not_retryable():
+    assert not is_retryable_status(None)
+
+
+# ---------------------------------------------------------------------------
+# is_transient_transport_error
+# ---------------------------------------------------------------------------
+
+
+def test_transient_transport_errors():
+    """Common transport exceptions should be flagged as transient."""
+    for msg in [
+        "ReadTimeout: connection pool timed out",
+        "ConnectError: connection refused",
+        "RemoteProtocolError: peer closed connection",
+        "network connection lost",
+    ]:
+        err = Exception(msg)
+        assert is_transient_transport_error(err), f"'{msg}' should be transient"
+
+
+def test_non_transient_errors():
+    """Auth and validation errors should NOT be transient."""
+    for msg in ["Invalid API key", "400 Bad Request", "model not found"]:
+        err = Exception(msg)
+        assert not is_transient_transport_error(err), f"'{msg}' should not be transient"
+
+
+# ---------------------------------------------------------------------------
+# jittered_backoff
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_is_exponential():
+    """Base delay should double each attempt (before jitter)."""
+    # Run many samples and check that the mean is close to the expected value.
+    # With jitter_ratio=0, there should be no jitter.
+    for attempt in (1, 2, 3, 4):
+        delays = [jittered_backoff(attempt, base_delay=5.0, max_delay=120.0, jitter_ratio=0.0) for _ in range(100)]
+        expected = min(5.0 * (2 ** (attempt - 1)), 120.0)
+        mean = sum(delays) / len(delays)
+        assert abs(mean - expected) < 0.01, f"attempt {attempt}: expected {expected}, got {mean}"
+
+
+def test_backoff_respects_max_delay():
+    """Even with high attempt numbers, delay should not exceed max_delay."""
+    for attempt in (10, 20, 100):
+        delay = jittered_backoff(attempt, base_delay=5.0, max_delay=60.0, jitter_ratio=0.0)
+        assert delay <= 60.0, f"attempt {attempt}: delay {delay} exceeds max 60s"
+
+
+def test_backoff_adds_jitter():
+    """With jitter enabled, delays should vary across calls."""
+    delays = [jittered_backoff(1, base_delay=10.0, max_delay=120.0, jitter_ratio=0.5) for _ in range(50)]
+    # At least some variation should exist
+    assert min(delays) != max(delays), "jitter should produce varying delays"
+    # All delays should be >= base (jitter is additive)
+    assert all(d >= 10.0 for d in delays), "jittered delay should be >= base delay"
+    # No delay should exceed base + jitter_range + small epsilon
+    assert all(d <= 10.0 + 5.0 + 0.01 for d in delays), "jittered delay should be bounded"
+
+
+def test_backoff_attempt_1_is_base():
+    """First attempt delay should equal base_delay (with no jitter)."""
+    delay = jittered_backoff(1, base_delay=3.0, max_delay=120.0, jitter_ratio=0.0)
+    assert delay == 3.0
+
+
+# ---------------------------------------------------------------------------
+# extract_retry_after
+# ---------------------------------------------------------------------------
+
+
+def test_extract_retry_after_from_headers():
+    """Should parse Retry-After from HTTP response headers."""
+    response = SimpleNamespace(headers={"Retry-After": "30"})
+    error = Exception("Rate limited")
+    error.response = response  # type: ignore[attr-defined]
+    assert extract_retry_after(error) == 30.0
+
+
+def test_extract_retry_after_from_lowercase_headers():
+    """Should parse retry-after (lowercase) from headers."""
+    response = SimpleNamespace(headers={"retry-after": "45"})
+    error = Exception("Rate limited")
+    error.response = response  # type: ignore[attr-defined]
+    assert extract_retry_after(error) == 45.0
+
+
+def test_extract_retry_after_from_message():
+    """Should parse 'retry after N seconds' from error message."""
+    error = Exception("Error code: 429 - Rate limit. Retry after 30 seconds.")
+    assert extract_retry_after(error) == 30.0
+
+
+def test_extract_retry_after_from_body():
+    """Should parse retry_after from error body dict."""
+    error = Exception("Rate limited")
+    error.body = {"retry_after": 15}  # type: ignore[attr-defined]
+    assert extract_retry_after(error) == 15.0
+
+
+def test_extract_retry_after_none_when_absent():
+    """Should return None when no Retry-After hint exists."""
+    error = Exception("Some other error")
+    assert extract_retry_after(error) is None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (from QC review)
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_with_zero_base_delay_returns_max():
+    """base_delay=0 should return max_delay (guard against busy-wait)."""
+    delay = jittered_backoff(1, base_delay=0.0, max_delay=60.0, jitter_ratio=0.0)
+    assert delay == 60.0
+
+
+def test_backoff_with_extreme_attempt_returns_max():
+    """Very large attempt numbers should not overflow — return max_delay."""
+    delay = jittered_backoff(999, base_delay=5.0, max_delay=120.0, jitter_ratio=0.0)
+    assert delay == 120.0
+
+
+def test_backoff_negative_attempt_treated_as_one():
+    """Negative attempt should not crash, behaves like attempt=1."""
+    delay = jittered_backoff(-5, base_delay=10.0, max_delay=120.0, jitter_ratio=0.0)
+    assert delay == 10.0
+
+
+def test_backoff_thread_safety():
+    """Concurrent calls should not produce identical seeds (no race condition)."""
+    import threading
+    results = []
+    barrier = threading.Barrier(8)
+
+    def _call_backoff():
+        barrier.wait()  # synchronize all threads
+        results.append(jittered_backoff(1, base_delay=10.0, max_delay=120.0, jitter_ratio=0.5))
+
+    threads = [threading.Thread(target=_call_backoff) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(results) == 8
+    # With proper thread-safe counter, seeds should be unique
+    # (not guaranteed but overwhelmingly likely with 8 threads)
+    unique = len(set(results))
+    assert unique >= 6, f"Expected mostly unique delays, got {unique}/8 unique"
+
+
+def test_extract_retry_after_no_response_attr():
+    """Should not crash when exception has no .response attribute."""
+    error = Exception("plain error")
+    assert extract_retry_after(error) is None
+
+
+def test_extract_retry_after_empty_headers():
+    """Should return None with empty headers dict."""
+    response = SimpleNamespace(headers={})
+    error = Exception("Rate limited")
+    error.response = response  # type: ignore[attr-defined]
+    assert extract_retry_after(error) is None

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -198,6 +198,14 @@ def test_extract_retry_after_from_lowercase_headers():
     assert extract_retry_after(error) == 45.0
 
 
+def test_extract_retry_after_from_uppercase_headers_dict():
+    """Plain dict headers should still handle uppercase RETRY-AFTER keys."""
+    response = SimpleNamespace(headers={"RETRY-AFTER": "25"})
+    error = Exception("Rate limited")
+    error.response = response  # type: ignore[attr-defined]
+    assert extract_retry_after(error) == 25.0
+
+
 def test_extract_retry_after_from_x_ratelimit_reset_future():
     """x-ratelimit-reset should return positive seconds until reset."""
     now = time.time()
@@ -229,6 +237,11 @@ def test_extract_retry_after_message_unit_variants():
     assert extract_retry_after(Exception("retry after 5 sec")) == 5.0
     assert extract_retry_after(Exception("retry after 6 secs")) == 6.0
     assert extract_retry_after(Exception("retry after 7s")) == 7.0
+
+
+def test_extract_retry_after_message_does_not_match_embedded_sec_substring():
+    """'sec' inside another word should not be treated as a time unit."""
+    assert extract_retry_after(Exception("Retry after 30 secretly.")) is None
 
 
 def test_extract_retry_after_from_body():

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -1,14 +1,15 @@
-"""Tests for agent.retry_utils — jittered backoff, retryable classification, Retry-After extraction."""
+"""Tests for agent.retry_utils retry helpers."""
 
+import threading
 import time
 from types import SimpleNamespace
 
+import agent.retry_utils as retry_utils
 from agent.retry_utils import (
-    jittered_backoff,
+    extract_retry_after,
     is_retryable_status,
     is_transient_transport_error,
-    extract_retry_after,
-    RETRYABLE_STATUS_CODES,
+    jittered_backoff,
 )
 
 
@@ -47,14 +48,19 @@ def test_transient_transport_errors():
         "network connection lost",
     ]:
         err = Exception(msg)
-        assert is_transient_transport_error(err), f"'{msg}' should be transient"
+        assert is_transient_transport_error(err), f"{msg!r} should be transient"
 
 
 def test_non_transient_errors():
     """Auth and validation errors should NOT be transient."""
     for msg in ["Invalid API key", "400 Bad Request", "model not found"]:
         err = Exception(msg)
-        assert not is_transient_transport_error(err), f"'{msg}' should not be transient"
+        assert not is_transient_transport_error(err), f"{msg!r} should not be transient"
+
+
+def test_transient_transport_error_is_case_insensitive():
+    err = Exception("NeTwOrK CoNnEcTiOn LoSt")
+    assert is_transient_transport_error(err)
 
 
 # ---------------------------------------------------------------------------
@@ -64,8 +70,6 @@ def test_non_transient_errors():
 
 def test_backoff_is_exponential():
     """Base delay should double each attempt (before jitter)."""
-    # Run many samples and check that the mean is close to the expected value.
-    # With jitter_ratio=0, there should be no jitter.
     for attempt in (1, 2, 3, 4):
         delays = [jittered_backoff(attempt, base_delay=5.0, max_delay=120.0, jitter_ratio=0.0) for _ in range(100)]
         expected = min(5.0 * (2 ** (attempt - 1)), 120.0)
@@ -83,18 +87,94 @@ def test_backoff_respects_max_delay():
 def test_backoff_adds_jitter():
     """With jitter enabled, delays should vary across calls."""
     delays = [jittered_backoff(1, base_delay=10.0, max_delay=120.0, jitter_ratio=0.5) for _ in range(50)]
-    # At least some variation should exist
     assert min(delays) != max(delays), "jitter should produce varying delays"
-    # All delays should be >= base (jitter is additive)
     assert all(d >= 10.0 for d in delays), "jittered delay should be >= base delay"
-    # No delay should exceed base + jitter_range + small epsilon
-    assert all(d <= 10.0 + 5.0 + 0.01 for d in delays), "jittered delay should be bounded"
+    assert all(d <= 15.0 for d in delays), "jittered delay should be bounded"
 
 
 def test_backoff_attempt_1_is_base():
     """First attempt delay should equal base_delay (with no jitter)."""
     delay = jittered_backoff(1, base_delay=3.0, max_delay=120.0, jitter_ratio=0.0)
     assert delay == 3.0
+
+
+def test_backoff_with_zero_base_delay_returns_max():
+    """base_delay=0 should return max_delay (guard against busy-wait)."""
+    delay = jittered_backoff(1, base_delay=0.0, max_delay=60.0, jitter_ratio=0.0)
+    assert delay == 60.0
+
+
+def test_backoff_with_extreme_attempt_returns_max():
+    """Very large attempt numbers should not overflow and should return max_delay."""
+    delay = jittered_backoff(999, base_delay=5.0, max_delay=120.0, jitter_ratio=0.0)
+    assert delay == 120.0
+
+
+def test_backoff_negative_attempt_treated_as_one():
+    """Negative attempt should not crash and behaves like attempt=1."""
+    delay = jittered_backoff(-5, base_delay=10.0, max_delay=120.0, jitter_ratio=0.0)
+    assert delay == 10.0
+
+
+def test_backoff_thread_safety():
+    """Concurrent calls should generally produce different delays."""
+    results = []
+    barrier = threading.Barrier(8)
+
+    def _call_backoff():
+        barrier.wait()
+        results.append(jittered_backoff(1, base_delay=10.0, max_delay=120.0, jitter_ratio=0.5))
+
+    threads = [threading.Thread(target=_call_backoff) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(results) == 8
+    unique = len(set(results))
+    assert unique >= 6, f"Expected mostly unique delays, got {unique}/8 unique"
+
+
+def test_backoff_uses_locked_tick_for_seed(monkeypatch):
+    """Seed derivation should use per-call tick captured under lock."""
+    monkeypatch.setattr(retry_utils, "_jitter_counter", 0)
+
+    recorded_seeds = []
+
+    class _RecordingRandom:
+        def __init__(self, seed):
+            recorded_seeds.append(seed)
+
+        def uniform(self, a, b):
+            return 0.0
+
+    monkeypatch.setattr(retry_utils.random, "Random", _RecordingRandom)
+
+    fixed_time_ns = 123456789
+
+    def _time_ns_wait_for_two_ticks():
+        deadline = time.time() + 2.0
+        while retry_utils._jitter_counter < 2 and time.time() < deadline:
+            time.sleep(0.001)
+        return fixed_time_ns
+
+    monkeypatch.setattr(retry_utils.time, "time_ns", _time_ns_wait_for_two_ticks)
+
+    barrier = threading.Barrier(2)
+
+    def _call():
+        barrier.wait()
+        jittered_backoff(1, base_delay=10.0, max_delay=120.0, jitter_ratio=0.5)
+
+    threads = [threading.Thread(target=_call) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(recorded_seeds) == 2
+    assert len(set(recorded_seeds)) == 2, f"Expected unique seeds, got {recorded_seeds}"
 
 
 # ---------------------------------------------------------------------------
@@ -118,10 +198,37 @@ def test_extract_retry_after_from_lowercase_headers():
     assert extract_retry_after(error) == 45.0
 
 
+def test_extract_retry_after_from_x_ratelimit_reset_future():
+    """x-ratelimit-reset should return positive seconds until reset."""
+    now = time.time()
+    response = SimpleNamespace(headers={"x-ratelimit-reset": str(now + 20)})
+    error = Exception("Rate limited")
+    error.response = response  # type: ignore[attr-defined]
+    retry_after = extract_retry_after(error)
+    assert retry_after is not None
+    assert 15.0 <= retry_after <= 20.0
+
+
+def test_extract_retry_after_from_x_ratelimit_reset_past_returns_zero():
+    """Past reset timestamps should translate to immediate retry (0s)."""
+    now = time.time()
+    response = SimpleNamespace(headers={"x-ratelimit-reset": str(now - 5)})
+    error = Exception("Rate limited")
+    error.response = response  # type: ignore[attr-defined]
+    assert extract_retry_after(error) == 0.0
+
+
 def test_extract_retry_after_from_message():
     """Should parse 'retry after N seconds' from error message."""
     error = Exception("Error code: 429 - Rate limit. Retry after 30 seconds.")
     assert extract_retry_after(error) == 30.0
+
+
+def test_extract_retry_after_message_unit_variants():
+    """All supported short unit variants should be parsed."""
+    assert extract_retry_after(Exception("retry after 5 sec")) == 5.0
+    assert extract_retry_after(Exception("retry after 6 secs")) == 6.0
+    assert extract_retry_after(Exception("retry after 7s")) == 7.0
 
 
 def test_extract_retry_after_from_body():
@@ -131,56 +238,30 @@ def test_extract_retry_after_from_body():
     assert extract_retry_after(error) == 15.0
 
 
+def test_extract_retry_after_priority_header_over_body_and_message():
+    response = SimpleNamespace(headers={"Retry-After": "30"})
+    error = Exception("Retry after 10 seconds")
+    error.response = response  # type: ignore[attr-defined]
+    error.body = {"retry_after": 20}  # type: ignore[attr-defined]
+    assert extract_retry_after(error) == 30.0
+
+
+def test_extract_retry_after_priority_body_over_message():
+    error = Exception("Retry after 10 seconds")
+    error.body = {"retry_after": 20}  # type: ignore[attr-defined]
+    assert extract_retry_after(error) == 20.0
+
+
+def test_extract_retry_after_ignores_non_dict_body():
+    error = Exception("not parseable")
+    error.body = "retry_after=25"  # type: ignore[attr-defined]
+    assert extract_retry_after(error) is None
+
+
 def test_extract_retry_after_none_when_absent():
     """Should return None when no Retry-After hint exists."""
     error = Exception("Some other error")
     assert extract_retry_after(error) is None
-
-
-# ---------------------------------------------------------------------------
-# Edge cases (from QC review)
-# ---------------------------------------------------------------------------
-
-
-def test_backoff_with_zero_base_delay_returns_max():
-    """base_delay=0 should return max_delay (guard against busy-wait)."""
-    delay = jittered_backoff(1, base_delay=0.0, max_delay=60.0, jitter_ratio=0.0)
-    assert delay == 60.0
-
-
-def test_backoff_with_extreme_attempt_returns_max():
-    """Very large attempt numbers should not overflow — return max_delay."""
-    delay = jittered_backoff(999, base_delay=5.0, max_delay=120.0, jitter_ratio=0.0)
-    assert delay == 120.0
-
-
-def test_backoff_negative_attempt_treated_as_one():
-    """Negative attempt should not crash, behaves like attempt=1."""
-    delay = jittered_backoff(-5, base_delay=10.0, max_delay=120.0, jitter_ratio=0.0)
-    assert delay == 10.0
-
-
-def test_backoff_thread_safety():
-    """Concurrent calls should not produce identical seeds (no race condition)."""
-    import threading
-    results = []
-    barrier = threading.Barrier(8)
-
-    def _call_backoff():
-        barrier.wait()  # synchronize all threads
-        results.append(jittered_backoff(1, base_delay=10.0, max_delay=120.0, jitter_ratio=0.5))
-
-    threads = [threading.Thread(target=_call_backoff) for _ in range(8)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join(timeout=5)
-
-    assert len(results) == 8
-    # With proper thread-safe counter, seeds should be unique
-    # (not guaranteed but overwhelmingly likely with 8 threads)
-    unique = len(set(results))
-    assert unique >= 6, f"Expected mostly unique delays, got {unique}/8 unique"
 
 
 def test_extract_retry_after_no_response_attr():

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -44,6 +44,7 @@ import fire
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.console import Console
 from hermes_constants import OPENROUTER_BASE_URL
+from agent.retry_utils import jittered_backoff
 
 # Load environment variables
 from dotenv import load_dotenv
@@ -585,7 +586,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 self.logger.warning(f"Summarization attempt {attempt + 1} failed: {e}")
                 
                 if attempt < self.config.max_retries - 1:
-                    time.sleep(self.config.retry_delay * (attempt + 1))
+                    time.sleep(jittered_backoff(attempt + 1, base_delay=self.config.retry_delay, max_delay=30.0))
                 else:
                     # Fallback: create a basic summary
                     return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"
@@ -647,7 +648,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 self.logger.warning(f"Summarization attempt {attempt + 1} failed: {e}")
                 
                 if attempt < self.config.max_retries - 1:
-                    await asyncio.sleep(self.config.retry_delay * (attempt + 1))
+                    await asyncio.sleep(jittered_backoff(attempt + 1, base_delay=self.config.retry_delay, max_delay=30.0))
                 else:
                     # Fallback: create a basic summary
                     return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"


### PR DESCRIPTION
## What does this PR do?

Improves Hermes' retry behavior by replacing fixed exponential backoff with jittered backoff and centralizing retry-related helpers in a shared utility module.

The main goal is to make retries more robust under rate limits and transient failures by avoiding synchronized retry spikes across sessions. This PR also hardens `Retry-After` parsing and adds focused regression tests for concurrency and parsing edge cases.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added `agent/retry_utils.py` with:
  - `jittered_backoff()`
  - `is_retryable_status()`
  - `is_transient_transport_error()`
  - `extract_retry_after()`
- Updated retry paths in `run_agent.py` to use jittered backoff instead of hardcoded exponential waits
- Updated retry paths in `trajectory_compressor.py` to use jittered backoff
- Fixed a concurrency bug in jitter seeding by using the lock-captured counter value
- Hardened `Retry-After` parsing:
  - returns `0.0` for expired `x-ratelimit-reset` timestamps
  - handles uppercase `RETRY-AFTER` keys on plain dict headers
  - avoids false matches like `"retry after 30 secretly"`
- Expanded `tests/test_retry_utils.py` with regression coverage for:
  - jitter seed uniqueness under concurrency
  - `x-ratelimit-reset` handling
  - retry-after precedence rules
  - message unit variants and parsing edge cases

## How to Test

1. Run:
   `uv run --extra dev pytest tests/test_retry_utils.py -q -n 0`
2. Confirm the retry utility test suite passes
3. Optionally inspect the retry helper call sites in `run_agent.py` and `trajectory_compressor.py` to verify they now use `jittered_backoff()`

## Platform Tested

- macOS

## Notes

This PR stays tightly scoped to retry robustness and retry parsing behavior. It does not change unrelated agent logic or broaden retry policy beyond the new shared helper layer.