### PR TITLE
feat: /new <message> inline support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6025,7 +6025,12 @@ class HermesCLI:
                 else:
                     _cprint("  Session database not available.")
         elif canonical == "new":
+            parts = cmd_original.split(maxsplit=1)
             self.new_session()
+            if len(parts) > 1:
+                inline_msg = parts[1].strip()
+                if inline_msg:
+                    self._pending_input.put(inline_msg)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
         elif canonical == "model":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3278,7 +3278,9 @@ class GatewayRunner:
                 )
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
-                return await self._handle_reset_command(event)
+                if _quick_key in self._running_agents:
+                    del self._running_agents[_quick_key]
+                return await self._reset_with_inline(event, source, _quick_key)
 
             # /queue <prompt> — queue without interrupting
             if event.get_command() in ("queue", "q"):
@@ -3548,7 +3550,7 @@ class GatewayRunner:
                     break
 
         if canonical == "new":
-            return await self._handle_reset_command(event)
+            return await self._reset_with_inline(event, source, _quick_key)
         
         if canonical == "help":
             return await self._handle_help_command(event)
@@ -4992,7 +4994,72 @@ class GatewayRunner:
         if session_info:
             return f"{header}\n\n{session_info}{_tip_line}"
         return f"{header}{_tip_line}"
