### PR TITLE
feat(memory): add native Nowledge Mem provider

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -199,6 +199,31 @@ class MemoryManager:
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
 
+    def _index_provider_tools(self, provider: MemoryProvider) -> None:
+        """Index tool names -> provider for dispatch routing.
+
+        Providers may expose their tool schemas before initialize() or only
+        after initialize() succeeds. Re-indexing must therefore be safe and
+        idempotent.
+        """
+        for schema in provider.get_tool_schemas():
+            tool_name = schema.get("name", "")
+            if not tool_name:
+                continue
+            existing = self._tool_to_provider.get(tool_name)
+            if existing is None:
+                self._tool_to_provider[tool_name] = provider
+                continue
+            if existing is provider:
+                continue
+            logger.warning(
+                "Memory tool name conflict: '%s' already registered by %s, "
+                "ignoring from %s",
+                tool_name,
+                existing.name,
+                provider.name,
+            )
+
     # -- Registration --------------------------------------------------------
 
     def add_provider(self, provider: MemoryProvider) -> None:
@@ -227,19 +252,8 @@ class MemoryManager:
 
         self._providers.append(provider)
 
-        # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
-            tool_name = schema.get("name", "")
-            if tool_name and tool_name not in self._tool_to_provider:
-                self._tool_to_provider[tool_name] = provider
-            elif tool_name in self._tool_to_provider:
-                logger.warning(
-                    "Memory tool name conflict: '%s' already registered by %s, "
-                    "ignoring from %s",
-                    tool_name,
-                    self._tool_to_provider[tool_name].name,
-                    provider.name,
-                )
+        # Index tool names -> provider for routing.
+        self._index_provider_tools(provider)
 
         logger.info(
             "Memory provider '%s' registered (%d tools)",
@@ -548,6 +562,7 @@ class MemoryManager:
         for provider in self._providers:
             try:
                 provider.initialize(session_id=session_id, **kwargs)
+                self._index_provider_tools(provider)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -92,6 +92,31 @@ class MemoryManager:
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
 
+    def _index_provider_tools(self, provider: MemoryProvider) -> None:
+        """Index tool names -> provider for dispatch routing.
+
+        Providers may expose their tool schemas before initialize() or only
+        after initialize() succeeds. Re-indexing must therefore be safe and
+        idempotent.
+        """
+        for schema in provider.get_tool_schemas():
+            tool_name = schema.get("name", "")
+            if not tool_name:
+                continue
+            existing = self._tool_to_provider.get(tool_name)
+            if existing is None:
+                self._tool_to_provider[tool_name] = provider
+                continue
+            if existing is provider:
+                continue
+            logger.warning(
+                "Memory tool name conflict: '%s' already registered by %s, "
+                "ignoring from %s",
+                tool_name,
+                existing.name,
+                provider.name,
+            )
+
     # -- Registration --------------------------------------------------------
 
     def add_provider(self, provider: MemoryProvider) -> None:
@@ -120,19 +145,8 @@ class MemoryManager:
 
         self._providers.append(provider)
 
-        # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
-            tool_name = schema.get("name", "")
-            if tool_name and tool_name not in self._tool_to_provider:
-                self._tool_to_provider[tool_name] = provider
-            elif tool_name in self._tool_to_provider:
-                logger.warning(
-                    "Memory tool name conflict: '%s' already registered by %s, "
-                    "ignoring from %s",
-                    tool_name,
-                    self._tool_to_provider[tool_name].name,
-                    provider.name,
-                )
+        # Index tool names -> provider for routing.
+        self._index_provider_tools(provider)
 
         logger.info(
             "Memory provider '%s' registered (%d tools)",
@@ -366,6 +380,7 @@ class MemoryManager:
         for provider in self._providers:
             try:
                 provider.initialize(session_id=session_id, **kwargs)
+                self._index_provider_tools(provider)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",

--- a/plugins/memory/nowledge-mem/README.md
+++ b/plugins/memory/nowledge-mem/README.md
@@ -55,23 +55,49 @@ use them.
 
 ## Configuration
 
-The only provider-specific setting is the request timeout:
-
-```json
-{
-  "timeout": 30
-}
-```
-
-Stored at:
+Store provider config in:
 
 ```text
 $HERMES_HOME/nowledge-mem.json
 ```
 
-Server URL and API key are managed by `nmem`, not the provider.
+Example:
 
-For remote Mem, configure the machine running Hermes with:
+```json
+{
+  "timeout": 30,
+  "space": "Research Agent",
+  "space_by_identity": {
+    "research": "Research Agent",
+    "ops": "Operations Agent"
+  },
+  "space_template": "agent-{identity}"
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `timeout` | `30` | Request timeout in seconds |
+| `space` | `""` | Optional default space name for this Hermes provider |
+| `space_by_identity` | `""` | Optional JSON object mapping Hermes identities to spaces |
+| `space_template` | `""` | Optional template like `research-{identity}` when `space` is empty |
+
+Use `space` when one Hermes profile always belongs to one lane. Use
+`space_by_identity` when a few Hermes identities map to named lanes. Use
+`space_template` when Hermes already has a stable identity and you want one
+lane per identity.
+
+If you are launching Hermes through a CLI wrapper with no provider config of
+its own, you can still set one session-wide fallback lane with:
+
+```bash
+NMEM_SPACE="Research Agent" hermes
+```
+
+If you do not have a real ambient lane, stay on `Default`.
+
+Server URL and API key are managed by `nmem`, not the provider. For remote
+Mem, configure the machine running Hermes with:
 
 ```bash
 nmem config client set url https://your-server:14242

--- a/plugins/memory/nowledge-mem/README.md
+++ b/plugins/memory/nowledge-mem/README.md
@@ -41,8 +41,9 @@ hermes config set memory.provider nowledge-mem
 Durable saves still happen through the native `nmem_` tools. In addition,
 the provider captures cleaned Hermes session transcripts at real session
 boundaries such as clean exit, `/new`, `/reset`, and gateway session expiry.
-The first flush uses `nmem t import`; later flushes in the same live Hermes
-session append only the delta with `nmem t append`.
+The first flush imports the transcript; later flushes in the same live Hermes
+session append only the delta. Transcript payloads use the Mem API directly so
+long sessions are not squeezed into shell arguments.
 
 ## Tools
 

--- a/plugins/memory/nowledge-mem/README.md
+++ b/plugins/memory/nowledge-mem/README.md
@@ -35,12 +35,14 @@ hermes config set memory.provider nowledge-mem
 - injects Working Memory into the system prompt
 - prefetches relevant memories before each turn
 - mirrors Hermes user-profile writes into Nowledge Mem
+- captures cleaned Hermes session transcripts as Mem threads when the session actually ends
 - exposes native tools for search, save, update, delete, and thread lookup
 
-The provider does not claim transcript-backed session import or silent
-background distillation. Durable saves still happen through the native
-`nmem_` tools, with guidance in the provider prompt telling Hermes when to
-use them.
+Durable saves still happen through the native `nmem_` tools. In addition,
+the provider captures cleaned Hermes session transcripts at real session
+boundaries such as clean exit, `/new`, `/reset`, and gateway session expiry.
+The first flush uses `nmem t import`; later flushes in the same live Hermes
+session append only the delta with `nmem t append`.
 
 ## Tools
 

--- a/plugins/memory/nowledge-mem/README.md
+++ b/plugins/memory/nowledge-mem/README.md
@@ -71,6 +71,16 @@ $HERMES_HOME/nowledge-mem.json
 
 Server URL and API key are managed by `nmem`, not the provider.
 
+For remote Mem, configure the machine running Hermes with:
+
+```bash
+nmem config client set url https://your-server:14242
+nmem config client set api-key your-key
+```
+
+That writes the shared local client config `nmem` reads. It is separate from
+server-side Access Anywhere or bind/allowlist settings on the Mem host.
+
 ## Verify
 
 Ask Hermes:

--- a/plugins/memory/nowledge-mem/README.md
+++ b/plugins/memory/nowledge-mem/README.md
@@ -1,0 +1,87 @@
+# Nowledge Mem Memory Provider
+
+Cross-tool knowledge graph memory for Hermes Agent. Decisions, procedures,
+lessons, and conversation context can stay available across Hermes, Cursor,
+Claude Code, Codex, Gemini, and other Nowledge Mem integrations.
+
+## Requirements
+
+- Nowledge Mem desktop app or reachable server
+- `nmem` CLI on PATH
+
+If the desktop app is installed on the same machine, `nmem` is already
+bundled. Otherwise:
+
+```bash
+pip install nmem-cli
+```
+
+## Setup
+
+```bash
+hermes memory setup
+```
+
+Select `nowledge-mem` from the provider picker.
+
+Or configure manually:
+
+```bash
+hermes config set memory.provider nowledge-mem
+```
+
+## What It Does
+
+- injects Working Memory into the system prompt
+- prefetches relevant memories before each turn
+- mirrors Hermes user-profile writes into Nowledge Mem
+- exposes native tools for search, save, update, delete, and thread lookup
+
+The provider does not claim transcript-backed session import or silent
+background distillation. Durable saves still happen through the native
+`nmem_` tools, with guidance in the provider prompt telling Hermes when to
+use them.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `nmem_search` | Search durable memories |
+| `nmem_save` | Save a decision, learning, or durable fact |
+| `nmem_update` | Refine an existing memory |
+| `nmem_delete` | Delete one or more memories |
+| `nmem_thread_search` | Search past conversations |
+| `nmem_thread_messages` | Fetch messages from a thread |
+
+## Configuration
+
+The only provider-specific setting is the request timeout:
+
+```json
+{
+  "timeout": 30
+}
+```
+
+Stored at:
+
+```text
+$HERMES_HOME/nowledge-mem.json
+```
+
+Server URL and API key are managed by `nmem`, not the provider.
+
+## Verify
+
+Ask Hermes:
+
+> Search my memories for recent decisions.
+
+The provider should call `nmem_search` and return results from Nowledge Mem.
+
+Then ask:
+
+> Save a memory that the Hermes Nowledge Mem plugin test passed.
+
+The provider should call `nmem_save`. If Hermes instead falls back to its
+built-in `memory` tool, you are running a build older than `0.5.5`.

--- a/plugins/memory/nowledge-mem/README.md
+++ b/plugins/memory/nowledge-mem/README.md
@@ -35,13 +35,14 @@ hermes config set memory.provider nowledge-mem
 - injects Working Memory into the system prompt
 - prefetches relevant memories before each turn
 - mirrors Hermes user-profile writes into Nowledge Mem
-- captures cleaned Hermes session transcripts as Mem threads when the session actually ends
+- captures cleaned Hermes transcript turns as Mem thread messages while the conversation runs, with a final delta flush when the session actually ends
 - exposes native tools for search, save, update, delete, and thread lookup
 
 Durable saves still happen through the native `nmem_` tools. In addition,
-the provider captures cleaned Hermes session transcripts at real session
-boundaries such as clean exit, `/new`, `/reset`, and gateway session expiry.
-The first flush imports the transcript; later flushes in the same live Hermes
+the provider captures cleaned Hermes transcript turns as Mem threads while the
+conversation runs, then performs a final delta flush at real session boundaries
+such as clean exit, `/new`, `/reset`, and gateway session expiry. The first
+write for each Hermes `session_id` imports a thread; later writes for that same
 session append only the delta. Transcript payloads use the Mem API directly so
 long sessions are not squeezed into shell arguments.
 

--- a/plugins/memory/nowledge-mem/__init__.py
+++ b/plugins/memory/nowledge-mem/__init__.py
@@ -61,7 +61,7 @@ def _get_fallback_provider(
             try:
                 _fallback_provider.shutdown()
             except Exception:
-                pass
+                logger.debug("Nowledge Mem fallback provider shutdown failed", exc_info=True)
 
         provider = NowledgeMemProvider()
         try:

--- a/plugins/memory/nowledge-mem/__init__.py
+++ b/plugins/memory/nowledge-mem/__init__.py
@@ -1,13 +1,94 @@
-"""Nowledge Mem memory provider plugin for Hermes Agent.
+"""Nowledge Mem memory provider plugin for Hermes Agent."""
 
-Registers as an external memory provider, replacing the generic MCP
-connection with native lifecycle hooks: automatic Working Memory
-injection, per-turn recall, user-profile mirroring, and native tools.
-"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
 
 from .provider import NowledgeMemProvider
 
+logger = logging.getLogger(__name__)
+
+_fallback_lock = threading.Lock()
+_fallback_provider: Optional[NowledgeMemProvider] = None
+_fallback_session_id = ""
+
 
 def register(ctx) -> None:
-    """Plugin entry point called by Hermes plugin loader."""
-    ctx.register_memory_provider(NowledgeMemProvider())
+    """Plugin entry point called by Hermes plugin loader.
+
+    New Hermes memory discovery passes a provider collector with
+    ``register_memory_provider``. Some Hermes releases also load user memory
+    providers through the general plugin loader, whose ``PluginContext`` only
+    exposes hooks. In that path we register a narrow ``post_llm_call`` fallback
+    so one-shot ``hermes chat -q`` sessions still capture completed turns.
+    """
+    if hasattr(ctx, "register_memory_provider"):
+        ctx.register_memory_provider(NowledgeMemProvider())
+        return
+
+    if hasattr(ctx, "register_hook"):
+        ctx.register_hook("post_llm_call", _post_llm_call)
+        logger.debug("Nowledge Mem registered Hermes post_llm_call fallback hook")
+
+
+def _post_llm_call(**kwargs: Any) -> None:
+    session_id = str(kwargs.get("session_id") or "").strip()
+    user_message = str(kwargs.get("user_message") or "")
+    assistant_response = str(kwargs.get("assistant_response") or "")
+    if not session_id or (not user_message and not assistant_response):
+        return
+
+    provider = _get_fallback_provider(session_id=session_id, kwargs=kwargs)
+    if provider is None:
+        return
+    provider.sync_turn(user_message, assistant_response, session_id=session_id)
+
+
+def _get_fallback_provider(
+    *,
+    session_id: str,
+    kwargs: dict[str, Any],
+) -> Optional[NowledgeMemProvider]:
+    global _fallback_provider, _fallback_session_id
+
+    with _fallback_lock:
+        if _fallback_provider is not None and _fallback_session_id == session_id:
+            return _fallback_provider
+
+        if _fallback_provider is not None:
+            try:
+                _fallback_provider.shutdown()
+            except Exception:
+                pass
+
+        provider = NowledgeMemProvider()
+        try:
+            provider.initialize(
+                session_id,
+                hermes_home=_resolve_hermes_home(kwargs),
+                platform=str(kwargs.get("platform") or "cli"),
+                agent_context="primary",
+            )
+        except Exception as error:
+            logger.debug("Nowledge Mem fallback provider init failed: %s", error)
+            _fallback_provider = None
+            _fallback_session_id = ""
+            return None
+
+        _fallback_provider = provider
+        _fallback_session_id = session_id
+        return provider
+
+
+def _resolve_hermes_home(kwargs: dict[str, Any]) -> str:
+    raw = kwargs.get("hermes_home")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    try:
+        from hermes_constants import get_hermes_home
+
+        return str(get_hermes_home())
+    except Exception:
+        return ""

--- a/plugins/memory/nowledge-mem/__init__.py
+++ b/plugins/memory/nowledge-mem/__init__.py
@@ -1,0 +1,13 @@
+"""Nowledge Mem memory provider plugin for Hermes Agent.
+
+Registers as an external memory provider, replacing the generic MCP
+connection with native lifecycle hooks: automatic Working Memory
+injection, per-turn recall, user-profile mirroring, and native tools.
+"""
+
+from .provider import NowledgeMemProvider
+
+
+def register(ctx) -> None:
+    """Plugin entry point called by Hermes plugin loader."""
+    ctx.register_memory_provider(NowledgeMemProvider())

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 from typing import Any, Dict, List, Optional
 
@@ -27,8 +28,10 @@ class NowledgeMemClient:
     The CLI owns auth, server URL, and remote config.
     """
 
-    def __init__(self, timeout: int = 30) -> None:
+    def __init__(self, timeout: int = 30, *, space: Optional[str] = None) -> None:
         self._timeout = timeout
+        self._has_explicit_space = isinstance(space, str)
+        self._space = space.strip() if isinstance(space, str) else None
 
     @staticmethod
     def is_available() -> bool:
@@ -173,12 +176,20 @@ class NowledgeMemClient:
     def _cli(self, args: List[str]) -> Any:
         """Run ``nmem --json <args>`` and return parsed JSON."""
         cmd = ["nmem", "--json"] + args
+        env = os.environ.copy()
+        if self._has_explicit_space:
+            env.pop("NMEM_SPACE", None)
+            env.pop("NMEM_SPACE_ID", None)
+        if self._has_explicit_space and self._space:
+            env["NMEM_SPACE"] = self._space
+            env["NMEM_SPACE_ID"] = self._space
         try:
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 timeout=self._timeout,
+                env=env,
             )
         except FileNotFoundError:
             raise RuntimeError(

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -184,7 +184,7 @@ class NowledgeMemClient:
             raise RuntimeError(
                 "nmem CLI not found. Install: pip install nmem-cli, "
                 "or enable CLI in Nowledge Mem: Settings > Developer Tools"
-            )
+            ) from None
         if result.returncode != 0:
             stderr = result.stderr.strip()
             raise RuntimeError(stderr or f"nmem exited with code {result.returncode}")

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -79,6 +79,7 @@ class NowledgeMemClient:
         limit: int = 10,
         filter_labels: Optional[List[str]] = None,
         mode: Optional[str] = None,
+        min_importance: Optional[float] = None,
     ) -> Any:
         """Search memories. CLI requires a query string."""
         if not query:
@@ -91,6 +92,8 @@ class NowledgeMemClient:
                 cmd.extend(["-l", label])
         if mode == "deep":
             cmd.extend(["--mode", "deep"])
+        if min_importance is not None:
+            cmd.extend(["--importance", str(min_importance)])
         return self._cli(cmd)
 
     def save(

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -1,13 +1,14 @@
-"""CLI-only client for Nowledge Mem.
+"""Small Nowledge Mem client used by the Hermes provider.
 
-Shells out to ``nmem --json <args>``. The CLI handles server URL, API key,
-and remote access configuration, so this client has zero config surface.
+Most operations shell out to ``nmem --json <args>`` so the CLI owns server
+URL, API key, and remote access configuration. Thread transcript capture posts
+JSON directly to the Mem API so long sessions are not packed into argv.
 
 If ``nmem`` is not installed, ``is_available`` returns False and the
 provider gracefully disables tools. On machines running the Nowledge Mem
 desktop app, ``nmem`` is already bundled. Otherwise: ``pip install nmem-cli``.
 
-No external dependencies: stdlib only (subprocess, json).
+No external dependencies: stdlib only.
 """
 
 from __future__ import annotations
@@ -17,15 +18,22 @@ import logging
 import os
 import subprocess
 from typing import Any, Dict, List, Optional
+from urllib import error as urlerror
+from urllib import parse as urlparse
+from urllib import request as urlrequest
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_API_URL = "http://127.0.0.1:14242"
+CONFIG_PATH = os.path.expanduser("~/.nowledge-mem/config.json")
+
 
 class NowledgeMemClient:
-    """Thin wrapper around the ``nmem`` CLI.
+    """Minimal client for ``nmem`` tools plus large transcript uploads.
 
-    Every domain method builds CLI args and calls ``nmem --json <args>``.
-    The CLI owns auth, server URL, and remote config.
+    Memory and lookup methods call ``nmem --json <args>``. Thread import/append
+    uses the same shared Mem config but sends JSON over HTTP to avoid OS
+    argument-length limits on real transcripts.
     """
 
     def __init__(self, timeout: int = 30, *, space: Optional[str] = None) -> None:
@@ -184,28 +192,24 @@ class NowledgeMemClient:
         """Create or replace a thread from a cleaned transcript batch."""
         if not messages:
             return {"success": True, "thread_id": thread_id, "imported": 0}
-        cmd = ["t", "import", "-m", json.dumps(messages, ensure_ascii=False)]
+        payload: Dict[str, Any] = {
+            "thread_id": thread_id,
+            "messages": messages,
+        }
         if title:
-            cmd.extend(["-t", title])
-        if thread_id:
-            cmd.extend(["--id", thread_id])
+            payload["title"] = title
         if source:
-            cmd.extend(["-s", source])
-        return self._cli(cmd)
+            payload["source"] = source
+        if self._has_explicit_space and self._space:
+            payload["metadata"] = {"space_id": self._space}
+        return self._api_post("/threads/import", payload)
 
     def append_thread(self, thread_id: str, messages: List[Dict[str, Any]]) -> Any:
         """Append cleaned transcript messages to an existing thread."""
         if not messages:
             return {"success": True, "thread_id": thread_id, "appended": 0}
-        return self._cli(
-            [
-                "t",
-                "append",
-                thread_id,
-                "-m",
-                json.dumps(messages, ensure_ascii=False),
-            ]
-        )
+        path = f"/threads/{urlparse.quote(thread_id, safe='')}/append"
+        return self._api_post(path, {"messages": messages, "deduplicate": True})
 
     def _cli(self, args: List[str]) -> Any:
         """Run ``nmem --json <args>`` and return parsed JSON."""
@@ -242,3 +246,112 @@ class NowledgeMemClient:
             raise RuntimeError(
                 f"nmem returned non-JSON output: {output[:200]}"
             ) from error
+
+    def _api_post(self, path: str, payload: Dict[str, Any]) -> Any:
+        """POST JSON directly to Mem for large transcript payloads.
+
+        Regular memory tools continue to use ``nmem``. Transcript capture uses
+        HTTP so long sessions are not serialized into a single argv token.
+        """
+        api_url = self._api_url().rstrip("/")
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        api_key = self._api_key()
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+            headers["X-NMEM-API-Key"] = api_key
+
+        url = f"{api_url}{path}"
+        try:
+            return self._request_json(url, body, headers)
+        except RuntimeError as first_error:
+            if not api_key:
+                raise
+            for retry_url in self._retry_urls(url, api_key):
+                try:
+                    return self._request_json(retry_url, body, headers)
+                except RuntimeError:
+                    continue
+            raise first_error
+
+    def _request_json(
+        self,
+        url: str,
+        body: bytes,
+        headers: Dict[str, str],
+    ) -> Any:
+        request = urlrequest.Request(url, data=body, headers=headers, method="POST")
+        try:
+            with urlrequest.urlopen(request, timeout=self._timeout) as response:
+                raw = response.read().decode("utf-8")
+        except urlerror.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Mem API error {error.code}: {detail[:300]}"
+            ) from error
+        except urlerror.URLError as error:
+            raise RuntimeError(f"Cannot connect to Mem API: {error}") from error
+
+        if not raw.strip():
+            return {}
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(f"Mem API returned non-JSON output: {raw[:200]}") from error
+
+    @staticmethod
+    def _load_cli_config() -> Dict[str, Any]:
+        try:
+            with open(CONFIG_PATH, "r", encoding="utf-8") as handle:
+                parsed = json.load(handle)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+
+    @classmethod
+    def _api_url(cls) -> str:
+        env_url = os.environ.get("NMEM_API_URL")
+        if env_url:
+            return env_url.strip().rstrip("/")
+        config = cls._load_cli_config()
+        configured = config.get("apiUrl") or config.get("api_url")
+        return str(configured or DEFAULT_API_URL).strip().rstrip("/")
+
+    @classmethod
+    def _api_key(cls) -> str:
+        env_key = os.environ.get("NMEM_API_KEY")
+        if env_key is not None:
+            return env_key.strip()
+        config = cls._load_cli_config()
+        return str(config.get("apiKey") or config.get("api_key") or "").strip()
+
+    @staticmethod
+    def _retry_urls(url: str, api_key: str) -> List[str]:
+        urls: List[str] = []
+
+        def add(candidate: str) -> None:
+            if candidate not in urls:
+                urls.append(candidate)
+
+        parsed = urlparse.urlsplit(url)
+        query = urlparse.parse_qsl(parsed.query, keep_blank_values=True)
+        if not any(key.lower() == "nmem_api_key" for key, _ in query):
+            query.append(("nmem_api_key", api_key))
+            add(urlparse.urlunsplit(parsed._replace(query=urlparse.urlencode(query))))
+
+        path = parsed.path or ""
+        if path == "/remote-api":
+            stripped_path = "/"
+        elif path.startswith("/remote-api/"):
+            stripped_path = path[len("/remote-api") :]
+        else:
+            stripped_path = ""
+        if stripped_path:
+            stripped = parsed._replace(path=stripped_path)
+            add(urlparse.urlunsplit(stripped))
+            stripped_query = urlparse.parse_qsl(stripped.query, keep_blank_values=True)
+            if not any(key.lower() == "nmem_api_key" for key, _ in stripped_query):
+                stripped_query.append(("nmem_api_key", api_key))
+                add(urlparse.urlunsplit(stripped._replace(query=urlparse.urlencode(stripped_query))))
+
+        return urls

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -173,6 +173,40 @@ class NowledgeMemClient:
             cmd.extend(["--offset", str(offset)])
         return self._cli(cmd)
 
+    def import_thread(
+        self,
+        thread_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        title: Optional[str] = None,
+        source: str = "hermes",
+    ) -> Any:
+        """Create or replace a thread from a cleaned transcript batch."""
+        if not messages:
+            return {"success": True, "thread_id": thread_id, "imported": 0}
+        cmd = ["t", "import", "-m", json.dumps(messages, ensure_ascii=False)]
+        if title:
+            cmd.extend(["-t", title])
+        if thread_id:
+            cmd.extend(["--id", thread_id])
+        if source:
+            cmd.extend(["-s", source])
+        return self._cli(cmd)
+
+    def append_thread(self, thread_id: str, messages: List[Dict[str, Any]]) -> Any:
+        """Append cleaned transcript messages to an existing thread."""
+        if not messages:
+            return {"success": True, "thread_id": thread_id, "appended": 0}
+        return self._cli(
+            [
+                "t",
+                "append",
+                thread_id,
+                "-m",
+                json.dumps(messages, ensure_ascii=False),
+            ]
+        )
+
     def _cli(self, args: List[str]) -> Any:
         """Run ``nmem --json <args>`` and return parsed JSON."""
         cmd = ["nmem", "--json"] + args

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -209,7 +209,10 @@ class NowledgeMemClient:
         if not messages:
             return {"success": True, "thread_id": thread_id, "appended": 0}
         path = f"/threads/{urlparse.quote(thread_id, safe='')}/append"
-        return self._api_post(path, {"messages": messages, "deduplicate": True})
+        payload: Dict[str, Any] = {"messages": messages, "deduplicate": True}
+        if self._has_explicit_space and self._space:
+            payload["space_id"] = self._space
+        return self._api_post(path, payload)
 
     def _cli(self, args: List[str]) -> Any:
         """Run ``nmem --json <args>`` and return parsed JSON."""
@@ -265,13 +268,9 @@ class NowledgeMemClient:
         try:
             return self._request_json(url, body, headers)
         except RuntimeError as first_error:
-            if not api_key:
-                raise
-
-            # Match nmem's proxy compatibility behavior: if a proxy strips
-            # auth headers, retry with the key in the query string; if the
-            # configured URL still includes /remote-api, retry once at root.
-            for retry_url in self._retry_urls(url, api_key):
+            # Keep proxy compatibility for configs that accidentally include
+            # /remote-api, but never move credentials from headers into URLs.
+            for retry_url in self._retry_urls(url):
                 try:
                     return self._request_json(retry_url, body, headers)
                 except RuntimeError:
@@ -330,7 +329,7 @@ class NowledgeMemClient:
         return str(config.get("apiKey") or config.get("api_key") or "").strip()
 
     @staticmethod
-    def _retry_urls(url: str, api_key: str) -> List[str]:
+    def _retry_urls(url: str) -> List[str]:
         urls: List[str] = []
 
         def add(candidate: str) -> None:
@@ -338,11 +337,6 @@ class NowledgeMemClient:
                 urls.append(candidate)
 
         parsed = urlparse.urlsplit(url)
-        query = urlparse.parse_qsl(parsed.query, keep_blank_values=True)
-        if not any(key.lower() == "nmem_api_key" for key, _ in query):
-            query.append(("nmem_api_key", api_key))
-            add(urlparse.urlunsplit(parsed._replace(query=urlparse.urlencode(query))))
-
         path = parsed.path or ""
         if path == "/remote-api":
             stripped_path = "/"
@@ -353,9 +347,5 @@ class NowledgeMemClient:
         if stripped_path:
             stripped = parsed._replace(path=stripped_path)
             add(urlparse.urlunsplit(stripped))
-            stripped_query = urlparse.parse_qsl(stripped.query, keep_blank_values=True)
-            if not any(key.lower() == "nmem_api_key" for key, _ in stripped_query):
-                stripped_query.append(("nmem_api_key", api_key))
-                add(urlparse.urlunsplit(stripped._replace(query=urlparse.urlencode(stripped_query))))
 
         return urls

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -1,0 +1,199 @@
+"""CLI-only client for Nowledge Mem.
+
+Shells out to ``nmem --json <args>``. The CLI handles server URL, API key,
+and remote access configuration, so this client has zero config surface.
+
+If ``nmem`` is not installed, ``is_available`` returns False and the
+provider gracefully disables tools. On machines running the Nowledge Mem
+desktop app, ``nmem`` is already bundled. Otherwise: ``pip install nmem-cli``.
+
+No external dependencies: stdlib only (subprocess, json).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class NowledgeMemClient:
+    """Thin wrapper around the ``nmem`` CLI.
+
+    Every domain method builds CLI args and calls ``nmem --json <args>``.
+    The CLI owns auth, server URL, and remote config.
+    """
+
+    def __init__(self, timeout: int = 30) -> None:
+        self._timeout = timeout
+
+    @staticmethod
+    def is_available() -> bool:
+        """Return True if ``nmem`` CLI is on PATH and responds."""
+        try:
+            result = subprocess.run(
+                ["nmem", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    def health(self) -> bool:
+        """Check that Nowledge Mem is reachable."""
+        try:
+            result = subprocess.run(
+                ["nmem", "--json", "status"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    def working_memory(self) -> Dict[str, Any]:
+        """Fetch the user's Working Memory briefing."""
+        return self._cli(["wm", "read"])
+
+    def search(
+        self,
+        query: str = "",
+        *,
+        limit: int = 10,
+        filter_labels: Optional[List[str]] = None,
+        mode: Optional[str] = None,
+    ) -> Any:
+        """Search memories. CLI requires a query string."""
+        if not query:
+            return {"memories": []}
+        cmd = ["m", "search", query]
+        if limit != 10:
+            cmd.extend(["-n", str(limit)])
+        if filter_labels:
+            for label in filter_labels:
+                cmd.extend(["-l", label])
+        if mode == "deep":
+            cmd.extend(["--mode", "deep"])
+        return self._cli(cmd)
+
+    def save(
+        self,
+        content: str,
+        *,
+        memory_id: Optional[str] = None,
+        title: Optional[str] = None,
+        importance: Optional[float] = None,
+        labels: Optional[List[str]] = None,
+        unit_type: Optional[str] = None,
+        event_date: Optional[str] = None,
+    ) -> Any:
+        """Save a new memory, or upsert by memory_id."""
+        cmd = ["m", "add", content]
+        cmd.extend(["-s", "hermes"])
+        if memory_id:
+            cmd.extend(["--id", memory_id])
+        if title:
+            cmd.extend(["-t", title])
+        if importance is not None:
+            cmd.extend(["-i", str(importance)])
+        if labels:
+            for label in labels:
+                cmd.extend(["-l", label])
+        if unit_type:
+            cmd.extend(["--unit-type", unit_type])
+        if event_date:
+            cmd.extend(["--event-start", event_date])
+        return self._cli(cmd)
+
+    def update(
+        self,
+        memory_id: str,
+        *,
+        content: Optional[str] = None,
+        title: Optional[str] = None,
+        importance: Optional[float] = None,
+    ) -> Any:
+        """Update an existing memory (content, title, importance)."""
+        cmd = ["m", "update", memory_id]
+        if content:
+            cmd.extend(["-c", content])
+        if title:
+            cmd.extend(["-t", title])
+        if importance is not None:
+            cmd.extend(["-i", str(importance)])
+        return self._cli(cmd)
+
+    def delete(self, memory_id: str) -> Any:
+        """Delete a single memory."""
+        return self._cli(["m", "delete", memory_id, "-f"])
+
+    def delete_many(self, memory_ids: List[str]) -> Any:
+        """Delete multiple memories."""
+        if not memory_ids:
+            raise ValueError("memory_ids must not be empty")
+        return self._cli(["m", "delete", *memory_ids, "-f"])
+
+    def thread_search(
+        self,
+        query: str = "",
+        *,
+        limit: int = 10,
+        source: Optional[str] = None,
+    ) -> Any:
+        """Search past conversations. CLI requires a query string."""
+        if not query:
+            return {"threads": []}
+        cmd = ["t", "search", query]
+        if limit != 10:
+            cmd.extend(["-n", str(limit)])
+        if source:
+            cmd.extend(["--source", source])
+        return self._cli(cmd)
+
+    def thread_messages(
+        self,
+        thread_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Any:
+        """Fetch messages from a thread."""
+        cmd = ["t", "show", thread_id]
+        cmd.extend(["-n", str(limit)])
+        if offset:
+            cmd.extend(["--offset", str(offset)])
+        return self._cli(cmd)
+
+    def _cli(self, args: List[str]) -> Any:
+        """Run ``nmem --json <args>`` and return parsed JSON."""
+        cmd = ["nmem", "--json"] + args
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+            )
+        except FileNotFoundError:
+            raise RuntimeError(
+                "nmem CLI not found. Install: pip install nmem-cli, "
+                "or enable CLI in Nowledge Mem: Settings > Developer Tools"
+            )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            raise RuntimeError(stderr or f"nmem exited with code {result.returncode}")
+        output = result.stdout.strip()
+        if not output:
+            return {}
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(
+                f"nmem returned non-JSON output: {output[:200]}"
+            ) from error

--- a/plugins/memory/nowledge-mem/client.py
+++ b/plugins/memory/nowledge-mem/client.py
@@ -267,6 +267,10 @@ class NowledgeMemClient:
         except RuntimeError as first_error:
             if not api_key:
                 raise
+
+            # Match nmem's proxy compatibility behavior: if a proxy strips
+            # auth headers, retry with the key in the query string; if the
+            # configured URL still includes /remote-api, retry once at root.
             for retry_url in self._retry_urls(url, api_key):
                 try:
                     return self._request_json(retry_url, body, headers)

--- a/plugins/memory/nowledge-mem/plugin.yaml
+++ b/plugins/memory/nowledge-mem/plugin.yaml
@@ -1,5 +1,5 @@
 name: nowledge-mem
-version: 0.5.5
+version: 0.5.7
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch

--- a/plugins/memory/nowledge-mem/plugin.yaml
+++ b/plugins/memory/nowledge-mem/plugin.yaml
@@ -1,8 +1,9 @@
 name: nowledge-mem
-version: 0.5.9
+version: 0.5.13
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch
+  - post_llm_call
   - on_memory_write
   - on_pre_compress
   - on_session_end

--- a/plugins/memory/nowledge-mem/plugin.yaml
+++ b/plugins/memory/nowledge-mem/plugin.yaml
@@ -1,5 +1,5 @@
 name: nowledge-mem
-version: 0.5.13
+version: 0.5.15
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch

--- a/plugins/memory/nowledge-mem/plugin.yaml
+++ b/plugins/memory/nowledge-mem/plugin.yaml
@@ -1,8 +1,9 @@
 name: nowledge-mem
-version: 0.5.7
+version: 0.5.9
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch
   - on_memory_write
   - on_pre_compress
+  - on_session_end
 author: Nowledge Labs

--- a/plugins/memory/nowledge-mem/plugin.yaml
+++ b/plugins/memory/nowledge-mem/plugin.yaml
@@ -1,0 +1,8 @@
+name: nowledge-mem
+version: 0.5.5
+description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
+hooks:
+  - prefetch
+  - on_memory_write
+  - on_pre_compress
+author: Nowledge Labs

--- a/plugins/memory/nowledge-mem/provider.py
+++ b/plugins/memory/nowledge-mem/provider.py
@@ -219,6 +219,8 @@ class NowledgeMemProvider(MemoryProvider):
         self._cron_skipped = False
         self._bg_threads: List[threading.Thread] = []
         self._resolved_space: str | None = None
+        self._session_id = ""
+        self._saved_message_count = 0
 
     @property
     def name(self) -> str:
@@ -255,6 +257,8 @@ class NowledgeMemProvider(MemoryProvider):
             timeout = 30
         self._resolved_space = self._resolve_space(config, kwargs)
         self._client = NowledgeMemClient(timeout=timeout, space=self._resolved_space)
+        self._session_id = session_id or ""
+        self._saved_message_count = 0
 
         if not self._client.health():
             logger.warning("Nowledge Mem not reachable via nmem CLI")
@@ -335,6 +339,54 @@ class NowledgeMemProvider(MemoryProvider):
             "from compressed messages can be recovered via nmem_search. Preserve references "
             "to memory IDs if any were mentioned."
         )
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if self._cron_skipped or not self._client:
+            return
+        session_id = (self._session_id or "").strip()
+        if not session_id:
+            return
+
+        cleaned_messages = self._clean_session_messages(messages)
+        if not cleaned_messages:
+            return
+
+        saved_count = int(self._saved_message_count or 0)
+        if saved_count > len(cleaned_messages):
+            saved_count = 0
+
+        if saved_count <= 0:
+            title = self._build_thread_title(cleaned_messages)
+            try:
+                self._client.import_thread(
+                    session_id,
+                    cleaned_messages,
+                    title=title or None,
+                    source="hermes",
+                )
+            except Exception as error:
+                logger.warning(
+                    "Nowledge Mem session import failed for %s: %s",
+                    session_id,
+                    error,
+                )
+                return
+            self._saved_message_count = len(cleaned_messages)
+            return
+
+        delta = cleaned_messages[saved_count:]
+        if not delta:
+            return
+        try:
+            self._client.append_thread(session_id, delta)
+        except Exception as error:
+            logger.warning(
+                "Nowledge Mem session append failed for %s: %s",
+                session_id,
+                error,
+            )
+            return
+        self._saved_message_count = len(cleaned_messages)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._cron_skipped:
@@ -443,6 +495,8 @@ class NowledgeMemProvider(MemoryProvider):
                 thread.join(timeout=3.0)
         self._bg_threads.clear()
         self._resolved_space = None
