### PR TITLE
fix: block gateway self-management from live gateway sessions

### DIFF
--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -9,9 +9,12 @@ import tools.approval as approval_module
 from tools.approval import (
     approve_session,
     check_all_command_guards,
+    check_dangerous_command,
     is_approved,
-    set_current_session_key,
+    register_gateway_notify,
     reset_current_session_key,
+    set_current_session_key,
+    unregister_gateway_notify,
 )
 
 # Ensure the module is importable so we can patch it
@@ -164,6 +167,79 @@ class TestTirithAllowDangerous:
         cb.assert_called_once()
         # allow_permanent should be True (no tirith warning)
         assert cb.call_args[1]["allow_permanent"] is True
+
+
+class TestGatewaySelfManagementHardBlock:
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_restart_from_gateway_session_is_hard_blocked(self, mock_tirith):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        result = check_all_command_guards("hermes gateway restart", "local")
+        assert result["approved"] is False
+        assert result.get("status") == "blocked_by_policy"
+        assert "local shell" in result["message"]
+        mock_tirith.assert_not_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_restart_is_blocked_even_in_yolo_mode(self, mock_tirith):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_YOLO_MODE"] = "1"
+        result = check_all_command_guards("hermes gateway restart", "local")
+        assert result["approved"] is False
+        assert result.get("status") == "blocked_by_policy"
+        mock_tirith.assert_not_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_restart_from_local_cli_is_not_hard_blocked(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        result = check_all_command_guards("hermes gateway restart", "local")
+        assert result["approved"] is True
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_status_commands_are_not_hard_blocked(self, mock_tirith):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        assert check_all_command_guards("systemctl --user status hermes-gateway", "local")["approved"] is True
+        assert check_all_command_guards("echo 'hermes gateway restart'", "local")["approved"] is True
+        mock_tirith.assert_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_callback_context_triggers_hard_block_without_env_var(self, mock_tirith):
+        session_key = "gateway-turn"
+        token = set_current_session_key(session_key)
+        register_gateway_notify(session_key, lambda _data: None)
+        try:
+            result = check_all_command_guards("hermes gateway restart", "local")
+        finally:
+            unregister_gateway_notify(session_key)
+            reset_current_session_key(token)
+        assert result["approved"] is False
+        assert result.get("status") == "blocked_by_policy"
+        mock_tirith.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "env FOO=1 hermes gateway restart",
+            "sudo -u alice systemctl --user restart hermes-gateway",
+            "bash -lc \"hermes gateway restart\"",
+            "service hermes-gateway restart",
+            "brew services restart hermes-gateway",
+        ],
+    )
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_wrapped_restart_variants_are_hard_blocked(self, mock_tirith, command):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        result = check_all_command_guards(command, "local")
+        assert result["approved"] is False
+        assert result.get("status") == "blocked_by_policy"
+        assert "local shell" in result["message"]
+        mock_tirith.assert_not_called()
+
+    def test_check_dangerous_command_hard_blocks_wrapped_gateway_restart(self):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        result = check_dangerous_command("bash -lc \"hermes gateway restart\"", "local")
+        assert result["approved"] is False
+        assert result.get("status") == "blocked_by_policy"
+        assert "local shell" in result["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -192,6 +192,128 @@ def detect_dangerous_command(command: str) -> tuple:
     return (False, None, None)
 
 
+_GATEWAY_SELF_MANAGEMENT_PATTERNS = [
+    (
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?(?:\S*/)?hermes\b(?:[^\n;&|]*?\s+--profile\s+\S+)?[^\n;&|]*?\bgateway\s+(?:start|stop|restart|run|install)\b',
+        "gateway self-management from inside a live gateway session",
+    ),
+    (
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?(?:\S*/)?python(?:3(?:\.\d+)?)?\s+-m\s+hermes_cli\.main\b(?:[^\n;&|]*?\s+--profile\s+\S+)?[^\n;&|]*?\bgateway\s+(?:start|stop|restart|run|install)\b',
+        "gateway self-management from inside a live gateway session",
+    ),
+    (
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?launchctl\s+(?:bootout|bootstrap|kickstart|kill|stop|start|unload|load)\b[^\n]*\bai\.hermes\.gateway\b',
+        "launchctl management of ai.hermes.gateway from inside a live gateway session",
+    ),
+    (
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?systemctl(?:\s+--user)?\s+(?:start|stop|restart|try-restart|reload-or-restart)\b[^\n]*\bhermes-gateway\b',
+        "systemd management of hermes-gateway from inside a live gateway session",
+    ),
+    (
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?service\s+hermes-gateway\s+(?:start|stop|restart)\b',
+        "service management of hermes-gateway from inside a live gateway session",
+    ),
+    (
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?brew\s+services\s+(?:start|stop|restart)\s+hermes-gateway\b',
+        "brew services management of hermes-gateway from inside a live gateway session",
+    ),
+]
+
+
+_GATEWAY_SELF_MANAGEMENT_MESSAGE = (
+    "Running gateway start/stop/restart commands from a live messaging "
+    "session would interrupt the current conversation. Run this from a "
+    "local shell on the agent machine instead."
+)
+
+
+def _blocked_gateway_self_management_result(description: str) -> dict:
+    """Return the hard-block response for gateway self-management commands."""
+    return {
+        "approved": False,
+        "status": "blocked_by_policy",
+        "description": description,
+        "message": f"BLOCKED: {description}. {_GATEWAY_SELF_MANAGEMENT_MESSAGE}",
+    }
+
+
+def _extract_gateway_self_management_candidates(segment: str) -> list[str]:
+    """Return normalized command variants to probe for gateway self-management.
+
+    This unwraps common wrappers like env-prefixes, sudo -u, and shell -c so
+    `env FOO=1 hermes gateway restart` and `bash -lc "hermes gateway restart"`
+    are checked against the same policy patterns.
+    """
+    candidates: list[str] = []
+
+    def _add(value: str) -> None:
+        value = value.strip()
+        if value and value not in candidates:
+            candidates.append(value)
+
+    _add(segment)
+
+    stripped = re.sub(
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?',
+        '',
+        segment,
+        count=1,
+    ).strip()
+    _add(stripped)
+
+    shell_match = re.match(
+        r'^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?(?:sudo(?:\s+-u\s+\S+)?\s+)?'
+        r'(?:bash|sh|zsh|ksh)\s+-[^\s]*c\s+(.+)$',
+        segment,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if shell_match:
+        inner = shell_match.group(1).strip()
+        if len(inner) >= 2 and inner[0] == inner[-1] and inner[0] in {'"', "'"}:
+            inner = inner[1:-1]
+        _add(inner)
+
+    return candidates
+
+
+def _is_live_gateway_session() -> bool:
+    """Return True when command guards are running inside an active gateway turn."""
+    if os.getenv("HERMES_GATEWAY_SESSION"):
+        return True
+
+    session_key = get_current_session_key("")
+    if not session_key:
+        return False
+
+    with _lock:
+        return session_key in _gateway_notify_cbs
+
+
+def detect_gateway_self_management_command(command: str) -> tuple[bool, Optional[str]]:
+    """Detect commands that would stop/restart the gateway from within itself.
+
+    Messaging sessions run inside the gateway process. Allowing a terminal
+    command like ``hermes gateway restart`` from a Telegram/Discord/etc. turn can
+    terminate the very process serving that turn, interrupting the response and
+    creating confusing restart loops in the same conversation.
+
+    These commands must be hard-blocked rather than routed through approval.
+    The operator can still manage the service from a local shell outside the
+    gateway session.
+    """
+    if not _is_live_gateway_session():
+        return (False, None)
+
+    command_lower = _normalize_command_for_detection(command).lower()
+    segments = [seg.strip() for seg in re.split(r'\s*(?:&&|\|\||;|\n)\s*', command_lower) if seg.strip()]
+    for segment in segments:
+        for candidate in _extract_gateway_self_management_candidates(segment):
+            for pattern, description in _GATEWAY_SELF_MANAGEMENT_PATTERNS:
+                if re.search(pattern, candidate, re.IGNORECASE | re.DOTALL):
+                    return (True, description)
+    return (False, None)
+
+
 # =========================================================================
 # Per-session approval state (thread-safe)
 # =========================================================================
@@ -596,6 +718,10 @@ def check_dangerous_command(command: str, env_type: str,
     if env_type in ("docker", "singularity", "modal", "daytona"):
         return {"approved": True, "message": None}
 
+    is_self_mgmt, self_mgmt_desc = detect_gateway_self_management_command(command)
+    if is_self_mgmt:
+        return _blocked_gateway_self_management_result(self_mgmt_desc)
+
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
     if os.getenv("HERMES_YOLO_MODE") or is_current_session_yolo_enabled():
@@ -697,6 +823,10 @@ def check_all_command_guards(command: str, env_type: str,
     # Skip containers for both checks
     if env_type in ("docker", "singularity", "modal", "daytona"):
         return {"approved": True, "message": None}
+
+    is_self_mgmt, self_mgmt_desc = detect_gateway_self_management_command(command)
+    if is_self_mgmt:
+        return _blocked_gateway_self_management_result(self_mgmt_desc)
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.


### PR DESCRIPTION
## Bug Description

When Hermes runs on a messaging gateway (for example Telegram), the agent can issue terminal commands that restart or stop the very gateway process currently serving the conversation. In practice this interrupts the reply mid-turn and makes a follow-up message like “如何了” continue a partially completed “restart the gateway” task, causing confusing self-restart loops.

Fixes #

## Root Cause

Dangerous-command approval treated gateway-management commands like any other command. In a live gateway turn, approving `hermes gateway restart` or equivalent `launchctl` / `systemctl` management commands allows the gateway to terminate itself from inside the active conversation.

## Fix

- hard-block gateway self-management commands during live gateway sessions instead of routing them through approval
- detect live gateway turns using the active gateway approval callback/session context, not just env vars
- narrow matching so actual service-mutating commands are blocked without false-positively blocking harmless strings/status checks
- add regression coverage for gateway-session hard block, YOLO bypass resistance, safe status/echo commands, and callback-context detection

## How to Verify

1. Run `./venv/bin/python -m pytest tests/tools/test_command_guards.py tests/tools/test_approval.py -q`
2. In a live messaging gateway session, attempt a command like `hermes gateway restart` via the terminal tool path and confirm it returns `blocked_by_policy`
3. Confirm harmless commands like `echo 'hermes gateway restart'` and `systemctl --user status hermes-gateway` are not hard-blocked

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

## Risk Assessment

Low — the change only affects service-management commands during active gateway turns and is intentionally scoped to prevent self-termination of the current messaging session.
