### PR TITLE
feat(telegram): add DM status footer

### DIFF
--- a/docs/telegram-status-footer.md
+++ b/docs/telegram-status-footer.md
@@ -1,0 +1,158 @@
+# Telegram DM Status Footer
+
+This document describes the Telegram DM status footer added to Hermes gateway responses.
+
+## Goal
+
+Surface lightweight runtime context directly inside Telegram private-chat replies so the user can see:
+
+- which model answered
+- which reasoning effort level is active
+- how much context the current request used relative to the model's context window
+
+The feature is intentionally narrow. It is designed for Telegram DMs first, not for every platform or chat type.
+
+## User-facing format
+
+The footer is appended as a compact three-line block:
+
+```text
+────────────
+🧠 gpt-5.4 · 💨 high
+📊 45k / 1050k · 4%
+```
+
+Meaning:
+
+- `🧠` — resolved model label
+- `💨` — reasoning effort label (`low`, `medium`, `high`, `default`, or `none`)
+- `📊` — current request context tokens vs. model context window, plus percent used
+
+## Scope
+
+The footer is appended only when all of the following are true:
+
+1. the destination platform is Telegram
+2. the chat type is DM
+3. the message has non-empty text
+4. the message does not already contain the footer separator
+
+It is intentionally skipped for:
+
+- Telegram group chats
+- non-Telegram platforms
+- empty responses
+- messages that already contain a footer block
+
+## Data sources
+
+### Model label
+
+The footer uses the resolved runtime model from the active agent instance.
+
+### Reasoning label
+
+The footer uses the gateway reasoning configuration and normalizes it for display:
+
+- disabled reasoning => `none`
+- missing/empty reasoning => `default`
+- otherwise the configured effort string is displayed as-is
+
+### Current token count
+
+The preferred source is:
+
+- `agent.context_compressor.last_prompt_tokens`
+
+This best represents the actual prompt size sent on the current request.
+
+If that value is unavailable, the footer falls back to:
+
+- `result["total_tokens"]`
+
+### Context window
+
+The footer uses `agent.model_metadata.get_model_context_length(...)` to resolve the best-known context limit for the active provider/model combination.
+
+## Integration points
+
+### `gateway/telegram_status_footer.py`
+
+This file owns the presentation and append rules:
+
+- `build_telegram_status_footer(...)`
+- `maybe_append_telegram_status_footer(...)`
+
+Responsibilities:
+
+- format token counts into compact `k` labels
+- compute the usage percentage
+- normalize reasoning labels
+- guard Telegram-only / DM-only behavior
+- avoid duplicate footer insertion
+
+### `gateway/run.py`
+
+The main gateway runner resolves the values needed for the footer:
+
+- display reasoning label
+- model context window
+- current request token count
+
+For non-streaming responses it appends the footer to the final response before delivery.
+
+For streaming responses it computes a final suffix and passes that suffix to the stream consumer so the footer appears on the final edit rather than as a duplicate follow-up message.
+
+### `gateway/stream_consumer.py`
+
+Streaming delivery now supports a final suffix via:
+
+- `set_final_suffix(...)`
+
+On stream completion, the suffix is appended only to the final edit/send. This keeps the streamed reply and the footer in one message.
+
+## Design decisions
+
+### Telegram DM only
+
+The first version is intentionally limited to Telegram DMs. Group chats and other platforms were left untouched to avoid adding unsolicited metadata where it may be noisy or undesirable.
+
+### Use prompt-size context pressure, not cumulative session spend
+
+The footer shows the size of the current request context, not total tokens ever spent in the session. This makes the percentage line useful for real-time context pressure monitoring.
+
+### Keep the format static and readable
+
+The current formatting uses rounded `k` values (`45k`, `1050k`) and a simple separator line. The output is optimized for fast scanning in Telegram bubbles rather than for exact accounting.
+
+## Tests
+
+The change is covered by targeted tests:
+
+- `tests/gateway/test_telegram_status_footer.py`
+- `tests/gateway/test_stream_consumer.py`
+- `tests/gateway/test_update_streaming.py`
+
+Coverage includes:
+
+- footer formatting
+- missing reasoning fallback
+- Telegram DM-only gating
+- duplicate footer suppression
+- final streamed message suffix behavior
+
+## Known limitations
+
+- The context line is a best-effort runtime display, not a billing report.
+- The footer currently has no user-facing on/off toggle.
+- The feature is not yet generalized for Discord, Slack, WhatsApp, or Telegram groups.
+- Some local test environments can affect auxiliary-client tests if they read a real `~/.hermes/config.yaml`; isolated HOME runs are safer for local verification when debugging unrelated failures.
+
+## Future extensions
+
+Possible follow-ups if desired:
+
+- add a config toggle for enabling/disabling the footer
+- support more compact context-window formatting (for example `1.05M`)
+- optionally extend to additional platforms
+- expose more runtime metadata only when explicitly enabled

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -234,6 +234,10 @@ from gateway.session import (
 )
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.telegram_status_footer import (
+    build_telegram_status_footer,
+    maybe_append_telegram_status_footer,
+)
 
 
 def _normalize_whatsapp_identifier(value: str) -> str:
