### PR TITLE
fix(auxiliary): guard against empty choices in extract_content_or_reasoning()

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1997,6 +1997,10 @@ def extract_content_or_reasoning(response) -> str:
     """
     import re
 
+    # Guard against malformed responses (choices=None, missing, or empty)
+    if not getattr(response, "choices", None):
+        return ""
+
     msg = response.choices[0].message
     content = (msg.content or "").strip()
 

--- a/tests/tools/test_llm_content_none_guard.py
+++ b/tests/tools/test_llm_content_none_guard.py
@@ -231,6 +231,21 @@ class TestSourceLinesAreGuarded:
 class TestExtractContentOrReasoning:
     """agent/auxiliary_client.py — extract_content_or_reasoning()"""
 
+    def test_choices_is_none(self):
+        """Gracefully handle response.choices=None."""
+        response = types.SimpleNamespace(choices=None)
+        assert extract_content_or_reasoning(response) == ""
+
+    def test_choices_is_empty_list(self):
+        """Gracefully handle response.choices=[]."""
+        response = types.SimpleNamespace(choices=[])
+        assert extract_content_or_reasoning(response) == ""
+
+    def test_choices_missing(self):
+        """Gracefully handle response without choices attribute."""
+        response = types.SimpleNamespace()
+        assert extract_content_or_reasoning(response) == ""
+
     def test_normal_content_returned(self):
         response = _make_response("  Hello world  ")
         assert extract_content_or_reasoning(response) == "Hello world"


### PR DESCRIPTION
## What broke

`extract_content_or_reasoning()` raises `TypeError` or `AttributeError` when `response.choices` is `None`, missing, or an empty list. This can happen when an upstream proxy/gateway returns an error response.

## Root cause

The function assumed `response.choices[0]` is always accessible, without checking for malformed responses.

## Why this fix is minimal

- Single guard added: `if not getattr(response, "choices", None): return ""`
- Only affects edge cases where response is malformed
- No behavior change for normal responses

## What I tested

- Added 3 regression tests for `choices=None`, `choices=[]`, and missing choices
- All existing tests should still pass

## What I intentionally did not change

- No changes to other functions in `auxiliary_client.py`
- No changes to the function's return type or contract
- No opportunistic refactoring

Fixes #5968