### PR TITLE
feat(web): add Bright Data as web search/extract backend (free 5k/month)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -245,6 +245,15 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "Bright Data",
+                "tag": "Free tier — search, extract, and crawl with Web Unlocker",
+                "web_backend": "brightdata",
+                "env_vars": [
+                    {"key": "BRIGHTDATA_API_KEY", "prompt": "Bright Data API key", "url": "https://brightdata.com/cp/setting/users"},
+                ],
+                "post_setup": "brightdata_zones",
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "tag": "Free - run your own instance",
                 "web_backend": "firecrawl",
@@ -367,6 +376,91 @@ TOOLSET_ENV_REQUIREMENTS = {
 }
 
 
+# ─── Bright Data Zone Provisioning ───────────────────────────────────────────
+
+_BRIGHTDATA_UNLOCKER_ZONE = "cli_unlocker"
+
+
+def _brightdata_ensure_zones():
+    """Auto-provision a ``cli_unlocker`` zone after the API key is saved.
+
+    Mirrors the zone provisioning logic from the Bright Data CLI
+    (``login.ts → ensure_zones``).  Runs once during ``hermes tools`` setup
+    and is idempotent — skips creation if the zone already exists.
+    """
+    import httpx as _httpx
+
+    api_key = get_env_value("BRIGHTDATA_API_KEY")
+    if not api_key:
+        _print_warning("    Bright Data API key not found — skipping zone provisioning.")
+        return
+
+    base_url = "https://api.brightdata.com"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": "hermes-agent",
+    }
+
+    # --- validate key --------------------------------------------------------
+    _print_info("    Validating API key...")
+    try:
+        resp = _httpx.get(f"{base_url}/zone", headers=headers, timeout=15)
+        if resp.status_code in (401, 403):
+            _print_warning(
+                "    Invalid or expired API key. "
+                "Check your key at https://brightdata.com/cp/setting/users"
+            )
+            return
+    except Exception as exc:
+        _print_warning(f"    Could not validate API key — {exc}")
+        return
+
+    # --- check existing zones ------------------------------------------------
+    _print_info("    Checking for required zones...")
+    try:
+        zones_resp = _httpx.get(
+            f"{base_url}/zone/get_active_zones", headers=headers, timeout=15
+        )
+        zones_resp.raise_for_status()
+        zones = zones_resp.json()
+    except Exception as exc:
+        _print_warning(f"    Could not fetch zones — {exc}")
+        return
+
+    has_unlocker = any(z.get("name") == _BRIGHTDATA_UNLOCKER_ZONE for z in zones)
+
+    # --- create zone if missing ----------------------------------------------
+    if not has_unlocker:
+        _print_info(f'    Zone "{_BRIGHTDATA_UNLOCKER_ZONE}" not found, creating...')
+        try:
+            create_resp = _httpx.post(
+                f"{base_url}/zone",
+                headers=headers,
+                json={
+                    "zone": {"name": _BRIGHTDATA_UNLOCKER_ZONE, "type": "unblocker"},
+                    "plan": {"type": "unblocker"},
+                },
+                timeout=15,
+            )
+            create_resp.raise_for_status()
+            _print_success(f'    Zone "{_BRIGHTDATA_UNLOCKER_ZONE}" created successfully.')
+        except Exception as exc:
+            _print_warning(
+                f'    Could not create zone "{_BRIGHTDATA_UNLOCKER_ZONE}" — {exc}\n'
+                "    You can create it manually at https://brightdata.com/cp/zones"
+            )
+            return
+    else:
+        _print_success(f'    Zone "{_BRIGHTDATA_UNLOCKER_ZONE}" already exists.')
+
+    # --- persist zone as env default -----------------------------------------
+    existing_zone = get_env_value("BRIGHTDATA_UNLOCKER_ZONE")
+    if not existing_zone:
+        save_env_value("BRIGHTDATA_UNLOCKER_ZONE", _BRIGHTDATA_UNLOCKER_ZONE)
+        _print_success(f"    Default zone saved: BRIGHTDATA_UNLOCKER_ZONE={_BRIGHTDATA_UNLOCKER_ZONE}")
+
+
 # ─── Post-Setup Hooks ─────────────────────────────────────────────────────────
 
 def _run_post_setup(post_setup_key: str):
