### PR TITLE
fix: tighten gateway update prompt handling

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2449,28 +2449,54 @@ class GatewayRunner:
         # .update_response so the update process can continue.
         _quick_key = self._session_key_for_source(source)
         _update_prompts = getattr(self, "_update_prompt_pending", {})
+
+        def _write_update_response(response_text: str) -> Optional[str]:
+            response_path = _hermes_home / ".update_response"
+            try:
+                tmp = response_path.with_suffix(".tmp")
+                tmp.write_text(response_text)
+                tmp.replace(response_path)
+            except OSError as e:
+                logger.warning("Failed to write update response: %s", e)
+                return f"✗ Failed to send response to update process: {e}"
+            return None
+
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()
-            # Accept /approve and /deny as shorthand for yes/no
             cmd = event.get_command()
-            if cmd in ("approve", "yes"):
-                response_text = "y"
-            elif cmd in ("deny", "no"):
-                response_text = "n"
-            else:
-                response_text = raw
-            if response_text:
-                response_path = _hermes_home / ".update_response"
+            if cmd in ("approve", "deny"):
                 try:
-                    tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text(response_text)
-                    tmp.replace(response_path)
-                except OSError as e:
-                    logger.warning("Failed to write update response: %s", e)
-                    return f"✗ Failed to send response to update process: {e}"
-                _update_prompts.pop(_quick_key, None)
-                label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
-                return f"✓ Sent `{label}` to the update process."
+                    from tools.approval import has_blocking_approval
+                except (ImportError, ModuleNotFoundError):
+                    has_blocking_approval = None
+                if has_blocking_approval and has_blocking_approval(_quick_key):
+                    # A real dangerous-command approval is waiting for /approve or
+                    # /deny in this same session. Let normal command dispatch
+                    # handle it instead of stealing the command for /update.
+                    pass
+                else:
+                    # Accept /approve and /deny as shorthand for yes/no only when
+                    # no dangerous-command approval is currently waiting.
+                    response_text = "y" if cmd == "approve" else "n"
+                    error = _write_update_response(response_text)
+                    if error:
+                        return error
+                    _update_prompts.pop(_quick_key, None)
+                    return f"✓ Sent `{response_text}` to the update process."
+            else:
+                if cmd == "yes":
+                    response_text = "y"
+                elif cmd == "no":
+                    response_text = "n"
+                else:
+                    response_text = raw
+                if response_text:
+                    error = _write_update_response(response_text)
+                    if error:
+                        return error
+                    _update_prompts.pop(_quick_key, None)
+                    label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
+                    return f"✓ Sent `{label}` to the update process."
 
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
@@ -6666,6 +6692,7 @@ class GatewayRunner:
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
         prompt_path = _hermes_home / ".update_prompt.json"
+        last_forwarded_prompt_key: Optional[str] = None
 
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
@@ -6790,7 +6817,8 @@ class GatewayRunner:
                     prompt_data = json.loads(prompt_path.read_text())
                     prompt_text = prompt_data.get("prompt", "")
                     default = prompt_data.get("default", "")
-                    if prompt_text:
+                    prompt_key = str(prompt_data.get("id") or json.dumps(prompt_data, sort_keys=True, ensure_ascii=False))
+                    if prompt_text and prompt_key != last_forwarded_prompt_key:
                         # Flush any buffered output first so the user sees
                         # context before the prompt
                         await _flush_buffer()
@@ -6818,13 +6846,16 @@ class GatewayRunner:
                             )
                         self._update_prompt_pending[session_key] = True
                         # Remove the prompt file so it isn't re-read on the
-                        # next poll cycle.  The update process only needs
+                        # next poll cycle. The update process only needs
                         # .update_response to continue — it doesn't re-check
                         # .update_prompt.json while waiting.
                         prompt_path.unlink(missing_ok=True)
+                        last_forwarded_prompt_key = prompt_key
                         logger.info("Forwarded update prompt to %s: %s", session_key, prompt_text[:80])
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug("Failed to read update prompt: %s", e)
+            if not prompt_path.exists():
+                last_forwarded_prompt_key = None
 
             await asyncio.sleep(poll_interval)
 

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -384,6 +384,7 @@ class TestWatchUpdateProgress:
             (hermes_home / ".update_prompt.json").write_text(json.dumps(prompt1))
             await asyncio.sleep(0.35)
             (hermes_home / ".update_response").write_text("y")
