### PR TITLE
fix(cli): honor model.max_tokens wiring for CLI and gateway agents

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -204,6 +204,7 @@ def load_cli_config() -> Dict[str, Any]:
             "default": "",
             "base_url": "",
             "provider": "auto",
+            "max_tokens": None,
         },
         "terminal": {
             "env_type": "local",
@@ -1348,6 +1349,14 @@ class HermesCLI:
             self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
         else:
             self.max_turns = 90
+
+        # Max output tokens: config only for now. CLI/gateway wrappers must
+        # pass this through explicitly or the server default wins.
+        _raw_max_tokens = _model_config.get("max_tokens") if isinstance(_model_config, dict) else None
+        try:
+            self.max_tokens = int(_raw_max_tokens) if _raw_max_tokens not in (None, "") else None
+        except (TypeError, ValueError):
+            self.max_tokens = None
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
@@ -2347,6 +2356,7 @@ class HermesCLI:
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
+                max_tokens=self.max_tokens,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
@@ -4706,6 +4716,7 @@ class HermesCLI:
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
                     max_iterations=self.max_turns,
+                    max_tokens=self.max_tokens,
                     enabled_toolsets=self.enabled_toolsets,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -4842,6 +4853,7 @@ class HermesCLI:
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
                     max_iterations=8,
+                    max_tokens=self.max_tokens,
                     enabled_toolsets=[],
                     quiet_mode=True,
                     verbose_logging=False,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -431,6 +431,19 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _resolve_gateway_max_tokens(config: dict | None = None) -> Optional[int]:
+    """Read model.max_tokens from config.yaml if configured."""
+    cfg = config if config is not None else _load_gateway_config()
+    model_cfg = cfg.get("model", {})
+    if not isinstance(model_cfg, dict):
+        return None
+    raw = model_cfg.get("max_tokens")
+    try:
+        return int(raw) if raw not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -666,6 +679,7 @@ class GatewayRunner:
                 **runtime_kwargs,
                 model=model,
                 max_iterations=8,
+                max_tokens=_resolve_gateway_max_tokens(),
                 quiet_mode=True,
                 skip_memory=True,  # Flush agent — no memory provider
                 enabled_toolsets=["memory", "skills"],
@@ -2613,6 +2627,7 @@ class GatewayRunner:
                                     **_hyg_runtime,
                                     model=_hyg_model,
                                     max_iterations=4,
+                                    max_tokens=_resolve_gateway_max_tokens(),
                                     quiet_mode=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
@@ -4547,6 +4562,7 @@ class GatewayRunner:
                     model=turn_route["model"],
                     **turn_route["runtime"],
                     max_iterations=max_iterations,
+                    max_tokens=_resolve_gateway_max_tokens(user_config),
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
@@ -4722,6 +4738,7 @@ class GatewayRunner:
                     model=turn_route["model"],
                     **turn_route["runtime"],
                     max_iterations=8,
+                    max_tokens=_resolve_gateway_max_tokens(user_config),
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=[],
@@ -4982,6 +4999,7 @@ class GatewayRunner:
                 **runtime_kwargs,
                 model=model,
                 max_iterations=4,
+                max_tokens=_resolve_gateway_max_tokens(),
                 quiet_mode=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
@@ -6650,6 +6668,7 @@ class GatewayRunner:
                     model=turn_route["model"],
                     **turn_route["runtime"],
                     max_iterations=max_iterations,
+                    max_tokens=_resolve_gateway_max_tokens(user_config),
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -3,6 +3,7 @@ that only manifest at runtime (not in mocked unit tests)."""
 
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -83,6 +84,52 @@ class TestMaxTurnsResolution:
         """The value passed to AIAgent must never be None (causes TypeError in run_conversation)."""
         cli = _make_cli()
         assert isinstance(cli.max_turns, int) and cli.max_turns == 90
+
+
+class TestMaxTokensResolution:
+    """model.max_tokens should flow from config into the live agent."""
+
+    def test_model_max_tokens_loaded_from_config(self):
+        cli_obj = _make_cli(config_overrides={
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "auto",
+                "max_tokens": 4096,
+            }
+        })
+        assert cli_obj.max_tokens == 4096
+
+    def test_init_agent_passes_model_max_tokens_to_ai_agent(self):
+        cli_obj = _make_cli(config_overrides={
+            "model": {
+                "default": "test-model",
+                "base_url": "http://localhost:8080/v1",
+                "provider": "custom",
+                "max_tokens": 4096,
+            }
+        })
+
+        class _DummyAgent:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.context_compressor = SimpleNamespace(context_length=131072)
+                self._print_fn = None
+
+        cli_obj._ensure_runtime_credentials = MagicMock(return_value=True)
+        cli_obj.api_key = "test-key"
+        cli_obj.base_url = "http://localhost:8080/v1"
+        cli_obj.provider = "custom"
+        cli_obj.api_mode = "chat_completions"
+
+        with patch.dict(cli_obj._init_agent.__globals__, {"AIAgent": _DummyAgent}), \
+             patch.dict(
+                 sys.modules,
+                 {"hermes_state": SimpleNamespace(SessionDB=lambda: MagicMock())},
+             ):
+            assert cli_obj._init_agent() is True
+
+        assert cli_obj.agent.kwargs["max_tokens"] == 4096
 
 
 class TestVerboseAndToolProgress:

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -233,6 +233,38 @@ class TestRunBackgroundTask:
         assert "Hello from background!" in content
 
     @pytest.mark.asyncio
+    async def test_successful_task_passes_configured_max_tokens(self):
+        """Background agents should honor model.max_tokens from config.yaml."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Hello from background!"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "Hello from background!", "messages": []}
+        user_config = {"model": {"default": "test-model", "max_tokens": 4096}}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value=user_config), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value=[]), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("say hello", source, "bg_test")
+
+        assert MockAgent.call_args.kwargs["max_tokens"] == 4096
+
+    @pytest.mark.asyncio
     async def test_exception_sends_error_message(self):
         """When the agent raises an exception, an error message is sent."""
         runner = _make_runner()


