### PR TITLE
fix(matrix): add stop_typing to clear typing indicator after response

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -545,6 +545,14 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+    async def stop_typing(self, chat_id: str) -> None:
+        """Stop typing indicator by sending typing_state=False to Matrix."""
+        if self._client:
+            try:
+                await self._client.room_typing(chat_id, typing_state=False, timeout=0)
+            except Exception:
+                pass
+
     async def edit_message(
         self, chat_id: str, message_id: str, content: str
     ) -> SendResult:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2188,3 +2188,44 @@ class TestMatrixMessageTypes:
         with patch.dict("sys.modules", {"nio": _make_fake_nio()}):
             result = await self.adapter.send_emote("!room:ex", "")
         assert result.success is False
+
+
+class TestMatrixStopTyping:
+    """Regression tests for Matrix stop_typing (#6016).
+
+    The Matrix adapter previously lacked a stop_typing method, causing the
+    typing indicator to linger for up to 30 seconds after the bot responded.
+    """
+
+    def setup_method(self):
+        with patch.dict("sys.modules", {"nio": _make_fake_nio()}):
+            self.adapter = _make_adapter()
+            self.adapter._client = None
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_sends_false_state(self):
+        """stop_typing should call room_typing with typing_state=False."""
+        mock_client = MagicMock()
+        mock_client.room_typing = AsyncMock()
+        self.adapter._client = mock_client
+
+        await self.adapter.stop_typing("!room:example.com")
+
+        mock_client.room_typing.assert_awaited_once_with(
+            "!room:example.com", typing_state=False, timeout=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_no_client(self):
+        """stop_typing should be a no-op when _client is None."""
+        self.adapter._client = None
+        await self.adapter.stop_typing("!room:example.com")  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_exception_suppressed(self):
+        """stop_typing should swallow exceptions from room_typing."""
+        mock_client = MagicMock()
+        mock_client.room_typing = AsyncMock(side_effect=Exception("network error"))
+        self.adapter._client = mock_client
+
+        await self.adapter.stop_typing("!room:example.com")  # should not raise


### PR DESCRIPTION
## Summary

Fixes #6016 — Matrix typing indicator lingers for up to 30 seconds after the bot sends its response.

The Matrix adapter implements `send_typing` (one-shot with 30s timeout) but did not implement `stop_typing`. The base class's `_keep_typing` calls `stop_typing` in its `finally` block, but falls back to the no-op default when the subclass doesn't override it.

## Changes

- **`gateway/platforms/matrix.py`**: Add `stop_typing()` that calls `room_typing(chat_id, typing_state=False, timeout=0)` to explicitly clear the typing indicator
- **`tests/gateway/test_matrix.py`**: 3 regression tests — normal stop, no-client no-op, exception suppression

## Test plan

- [x] `stop_typing` sends `typing_state=False` via `room_typing`
- [x] No-op when `_client` is None
- [x] Exceptions from `room_typing` are suppressed (matching `send_typing` behavior)