@@ -410,6 +504,9 @@ def _run_post_setup(post_setup_key: str):
         elif not shutil.which("npm"):
             _print_warning("    Node.js not found. Install Camofox via Docker:")
             _print_info("      docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
+
+    elif post_setup_key == "brightdata_zones":
+        _brightdata_ensure_zones()
 
     elif post_setup_key == "rl_training":
         try:

--- a/tests/tools/test_web_tools_brightdata.py
+++ b/tests/tools/test_web_tools_brightdata.py
@@ -1,0 +1,476 @@
+"""Tests for Bright Data web backend integration.
+
+Coverage:
+  _get_brightdata_api_key() — API key handling, missing key error.
+  _get_brightdata_zone() — zone resolution from env, config, default.
+  _brightdata_request() — request construction, retry logic, error headers.
+  _brightdata_search() — search response parsing, URL encoding, edge cases.
+  _brightdata_extract() — extract response handling, per-URL errors.
+  web_search_tool / web_extract_tool / web_crawl_tool — Bright Data dispatch paths.
+  _is_backend_available / check_web_api_key — availability with BRIGHTDATA_API_KEY.
+  _get_backend — config and fallback selection with brightdata.
+"""
+
+import json
+import os
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ─── _get_brightdata_api_key ────────────────────────────────────────────────
+
+class TestBrightdataApiKey:
+    """Test suite for the _get_brightdata_api_key helper."""
+
+    def test_returns_key_when_set(self):
+        """BRIGHTDATA_API_KEY set → returns trimmed key."""
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "  test-key  "}):
+            from tools.web_tools import _get_brightdata_api_key
+            assert _get_brightdata_api_key() == "test-key"
+
+    def test_raises_without_api_key(self):
+        """No BRIGHTDATA_API_KEY → ValueError with guidance."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRIGHTDATA_API_KEY", None)
+            from tools.web_tools import _get_brightdata_api_key
+            with pytest.raises(ValueError, match="BRIGHTDATA_API_KEY"):
+                _get_brightdata_api_key()
+
+    def test_empty_string_raises(self):
+        """BRIGHTDATA_API_KEY='' → ValueError."""
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": ""}):
+            from tools.web_tools import _get_brightdata_api_key
+            with pytest.raises(ValueError, match="BRIGHTDATA_API_KEY"):
+                _get_brightdata_api_key()
+
+
+# ─── _get_brightdata_zone ───────────────────────────────────────────────────
+
+class TestBrightdataZone:
+    """Test suite for zone resolution."""
+
+    def test_env_var_takes_priority(self):
+        """BRIGHTDATA_UNLOCKER_ZONE env → used over config and default."""
+        with patch.dict(os.environ, {"BRIGHTDATA_UNLOCKER_ZONE": "my_zone"}):
+            with patch("tools.web_tools._load_web_config", return_value={"brightdata_zone": "config_zone"}):
+                from tools.web_tools import _get_brightdata_zone
+                assert _get_brightdata_zone() == "my_zone"
+
+    def test_config_fallback(self):
+        """No env var, web.brightdata_zone in config → used."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRIGHTDATA_UNLOCKER_ZONE", None)
+            with patch("tools.web_tools._load_web_config", return_value={"brightdata_zone": "config_zone"}):
+                from tools.web_tools import _get_brightdata_zone
+                assert _get_brightdata_zone() == "config_zone"
+
+    def test_default_zone(self):
+        """No env var, no config → default 'cli_unlocker'."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRIGHTDATA_UNLOCKER_ZONE", None)
+            with patch("tools.web_tools._load_web_config", return_value={}):
+                from tools.web_tools import _get_brightdata_zone
+                assert _get_brightdata_zone() == "cli_unlocker"
+
+
+# ─── _brightdata_request ────────────────────────────────────────────────────
+
+class TestBrightdataRequest:
+    """Test suite for the _brightdata_request helper."""
+
+    def test_posts_with_bearer_auth(self):
+        """Request uses Bearer token and correct headers."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {"organic": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}):
+            with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+                from tools.web_tools import _brightdata_request
+                _brightdata_request({"zone": "cli_unlocker", "url": "https://example.com"})
+
+                mock_post.assert_called_once()
+                call_kwargs = mock_post.call_args
+                headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+                assert headers["Authorization"] == "Bearer test-key"
+                assert headers["User-Agent"] == "hermes-agent"
+                assert "api.brightdata.com/request" in call_kwargs.args[0]
+
+    def test_returns_text_when_not_json(self):
+        """Non-JSON content-type → returns response.text."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.text = "markdown content here"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}):
+            with patch("tools.web_tools.httpx.post", return_value=mock_response):
+                from tools.web_tools import _brightdata_request
+                result = _brightdata_request({"zone": "z", "url": "https://example.com"})
+                assert result == "markdown content here"
+
+    def test_raises_on_brd_error_header(self):
+        """x-brd-error header → ValueError with the error message."""
+        import httpx as _httpx
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.headers = {"x-brd-error": "zone not found"}
+        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
+            "400", request=MagicMock(), response=mock_response
+        )
+
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}):
+            with patch("tools.web_tools.httpx.post", return_value=mock_response):
+                from tools.web_tools import _brightdata_request
+                with pytest.raises(ValueError, match="zone not found"):
+                    _brightdata_request({"zone": "z", "url": "https://example.com"})
+
+
+# ─── _brightdata_search ─────────────────────────────────────────────────────
+
+class TestBrightdataSearch:
+    """Test search response parsing."""
+
+    def _mock_request(self, return_value):
+        """Helper to patch _brightdata_request and interrupt check."""
+        return patch("tools.web_tools._brightdata_request", return_value=return_value)
+
+    def test_parses_organic_results(self):
+        """Standard Google SERP JSON → normalized web results."""
+        raw = {
+            "organic": [
+                {"link": "https://example.com", "title": "Example", "description": "A site", "rank": 1},
+                {"link": "https://other.com", "title": "Other", "description": "Another", "rank": 2},
+            ]
+        }
+        with self._mock_request(raw), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_search
+            result = _brightdata_search("test query", limit=5)
+            assert result["success"] is True
+            web = result["data"]["web"]
+            assert len(web) == 2
+            assert web[0]["title"] == "Example"
+            assert web[0]["url"] == "https://example.com"
+            assert web[0]["description"] == "A site"
+            assert web[0]["position"] == 1
+
+    def test_parses_text_json_response(self):
+        """API returns text/plain with JSON content → parsed correctly."""
+        raw_text = json.dumps({
+            "organic": [
+                {"link": "https://r.com", "title": "Result", "description": "Desc"},
+            ]
+        })
+        with self._mock_request(raw_text), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_search
+            result = _brightdata_search("test", limit=5)
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 1
+            assert result["data"]["web"][0]["title"] == "Result"
+
+    def test_skips_entries_without_link_or_title(self):
+        """Entries missing link or title are filtered out."""
+        raw = {
+            "organic": [
+                {"link": "", "title": "No Link", "description": "x"},
+                {"link": "https://ok.com", "title": "", "description": "x"},
+                {"link": "https://ok.com", "title": "Good", "description": "x"},
+            ]
+        }
+        with self._mock_request(raw), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_search
+            result = _brightdata_search("test", limit=5)
+            assert len(result["data"]["web"]) == 1
+            assert result["data"]["web"][0]["title"] == "Good"
+
+    def test_empty_organic(self):
+        """No organic results → empty web list."""
+        with self._mock_request({"organic": []}), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_search
+            result = _brightdata_search("test", limit=5)
+            assert result["success"] is True
+            assert result["data"]["web"] == []
+
+    def test_unparseable_text_returns_empty(self):
+        """Non-JSON text response → empty results (no crash)."""
+        with self._mock_request("This is not JSON"), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_search
+            result = _brightdata_search("test", limit=5)
+            assert result["success"] is True
+            assert result["data"]["web"] == []
+
+    def test_respects_limit(self):
+        """Results are capped at the requested limit."""
+        raw = {"organic": [
+            {"link": f"https://r{i}.com", "title": f"R{i}", "description": "x"}
+            for i in range(10)
+        ]}
+        with self._mock_request(raw), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_search
+            result = _brightdata_search("test", limit=3)
+            assert len(result["data"]["web"]) == 3
+
+    def test_request_includes_parsed_light(self):
+        """Search request must include data_format=parsed_light."""
+        with patch("tools.web_tools._get_brightdata_api_key", return_value="k"), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="z"), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.json.return_value = {"organic": []}
+            mock_response.raise_for_status = MagicMock()
+
+            with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+                from tools.web_tools import _brightdata_search
+                _brightdata_search("hello world", limit=5)
+                payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+                assert payload["data_format"] == "parsed_light"
+                assert payload["zone"] == "z"
+                assert "brd_json=1" in payload["url"]
+                assert "hello+world" in payload["url"] or "hello%20world" in payload["url"]
+
+
+# ─── _brightdata_extract ────────────────────────────────────────────────────
+
+class TestBrightdataExtract:
+    """Test extract response handling."""
+
+    def test_basic_extract(self):
+        """Single URL → markdown content returned."""
+        with patch("tools.web_tools._brightdata_request", return_value="# Hello World"), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_extract
+            results = _brightdata_extract(["https://example.com"])
+            assert len(results) == 1
+            assert results[0]["url"] == "https://example.com"
+            assert results[0]["content"] == "# Hello World"
+            assert results[0]["metadata"]["sourceURL"] == "https://example.com"
+
+    def test_extract_error_per_url(self):
+        """Failed URL → error entry, other URLs still succeed."""
+        call_count = 0
+
+        def mock_request(payload, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("connection refused")
+            return "# Content"
+
+        with patch("tools.web_tools._brightdata_request", side_effect=mock_request), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_extract
+            results = _brightdata_extract(["https://fail.com", "https://ok.com"])
+            assert len(results) == 2
+            assert "error" in results[0]
+            assert "connection refused" in results[0]["error"]
+            assert results[1]["content"] == "# Content"
+
+    def test_extract_json_response(self):
+        """API returns dict instead of text → serialized to JSON string."""
+        with patch("tools.web_tools._brightdata_request", return_value={"html": "<p>hi</p>"}), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _brightdata_extract
+            results = _brightdata_extract(["https://example.com"])
+            assert '"html"' in results[0]["content"]
+
+
+# ─── web_search_tool (Bright Data dispatch) ─────────────────────────────────
+
+class TestWebSearchBrightdata:
+    """Test web_search_tool dispatch to Bright Data."""
+
+    def test_search_dispatches_to_brightdata(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "organic": [{"link": "https://r.com", "title": "Result", "description": "desc"}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools._get_backend", return_value="brightdata"), \
+             patch("tools.web_tools._get_brightdata_zone", return_value="cli_unlocker"), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}), \
+             patch("tools.web_tools.httpx.post", return_value=mock_response), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            result = json.loads(web_search_tool("test query", limit=3))
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 1
+            assert result["data"]["web"][0]["title"] == "Result"
+
+
+# ─── web_extract_tool (Bright Data dispatch) ────────────────────────────────
+
+class TestWebExtractBrightdata:
+    """Test web_extract_tool dispatch to Bright Data."""
+
+    def test_extract_dispatches_to_brightdata(self):
+        with patch("tools.web_tools._get_backend", return_value="brightdata"), \
+             patch("tools.web_tools._brightdata_extract", return_value=[{
+                 "url": "https://example.com", "title": "Page",
+                 "content": "# Content", "raw_content": "# Content",
+                 "metadata": {"sourceURL": "https://example.com"},
+             }]), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}):
+            from tools.web_tools import web_extract_tool
+            result = json.loads(asyncio.get_event_loop().run_until_complete(
+                web_extract_tool(["https://example.com"], use_llm_processing=False)
+            ))
+            assert "results" in result
+            assert len(result["results"]) == 1
+            assert result["results"][0]["url"] == "https://example.com"
+
+
+# ─── web_crawl_tool (Bright Data dispatch) ──────────────────────────────────
+
+class TestWebCrawlBrightdata:
+    """Test web_crawl_tool dispatch to Bright Data."""
+
+    def test_crawl_dispatches_to_brightdata(self):
+        with patch("tools.web_tools._get_backend", return_value="brightdata"), \
+             patch("tools.web_tools._brightdata_extract", return_value=[{
+                 "url": "https://example.com", "title": "",
+                 "content": "# Page content", "raw_content": "# Page content",
+                 "metadata": {"sourceURL": "https://example.com"},
+             }]), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "test-key"}):
+            from tools.web_tools import web_crawl_tool
+            result = json.loads(asyncio.get_event_loop().run_until_complete(
+                web_crawl_tool("https://example.com", use_llm_processing=False)
+            ))
+            assert "results" in result
+            assert len(result["results"]) == 1
+            assert "Page content" in result["results"][0]["content"]
+
+
+# ─── Backend selection & availability ────────────────────────────────────────
+
+class TestBackendSelectionBrightdata:
+    """Test _get_backend and availability checks with Bright Data."""
+
+    _ENV_KEYS = (
+        "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+        "BRIGHTDATA_API_KEY",
+        "EXA_API_KEY",
+        "PARALLEL_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "FIRECRAWL_API_URL",
+        "TAVILY_API_KEY",
+    )
+
+    def setup_method(self):
+        os.environ["HERMES_ENABLE_NOUS_MANAGED_TOOLS"] = "1"
+        for key in self._ENV_KEYS:
+            if key != "HERMES_ENABLE_NOUS_MANAGED_TOOLS":
+                os.environ.pop(key, None)
+
+    def teardown_method(self):
+        for key in self._ENV_KEYS:
+            os.environ.pop(key, None)
+
+    def test_config_brightdata(self):
+        """web.backend=brightdata in config → 'brightdata' regardless of keys."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "brightdata"}):
+            assert _get_backend() == "brightdata"
+
+    def test_config_brightdata_case_insensitive(self):
+        """web.backend=BrightData (mixed case) → 'brightdata'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "BrightData"}):
+            assert _get_backend() == "brightdata"
+
+    def test_config_brightdata_overrides_env_keys(self):
+        """web.backend=brightdata → 'brightdata' even if Firecrawl key set."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "brightdata"}), \
+             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+            assert _get_backend() == "brightdata"
+
+    def test_fallback_brightdata_only_key(self):
+        """Only BRIGHTDATA_API_KEY set → 'brightdata'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "bd-test"}):
+            assert _get_backend() == "brightdata"
+
+    def test_fallback_firecrawl_takes_priority_over_brightdata(self):
+        """Firecrawl + Bright Data keys, no config → 'firecrawl' (backward compat)."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "bd-test", "FIRECRAWL_API_KEY": "fc-test"}):
+            assert _get_backend() == "firecrawl"
+
+    def test_fallback_brightdata_takes_priority_over_parallel(self):
+        """Bright Data + Parallel keys, no config → 'brightdata'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "bd-test", "PARALLEL_API_KEY": "par-test"}):
+            assert _get_backend() == "brightdata"
+
+    def test_is_backend_available_brightdata(self):
+        """_is_backend_available('brightdata') checks BRIGHTDATA_API_KEY."""
+        from tools.web_tools import _is_backend_available
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "bd-test"}):
+            assert _is_backend_available("brightdata") is True
+
+    def test_is_backend_available_brightdata_missing(self):
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("brightdata") is False
+
+    def test_check_web_api_key_brightdata_only(self):
+        """check_web_api_key() returns True with only BRIGHTDATA_API_KEY."""
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "bd-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_check_web_api_key_configured_brightdata(self):
+        """web.backend=brightdata + key set → True."""
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "brightdata"}), \
+             patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "bd-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_check_web_api_key_configured_brightdata_no_key(self):
+        """web.backend=brightdata but no key → False."""
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "brightdata"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
+
+
+def test_web_requires_env_includes_brightdata_key():
+    from tools.web_tools import _web_requires_env
+    assert "BRIGHTDATA_API_KEY" in _web_requires_env()

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -299,6 +299,7 @@ class TestBackendSelection:
 
     _ENV_KEYS = (
         "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+        "BRIGHTDATA_API_KEY",
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "FIRECRAWL_API_KEY",
@@ -524,6 +525,7 @@ class TestCheckWebApiKey:
 
     _ENV_KEYS = (
         "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+        "BRIGHTDATA_API_KEY",
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "FIRECRAWL_API_KEY",
@@ -610,8 +612,24 @@ class TestCheckWebApiKey:
                     from tools.web_tools import check_web_api_key
                     assert check_web_api_key() is True
 
+    def test_brightdata_key_only(self):
+        with patch.dict(os.environ, {"BRIGHTDATA_API_KEY": "bd-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_configured_brightdata_backend_requires_key(self):
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "brightdata"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
+
 
 def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+def test_web_requires_env_includes_brightdata_key():
+    from tools.web_tools import _web_requires_env
+
+    assert "BRIGHTDATA_API_KEY" in _web_requires_env()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -444,43 +444,50 @@ def _brightdata_search(query: str, limit: int = 5) -> dict:
     """Search using the Bright Data SERP API and return normalised results.
 
     Scrapes a Google search URL via the ``/request`` endpoint with
