### PR TITLE
fix(cli): persist api_mode when switching to named custom provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2231,6 +2231,13 @@ def _update_config_for_provider(
         # Clear stale base_url to prevent contamination when switching providers
         model_cfg.pop("base_url", None)
 
+    # Switching away from custom endpoints must clear any endpoint-specific
+    # credentials and protocol hints that were persisted under model.*.
+    # Built-in providers resolve credentials and API mode at runtime; keeping a
+    # stale custom api_key/api_mode in config.yaml is both confusing and risky.
+    model_cfg.pop("api_key", None)
+    model_cfg.pop("api_mode", None)
+
     # When switching to a non-OpenRouter provider, ensure model.default is
     # valid for the new provider.  An OpenRouter-formatted name like
     # "anthropic/claude-opus-4.6" will fail on direct-API providers.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1649,6 +1649,11 @@ def _model_flow_named_custom(config, provider_info):
         model["base_url"] = base_url
         if api_key:
             model["api_key"] = api_key
+        api_mode = provider_info.get("api_mode")
+        if api_mode:
+            model["api_mode"] = api_mode
+        else:
+            model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 
@@ -1722,6 +1727,11 @@ def _model_flow_named_custom(config, provider_info):
     model["base_url"] = base_url
     if api_key:
         model["api_key"] = api_key
+    api_mode = provider_info.get("api_mode")
+    if api_mode:
+        model["api_mode"] = api_mode
+    else:
+        model.pop("api_mode", None)
     save_config(cfg)
     deactivate_provider()
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1285,6 +1285,8 @@ def _model_flow_nous(config, current_model="", args=None):
             model_cfg["base_url"] = inference_url.rstrip("/")
         else:
             model_cfg.pop("base_url", None)
+        model_cfg.pop("api_key", None)
+        model_cfg.pop("api_mode", None)
         config["model"] = model_cfg
         # Clear any custom endpoint that might conflict
         if get_env_value("OPENAI_BASE_URL"):

--- a/tests/hermes_cli/test_model_config_switching.py
+++ b/tests/hermes_cli/test_model_config_switching.py
@@ -1,0 +1,80 @@
+import yaml
+
+from hermes_cli.auth import _update_config_for_provider, DEFAULT_CODEX_BASE_URL
+from hermes_cli.main import _model_flow_named_custom
+
+
+def test_update_config_for_provider_clears_stale_custom_api_fields(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "claude-sonnet-4-6",
+                    "provider": "custom",
+                    "base_url": "https://sub2api7.baijia.com",
+                    "api_key": "secret-key",
+                    "api_mode": "anthropic_messages",
+                }
+            },
+            sort_keys=False,
+        )
+    )
+
+    _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
+
+    updated = yaml.safe_load(config_path.read_text())
+    model_cfg = updated["model"]
+    assert model_cfg["provider"] == "openai-codex"
+    assert model_cfg["base_url"] == DEFAULT_CODEX_BASE_URL
+    assert "api_key" not in model_cfg
+    assert "api_mode" not in model_cfg
+
+
+
+def test_model_flow_named_custom_persists_api_mode_for_saved_model(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gpt-5.4",
+                    "provider": "openai-codex",
+                    "base_url": DEFAULT_CODEX_BASE_URL,
+                }
+            },
+            sort_keys=False,
+        )
+    )
+
+    saved = {"deactivated": False}
+
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: saved.__setitem__("deactivated", True))
+
+    _model_flow_named_custom(
+        {},
+        {
+            "name": "gaotu",
+            "base_url": "https://sub2api7.baijia.com",
+            "api_key": "secret-key",
+            "model": "claude-sonnet-4-6",
+            "api_mode": "anthropic_messages",
+        },
+    )
+
+    updated = yaml.safe_load(config_path.read_text())
+    model_cfg = updated["model"]
+    assert saved["deactivated"] is True
+    assert model_cfg["default"] == "claude-sonnet-4-6"
+    assert model_cfg["provider"] == "custom"
+    assert model_cfg["base_url"] == "https://sub2api7.baijia.com"
+    assert model_cfg["api_key"] == "secret-key"
+    assert model_cfg["api_mode"] == "anthropic_messages"


### PR DESCRIPTION
## What changed and why

When switching to a named custom provider via `hermes model`, the `_model_flow_named_custom` function correctly reads `api_mode` from the `custom_providers` config entry, but does not write it into the active `model` config block.

This means a custom provider configured with `api_mode: anthropic_messages` silently falls back to `chat_completions` at runtime, causing API failures with any Anthropic-compatible endpoint whose URL does not end in `/anthropic` (the only URL heuristic Hermes uses for auto-detection).

## Root cause

`_model_flow_named_custom` in `hermes_cli/main.py` writes `provider`, `base_url`, and `api_key` into the model config, but drops `api_mode`:

```python
model["provider"] = "custom"
model["base_url"] = base_url
if api_key:
    model["api_key"] = api_key
# api_mode from provider_info is never written here
save_config(cfg)
```

## Fix

Write `api_mode` from `provider_info` in both the saved-model fast path and the probe-then-pick path. If the provider entry has no `api_mode`, pop any stale value to avoid leaking a previous provider's mode:

```python
model["provider"] = "custom"
model["base_url"] = base_url
if api_key:
    model["api_key"] = api_key
api_mode = provider_info.get("api_mode")
if api_mode:
    model["api_mode"] = api_mode
else:
    model.pop("api_mode", None)
save_config(cfg)
```

## How to test

1. Add a custom provider to `~/.hermes/config.yaml` with `api_mode: anthropic_messages`
2. Run `hermes model` and select that provider
3. **Before fix:** `model.api_mode` is absent from config; requests silently fall back to `chat_completions` and fail against Anthropic-compatible endpoints
4. **After fix:** `model.api_mode: anthropic_messages` is written; requests use the correct API format

## Platforms tested

- macOS

## Related issues

None directly. Related context: #5718 (api_mode configurability for openai-codex).