### PR DESCRIPTION
## Summary

- Honor `model.max_tokens` from config in the CLI path and gateway-created agent paths.
- Add regression tests covering CLI initialization and background task agent creation.

## What Was Happening

On local/custom backends with low server-side output defaults, Hermes could truncate long responses even when `model.max_tokens` was set in `config.yaml`.

A concrete failure mode was local tool use against `mlx_vlm`: asking Hermes to write a moderately long file could return a partial raw `<|tool_call>call:write_file{...` payload instead of a complete parsed tool call, so the file was never written.

## Root Cause

The core `AIAgent` already supports `max_tokens`, but the CLI wrapper was not loading/passing `model.max_tokens`, and several gateway-created agent paths also omitted it. That made the documented config knob ineffective in those flows.

## Repro

1. Configure Hermes to use a local/custom provider with a low server-side output cap and set `model.max_tokens` in `~/.hermes/config.yaml`.
2. Start a session and ask Hermes to perform a long tool-writing action, such as writing a Python script to disk.
3. Before this change, the response can cut off mid-tool-call and no file is written because the configured `model.max_tokens` never reaches `AIAgent`.
4. After this change, the configured limit is passed through and the same request completes normally.

## Why This Change

This makes the documented `model.max_tokens` setting behave as expected for CLI and gateway agent wrappers, which is especially important for local model backends with conservative generation defaults.

## Validation

- `pytest tests/cli/test_cli_init.py -q`
- `pytest tests/gateway/test_background_command.py -q`
- `pytest tests/gateway/test_api_server.py -q`
- `pytest tests/gateway/test_api_server_jobs.py -q`
- Manual verification on macOS with Hermes against a local `mlx_vlm` endpoint by reproducing and fixing truncated tool calls

## Platform

- macOS (Apple Silicon)
- Linux/WSL2 not manually verified yet

## Related Issues

- None found
