### PR TITLE
fix(hindsight): add missing get_hermes_home import

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -23,6 +23,8 @@ import json
 import logging
 import os
 import threading
+
+from hermes_constants import get_hermes_home
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -142,7 +144,6 @@ def _load_config() -> dict:
       3. Environment variables
     """
     from pathlib import Path
-    from hermes_constants import get_hermes_home
 
     # Profile-scoped path (preferred)
     profile_path = get_hermes_home() / "hindsight" / "config.json"


### PR DESCRIPTION
Salvage of #6093 by @Archerouyang.

## Problem

`get_hermes_home` was only imported inside `_load_config()`, but `_start_daemon()` (called in local mode) also references it at line 295, causing `NameError` at runtime.

## Fix

Move the import to module level so it's available everywhere in the file. Remove the now-redundant import from `_load_config()`.

Fixes #5993