### PR TITLE
fix(gateway/telegram): fall back to chat.id when from_user is None in DMs

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2826,13 +2826,17 @@ class TelegramAdapter(BasePlatformAdapter):
                             break
                     break
 
+        # Telegram can omit from_user on some DM updates; fall back to the DM chat identity.
+        dm_fallback_user_id = str(chat.id) if chat_type == "dm" else None
+        dm_fallback_user_name = chat.full_name if hasattr(chat, "full_name") and chat_type == "dm" else None
+
         # Build source
         source = self.build_source(
             chat_id=str(chat.id),
             chat_name=chat.title or (chat.full_name if hasattr(chat, "full_name") else None),
             chat_type=chat_type,
-            user_id=str(user.id) if user else None,
-            user_name=user.full_name if user else None,
+            user_id=str(user.id) if user else dm_fallback_user_id,
+            user_name=user.full_name if user else dm_fallback_user_name,
             thread_id=thread_id_str,
             chat_topic=chat_topic,
         )

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -132,6 +132,32 @@ def test_forum_general_topic_without_message_thread_id_keeps_thread_context():
     assert event.source.thread_id == "1"
 
 
+def test_dm_without_from_user_falls_back_to_chat_identity():
+    """DM messages without from_user should still keep a usable user identity."""
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="hello from DM",
+        caption=None,
+        chat=SimpleNamespace(
+            id=789,
+            type="private",
+            title=None,
+            full_name="Fallback User",
+        ),
+        from_user=None,
+        message_thread_id=None,
+        reply_to_message=None,
+        message_id=11,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.chat_type == "dm"
+    assert event.source.user_id == "789"
+    assert event.source.user_name == "Fallback User"
+
+
 @pytest.mark.asyncio
 async def test_send_omits_general_topic_thread_id():
     """Telegram sends to forum General should omit message_thread_id=1."""


### PR DESCRIPTION
## Summary

Fixes a DM access-control bug where users in `TELEGRAM_ALLOWED_USERS` get locked out and trigger an infinite pairing-code loop when `message.from_user` is `None`.

## Repro

1. Configure `TELEGRAM_ALLOWED_USERS=<your_id>` in `~/.hermes/.env`
2. Send a DM to the bot under conditions that produce `message.from_user is None` (forwarded message, anonymous admin context, or in our case it just happened on a fresh Hermes restart with `xiaomi/mimo-v2-pro` via Nous Portal — likely a Telegram-side artifact)
3. Bot replies with a pairing code prompt instead of routing to the agent
4. Run `hermes pairing approve telegram <code>` — approval succeeds but stores key `"null"` because `user_id` was `None`
5. Subsequent DMs still get the pairing prompt because real `user_id` ≠ `"null"`

## Root cause

`gateway/platforms/telegram.py:_build_message_event` sets:

```python
user_id=str(user.id) if user else None,
```

When `user` is `None`, the resulting `source.user_id` is `None`. Then in `gateway/run.py:_is_user_authorized`:

```python
user_id = source.user_id
if not user_id:
    return False  # never even checks the allowlist
```

So the user is denied before the allowlist comparison runs. The unauthorized DM behavior (`pair`) then fires, generating a pairing code for `user_id=None`. `PairingStore.approve` saves the entry under the literal string `"null"`, which never matches the user's real ID on subsequent messages.

## Fix

For DMs (`chat_type == "dm"`), Telegram's protocol guarantees `chat.id == user.id` — they are literally the same numeric ID for private chats. Falling back to `chat.id` when `from_user is None` is correct and surgical: it does not affect group/channel chats (which legitimately can have a `None` sender for channel posts and anonymous admin messages — those should remain unauthorized by default).

```python
user_id=str(user.id) if user else (str(chat.id) if chat_type == "dm" else None),
user_name=user.full_name if user else (chat.full_name if hasattr(chat, "full_name") and chat_type == "dm" else None),
```

## Tests

- Manual: confirmed locally that DMs now correctly authorize the configured allowlisted user even when `from_user` is `None`, and that pairing flow no longer fires with a `null` user_id.
- I'd be happy to add a unit test on `_build_message_event` if you'd like — the current test file structure for `gateway/platforms/telegram.py` doesn't seem to have one yet, so let me know if you'd prefer me to add `tests/gateway/test_telegram_user_id_fallback.py`.

## Risk

Minimal. The fallback is gated on `chat_type == "dm"`, so:
- Group chats and channel posts are unaffected (they continue to return `None` for user_id, which is the correct/safe default).
- DMs with a normal `from_user` are unaffected (the original branch is taken).
- Only the edge case of "DM with `from_user is None`" gets the new behavior, and even then, the fallback uses an ID Telegram guarantees is equivalent.