### PR TITLE
fix(browser): handle install paths with spaces

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -152,6 +152,50 @@ class TestFindAgentBrowser:
 class TestRunBrowserCommandPathConstruction:
     """Verify _run_browser_command() includes Homebrew node dirs in subprocess PATH."""
 
+    def test_handles_browser_paths_with_spaces(self, tmp_path):
+        """Quoted executable paths should survive command construction."""
+        captured_cmd = []
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            captured_cmd[:] = cmd
+            return mock_proc
+
+        fake_session = {
+            "session_name": "test-session",
+            "session_id": "test-id",
+            "cdp_url": None,
+        }
+
+        fake_json = json.dumps({"success": True})
+        real_isdir = os.path.isdir
+
+        def selective_isdir(p):
+            if p.startswith(str(tmp_path)):
+                return True
+            return real_isdir(p)
+
+        browser_cmd = '"/Users/test/Library/Application Support/hermes/node_modules/.bin/agent-browser"'
+
+        with patch("tools.browser_tool._find_agent_browser", return_value=browser_cmd), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("os.path.isdir", side_effect=selective_isdir), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(os.environ, {"PATH": "/usr/bin:/bin", "HOME": "/home/test"}, clear=True):
+            with patch("builtins.open", mock_open(read_data=fake_json)):
+                _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+        assert captured_cmd[0] == "/Users/test/Library/Application Support/hermes/node_modules/.bin/agent-browser"
+        assert captured_cmd[1:4] == ["--session", "test-session", "--json"]
+
     def test_subprocess_path_includes_homebrew_node_dirs(self, tmp_path):
         """When _discover_homebrew_node_dirs returns dirs, they should appear
         in the subprocess env PATH passed to Popen."""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -54,6 +54,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import signal
 import subprocess
 import shutil
@@ -877,7 +878,7 @@ def _run_browser_command(
         # Local mode — launch a headless Chromium instance
         backend_args = ["--session", session_info["session_name"]]
 
-    cmd_parts = browser_cmd.split() + backend_args + [
+    cmd_parts = shlex.split(browser_cmd) + backend_args + [
         "--json",
         command
     ] + args


### PR DESCRIPTION
## Summary
- fix browser command construction for Hermes installs under paths with spaces
- add a regression test covering quoted `agent-browser` executable paths

## Testing
- `python -m pytest tests/tools/test_browser_homebrew_paths.py -q`
- `python -m pytest tests/tools/test_browser_homebrew_paths.py tests/tools/test_managed_browserbase_and_modal.py -q`
- `python -m pytest tests/tools/ -q` *(fails on pre-existing docker environment tests unrelated to this change: `tests/tools/test_docker_environment.py::test_execute_uses_hermes_dotenv_for_allowlisted_env` and `tests/tools/test_docker_environment.py::test_execute_prefers_shell_env_over_hermes_dotenv`)*

Fixes #6064
