### PR TITLE
fix(tools): quote Daytona sync paths before remote mkdir

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -321,6 +321,28 @@ class TestExecute:
         assert result["returncode"] == 0
 
 
+class TestSkillAndCredentialSync:
+    def test_upload_if_changed_quotes_remote_parent_path(self, make_env, tmp_path):
+        sb = _make_sandbox()
+        sb.process.exec.side_effect = [
+            _make_exec_response(result="/root"),
+            _make_exec_response(result="", exit_code=0),
+        ]
+        sb.state = "started"
+        env = make_env(sandbox=sb)
+
+        host_file = tmp_path / "credential.txt"
+        host_file.write_text("secret", encoding="utf-8")
+        remote_path = "/root/.hermes/skills/evil; touch /tmp/pwned #/SKILL.md"
+
+        uploaded = env._upload_if_changed(str(host_file), remote_path)
+
+        assert uploaded is True
+        mkdir_cmd = sb.process.exec.call_args_list[-1][0][0]
+        assert mkdir_cmd == "mkdir -p -- '/root/.hermes/skills/evil; touch /tmp/pwned #'"
+        sb.fs.upload_file.assert_called_once_with(str(host_file), remote_path)
+
+
 # ---------------------------------------------------------------------------
 # Resource conversion
 # ---------------------------------------------------------------------------

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -145,7 +145,7 @@ class DaytonaEnvironment(BaseEnvironment):
             return False
         try:
             parent = str(Path(remote_path).parent)
-            self._sandbox.process.exec(f"mkdir -p {parent}")
+            self._sandbox.process.exec(f"mkdir -p -- {shlex.quote(parent)}")
             self._sandbox.fs.upload_file(host_path, remote_path)
             self._synced_files[remote_path] = file_key
             return True


### PR DESCRIPTION
While exploring the Daytona environment integration, I found myself tracing the initial synchronization process that Hermes performs to mirror local skills and credentials into the sandbox. Everything appeared standard on the surface, but as I dug deeper into the _upload_if_changed method, something caught my eye.

I noticed that before any file is uploaded, the system has to ensure the remote parent directory exists. It does this by building a quick mkdir -p shell command. However, the path was being dropped directly into the command string without any defensive quoting.

This led me to wonder: what if a skill file wasn't named as expected? Upon closer inspection, I realized that an attacker who could control a skill's filename—perhaps by submitting a malicious repository—could inject shell metacharacters. The plot thickened when I realized that Hermes syncs credentials into the same sandbox. An injected ; or & in a filename could allow a command to run and exfiltrate those very secrets before the backend even finished initializing.

To secure this boundary, I’ve introduced proper shell quoting using shlex.quote() and added the POSIX -- flag to the mkdir call. This ensures that every directory path is treated strictly as data, no matter how "evil" its name might be.

I've included a regression test that mimics a malicious skill path to prove the fix works. The test demonstrates that a path containing a command injection payload is now safely neutralized and treated as a literal string by the Daytona backend.