### PR TITLE
fix: mount clipboard images directory into remote sandboxes

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -476,3 +476,32 @@ class TestIterCacheFiles:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert iter_cache_files() == []
+
+    def test_mounts_clipboard_images_directory(self, tmp_path, monkeypatch):
+        """Clipboard images saved under ~/.hermes/images must mount into sandboxes."""
+        hermes_home = tmp_path / ".hermes"
+        images_dir = hermes_home / "images"
+        images_dir.mkdir(parents=True)
+        (images_dir / "clip_test.png").write_bytes(b"PNG")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mounts = get_cache_directory_mounts()
+        assert {
+            "host_path": str(images_dir),
+            "container_path": "/root/.hermes/images",
+        } in mounts
+
+    def test_iterates_clipboard_images_directory(self, tmp_path, monkeypatch):
+        """Modal-style per-file sync should include ~/.hermes/images files too."""
+        hermes_home = tmp_path / ".hermes"
+        images_dir = hermes_home / "images"
+        images_dir.mkdir(parents=True)
+        image_file = images_dir / "clip_test.png"
+        image_file.write_bytes(b"PNG")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        entries = iter_cache_files()
+        assert {
+            "host_path": str(image_file),
+            "container_path": "/root/.hermes/images/clip_test.png",
+        } in entries

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -345,6 +345,7 @@ def iter_skills_files(
 _CACHE_DIRS: list[tuple[str, str]] = [
     ("cache/documents", "document_cache"),
     ("cache/images", "image_cache"),
+    ("images", "images"),
     ("cache/audio", "audio_cache"),
     ("cache/screenshots", "browser_screenshots"),
 ]


### PR DESCRIPTION
## What does this PR do?

Mounts `~/.hermes/images` into remote sandboxes in addition to the existing cache directories. Clipboard screenshots are saved under `~/.hermes/images`, but remote backends only mirrored cache directories like `image_cache`, which left pasted screenshots invisible inside Docker/remote sandboxes. This PR adds the missing mount + per-file sync coverage so pasted clipboard images become visible to sandboxed runs.

## Related Issue

Closes #6004

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `("images", "images")` to `_CACHE_DIRS` in `tools/credential_files.py`
- Add tests verifying:
  - sandbox mount entry for `/root/.hermes/images`
  - per-file iteration includes files from `~/.hermes/images`

## How to Test

1. Activate the repo venv
2. Run:
   ```bash
   /workspace/Projects/hermes-agent/.venv/bin/python -m pytest -n 0 \
     tests/tools/test_credential_files.py \
     tests/tools/test_clipboard.py -q
   ```
3. Confirm all tests pass (observed locally: `126 passed in 7.58s`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
/workspace/Projects/hermes-agent/.venv/bin/python -m pytest -n 0 \
  tests/tools/test_credential_files.py \
  tests/tools/test_clipboard.py -q
# 126 passed in 7.58s
```
