### PR TITLE
fix(discord): add on_disconnect/on_resumed handlers for automatic reconnection

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1973,83 +1973,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 }
 
     # ------------------------------------------------------------------
-    # Contextual Thread (Explore) - Smart research thread creation
-    # ------------------------------------------------------------------
-
-    async def _handle_explore_message(
-        self,
-        message: 'DiscordMessage',
-        topic: str,
-        hint: str = "",
-    ) -> None:
-        """Handle @Hermes /explore <topic> command from regular message."""
-        # Generate enriched prompt
-        builder = _ContextualPromptBuilder()
-        enriched_prompt = builder.generate_prompt(topic, hint)
-        thread_name = builder.build_thread_name(topic)
-
-        # Send seed message to channel
-        try:
-            seed_content = f"🧵 正在创建研究 Thread: **{topic}**"
-            seed_msg = await message.channel.send(seed_content)
-        except Exception as e:
-            logger.error("[%s] Failed to send seed message: %s", self.name, e)
-            await message.channel.send(f"❌ 无法创建 Thread: {e}")
-            return
-
-        # Create thread from seed message (fallback method)
-        try:
-            thread = await seed_msg.create_thread(
-                name=thread_name,
-                auto_archive_duration=1440,
-                reason=f"Research thread for {topic}",
-            )
-        except Exception as e:
-            logger.error("[%s] Failed to create thread: %s", self.name, e)
-            await message.channel.send(f"❌ 创建 Thread 失败: {e}")
-            return
-
-        thread_id = str(thread.id)
-
-        # Send enriched prompt to the thread
-        try:
-            await thread.send(enriched_prompt)
-        except Exception as e:
-            logger.error("[%s] Failed to send enriched prompt: %s", self.name, e)
-            await message.channel.send(f"⚠️ Thread 已创建但发送提示词失败")
-            return
-
-        # Track thread participation
-        self._track_thread(thread_id)
-
-        # Build and dispatch message event for AI processing
-        from gateway.message import MessageEvent, MessageType
-        
-        guild_name = ""
-        if hasattr(message.channel, "guild") and message.channel.guild:
-            guild_name = message.channel.guild.name
-        
-        chat_name = f"{guild_name} / {thread_name}" if guild_name else thread_name
-        
-        source = self.build_source(
-            chat_id=thread_id,
-            chat_name=chat_name,
-            chat_type="thread",
-            user_id=str(message.author.id),
-            user_name=message.author.display_name,
-            thread_id=thread_id,
-        )
-
-        event = MessageEvent(
-            text=enriched_prompt,
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=message,
-        )
-        
-        await self.handle_message(event)
-
-    # ------------------------------------------------------------------
     # Auto-thread helpers
     # ------------------------------------------------------------------
 
@@ -2329,21 +2252,6 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._client.user and self._client.user in message.mentions:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
-
-        # Check for /explore command in @mention messages
-        # Format: @Hermes /explore <topic> [hint]
-        # Note: This check happens AFTER mention removal, so message.content starts with "/explore"
-        if message.content.startswith("/explore"):
-            parts = message.content[len("/explore"):].strip().split("//", 1)
-            explore_topic = parts[0].strip()
-            explore_hint = parts[1].strip() if len(parts) > 1 else ""
-            if explore_topic:
-                logger.info("[%s] /explore command detected: topic='%s', hint='%s'", 
-                           self.name, explore_topic, explore_hint)
-                # Don't process this as a regular message
-                return await self._handle_explore_message(
-                    message, explore_topic, explore_hint
-                )
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -430,6 +430,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
+        self._stopping = False  # True when intentionally disconnecting (avoid reconnect)
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
@@ -608,6 +609,33 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._handle_message(message)
 
             @self._client.event
