### PR TITLE
Add ladybug as a memory plugin

### DIFF
--- a/plugins/memory/ladybug/README.md
+++ b/plugins/memory/ladybug/README.md
@@ -1,0 +1,75 @@
+# Ladybug Memory Plugin
+
+Local, file-based memory for Hermes Agent backed by
+[LadybugMemory](https://github.com/your-org/ladybug) — a columnar embedded graph
+database (`.lbdb`), similar to DuckDB.
+No API keys, no cloud — everything stays on disk in your `HERMES_HOME`.
+
+## Features
+
+| Capability | Details |
+|---|---|
+| Storage | Typed entries with importance scores (1–10) |
+| Search | BM25 keyword search (`ladybug_search`) |
+| Recall | Importance-weighted retrieval (`ladybug_recall`) |
+| Graph | Named edges between entries (`ladybug_link`, `ladybug_related`) |
+| Entity KG | GLiNER2 entity extraction (optional, `ladybug_entity`) |
+| Prefetch | Background recall before every turn |
+| Mirror | Syncs built-in MEMORY.md / USER.md writes automatically |
+
+## Installation
+
+```bash
+pip install ladybug-memory          # required
+pip install ladybug-memory[extract] # for entity extraction
+```
+
+## Activation
+
+```bash
+hermes memory select ladybug
+```
+
+Or manually in `~/.hermes/config.yaml`:
+
+```yaml
+memory:
+  provider: ladybug
+```
+
+## Configuration (optional)
+
+All keys go under `memory.ladybug` in `~/.hermes/config.yaml`:
+
+```yaml
+memory:
+  provider: ladybug
+  ladybug:
+    db_path: ~/.hermes/ladybug.lbdb   # default
+    prefetch_limit: 6                 # memories surfaced before each turn
+    min_importance: 3                 # importance threshold for prefetch
+    auto_link: false                  # chain-link mirrored built-in writes
+```
+
+## Tools exposed to the agent
+
+| Tool | Purpose |
+|---|---|
+| `ladybug_store` | Persist a new memory entry |
+| `ladybug_search` | Keyword / BM25 search |
+| `ladybug_recall` | Retrieve recent / high-importance memories |
+| `ladybug_update` | Correct or update a memory by ID |
+| `ladybug_delete` | Delete a memory by ID |
+| `ladybug_link` | Create a named relationship between two memories |
+| `ladybug_related` | Traverse the relationship graph |
+| `ladybug_entity` | Entity-level KG queries (requires GLiNER2) |
+
+## Memory types
+
+`general` · `preference` · `fact` · `project` · `person` · `event` · `task`
+
+## Importance scores
+
+1–10 scale. Higher scores surface more often in prefetch recall.
+Built-in MEMORY.md / USER.md mirrors use importance **6** (explicit user signal).
+Use `ladybug_update` to tune scores over time.

--- a/plugins/memory/ladybug/__init__.py
+++ b/plugins/memory/ladybug/__init__.py
@@ -1,0 +1,840 @@
+"""Ladybug memory plugin — MemoryProvider backed by LadybugMemory.
+
+LadybugMemory is a local columnar embedded graph database (*.lbdb), similar to
+DuckDB, with:
+  - BM25 keyword search and optional semantic (embedding) search
+  - Importance-weighted recall
+  - Typed memory entries (general, preference, fact, project, person, ...)
+  - Graph edges between entries (link / get_related)
+  - Knowledge graph via GLiNER2 entity extraction (optional — gracefully
+    skipped when the model is not installed)
+
+The plugin exposes 8 tools to the agent:
+  ladybug_store           — store a new memory entry
+  ladybug_search          — keyword / BM25 search
+  ladybug_recall          — retrieve recent / high-importance memories
+  ladybug_update          — update content, importance or metadata
+  ladybug_delete          — delete a memory by ID
+  ladybug_link            — create a named relationship between two memories
+  ladybug_related         — traverse the relationship graph
+  ladybug_entity          — entity-level KG queries (needs GLiNER2)
+
+Prefetch runs in a background thread after every turn and injects
+the top recalled + query-matched memories before the next API call.
+
+Config in config.yaml (all optional):
+  memory:
+    provider: ladybug
+    ladybug:
+      db_path: ~/.hermes/ladybug.lbdb   # default: $HERMES_HOME/ladybug.lbdb
+      prefetch_limit: 6                 # memories surfaced before each turn
+      min_importance: 3                 # minimum importance for prefetch recall
+      auto_link: false                  # auto-link mirrored built-in writes
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import threading
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+STORE_SCHEMA = {
+    "name": "ladybug_store",
+    "description": (
+        "Persist a memory entry to Ladybug's local store. "
+        "Use whenever the user shares something to remember across sessions: "
+        "preferences, facts, decisions, project context, names, recurring tasks. "
+        "Returns the assigned memory ID."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "The memory to store.",
+            },
+            "memory_type": {
+                "type": "string",
+                "enum": ["general", "preference", "fact", "project", "person", "event", "task"],
+                "description": "Category of the memory (default: general).",
+            },
+            "importance": {
+                "type": "integer",
+                "description": "Importance score 1–10 (default: 5). Higher = surfaced more often.",
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Optional arbitrary key/value metadata to attach.",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+SEARCH_SCHEMA = {
+    "name": "ladybug_search",
+    "description": (
+        "Keyword / full-text search across stored memories. "
+        "Fast and cheap — no LLM involved. "
+        "Use to find specific past facts by keyword, name, or phrase."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search terms.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum results (default: 8).",
+            },
+            "memory_type": {
+                "type": "string",
+                "description": "Filter by category (e.g. 'preference', 'project').",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "ladybug_recall",
+    "description": (
+        "Retrieve the most important or recent memories. "
+        "Use at conversation start to orient yourself, or when you need a "
+        "general overview of what's been stored."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum memories to return (default: 10).",
+            },
+            "min_importance": {
+                "type": "integer",
+                "description": "Only return memories at or above this importance score (default: 0).",
+            },
+            "memory_type": {
+                "type": "string",
+                "description": "Filter by category.",
+            },
+        },
+        "required": [],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "ladybug_update",
+    "description": (
+        "Update an existing memory by ID. "
+        "Use when a fact changes or the user corrects earlier information. "
+        "Omit fields you don't want to change."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "integer",
+                "description": "ID of the memory to update (from ladybug_store or ladybug_search).",
+            },
+            "content": {
+                "type": "string",
+                "description": "Replacement content (omit to keep current).",
+            },
+            "importance": {
+                "type": "integer",
+                "description": "New importance score 1–10 (omit to keep current).",
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Metadata to merge in (omit to keep current).",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+DELETE_SCHEMA = {
+    "name": "ladybug_delete",
+    "description": (
+        "Delete a memory by ID. "
+        "Use when the user asks you to forget something, or when a stored "
+        "fact is clearly no longer true."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "integer",
+                "description": "ID of the memory to delete.",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+LINK_SCHEMA = {
+    "name": "ladybug_link",
+    "description": (
+        "Create a named relationship edge between two memories. "
+        "Use to make explicit connections: 'Alice works-at Acme', "
+        "'project-X depends-on library-Y'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "source_id": {
+                "type": "integer",
+                "description": "ID of the source memory.",
+            },
+            "target_id": {
+                "type": "integer",
+                "description": "ID of the target memory.",
+            },
+            "relation": {
+                "type": "string",
+                "description": "Relationship label (e.g. 'works-at', 'depends-on', 'related'). Default: 'related'.",
+            },
+        },
+        "required": ["source_id", "target_id"],
+    },
+}
+
+RELATED_SCHEMA = {
+    "name": "ladybug_related",
+    "description": (
+        "Traverse the memory graph to find related entries. "
+        "Use to discover connections: what else is linked to a given memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "integer",
+                "description": "ID of the memory to start from.",
+            },
+            "relation": {
+                "type": "string",
+                "description": "Filter by relationship label (omit for all relations).",
+            },
+            "max_depth": {
+                "type": "integer",
+                "description": "Traversal depth (default: 1).",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+ENTITY_SCHEMA = {
+    "name": "ladybug_entity",
+    "description": (
+        "Entity-level knowledge graph queries powered by GLiNER2. "
+        "Three actions:\n"
+        "• extract — extract entities from a text snippet\n"
+        "• search  — find memories mentioning a specific entity\n"
+        "• graph   — explore entity relationships by entity ID\n"
+        "Requires GLiNER2 to be installed; returns an error if unavailable."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["extract", "search", "graph"],
+                "description": "What to do.",
+            },
+            "content": {
+                "type": "string",
+                "description": "Text to extract entities from (required for 'extract').",
+            },
+            "entity_name": {
+                "type": "string",
+                "description": "Entity name to search for (required for 'search').",
+            },
+            "entity_id": {
+                "type": "string",
+                "description": "Entity ID to build a graph for (required for 'graph').",
+            },
+            "labels": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Entity type labels for extraction (optional).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results for 'search' (default: 5).",
+            },
+            "max_depth": {
+                "type": "integer",
+                "description": "Graph traversal depth for 'graph' (default: 1).",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _entry_to_dict(entry) -> dict:
+    """Convert a MemoryEntry dataclass to a JSON-serialisable dict."""
+    return {
+        "id": entry.id,
+        "content": entry.content,
+        "memory_type": entry.memory_type,
+        "importance": entry.importance,
+        "metadata": entry.metadata or {},
+        "created_at": entry.created_at.isoformat() if entry.created_at else None,
+        "updated_at": entry.updated_at.isoformat() if entry.updated_at else None,
+    }
+
+
+def _result_to_dict(result) -> dict:
+    """Convert a MemorySearchResult dataclass to a JSON-serialisable dict."""
+    return {
+        "score": result.score,
+        **_entry_to_dict(result.entry),
+    }
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class LadybugMemoryProvider(MemoryProvider):
+    """Local LadybugMemory (*.lbdb) columnar embedded graph database provider with BM25 and graph edges."""
+
+    def __init__(self):
+        self._db: Optional[Any] = None          # LadybugMemory instance
+        self._db_path: str = ""
+        self._prefetch_limit: int = 6
+        self._min_importance: int = 3
+        self._auto_link: bool = False
+        self._last_stored_id: Optional[int] = None  # for auto-link chaining
+
+        # Background prefetch state
+        self._prefetch_result: str = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+
+    # -- Identity ------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "ladybug"
+
+    # -- Availability --------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Return True when the 'memory' package (LadybugMemory) is installed."""
+        return importlib.util.find_spec("lbmemory") is not None
+
+    # -- Config schema -------------------------------------------------------
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        from hermes_constants import display_hermes_home
+        default_db = f"{display_hermes_home()}/ladybug.lbdb"
+        return [
+            {
+                "key": "db_path",
+                "description": "Path to the Ladybug database file",
+                "default": default_db,
+            },
+            {
+                "key": "prefetch_limit",
+                "description": "Number of memories to surface before each turn",
+                "default": "6",
+            },
+            {
+                "key": "min_importance",
+                "description": "Minimum importance score for prefetch recall (0–10)",
+                "default": "3",
+            },
+            {
+                "key": "auto_link",
+                "description": "Auto-link mirrored built-in memory writes",
+                "default": "false",
+                "choices": ["true", "false"],
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Write config to config.yaml under memory.ladybug."""
+        from pathlib import Path
+        config_path = Path(hermes_home) / "config.yaml"
+        try:
+            import yaml
+            existing: dict = {}
+            if config_path.exists():
+                with open(config_path) as f:
+                    existing = yaml.safe_load(f) or {}
+            existing.setdefault("memory", {})
+            existing["memory"].setdefault("ladybug", {})
+            existing["memory"]["ladybug"].update(values)
+            with open(config_path, "w") as f:
+                yaml.dump(existing, f, default_flow_style=False)
+        except Exception as e:
+            logger.warning("Ladybug save_config failed: %s", e)
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Open (or create) the Ladybug database for this session."""
+        try:
+            from lbmemory import LadybugMemory
+        except ImportError:
+            logger.warning(
+                "Ladybug plugin: 'memory' package not installed. "
+                "Run: pip install ladybug-memory"
+            )
+            return
+
+        # Resolve DB path
+        from hermes_constants import get_hermes_home
+        hermes_home = kwargs.get("hermes_home", str(get_hermes_home()))
+        hermes_home_path = hermes_home  # str
+
+        # Read plugin config from config.yaml (memory.ladybug section)
+        plugin_cfg = self._load_plugin_config(hermes_home_path)
+
+        import os
+        raw_db_path = plugin_cfg.get("db_path", "")
+        if raw_db_path:
+            # Expand $HERMES_HOME placeholder in user-supplied paths
+            raw_db_path = raw_db_path.replace("$HERMES_HOME", hermes_home_path)
+            raw_db_path = raw_db_path.replace("${HERMES_HOME}", hermes_home_path)
+            raw_db_path = os.path.expanduser(raw_db_path)
+            self._db_path = raw_db_path
+        else:
+            self._db_path = os.path.join(hermes_home_path, "ladybug.lbdb")
+
+        self._prefetch_limit = int(plugin_cfg.get("prefetch_limit", 6))
+        self._min_importance = int(plugin_cfg.get("min_importance", 3))
+        self._auto_link = str(plugin_cfg.get("auto_link", "false")).lower() == "true"
+
+        try:
+            self._db = LadybugMemory(self._db_path, enable_entity_extraction=True)
+            logger.info("Ladybug opened at %s (%d entries)", self._db_path, self._db.count())
+        except ImportError:
+            # GLiNER2 / extract extra not installed — open without entity extraction.
+            # ladybug_entity tool will still exist but will return a clear error message.
+            logger.debug(
+                "Ladybug: GLiNER2 not installed, opening without entity extraction "
+                "(install ladybug-memory[extract] to enable ladybug_entity)"
+            )
+            try:
+                self._db = LadybugMemory(self._db_path, enable_entity_extraction=False)
+                logger.info(
+                    "Ladybug opened at %s (%d entries, no entity extraction)",
+                    self._db_path,
+                    self._db.count(),
+                )
+            except Exception as e:
+                logger.warning("Ladybug failed to open %s: %s", self._db_path, e)
+                self._db = None
+        except Exception as e:
+            logger.warning("Ladybug failed to open %s: %s", self._db_path, e)
+            self._db = None
+
+    @staticmethod
+    def _load_plugin_config(hermes_home: str) -> dict:
+        """Read memory.ladybug section from config.yaml."""
+        import os
+        config_path = os.path.join(hermes_home, "config.yaml")
+        try:
+            import yaml
+            with open(config_path) as f:
+                all_cfg = yaml.safe_load(f) or {}
+            return all_cfg.get("memory", {}).get("ladybug", {}) or {}
+        except Exception:
+            return {}
+
+    def shutdown(self) -> None:
+        """Wait for any running prefetch thread and release resources."""
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=5.0)
+        self._db = None
+
+    # -- System prompt -------------------------------------------------------
+
+    def system_prompt_block(self) -> str:
+        if not self._db:
+            return ""
+        try:
+            total = self._db.count()
+        except Exception:
+            total = 0
+        if total == 0:
+            return (
+                "# Ladybug Memory\n"
+                "Active (empty). Use ladybug_store to persist facts, preferences, "
+                "decisions, and context the user would expect you to remember across sessions."
+            )
+        return (
+            f"# Ladybug Memory\n"
+            f"Active. {total} memories stored locally.\n"
+            "Use ladybug_search / ladybug_recall to retrieve context, "
+            "ladybug_store to add new memories, ladybug_update to correct old ones."
+        )
+
+    # -- Prefetch ------------------------------------------------------------
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Kick off a background recall + search for the next turn."""
+        if not self._db:
+            return
+
+        def _run(q: str) -> None:
+            try:
+                lines: List[str] = []
+
+                # 1. Importance-weighted recent recall
+                recalled = self._db.recall(
+                    limit=self._prefetch_limit,
+                    min_importance=self._min_importance,
+                )
+                for entry in recalled:
+                    lines.append(f"[{entry.memory_type}:{entry.importance}] {entry.content}")
+
+                # 2. Query-relevant keyword search (deduplicated)
+                if q:
+                    seen_ids = {e.id for e in recalled}
+                    results = self._db.search(q, limit=self._prefetch_limit)
+                    for r in results:
+                        if r.entry.id not in seen_ids:
+                            lines.append(f"[{r.entry.memory_type}:{r.entry.importance}] {r.entry.content}")
+                            seen_ids.add(r.entry.id)
+
+                text = "\n".join(f"- {l}" for l in lines) if lines else ""
+                with self._prefetch_lock:
+                    self._prefetch_result = text
+            except Exception as e:
+                logger.debug("Ladybug prefetch failed: %s", e)
+
+        # Cancel any still-running prefetch before starting a new one
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=2.0)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, args=(query,), daemon=True, name="ladybug-prefetch"
+        )
+        self._prefetch_thread.start()
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return cached prefetch result (collected by the background thread)."""
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Ladybug Memory\n{result}"
+
+    # -- Turn sync -----------------------------------------------------------
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Ladybug is tool-driven; automatic ingestion is not performed."""
+
+    # -- Tools ---------------------------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            STORE_SCHEMA,
+            SEARCH_SCHEMA,
+            RECALL_SCHEMA,
+            UPDATE_SCHEMA,
+            DELETE_SCHEMA,
+            LINK_SCHEMA,
+            RELATED_SCHEMA,
+            ENTITY_SCHEMA,
+        ]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if not self._db:
+            return json.dumps({"error": "Ladybug database is not initialised."})
+
+        try:
+            if tool_name == "ladybug_store":
+                return self._tool_store(args)
+            elif tool_name == "ladybug_search":
+                return self._tool_search(args)
+            elif tool_name == "ladybug_recall":
+                return self._tool_recall(args)
+            elif tool_name == "ladybug_update":
+                return self._tool_update(args)
+            elif tool_name == "ladybug_delete":
+                return self._tool_delete(args)
+            elif tool_name == "ladybug_link":
+                return self._tool_link(args)
+            elif tool_name == "ladybug_related":
+                return self._tool_related(args)
+            elif tool_name == "ladybug_entity":
+                return self._tool_entity(args)
+            return json.dumps({"error": f"Unknown tool: {tool_name}"})
+        except Exception as e:
+            logger.exception("Ladybug tool %s failed", tool_name)
+            return json.dumps({"error": str(e)})
+
+    # -- Individual tool handlers --------------------------------------------
+
+    def _tool_store(self, args: dict) -> str:
+        content = args.get("content", "").strip()
+        if not content:
+            return json.dumps({"error": "content is required"})
+
+        entry = self._db.store(
+            content=content,
+            memory_type=args.get("memory_type", "general"),
+            importance=int(args.get("importance", 5)),
+            metadata=args.get("metadata") or None,
+        )
+        self._last_stored_id = entry.id
+        return json.dumps({"memory_id": entry.id, "status": "stored"})
+
+    def _tool_search(self, args: dict) -> str:
+        query = args.get("query", "").strip()
+        if not query:
+            return json.dumps({"error": "query is required"})
+
+        results = self._db.search(
+            query=query,
+            limit=int(args.get("limit", 8)),
+            memory_type=args.get("memory_type") or None,
+        )
+        return json.dumps({
+            "results": [_result_to_dict(r) for r in results],
+            "count": len(results),
+        })
+
+    def _tool_recall(self, args: dict) -> str:
+        entries = self._db.recall(
+            limit=int(args.get("limit", 10)),
+            min_importance=int(args.get("min_importance", 0)),
+            memory_type=args.get("memory_type") or None,
+        )
+        return json.dumps({
+            "memories": [_entry_to_dict(e) for e in entries],
+            "count": len(entries),
+        })
+
+    def _tool_update(self, args: dict) -> str:
+        memory_id = args.get("memory_id")
+        if memory_id is None:
+            return json.dumps({"error": "memory_id is required"})
+
+        entry = self._db.update(
+            memory_id=str(memory_id),
+            content=args.get("content") or None,
+            importance=int(args["importance"]) if "importance" in args else None,
+            metadata=args.get("metadata") or None,
+        )
+        if entry is None:
+            return json.dumps({"error": f"Memory {memory_id} not found"})
+        return json.dumps({"status": "updated", **_entry_to_dict(entry)})
+
+    def _tool_delete(self, args: dict) -> str:
+        memory_id = args.get("memory_id")
+        if memory_id is None:
+            return json.dumps({"error": "memory_id is required"})
+
+        ok = self._db.delete(str(memory_id))
+        if not ok:
+            return json.dumps({"error": f"Memory {memory_id} not found or already deleted"})
+        return json.dumps({"status": "deleted", "memory_id": memory_id})
+
+    def _tool_link(self, args: dict) -> str:
+        source_id = args.get("source_id")
+        target_id = args.get("target_id")
+        if source_id is None or target_id is None:
+            return json.dumps({"error": "source_id and target_id are required"})
+
+        ok = self._db.link(
+            source_id=str(source_id),
+            target_id=str(target_id),
+            relation=args.get("relation", "related"),
+        )
+        if not ok:
+            return json.dumps({"error": "Failed to create link (one or both IDs may not exist)"})
+        return json.dumps({
+            "status": "linked",
+            "source_id": source_id,
+            "target_id": target_id,
+            "relation": args.get("relation", "related"),
+        })
+
+    def _tool_related(self, args: dict) -> str:
+        memory_id = args.get("memory_id")
+        if memory_id is None:
+            return json.dumps({"error": "memory_id is required"})
+
+        pairs = self._db.get_related(
+            memory_id=str(memory_id),
+            relation=args.get("relation") or None,
+            max_depth=int(args.get("max_depth", 1)),
+        )
+        items = []
+        for entry, relation in pairs:
+            items.append({"relation": relation, **_entry_to_dict(entry)})
+        return json.dumps({"related": items, "count": len(items)})
+
+    def _tool_entity(self, args: dict) -> str:
+        action = args.get("action", "")
+        if not action:
+            return json.dumps({"error": "action is required"})
+
+        try:
+            if action == "extract":
+                content = args.get("content", "")
+                if not content:
+                    return json.dumps({"error": "content is required for extract"})
+                entities = self._db.extract_entities(
+                    content=content,
+                    labels=args.get("labels") or None,
+                )
+                # Entity objects may not be JSON-serialisable — coerce to str
+                return json.dumps({
+                    "entities": [
+                        e if isinstance(e, (str, dict)) else str(e)
+                        for e in entities
+                    ],
+                    "count": len(entities),
+                })
+
+            elif action == "search":
+                entity_name = args.get("entity_name", "")
+                if not entity_name:
+                    return json.dumps({"error": "entity_name is required for search"})
+                memories = self._db.search_by_entity(
+                    entity_name=entity_name,
+                    limit=int(args.get("limit", 5)),
+                )
+                return json.dumps({
+                    "memories": [
+                        m if isinstance(m, dict) else str(m)
+                        for m in memories
+                    ],
+                    "count": len(memories),
+                })
+
+            elif action == "graph":
+                entity_id = args.get("entity_id", "")
+                if not entity_id:
+                    return json.dumps({"error": "entity_id is required for graph"})
+                graph = self._db.get_entity_graph(
+                    entity_id=entity_id,
+                    max_depth=int(args.get("max_depth", 1)),
+                )
+                return json.dumps(graph)
+
+            return json.dumps({"error": f"Unknown action: {action}"})
+
+        except NotImplementedError:
+            return json.dumps({
+                "error": (
+                    "Entity KG features require GLiNER2 to be installed. "
+                    "Run: pip install gliner"
+                )
+            })
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    # -- Setup hook ----------------------------------------------------------
+
+    def post_setup(self, hermes_home: str, config: dict) -> None:
+        """Called by 'hermes memory setup' after provider selection.
+
+        Writes activation to config.yaml, then attempts to open the DB
+        so the user gets immediate feedback on whether the path is valid.
+        """
+        from hermes_cli.config import save_config
+        config.setdefault("memory", {})["provider"] = "ladybug"
+        save_config(config)
+        print(f"\n  Memory provider: ladybug")
+        print(f"  Activation saved to config.yaml")
+
+        # Test DB creation at the configured path
+        self.initialize(session_id="setup-test", hermes_home=hermes_home)
+        if self._db is not None:
+            try:
+                count = self._db.count()
+            except Exception:
+                count = 0
+            print(f"  ✓ Ladybug DB opened at {self._db_path} ({count} entries)")
+            self.shutdown()
+        else:
+            print(f"  ✗ Failed to open DB at {self._db_path}")
+            print(f"    Check that the path is writable and lbmemory is installed.")
+        print()
+
+    # -- Optional hooks ------------------------------------------------------
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in MEMORY.md / USER.md writes into Ladybug."""
+        if not self._db or not content:
+            return
+
+        if action == "add":
+            try:
+                memory_type = "preference" if target == "user" else "fact"
+                entry = self._db.store(
+                    content=content,
+                    memory_type=memory_type,
+                    importance=6,  # slightly above default — explicit user signal
+                )
+                logger.debug("Ladybug mirrored built-in write → id=%d", entry.id)
+            except Exception as e:
+                logger.debug("Ladybug on_memory_write failed: %s", e)
+
+        elif action == "replace":
+            # Best-effort: search for a close match and update it
+            try:
+                results = self._db.search(content[:60], limit=1)
+                if results:
+                    self._db.update(
+                        memory_id=str(results[0].entry.id),
+                        content=content,
+                    )
+                else:
+                    memory_type = "preference" if target == "user" else "fact"
+                    self._db.store(content=content, memory_type=memory_type, importance=6)
+            except Exception as e:
+                logger.debug("Ladybug on_memory_write (replace) failed: %s", e)
+
+    def on_pre_compress(self, messages) -> str:
+        """Surface high-importance memories to include in compression summary."""
+        if not self._db:
+            return ""
+        try:
+            entries = self._db.recall(limit=5, min_importance=7)
+            if not entries:
+                return ""
+            lines = [f"- [{e.memory_type}] {e.content}" for e in entries]
+            return "Key Ladybug memories (importance ≥ 7):\n" + "\n".join(lines)
+        except Exception:
+            return ""
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register LadybugMemoryProvider with the plugin system."""
+    ctx.register_memory_provider(LadybugMemoryProvider())

--- a/plugins/memory/ladybug/plugin.yaml
+++ b/plugins/memory/ladybug/plugin.yaml
@@ -1,0 +1,7 @@
+name: ladybug
+version: 1.0.0
+description: "Ladybug — local columnar graph database (*.lbdb) with BM25 search, importance scoring, graph edges, and optional GLiNER2 entity extraction."
+pip_dependencies:
+  - ladybug-memory
+optional_dependencies:
+  - gliner   # for entity KG features (ladybug_entity tool)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ pty = [
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
 ]
 honcho = ["honcho-ai>=2.0.1,<3"]
+ladybug = ["ladybug-memory>=0.1.4,<1"]
 mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
@@ -87,6 +88,7 @@ all = [
   "hermes-agent[slack]",
   "hermes-agent[pty]",
   "hermes-agent[honcho]",
+  "hermes-agent[ladybug]",
   "hermes-agent[mcp]",
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",

--- a/tests/agent/test_ladybug_memory_plugin.py
+++ b/tests/agent/test_ladybug_memory_plugin.py
@@ -1,0 +1,952 @@
+"""Tests for the Ladybug memory plugin (plugins/memory/ladybug/).
+
+Uses a mock LadybugMemory (built from ladybug_intf.AgentMemory) so the
+tests run with no external dependencies. All tool handlers, lifecycle
+hooks, prefetch, and MemoryManager integration are covered.
+
+Run with:
+    python -m pytest tests/agent/test_ladybug_memory_plugin.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import time
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.memory_manager import MemoryManager
+from agent.builtin_memory_provider import BuiltinMemoryProvider
+from memory.interface import AgentMemory, MemoryEntry, MemorySearchResult
+from plugins.memory.ladybug import LadybugMemoryProvider
+
+
+# ---------------------------------------------------------------------------
+# In-process mock LadybugMemory (implements AgentMemory ABC)
+# ---------------------------------------------------------------------------
+
+
+class MockLadybugMemory(AgentMemory):
+    """Full in-memory implementation of AgentMemory for testing."""
+
+    def __init__(self, db_path: str = ":memory:"):
+        self.db_path = db_path
+        self._entries: dict[int, MemoryEntry] = {}
+        self._next_id = 1
+        self._links: list[tuple[str, str, str]] = []  # (src, tgt, relation)
+
+    # -- Core CRUD -----------------------------------------------------------
+
+    def store(
+        self,
+        content: str,
+        memory_type: str = "general",
+        importance: int = 5,
+        metadata: dict[str, Any] | None = None,
+    ) -> MemoryEntry:
+        entry = MemoryEntry(
+            id=self._next_id,
+            content=content,
+            memory_type=memory_type,
+            importance=importance,
+            metadata=metadata,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        self._entries[self._next_id] = entry
+        self._next_id += 1
+        return entry
+
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        memory_type: str | None = None,
+    ) -> list[MemorySearchResult]:
+        results = []
+        for e in self._entries.values():
+            if query.lower() in e.content.lower():
+                if memory_type is None or e.memory_type == memory_type:
+                    results.append(MemorySearchResult(entry=e, score=0.9))
+        return results[:limit]
+
+    def semantic_search(
+        self,
+        query: str,
+        limit: int = 5,
+        memory_type: str | None = None,
+    ) -> list[MemorySearchResult]:
+        return self.search(query, limit, memory_type)
+
+    def recall(
+        self,
+        limit: int = 10,
+        min_importance: int = 0,
+        memory_type: str | None = None,
+    ) -> list[MemoryEntry]:
+        entries = [
+            e for e in self._entries.values()
+            if e.importance >= min_importance
+            and (memory_type is None or e.memory_type == memory_type)
+        ]
+        entries.sort(key=lambda e: e.importance, reverse=True)
+        return entries[:limit]
+
+    def get(self, memory_id: str) -> MemoryEntry | None:
+        return self._entries.get(int(memory_id))
+
+    def update(
+        self,
+        memory_id: str,
+        content: str | None = None,
+        importance: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> MemoryEntry | None:
+        entry = self._entries.get(int(memory_id))
+        if entry is None:
+            return None
+        new_entry = MemoryEntry(
+            id=entry.id,
+            content=content if content is not None else entry.content,
+            memory_type=entry.memory_type,
+            importance=importance if importance is not None else entry.importance,
+            metadata=metadata if metadata is not None else entry.metadata,
+            created_at=entry.created_at,
+            updated_at=datetime.now(),
+        )
+        self._entries[entry.id] = new_entry
+        return new_entry
+
+    def delete(self, memory_id: str) -> bool:
+        return self._entries.pop(int(memory_id), None) is not None
+
+    def link(
+        self,
+        source_id: str,
+        target_id: str,
+        relation: str = "related",
+        start_timestamp=None,
+        end_timestamp=None,
+    ) -> bool:
+        self._links.append((source_id, target_id, relation))
+        return True
+
+    def get_related(
+        self,
+        memory_id: str,
+        relation: str | None = None,
+        max_depth: int = 1,
+    ) -> list[tuple[MemoryEntry, str]]:
+        results = []
+        for src, tgt, rel in self._links:
+            if src == str(memory_id):
+                if relation is None or rel == relation:
+                    entry = self._entries.get(int(tgt))
+                    if entry:
+                        results.append((entry, rel))
+        return results
+
+    def count(self) -> int:
+        return len(self._entries)
+
+    # -- Entity KG (GLiNER2) -------------------------------------------------
+
+    def extract_entities(self, content, labels=None, threshold=None):
+        raise NotImplementedError("GLiNER2 not available in tests")
+
+    def search_by_entity(self, entity_name, limit=5):
+        raise NotImplementedError("GLiNER2 not available in tests")
+
+    def get_entity_graph(self, entity_id, max_depth=1):
+        raise NotImplementedError("GLiNER2 not available in tests")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db() -> MockLadybugMemory:
+    return MockLadybugMemory()
+
+
+@pytest.fixture
+def provider(db: MockLadybugMemory) -> LadybugMemoryProvider:
+    """LadybugMemoryProvider wired to a fresh in-memory mock DB."""
+    p = LadybugMemoryProvider()
+    p._db = db
+    p._prefetch_limit = 6
+    p._min_importance = 3
+    return p
+
+
+# ---------------------------------------------------------------------------
+# is_available
+# ---------------------------------------------------------------------------
+
+
+class TestIsAvailable:
+    def test_available_when_memory_installed(self):
+        p = LadybugMemoryProvider()
+        with patch.object(importlib.util, "find_spec", return_value=MagicMock()):
+            assert p.is_available() is True
+
+    def test_unavailable_when_memory_not_installed(self):
+        p = LadybugMemoryProvider()
+        with patch.object(importlib.util, "find_spec", return_value=None):
+            assert p.is_available() is False
+
+    def test_no_import_side_effects(self):
+        """is_available must not import 'memory' — only inspect the spec."""
+        p = LadybugMemoryProvider()
+        import sys
+        sys.modules.pop("memory", None)
+        # Should not raise even if the package doesn't exist
+        result = p.is_available()
+        assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# initialize
+# ---------------------------------------------------------------------------
+
+
+class TestInitialize:
+    def test_opens_db_at_hermes_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db_path = str(tmp_path / "ladybug.lbdb")
+
+        mock_db = MockLadybugMemory(db_path)
+        fake_cls = MagicMock(return_value=mock_db)
+
+        with patch.dict("sys.modules", {"memory": MagicMock(LadybugMemory=fake_cls)}):
+            p = LadybugMemoryProvider()
+            p.initialize("sess-1", hermes_home=str(tmp_path))
+
+        fake_cls.assert_called_once_with(db_path)
+        assert p._db is mock_db
+
+    def test_expand_hermes_home_in_db_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = {"db_path": "$HERMES_HOME/custom.lbdb"}
+
+        fake_cls = MagicMock(return_value=MockLadybugMemory())
+        with patch.object(LadybugMemoryProvider, "_load_plugin_config", return_value=config):
+            with patch.dict("sys.modules", {"memory": MagicMock(LadybugMemory=fake_cls)}):
+                p = LadybugMemoryProvider()
+                p.initialize("sess-1", hermes_home=str(tmp_path))
+
+        expected = str(tmp_path / "custom.lbdb")
+        fake_cls.assert_called_once_with(expected)
+
+    def test_missing_package_leaves_db_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = LadybugMemoryProvider()
+        # Simulate ImportError from 'from memory import LadybugMemory'
+        with patch.dict("sys.modules", {"memory": None}):
+            p.initialize("sess-1", hermes_home=str(tmp_path))
+        assert p._db is None
+
+    def test_reads_prefetch_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = {"prefetch_limit": "12", "min_importance": "7"}
+
+        fake_cls = MagicMock(return_value=MockLadybugMemory())
+        with patch.object(LadybugMemoryProvider, "_load_plugin_config", return_value=config):
+            with patch.dict("sys.modules", {"memory": MagicMock(LadybugMemory=fake_cls)}):
+                p = LadybugMemoryProvider()
+                p.initialize("sess-1", hermes_home=str(tmp_path))
+
+        assert p._prefetch_limit == 12
+        assert p._min_importance == 7
+
+
+# ---------------------------------------------------------------------------
+# system_prompt_block
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptBlock:
+    def test_empty_store(self, provider, db):
+        block = provider.system_prompt_block()
+        assert "Ladybug Memory" in block
+        assert "empty" in block.lower()
+
+    def test_with_entries(self, provider, db):
+        db.store("User prefers dark mode")
+        db.store("Project: Athena")
+        block = provider.system_prompt_block()
+        assert "2 memories" in block
+        assert "empty" not in block.lower()
+
+    def test_no_db_returns_empty(self):
+        p = LadybugMemoryProvider()
+        p._db = None
+        assert p.system_prompt_block() == ""
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_store
+# ---------------------------------------------------------------------------
+
+
+class TestToolStore:
+    def test_store_basic(self, provider, db):
+        r = json.loads(provider.handle_tool_call("ladybug_store", {"content": "Dark mode preferred"}))
+        assert r["status"] == "stored"
+        assert "memory_id" in r
+        assert db.count() == 1
+
+    def test_store_sets_type_and_importance(self, provider, db):
+        provider.handle_tool_call("ladybug_store", {
+            "content": "Loves Python",
+            "memory_type": "preference",
+            "importance": 9,
+        })
+        entry = list(db._entries.values())[0]
+        assert entry.memory_type == "preference"
+        assert entry.importance == 9
+
+    def test_store_defaults(self, provider, db):
+        provider.handle_tool_call("ladybug_store", {"content": "Some fact"})
+        entry = list(db._entries.values())[0]
+        assert entry.memory_type == "general"
+        assert entry.importance == 5
+
+    def test_store_with_metadata(self, provider, db):
+        provider.handle_tool_call("ladybug_store", {
+            "content": "Deploy on Fridays",
+            "metadata": {"source": "retro"},
+        })
+        entry = list(db._entries.values())[0]
+        assert entry.metadata == {"source": "retro"}
+
+    def test_store_missing_content_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_store", {}))
+        assert "error" in r
+
+    def test_store_empty_content_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_store", {"content": "   "}))
+        assert "error" in r
+
+    def test_store_no_db_returns_error(self):
+        p = LadybugMemoryProvider()
+        p._db = None
+        r = json.loads(p.handle_tool_call("ladybug_store", {"content": "Anything"}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_search
+# ---------------------------------------------------------------------------
+
+
+class TestToolSearch:
+    def test_search_finds_match(self, provider, db):
+        db.store("User loves Python")
+        db.store("User hates YAML")
+
+        r = json.loads(provider.handle_tool_call("ladybug_search", {"query": "Python"}))
+        assert r["count"] == 1
+        assert "Python" in r["results"][0]["content"]
+
+    def test_search_returns_score(self, provider, db):
+        db.store("Python developer")
+        r = json.loads(provider.handle_tool_call("ladybug_search", {"query": "Python"}))
+        assert "score" in r["results"][0]
+
+    def test_search_limit_respected(self, provider, db):
+        for i in range(10):
+            db.store(f"Python fact {i}")
+        r = json.loads(provider.handle_tool_call("ladybug_search", {"query": "Python", "limit": 3}))
+        assert r["count"] <= 3
+
+    def test_search_memory_type_filter(self, provider, db):
+        db.store("Python pref", memory_type="preference")
+        db.store("Python fact", memory_type="fact")
+        r = json.loads(provider.handle_tool_call("ladybug_search", {"query": "Python", "memory_type": "preference"}))
+        assert all(m["memory_type"] == "preference" for m in r["results"])
+
+    def test_search_no_match_returns_empty(self, provider, db):
+        db.store("Loves Rust")
+        r = json.loads(provider.handle_tool_call("ladybug_search", {"query": "Python"}))
+        assert r["count"] == 0
+        assert r["results"] == []
+
+    def test_search_missing_query_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_search", {}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_recall
+# ---------------------------------------------------------------------------
+
+
+class TestToolRecall:
+    def test_recall_all(self, provider, db):
+        db.store("low", importance=2)
+        db.store("high", importance=8)
+        r = json.loads(provider.handle_tool_call("ladybug_recall", {}))
+        assert r["count"] == 2
+
+    def test_recall_min_importance_filter(self, provider, db):
+        db.store("low", importance=2)
+        db.store("high", importance=8)
+        r = json.loads(provider.handle_tool_call("ladybug_recall", {"min_importance": 5}))
+        assert r["count"] == 1
+        assert r["memories"][0]["importance"] == 8
+
+    def test_recall_sorted_by_importance(self, provider, db):
+        db.store("medium", importance=5)
+        db.store("high", importance=9)
+        db.store("low", importance=1)
+        r = json.loads(provider.handle_tool_call("ladybug_recall", {}))
+        importances = [m["importance"] for m in r["memories"]]
+        assert importances == sorted(importances, reverse=True)
+
+    def test_recall_limit(self, provider, db):
+        for i in range(10):
+            db.store(f"Memory {i}", importance=i)
+        r = json.loads(provider.handle_tool_call("ladybug_recall", {"limit": 3}))
+        assert len(r["memories"]) <= 3
+
+    def test_recall_type_filter(self, provider, db):
+        db.store("pref", memory_type="preference")
+        db.store("fact", memory_type="fact")
+        r = json.loads(provider.handle_tool_call("ladybug_recall", {"memory_type": "preference"}))
+        assert all(m["memory_type"] == "preference" for m in r["memories"])
+
+    def test_recall_entry_has_expected_fields(self, provider, db):
+        db.store("Test memory", memory_type="fact", importance=7)
+        r = json.loads(provider.handle_tool_call("ladybug_recall", {}))
+        m = r["memories"][0]
+        for field in ("id", "content", "memory_type", "importance", "metadata"):
+            assert field in m
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_update
+# ---------------------------------------------------------------------------
+
+
+class TestToolUpdate:
+    def test_update_content(self, provider, db):
+        entry = db.store("Old content")
+        r = json.loads(provider.handle_tool_call("ladybug_update", {
+            "memory_id": entry.id,
+            "content": "New content",
+        }))
+        assert r["status"] == "updated"
+        assert r["content"] == "New content"
+
+    def test_update_importance(self, provider, db):
+        entry = db.store("Fact", importance=5)
+        r = json.loads(provider.handle_tool_call("ladybug_update", {
+            "memory_id": entry.id,
+            "importance": 9,
+        }))
+        assert r["importance"] == 9
+        assert r["content"] == "Fact"  # unchanged
+
+    def test_update_nonexistent_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_update", {"memory_id": 9999}))
+        assert "error" in r
+
+    def test_update_missing_id_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_update", {"content": "x"}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_delete
+# ---------------------------------------------------------------------------
+
+
+class TestToolDelete:
+    def test_delete_existing(self, provider, db):
+        entry = db.store("To be deleted")
+        r = json.loads(provider.handle_tool_call("ladybug_delete", {"memory_id": entry.id}))
+        assert r["status"] == "deleted"
+        assert db.count() == 0
+
+    def test_delete_nonexistent_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_delete", {"memory_id": 9999}))
+        assert "error" in r
+
+    def test_delete_missing_id_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_delete", {}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_link
+# ---------------------------------------------------------------------------
+
+
+class TestToolLink:
+    def test_link_creates_edge(self, provider, db):
+        e1 = db.store("Alice")
+        e2 = db.store("Acme Corp")
+        r = json.loads(provider.handle_tool_call("ladybug_link", {
+            "source_id": e1.id,
+            "target_id": e2.id,
+            "relation": "works-at",
+        }))
+        assert r["status"] == "linked"
+        assert r["relation"] == "works-at"
+
+    def test_link_default_relation(self, provider, db):
+        e1 = db.store("A")
+        e2 = db.store("B")
+        r = json.loads(provider.handle_tool_call("ladybug_link", {
+            "source_id": e1.id,
+            "target_id": e2.id,
+        }))
+        assert r["relation"] == "related"
+
+    def test_link_missing_ids_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_link", {"source_id": 1}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_related
+# ---------------------------------------------------------------------------
+
+
+class TestToolRelated:
+    def test_related_finds_linked_entries(self, provider, db):
+        src = db.store("Alice")
+        tgt = db.store("Acme")
+        db.link(str(src.id), str(tgt.id), "works-at")
+
+        r = json.loads(provider.handle_tool_call("ladybug_related", {"memory_id": src.id}))
+        assert r["count"] == 1
+        assert r["related"][0]["content"] == "Acme"
+        assert r["related"][0]["relation"] == "works-at"
+
+    def test_related_relation_filter(self, provider, db):
+        src = db.store("Alice")
+        t1 = db.store("Acme")
+        t2 = db.store("Python")
+        db.link(str(src.id), str(t1.id), "works-at")
+        db.link(str(src.id), str(t2.id), "uses")
+
+        r = json.loads(provider.handle_tool_call("ladybug_related", {
+            "memory_id": src.id,
+            "relation": "works-at",
+        }))
+        assert r["count"] == 1
+        assert r["related"][0]["content"] == "Acme"
+
+    def test_related_no_links_returns_empty(self, provider, db):
+        e = db.store("Lonely entry")
+        r = json.loads(provider.handle_tool_call("ladybug_related", {"memory_id": e.id}))
+        assert r["count"] == 0
+        assert r["related"] == []
+
+    def test_related_missing_id_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_related", {}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Tools: ladybug_entity (GLiNER2 graceful degradation)
+# ---------------------------------------------------------------------------
+
+
+class TestToolEntity:
+    def test_extract_no_gliner_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {
+            "action": "extract",
+            "content": "Alice works at Acme",
+        }))
+        assert "error" in r
+        assert "GLiNER2" in r["error"]
+
+    def test_search_entity_no_gliner_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {
+            "action": "search",
+            "entity_name": "Alice",
+        }))
+        assert "error" in r
+
+    def test_graph_no_gliner_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {
+            "action": "graph",
+            "entity_id": "ent-1",
+        }))
+        assert "error" in r
+
+    def test_extract_missing_content_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {"action": "extract"}))
+        assert "error" in r
+
+    def test_search_missing_entity_name_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {"action": "search"}))
+        assert "error" in r
+
+    def test_graph_missing_entity_id_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {"action": "graph"}))
+        assert "error" in r
+
+    def test_unknown_action_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {"action": "frobnicate"}))
+        assert "error" in r
+
+    def test_extract_with_gliner_available(self, provider, db):
+        """When GLiNER2 IS available, extract should return entity list."""
+        entities = [{"text": "Alice", "label": "PERSON"}, {"text": "Acme", "label": "ORG"}]
+        db.extract_entities = MagicMock(return_value=entities)
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {
+            "action": "extract",
+            "content": "Alice works at Acme",
+        }))
+        assert r["count"] == 2
+        assert r["entities"] == entities
+
+    def test_search_entity_with_gliner_available(self, provider, db):
+        memories = [{"id": 1, "content": "Alice works at Acme"}]
+        db.search_by_entity = MagicMock(return_value=memories)
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {
+            "action": "search",
+            "entity_name": "Alice",
+            "limit": 3,
+        }))
+        assert r["count"] == 1
+        db.search_by_entity.assert_called_once_with(entity_name="Alice", limit=3)
+
+    def test_graph_with_gliner_available(self, provider, db):
+        graph = {"entity": "Alice", "related": [{"entity": "Acme", "relation": "works-at"}]}
+        db.get_entity_graph = MagicMock(return_value=graph)
+        r = json.loads(provider.handle_tool_call("ladybug_entity", {
+            "action": "graph",
+            "entity_id": "ent-alice",
+            "max_depth": 2,
+        }))
+        assert "entity" in r
+        db.get_entity_graph.assert_called_once_with(entity_id="ent-alice", max_depth=2)
+
+
+# ---------------------------------------------------------------------------
+# Unknown tool
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownTool:
+    def test_unknown_tool_returns_error(self, provider):
+        r = json.loads(provider.handle_tool_call("ladybug_frobnicate", {}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Prefetch
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetch:
+    def test_prefetch_returns_empty_with_no_memories(self, provider):
+        assert provider.prefetch("anything") == ""
+
+    def test_queue_then_prefetch(self, provider, db):
+        db.store("User loves dark mode", importance=8)
+        db.store("Afternoon standup at 3pm", importance=6)
+
+        provider.queue_prefetch("dark mode")
+        # Give the background thread time to finish
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=3.0)
+
+        result = provider.prefetch("dark mode")
+        assert "Ladybug Memory" in result
+        assert "dark mode" in result.lower()
+
+    def test_prefetch_deduplicates_recall_and_search(self, provider, db):
+        """An entry matching both recall and search should appear only once."""
+        e = db.store("dark mode preference", importance=8)
+
+        provider.queue_prefetch("dark mode")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=3.0)
+
+        result = provider.prefetch("dark mode")
+        # Count occurrences of the memory content
+        assert result.count("dark mode preference") == 1
+
+    def test_prefetch_min_importance_filters_recall(self, provider, db):
+        db.store("low importance fact", importance=1)
+        provider._min_importance = 5
+
+        provider.queue_prefetch("")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=3.0)
+
+        result = provider.prefetch("")
+        assert "low importance fact" not in result
+
+    def test_prefetch_clears_after_consumption(self, provider, db):
+        db.store("Important fact", importance=9)
+
+        provider.queue_prefetch("fact")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=3.0)
+
+        provider.prefetch("fact")        # consumes the result
+        second = provider.prefetch("fact")  # should be empty now
+        assert second == ""
+
+    def test_prefetch_db_none_does_not_raise(self):
+        p = LadybugMemoryProvider()
+        p._db = None
+        p.queue_prefetch("anything")
+        assert p.prefetch("anything") == ""
+
+
+# ---------------------------------------------------------------------------
+# on_memory_write (built-in memory mirror)
+# ---------------------------------------------------------------------------
+
+
+class TestOnMemoryWrite:
+    def test_add_stores_new_entry(self, provider, db):
+        provider.on_memory_write("add", "user", "User is a Python developer")
+        assert db.count() == 1
+        entry = list(db._entries.values())[0]
+        assert entry.content == "User is a Python developer"
+        assert entry.memory_type == "preference"
+        assert entry.importance == 6
+
+    def test_add_fact_target_uses_fact_type(self, provider, db):
+        provider.on_memory_write("add", "memory", "Deploy happens on Fridays")
+        entry = list(db._entries.values())[0]
+        assert entry.memory_type == "fact"
+
+    def test_replace_updates_existing(self, provider, db):
+        db.store("Old preference for light mode", memory_type="preference")
+        provider.on_memory_write("replace", "user", "Old preference for light mode — now dark")
+        # The entry should be updated (count stays 1) or a new one added
+        assert db.count() >= 1
+
+    def test_replace_no_match_stores_new(self, provider, db):
+        provider.on_memory_write("replace", "user", "Completely new fact with no prior match")
+        assert db.count() == 1
+
+    def test_unknown_action_is_ignored(self, provider, db):
+        provider.on_memory_write("remove", "memory", "Something")
+        assert db.count() == 0
+
+    def test_empty_content_is_ignored(self, provider, db):
+        provider.on_memory_write("add", "user", "")
+        assert db.count() == 0
+
+    def test_no_db_does_not_raise(self):
+        p = LadybugMemoryProvider()
+        p._db = None
+        p.on_memory_write("add", "user", "Should not crash")  # no exception
+
+
+# ---------------------------------------------------------------------------
+# on_pre_compress
+# ---------------------------------------------------------------------------
+
+
+class TestOnPreCompress:
+    def test_high_importance_surfaces_in_compression(self, provider, db):
+        db.store("Must never delete prod DB", importance=10)
+        db.store("Low priority note", importance=2)
+        result = provider.on_pre_compress([])
+        assert "Must never delete prod DB" in result
+        assert "Low priority note" not in result
+
+    def test_returns_empty_when_no_high_importance(self, provider, db):
+        db.store("Low fact", importance=3)
+        result = provider.on_pre_compress([])
+        assert result == ""
+
+    def test_returns_empty_when_no_db(self):
+        p = LadybugMemoryProvider()
+        p._db = None
+        assert p.on_pre_compress([]) == ""
+
+    def test_returns_empty_when_store_is_empty(self, provider):
+        assert provider.on_pre_compress([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# sync_turn (no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncTurn:
+    def test_sync_turn_does_not_store(self, provider, db):
+        provider.sync_turn("user message", "assistant reply")
+        assert db.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestShutdown:
+    def test_shutdown_clears_db(self, provider):
+        assert provider._db is not None
+        provider.shutdown()
+        assert provider._db is None
+
+    def test_shutdown_joins_prefetch_thread(self, provider, db):
+        db.store("Entry", importance=9)
+        provider.queue_prefetch("Entry")
+        # Don't wait — let shutdown join
+        provider.shutdown()
+        assert provider._prefetch_thread is None or not provider._prefetch_thread.is_alive()
+
+    def test_shutdown_no_db_does_not_raise(self):
+        p = LadybugMemoryProvider()
+        p._db = None
+        p.shutdown()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# get_tool_schemas
+# ---------------------------------------------------------------------------
+
+
+class TestToolSchemas:
+    def test_all_eight_tools_exposed(self, provider):
+        schemas = provider.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        assert names == {
+            "ladybug_store",
+            "ladybug_search",
+            "ladybug_recall",
+            "ladybug_update",
+            "ladybug_delete",
+            "ladybug_link",
+            "ladybug_related",
+            "ladybug_entity",
+        }
+
+    def test_schemas_have_required_fields(self, provider):
+        for schema in provider.get_tool_schemas():
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+
+    def test_store_requires_content(self, provider):
+        store_schema = next(s for s in provider.get_tool_schemas() if s["name"] == "ladybug_store")
+        assert "content" in store_schema["parameters"]["properties"]
+        assert "content" in store_schema["parameters"].get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# MemoryManager integration
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryManagerIntegration:
+    def test_ladybug_tools_routed_through_manager(self, db):
+        p = LadybugMemoryProvider()
+        p._db = db
+
+        mgr = MemoryManager()
+        mgr.add_provider(BuiltinMemoryProvider())
+        mgr.add_provider(p)
+
+        assert mgr.has_tool("ladybug_store")
+        assert mgr.has_tool("ladybug_search")
+        assert mgr.has_tool("ladybug_recall")
+        assert not mgr.has_tool("terminal")
+
+    def test_store_and_recall_via_manager(self, db):
+        p = LadybugMemoryProvider()
+        p._db = db
+
+        mgr = MemoryManager()
+        mgr.add_provider(BuiltinMemoryProvider())
+        mgr.add_provider(p)
+
+        r = json.loads(mgr.handle_tool_call("ladybug_store", {"content": "Prefers vim"}))
+        assert r["status"] == "stored"
+
+        r = json.loads(mgr.handle_tool_call("ladybug_recall", {}))
+        assert r["count"] == 1
+        assert "vim" in r["memories"][0]["content"]
+
+    def test_memory_bridge_propagates_to_ladybug(self, db):
+        p = LadybugMemoryProvider()
+        p._db = db
+
+        mgr = MemoryManager()
+        mgr.add_provider(BuiltinMemoryProvider())
+        mgr.add_provider(p)
+
+        mgr.on_memory_write("add", "user", "User timezone: US Pacific")
+        assert db.count() == 1
+
+    def test_system_prompt_included_in_manager_build(self, db):
+        p = LadybugMemoryProvider()
+        p._db = db
+        db.store("A fact")
+
+        mgr = MemoryManager()
+        mgr.add_provider(BuiltinMemoryProvider())
+        mgr.add_provider(p)
+
+        prompt = mgr.build_system_prompt()
+        assert "Ladybug Memory" in prompt
+
+    def test_on_pre_compress_contributes_to_manager(self, db):
+        p = LadybugMemoryProvider()
+        p._db = db
+        db.store("Critical fact — never ignore", importance=10)
+
+        mgr = MemoryManager()
+        mgr.add_provider(BuiltinMemoryProvider())
+        mgr.add_provider(p)
+
+        # on_pre_compress is called on each provider
+        p.on_pre_compress([])  # direct call; MemoryManager calls each provider
+
+    def test_shutdown_via_manager(self, db):
+        p = LadybugMemoryProvider()
+        p._db = db
+
+        mgr = MemoryManager()
+        mgr.add_provider(BuiltinMemoryProvider())
+        mgr.add_provider(p)
+
+        mgr.shutdown_all()
+        assert p._db is None
+
+
+# ---------------------------------------------------------------------------
+# Plugin discovery
+# ---------------------------------------------------------------------------
+
+
+class TestPluginDiscovery:
+    def test_ladybug_discovered(self):
+        from plugins.memory import discover_memory_providers
+        names = [name for name, _, _ in discover_memory_providers()]
+        assert "ladybug" in names
+
+    def test_ladybug_loadable(self):
+        from plugins.memory import load_memory_provider
+        p = load_memory_provider("ladybug")
+        assert p is not None
+        assert p.name == "ladybug"
+
+    def test_ladybug_has_correct_tools_when_loaded(self):
+        from plugins.memory import load_memory_provider
+        p = load_memory_provider("ladybug")
+        names = {s["name"] for s in p.get_tool_schemas()}
+        assert "ladybug_store" in names
+        assert "ladybug_recall" in names


### PR DESCRIPTION
## What does this PR do?

Adds a new memory plugin: ladybug (based on ladybugdb.com)


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #6010 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. hermes memory setup and choose ladybug
2. store a test memory
3. recall a test memory

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