@@ -310,6 +314,32 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+
+
+def _resolve_reasoning_effort_label(reasoning_config: dict | None) -> str | None:
+    """Return the user-facing reasoning label for footer display."""
+    if not isinstance(reasoning_config, dict):
+        return None
+    if reasoning_config.get("enabled") is False:
+        return "none"
+    effort = str(reasoning_config.get("effort", "") or "").strip()
+    return effort or None
+
+
+def _resolve_context_window_for_footer(agent: Any) -> int:
+    """Best-effort context window lookup for Telegram footer display."""
+    if not agent:
+        return 0
+    try:
+        from agent.model_metadata import get_model_context_length
+        return int(get_model_context_length(
+            getattr(agent, "model", "") or "",
+            base_url=getattr(agent, "base_url", "") or "",
+            api_key=getattr(agent, "api_key", "") or "",
+            provider=getattr(agent, "provider", "") or "",
+        ) or 0)
+    except Exception:
+        return 0
 
 
 def _build_media_placeholder(event) -> str:
@@ -6859,10 +6889,6 @@ class GatewayRunner:
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
 
-            # Signal the stream consumer that the agent is done
-            if _stream_consumer is not None:
-                _stream_consumer.finish()
-            
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
 
@@ -6876,6 +6902,29 @@ class GatewayRunner:
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _resolved_reasoning = _resolve_reasoning_effort_label(reasoning_config)
+            _resolved_context_window = _resolve_context_window_for_footer(_agent)
+            _footer_current_tokens = _last_prompt_toks or int(result.get("total_tokens", 0) or 0)
+            _final_footer_suffix = ""
+            if (
+                final_response
+                and source.platform == Platform.TELEGRAM
+                and source.chat_type == "dm"
+                and "────────────" not in final_response
+            ):
+                _final_footer_suffix = "\n\n" + build_telegram_status_footer(
+                    model=_resolved_model,
+                    reasoning_effort=_resolved_reasoning,
+                    current_tokens=_footer_current_tokens,
+                    context_window=_resolved_context_window,
+                )
+
+            # Signal the stream consumer that the agent is done.
+            # For streaming sessions, append the footer during the final edit so
+            # the user sees it in the streamed message instead of a duplicate send.
+            if _stream_consumer is not None:
+                _stream_consumer.set_final_suffix(_final_footer_suffix)
+                _stream_consumer.finish()
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else "(No response generated)"
@@ -6909,7 +6958,7 @@ class GatewayRunner:
                         content = msg.get("content", "")
                         if "MEDIA:" in content:
                             for match in re.finditer(r'MEDIA:(\S+)', content):
-                                path = match.group(1).strip().rstrip('",}')
+                                path = match.group(1).strip().rstrip('\",}')
                                 if path and path not in _history_media_paths:
                                     media_tags.append(f"MEDIA:{path}")
                             if "[[audio_as_voice]]" in content:
@@ -6925,9 +6974,19 @@ class GatewayRunner:
                     if has_voice_directive:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
+
+            final_response = maybe_append_telegram_status_footer(
+                final_response,
+                platform=source.platform,
+                chat_type=source.chat_type,
+                model=_resolved_model,
+                reasoning_effort=_resolved_reasoning,
+                current_tokens=_footer_current_tokens,
+                context_window=_resolved_context_window,
+            )
             
             # Sync session_id: the agent may have created a new session during