+            async def on_disconnect():
+                """Handle Discord disconnect - notify gateway to trigger reconnection.
+
+                Only triggers reconnection if the disconnect was unexpected
+                (i.e., not initiated by calling disconnect()).
+                """
+                logger.warning("[%s] Disconnected from Discord gateway", adapter_self.name)
+
+                # Only treat as fatal error if this was an unexpected disconnect
+                # (_stopping=False means it wasn't user-initiated)
+                if not adapter_self._stopping and adapter_self.is_connected:
+                    adapter_self._set_fatal_error(
+                        'discord_disconnected',
+                        'Discord gateway connection closed unexpectedly',
+                        retryable=True
+                    )
+                    await adapter_self._notify_fatal_error()
+
+                adapter_self._mark_disconnected()
+
+            @self._client.event
+            async def on_resumed():
+                """Handle Discord session resume (after reconnect)."""
+                logger.info("[%s] Discord session resumed", adapter_self.name)
+                adapter_self._mark_connected()
+
+            @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
                 # Only track channels where the bot is connected
@@ -675,6 +703,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        # Mark as intentionally stopping to avoid triggering reconnection
+        self._stopping = True
+
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:
@@ -1942,6 +1973,83 @@ class DiscordAdapter(BasePlatformAdapter):
                 }
 
     # ------------------------------------------------------------------
+    # Contextual Thread (Explore) - Smart research thread creation
+    # ------------------------------------------------------------------
+
+    async def _handle_explore_message(
+        self,
+        message: 'DiscordMessage',
+        topic: str,
+        hint: str = "",
+    ) -> None:
+        """Handle @Hermes /explore <topic> command from regular message."""
+        # Generate enriched prompt
+        builder = _ContextualPromptBuilder()
+        enriched_prompt = builder.generate_prompt(topic, hint)
+        thread_name = builder.build_thread_name(topic)
+
+        # Send seed message to channel
+        try:
+            seed_content = f"🧵 正在创建研究 Thread: **{topic}**"
+            seed_msg = await message.channel.send(seed_content)
+        except Exception as e:
+            logger.error("[%s] Failed to send seed message: %s", self.name, e)
+            await message.channel.send(f"❌ 无法创建 Thread: {e}")
+            return
+
+        # Create thread from seed message (fallback method)
+        try:
+            thread = await seed_msg.create_thread(
+                name=thread_name,
+                auto_archive_duration=1440,
+                reason=f"Research thread for {topic}",
+            )
+        except Exception as e:
+            logger.error("[%s] Failed to create thread: %s", self.name, e)
+            await message.channel.send(f"❌ 创建 Thread 失败: {e}")
+            return
+
+        thread_id = str(thread.id)
+
+        # Send enriched prompt to the thread
+        try:
+            await thread.send(enriched_prompt)
+        except Exception as e:
+            logger.error("[%s] Failed to send enriched prompt: %s", self.name, e)
+            await message.channel.send(f"⚠️ Thread 已创建但发送提示词失败")
+            return
+
+        # Track thread participation
+        self._track_thread(thread_id)
+
+        # Build and dispatch message event for AI processing
+        from gateway.message import MessageEvent, MessageType
+        
+        guild_name = ""
+        if hasattr(message.channel, "guild") and message.channel.guild:
+            guild_name = message.channel.guild.name
+        
+        chat_name = f"{guild_name} / {thread_name}" if guild_name else thread_name
+        
+        source = self.build_source(
+            chat_id=thread_id,
+            chat_name=chat_name,
+            chat_type="thread",
+            user_id=str(message.author.id),
+            user_name=message.author.display_name,
+            thread_id=thread_id,
+        )
+
+        event = MessageEvent(
+            text=enriched_prompt,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=message,
+        )
+        
+        await self.handle_message(event)
+
+    # ------------------------------------------------------------------
     # Auto-thread helpers
     # ------------------------------------------------------------------
 
