### PR TITLE
fix(models): preserve model tags for aggregator providers during normalisation

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -306,6 +306,11 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     provider = (target_provider or "").strip().lower()
 
+    # FIX: Safely convert legacy 'vendor:model' format to 'vendor/model',
+    # while preserving provider tags (like ':free') in strings that already use a slash.
+    if ":" in name and "/" not in name:
+        name = name.replace(":", "/", 1)
+
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
         return _prepend_vendor(name)


### PR DESCRIPTION
Previously, the model normalization logic indiscriminately replaced `:` with `/` for aggregator providers (like OpenRouter). This broke valid model IDs that already followed the `vendor/model` slug format but included a version or tier tag, such as `nvidia/nemotron-3-super-120b-a12b:free`. The logic incorrectly converted the tag to `.../free`, resulting in a 400 Bad Request error from the API. As can be seen in this issue : https://discord.com/channels/1053877538025386074/1491347485728313354

This commit updates `normalize_model_for_provider` in `hermes_cli/model_normalize.py`. It now safely converts legacy `vendor:model` inputs to the required `vendor/model` format ONLY if a forward slash (`/`) is not already present in the string, ensuring that provider-specific trailing tags remain intact.