### PR TITLE
fix: skip config-driven worktrees outside git repos

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -653,6 +653,28 @@ def _path_is_within_root(path: Path, root: Path) -> bool:
         return False
 
 
+def _should_use_worktree(
+    explicit_worktree: bool = False,
+    shorthand_worktree: bool = False,
+    config_worktree: bool = False,
+    repo_root: Optional[str] = None,
+) -> bool:
+    """Decide whether this CLI invocation should run in a git worktree.
+
+    Explicit CLI flags keep their current strict behavior: if the user asked for
+    a worktree, we'll try to create one and fail fast outside git repos.
+
+    Config-driven worktree mode is softer: enable it automatically when the
+    current directory is inside a git repository, but do not block startup when
+    Hermes is launched from a non-git directory such as ``~``.
+    """
+    if explicit_worktree or shorthand_worktree:
+        return True
+    if not config_worktree:
+        return False
+    return bool(repo_root)
+
+
 def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
     """Create an isolated git worktree for this CLI session.
 
@@ -8479,14 +8501,19 @@ def main(
         # ── Git worktree isolation (#652) ──
         # Create an isolated worktree so this agent instance doesn't collide
         # with other agents working on the same repo.
-        use_worktree = worktree or w or CLI_CONFIG.get("worktree", False)
+        _repo = _git_repo_root()
+        use_worktree = _should_use_worktree(
+            explicit_worktree=worktree,
+            shorthand_worktree=w,
+            config_worktree=CLI_CONFIG.get("worktree", False),
+            repo_root=_repo,
+        )
         wt_info = None
         if use_worktree:
             # Prune stale worktrees from crashed/killed sessions
-            _repo = _git_repo_root()
             if _repo:
                 _prune_stale_worktrees(_repo)
-            wt_info = _setup_worktree()
+            wt_info = _setup_worktree(_repo)
             if wt_info:
                 _active_worktree = wt_info
                 os.environ["TERMINAL_CWD"] = wt_info["path"]

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -55,6 +55,21 @@ def _git_repo_root(cwd=None):
     return None
 
 
+def _should_use_worktree(
+    explicit_worktree=False,
+    shorthand_worktree=False,
+    config_worktree=False,
+    repo_root=None,
+):
+    """Mirror cli._should_use_worktree for focused unit tests."""
+    if explicit_worktree or shorthand_worktree:
+        return True
+    if not config_worktree:
+        return False
+    return bool(repo_root)
+
+
+
 def _setup_worktree(repo_root):
     """Test version of _setup_worktree — creates a worktree."""
     import uuid
@@ -548,39 +563,27 @@ class TestEdgeCases:
 
 
 class TestCLIFlagLogic:
-    """Test the flag/config OR logic from main()."""
+    """Test the flag/config worktree decision logic from main()."""
 
     def test_worktree_flag_triggers(self):
         """--worktree flag should trigger worktree creation."""
-        worktree = True
-        w = False
-        config_worktree = False
-        use_worktree = worktree or w or config_worktree
-        assert use_worktree
+        assert _should_use_worktree(explicit_worktree=True) is True
 
     def test_w_flag_triggers(self):
         """-w flag should trigger worktree creation."""
-        worktree = False
-        w = True
-        config_worktree = False
-        use_worktree = worktree or w or config_worktree
-        assert use_worktree
+        assert _should_use_worktree(shorthand_worktree=True) is True
 
-    def test_config_triggers(self):
-        """worktree: true in config should trigger worktree creation."""
-        worktree = False
-        w = False
-        config_worktree = True
-        use_worktree = worktree or w or config_worktree
-        assert use_worktree
+    def test_config_triggers_inside_git_repo(self, git_repo):
+        """worktree: true in config should trigger inside git repos."""
+        assert _should_use_worktree(config_worktree=True, repo_root=str(git_repo)) is True
+
+    def test_config_does_not_trigger_outside_git_repo(self):
+        """Config-driven worktrees should not block startup outside git repos."""
+        assert _should_use_worktree(config_worktree=True, repo_root="") is False
 
     def test_none_set_no_trigger(self):
         """No flags and no config should not trigger."""
-        worktree = False
-        w = False
-        config_worktree = False
-        use_worktree = worktree or w or config_worktree
-        assert not use_worktree
+        assert _should_use_worktree() is False
 
 
 class TestTerminalCWDIntegration:


### PR DESCRIPTION
## Summary
- add a helper that only auto-enables config-driven worktrees when the current directory is inside a git repo
- keep explicit -w/--worktree behavior unchanged so it still fails fast outside repos
- cover the decision logic with focused worktree tests

## Verification
- source venv/bin/activate && pytest tests/cli/test_worktree.py -q
- source /Users/zhangc/.hermes/hermes-agent/venv/bin/activate && hermes chat -q 'hi' --max-turns 1 (from ~)
- source /Users/zhangc/.hermes/hermes-agent/venv/bin/activate && hermes -w chat -q 'hi' --max-turns 1 (from ~, still fails fast)
- source /Users/zhangc/.hermes/hermes-agent/venv/bin/activate && hermes chat -q 'hi' --max-turns 1 (from repo, still uses a worktree)