+            runner._update_prompt_pending.pop(pending["session_key"], None)
             await asyncio.sleep(0.15)
             (hermes_home / ".update_response").unlink(missing_ok=True)
 
@@ -391,6 +392,7 @@ class TestWatchUpdateProgress:
             (hermes_home / ".update_prompt.json").write_text(json.dumps(prompt2))
             await asyncio.sleep(0.35)
             (hermes_home / ".update_response").write_text("n")
+            runner._update_prompt_pending.pop(pending["session_key"], None)
             await asyncio.sleep(0.15)
             (hermes_home / ".update_exit_code").write_text("0")
 

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -45,6 +45,8 @@ def _make_runner(hermes_home=None):
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._failed_platforms = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
     return runner
 
 
@@ -322,6 +324,92 @@ class TestWatchUpdateProgress:
         # (may be cleared by the time we check since update finished)
 
     @pytest.mark.asyncio
+    async def test_forwards_each_prompt_only_once_while_file_persists(self, tmp_path):
+        """A single prompt file should not be forwarded repeatedly every poll."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {"platform": "telegram", "chat_id": "111", "user_id": "222",
+                   "session_key": "agent:main:telegram:dm:111"}
+        (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
+        (hermes_home / ".update_output.txt").write_text("context\n")
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        async def simulate_prompt_cycle():
+            await asyncio.sleep(0.2)
+            prompt = {"prompt": "Restore local changes? [Y/n]", "default": "y", "id": "dup-test"}
+            (hermes_home / ".update_prompt.json").write_text(json.dumps(prompt))
+            await asyncio.sleep(0.55)
+            (hermes_home / ".update_response").write_text("y")
+            (hermes_home / ".update_prompt.json").unlink(missing_ok=True)
+            await asyncio.sleep(0.2)
+            (hermes_home / ".update_exit_code").write_text("0")
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            task = asyncio.create_task(simulate_prompt_cycle())
+            await runner._watch_update_progress(
+                poll_interval=0.1,
+                stream_interval=0.2,
+                timeout=10.0,
+            )
+            await task
+
+        prompt_messages = [
+            call for call in mock_adapter.send.call_args_list
+            if "Restore local changes" in str(call)
+        ]
+        assert len(prompt_messages) == 1, mock_adapter.send.call_args_list
+
+    @pytest.mark.asyncio
+    async def test_forwards_rewritten_prompt_when_id_changes(self, tmp_path):
+        """A new prompt id should be forwarded even if the text stays the same."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {"platform": "telegram", "chat_id": "111", "user_id": "222",
+                   "session_key": "agent:main:telegram:dm:111"}
+        (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
+        (hermes_home / ".update_output.txt").write_text("context\n")
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        async def simulate_two_prompt_cycles():
+            await asyncio.sleep(0.2)
+            prompt1 = {"prompt": "Restore local changes? [Y/n]", "default": "y", "id": "prompt-1"}
+            (hermes_home / ".update_prompt.json").write_text(json.dumps(prompt1))
+            await asyncio.sleep(0.35)
+            (hermes_home / ".update_response").write_text("y")
+            await asyncio.sleep(0.15)
+            (hermes_home / ".update_response").unlink(missing_ok=True)
+
+            prompt2 = {"prompt": "Restore local changes? [Y/n]", "default": "y", "id": "prompt-2"}
+            (hermes_home / ".update_prompt.json").write_text(json.dumps(prompt2))
+            await asyncio.sleep(0.35)
+            (hermes_home / ".update_response").write_text("n")
+            await asyncio.sleep(0.15)
+            (hermes_home / ".update_exit_code").write_text("0")
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            task = asyncio.create_task(simulate_two_prompt_cycles())
+            await runner._watch_update_progress(
+                poll_interval=0.1,
+                stream_interval=0.2,
+                timeout=10.0,
+            )
+            await task
+
+        prompt_messages = [
+            call for call in mock_adapter.send.call_args_list
+            if "Restore local changes" in str(call)
+        ]
+        assert len(prompt_messages) == 2, mock_adapter.send.call_args_list
+
+    @pytest.mark.asyncio
     async def test_cleans_up_on_completion(self, tmp_path):
         """All marker files are cleaned up when update finishes."""
         runner = _make_runner()
@@ -488,6 +576,62 @@ class TestUpdatePromptInterception:
         assert response_path.read_text() == "y"
         # Should clear the pending flag
         assert session_key not in runner._update_prompt_pending
+
+    @pytest.mark.asyncio
+    async def test_approve_prefers_blocking_dangerous_command_over_update_prompt(self, tmp_path):
+        """/approve should resolve real command approvals before acting as update yes/no."""
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        event = _make_event(text="/approve", chat_id="67890")
+        session_key = "agent:main:telegram:dm:67890"
+        runner._update_prompt_pending[session_key] = True
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._session_key_for_source = MagicMock(return_value=session_key)
+
+        entry = _ApprovalEntry({"command": "rm -rf /tmp/test"})
+        _gateway_queues[session_key] = [entry]
+        try:
+            with patch("gateway.run._hermes_home", hermes_home):
+                result = await runner._handle_message(event)
+        finally:
+            _gateway_queues.pop(session_key, None)
+
+        assert "approved" in result.lower()
+        assert entry.event.is_set()
+        assert not (hermes_home / ".update_response").exists()
+        assert session_key in runner._update_prompt_pending
+
+    @pytest.mark.asyncio
+    async def test_deny_prefers_blocking_dangerous_command_over_update_prompt(self, tmp_path):
+        """/deny should resolve real command approvals before acting as update yes/no."""
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        event = _make_event(text="/deny", chat_id="67890")
+        session_key = "agent:main:telegram:dm:67890"
+        runner._update_prompt_pending[session_key] = True
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._session_key_for_source = MagicMock(return_value=session_key)
+
+        entry = _ApprovalEntry({"command": "rm -rf /tmp/test"})
+        _gateway_queues[session_key] = [entry]
+        try:
+            with patch("gateway.run._hermes_home", hermes_home):
+                result = await runner._handle_message(event)
+        finally:
+            _gateway_queues.pop(session_key, None)
+
+        assert "denied" in result.lower()
+        assert entry.event.is_set()
+        assert not (hermes_home / ".update_response").exists()
+        assert session_key in runner._update_prompt_pending
 
     @pytest.mark.asyncio
     async def test_normal_message_when_no_prompt_pending(self, tmp_path):


### PR DESCRIPTION
## Bug Description

Gateway `/update` handling had two user-visible issues:

1. While `.update_prompt.json` remained on disk, the watcher could forward the same prompt repeatedly on every poll cycle, spamming the chat with duplicate update prompts.
2. If an `/update` prompt was pending and a real dangerous-command approval was also waiting in the same session, `/approve` or `/deny` could be consumed as yes/no for the update flow instead of resolving the blocked dangerous command.

## Root Cause

- `_watch_update_progress()` forwarded `.update_prompt.json` whenever it existed, but did not deduplicate already-forwarded prompts by prompt id/payload.
- `_handle_message()` intercepted `/approve` and `/deny` for pending update prompts before normal dangerous-command approval routing, even when `tools.approval` was actively waiting on the same session.

## Fix

- deduplicate forwarded update prompts using prompt `id` when present, otherwise a stable serialized payload key, and reset dedupe state when the prompt file disappears
- make `/approve` and `/deny` fall through to normal dangerous-command approval handling when a real blocking approval is waiting for that same session
- add regression tests for duplicate prompt suppression and approval precedence

## How to Verify

1. Run `python -m pytest tests/gateway/test_update_streaming.py -q`
2. Trigger an update prompt that remains pending for multiple poll cycles and confirm it is only forwarded once
3. With both an update prompt and a blocked dangerous-command approval pending in the same session, send `/approve` and confirm the dangerous-command approval is resolved instead of writing `.update_response`

## Test Plan

- [x] Added regression tests for both bugs
- [x] `python -m pytest tests/gateway/test_update_streaming.py -q`
- [x] `python -m py_compile gateway/run.py`
- [x] manual repro confirming `/approve` resolves the dangerous command and does not write `.update_response`

## Risk Assessment

Low — the patch is scoped to `/update` prompt routing and prompt forwarding in gateway update handling. It does not change normal non-update message flow.