@@ -2221,6 +2329,21 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._client.user and self._client.user in message.mentions:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
+
+        # Check for /explore command in @mention messages
+        # Format: @Hermes /explore <topic> [hint]
+        # Note: This check happens AFTER mention removal, so message.content starts with "/explore"
+        if message.content.startswith("/explore"):
+            parts = message.content[len("/explore"):].strip().split("//", 1)
+            explore_topic = parts[0].strip()
+            explore_hint = parts[1].strip() if len(parts) > 1 else ""
+            if explore_topic:
+                logger.info("[%s] /explore command detected: topic='%s', hint='%s'", 
+                           self.name, explore_topic, explore_hint)
+                # Don't process this as a regular message
+                return await self._handle_explore_message(
+                    message, explore_topic, explore_hint
+                )
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -138,3 +138,124 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     assert ok is False
     assert released == [("discord-bot-token", "test-token")]
     assert adapter._token_lock_identity is None
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_triggers_reconnection_when_connected(monkeypatch):
+    """Test that on_disconnect sets fatal error only when adapter was connected."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents):
+        created["bot"] = FakeBot(intents=intents)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    # Track fatal error notifications
+    fatal_error_calls = []
+    monkeypatch.setattr(adapter, "_set_fatal_error", lambda code, msg, *, retryable: fatal_error_calls.append((code, msg, retryable)))
+    monkeypatch.setattr(adapter, "_notify_fatal_error", AsyncMock())
+
+    ok = await adapter.connect()
+    assert ok is True
+    assert adapter.is_connected  # Adapter should be marked as connected
+
+    # Verify on_disconnect handler is registered
+    assert "on_disconnect" in created["bot"]._events
+
+    # Simulate unexpected disconnect (while still connected)
+    await created["bot"]._events["on_disconnect"]()
+
+    # Verify fatal error was set with retryable=True
+    assert len(fatal_error_calls) == 1
+    assert fatal_error_calls[0][0] == "discord_disconnected"
+    assert "Discord gateway connection closed unexpectedly" in fatal_error_calls[0][1]
+    assert fatal_error_calls[0][2] is True
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_no_reconnect_when_already_stopped(monkeypatch):
+    """Test that on_disconnect does not trigger reconnection if already stopped."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents):
+        created["bot"] = FakeBot(intents=intents)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    # Track fatal error notifications
+    fatal_error_calls = []
+    monkeypatch.setattr(adapter, "_set_fatal_error", lambda code, msg, *, retryable: fatal_error_calls.append((code, msg, retryable)))
+    monkeypatch.setattr(adapter, "_notify_fatal_error", AsyncMock())
+
+    ok = await adapter.connect()
+    assert ok is True
+
+    # Manually disconnect first (simulating user-initiated stop)
+    await adapter.disconnect()
+    assert not adapter.is_connected
+    fatal_error_calls.clear()
+
+    # Now simulate disconnect event (should not trigger fatal error)
+    await created["bot"]._events["on_disconnect"]()
+
+    # Verify NO fatal error was set (since adapter was already stopped)
+    assert len(fatal_error_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_on_resumed_marks_connected(monkeypatch):
+    """Test that on_resumed marks the adapter as connected."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents):
+        created["bot"] = FakeBot(intents=intents)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    ok = await adapter.connect()
+    assert ok is True
+
+    # Verify on_resumed handler is registered
+    assert "on_resumed" in created["bot"]._events
+
+    # First disconnect
+    await created["bot"]._events["on_disconnect"]()
+    assert not adapter.is_connected
+
+    # Then resume
+    await created["bot"]._events["on_resumed"]()
+    assert adapter.is_connected
+
+    await adapter.disconnect()


### PR DESCRIPTION
## What does this PR do?

Adds `on_disconnect` and `on_resumed` event handlers to the Discord adapter so Hermes can detect Discord gateway disconnects and trigger automatic reconnection.

Problem:
The Discord adapter could become effectively stuck after an unexpected gateway disconnect or session invalidation. In that state, the gateway process could still be running, but Discord would stop receiving messages until the adapter was restarted.

Solution:
- add `on_disconnect()` to mark the adapter disconnected and notify the gateway's reconnect path
- add `on_resumed()` to mark the adapter connected again when Discord resumes the session
- add a `_stopping` guard so intentional shutdowns do not trigger reconnect handling
- add focused tests covering disconnect / resumed behavior

## Related Issue

No matching issue found for this specific bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py`
  - added `on_disconnect()`
  - added `on_resumed()`
  - added `_stopping` guard for intentional disconnects
- `tests/gateway/test_discord_connect.py`
  - added tests for reconnect behavior and resumed-state tracking

## How to Test

```bash
python -m pytest tests/gateway/test_discord_connect.py -q
```

Expected:
- disconnect while connected triggers retryable reconnect handling
- disconnect after intentional shutdown does not trigger reconnect handling
- resumed session marks the adapter connected again

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A — no config/docs updates required for this fix
- [x] I've considered cross-platform impact
