### PR TITLE
fix: surface non-retryable API errors in response instead of silent blank

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8262,7 +8262,9 @@ class AIAgent:
                         else:
                             self._persist_session(messages, conversation_history)
                         return {
-                            "final_response": None,
+                            "final_response": (
+                                f"❌ {self._summarize_api_error(api_error)}"
+                            ),
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,


### PR DESCRIPTION
## Problem

When the model/provider returns a non-retryable 4xx error (e.g. a deprecated model, invalid API key, 404 not found), `run_conversation()` returns `final_response=None`. The API gateway converts `None` to an empty string and sends a `run.completed` event with `output: ""` — so every frontend (webapp, Telegram, API clients) shows a **silent blank response** with no indication of what went wrong.

Real-world trigger that prompted this fix: OpenRouter deprecated `qwen/qwen3.6-plus:free`, returning HTTP 404. Users saw empty chat bubbles and had no way to know why.

## Fix

Return `_summarize_api_error(api_error)` as `final_response` on the non-retryable error path, prefixed with ❌. This value is already computed and logged to the terminal — this change ensures it also reaches the user through whatever frontend they're using.

This mirrors the existing behaviour on the **max-retries-exhausted** path (~20 lines below), which already sets `_final_response = f"API call failed after {max_retries} retries: {_final_summary}"` before returning.

## Before / After

**Before:** blank bubble, error only visible in `gateway.log`

**After:** `❌ The free model has been deprecated. Transition to qwen/qwen3.6-plus for continued paid access.`

## Test plan

- [ ] Verify existing tests pass (`pytest tests/`)
- [ ] Manually trigger a 404 (point config at a non-existent model) and confirm the error message appears in the chat response

🤖 Generated with [Claude Code](https://claude.com/claude-code)