-            # mid-run context compression (_compress_context splits sessions).
+
             # If so, update the session store entry so the NEXT message loads
             # the compressed transcript, not the stale pre-compression one.
             agent = agent_holder[0]

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -74,6 +74,7 @@ class GatewayStreamConsumer:
         self._edit_supported = True  # Disabled on first edit failure (Signal/Email/HA)
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
+        self._final_suffix = ""
 
     @property
     def already_sent(self) -> bool:
@@ -92,6 +93,10 @@ class GatewayStreamConsumer:
             self._queue.put(text)
         elif text is None:
             self._queue.put(_NEW_SEGMENT)
+
+    def set_final_suffix(self, suffix: str | None) -> None:
+        """Set text to append only on the final streamed message edit/send."""
+        self._final_suffix = suffix or ""
 
     def finish(self) -> None:
         """Signal that the stream is complete."""
@@ -149,16 +154,23 @@ class GatewayStreamConsumer:
                         self._last_sent_text = ""
 
                     display_text = self._accumulated
-                    if not got_done and not got_segment_break:
+                    if got_done and self._final_suffix and self._final_suffix not in display_text:
+                        display_text = f"{display_text.rstrip()}{self._final_suffix}"
+                    elif not got_done and not got_segment_break:
                         display_text += self.cfg.cursor
 
                     await self._send_or_edit(display_text)
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
-                    # Final edit without cursor
+                    # Final edit without cursor. Preserve any configured final
+                    # suffix so the stream doesn't overwrite the footer it just
+                    # added during the last flush.
                     if self._accumulated and self._message_id:
-                        await self._send_or_edit(self._accumulated)
+                        final_text = self._accumulated
+                        if self._final_suffix and self._final_suffix not in final_text:
+                            final_text = f"{final_text.rstrip()}{self._final_suffix}"
+                        await self._send_or_edit(final_text)
                     return
 
                 # Tool boundary: the should_edit block above already flushed