-    ``brd_json=1`` to get parsed structured results, then maps them to the
-    standard ``{success, data: {web: [...]}}`` format.
+    ``brd_json=1`` + ``data_format: parsed_light`` to get structured JSON
+    results, then maps them to the standard format.
     """
     from tools.interrupt import is_interrupted
+    from urllib.parse import quote
     if is_interrupted():
         return {"error": "Interrupted", "success": False}
 
     zone = _get_brightdata_zone()
-    search_url = f"https://www.google.com/search?q={query}&brd_json=1&num={limit}"
+    encoded_query = quote(query)
+    search_url = f"https://www.google.com/search?q={encoded_query}&start=0&brd_json=1&num={limit}"
     logger.info("Bright Data search: '%s' (zone=%s, limit=%d)", query, zone, limit)
 
     raw = _brightdata_request({
         "zone": zone,
         "url": search_url,
         "format": "raw",
+        "data_format": "parsed_light",
     })
 
-    # Parse the structured Google SERP response
+    # The API may return text/plain with JSON content — try to parse.
+    search_data = raw
+    if isinstance(raw, str):
+        try:
+            search_data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            search_data = raw
+
     web_results = []
-    if isinstance(raw, dict):
-        for i, result in enumerate(raw.get("organic", [])):
+    if isinstance(search_data, dict):
+        for i, result in enumerate(search_data.get("organic", [])):
+            link = (result.get("link") or "").strip()
+            title = (result.get("title") or "").strip()
+            description = (result.get("description") or "").strip()
+            if not link or not title:
+                continue
             web_results.append({
-                "title": result.get("title", ""),
-                "url": result.get("link", ""),
-                "description": result.get("description", ""),
+                "title": title,
+                "url": link,
+                "description": description,
                 "position": result.get("rank", i + 1),
             })
-    elif isinstance(raw, str):
-        # Fallback: response came back as text (non-JSON Google page).
-        # Wrap as a single result so callers still get something useful.
-        logger.warning("Bright Data search returned text instead of parsed JSON")
-        web_results.append({
-            "title": f"Search results for: {query}",
-            "url": f"https://www.google.com/search?q={query}",
-            "description": raw[:500],
-            "position": 1,
-        })
+    else:
+        logger.warning("Bright Data search returned unparsed text")
 
     return {"success": True, "data": {"web": web_results[:limit]}}
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -13,6 +13,7 @@ Available tools:
 - web_crawl_tool: Crawl websites with specific instructions
 
 Backend compatibility:
+- Bright Data: https://brightdata.com (search, extract — free tier available)
 - Exa: https://exa.ai (search, extract)
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
@@ -88,7 +89,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "brightdata"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -96,6 +97,7 @@ def _get_backend() -> str:
     # tool gateway is configured for Nous subscribers.
     backend_candidates = (
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
+        ("brightdata", _has_env("BRIGHTDATA_API_KEY")),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
@@ -109,6 +111,8 @@ def _get_backend() -> str:
 
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
+    if backend == "brightdata":
+        return _has_env("BRIGHTDATA_API_KEY")
     if backend == "exa":
         return _has_env("EXA_API_KEY")
     if backend == "parallel":
@@ -184,6 +188,7 @@ def _firecrawl_backend_help_suffix() -> str:
 def _web_requires_env() -> list[str]:
     """Return tool metadata env vars for the currently enabled web backends."""
     requires = [
+        "BRIGHTDATA_API_KEY",
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "TAVILY_API_KEY",
@@ -359,6 +364,170 @@ def _normalize_tavily_documents(response: dict, fallback_url: str = "") -> List[
             "metadata": {"sourceURL": url_str},
         })
     return documents
+
+
+# ─── Bright Data Client ─────────────────────────────────────────────────────
+
+_BRIGHTDATA_BASE_URL = "https://api.brightdata.com"
+_BRIGHTDATA_RETRY_STATUSES = (429, 500, 502, 503, 504)
+_BRIGHTDATA_MAX_RETRIES = 3
+_BRIGHTDATA_RETRY_BASE_MS = 500
+
+
+def _get_brightdata_api_key() -> str:
+    """Return the Bright Data API key or raise with setup instructions."""
+    api_key = os.getenv("BRIGHTDATA_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError(
+            "BRIGHTDATA_API_KEY environment variable not set. "
+            "Get your API key at https://brightdata.com/cp/setting/users"
+        )
+    return api_key
+
+
+def _get_brightdata_zone() -> str:
+    """Resolve the Bright Data zone name.
+
+    Priority: BRIGHTDATA_UNLOCKER_ZONE env → web.brightdata_zone config → default.
+    """
+    env_zone = os.getenv("BRIGHTDATA_UNLOCKER_ZONE", "").strip()
+    if env_zone:
+        return env_zone
+    config_zone = _load_web_config().get("brightdata_zone", "").strip()
+    if config_zone:
+        return config_zone
+    return "cli_unlocker"
+
+
+def _brightdata_request(payload: dict, *, timeout: int = 60) -> Any:
+    """Send a POST to ``/request`` on the Bright Data API with retry logic.
+
+    Uses Bearer token auth. Retries on transient HTTP errors with
+    exponential backoff (matches the Bright Data CLI convention).
+    """
+    api_key = _get_brightdata_api_key()
+    url = f"{_BRIGHTDATA_BASE_URL}/request"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": "hermes-agent",
+    }
+
+    last_error: Optional[Exception] = None
+    for attempt in range(_BRIGHTDATA_MAX_RETRIES + 1):
+        try:
+            response = httpx.post(url, json=payload, headers=headers, timeout=timeout)
+            if response.status_code in _BRIGHTDATA_RETRY_STATUSES and attempt < _BRIGHTDATA_MAX_RETRIES:
+                import time
+                time.sleep(_BRIGHTDATA_RETRY_BASE_MS / 1000 * (2 ** attempt))
+                continue
+            response.raise_for_status()
+            content_type = response.headers.get("content-type", "")
+            if "application/json" in content_type:
+                return response.json()
+            return response.text
+        except httpx.HTTPStatusError as exc:
+            brd_error = exc.response.headers.get("x-brd-error") or exc.response.headers.get("x-luminati-error")
+            if brd_error:
+                raise ValueError(f"Bright Data API error: {brd_error}") from exc
+            raise
+        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+            last_error = exc
+            if attempt < _BRIGHTDATA_MAX_RETRIES:
+                import time
+                time.sleep(_BRIGHTDATA_RETRY_BASE_MS / 1000 * (2 ** attempt))
+                continue
+    raise last_error or RuntimeError("Bright Data request failed after retries")
+
+
+def _brightdata_search(query: str, limit: int = 5) -> dict:
+    """Search using the Bright Data SERP API and return normalised results.
+
+    Scrapes a Google search URL via the ``/request`` endpoint with
+    ``brd_json=1`` to get parsed structured results, then maps them to the
+    standard ``{success, data: {web: [...]}}`` format.
+    """
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return {"error": "Interrupted", "success": False}
+
+    zone = _get_brightdata_zone()
+    search_url = f"https://www.google.com/search?q={query}&brd_json=1&num={limit}"
+    logger.info("Bright Data search: '%s' (zone=%s, limit=%d)", query, zone, limit)
+
+    raw = _brightdata_request({
+        "zone": zone,
+        "url": search_url,
+        "format": "raw",
+    })
+
+    # Parse the structured Google SERP response
+    web_results = []
+    if isinstance(raw, dict):
+        for i, result in enumerate(raw.get("organic", [])):
+            web_results.append({
+                "title": result.get("title", ""),
+                "url": result.get("link", ""),
+                "description": result.get("description", ""),
+                "position": result.get("rank", i + 1),
+            })
+    elif isinstance(raw, str):
+        # Fallback: response came back as text (non-JSON Google page).
+        # Wrap as a single result so callers still get something useful.
+        logger.warning("Bright Data search returned text instead of parsed JSON")
+        web_results.append({
+            "title": f"Search results for: {query}",
+            "url": f"https://www.google.com/search?q={query}",
+            "description": raw[:500],
+            "position": 1,
+        })
+
+    return {"success": True, "data": {"web": web_results[:limit]}}
+
+
+def _brightdata_extract(urls: List[str]) -> List[Dict[str, Any]]:
+    """Extract content from URLs using Bright Data Web Unlocker.
+
+    Each URL is scraped with ``data_format: markdown`` and returned in the
+    standard document format expected by the LLM post-processing pipeline.
+    """
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+    zone = _get_brightdata_zone()
+    logger.info("Bright Data extract: %d URL(s) (zone=%s)", len(urls), zone)
+
+    results: List[Dict[str, Any]] = []
+    for url in urls:
+        if is_interrupted():
+            results.append({"url": url, "error": "Interrupted", "title": ""})
+            continue
+        try:
+            content = _brightdata_request({
+                "zone": zone,
+                "url": url,
+                "format": "raw",
+                "data_format": "markdown",
+            })
+            text = content if isinstance(content, str) else json.dumps(content)
+            results.append({
+                "url": url,
+                "title": "",
+                "content": text,
+                "raw_content": text,
+                "metadata": {"sourceURL": url},
+            })
+        except Exception as exc:
+            logger.debug("Bright Data extract failed for %s: %s", url, exc)
+            results.append({
+                "url": url,
+                "title": "",
+                "content": "",
+                "raw_content": "",
+                "error": str(exc),
+            })
+    return results
 
 
 def _to_plain_object(value: Any) -> Any:
@@ -1083,6 +1252,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
 
         # Dispatch to the configured backend
         backend = _get_backend()
+        if backend == "brightdata":
+            response_data = _brightdata_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         if backend == "parallel":
             response_data = _parallel_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
@@ -1238,7 +1416,9 @@ async def web_extract_tool(
         else:
             backend = _get_backend()
 
-            if backend == "parallel":
+            if backend == "brightdata":
+                results = _brightdata_extract(safe_urls)
+            elif backend == "parallel":
                 results = await _parallel_extract(safe_urls)
             elif backend == "exa":
                 results = _exa_extract(safe_urls)
@@ -1539,6 +1719,76 @@ async def web_crawl_tool(
         effective_model = model or _get_default_summarizer_model()
         auxiliary_available = check_auxiliary_model()
         backend = _get_backend()
+
+        # Bright Data supports crawl via its /request endpoint (single-page scrape)
+        if backend == "brightdata":
+            if not url.startswith(('http://', 'https://')):
+                url = f'https://{url}'
+
+            if not is_safe_url(url):
+                return json.dumps({"results": [{"url": url, "title": "", "content": "",
+                    "error": "Blocked: URL targets a private or internal network address"}]}, ensure_ascii=False)
+
+            blocked = check_website_access(url)
+            if blocked:
+                logger.info("Blocked web_crawl for %s by rule %s", blocked["host"], blocked["rule"])
+                return json.dumps({"results": [{"url": url, "title": "", "content": "", "error": blocked["message"],
+                    "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]}}]}, ensure_ascii=False)
+
+            from tools.interrupt import is_interrupted as _is_int
+            if _is_int():
+                return json.dumps({"error": "Interrupted", "success": False})
+
+            logger.info("Bright Data crawl (single-page scrape): %s", url)
+            results = _brightdata_extract([url])
+            response = {"results": results}
+
+            pages_crawled = len(response.get('results', []))
+            logger.info("Crawled %d pages", pages_crawled)
+            debug_call_data["pages_crawled"] = pages_crawled
+            debug_call_data["original_response_size"] = len(json.dumps(response))
+
+            if use_llm_processing and auxiliary_available:
+                logger.info("Processing crawled content with LLM (parallel)...")
+                debug_call_data["processing_applied"].append("llm_processing")
+
+                async def _process_bd_crawl(result):
+                    page_url = result.get('url', 'Unknown URL')
+                    page_title = result.get('title', '')
+                    content = result.get('content', '')
+                    if not content:
+                        return result, None, "no_content"
+                    original_size = len(content)
+                    processed = await process_content_with_llm(content, page_url, page_title, effective_model, min_length)
+                    if processed:
+                        result['raw_content'] = content
+                        result['content'] = processed
+                        metrics = {"url": page_url, "original_size": original_size, "processed_size": len(processed),
+                                   "compression_ratio": len(processed) / original_size if original_size else 1.0, "model_used": effective_model}
+                        return result, metrics, "processed"
+                    metrics = {"url": page_url, "original_size": original_size, "processed_size": original_size,
+                               "compression_ratio": 1.0, "model_used": None, "reason": "content_too_short"}
+                    return result, metrics, "too_short"
+
+                tasks = [_process_bd_crawl(r) for r in response.get('results', [])]
+                processed_results = await asyncio.gather(*tasks)
+                for result, metrics, status in processed_results:
+                    if status == "processed":
+                        debug_call_data["compression_metrics"].append(metrics)
+                        debug_call_data["pages_processed_with_llm"] += 1
+
+            if use_llm_processing and not auxiliary_available:
+                logger.warning("LLM processing requested but no auxiliary model available, returning raw content")
+                debug_call_data["processing_applied"].append("llm_processing_unavailable")
+
+            trimmed_results = [{"url": r.get("url", ""), "title": r.get("title", ""), "content": r.get("content", ""), "error": r.get("error"),
+                **({  "blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {})} for r in response.get("results", [])]
+            result_json = json.dumps({"results": trimmed_results}, indent=2, ensure_ascii=False)
+            cleaned_result = clean_base64_images(result_json)
+            debug_call_data["final_response_size"] = len(cleaned_result)
+            _debug.log_call("web_crawl_tool", debug_call_data)
+            _debug.save()
+            return cleaned_result
 
         # Tavily supports crawl via its /crawl endpoint
         if backend == "tavily":
@@ -1919,9 +2169,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("brightdata", "exa", "parallel", "firecrawl", "tavily"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("brightdata", "exa", "parallel", "firecrawl", "tavily"))
 
 
 def check_auxiliary_model() -> bool:
@@ -1953,7 +2203,9 @@ if __name__ == "__main__":
     if web_available:
         backend = _get_backend()
         print(f"✅ Web backend: {backend}")
-        if backend == "exa":
+        if backend == "brightdata":
+            print(f"   Using Bright Data API (zone={_get_brightdata_zone()})")
+        elif backend == "exa":
             print("   Using Exa API (https://exa.ai)")
         elif backend == "parallel":
             print("   Using Parallel API (https://parallel.ai)")
@@ -1971,7 +2223,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set BRIGHTDATA_API_KEY, EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -27,6 +27,7 @@ The `web_search` and `web_extract` tools support four backend providers, configu
 | Backend | Env Var | Search | Extract | Crawl |
 |---------|---------|--------|---------|-------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | ✔ |
+| **Bright Data** | `BRIGHTDATA_API_KEY` | ✔ | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
@@ -35,7 +36,7 @@ Quick setup example:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | parallel | tavily | exa
+  backend: firecrawl    # firecrawl | brightdata | parallel | tavily | exa
 ```
 
 If `web.backend` is not set, the backend is auto-detected from whichever API key is available. Self-hosted Firecrawl is also supported via `FIRECRAWL_API_URL`.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -725,6 +725,7 @@ You can switch between providers at any time with `hermes model` — no restart 
 | Feature | Provider | Env Variable |
 |---------|----------|--------------|
 | Web scraping | [Firecrawl](https://firecrawl.dev/) | `FIRECRAWL_API_KEY`, `FIRECRAWL_API_URL` |
+| Web scraping | [Bright Data](https://brightdata.com/) | `BRIGHTDATA_API_KEY` |
 | Browser automation | [Browserbase](https://browserbase.com/) | `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID` |
 | Image generation | [FAL](https://fal.ai/) | `FAL_KEY` |
 | Premium TTS voices | [ElevenLabs](https://elevenlabs.io/) | `ELEVENLABS_API_KEY` |
@@ -756,6 +757,31 @@ By default, Hermes uses the [Firecrawl cloud API](https://firecrawl.dev/) for we
    ```
 
 You can also set both `FIRECRAWL_API_KEY` and `FIRECRAWL_API_URL` if your self-hosted instance has authentication enabled.
+
+### Bright Data
+
+[Bright Data](https://brightdata.com/) provides web search and scraping via its Web Unlocker API. It offers a free tier and handles anti-bot bypassing, CAPTCHAs, and IP rotation out of the box.
+
+**Setup:**
+
+1. Get your API key from the [Bright Data control panel](https://brightdata.com/cp/setting/users).
+
+2. Run the setup wizard:
+   ```bash
+   hermes tools
+   ```
+   Select **Bright Data** as the web search provider and paste your API key. A `cli_unlocker` zone is automatically provisioned on your account.
+
+   Or configure manually:
+   ```bash
+   hermes config set BRIGHTDATA_API_KEY your-key-here
+   hermes config set web.backend brightdata
+   ```
+
+3. (Optional) Override the default zone name:
+   ```bash
+   hermes config set BRIGHTDATA_UNLOCKER_ZONE my_custom_zone
+   ```
 
 ## OpenRouter Provider Routing
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -989,21 +989,23 @@ code_execution:
 
 ## Web Search Backends
 
-The `web_search`, `web_extract`, and `web_crawl` tools support four backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
+The `web_search`, `web_extract`, and `web_crawl` tools support five backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | parallel | tavily | exa
+  backend: firecrawl    # firecrawl | brightdata | parallel | tavily | exa
 ```
 
 | Backend | Env Var | Search | Extract | Crawl |
 |---------|---------|--------|---------|-------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | ✔ |
+| **Bright Data** | `BRIGHTDATA_API_KEY` | ✔ | ✔ | ✔ |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
 
-**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+
+**Bright Data:** Free tier available (5k requests EVERY month). During setup (`hermes tools`), a `cli_unlocker` zone is auto-provisioned on your account. Override the zone name with `BRIGHTDATA_UNLOCKER_ZONE` or `web.brightdata_zone` in config.yaml.
 
 **Self-hosted Firecrawl:** Set `FIRECRAWL_API_URL` to point at your own instance. When a custom URL is set, the API key becomes optional (set `USE_DB_AUTHENTICATION=false` on the server to disable auth).
 


### PR DESCRIPTION
## What does this PR do?

Adds [Bright Data](https://brightdata.com/) as a first-class web search, extract, and crawl backend in Hermes Agent - on par with Firecrawl, Tavily, Exa, and Parallel. Bright Data offers a free tier and uses its Web Unlocker API (`/request` endpoint) for SERP parsing and markdown extraction.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Core backend (`tools/web_tools.py`)
- Added `"brightdata"` to `_get_backend()`, `_is_backend_available()`, `check_web_api_key()`, `_web_requires_env()`
- New Bright Data client section: `_get_brightdata_api_key()`, `_get_brightdata_zone()`, `_brightdata_request()` (with retry/exponential backoff, `x-brd-error` header handling), `_brightdata_search()`, `_brightdata_extract()`
- Wired into all three dispatch functions: `web_search_tool()`, `web_extract_tool()`, `web_crawl_tool()`
- Search uses Google SERP via `/request` with `brd_json=1` + `data_format: parsed_light` 
- Extract uses `/request` with `data_format: markdown`
- Crawl delegates to `_brightdata_extract()` 
- Updated `__main__` block and error messages to include Bright Data

### Onboarding & zone provisioning (`hermes_cli/tools_config.py`)
- Added Bright Data provider entry to `TOOL_CATEGORIES["web"]["providers"]` with `post_setup: "brightdata_zones"`
- Implemented `_brightdata_ensure_zones()`: validates API key → `GET /zone/get_active_zones` → `POST /zone` if `cli_unlocker` missing → saves `BRIGHTDATA_UNLOCKER_ZONE` to `.env`
- Zone name is configurable via `BRIGHTDATA_UNLOCKER_ZONE` env var or `web.brightdata_zone` in config.yaml

### Documentation
- `website/docs/user-guide/configuration.md` — updated backend table (5 providers), yaml comment, auto-detection text, new Bright Data paragraph
- `website/docs/integrations/providers.md` — added row to Optional API Keys table + full "Bright Data" setup subsection
- `website/docs/integrations/index.md` — updated backend table and count

### Tests
- New `tests/tools/test_web_tools_brightdata.py` — 30 unit tests covering API key, zone resolution, request mechanics, search parsing, extract handling, all three tool dispatch paths, backend selection, and availability checks
- Updated `tests/tools/test_web_tools_config.py` — added `BRIGHTDATA_API_KEY` to env cleanup, 3 new tests for `check_web_api_key()` and `_web_requires_env()`

## How to Test

1. Install and configure:
   ```bash
   source venv/bin/activate
   uv pip install -e ".[all,dev]"
   hermes config set BRIGHTDATA_API_KEY <your-key>
   hermes config set web.backend brightdata
   ```

2. Run the test suite:
   ```bash
   python -m pytest tests/tools/test_web_tools_brightdata.py tests/tools/test_web_tools_config.py -v
   ```

3. Smoke test search + extract:
   ```bash
   export $(grep BRIGHTDATA ~/.hermes/.env | xargs)
   python3 -c "from tools.web_tools import web_search_tool; print(web_search_tool('Python tutorials', limit=3))"
   ```

4. Full E2E in a chat session:
   ```bash
   hermes chat
   # Ask: "search the web for latest AI news"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 20.04 ARM

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python, no platform-specific code)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A (existing `web_search`/`web_extract` schemas unchanged)

## Screenshots / Logs

**Search result:**
```json
{
  "success": true,
  "data": {
    "web": [
      {
        "title": "Web Scraping API - No Blocks, 400M+ Proxies - Free Trial",
        "url": "https://brightdata.com/products/web-scraper",
        "description": "What makes Bright Data's Web Scraper APIs unique...",
        "position": 1
      },
      {
        "title": "Bright Data - All in One Platform for Proxies and Web Scraping",
        "url": "https://brightdata.com/",
        "description": "Award winning proxy networks, powerful web scrapers...",
        "position": 2
      }
    ]
  }
}
```

**Test run:**
```
87 passed in 4.10s
```
