### PR TITLE
fix: return success false when vision model yields empty content

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -677,6 +677,22 @@ class TestTildeExpansion:
         data = json.loads(result)
         assert data["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_empty_after_retry_returns_failure(self, tmp_path):
+        """An empty vision response after retry must fail closed, not success-open."""
+        image_path = tmp_path / "test.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        with (
+            patch("tools.vision_tools.async_call_llm", new=AsyncMock(return_value=MagicMock())),
+            patch("tools.vision_tools.extract_content_or_reasoning", return_value=""),
+        ):
+            result = await vision_analyze_tool(str(image_path), "describe this", "test/model")
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "empty content" in data["error"].lower()
+
 
 # ---------------------------------------------------------------------------
 # file:// URI support

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1277,6 +1277,19 @@ async def vision_analyze_tool(
             response = await async_call_llm(**call_kwargs)
             analysis = extract_content_or_reasoning(response)
 
+        if not analysis:
+            error_msg = "Vision model returned empty content after retry"
+            logger.error("%s", error_msg)
+            result = {
+                "success": False,
+                "error": error_msg,
+                "analysis": "There was a problem with the request and the image could not be analyzed.",
+            }
+            debug_call_data["error"] = error_msg
+            _debug.log_call("vision_analyze_tool", debug_call_data)
+            _debug.save()
+            return json.dumps(result, indent=2, ensure_ascii=False)
+
         analysis_length = len(analysis)
         
         logger.info("Image analysis completed (%s characters)", analysis_length)
@@ -1284,7 +1297,7 @@ async def vision_analyze_tool(
         # Prepare successful response
         result = {
             "success": True,
-            "analysis": analysis or "There was a problem with the request and the image could not be analyzed."
+            "analysis": analysis,
         }
         
         debug_call_data["success"] = True


### PR DESCRIPTION
## What does this PR do?

`vision_analyze_tool` retried once when the auxiliary vision model returned empty content, but if the second attempt was also empty it still returned a success-shaped payload with a fallback error string inside `analysis`. That is fail-open behavior for callers that branch on `success`.

This PR returns `success: false` when the vision model yields empty content even after retry, and adds a regression test for the empty-after-retry path. Narrow fail-closed semantics fix only.

## Related Issue

Closes #6031

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/vision_tools.py`: detect still-empty analysis after retry and return `success: false`, `error: ...`, fallback `analysis` message
- Keep debug logging/save behavior intact
- Add test covering the empty-after-retry path

## How to Test

1. Run the regression suite:
   ```bash
   /workspace/Projects/hermes-agent/.venv/bin/python -m pytest -n 0 \
     tests/tools/test_vision_tools.py -q
   ```
2. Observed locally: `50 passed in 4.68s`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest -n 0 tests/tools/test_vision_tools.py -q
50 passed in 4.68s
```