--- a/gateway/telegram_status_footer.py
+++ b/gateway/telegram_status_footer.py
@@ -1,0 +1,79 @@
+"""Helpers for Hermes Telegram DM status footers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gateway.config import Platform
+
+_FOOTER_SEPARATOR = "────────────"
+
+
+def _format_token_count(value: int) -> str:
+    if value >= 1000:
+        return f"{round(value / 1000)}k"
+    return str(value)
+
+
+def _normalize_reasoning_label(reasoning_effort: str | None) -> str:
+    label = str(reasoning_effort or "").strip()
+    return label or "default"
+
+
+def _coerce_platform(platform: Any) -> str:
+    if isinstance(platform, Platform):
+        return platform.value
+    return str(platform or "").strip().lower()
+
+
+def build_telegram_status_footer(
+    *,
+    model: str | None,
+    reasoning_effort: str | None,
+    current_tokens: int,
+    context_window: int,
+) -> str:
+    model_label = str(model or "unknown").strip() or "unknown"
+    reasoning_label = _normalize_reasoning_label(reasoning_effort)
+    current = max(int(current_tokens or 0), 0)
+    maximum = max(int(context_window or 0), 0)
+    percent = "?"
+    if maximum > 0:
+        pct = round((current / maximum) * 100)
+        pct = max(0, min(100, pct))
+        percent = f"{pct}%"
+    max_label = _format_token_count(maximum) if maximum > 0 else "?"
+    current_label = _format_token_count(current)
+    return (
+        f"{_FOOTER_SEPARATOR}\n"
+        f"🧠 {model_label} · 💨 {reasoning_label}\n"
+        f"📊 {current_label} / {max_label} · {percent}"
+    )
+
+
+def maybe_append_telegram_status_footer(
+    content: str,
+    *,
+    platform: Platform | str | None,
+    chat_type: str | None,
+    model: str | None,
+    reasoning_effort: str | None,
+    current_tokens: int,
+    context_window: int,
+) -> str:
+    text = content or ""
+    if not text.strip():
+        return text
+    if _FOOTER_SEPARATOR in text:
+        return text
+    if _coerce_platform(platform) != Platform.TELEGRAM.value:
+        return text
+    if str(chat_type or "").strip().lower() != "dm":
+        return text
+    footer = build_telegram_status_footer(
+        model=model,
+        reasoning_effort=reasoning_effort,
+        current_tokens=current_tokens,
+        context_window=context_window,
+    )
+    return f"{text.rstrip()}\n\n{footer}"

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -324,3 +324,33 @@ class TestSegmentBreakOnToolBoundary:
         await consumer.run()
 
         assert consumer.already_sent
+
+
+class TestFinalSuffix:
+    """Verify streaming can append a final footer/status suffix on completion."""
+
+    @pytest.mark.asyncio
+    async def test_final_suffix_appended_on_finish(self):
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="msg_1")
+        edit_result = SimpleNamespace(success=True)
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=edit_result)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Hello from stream")
+        consumer.set_final_suffix("\n\n────────────\n🧠 gpt-5.4 · 💨 low\n📊 45k / 128k · 35%")
+        consumer.finish()
+
+        await consumer.run()
+
+        final_texts = [call[1]["content"] for call in adapter.edit_message.call_args_list]
+        if not final_texts:
+            final_texts = [call[1]["content"] for call in adapter.send.call_args_list]
+
+        assert final_texts
+        assert final_texts[-1].endswith("📊 45k / 128k · 35%")
+        assert "🧠 gpt-5.4 · 💨 low" in final_texts[-1]

--- a/tests/gateway/test_telegram_status_footer.py
+++ b/tests/gateway/test_telegram_status_footer.py
@@ -1,0 +1,93 @@
+"""Tests for Telegram status footer helpers."""
+
+from gateway.config import Platform
+from gateway.telegram_status_footer import (
+    build_telegram_status_footer,
+    maybe_append_telegram_status_footer,
+)
+
+
+class TestBuildTelegramStatusFooter:
+    def test_formats_model_reasoning_and_usage(self):
+        footer = build_telegram_status_footer(
+            model="gpt-5.4",
+            reasoning_effort="low",
+            current_tokens=45000,
+            context_window=128000,
+        )
+
+        assert footer == (
+            "────────────\n"
+            "🧠 gpt-5.4 · 💨 low\n"
+            "📊 45k / 128k · 35%"
+        )
+
+    def test_uses_default_when_reasoning_is_missing(self):
+        footer = build_telegram_status_footer(
+            model="gpt-5.4",
+            reasoning_effort=None,
+            current_tokens=999,
+            context_window=2000,
+        )
+
+        assert "💨 default" in footer
+        assert "📊 999 / 2k · 50%" in footer
+
+
+class TestMaybeAppendTelegramStatusFooter:
+    def test_appends_for_telegram_dm_only(self):
+        result = maybe_append_telegram_status_footer(
+            "Hello world",
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            model="gpt-5.4",
+            reasoning_effort="low",
+            current_tokens=45000,
+            context_window=128000,
+        )
+
+        assert result.endswith("📊 45k / 128k · 35%")
+        assert "Hello world\n\n────────────" in result
+
+    def test_skips_for_non_dm_or_non_telegram(self):
+        group_result = maybe_append_telegram_status_footer(
+            "Hello group",
+            platform=Platform.TELEGRAM,
+            chat_type="group",
+            model="gpt-5.4",
+            reasoning_effort="low",
+            current_tokens=45000,
+            context_window=128000,
+        )
+        discord_result = maybe_append_telegram_status_footer(
+            "Hello discord",
+            platform=Platform.DISCORD,
+            chat_type="dm",
+            model="gpt-5.4",
+            reasoning_effort="low",
+            current_tokens=45000,
+            context_window=128000,
+        )
+
+        assert group_result == "Hello group"
+        assert discord_result == "Hello discord"
+
+    def test_skips_when_footer_already_present(self):
+        content = (
+            "Hello\n\n"
+            "────────────\n"
+            "🧠 gpt-5.4 · 💨 low\n"
+            "📊 45k / 128k · 35%"
+        )
+
+        result = maybe_append_telegram_status_footer(
+            content,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            model="gpt-5.4",
+            reasoning_effort="low",
+            current_tokens=45000,
+            context_window=128000,
+        )
+
+        assert result == content


### PR DESCRIPTION
## Summary
- add a Telegram DM status footer showing model, reasoning effort, and prompt/context usage
- append the footer for non-streaming replies in the gateway runner
- append the same footer on the final streamed edit so streaming replies stay single-message
- document the feature in `docs/telegram-status-footer.md`

## Behavior
- Telegram DM only
- skips groups, non-Telegram platforms, empty messages, and duplicate footers
- uses `last_prompt_tokens` when available and falls back to `total_tokens`
- resolves context window via model metadata

## Testing
- `pytest -q tests/gateway/test_telegram_status_footer.py tests/gateway/test_stream_consumer.py tests/gateway/test_update_streaming.py`