-    
+
+    async def _reset_with_inline(self, event: MessageEvent, source, _quick_key: str) -> Optional[str]:
+        """Handle /new or /reset, optionally processing inline text after reset.
+
+        If the command has trailing text (e.g. ``/new hello``), the session is
+        reset, the confirmation is sent immediately, and the inline text is
+        dispatched to the agent as the first message of the fresh session.
+        """
+        import copy
+        from dataclasses import replace as _dc_replace
+
+        # Extract inline args BEFORE reset so we don't depend on post-reset state.
+        inline_text = event.get_command_args().strip()
+
+        # Claim the session synchronously before any await to prevent a second
+        # message from passing the "no running agent" guard while we do async
+        # reset/send work.  Cleaned up in the finally block below, or in the
+        # early-return path when there is no inline text.
+        self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
+        self._running_agents_ts[_quick_key] = time.time()
+        try:
+            reset_response = await self._handle_reset_command(event)
+            if not inline_text:
+                return reset_response
+
+            # Send reset confirmation first so the user sees it immediately.
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                _thread_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=reset_response,
+                    reply_to=event.message_id,
+                    metadata=_thread_meta,
+                )
+            else:
+                # No adapter — return confirmation for the caller to send.
+                return reset_response
+
+            # Clone the original event, replacing only text.  dataclasses.replace
+            # preserves media, reply context, raw_message, auto_skill, etc.
+            inline_event = _dc_replace(
+                event,
+                text=inline_text,
+                message_type=MessageType.TEXT,
+                source=copy.copy(event.source),
+            )
+
+            # Dispatch directly to the agent (skips auth / command re-parsing).
+            return await self._handle_message_with_agent(inline_event, source, _quick_key)
+        except Exception as e:
+            logger.error("Inline message dispatch after /new failed: %s", e, exc_info=True)
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                _thread_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content="Session was reset, but your message could not be processed. Please resend.",
+                    metadata=_thread_meta,
+                )
+            return None
+        finally:
+            if self._running_agents.get(_quick_key) is _AGENT_PENDING_SENTINEL:
+                del self._running_agents[_quick_key]
+            self._running_agents_ts.pop(_quick_key, None)
+
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""
         from hermes_constants import display_hermes_home

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -58,8 +58,8 @@ class CommandDef:
 
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
-    CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
-               aliases=("reset",)),
+    CommandDef("new", "Start a new session, optionally with a first message", "Session",
+               aliases=("reset",), args_hint="[initial prompt]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("history", "Show conversation history", "Session",

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -219,3 +219,51 @@ def test_new_session_resets_token_counters(tmp_path):
     assert comp.last_total_tokens == 0
     assert comp.compression_count == 0
     assert comp._context_probed is False
+
+
+def test_new_command_with_inline_message_queues_to_pending_input(tmp_path):
+    """``/new hello`` should reset the session AND queue 'hello' for the agent."""
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_session_id = cli.session_id
+
+    cli.process_command("/new find best korean barbeque for 7")
+
+    # Session was reset
+    assert cli.session_id != old_session_id
+    assert cli.conversation_history == []
+    cli.agent.flush_memories.assert_called_once()
+
+    # Inline message was queued
+    assert not cli._pending_input.empty()
+    queued = cli._pending_input.get_nowait()
+    assert queued == "find best korean barbeque for 7"
+
+
+def test_new_command_without_args_does_not_queue(tmp_path):
+    """/new with no trailing text should NOT put anything in the queue."""
+    cli = _prepare_cli_with_active_session(tmp_path)
+
+    cli.process_command("/new")
+
+    assert cli._pending_input.empty()
+
+
+def test_new_command_whitespace_only_does_not_queue(tmp_path):
+    """/new followed by only spaces should behave like bare /new."""
+    cli = _prepare_cli_with_active_session(tmp_path)
+
+    cli.process_command("/new    ")
+
+    assert cli._pending_input.empty()
+
+
+def test_reset_alias_with_inline_message(tmp_path):
+    """/reset <msg> should behave identically to /new <msg>."""
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_session_id = cli.session_id
+
+    cli.process_command("/reset hello world")
+
+    assert cli.session_id != old_session_id
+    assert not cli._pending_input.empty()
+    assert cli._pending_input.get_nowait() == "hello world"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -183,6 +183,7 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     runner.session_store.reset_session = MagicMock()
 
     runner._running_agents = {}
+    runner._running_agents_ts = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._session_db = None
@@ -190,6 +191,8 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     runner._provider_routing = {}
     runner._fallback_model = None
     runner._show_reasoning = False
+    runner._session_model_overrides = {}
+    runner._background_tasks = set()
 
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
@@ -197,6 +200,8 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     runner._send_voice_reply = AsyncMock()
     runner._capture_gateway_honcho_if_configured = lambda *a, **kw: None
     runner._emit_gateway_run_progress = AsyncMock()
+    runner._async_flush_memories = AsyncMock()
+    runner._evict_cached_agent = MagicMock()
 
     runner.pairing_store = MagicMock()
     runner.pairing_store._is_rate_limited = MagicMock(return_value=False)

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -165,6 +165,72 @@ class TestAuthorization:
             assert "/new" not in response_text
 
 
+class TestNewInlineMessage:
+    """Verify /new <message> resets session then dispatches inline text."""
+
+    @pytest.mark.asyncio
+    async def test_new_with_inline_text_sends_reset_then_dispatches(self, adapter, runner):
+        """/new hello should send the reset confirmation AND dispatch 'hello' to agent."""
+        # Mock _handle_message_with_agent so the inline dispatch doesn't need a real agent.
+        runner._handle_message_with_agent = AsyncMock(return_value="Agent response")
+        runner._running_agents_ts = {}
+
+        await send_and_capture(adapter, "/new hello world")
+
+        # Session was reset
+        runner.session_store.reset_session.assert_called_once()
+
+        # At least two sends: reset confirmation + agent response
+        assert adapter.send.call_count >= 2
+        first_call_content = adapter.send.call_args_list[0][1].get("content", "")
+        assert "reset" in first_call_content.lower() or "new session" in first_call_content.lower() or "✨" in first_call_content
+
+        # _handle_message_with_agent was called with the inline text
+        runner._handle_message_with_agent.assert_called_once()
+        inline_event = runner._handle_message_with_agent.call_args[0][0]
+        assert inline_event.text == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_new_without_args_does_not_dispatch(self, adapter, runner):
+        """/new with no trailing text should only reset, not call the agent."""
+        runner._handle_message_with_agent = AsyncMock()
+        runner._running_agents_ts = {}
+
+        await send_and_capture(adapter, "/new")
+
+        runner.session_store.reset_session.assert_called_once()
+        runner._handle_message_with_agent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_new_inline_preserves_source(self, adapter, runner):
+        """The synthetic event for the inline message must have an isolated source copy."""
+        runner._handle_message_with_agent = AsyncMock(return_value=None)
+        runner._running_agents_ts = {}
+
+        event = make_event("/new check this")
+        original_source_id = id(event.source)
+
+        adapter.send.reset_mock()
+        await adapter.handle_message(event)
+        await asyncio.sleep(0.3)
+
+        runner._handle_message_with_agent.assert_called_once()
+        inline_event = runner._handle_message_with_agent.call_args[0][0]
+        # Source should be a copy, not the same object
+        assert id(inline_event.source) != original_source_id
+
+    @pytest.mark.asyncio
+    async def test_new_whitespace_only_does_not_dispatch(self, adapter, runner):
+        """/new followed by only spaces should behave like bare /new."""
+        runner._handle_message_with_agent = AsyncMock()
+        runner._running_agents_ts = {}
+
+        await send_and_capture(adapter, "/new    ")
+
+        runner.session_store.reset_session.assert_called_once()
+        runner._handle_message_with_agent.assert_not_called()
+
+
 class TestSendFailureResilience:
     """Verify the pipeline handles send failures gracefully."""
 


### PR DESCRIPTION
## Summary

- **`/new <message>` inline support**: resets the session and immediately processes the trailing text as the first message, saving a round-trip on every topic switch
- Works on all gateway platforms (Telegram, Discord, Slack, etc.) and the interactive CLI (`/reset` alias included)
- Sentinel guard set before any async work to prevent concurrent agent dispatch during the reset window

## Test Coverage

8 new tests across CLI and gateway e2e. Coverage: 10/11 code paths (91%).

## Pre-Landing Review

3 issues found and fixed:
- [FIXED] P1: Race condition — sentinel set after async work in `_reset_with_inline`
- [FIXED] P3: Conditional assertion made test vacuous
- [FIXED] P3: Unused variable in test methods

## Plan Completion

All 8/8 plan items DONE.

## Test plan
- [x] All pytest tests pass (9155 passed, 33 pre-existing failures unrelated)
- [x] Manual Telegram test confirmed