### PR TITLE
fix(gateway): bridge_port, bridge_script, session_path from config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -530,6 +530,12 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
+                if "bridge_port" in platform_cfg:
+                    bridged["bridge_port"] = platform_cfg["bridge_port"]
+                if "bridge_script" in platform_cfg:
+                    bridged["bridge_script"] = platform_cfg["bridge_script"]
+                if "session_path" in platform_cfg:
+                    bridged["session_path"] = platform_cfg["session_path"]
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})


### PR DESCRIPTION
## Bug

The `whatsapp.bridge_port` setting in `config.yaml` is silently ignored
because `yaml_cfg` was not in scope in `_apply_env_overrides()`, and more
importantly, the three WhatsApp extra keys (`bridge_port`, `bridge_script`,
`session_path`) were never added to the `'bridged'` dict that propagates
platform config into `config.platforms[Platform.WHATSAPP].extra`.

## Fix

Add `bridge_port`, `bridge_script`, and `session_path` to the bridged
dict in `gateway/config.py`, alongside the existing `reply_prefix`,
`require_mention`, and `mention_patterns` keys.

## Impact

Without this fix, WhatsApp bridge always starts on port 3000 regardless of
`config.yaml`, and `session_path` / `bridge_script` settings are ignored.

## Testing

`tests/gateway/test_whatsapp_reply_prefix.py` and `tests/gateway/test_config.py`
pass (25 tests).

Closes #5965