### PR TITLE
fix(hindsight): add missing get_hermes_home import

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -23,6 +23,8 @@ import json
 import logging
 import os
 import threading
+
+from hermes_constants import get_hermes_home
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -142,7 +144,6 @@ def _load_config() -> dict:
       3. Environment variables
     """
     from pathlib import Path
-    from hermes_constants import get_hermes_home
 
     # Profile-scoped path (preferred)
     profile_path = get_hermes_home() / "hindsight" / "config.json"


### PR DESCRIPTION
## Problem

`get_hermes_home` was only imported inside `_load_config()`, but `_start_daemon()` (called when `mode=local`) also references it, causing:

```
NameError: get_hermes_home is not defined
```

## Fix

- Move the import to module level so it is available everywhere in the file
- Remove the now-redundant import from `_load_config()`

## Verification

- `python -m py_compile plugins/memory/hindsight/__init__.py` passes
- The local mode daemon start path no longer references an undefined name

Fixes #5993