### PR TITLE
fix(honcho): respect HERMES_HOME in resolve_config_path fallback

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -67,10 +67,14 @@ def resolve_config_path() -> Path:
     if local_path.exists():
         return local_path
 
-    # Default profile's config — host blocks accumulate here via setup/clone
+    # Default profile's config — host blocks accumulate here via setup/clone.
+    # Only fall back when HERMES_HOME is unset (defaults to ~/.hermes) to avoid
+    # leaking the default profile's config into an isolated profile home.
     default_path = Path.home() / ".hermes" / "honcho.json"
-    if default_path != local_path and default_path.exists():
-        return default_path
+    hermes_home_from_env = os.environ.get("HERMES_HOME", "")
+    if hermes_home_from_env in ("", str(Path.home() / ".hermes")):
+        if default_path != local_path and default_path.exists():
+            return default_path
 
     return GLOBAL_CONFIG_PATH
 


### PR DESCRIPTION
## Bug D (part of #5947)

`resolve_config_path()` in `plugins/memory/honcho/client.py` unconditionally
fell back to `~/.hermes/honcho.json` when the profile-local path did not
exist, even when `HERMES_HOME` was set to a non-default location (e.g.
`~/Code/wolf/`).

This caused isolated profiles to silently inherit the default profile's honcho
config (workspace, peer prefix, session strategy) on first run.

## Fix

Only fall back to the default path (`~/.hermes/honcho.json`) when
`HERMES_HOME` is unset or equals the default `~/.hermes`. When a custom
`HERMES_HOME` is set, the function now returns `GLOBAL_CONFIG_PATH` instead
of leaking the default profile's config.

## Testing

`tests/plugins/memory/` passes (44 tests).

Closes part of #5947