### PR TITLE
fix(gateway): warn when starting with default config while named profiles exist

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4816,6 +4816,69 @@ def _guard_official_docker_root_gateway() -> None:
     sys.exit(1)
 
 
+def _default_gateway_multiplex_enabled(default_root: Path) -> bool:
+    """Return whether the default root is configured to multiplex profiles."""
+    try:
+        from gateway.config import _env_multiplex_profiles_override
+
+        env_multiplex = _env_multiplex_profiles_override()
+        if env_multiplex is not None:
+            return env_multiplex
+
+        cfg_path = default_root / "config.yaml"
+        if not cfg_path.exists():
+            return False
+
+        from hermes_cli.config import read_user_config_raw
+
+        cfg = read_user_config_raw(cfg_path)
+        return bool(
+            cfg.get("multiplex_profiles")
+            or (cfg.get("gateway", {}) or {}).get("multiplex_profiles")
+        )
+    except Exception:
+        logger.debug("Default gateway multiplex probe failed", exc_info=True)
+        return False
+
+
+def _warn_default_gateway_with_named_profiles(quiet: bool = False) -> None:
+    """Warn when a default-root gateway may be a mistaken profile launch."""
+    if quiet:
+        return
+
+    try:
+        from hermes_constants import display_hermes_home, get_default_hermes_root
+
+        hermes_home = get_hermes_home().resolve()
+        default_root = get_default_hermes_root().resolve()
+    except Exception:
+        return
+
+    if hermes_home != default_root:
+        return
+    if _default_gateway_multiplex_enabled(default_root):
+        return
+
+    profiles_dir = default_root / "profiles"
+    try:
+        profiles = sorted(path.name for path in profiles_dir.iterdir() if path.is_dir())
+    except (FileNotFoundError, NotADirectoryError, OSError):
+        return
+    if not profiles:
+        return
+
+    rendered_home = display_hermes_home()
+    print(
+        f"\nWarning: starting gateway with the default config ({rendered_home}/config.yaml).\n"
+        f"   Profiles detected: {', '.join(profiles)}\n"
+        "   If you meant to run a profile gateway, use:\n"
+        "     hermes --profile <name> gateway run\n"
+        "   or set a default profile with:\n"
+        "     hermes profile use <name>\n",
+        file=sys.stderr,
+    )
+
+
 def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, force: bool = False):
     """Run the gateway in foreground.
 
@@ -4832,6 +4895,7 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     _guard_named_profile_under_multiplexer(force=force)
     _guard_supervised_gateway_conflict(force=force)
     _guard_existing_gateway_process_conflict(replace=replace)
+    _warn_default_gateway_with_named_profiles(quiet=quiet)
     sys.path.insert(0, str(PROJECT_ROOT))
 
     # Detached Windows gateway runs must ignore console-control broadcasts

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -390,3 +390,68 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+def test_default_gateway_warns_when_named_profiles_exist(monkeypatch, tmp_path, capsys):
+    profiles = tmp_path / "profiles"
+    (profiles / "alpha").mkdir(parents=True)
+    (profiles / "beta").mkdir()
+
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.display_hermes_home", lambda: str(tmp_path))
+
+    gateway._warn_default_gateway_with_named_profiles()
+
+    err = capsys.readouterr().err
+    assert "starting gateway with the default config" in err
+    assert "Profiles detected: alpha, beta" in err
+    assert "hermes --profile <name> gateway run" in err
+
+
+def test_default_gateway_warning_honors_quiet(monkeypatch, tmp_path, capsys):
+    (tmp_path / "profiles" / "alpha").mkdir(parents=True)
+
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.display_hermes_home", lambda: str(tmp_path))
+
+    gateway._warn_default_gateway_with_named_profiles(quiet=True)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_default_gateway_warning_skips_multiplex_mode(monkeypatch, tmp_path, capsys):
+    (tmp_path / "profiles" / "alpha").mkdir(parents=True)
+    (tmp_path / "config.yaml").write_text(
+        "gateway:\n  multiplex_profiles: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: tmp_path)
+    monkeypatch.setattr("hermes_constants.display_hermes_home", lambda: str(tmp_path))
+
+    gateway._warn_default_gateway_with_named_profiles()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_default_gateway_warning_uses_resolved_default_root(monkeypatch, tmp_path, capsys):
+    default_root = tmp_path / "custom-root"
+    profile_home = default_root / "profiles" / "alpha"
+    profile_home.mkdir(parents=True)
+
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: profile_home)
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: default_root)
+    monkeypatch.setattr("hermes_constants.display_hermes_home", lambda: str(profile_home))
+
+    gateway._warn_default_gateway_with_named_profiles()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

- Warn when the default-root gateway starts while named profiles exist.
- Skip the warning when profile multiplexing is enabled or output is quiet.
- Use profile-aware root helpers and cover the behavior with focused tests.

## Problem

Starting the default-root gateway when named profiles exist can silently use an unintended configuration.

## Validation

- `python -m pytest tests/hermes_cli/test_gateway.py -q` (18 passed)
- `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway.py`