+        self._session_id = ""
+        self._saved_message_count = 0
 
     @staticmethod
     def _parse_csv(value: Any) -> Optional[List[str]]:
@@ -563,3 +617,48 @@ class NowledgeMemProvider(MemoryProvider):
         if not lines:
             return ""
         return "## Recalled from Nowledge Mem\n" + "\n".join(lines)
+
+    @staticmethod
+    def _clean_session_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+        cleaned: List[Dict[str, str]] = []
+        for message in messages or []:
+            if not isinstance(message, dict):
+                continue
+            role = str(message.get("role") or "").strip()
+            if role not in {"user", "assistant"}:
+                continue
+            content = NowledgeMemProvider._extract_message_text(message.get("content"))
+            if not content:
+                continue
+            cleaned.append({"role": role, "content": content})
+        return cleaned
+
+    @staticmethod
+    def _extract_message_text(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content.strip()
+        if isinstance(content, list):
+            parts = [NowledgeMemProvider._extract_message_text(item) for item in content]
+            return "\n".join(part for part in parts if part).strip()
+        if isinstance(content, dict):
+            if "text" in content:
+                return NowledgeMemProvider._extract_message_text(content.get("text"))
+            if "content" in content:
+                return NowledgeMemProvider._extract_message_text(content.get("content"))
+            return ""
+        return str(content).strip()
+
+    @staticmethod
+    def _build_thread_title(messages: List[Dict[str, str]]) -> str:
+        for message in messages:
+            if message.get("role") != "user":
+                continue
+            first_line = next(
+                (line.strip() for line in message.get("content", "").splitlines() if line.strip()),
+                "",
+            )
+            if first_line:
+                return first_line[:80]
+        return "Hermes session"

--- a/plugins/memory/nowledge-mem/provider.py
+++ b/plugins/memory/nowledge-mem/provider.py
@@ -19,7 +19,16 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
-from tools.registry import tool_error, tool_result
+
+try:
+    from tools.registry import tool_error as _registry_tool_error
+except ImportError:
+    _registry_tool_error = None
+
+try:
+    from tools.registry import tool_result as _registry_tool_result
+except ImportError:
+    _registry_tool_result = None
 
 from .client import NowledgeMemClient
 
@@ -175,6 +184,29 @@ ALL_TOOL_SCHEMAS = [
     _THREAD_SEARCH,
     _THREAD_MESSAGES,
 ]
+
+
+def tool_error(message: Any, **extra: Any) -> str:
+    """Return Hermes-style JSON error payloads across old and new releases."""
+    if _registry_tool_error is not None:
+        return _registry_tool_error(message, **extra)
+
+    payload = {"error": str(message)}
+    if extra:
+        payload.update(extra)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def tool_result(data: Any = None, **kwargs: Any) -> str:
+    """Return Hermes-style JSON result payloads across old and new releases."""
+    if _registry_tool_result is not None:
+        return _registry_tool_result(data, **kwargs)
+
+    if data is not None:
+        if kwargs:
+            raise ValueError("tool_result accepts either data or kwargs, not both")
+        return json.dumps(data, ensure_ascii=False)
+    return json.dumps(kwargs, ensure_ascii=False)
 
 
 class NowledgeMemProvider(MemoryProvider):
@@ -379,19 +411,14 @@ class NowledgeMemProvider(MemoryProvider):
 
     @staticmethod
     def _parse_csv(value: Any) -> Optional[List[str]]:
-        if value is None:
-            return None
-        if isinstance(value, str):
-            return [item.strip() for item in value.split(",") if item.strip()]
-        if isinstance(value, (list, tuple, set)):
-            parsed = [str(item).strip() for item in value if str(item).strip()]
-            return parsed or None
-
-        text = str(value).strip()
-        return [text] if text else None
+        return NowledgeMemProvider._to_str_list(value)
 
     @staticmethod
     def _normalize_id_list(value: Any) -> Optional[List[str]]:
+        return NowledgeMemProvider._to_str_list(value)
+
+    @staticmethod
+    def _to_str_list(value: Any) -> Optional[List[str]]:
         if value is None:
             return None
         if isinstance(value, str):

--- a/plugins/memory/nowledge-mem/provider.py
+++ b/plugins/memory/nowledge-mem/provider.py
@@ -17,7 +17,7 @@ import logging
 import os
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from agent.memory_provider import MemoryProvider
 
@@ -59,7 +59,7 @@ topic, use nmem_update rather than create a duplicate."""
 
 _SEARCH = {
     "name": "nmem_search",
-    "description": "Search stored memories. Supports label filtering and deep search mode.",
+    "description": "Search stored memories. Supports label filtering, minimum-importance filtering, and deep search mode.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -72,6 +72,10 @@ _SEARCH = {
             "mode": {
                 "type": "string",
                 "description": "'normal' (fast, default) or 'deep' (graph-enhanced).",
+            },
+            "min_importance": {
+                "type": "number",
+                "description": "Minimum importance threshold, 0.0-1.0. Filters out lower-priority memories.",
             },
         },
         "required": ["query"],
@@ -221,6 +225,8 @@ class NowledgeMemProvider(MemoryProvider):
         self._resolved_space: str | None = None
         self._session_id = ""
         self._saved_message_count = 0
+        self._saved_message_counts: Dict[str, int] = {}
+        self._delta_only_sessions: Set[str] = set()
 
     @property
     def name(self) -> str:
@@ -257,8 +263,7 @@ class NowledgeMemProvider(MemoryProvider):
             timeout = 30
         self._resolved_space = self._resolve_space(config, kwargs)
         self._client = NowledgeMemClient(timeout=timeout, space=self._resolved_space)
-        self._session_id = session_id or ""
-        self._saved_message_count = 0
+        self._activate_session(session_id or "", reset=True)
 
         if not self._client.health():
             logger.warning("Nowledge Mem not reachable via nmem CLI")
@@ -341,18 +346,58 @@ class NowledgeMemProvider(MemoryProvider):
         if not user_content and not assistant_content:
             return
 
+        self._activate_session(active_session_id)
+        cleaned_messages = self._clean_session_messages(
+            [
+                {"role": "user", "content": user_content},
+                {"role": "assistant", "content": assistant_content},
+            ]
+        )
+        self._write_thread_messages(cleaned_messages, title_messages=cleaned_messages)
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        if self._cron_skipped:
+            return
+        self._activate_session(new_session_id, reset=reset)
+
+    def _activate_session(self, session_id: str, *, reset: bool = False) -> None:
+        session_id = (session_id or "").strip()
+        if not session_id:
+            return
         previous_session_id = self._session_id
-        self._session_id = active_session_id
-        try:
-            cleaned_messages = self._clean_session_messages(
-                [
-                    {"role": "user", "content": user_content},
-                    {"role": "assistant", "content": assistant_content},
-                ]
-            )
-            self._write_thread_messages(cleaned_messages, title_messages=cleaned_messages)
-        finally:
-            self._session_id = previous_session_id or active_session_id
+        if reset:
+            count = 0
+            self._delta_only_sessions.discard(session_id)
+        elif session_id in self._saved_message_counts:
+            count = self._get_saved_message_count(session_id)
+        elif session_id == previous_session_id:
+            count = int(self._saved_message_count or 0)
+        else:
+            count = 0
+            self._delta_only_sessions.add(session_id)
+        self._saved_message_counts[session_id] = count
+        self._session_id = session_id
+        self._saved_message_count = count
+
+    def _get_saved_message_count(self, session_id: str) -> int:
+        if session_id in self._saved_message_counts:
+            return int(self._saved_message_counts.get(session_id) or 0)
+        if session_id == self._session_id:
+            return int(self._saved_message_count or 0)
+        return 0
+
+    def _set_saved_message_count(self, session_id: str, count: int) -> None:
+        count = max(0, int(count or 0))
+        self._saved_message_counts[session_id] = count
+        if session_id == self._session_id:
+            self._saved_message_count = count
 
     def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
         if self._cron_skipped or not self._client:
@@ -373,10 +418,17 @@ class NowledgeMemProvider(MemoryProvider):
         cleaned_messages = self._clean_session_messages(messages)
         if not cleaned_messages:
             return
+        if session_id in self._delta_only_sessions:
+            logger.debug(
+                "Skipping Nowledge Mem session-end flush for %s: only per-turn deltas are tracked",
+                session_id,
+            )
+            return
 
-        saved_count = int(self._saved_message_count or 0)
+        saved_count = self._get_saved_message_count(session_id)
         if saved_count > len(cleaned_messages):
             saved_count = 0
+            self._set_saved_message_count(session_id, 0)
 
         if saved_count <= 0:
             self._write_thread_messages(cleaned_messages, title_messages=cleaned_messages)
@@ -399,7 +451,8 @@ class NowledgeMemProvider(MemoryProvider):
         if not session_id:
             return
 
-        if self._saved_message_count <= 0:
+        saved_count = self._get_saved_message_count(session_id)
+        if saved_count <= 0:
             title = self._build_thread_title(title_messages or messages)
             try:
                 result = self._client.import_thread(
@@ -410,8 +463,9 @@ class NowledgeMemProvider(MemoryProvider):
                 )
                 if not self._response_succeeded(result):
                     if self._thread_already_exists(result):
+                        self._delta_only_sessions.add(session_id)
                         self._append_existing_thread(session_id, messages)
-                        self._saved_message_count += len(messages)
+                        self._set_saved_message_count(session_id, saved_count + len(messages))
                         return
                     logger.warning(
                         "Nowledge Mem session import did not succeed for %s: %s",
@@ -426,7 +480,7 @@ class NowledgeMemProvider(MemoryProvider):
                     error,
                 )
                 return
-            self._saved_message_count += len(messages)
+            self._set_saved_message_count(session_id, saved_count + len(messages))
             return
 
         try:
@@ -438,7 +492,7 @@ class NowledgeMemProvider(MemoryProvider):
                 error,
             )
             return
-        self._saved_message_count += len(messages)
+        self._set_saved_message_count(session_id, saved_count + len(messages))
 
     def _append_existing_thread(self, session_id: str, messages: List[Dict[str, str]]) -> None:
         assert self._client is not None
@@ -472,6 +526,7 @@ class NowledgeMemProvider(MemoryProvider):
                 limit=args.get("limit", 10),
                 filter_labels=self._parse_csv(args.get("filter_labels")),
                 mode=args.get("mode"),
+                min_importance=args.get("min_importance"),
             )
         if tool_name == "nmem_save":
             return client.save(
@@ -555,6 +610,8 @@ class NowledgeMemProvider(MemoryProvider):
         self._resolved_space = None
         self._session_id = ""
         self._saved_message_count = 0
+        self._saved_message_counts.clear()
+        self._delta_only_sessions.clear()
 
     @staticmethod
     def _parse_csv(value: Any) -> Optional[List[str]]:

--- a/plugins/memory/nowledge-mem/provider.py
+++ b/plugins/memory/nowledge-mem/provider.py
@@ -474,7 +474,7 @@ class NowledgeMemProvider(MemoryProvider):
                 "key": "space_template",
                 "description": "Optional template like research-{identity}; used when space is empty",
                 "default": "",
-            }
+            },
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:

--- a/plugins/memory/nowledge-mem/provider.py
+++ b/plugins/memory/nowledge-mem/provider.py
@@ -1,0 +1,460 @@
+"""Nowledge Mem memory provider for Hermes Agent.
+
+Implements the MemoryProvider ABC to give Hermes native access to the
+user's cross-tool knowledge graph. Replaces the generic MCP connection
+with lifecycle hooks: automatic Working Memory injection, per-turn
+recall, user-profile mirroring, and native tool names.
+
+Transport: ``nmem`` CLI only. The CLI handles server URL, API key, and
+remote access. If ``nmem`` is not installed, the provider disables
+gracefully.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error, tool_result
+
+from .client import NowledgeMemClient
+
+logger = logging.getLogger(__name__)
+
+GUIDANCE = """\
+# Nowledge Mem
+Cross-tool personal knowledge graph. Knowledge saved here persists across \
+all tools and sessions.
+
+**Nowledge Mem vs Hermes memory:** Hermes memory stores Hermes-specific \
+facts (env details, tool quirks). Nowledge Mem stores cross-tool knowledge: \
+decisions, procedures, and learnings. Ask yourself: "Would this matter in a \
+Claude Code, Cursor, or Codex session?" If yes, save to Nowledge Mem.
+
+Save proactively when the conversation produces a decision, procedure, \
+learning, or important context. One strong memory is better than three \
+weak ones.
+
+**Upsert by ID:** pass a stable id to nmem_save to create-or-update in one \
+call. If a memory with that ID already exists it is updated; otherwise a new \
+one is created. Use this when you have a natural key (for example a topic or \
+decision name) instead of the search-then-update dance.
+
+Without an id, search first (nmem_search); if existing knowledge covers the \
+topic, use nmem_update rather than create a duplicate."""
+
+_SEARCH = {
+    "name": "nmem_search",
+    "description": "Search stored memories. Supports label filtering and deep search mode.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Max results, 1-20 (default 10)."},
+            "filter_labels": {
+                "type": "string",
+                "description": "Comma-separated labels to filter by.",
+            },
+            "mode": {
+                "type": "string",
+                "description": "'normal' (fast, default) or 'deep' (graph-enhanced).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+_SAVE = {
+    "name": "nmem_save",
+    "description": (
+        "Save a decision, insight, procedure, or learning. Pass id to upsert: "
+        "update if that ID exists, create if not. Without id, search first to avoid duplicates."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Memory content."},
+            "id": {
+                "type": "string",
+                "description": "Stable ID for upsert. Omit to auto-generate.",
+            },
+            "title": {"type": "string", "description": "Descriptive title."},
+            "importance": {
+                "type": "number",
+                "description": "0.0-1.0. 0.8+ major, 0.5-0.7 useful, 0.3-0.4 minor.",
+            },
+            "labels": {
+                "type": "string",
+                "description": "Comma-separated labels.",
+            },
+            "unit_type": {
+                "type": "string",
+                "description": "fact, preference, decision, plan, procedure, learning, context, or event.",
+            },
+            "event_date": {
+                "type": "string",
+                "description": "When it happened (YYYY, YYYY-MM, or YYYY-MM-DD).",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+_UPDATE = {
+    "name": "nmem_update",
+    "description": "Refine an existing memory. Search first to find the memory_id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "Memory ID from search results."},
+            "content": {"type": "string", "description": "Updated content (omit to keep current)."},
+            "title": {"type": "string", "description": "Updated title (omit to keep current)."},
+            "importance": {"type": "number", "description": "Updated importance (omit to keep current)."},
+        },
+        "required": ["memory_id"],
+    },
+}
+
+_DELETE = {
+    "name": "nmem_delete",
+    "description": "Delete one or more memories. Also removes associated relationships and entity links.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "Single memory ID to delete."},
+            "memory_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Multiple memory IDs for bulk delete.",
+            },
+        },
+        "required": [],
+    },
+}
+
+_THREAD_SEARCH = {
+    "name": "nmem_thread_search",
+    "description": "Search past conversations. Returns threads with matched message snippets.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Max threads, 1-50 (default 10)."},
+            "source": {
+                "type": "string",
+                "description": "Filter by source (for example 'claude-code' or 'hermes').",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+_THREAD_MESSAGES = {
+    "name": "nmem_thread_messages",
+    "description": "Fetch messages from a thread. Use after nmem_thread_search.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "thread_id": {"type": "string", "description": "Thread ID."},
+            "offset": {"type": "integer", "description": "Messages to skip (default 0)."},
+            "limit": {"type": "integer", "description": "Max messages, 1-100 (default 50)."},
+        },
+        "required": ["thread_id"],
+    },
+}
+
+ALL_TOOL_SCHEMAS = [
+    _SEARCH,
+    _SAVE,
+    _UPDATE,
+    _DELETE,
+    _THREAD_SEARCH,
+    _THREAD_MESSAGES,
+]
+
+
+class NowledgeMemProvider(MemoryProvider):
+    """Nowledge Mem as a native Hermes memory provider."""
+
+    def __init__(self) -> None:
+        self._client: Optional[NowledgeMemClient] = None
+        self._working_memory = ""
+        self._cron_skipped = False
+        self._bg_threads: List[threading.Thread] = []
+
+    @property
+    def name(self) -> str:
+        return "nowledge-mem"
+
+    def is_available(self) -> bool:
+        """Check if nmem CLI is installed. No network calls."""
+        return NowledgeMemClient.is_available()
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        agent_context = kwargs.get("agent_context", "")
+        platform = kwargs.get("platform", "cli")
+
+        if agent_context in ("cron", "flush") or platform == "cron":
+            logger.debug(
+                "Nowledge Mem skipped: cron/flush context (agent_context=%s, platform=%s)",
+                agent_context,
+                platform,
+            )
+            self._cron_skipped = True
+            return
+
+        timeout = self._load_timeout(kwargs.get("hermes_home", ""))
+        self._client = NowledgeMemClient(timeout=timeout)
+
+        if not self._client.health():
+            logger.warning("Nowledge Mem not reachable via nmem CLI")
+            self._client = None
+            return
+
+        try:
+            wm = self._client.working_memory()
+            self._working_memory = self._format_working_memory(wm)
+        except Exception as error:
+            logger.debug("Working memory fetch failed: %s", error)
+            self._working_memory = ""
+
+        logger.info("Nowledge Mem provider initialized (CLI transport)")
+
+    def system_prompt_block(self) -> str:
+        if self._cron_skipped:
+            return ""
+
+        parts = [GUIDANCE]
+        if self._working_memory:
+            parts.append(f"## Working Memory\n\n{self._working_memory}")
+        elif self._client:
+            parts.append("## Working Memory\n\nNo briefing available yet. The knowledge graph is connected.")
+        else:
+            parts.append(
+                "## Working Memory\n\nNowledge Mem server is not reachable. Tools are unavailable until the server is running."
+            )
+        return "\n\n".join(parts)
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._cron_skipped or not self._client:
+            return ""
+        if not query or len(query.strip()) < 10:
+            return ""
+
+        try:
+            result = self._client.search(query.strip()[:200], limit=5)
+            return self._format_prefetch(result)
+        except Exception as error:
+            logger.debug("Nowledge Mem prefetch failed: %s", error)
+            return ""
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if self._cron_skipped or not self._client:
+            return
+        if action != "add" or target != "user" or not content:
+            return
+
+        client = self._client
+
+        def _mirror() -> None:
+            try:
+                client.save(
+                    content,
+                    title="User profile (synced from Hermes)",
+                    labels=["hermes-profile"],
+                    importance=0.5,
+                )
+                logger.debug("Mirrored user-profile write to Nowledge Mem")
+            except Exception as error:
+                logger.debug("Mirror write failed (non-fatal): %s", error)
+
+        thread = threading.Thread(target=_mirror, daemon=True, name="nmem-mirror")
+        thread.start()
+        self._bg_threads.append(thread)
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if self._cron_skipped or not self._client:
+            return ""
+        return (
+            "Cross-session knowledge is stored in Nowledge Mem. Decisions and insights "
+            "from compressed messages can be recovered via nmem_search. Preserve references "
+            "to memory IDs if any were mentioned."
+        )
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        if self._cron_skipped:
+            return []
+        return list(ALL_TOOL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        if not self._client:
+            return tool_error("Nowledge Mem is not connected.", success=False)
+
+        try:
+            result = self._dispatch(tool_name, args)
+            return tool_result(self._normalize_tool_result(result))
+        except Exception as error:
+            logger.error("Tool %s failed: %s", tool_name, error)
+            return tool_error(f"{tool_name} failed: {error}", success=False, tool=tool_name)
+
+    def _dispatch(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        assert self._client is not None
+        client = self._client
+
+        if tool_name == "nmem_search":
+            return client.search(
+                args.get("query", ""),
+                limit=args.get("limit", 10),
+                filter_labels=self._parse_csv(args.get("filter_labels")),
+                mode=args.get("mode"),
+            )
+        if tool_name == "nmem_save":
+            return client.save(
+                args["content"],
+                memory_id=args.get("id"),
+                title=args.get("title"),
+                importance=args.get("importance"),
+                labels=self._parse_csv(args.get("labels")),
+                unit_type=args.get("unit_type"),
+                event_date=args.get("event_date"),
+            )
+        if tool_name == "nmem_update":
+            return client.update(
+                args["memory_id"],
+                content=args.get("content"),
+                title=args.get("title"),
+                importance=args.get("importance"),
+            )
+        if tool_name == "nmem_delete":
+            memory_ids = self._normalize_id_list(args.get("memory_ids"))
+            if memory_ids:
+                return client.delete_many(memory_ids)
+            if args.get("memory_id"):
+                return client.delete(args["memory_id"])
+            raise ValueError("nmem_delete requires memory_id or memory_ids")
+        if tool_name == "nmem_thread_search":
+            return client.thread_search(
+                args.get("query", ""),
+                limit=args.get("limit", 10),
+                source=args.get("source"),
+            )
+        if tool_name == "nmem_thread_messages":
+            return client.thread_messages(
+                args["thread_id"],
+                limit=args.get("limit", 50),
+                offset=args.get("offset", 0),
+            )
+        raise ValueError(f"Unknown tool: {tool_name}")
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "timeout",
+                "description": "Request timeout in seconds",
+                "default": "30",
+            }
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = Path(hermes_home) / "nowledge-mem.json"
+        existing: dict = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text())
+            except Exception:
+                pass
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2))
+        logger.info("Nowledge Mem config saved to %s", config_path)
+
+    def shutdown(self) -> None:
+        for thread in self._bg_threads:
+            if thread.is_alive():
+                thread.join(timeout=3.0)
+        self._bg_threads.clear()
+
+    @staticmethod
+    def _parse_csv(value: Any) -> Optional[List[str]]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, (list, tuple, set)):
+            parsed = [str(item).strip() for item in value if str(item).strip()]
+            return parsed or None
+
+        text = str(value).strip()
+        return [text] if text else None
+
+    @staticmethod
+    def _normalize_id_list(value: Any) -> Optional[List[str]]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, (list, tuple, set)):
+            parsed = [str(item).strip() for item in value if str(item).strip()]
+            return parsed or None
+
+        text = str(value).strip()
+        return [text] if text else None
+
+    @staticmethod
+    def _normalize_tool_result(result: Any) -> Any:
+        if isinstance(result, dict):
+            if "success" not in result and "error" not in result:
+                return {"success": True, **result}
+            return result
+        return {"success": True, "result": result}
+
+    @staticmethod
+    def _load_timeout(hermes_home: str) -> int:
+        if hermes_home:
+            config_path = Path(hermes_home) / "nowledge-mem.json"
+            if config_path.exists():
+                try:
+                    cfg = json.loads(config_path.read_text())
+                    return int(cfg.get("timeout", 30))
+                except Exception:
+                    pass
+        return 30
+
+    @staticmethod
+    def _format_working_memory(wm: Any) -> str:
+        if not wm:
+            return ""
+        if isinstance(wm, dict):
+            content = wm.get("content", "") or wm.get("briefing", "")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+            return json.dumps(wm, indent=2, ensure_ascii=False)
+        if isinstance(wm, str):
+            return wm.strip()
+        return str(wm)
+
+    @staticmethod
+    def _format_prefetch(result: Any) -> str:
+        if not result or not isinstance(result, dict):
+            return ""
+        memories = result.get("memories", result.get("results", []))
+        if not memories:
+            return ""
+
+        lines: List[str] = []
+        for memory in memories[:5]:
+            score = memory.get("score", memory.get("relevance_score", 0))
+            if score < 0.3:
+                continue
+            title = memory.get("title", "Untitled")
+            content = (memory.get("content", "") or "")[:300]
+            labels = memory.get("labels", [])
+            label_str = f" [{', '.join(labels)}]" if labels else ""
+            lines.append(f"- **{title}**{label_str}: {content}")
+
+        if not lines:
+            return ""
+        return "## Recalled from Nowledge Mem\n" + "\n".join(lines)

