### PR TITLE
fix(agent): enable vision support for Kimi provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1377,6 +1377,7 @@ _VISION_AUTO_PROVIDER_ORDER = (
     "nous",
     "openai-codex",
     "anthropic",
+    "kimi-coding",
     "custom",
 )
 
@@ -1405,6 +1406,8 @@ def _resolve_strict_vision_backend(provider: str) -> Tuple[Optional[Any], Option
         return _try_codex()
     if provider == "anthropic":
         return _try_anthropic()
+    if provider == "kimi-coding":
+        return resolve_provider_client("kimi-coding", model="kimi-k2.5")
     if provider == "custom":
         return _try_custom_endpoint()
     return None, None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -863,6 +863,40 @@ class TestAuxiliaryPoolAwareness:
         assert isinstance(client, CodexAuxiliaryClient)
         assert model == "gpt-5.2-codex"
 
+    def test_vision_auto_includes_kimi_when_configured(self, monkeypatch):
+        """Verify kimi-coding shows up in available vision backends when key is set."""
+        monkeypatch.setenv("KIMI_API_KEY", "kimi-test-key")
+        mock_client = MagicMock()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, "kimi-k2.5")):
+            backends = get_available_vision_backends()
+        assert "kimi-coding" in backends
+
+    def test_resolve_kimi_vision_client(self, monkeypatch):
+        """Verify kimi-coding resolves to the correct model for vision."""
+        monkeypatch.setenv("KIMI_API_KEY", "kimi-test-key")
+        mock_client = MagicMock()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, "kimi-k2.5")) as mock_resolve:
+            provider, client, model = resolve_vision_provider_client(provider="kimi-coding")
+        assert provider == "kimi-coding"
+        assert client is mock_client
+        assert model == "kimi-k2.5"
+        mock_resolve.assert_called_with("kimi-coding", model="kimi-k2.5")
+
+    def test_selected_kimi_provider_is_preferred_for_vision_auto(self, monkeypatch):
+        """Verify kimi-coding is preferred for vision when it is the main provider."""
+        monkeypatch.setenv("KIMI_API_KEY", "kimi-test-key")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        def fake_load_config():
+            return {"model": {"provider": "kimi-coding", "default": "kimi-k2-turbo-preview"}}
+
+        with patch("hermes_cli.config.load_config", fake_load_config), \
+             patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            mock_resolve.side_effect = lambda p, model=None: (MagicMock(), model or "default")
+            provider, client, model = resolve_vision_provider_client(provider="auto")
+        assert provider == "kimi-coding"
+        assert model == "kimi-k2.5"
+
 
 class TestGetAuxiliaryProvider:
     """Tests for _get_auxiliary_provider env var resolution."""


### PR DESCRIPTION
## What does this PR do?

This PR enables Vision API support for the Kimi provider (`kimi-coding`). Previously, while Kimi was a supported text provider, it was missing from the vision auto-selection order and the backend resolver, preventing it from being used for multimodal tasks even when configured as the main provider.

## Related Issue

Fixes #2125

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/auxiliary_client.py`**: Added `kimi-coding` to `_VISION_AUTO_PROVIDER_ORDER` and updated `_resolve_strict_vision_backend` to route vision requests to the `kimi-k2.5` multimodal model.
- **`tests/agent/test_auxiliary_client.py`**: Added unit tests to `TestVisionClientFallback` to verify Kimi's presence in available backends, correct model resolution, and preference when set as the main provider.

## How to Test

1. Configure a Kimi API key: `export KIMI_API_KEY=your-key`
2. Run the newly added unit tests:
   ```bash
   uv run pytest tests/agent/test_auxiliary_client.py -k vision_kimi
   ```
3. (Manual) Set Kimi as your main provider and attempt a vision task (e.g., describing a sticker or image).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.4 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (N/A - internal routing fix)
- [x] I've updated `cli-config.yaml.example` (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` (N/A)
- [x] I've considered cross-platform impact (Verified logic is platform-agnostic)
- [x] I've updated tool descriptions/schemas (N/A)