### PR TITLE
fix: sanitize browser and rl subprocess environments

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -512,3 +512,69 @@ class TestRunBrowserCommandPathConstruction:
         result_path = captured_env.get("PATH", "")
         assert "/data/data/com.termux/files/usr/bin" in result_path
         assert "/data/data/com.termux/files/usr/sbin" in result_path
+
+
+class TestBrowserSubprocessEnvSanitization:
+    """Verify browser subprocesses keep only the minimum required secrets."""
+
+    def test_cloud_browser_keys_preserved_but_provider_keys_stripped(self, tmp_path):
+        captured_env = {}
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            return mock_proc
+
+        fake_session = {
+            "session_name": "test-session",
+            "session_id": "test-id",
+            "cdp_url": "wss://browserbase.example/ws",
+        }
+        fake_json = json.dumps({"success": True})
+
+        real_isdir = os.path.isdir
+
+        def selective_isdir(p):
+            if p.startswith(str(tmp_path)):
+                return True
+            if "/opt/homebrew/" in p:
+                return True
+            return real_isdir(p)
+
+        with patch("tools.browser_tool._find_agent_browser", return_value="/usr/local/bin/agent-browser"), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("os.path.isdir", side_effect=selective_isdir), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(
+                 os.environ,
+                 {
+                     "PATH": "/usr/bin:/bin",
+                     "HOME": "/home/test",
+                     "OPENAI_API_KEY": "sk-secret-should-not-leak",
+                     "BROWSERBASE_API_KEY": "bb-key",
+                     "BROWSERBASE_PROJECT_ID": "bb-project",
+                     "BROWSER_USE_API_KEY": "browser-use-key",
+                     "FIRECRAWL_API_KEY": "firecrawl-key",
+                     "FIRECRAWL_API_URL": "https://firecrawl.example",
+                     "FIRECRAWL_BROWSER_TTL": "600",
+                 },
+                 clear=True,
+             ):
+            with patch("builtins.open", mock_open(read_data=fake_json)):
+                _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+        assert captured_env["BROWSERBASE_API_KEY"] == "bb-key"
+        assert captured_env["BROWSERBASE_PROJECT_ID"] == "bb-project"
+        assert captured_env["BROWSER_USE_API_KEY"] == "browser-use-key"
+        assert captured_env["FIRECRAWL_API_KEY"] == "firecrawl-key"
+        assert captured_env["FIRECRAWL_API_URL"] == "https://firecrawl.example"
+        assert captured_env["FIRECRAWL_BROWSER_TTL"] == "600"
+        assert "OPENAI_API_KEY" not in captured_env

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -69,6 +69,7 @@ from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value
 from hermes_cli.config import cfg_get
+from tools.environments.local import _sanitize_subprocess_env
 
 try:
     from tools.website_policy import check_website_access
@@ -1992,7 +1993,20 @@ def _run_browser_command(
         logger.debug("browser cmd=%s task=%s socket_dir=%s (%d chars)",
                      command, task_id, task_socket_dir, len(task_socket_dir))
 
-        browser_env = {**os.environ}
+        # Sanitize subprocess env to drop secrets the browser worker doesn't
+        # need; pass browser-specific credentials through _HERMES_FORCE_* so
+        # the worker can opt back in without seeing the full hermes env.
+        browser_env = _sanitize_subprocess_env(
+            os.environ,
+            {
+                "_HERMES_FORCE_BROWSERBASE_API_KEY": os.getenv("BROWSERBASE_API_KEY", ""),
+                "_HERMES_FORCE_BROWSERBASE_PROJECT_ID": os.getenv("BROWSERBASE_PROJECT_ID", ""),
+                "_HERMES_FORCE_BROWSER_USE_API_KEY": os.getenv("BROWSER_USE_API_KEY", ""),
+                "_HERMES_FORCE_FIRECRAWL_API_KEY": os.getenv("FIRECRAWL_API_KEY", ""),
+                "_HERMES_FORCE_FIRECRAWL_API_URL": os.getenv("FIRECRAWL_API_URL", ""),
+                "_HERMES_FORCE_FIRECRAWL_BROWSER_TTL": os.getenv("FIRECRAWL_BROWSER_TTL", ""),
+            },
+        )
 
         # Ensure subprocesses inherit the same browser-specific PATH fallbacks
         # used during CLI discovery.


### PR DESCRIPTION
## What does this PR do?

Sanitizes browser and RL training subprocess environments so unrelated provider credentials no longer leak into child processes (and their logs).

Both browser and RL subprocess launches inherited the parent environment too broadly. A naive sanitization would break:

- Browserbase / Browser Use cloud browser mode
- Firecrawl browser mode
- Tinker / WandB auth for RL training

This patch keeps the minimum required vars via `_HERMES_FORCE_*` passthrough while stripping unrelated provider secrets.

## Related Issue

Closes #6032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_tool.py`
  - Replace broad `os.environ` passthrough with `_sanitize_subprocess_env(...)`.
  - Explicitly preserve:
    - `BROWSERBASE_API_KEY`
    - `BROWSERBASE_PROJECT_ID`
    - `BROWSER_USE_API_KEY`
    - `FIRECRAWL_API_KEY`
    - `FIRECRAWL_API_URL`
    - `FIRECRAWL_BROWSER_TTL`
- `tools/rl_training_tool.py`
  - Sanitize trainer subprocess env.
  - Explicitly preserve:
    - `TINKER_API_KEY`
    - `WANDB_API_KEY`
- Add regression tests verifying required vars survive while unrelated provider vars such as `OPENAI_API_KEY` do not.

## How to Test

1. Run the focused test set:
   ```bash
   /workspace/Projects/hermes-agent/.venv/bin/python -m pytest -n 0 \
     tests/tools/test_browser_homebrew_paths.py \
     tests/tools/test_browser_secret_exfil.py \
     tests/tools/test_rl_training_tool.py -q
   ```
2. Observed locally: `37 passed in 14.18s`.

Scope is narrow: subprocess env hardening only.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest -n 0 tests/tools/test_browser_homebrew_paths.py tests/tools/test_browser_secret_exfil.py tests/tools/test_rl_training_tool.py -q
37 passed in 14.18s
```
