### PR TITLE
fix(gateway): /status reads token totals from SessionDB

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3350,11 +3350,17 @@ class GatewayRunner:
         is_running = session_key in self._running_agents
 
         title = None
+        token_totals = None
         if self._session_db:
             try:
                 title = self._session_db.get_session_title(session_entry.session_id)
+                token_totals = self._session_db.get_session_token_totals(session_entry.session_id)
             except Exception:
                 title = None
+                token_totals = None
+
+        # Use SessionDB token totals for authoritative count; fall back to session_store
+        total_tokens = token_totals["total_tokens"] if token_totals else session_entry.total_tokens
 
         lines = [
             "📊 **Hermes Gateway Status**",
@@ -3366,7 +3372,7 @@ class GatewayRunner:
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Tokens:** {session_entry.total_tokens:,}",
+            f"**Tokens:** {total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -595,6 +595,46 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def get_session_token_totals(self, session_id: str) -> Dict[str, int]:
+        """Get token totals for a session from SessionDB.
+
+        Returns a dict with input_tokens, output_tokens, cache_read_tokens,
+        cache_write_tokens, reasoning_tokens, and total_tokens (sum of all).
+        Returns zeros for all fields if the session is not found.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                """SELECT input_tokens, output_tokens, cache_read_tokens,
+                          cache_write_tokens, reasoning_tokens
+                   FROM sessions WHERE id = ?""",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        if row:
+            totals = {
+                "input_tokens": row["input_tokens"] or 0,
+                "output_tokens": row["output_tokens"] or 0,
+                "cache_read_tokens": row["cache_read_tokens"] or 0,
+                "cache_write_tokens": row["cache_write_tokens"] or 0,
+                "reasoning_tokens": row["reasoning_tokens"] or 0,
+            }
+            totals["total_tokens"] = (
+                totals["input_tokens"]
+                + totals["output_tokens"]
+                + totals["cache_read_tokens"]
+                + totals["cache_write_tokens"]
+                + totals["reasoning_tokens"]
+            )
+            return totals
+        return {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+            "total_tokens": 0,
+        }
+
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -595,12 +595,12 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def get_session_token_totals(self, session_id: str) -> Dict[str, int]:
+    def get_session_token_totals(self, session_id: str) -> Optional[Dict[str, int]]:
         """Get token totals for a session from SessionDB.
 
         Returns a dict with input_tokens, output_tokens, cache_read_tokens,
         cache_write_tokens, reasoning_tokens, and total_tokens (sum of all).
-        Returns zeros for all fields if the session is not found.
+        Returns None if the session is not found.
         """
         with self._lock:
             cursor = self._conn.execute(
@@ -626,14 +626,7 @@ class SessionDB:
                 + totals["reasoning_tokens"]
             )
             return totals
-        return {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_tokens": 0,
-            "cache_write_tokens": 0,
-            "reasoning_tokens": 0,
-            "total_tokens": 0,
-        }
+        return None
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -53,6 +53,7 @@ def _make_runner(session_entry: SessionEntry):
     runner._pending_approvals = {}
     runner._session_db = MagicMock()
     runner._session_db.get_session_title.return_value = None
+    runner._session_db.get_session_token_totals.return_value = None
     runner._reasoning_config = None
     runner._provider_routing = {}
     runner._fallback_model = None
@@ -109,6 +110,51 @@ async def test_status_command_includes_session_title_when_present():
 
     assert "**Session ID:** `sess-1`" in result
     assert "**Title:** My titled session" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_sessiondb_token_totals():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=321,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session_token_totals.return_value = {
+        "input_tokens": 100,
+        "output_tokens": 200,
+        "cache_read_tokens": 10,
+        "cache_write_tokens": 5,
+        "reasoning_tokens": 6,
+        "total_tokens": 3210,
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tokens:** 3,210" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_falls_back_when_sessiondb_row_missing():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=321,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session_token_totals.return_value = None
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tokens:** 321" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -76,6 +76,30 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["model"] == "anthropic/claude-opus-4.6"
 
+    def test_get_session_token_totals_sums_all_columns(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.set_token_counts(
+            "s1",
+            input_tokens=10,
+            output_tokens=20,
+            cache_read_tokens=3,
+            cache_write_tokens=4,
+            reasoning_tokens=5,
+        )
+
+        totals = db.get_session_token_totals("s1")
+        assert totals == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "cache_read_tokens": 3,
+            "cache_write_tokens": 4,
+            "reasoning_tokens": 5,
+            "total_tokens": 42,
+        }
+
+    def test_get_session_token_totals_returns_none_for_missing_session(self, db):
+        assert db.get_session_token_totals("missing") is None
+
     def test_parent_session(self, db):
         db.create_session(session_id="parent", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="parent")


### PR DESCRIPTION
## Summary

- `/status` was reading `session_entry.total_tokens`, which is never updated after the token-persistence refactor (commit 20441cf2) — real usage lives in SessionDB (SQLite)
- Adds `get_session_token_totals()` helper to `hermes_state.py` that reads aggregated token counts from SessionDB
- `/status` now prefers SessionDB totals and falls back to `session_entry.total_tokens` when the DB row is missing
- Corrects `None`-handling so missing rows don't raise, they fall back cleanly

Fixes #5960.

## Files changed

- `hermes_state.py` — `get_session_token_totals()` helper + `None`-row fallback fix
- `gateway/run.py` — `/status` wired to use the new helper
- `tests/gateway/test_status_command.py` — tests for SessionDB-preferred totals and session_store fallback
- `tests/test_hermes_state.py` — unit tests for token aggregation and missing-row None behavior

## Test plan

- [ ] `pytest tests/gateway/test_status_command.py tests/test_hermes_state.py` passes
- [ ] `/status` on a live session reports correct cumulative token counts
- [ ] `/status` with no SessionDB row (fresh install / DB unavailable) falls back without error