### PR TITLE
fix(agent): raw_codex client uses runtime-resolved base_url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4585,8 +4585,20 @@ def resolve_provider_client(
             return None, None
         if raw_codex:
             # Return the raw OpenAI client for callers that need direct
-            # access to responses.stream() (e.g., the main agent loop).
-            codex_token = _read_codex_access_token()
+            # access to responses.stream() (e.g., the main agent loop). Use
+            # Hermes' runtime credential resolver so refreshes and base URL
+            # overrides (HERMES_CODEX_BASE_URL) are honored consistently with
+            # the primary Codex runtime path.
+            codex_token = ""
+            base_url = _CODEX_AUX_BASE_URL
+            try:
+                from hermes_cli.auth import resolve_codex_runtime_credentials
+
+                creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+                codex_token = str(creds.get("api_key") or "").strip()
+                base_url = str(creds.get("base_url") or base_url).strip().rstrip("/") or base_url
+            except Exception:
+                codex_token = _read_codex_access_token() or ""
             if not codex_token:
                 logger.warning("resolve_provider_client: openai-codex requested "
                                "but no Codex OAuth token found (run: hermes model)")
@@ -4594,7 +4606,7 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model, provider)
             raw_client = _create_openai_client(
                 api_key=codex_token,
-                base_url=_CODEX_AUX_BASE_URL,
+                base_url=base_url,
                 default_headers=_codex_cloudflare_headers(codex_token),
             )
             return (raw_client, final_model)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -676,6 +676,34 @@ class TestBuildCodexClient:
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
 
+    def test_resolve_provider_client_raw_codex_uses_runtime_resolved_base_url(self, monkeypatch):
+        class DummyClient:
+            def __init__(self, *, api_key, base_url, default_headers=None):
+                self.api_key = api_key
+                self.base_url = base_url
+                self.default_headers = default_headers
+
+        monkeypatch.setattr("agent.auxiliary_client.OpenAI", DummyClient)
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_codex_runtime_credentials",
+            lambda refresh_if_expiring=True: {
+                "api_key": "codex-runtime-token",
+                "base_url": "https://runtime.example/codex",
+            },
+        )
+
+        client, model = resolve_provider_client(
+            "openai-codex",
+            "gpt-5.4",
+            async_mode=False,
+            raw_codex=True,
+        )
+
+        assert isinstance(client, DummyClient)
+        assert client.api_key == "codex-runtime-token"
+        assert client.base_url == "https://runtime.example/codex"
+        assert model == "gpt-5.4"
+
     def test_rejects_missing_model(self):
         """Callers must pass an explicit model; no hardcoded default."""
         from agent.auxiliary_client import _build_codex_client


### PR DESCRIPTION
## What does this PR do?

`resolve_provider_client()` was hardcoding `_CODEX_AUX_BASE_URL` for the `raw_codex=True` path, ignoring any custom base URL set via `HERMES_CODEX_BASE_URL` or a Codex-compatible proxy. This change calls `resolve_codex_runtime_credentials()` (the same resolver used by the non-raw path) so custom proxies and load balancers work correctly.

## Related Issue

Fixes #5875

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py` — targeted fix in `resolve_provider_client()` so the `raw_codex=True` path uses `resolve_codex_runtime_credentials()` instead of the hardcoded base URL constant
- `tests/agent/test_auxiliary_client.py` — regression test covering runtime-resolved `base_url` for the raw Codex client

## How to Test

1. `pytest tests/agent/test_auxiliary_client.py` — passes
2. With `HERMES_CODEX_BASE_URL` set to a proxy URL, confirm `raw_codex=True` sessions hit the custom endpoint correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_auxiliary_client.py
```
