### PR TITLE
fix(codex): use terminal event response when get_final_response has empty output

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3807,6 +3807,7 @@ class AIAgent:
         self._codex_streamed_text_parts: list = []
         for attempt in range(max_stream_retries + 1):
             collected_output_items: list = []
+            terminal_response = None
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
                     for event in stream:
@@ -3844,8 +3845,10 @@ class AIAgent:
                             if done_item is not None:
                                 collected_output_items.append(done_item)
                         # Log non-completed terminal events for diagnostics
-                        elif event_type in ("response.incomplete", "response.failed"):
+                        elif event_type in ("response.completed", "response.incomplete", "response.failed"):
                             resp_obj = getattr(event, "response", None)
+                            if resp_obj is not None:
+                                terminal_response = resp_obj
                             status = getattr(resp_obj, "status", None) if resp_obj else None
                             incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
                             logger.warning(
@@ -3856,6 +3859,17 @@ class AIAgent:
                                 self._client_log_context(),
                             )
                     final_response = stream.get_final_response()
+                    # Prefer the terminal event's response when get_final_response()
+                    # has empty output but the terminal event carries valid output.
+                    if terminal_response is not None:
+                        _final_output = getattr(final_response, "output", None)
+                        _terminal_output = getattr(terminal_response, "output", None)
+                        if (
+                            isinstance(_terminal_output, list)
+                            and _terminal_output
+                            and (not isinstance(_final_output, list) or not _final_output)
+                        ):
+                            final_response = terminal_response
                     # PATCH: ChatGPT Codex backend streams valid output items
                     # but get_final_response() can return an empty output list.
                     # Backfill from collected items or synthesize from deltas.


### PR DESCRIPTION
## Bug (closes #5883)

GPT-5.4 via openai-codex fails in normal mode with "Empty/malformed response"
but works in verbose mode. The root cause: when
`stream.get_final_response()` returns an empty `output` list, the existing
backfill logic (from `output_item.done` events and text-delta synthesis) can
fail silently in normal mode. However, the terminal stream event
(`response.completed`) carries a fully-populated response object in
`event.response` that is never captured.

## Fix

1. Capture `event.response` for all terminal stream events
   (`response.completed`, `response.incomplete`, `response.failed`).
2. After `get_final_response()`, prefer the terminal event's response when
   `get_final_response()` has empty output but the terminal event carries
   valid output.

This is the same approach as open PR #5720, implemented cleanly against the
current upstream.

## Testing

`tests/run_agent/test_run_agent_codex_responses.py` passes (35 tests).

Closes #5883