--- a/plugins/memory/nowledge-mem/provider.py
+++ b/plugins/memory/nowledge-mem/provider.py
@@ -5,9 +5,9 @@ user's cross-tool knowledge graph. Replaces the generic MCP connection
 with lifecycle hooks: automatic Working Memory injection, per-turn
 recall, user-profile mirroring, and native tool names.
 
-Transport: ``nmem`` CLI only. The CLI handles server URL, API key, and
-remote access. If ``nmem`` is not installed, the provider disables
-gracefully.
+Transport: ``nmem`` CLI for memory operations, plus direct Mem API calls for
+large transcript payloads. The shared ``nmem`` client config still owns server
+URL, API key, and remote access.
 """
 
 from __future__ import annotations
@@ -331,6 +331,29 @@ class NowledgeMemProvider(MemoryProvider):
         thread.start()
         self._bg_threads.append(thread)
 
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._cron_skipped or not self._client:
+            return
+
+        active_session_id = (session_id or self._session_id or "").strip()
+        if not active_session_id:
+            return
+        if not user_content and not assistant_content:
+            return
+
+        previous_session_id = self._session_id
+        self._session_id = active_session_id
+        try:
+            cleaned_messages = self._clean_session_messages(
+                [
+                    {"role": "user", "content": user_content},
+                    {"role": "assistant", "content": assistant_content},
+                ]
+            )
+            self._write_thread_messages(cleaned_messages, title_messages=cleaned_messages)
+        finally:
+            self._session_id = previous_session_id or active_session_id
+
     def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
         if self._cron_skipped or not self._client:
             return ""
@@ -356,14 +379,46 @@ class NowledgeMemProvider(MemoryProvider):
             saved_count = 0
 
         if saved_count <= 0:
-            title = self._build_thread_title(cleaned_messages)
+            self._write_thread_messages(cleaned_messages, title_messages=cleaned_messages)
+            return
+
+        delta = cleaned_messages[saved_count:]
+        if not delta:
+            return
+        self._write_thread_messages(delta, title_messages=cleaned_messages)
+
+    def _write_thread_messages(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        title_messages: Optional[List[Dict[str, str]]] = None,
+    ) -> None:
+        if not self._client or not messages:
+            return
+        session_id = (self._session_id or "").strip()
+        if not session_id:
+            return
+
+        if self._saved_message_count <= 0:
+            title = self._build_thread_title(title_messages or messages)
             try:
-                self._client.import_thread(
+                result = self._client.import_thread(
                     session_id,
-                    cleaned_messages,
+                    messages,
                     title=title or None,
                     source="hermes",
                 )
+                if not self._response_succeeded(result):
+                    if self._thread_already_exists(result):
+                        self._append_existing_thread(session_id, messages)
+                        self._saved_message_count += len(messages)
+                        return
+                    logger.warning(
+                        "Nowledge Mem session import did not succeed for %s: %s",
+                        session_id,
+                        self._response_error(result),
+                    )
+                    return
             except Exception as error:
                 logger.warning(
                     "Nowledge Mem session import failed for %s: %s",
@@ -371,14 +426,11 @@ class NowledgeMemProvider(MemoryProvider):
                     error,
                 )
                 return
-            self._saved_message_count = len(cleaned_messages)
+            self._saved_message_count += len(messages)
             return
 
-        delta = cleaned_messages[saved_count:]
-        if not delta:
-            return
         try:
-            self._client.append_thread(session_id, delta)
+            self._append_existing_thread(session_id, messages)
         except Exception as error:
             logger.warning(
                 "Nowledge Mem session append failed for %s: %s",
@@ -386,7 +438,13 @@ class NowledgeMemProvider(MemoryProvider):
                 error,
             )
             return
-        self._saved_message_count = len(cleaned_messages)
+        self._saved_message_count += len(messages)
+
+    def _append_existing_thread(self, session_id: str, messages: List[Dict[str, str]]) -> None:
+        assert self._client is not None
+        result = self._client.append_thread(session_id, messages)
+        if not self._response_succeeded(result):
+            raise RuntimeError(self._response_error(result))
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._cron_skipped:
@@ -526,6 +584,37 @@ class NowledgeMemProvider(MemoryProvider):
                 return {"success": True, **result}
             return result
         return {"success": True, "result": result}
+
+    @staticmethod
+    def _response_succeeded(result: Any) -> bool:
+        if not isinstance(result, dict):
+            return True
+        success = result.get("success")
+        if success is False:
+            return False
+        results = result.get("results")
+        if isinstance(results, list) and results:
+            return all(
+                not isinstance(item, dict) or item.get("success") is not False
+                for item in results
+            )
+        return True
+
+    @staticmethod
+    def _thread_already_exists(result: Any) -> bool:
+        return "already exists" in NowledgeMemProvider._response_error(result).lower()
+
+    @staticmethod
+    def _response_error(result: Any) -> str:
+        if not isinstance(result, dict):
+            return str(result)
+        errors: List[str] = []
+        if result.get("error"):
+            errors.append(str(result.get("error")))
+        for item in result.get("results") or []:
+            if isinstance(item, dict) and item.get("error"):
+                errors.append(str(item.get("error")))
+        return "; ".join(errors) or json.dumps(result, ensure_ascii=False)[:300]
 
     @staticmethod
     def _load_config(hermes_home: str) -> Dict[str, Any]:

--- a/plugins/memory/nowledge-mem/provider.py
+++ b/plugins/memory/nowledge-mem/provider.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -217,6 +218,7 @@ class NowledgeMemProvider(MemoryProvider):
         self._working_memory = ""
         self._cron_skipped = False
         self._bg_threads: List[threading.Thread] = []
+        self._resolved_space: str | None = None
 
     @property
     def name(self) -> str:
@@ -239,8 +241,20 @@ class NowledgeMemProvider(MemoryProvider):
             self._cron_skipped = True
             return
 
-        timeout = self._load_timeout(kwargs.get("hermes_home", ""))
-        self._client = NowledgeMemClient(timeout=timeout)
+        config = self._load_config(kwargs.get("hermes_home", ""))
+        raw_timeout = config.get("timeout", 30)
+        try:
+            timeout = int(raw_timeout or 30)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid timeout in nowledge-mem.json: %r; falling back to 30s",
+                raw_timeout,
+            )
+            timeout = 30
+        if timeout <= 0:
+            timeout = 30
+        self._resolved_space = self._resolve_space(config, kwargs)
+        self._client = NowledgeMemClient(timeout=timeout, space=self._resolved_space)
 
         if not self._client.health():
             logger.warning("Nowledge Mem not reachable via nmem CLI")
@@ -254,13 +268,18 @@ class NowledgeMemProvider(MemoryProvider):
             logger.debug("Working memory fetch failed: %s", error)
             self._working_memory = ""
 
-        logger.info("Nowledge Mem provider initialized (CLI transport)")
+        logger.info(
+            "Nowledge Mem provider initialized (CLI transport)",
+            extra={"space": self._resolved_space or "default"},
+        )
 
     def system_prompt_block(self) -> str:
         if self._cron_skipped:
             return ""
 
         parts = [GUIDANCE]
+        if self._resolved_space:
+            parts.append(f"## Active Space\n\n{self._resolved_space}")
         if self._working_memory:
             parts.append(f"## Working Memory\n\n{self._working_memory}")
         elif self._client:
@@ -388,6 +407,21 @@ class NowledgeMemProvider(MemoryProvider):
                 "key": "timeout",
                 "description": "Request timeout in seconds",
                 "default": "30",
+            },
+            {
+                "key": "space",
+                "description": "Optional default space name for this Hermes provider",
+                "default": "",
+            },
+            {
+                "key": "space_by_identity",
+                "description": 'Optional JSON object mapping Hermes identities to space names, for example {"research":"Research Agent"}',
+                "default": "",
+            },
+            {
+                "key": "space_template",
+                "description": "Optional template like research-{identity}; used when space is empty",
+                "default": "",
             }
         ]
 
@@ -408,6 +442,7 @@ class NowledgeMemProvider(MemoryProvider):
             if thread.is_alive():
                 thread.join(timeout=3.0)
         self._bg_threads.clear()
+        self._resolved_space = None
 
     @staticmethod
     def _parse_csv(value: Any) -> Optional[List[str]]:
@@ -439,16 +474,59 @@ class NowledgeMemProvider(MemoryProvider):
         return {"success": True, "result": result}
 
     @staticmethod
-    def _load_timeout(hermes_home: str) -> int:
+    def _load_config(hermes_home: str) -> Dict[str, Any]:
         if hermes_home:
             config_path = Path(hermes_home) / "nowledge-mem.json"
             if config_path.exists():
                 try:
                     cfg = json.loads(config_path.read_text())
-                    return int(cfg.get("timeout", 30))
-                except Exception:
-                    pass
-        return 30
+                    if isinstance(cfg, dict):
+                        return cfg
+                except Exception as err:
+                    logger.debug(
+                        "Failed to parse nowledge-mem config %s under hermes_home=%s: %s",
+                        config_path,
+                        hermes_home,
+                        err,
+                    )
+        return {}
+
+    @staticmethod
+    def _resolve_space(config: Dict[str, Any], kwargs: Dict[str, Any]) -> str | None:
+        if "space" in config:
+            raw_space = config.get("space")
+            if isinstance(raw_space, str):
+                return raw_space.strip()
+
+        raw_identity = kwargs.get("agent_identity")
+        identity = str(raw_identity or "").strip()
+        identity_map = config.get("space_by_identity")
+        if isinstance(identity_map, str):
+            try:
+                identity_map = json.loads(identity_map)
+            except Exception:
+                identity_map = None
+        if identity and isinstance(identity_map, dict):
+            mapped = identity_map.get(identity)
+            if isinstance(mapped, str) and mapped.strip():
+                return mapped.strip()
+
+        template = str(config.get("space_template") or "").strip()
+        if identity and template:
+            resolved = template.replace("{identity}", identity)
+            resolved = " ".join(resolved.split()).strip()
+            if resolved:
+                return resolved
+
+        env_space = (os.environ.get("NMEM_SPACE") or "").strip()
+        if env_space:
+            return env_space
+
+        legacy_env_space = (os.environ.get("NMEM_SPACE_ID") or "").strip()
+        if legacy_env_space:
+            return legacy_env_space
+
+        return None
 
     @staticmethod
     def _format_working_memory(wm: Any) -> str:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -84,6 +84,23 @@ class MetadataMemoryProvider(FakeMemoryProvider):
         self.memory_writes.append((action, target, content, metadata or {}))
 
 
+class LazyToolMemoryProvider(FakeMemoryProvider):
+    """Provider whose tools appear only after initialize().
+
+    This matches plugins that need initialization to decide availability or
+    build a client, but still rely on MemoryManager routing for native tools.
+    """
+
+    def __init__(self, name="lazy", available=True, tools=None):
+        super().__init__(name=name, available=available, tools=tools)
+        self._tools_after_init = list(tools or [])
+        self._tools = []
+
+    def initialize(self, session_id, **kwargs):
+        super().initialize(session_id, **kwargs)
+        self._tools = list(self._tools_after_init)
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider ABC tests
 # ---------------------------------------------------------------------------
@@ -608,6 +625,31 @@ class TestSequentialDispatchRouting:
 
         names = mgr.get_all_tool_names()
         assert names == {"builtin_tool", "ext_recall", "ext_retain"}
+
+    def test_initialize_all_reindexes_tools_added_during_initialize(self):
+        """Tools that appear only after initialize() must still route.
+
+        Regression test for providers that returned no tool schemas during
+        add_provider(), then populated schemas during initialize().
+        """
+        mgr = MemoryManager()
+        provider = LazyToolMemoryProvider("nowledge-mem", tools=[
+            {"name": "nmem_save", "description": "Save", "parameters": {}},
+            {"name": "nmem_search", "description": "Search", "parameters": {}},
+        ])
+        mgr.add_provider(provider)
+
+        assert not mgr.has_tool("nmem_save")
+        assert mgr.get_all_tool_schemas() == []
+
+        mgr.initialize_all(session_id="lazy-session")
+
+        assert mgr.has_tool("nmem_save")
+        assert mgr.has_tool("nmem_search")
+
+        result = json.loads(mgr.handle_tool_call("nmem_save", {"content": "test"}))
+        assert result["handled"] == "nmem_save"
+        assert result["args"] == {"content": "test"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -77,6 +77,23 @@ class FakeMemoryProvider(MemoryProvider):
         self.memory_writes.append((action, target, content))
 
 
+class LazyToolMemoryProvider(FakeMemoryProvider):
+    """Provider whose tools appear only after initialize().
+
+    This matches plugins that need initialization to decide availability or
+    build a client, but still rely on MemoryManager routing for native tools.
+    """
+
+    def __init__(self, name="lazy", available=True, tools=None):
+        super().__init__(name=name, available=available, tools=tools)
+        self._tools_after_init = list(tools or [])
+        self._tools = []
+
+    def initialize(self, session_id, **kwargs):
+        super().initialize(session_id, **kwargs)
+        self._tools = list(self._tools_after_init)
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider ABC tests
 # ---------------------------------------------------------------------------
@@ -601,6 +618,31 @@ class TestSequentialDispatchRouting:
 
         names = mgr.get_all_tool_names()
         assert names == {"builtin_tool", "ext_recall", "ext_retain"}
+
+    def test_initialize_all_reindexes_tools_added_during_initialize(self):
+        """Tools that appear only after initialize() must still route.
+
+        Regression test for providers that returned no tool schemas during
+        add_provider(), then populated schemas during initialize().
+        """
+        mgr = MemoryManager()
+        provider = LazyToolMemoryProvider("nowledge-mem", tools=[
+            {"name": "nmem_save", "description": "Save", "parameters": {}},
+            {"name": "nmem_search", "description": "Search", "parameters": {}},
+        ])
+        mgr.add_provider(provider)
+
+        assert not mgr.has_tool("nmem_save")
+        assert mgr.get_all_tool_schemas() == []
+
+        mgr.initialize_all(session_id="lazy-session")
+
+        assert mgr.has_tool("nmem_save")
+        assert mgr.has_tool("nmem_search")
+
+        result = json.loads(mgr.handle_tool_call("nmem_save", {"content": "test"}))
+        assert result["handled"] == "nmem_save"
+        assert result["args"] == {"content": "test"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_nowledge_mem_provider.py
+++ b/tests/plugins/memory/test_nowledge_mem_provider.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+import os
 
 
 provider_module = importlib.import_module("plugins.memory.nowledge-mem.provider")
@@ -11,8 +12,9 @@ NowledgeMemProvider = provider_module.NowledgeMemProvider
 class FakeClient:
     available = True
 
-    def __init__(self, timeout=30):
+    def __init__(self, timeout=30, space=None):
         self.timeout = timeout
+        self.space = space
         self.saved = []
 
     @staticmethod
@@ -73,6 +75,40 @@ def test_initialize_and_prompt(monkeypatch, tmp_path):
     prompt = provider.system_prompt_block()
     assert "Nowledge Mem" in prompt
     assert "ship plugin quality" in prompt
+
+
+def test_initialize_falls_back_on_invalid_timeout(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    (tmp_path / "nowledge-mem.json").write_text(json.dumps({"timeout": "abc"}))
+
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    assert provider._client.timeout == 30
+
+
+def test_initialize_passes_resolved_space_to_client(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    (tmp_path / "nowledge-mem.json").write_text(
+        json.dumps(
+            {
+                "space_by_identity": {
+                    "research": "Research Agent",
+                }
+            }
+        )
+    )
+
+    provider = NowledgeMemProvider()
+    provider.initialize(
+        "session-1",
+        hermes_home=str(tmp_path),
+        platform="cli",
+        agent_identity="research",
+    )
+
+    assert provider._client.space == "Research Agent"
+    assert "## Active Space" in provider.system_prompt_block()
 
 
 def test_tool_schemas_are_available_before_initialize(monkeypatch):
@@ -176,3 +212,27 @@ def test_handle_tool_call_falls_back_without_registry_helpers(monkeypatch, tmp_p
     payload = json.loads(provider.handle_tool_call("nmem_search", {"query": "release"}))
     assert payload["success"] is True
     assert payload["memories"][0]["title"] == "Shipping focus"
+
+
+def test_resolve_space_explicit_empty_beats_environment():
+    previous = os.environ.get("NMEM_SPACE")
+    os.environ["NMEM_SPACE"] = "Env Space"
+    try:
+        resolved = NowledgeMemProvider._resolve_space({"space": ""}, {})
+        assert resolved == ""
+    finally:
+        if previous is None:
+            os.environ.pop("NMEM_SPACE", None)
+        else:
+            os.environ["NMEM_SPACE"] = previous
+
+
+def test_resolve_space_non_string_falls_through_to_identity():
+    resolved = NowledgeMemProvider._resolve_space(
+        {
+            "space": None,
+            "space_by_identity": {"research": "Research Agent"},
+        },
+        {"agent_identity": "research"},
+    )
+    assert resolved == "Research Agent"

--- a/tests/plugins/memory/test_nowledge_mem_provider.py
+++ b/tests/plugins/memory/test_nowledge_mem_provider.py
@@ -3,6 +3,7 @@ import json
 import os
 
 
+client_module = importlib.import_module("plugins.memory.nowledge-mem.client")
 provider_module = importlib.import_module("plugins.memory.nowledge-mem.provider")
 loader_module = importlib.import_module("plugins.memory")
 
@@ -336,3 +337,82 @@ def test_on_session_end_failed_append_does_not_advance_count(monkeypatch, tmp_pa
 
     assert provider._saved_message_count == 2
     assert provider._client.append_calls == []
+
+
+def test_client_thread_import_posts_payload_without_subprocess_argv(monkeypatch):
+    captured = {}
+
+    def _bad_run(*_args, **_kwargs):
+        raise AssertionError("thread import must not send transcript through argv")
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"success": true}'
+
+    def _fake_urlopen(request, **_kwargs):
+        captured["url"] = request.full_url
+        captured["body"] = request.data.decode("utf-8")
+        return _Response()
+
+    monkeypatch.setattr(client_module.subprocess, "run", _bad_run)
+    monkeypatch.setattr(client_module.urlrequest, "urlopen", _fake_urlopen)
+    monkeypatch.setenv("NMEM_API_URL", "http://mem.test")
+    monkeypatch.setenv("NMEM_API_KEY", "")
+
+    client = client_module.NowledgeMemClient(space="Research Agent")
+    result = client.import_thread(
+        "hermes-session-1",
+        [{"role": "user", "content": "x" * 100_000}],
+        title="Long session",
+    )
+
+    payload = json.loads(captured["body"])
+    assert result["success"] is True
+    assert captured["url"] == "http://mem.test/threads/import"
+    assert payload["thread_id"] == "hermes-session-1"
+    assert payload["metadata"]["space_id"] == "Research Agent"
+    assert payload["messages"][0]["content"] == "x" * 100_000
+
+
+def test_client_thread_append_posts_payload_without_subprocess_argv(monkeypatch):
+    captured = {}
+
+    def _bad_run(*_args, **_kwargs):
+        raise AssertionError("thread append must not send transcript through argv")
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"success": true, "messages_added": 1}'
+
+    def _fake_urlopen(request, **_kwargs):
+        captured["url"] = request.full_url
+        captured["body"] = request.data.decode("utf-8")
+        return _Response()
+
+    monkeypatch.setattr(client_module.subprocess, "run", _bad_run)
+    monkeypatch.setattr(client_module.urlrequest, "urlopen", _fake_urlopen)
+    monkeypatch.setenv("NMEM_API_URL", "http://mem.test")
+    monkeypatch.setenv("NMEM_API_KEY", "")
+
+    client = client_module.NowledgeMemClient()
+    result = client.append_thread(
+        "hermes/session 1",
+        [{"role": "assistant", "content": "y" * 100_000}],
+    )
+
+    payload = json.loads(captured["body"])
+    assert result["messages_added"] == 1
+    assert captured["url"] == "http://mem.test/threads/hermes%2Fsession%201/append"
+    assert payload["messages"][0]["content"] == "y" * 100_000

--- a/tests/plugins/memory/test_nowledge_mem_provider.py
+++ b/tests/plugins/memory/test_nowledge_mem_provider.py
@@ -251,6 +251,30 @@ def test_resolve_space_explicit_empty_beats_environment():
             os.environ["NMEM_SPACE"] = previous
 
 
+def test_resolve_space_configured_beats_environment():
+    previous = os.environ.get("NMEM_SPACE")
+    os.environ["NMEM_SPACE"] = "Env Space"
+    try:
+        resolved = NowledgeMemProvider._resolve_space(
+            {"space": "Research Agent"},
+            {"agent_identity": "research"},
+        )
+        assert resolved == "Research Agent"
+    finally:
+        if previous is None:
+            os.environ.pop("NMEM_SPACE", None)
+        else:
+            os.environ["NMEM_SPACE"] = previous
+
+
+def test_resolve_space_template_falls_back_when_no_mapping():
+    resolved = NowledgeMemProvider._resolve_space(
+        {"space_template": "agent-{identity}"},
+        {"agent_identity": "ops"},
+    )
+    assert resolved == "agent-ops"
+
+
 def test_resolve_space_non_string_falls_through_to_identity():
     resolved = NowledgeMemProvider._resolve_space(
         {
@@ -260,6 +284,69 @@ def test_resolve_space_non_string_falls_through_to_identity():
         {"agent_identity": "research"},
     )
     assert resolved == "Research Agent"
+
+
+def test_resolve_space_missing_identity_does_not_synthesize_space(monkeypatch):
+    monkeypatch.delenv("NMEM_SPACE", raising=False)
+    monkeypatch.delenv("NMEM_SPACE_ID", raising=False)
+
+    resolved = NowledgeMemProvider._resolve_space(
+        {
+            "space_by_identity": {"default": "Default Agent"},
+            "space_template": "agent-{identity}",
+        },
+        {},
+    )
+
+    assert resolved is None
+
+
+def test_cli_explicit_empty_space_clears_inherited_environment(monkeypatch):
+    captured = {}
+
+    def _fake_run(_cmd, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+
+        class _Result:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(client_module.subprocess, "run", _fake_run)
+    monkeypatch.setenv("NMEM_SPACE", "Env Space")
+    monkeypatch.setenv("NMEM_SPACE_ID", "Env Space")
+
+    client = client_module.NowledgeMemClient(space="")
+    client.working_memory()
+
+    assert "NMEM_SPACE" not in captured["env"]
+    assert "NMEM_SPACE_ID" not in captured["env"]
+
+
+def test_cli_explicit_space_sets_subprocess_environment(monkeypatch):
+    captured = {}
+
+    def _fake_run(_cmd, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+
+        class _Result:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(client_module.subprocess, "run", _fake_run)
+    monkeypatch.setenv("NMEM_SPACE", "Env Space")
+    monkeypatch.setenv("NMEM_SPACE_ID", "Env Space")
+
+    client = client_module.NowledgeMemClient(space="Research Agent")
+    client.working_memory()
+
+    assert captured["env"]["NMEM_SPACE"] == "Research Agent"
+    assert captured["env"]["NMEM_SPACE_ID"] == "Research Agent"
 
 
 def test_on_session_end_imports_clean_messages_then_appends_delta(monkeypatch, tmp_path):
@@ -416,3 +503,77 @@ def test_client_thread_append_posts_payload_without_subprocess_argv(monkeypatch)
     assert result["messages_added"] == 1
     assert captured["url"] == "http://mem.test/threads/hermes%2Fsession%201/append"
     assert payload["messages"][0]["content"] == "y" * 100_000
+    assert "space_id" not in payload
+
+
+def test_client_thread_append_includes_space_when_configured(monkeypatch):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"success": true, "messages_added": 1}'
+
+    def _fake_urlopen(request, **_kwargs):
+        captured["body"] = request.data.decode("utf-8")
+        return _Response()
+
+    monkeypatch.setattr(
+        client_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("thread append must not send transcript through argv")
+        ),
+    )
+    monkeypatch.setattr(client_module.urlrequest, "urlopen", _fake_urlopen)
+    monkeypatch.setenv("NMEM_API_URL", "http://mem.test")
+    monkeypatch.setenv("NMEM_API_KEY", "")
+
+    client = client_module.NowledgeMemClient(space="Research Agent")
+    result = client.append_thread(
+        "hermes/session 1",
+        [{"role": "assistant", "content": "hello"}],
+    )
+
+    payload = json.loads(captured["body"])
+    assert result["messages_added"] == 1
+    assert payload["space_id"] == "Research Agent"
+
+
+def test_retry_urls_strip_remote_api_without_credential_query_params():
+    urls = client_module.NowledgeMemClient._retry_urls(
+        "https://mem.example.com/remote-api/threads/import?existing=1"
+    )
+
+    assert urls == ["https://mem.example.com/threads/import?existing=1"]
+    assert all("nmem_api_key" not in url.lower() for url in urls)
+
+
+def test_api_post_retries_remote_api_path_with_auth_headers_only(monkeypatch):
+    client = client_module.NowledgeMemClient()
+    seen = []
+
+    monkeypatch.setattr(client, "_api_url", lambda: "https://mem.example.com/remote-api")
+    monkeypatch.setattr(client, "_api_key", lambda: "secret-token")
+
+    def _fake_request_json(url, body, headers):
+        seen.append((url, body, headers.copy()))
+        if len(seen) == 1:
+            raise RuntimeError("proxy path failed")
+        return {"success": True}
+
+    monkeypatch.setattr(client, "_request_json", _fake_request_json)
+
+    assert client._api_post("/threads/import", {"messages": []}) == {"success": True}
+    assert [url for url, _body, _headers in seen] == [
+        "https://mem.example.com/remote-api/threads/import",
+        "https://mem.example.com/threads/import",
+    ]
+    assert all("nmem_api_key" not in url.lower() for url, _body, _headers in seen)
+    assert all(headers["Authorization"] == "Bearer secret-token" for _url, _body, headers in seen)
+    assert all(headers["X-NMEM-API-Key"] == "secret-token" for _url, _body, headers in seen)

--- a/tests/plugins/memory/test_nowledge_mem_provider.py
+++ b/tests/plugins/memory/test_nowledge_mem_provider.py
@@ -1,0 +1,165 @@
+import importlib
+import json
+
+
+provider_module = importlib.import_module("plugins.memory.nowledge-mem.provider")
+loader_module = importlib.import_module("plugins.memory")
+
+NowledgeMemProvider = provider_module.NowledgeMemProvider
+
+
+class FakeClient:
+    available = True
+
+    def __init__(self, timeout=30):
+        self.timeout = timeout
+        self.saved = []
+
+    @staticmethod
+    def is_available():
+        return FakeClient.available
+
+    def health(self):
+        return True
+
+    def working_memory(self):
+        return {"content": "Focus: ship plugin quality"}
+
+    def search(self, query="", *, limit=10, filter_labels=None, mode=None):
+        return {
+            "memories": [
+                {
+                    "title": "Shipping focus",
+                    "content": f"Query was {query}",
+                    "labels": ["release"],
+                    "score": 0.92,
+                }
+            ]
+        }
+
+    def save(self, content, **kwargs):
+        self.saved.append({"content": content, **kwargs})
+        return {"id": "mem_123", "content": content}
+
+    def update(self, memory_id, **kwargs):
+        return {"memory_id": memory_id, **kwargs}
+
+    def delete(self, memory_id):
+        return {"deleted": [memory_id]}
+
+    def delete_many(self, memory_ids):
+        return {"deleted": memory_ids}
+
+    def thread_search(self, query="", *, limit=10, source=None):
+        return {"threads": [{"id": "thr_1", "query": query, "source": source}]}
+
+    def thread_messages(self, thread_id, *, limit=50, offset=0):
+        return {"thread_id": thread_id, "limit": limit, "offset": offset}
+
+
+def test_load_memory_provider_nowledge_mem(monkeypatch):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = loader_module.load_memory_provider("nowledge-mem")
+    assert provider is not None
+    assert provider.name == "nowledge-mem"
+    assert provider.is_available() is True
+
+
+def test_initialize_and_prompt(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    prompt = provider.system_prompt_block()
+    assert "Nowledge Mem" in prompt
+    assert "ship plugin quality" in prompt
+
+
+def test_tool_schemas_are_available_before_initialize(monkeypatch):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+
+    schemas = provider.get_tool_schemas()
+    assert {schema["name"] for schema in schemas} == {
+        "nmem_search",
+        "nmem_save",
+        "nmem_update",
+        "nmem_delete",
+        "nmem_thread_search",
+        "nmem_thread_messages",
+    }
+
+
+def test_prefetch_formats_results(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    result = provider.prefetch("what are we shipping?")
+    assert "Recalled from Nowledge Mem" in result
+    assert "Shipping focus" in result
+
+
+def test_handle_tool_call_search(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    payload = json.loads(provider.handle_tool_call("nmem_search", {"query": "release"}))
+    assert payload["success"] is True
+    assert payload["memories"][0]["title"] == "Shipping focus"
+
+
+def test_on_memory_write_mirrors_user_profile(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    provider.on_memory_write("add", "user", "User prefers concise reviews")
+    provider.shutdown()
+
+    assert provider._client.saved[0]["content"] == "User prefers concise reviews"
+
+
+def test_handle_tool_call_accepts_list_args(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    save_payload = json.loads(
+        provider.handle_tool_call(
+            "nmem_save",
+            {
+                "content": "Hermes plugin integration test passed",
+                "labels": ["hermes", "integration"],
+            },
+        )
+    )
+    assert save_payload["id"] == "mem_123"
+    assert provider._client.saved[-1]["labels"] == ["hermes", "integration"]
+
+    search_payload = json.loads(
+        provider.handle_tool_call(
+            "nmem_search",
+            {
+                "query": "OpenClaw",
+                "filter_labels": ["release", "plugin"],
+            },
+        )
+    )
+    assert search_payload["success"] is True
+    assert search_payload["memories"][0]["title"] == "Shipping focus"
+
+
+def test_handle_tool_call_returns_structured_error(monkeypatch, tmp_path):
+    class FailingClient(FakeClient):
+        def save(self, content, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FailingClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    payload = json.loads(provider.handle_tool_call("nmem_save", {"content": "x"}))
+    assert payload["success"] is False
+    assert "nmem_save failed" in payload["error"]

--- a/tests/plugins/memory/test_nowledge_mem_provider.py
+++ b/tests/plugins/memory/test_nowledge_mem_provider.py
@@ -163,3 +163,16 @@ def test_handle_tool_call_returns_structured_error(monkeypatch, tmp_path):
     payload = json.loads(provider.handle_tool_call("nmem_save", {"content": "x"}))
     assert payload["success"] is False
     assert "nmem_save failed" in payload["error"]
+
+
+def test_handle_tool_call_falls_back_without_registry_helpers(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    monkeypatch.setattr(provider_module, "_registry_tool_error", None)
+    monkeypatch.setattr(provider_module, "_registry_tool_result", None)
+
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    payload = json.loads(provider.handle_tool_call("nmem_search", {"query": "release"}))
+    assert payload["success"] is True
+    assert payload["memories"][0]["title"] == "Shipping focus"

--- a/tests/plugins/memory/test_nowledge_mem_provider.py
+++ b/tests/plugins/memory/test_nowledge_mem_provider.py
@@ -16,6 +16,10 @@ class FakeClient:
         self.timeout = timeout
         self.space = space
         self.saved = []
+        self.import_calls = []
+        self.append_calls = []
+        self.fail_import = False
+        self.fail_append = False
 
     @staticmethod
     def is_available():
@@ -57,6 +61,25 @@ class FakeClient:
 
     def thread_messages(self, thread_id, *, limit=50, offset=0):
         return {"thread_id": thread_id, "limit": limit, "offset": offset}
+
+    def import_thread(self, thread_id, messages, *, title=None, source="hermes"):
+        if self.fail_import:
+            raise RuntimeError("import failed")
+        self.import_calls.append(
+            {
+                "thread_id": thread_id,
+                "messages": messages,
+                "title": title,
+                "source": source,
+            }
+        )
+        return {"success": True, "thread_id": thread_id}
+
+    def append_thread(self, thread_id, messages):
+        if self.fail_append:
+            raise RuntimeError("append failed")
+        self.append_calls.append({"thread_id": thread_id, "messages": messages})
+        return {"success": True, "thread_id": thread_id}
 
 
 def test_load_memory_provider_nowledge_mem(monkeypatch):
@@ -236,3 +259,80 @@ def test_resolve_space_non_string_falls_through_to_identity():
         {"agent_identity": "research"},
     )
     assert resolved == "Research Agent"
+
+
+def test_on_session_end_imports_clean_messages_then_appends_delta(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    first_messages = [
+        {"role": "system", "content": "skip"},
+        {"role": "user", "content": [{"type": "text", "text": " hello "}]},
+        {"role": "assistant", "content": "hi there"},
+        {"role": "tool", "content": "skip"},
+        {"role": "assistant", "content": {"text": " more detail "}},
+    ]
+
+    provider.on_session_end(first_messages)
+
+    assert provider._client.import_calls == [
+        {
+            "thread_id": "session-1",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+                {"role": "assistant", "content": "more detail"},
+            ],
+            "title": "hello",
+            "source": "hermes",
+        }
+    ]
+    assert provider._client.append_calls == []
+
+    next_messages = first_messages + [{"role": "user", "content": "next step"}]
+    provider.on_session_end(next_messages)
+
+    assert provider._client.append_calls == [
+        {
+            "thread_id": "session-1",
+            "messages": [{"role": "user", "content": "next step"}],
+        }
+    ]
+
+
+def test_on_session_end_failed_import_does_not_advance_count(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-2", hermes_home=str(tmp_path), platform="cli")
+    provider._client.fail_import = True
+
+    provider.on_session_end(
+        [
+            "bad",
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": {"content": "world"}},
+        ]
+    )
+
+    assert provider._saved_message_count == 0
+    assert provider._client.import_calls == []
+
+
+def test_on_session_end_failed_append_does_not_advance_count(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-3", hermes_home=str(tmp_path), platform="cli")
+    provider._saved_message_count = 2
+    provider._client.fail_append = True
+
+    provider.on_session_end(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+            {"role": "user", "content": "next step"},
+        ]
+    )
+
+    assert provider._saved_message_count == 2
+    assert provider._client.append_calls == []

--- a/tests/plugins/memory/test_nowledge_mem_provider.py
+++ b/tests/plugins/memory/test_nowledge_mem_provider.py
@@ -32,7 +32,7 @@ class FakeClient:
     def working_memory(self):
         return {"content": "Focus: ship plugin quality"}
 
-    def search(self, query="", *, limit=10, filter_labels=None, mode=None):
+    def search(self, query="", *, limit=10, filter_labels=None, mode=None, min_importance=None):
         return {
             "memories": [
                 {
@@ -389,6 +389,115 @@ def test_on_session_end_imports_clean_messages_then_appends_delta(monkeypatch, t
     ]
 
 
+def test_session_switch_resets_new_session_delta_before_sync_turn(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-old", hermes_home=str(tmp_path), platform="cli")
+
+    provider.sync_turn("old question", "old answer", session_id="session-old")
+    provider.on_session_switch(
+        "session-new",
+        parent_session_id="session-old",
+        reset=True,
+        reason="new_session",
+    )
+    provider.sync_turn("new question", "new answer", session_id="session-new")
+
+    assert provider._client.import_calls == [
+        {
+            "thread_id": "session-old",
+            "messages": [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ],
+            "title": "old question",
+            "source": "hermes",
+        },
+        {
+            "thread_id": "session-new",
+            "messages": [
+                {"role": "user", "content": "new question"},
+                {"role": "assistant", "content": "new answer"},
+            ],
+            "title": "new question",
+            "source": "hermes",
+        },
+    ]
+    assert provider._client.append_calls == []
+    assert provider._session_id == "session-new"
+    assert provider._saved_message_count == 2
+
+
+def test_session_switch_preserves_per_session_delta_when_resuming(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-a", hermes_home=str(tmp_path), platform="cli")
+
+    provider.sync_turn("a1", "a2", session_id="session-a")
+    provider.on_session_switch("session-b", parent_session_id="session-a", reset=True)
+    provider.sync_turn("b1", "b2", session_id="session-b")
+    provider.on_session_switch("session-a", parent_session_id="session-b", reset=False)
+    provider.sync_turn("a3", "a4", session_id="session-a")
+
+    assert provider._client.import_calls[0]["thread_id"] == "session-a"
+    assert provider._client.import_calls[1]["thread_id"] == "session-b"
+    assert provider._client.append_calls == [
+        {
+            "thread_id": "session-a",
+            "messages": [
+                {"role": "user", "content": "a3"},
+                {"role": "assistant", "content": "a4"},
+            ],
+        }
+    ]
+    assert provider._saved_message_counts["session-a"] == 4
+    assert provider._saved_message_counts["session-b"] == 2
+
+
+def test_session_switch_without_reset_does_not_reuse_previous_session_count(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-old", hermes_home=str(tmp_path), platform="cli")
+
+    provider.sync_turn("old question", "old answer", session_id="session-old")
+    provider.on_session_switch(
+        "session-branch",
+        parent_session_id="session-old",
+        reset=False,
+        reason="branch",
+    )
+    provider.sync_turn("branch question", "branch answer", session_id="session-branch")
+
+    assert [call["thread_id"] for call in provider._client.import_calls] == [
+        "session-old",
+        "session-branch",
+    ]
+    assert provider._client.append_calls == []
+    assert provider._saved_message_counts["session-branch"] == 2
+    assert "session-branch" in provider._delta_only_sessions
+
+
+def test_session_end_skips_full_flush_when_only_delta_count_is_known(monkeypatch, tmp_path):
+    monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
+    provider = NowledgeMemProvider()
+    provider.initialize("session-old", hermes_home=str(tmp_path), platform="cli")
+
+    provider.sync_turn("old question", "old answer", session_id="session-old")
+    provider.on_session_switch("session-branch", parent_session_id="session-old", reset=False)
+    provider.sync_turn("branch question", "branch answer", session_id="session-branch")
+
+    provider.on_session_end(
+        [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "branch question"},
+            {"role": "assistant", "content": "branch answer"},
+        ]
+    )
+
+    assert provider._client.append_calls == []
+
+
 def test_on_session_end_failed_import_does_not_advance_count(monkeypatch, tmp_path):
     monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
     provider = NowledgeMemProvider()
@@ -411,7 +520,7 @@ def test_on_session_end_failed_append_does_not_advance_count(monkeypatch, tmp_pa
     monkeypatch.setattr(provider_module, "NowledgeMemClient", FakeClient)
     provider = NowledgeMemProvider()
     provider.initialize("session-3", hermes_home=str(tmp_path), platform="cli")
-    provider._saved_message_count = 2
+    provider._set_saved_message_count("session-3", 2)
     provider._client.fail_append = True
 
     provider.on_session_end(

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -895,7 +895,7 @@ See [Hooks](../user-guide/features/hooks.md) for event signatures and payload sh
 hermes memory <subcommand>
 ```
 
-Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
+Set up and manage external memory provider plugins. Available providers: honcho, nowledge-mem, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
 
 Subcommands:
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -624,7 +624,7 @@ Subcommands:
 hermes memory <subcommand>
 ```
 
-Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
+Set up and manage external memory provider plugins. Available providers: honcho, nowledge-mem, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
 
 Subcommands:
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -590,12 +590,8 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
 |----------|---------|------|-------|-------------|----------------|
-<<<<<<< HEAD
 | **Honcho** | Cloud | Paid | 5 | `honcho-ai` | Dialectic user modeling + session-scoped context |
-=======
-| **Honcho** | Cloud | Paid | 4 | `honcho-ai` | Dialectic user modeling |
 | **Nowledge Mem** | Local/Self-hosted | Free | 6 | `nmem` CLI | Cross-tool shared memory + Working Memory |
->>>>>>> d703cdd5 (feat(memory): add Nowledge Mem memory provider)
 | **OpenViking** | Self-hosted | Free | 5 | `openviking` + server | Filesystem hierarchy + tiered loading |
 | **Mem0** | Cloud | Paid | 3 | `mem0ai` | Server-side LLM extraction |
 | **Hindsight** | Cloud/Local | Free/Paid | 3 | `hindsight-client` | Knowledge graph + reflect synthesis |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -286,6 +286,15 @@ If the Nowledge Mem desktop app is installed on the same machine, `nmem` is alre
 pip install nmem-cli
 ```
 
+For remote Mem, configure the machine running Hermes with:
+
+```bash
+nmem config client set url https://your-server:14242
+nmem config client set api-key your-key
+```
+
+That writes the shared local client config used by `nmem`. It is separate from server-side Access Anywhere or host bind settings on the Mem machine.
+
 **Config:** `$HERMES_HOME/nowledge-mem.json`
 
 | Key | Default | Description |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -304,6 +304,17 @@ That writes the shared local client config used by `nmem`. It is separate from s
 | `space_by_identity` | `""` | Optional JSON object mapping Hermes identities to named spaces |
 | `space_template` | `""` | Optional template like `research-{identity}` when `space` is empty |
 
+Use `space` when one Hermes profile always belongs to one lane. Use `space_by_identity`
+when a few Hermes identities map to named lanes. Use `space_template` when Hermes
+already has a stable identity and you want one lane per identity.
+
+If you launch Hermes through a CLI wrapper with no provider config of its own, you
+can still set one session-wide fallback lane with:
+
+```bash
+NMEM_SPACE="Research Agent" hermes
+```
+
 **Key features:**
 - Working Memory injected into the system prompt
 - Search-backed prefetch before each turn

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, Nowledge Mem, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: nowledge-mem   # or honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory
 ```
 
 ## How It Works
@@ -257,6 +257,50 @@ See the [Honcho page](./honcho.md#observation-directional-vs-unified) for the fu
 
 See the [config reference](https://github.com/hermes-ai/hermes-agent/blob/main/plugins/memory/honcho/README.md) and [Honcho integration guide](https://docs.honcho.dev/v3/guides/integrations/hermes).
 
+
+---
+
+### Nowledge Mem
+
+Cross-tool knowledge graph memory shared across Hermes, Cursor, Claude Code, Codex, Gemini, and other Nowledge Mem integrations.
+
+| | |
+|---|---|
+| **Best for** | Durable knowledge that should stay available across multiple agent tools, not just Hermes |
+| **Requires** | Running Nowledge Mem app or server + `nmem` CLI |
+| **Data storage** | Local-first desktop app or remote self-hosted server |
+| **Cost** | Free local use / self-hosted |
+
+**Tools:** `nmem_search` (memory search), `nmem_save` (save durable knowledge), `nmem_update` (refine memory), `nmem_delete` (delete memory), `nmem_thread_search` (search conversations), `nmem_thread_messages` (fetch thread messages)
+
+**Setup:**
+```bash
+hermes memory setup    # select "nowledge-mem"
+# Or manually:
+hermes config set memory.provider nowledge-mem
+```
+
+If the Nowledge Mem desktop app is installed on the same machine, `nmem` is already bundled. Otherwise:
+
+```bash
+pip install nmem-cli
+```
+
+**Config:** `$HERMES_HOME/nowledge-mem.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `timeout` | `30` | Request timeout in seconds |
+| `space` | `""` | Optional default space name for this Hermes provider |
+| `space_by_identity` | `""` | Optional JSON object mapping Hermes identities to named spaces |
+| `space_template` | `""` | Optional template like `research-{identity}` when `space` is empty |
+
+**Key features:**
+- Working Memory injected into the system prompt
+- Search-backed prefetch before each turn
+- Hermes user-profile writes mirrored into cross-tool memory
+- Cleaned Hermes transcripts captured as Mem threads when the session actually ends
+- Conversation thread search alongside durable memories
 
 ---
 
@@ -526,7 +570,12 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
 |----------|---------|------|-------|-------------|----------------|
+<<<<<<< HEAD
 | **Honcho** | Cloud | Paid | 5 | `honcho-ai` | Dialectic user modeling + session-scoped context |
+=======
+| **Honcho** | Cloud | Paid | 4 | `honcho-ai` | Dialectic user modeling |
+| **Nowledge Mem** | Local/Self-hosted | Free | 6 | `nmem` CLI | Cross-tool shared memory + Working Memory |
+>>>>>>> d703cdd5 (feat(memory): add Nowledge Mem memory provider)
 | **OpenViking** | Self-hosted | Free | 5 | `openviking` + server | Filesystem hierarchy + tiered loading |
 | **Mem0** | Cloud | Paid | 3 | `mem0ai` | Server-side LLM extraction |
 | **Hindsight** | Cloud/Local | Free/Paid | 3 | `hindsight-client` | Knowledge graph + reflect synthesis |
@@ -540,7 +589,7 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Honcho, Nowledge Mem, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, Nowledge Mem, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: nowledge-mem   # or honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory
 ```
 
 ## How It Works
@@ -216,6 +216,50 @@ This inherits settings from the default `hermes` host block and creates new AI p
 
 See the [config reference](https://github.com/hermes-ai/hermes-agent/blob/main/plugins/memory/honcho/README.md) and [Honcho integration guide](https://docs.honcho.dev/v3/guides/integrations/hermes).
 
+
+---
+
+### Nowledge Mem
+
+Cross-tool knowledge graph memory shared across Hermes, Cursor, Claude Code, Codex, Gemini, and other Nowledge Mem integrations.
+
+| | |
+|---|---|
+| **Best for** | Durable knowledge that should stay available across multiple agent tools, not just Hermes |
+| **Requires** | Running Nowledge Mem app or server + `nmem` CLI |
+| **Data storage** | Local-first desktop app or remote self-hosted server |
+| **Cost** | Free local use / self-hosted |
+
+**Tools:** `nmem_search` (memory search), `nmem_save` (save durable knowledge), `nmem_update` (refine memory), `nmem_delete` (delete memory), `nmem_thread_search` (search conversations), `nmem_thread_messages` (fetch thread messages)
+
+**Setup:**
+```bash
+hermes memory setup    # select "nowledge-mem"
+# Or manually:
+hermes config set memory.provider nowledge-mem
+```
+
+If the Nowledge Mem desktop app is installed on the same machine, `nmem` is already bundled. Otherwise:
+
+```bash
+pip install nmem-cli
+```
+
+**Config:** `$HERMES_HOME/nowledge-mem.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `timeout` | `30` | Request timeout in seconds |
+| `space` | `""` | Optional default space name for this Hermes provider |
+| `space_by_identity` | `""` | Optional JSON object mapping Hermes identities to named spaces |
+| `space_template` | `""` | Optional template like `research-{identity}` when `space` is empty |
+
+**Key features:**
+- Working Memory injected into the system prompt
+- Search-backed prefetch before each turn
+- Hermes user-profile writes mirrored into cross-tool memory
+- Cleaned Hermes transcripts captured as Mem threads when the session actually ends
+- Conversation thread search alongside durable memories
 
 ---
 
@@ -481,7 +525,12 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
 |----------|---------|------|-------|-------------|----------------|
+<<<<<<< HEAD
 | **Honcho** | Cloud | Paid | 5 | `honcho-ai` | Dialectic user modeling + session-scoped context |
+=======
+| **Honcho** | Cloud | Paid | 4 | `honcho-ai` | Dialectic user modeling |
+| **Nowledge Mem** | Local/Self-hosted | Free | 6 | `nmem` CLI | Cross-tool shared memory + Working Memory |
+>>>>>>> d703cdd5 (feat(memory): add Nowledge Mem memory provider)
 | **OpenViking** | Self-hosted | Free | 5 | `openviking` + server | Filesystem hierarchy + tiered loading |
 | **Mem0** | Cloud | Paid | 3 | `mem0ai` | Server-side LLM extraction |
 | **Hindsight** | Cloud/Local | Free/Paid | 3 | `hindsight-client` | Knowledge graph + reflect synthesis |
@@ -495,7 +544,7 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Honcho, Nowledge Mem, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -263,6 +263,17 @@ That writes the shared local client config used by `nmem`. It is separate from s
 | `space_by_identity` | `""` | Optional JSON object mapping Hermes identities to named spaces |
 | `space_template` | `""` | Optional template like `research-{identity}` when `space` is empty |
 
+Use `space` when one Hermes profile always belongs to one lane. Use `space_by_identity`
+when a few Hermes identities map to named lanes. Use `space_template` when Hermes
+already has a stable identity and you want one lane per identity.
+
+If you launch Hermes through a CLI wrapper with no provider config of its own, you
+can still set one session-wide fallback lane with:
+
+```bash
+NMEM_SPACE="Research Agent" hermes
+```
+
 **Key features:**
 - Working Memory injected into the system prompt
 - Search-backed prefetch before each turn

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -245,6 +245,15 @@ If the Nowledge Mem desktop app is installed on the same machine, `nmem` is alre
 pip install nmem-cli
 ```
 
+For remote Mem, configure the machine running Hermes with:
+
+```bash
+nmem config client set url https://your-server:14242
+nmem config client set api-key your-key
+```
+
+That writes the shared local client config used by `nmem`. It is separate from server-side Access Anywhere or host bind settings on the Mem machine.
+
 **Config:** `$HERMES_HOME/nowledge-mem.json`
 
 | Key | Default | Description |


### PR DESCRIPTION
## Summary

Adds a native Nowledge Mem memory provider to Hermes.

The provider gives Hermes direct access to Nowledge Mem for Working Memory, proactive recall, durable memory tools, thread lookup, and cleaned transcript capture into Mem threads.

## Behavior

- injects Working Memory at session start
- prefetches relevant memories before each turn
- mirrors Hermes user-profile writes into Nowledge Mem
- exposes native `nmem_*` tools for search, save, update, delete, and thread lookup
- syncs completed `user` / `assistant` turns into Mem threads as replies finish
- performs a final delta flush when Hermes fires real session boundaries such as clean exit, `/new`, `/reset`, or gateway expiry
- tracks transcript counters per Hermes `session_id`, including in-process session switches
- keeps a narrow `post_llm_call` fallback for Hermes releases that load memory plugins through the general hook context
- sends transcript payloads through the Mem HTTP API to avoid OS argv-size limits on long sessions

## Contract

Per-turn sync is the normal capture path. `on_session_end` is a final flush, not the only place where transcript persistence happens. Fresh `/new` and `/reset` sessions reset their own counters so the first completed turn imports a new Mem thread. Lineage-preserving switches such as branch or compression are treated as per-turn delta sync until the provider has a safe full-transcript baseline.

Failures are non-fatal and do not advance the provider's local delta pointer.

## Validation

- `uv run --with pytest pytest tests/plugins/memory/test_nowledge_mem_provider.py -q`
- `uv run --with pytest pytest tests/agent/test_memory_provider.py tests/cli/test_session_boundary_hooks.py tests/gateway/test_session_boundary_hooks.py tests/gateway/test_shutdown_memory_provider_messages.py tests/cli/test_cli_shutdown_memory_messages.py -q`
