### PR TITLE
fix: slash commands now respect require_mention in Telegram groups

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1619,18 +1619,22 @@ class TelegramAdapter(BasePlatformAdapter):
         DMs remain unrestricted. Group/supergroup messages are accepted when:
         - the chat is explicitly allowlisted in ``free_response_chats``
         - ``require_mention`` is disabled
-        - the message is a command
         - the message replies to the bot
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
+
+        When ``require_mention`` is enabled, slash commands are not given
+        special treatment — they must pass the same mention/reply checks
+        as any other group message.  Users can still trigger commands via
+        the Telegram bot menu (``/command@botname``) or by explicitly
+        mentioning the bot (``@botname /command``), both of which are
+        recognised as mentions by :meth:`_message_mentions_bot`.
         """
         if not self._is_group_chat(message):
             return True
         if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
             return True
         if not self._telegram_require_mention():
-            return True
-        if is_command:
             return True
         if self._is_reply_to_bot(message):
             return True

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -59,7 +59,13 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("hello everyone")) is False
     assert adapter._should_process_message(_group_message("hi @hermes_bot", entities=[_mention_entity("hi @hermes_bot")])) is True
     assert adapter._should_process_message(_group_message("replying", reply_to_bot=True)) is True
-    assert adapter._should_process_message(_group_message("/status"), is_command=True) is True
+    # Commands must also respect require_mention when it is enabled
+    assert adapter._should_process_message(_group_message("/status"), is_command=True) is False
+    # But commands with @mention still pass
+    assert adapter._should_process_message(_group_message("/status@hermes_bot")) is True
+    # And commands still pass unconditionally when require_mention is disabled
+    adapter_no_mention = _make_adapter(require_mention=False)
+    assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True
 
 
 def test_free_response_chats_bypass_mention_requirement():


### PR DESCRIPTION
## Summary

Fixes #6033

When `require_mention: true` is set, slash commands currently bypass all mention checks via a hardcoded `if is_command: return True` in `_should_process_message()`. In multi-bot groups this causes every bot to respond to every command.

## Changes

- **gateway/platforms/telegram.py**: Remove the `is_command` unconditional bypass (lines 1633-1634). When `require_mention` is `false`, commands still pass unconditionally at line 1631. When `require_mention` is `true`, commands now fall through to mention/reply checks like any other group message.
- **tests/gateway/test_telegram_group_gating.py**: Update existing test and add new cases:
  - `require_mention: true` + bare `/status` → filtered
  - `require_mention: true` + `/status@hermes_bot` → passes (mention detected)
  - `require_mention: false` + bare `/status` → passes (backward compatible)
- **Docstring**: Updated to document the new behavior and explain how users can still trigger commands via bot menu (`/command@botname`) or explicit mention.

## Backward Compatibility

Users with `require_mention: false` (the default) see no change. Only users who explicitly enabled `require_mention: true` will notice that bare commands are now filtered in groups — which is the consistent and expected behavior for that setting.
