### PR TITLE
fix(cli): honor active skin for thinking spinner text

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -95,6 +95,8 @@ from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
     get_cute_tool_message as _get_cute_tool_message_impl,
     _detect_tool_failure,
+    get_skin_faces,
+    get_skin_verbs,
     get_tool_emoji as _get_tool_emoji,
 )
 from agent.trajectory import (
@@ -7262,8 +7264,10 @@ class AIAgent:
                 self._vprint(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
             else:
                 # Animated thinking spinner in quiet mode
-                face = random.choice(KawaiiSpinner.KAWAII_THINKING)
-                verb = random.choice(KawaiiSpinner.THINKING_VERBS)
+                thinking_faces = get_skin_faces("thinking_faces", KawaiiSpinner.KAWAII_THINKING)
+                thinking_verbs = get_skin_verbs()
+                face = random.choice(thinking_faces)
+                verb = random.choice(thinking_verbs)
                 if self.thinking_callback:
                     # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                     # (works in both streaming and non-streaming modes)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -9,6 +9,7 @@ import json
 import logging
 import re
 import uuid
+from contextlib import contextmanager
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import SimpleNamespace
@@ -80,6 +81,17 @@ def agent_with_memory_tool():
         )
         a.client = MagicMock()
         return a
+
+
+@contextmanager
+def _active_skin(name: str):
+    from hermes_cli.skin_engine import set_active_skin
+
+    set_active_skin(name)
+    try:
+        yield
+    finally:
+        set_active_skin("default")
 
 
 def test_aiagent_reuses_existing_errors_log_handler():
@@ -1524,6 +1536,48 @@ class TestRunConversation:
         assert result["final_response"] == "Got it"
         assert result["completed"] is True
         assert result["api_calls"] == 2
+
+    def test_thinking_callback_uses_active_skin_spinner_text(self, agent, monkeypatch):
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+        thinking_updates = []
+        agent.thinking_callback = thinking_updates.append
+        monkeypatch.setattr(run_agent.random, "choice", lambda seq: seq[0])
+
+        with _active_skin("ares"):
+            with (
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+            ):
+                result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Final answer"
+        assert thinking_updates[0] == "(⚔) forging..."
+        assert thinking_updates[-1] == ""
+
+    def test_thinking_callback_falls_back_to_default_spinner_text(self, agent, monkeypatch):
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+        thinking_updates = []
+        agent.thinking_callback = thinking_updates.append
+        monkeypatch.setattr(run_agent.random, "choice", lambda seq: seq[0])
+
+        with _active_skin("default"):
+            with (
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+            ):
+                result = agent.run_conversation("hello")
+
+        from agent.display import KawaiiSpinner
+
+        assert result["final_response"] == "Final answer"
+        assert thinking_updates[0] == f"{KawaiiSpinner.KAWAII_THINKING[0]} {KawaiiSpinner.THINKING_VERBS[0]}..."
+        assert thinking_updates[-1] == ""
 
     def test_inline_think_blocks_reasoning_only_accepted(self, agent):
         """Inline <think> reasoning-only responses accepted with (empty) content, no retries."""


### PR DESCRIPTION
Summary:
- Fixes a CLI runtime bug where quiet-mode thinking spinner text ignored the active skin and always used the default kawaii thinking faces/verbs.

Root cause:
- run_agent.py built the quiet-mode thinking text directly from KawaiiSpinner.KAWAII_THINKING and KawaiiSpinner.THINKING_VERBS instead of using the existing skin-aware helpers.

Fix:
- use get_skin_faces("thinking_faces", KawaiiSpinner.KAWAII_THINKING)
- use get_skin_verbs()

Tests:
- added regression test for custom skin runtime thinking text
- added fallback test for default skin behavior
- verified:
  - pytest tests/run_agent/test_run_agent.py -q
  - pytest tests/hermes_cli/test_skin_engine.py -q
