### PR TITLE
fix(gateway): validate MEDIA tag paths to block arbitrary local file …

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -35,6 +35,14 @@ GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Load this skill in the local CLI to be prompted, or add the key to ~/.hermes/.env manually."
 )
 
+_MEDIA_TAG_ALLOWED_EXTS = frozenset({
+    ".png", ".jpg", ".jpeg", ".gif", ".webp",
+    ".mp4", ".mov", ".avi", ".mkv", ".webm",
+    ".ogg", ".opus", ".mp3", ".wav", ".m4a",
+})
+_MEDIA_TAG_REMOTE_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://")
+_MEDIA_TAG_WINDOWS_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
 
 def _safe_url_for_log(url: str, max_len: int = 80) -> str:
     """Return a URL string safe for logs (no query/fragment/userinfo)."""
@@ -845,6 +853,34 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
 
     @staticmethod
+    def _normalize_media_tag_path(raw_path: str) -> Optional[str]:
+        """Normalize and validate MEDIA: path values before attachment sends."""
+        if not raw_path:
+            return None
+
+        path = raw_path.strip()
+        if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
+            path = path[1:-1].strip()
+        path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+        if not path:
+            return None
+
+        # Block remote URLs and keep MEDIA tags local-path only.
+        if _MEDIA_TAG_REMOTE_SCHEME_RE.match(path):
+            return None
+
+        expanded = os.path.expanduser(path)
+        is_abs = os.path.isabs(expanded) or bool(_MEDIA_TAG_WINDOWS_ABS_RE.match(expanded))
+        if not is_abs:
+            return None
+
+        ext = Path(expanded).suffix.lower()
+        if ext not in _MEDIA_TAG_ALLOWED_EXTS:
+            return None
+
+        return expanded
+
+    @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
         """
         Extract MEDIA:<path> tags and [[audio_as_voice]] directives from response text.
@@ -872,10 +908,9 @@ class BasePlatformAdapter(ABC):
             r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
-            path = match.group("path").strip()
-            if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
-                path = path[1:-1].strip()
-            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+            path = BasePlatformAdapter._normalize_media_tag_path(
+                match.group("path").strip()
+            )
             if path:
                 media.append((path, has_voice_tag))
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -319,6 +319,14 @@ class TestExtractMedia:
         assert "Here" in cleaned
         assert "After" in cleaned
 
+    def test_media_tag_ignores_non_media_file_paths(self):
+        """Regression: MEDIA tags must not extract arbitrary local files."""
+        content = "MEDIA:'/etc/passwd'\nMEDIA:/tmp/secrets.env\nMEDIA:\"/tmp/report.txt\""
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        # Invalid tags remain plain text; only validated media paths are stripped.
+        assert "MEDIA:'/etc/passwd'" in cleaned
+
 
 # ---------------------------------------------------------------------------
 # truncate_message


### PR DESCRIPTION
## Context
`MEDIA:` directives are intended for explicit media attachment delivery (images/audio/video), but the parser currently accepts overly broad path tokens.  
This creates a trust-boundary issue: model-generated text can influence which local files are sent as platform attachments.

## What’s wrong (concrete exploit path)
A crafted response such as:

- `MEDIA:'/etc/passwd'`
- `MEDIA:/tmp/secrets.env`
- `MEDIA:"/home/user/.ssh/config"`

can be parsed as a valid attachment candidate and routed into native send flows (`send_document` / `send_image_file` / `send_video`), depending on adapter behavior.

That means non-media host files can be exfiltrated through normal chat output delivery.

## Behavioral change in this PR
`MEDIA:` extraction is now strict and intentionally conservative:

| Rule | Before | After |
|---|---|---|
| Remote schemes (`http://`, `https://`, etc.) | Could pass parser path branch in edge cases | Rejected |
| Relative paths | Could be accepted depending on token shape | Rejected |
| Absolute local paths | Accepted | Accepted only if extension is allowlisted media type |
| Non-media extensions (`.env`, `.txt`, `.conf`, etc.) | Could be extracted | Rejected |

## Implementation overview
### `gateway/platforms/base.py`
- Added `_normalize_media_tag_path()` as a single validation gate for `MEDIA:` values.
- Added media extension allowlist for extracted attachment paths.
- Added explicit remote-scheme and path-shape checks (local absolute paths only).
- Updated `extract_media()` to use normalized/validated output only.

## Regression coverage
### `tests/gateway/test_platform_base.py`
Added:

- `test_media_tag_ignores_non_media_file_paths`

This test verifies that sensitive/non-media files are **not** extracted from `MEDIA:` tags and therefore are not eligible for attachment routing.

## Why this fix is scoped correctly
- No adapter-specific refactor.
- No protocol/UX changes for valid media paths.
- No new dependencies.
- Keeps existing `MEDIA:` contract for real media outputs intact.

## Validation status
- [x] Regression test added
- [x] No new dependencies
