### PR TITLE
fix(tools): add messaging to CONFIGURABLE_TOOLSETS

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -85,6 +85,7 @@ CONFIGURABLE_TOOLSETS = [
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
+    ("messaging",        "📨 Cross-platform Messaging", "send_message"),
 ]
 
 # Toolsets that are OFF by default for new installs.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -420,3 +420,22 @@ class TestPlatformToolsetConsistency:
                 f"Platform {platform!r} in tools_config but missing from "
                 f"skills_config PLATFORMS"
             )
+
+
+def test_messaging_toolset_in_configurable_toolsets():
+    """Regression: 'messaging' must be in CONFIGURABLE_TOOLSETS.
+
+    Without this entry, tools registered to the 'messaging' toolset
+    (e.g. send_message) are silently dropped from every messaging-platform
+    session because _get_platform_tools() only reverse-maps toolset keys
+    that appear in CONFIGURABLE_TOOLSETS.
+
+    See https://github.com/NousResearch/hermes-agent/issues/5991
+    """
+    from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS
+
+    configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    assert "messaging" in configurable_keys, (
+        "'messaging' toolset missing from CONFIGURABLE_TOOLSETS — "
+        "send_message will be silently dropped from platform sessions"
+    )


### PR DESCRIPTION
## Summary

Tools registered to the `messaging` toolset (e.g. `send_message`) are silently dropped from every messaging-platform session (Telegram, Discord, Slack, WhatsApp, Signal, Matrix) because `messaging` has no entry in `CONFIGURABLE_TOOLSETS`.

## Root cause

`_get_platform_tools()` resolves composite toolset names (e.g. `hermes-matrix`) by calling `resolve_toolset()` then reverse-mapping individual tool names back to `CONFIGURABLE_TOOLSETS` keys. Since `messaging` is not listed there, the subset-match at line 521-524 never adds it, and `send_message` is silently excluded from the tool list passed to `get_tool_definitions()`.

## Fix

Add `("messaging", "📨 Cross-platform Messaging", "send_message")` to `CONFIGURABLE_TOOLSETS` — same pattern as every other registered toolset.

## Changes

- `hermes_cli/tools_config.py`: Add `messaging` entry to `CONFIGURABLE_TOOLSETS`
- `tests/hermes_cli/test_tools_config.py`: Add regression test asserting `messaging` is in configurable keys

Fixes #5991