### PR TITLE
fix(approval): bind interactive approvals to exact requests

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2335,6 +2335,7 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_message: Optional[str] = None
         self._fatal_error_retryable = True
         self._fatal_error_handler: Optional[Callable[["BasePlatformAdapter"], Awaitable[None] | None]] = None
+        self._approval_authorizer: Optional[Callable[[SessionSource], bool]] = None
         
         # Track active message handlers per session for interrupt support.
         # _active_sessions stores the per-session interrupt Event; _session_tasks
@@ -2665,6 +2666,20 @@ class BasePlatformAdapter(ABC):
 
     def set_fatal_error_handler(self, handler: Callable[["BasePlatformAdapter"], Awaitable[None] | None]) -> None:
         self._fatal_error_handler = handler
+
+    def set_approval_authorizer(self, authorizer: Callable[[SessionSource], bool]) -> None:
+        """Register the gateway's approval authorization check."""
+        self._approval_authorizer = authorizer
+
+    def is_approval_actor_authorized(self, source: SessionSource) -> bool:
+        """Check whether a button-click actor may resolve interactive approvals."""
+        if self._approval_authorizer is None:
+            return True
+        try:
+            return bool(self._approval_authorizer(source))
+        except Exception:
+            logger.exception("Approval authorizer failed for %s", source.to_dict())
+            return False
 
     def _mark_connected(self) -> None:
         self._running = True

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -260,6 +260,7 @@ class QQAdapter(BasePlatformAdapter):
         # box; callers can override with set_interaction_callback(None) or
         # register a custom handler.
         self._interaction_callback = self._default_interaction_dispatch
+        self._exec_approval_state: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Properties
@@ -1137,9 +1138,13 @@ class QQAdapter(BasePlatformAdapter):
 
         approval = parse_approval_button_data(button_data)
         if approval is not None:
-            session_key, decision = approval
+            request_id, decision = approval
+            session_key = self._exec_approval_state.get(request_id, "")
+            exact_request = bool(session_key)
+            if not session_key:
+                session_key = request_id
             choice = self._APPROVAL_BUTTON_TO_CHOICE.get(decision)
-            if choice is None:
+            if choice is None or not session_key:
                 logger.warning(
                     "[%s] Unknown approval decision %r (session=%s)",
                     self._log_tag, decision, session_key,
@@ -1156,7 +1161,14 @@ class QQAdapter(BasePlatformAdapter):
                 # Import lazily to keep the adapter importable in tests that
                 # don't exercise the approval subsystem.
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(session_key, choice)
+                if exact_request:
+                    count = resolve_gateway_approval(
+                        session_key, choice, request_id=request_id
+                    )
+                else:
+                    count = resolve_gateway_approval(session_key, choice)
+                if count:
+                    self._exec_approval_state.pop(request_id, None)
                 logger.info(
                     "[%s] Button resolved %d approval(s) for session %s "
                     "(choice=%s, operator=%s)",
@@ -2676,7 +2688,10 @@ class QQAdapter(BasePlatformAdapter):
         :func:`tools.approval.resolve_gateway_approval` — dispatched by the
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
         """
-        del metadata  # QQ doesn't have thread_id / DM targeting overrides.
+        request_id = str((metadata or {}).get("approval_request_id") or "")
+        if not request_id:
+            request_id = uuid.uuid4().hex
+        self._exec_approval_state[request_id] = session_key
 
         # Use the reply-to message for passive-message context when we have one.
         # QQ requires a msg_id on outbound messages to a user we've never
@@ -2684,15 +2699,18 @@ class QQAdapter(BasePlatformAdapter):
         msg_id = self._last_msg_id.get(chat_id)
 
         req = ApprovalRequest(
-            session_key=session_key,
+            session_key=request_id,
             title="Execute this command?",
             description=description,
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
         )
-        return await self.send_approval_request(
+        result = await self.send_approval_request(
             chat_id, req, reply_to=msg_id,
         )
+        if not result.success:
+            self._exec_approval_state.pop(request_id, None)
+        return result
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # matches gateway's default gateway_timeout
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -316,7 +316,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         #   _slash_confirm_state:  confirm_id → session_key (resolves via
         #                          tools.slash_confirm.resolve)
         self._clarify_state: "OrderedDict[str, str]" = OrderedDict()
-        self._exec_approval_state: "OrderedDict[str, str]" = OrderedDict()
+        self._exec_approval_state: "OrderedDict[str, Dict[str, str]]" = OrderedDict()
         self._slash_confirm_state: "OrderedDict[str, str]" = OrderedDict()
 
         # Runtime
@@ -826,7 +826,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             f"Reason: {description}"
         )
 
-        approval_id = uuid.uuid4().hex[:12]
+        approval_id = str((metadata or {}).get("approval_request_id") or "")
+        if not approval_id:
+            approval_id = uuid.uuid4().hex
         reply_to = (metadata or {}).get("reply_to_message_id") if metadata else None
 
         interactive = {
@@ -848,7 +850,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         result = await self._post_interactive(chat_id, interactive, reply_to=reply_to)
         if result.success:
-            self._bounded_put(self._exec_approval_state, approval_id, session_key)
+            self._bounded_put(
+                self._exec_approval_state,
+                approval_id,
+                {"session_key": session_key, "request_id": approval_id},
+            )
         return result
 
     async def send_slash_confirm(
@@ -1733,8 +1739,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if len(parts) != 3:
                 return False
             _, approval_id, choice = parts
-            session_key = self._exec_approval_state.pop(approval_id, None)
-            if not session_key:
+            state = self._exec_approval_state.pop(approval_id, None)
+            if not state:
                 logger.info(
                     "[whatsapp_cloud] approval tap with no matching state "
                     "(approval_id=%s) — likely stale; falling back to text",
@@ -1742,7 +1748,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 )
                 return False
             if choice not in ("approve", "deny"):
-                self._exec_approval_state[approval_id] = session_key
+                self._exec_approval_state[approval_id] = state
                 return False
             try:
                 from tools.approval import resolve_gateway_approval
@@ -1751,7 +1757,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "[whatsapp_cloud] approval resolver unavailable"
                 )
                 return False
-            count = resolve_gateway_approval(session_key, choice)
+            if isinstance(state, dict):
+                session_key = state["session_key"]
+                count = resolve_gateway_approval(
+                    session_key, choice, request_id=state["request_id"]
+                )
+            else:
+                session_key = state
+                count = resolve_gateway_approval(session_key, choice)
             if not count:
                 logger.info(
                     "[whatsapp_cloud] approval resolver reported no waiter "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7062,6 +7062,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+            adapter.set_approval_authorizer(self._is_user_authorized)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
@@ -7898,6 +7899,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     adapter.set_message_handler(self._handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+                    adapter.set_approval_authorizer(self._is_user_authorized)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
@@ -18620,6 +18622,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                approval_meta = dict(_status_thread_metadata or {})
+                request_id = approval_data.get("request_id")
+                if request_id:
+                    approval_meta["approval_request_id"] = request_id
 
                 # Redact credentials from the command before displaying it in
                 # the approval prompt — Tirith's findings are already redacted,
@@ -18640,7 +18646,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=approval_meta or None,
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5582,6 +5582,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            request_id = str((metadata or {}).get("approval_request_id") or "")
             # Resolve channel — use thread_id from metadata if present
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
@@ -5638,6 +5639,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             view = ExecApprovalView(
                 session_key=session_key,
+                request_id=request_id,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
                 require_admin=require_admin,
@@ -6836,9 +6838,11 @@ def _define_discord_view_classes() -> None:
             allowed_role_ids: Optional[set] = None,
             require_admin: bool = False,
             admin_user_ids: Optional[set] = None,
+            request_id: str = "",
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
+            self.request_id = request_id
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             # Opt-in admin gate for exec approval (default off → user-scope,
@@ -6917,7 +6921,12 @@ def _define_discord_view_classes() -> None:
             # Unblock the waiting agent thread via the gateway approval queue
             try:
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(self.session_key, choice)
+                if self.request_id:
+                    count = resolve_gateway_approval(
+                        self.session_key, choice, request_id=self.request_id
+                    )
+                else:
+                    count = resolve_gateway_approval(self.session_key, choice)
                 logger.info(
                     "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                     count, self.session_key, choice, interaction.user.display_name,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1490,7 +1490,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_media_batches = self._media_batch_state.events
         self._pending_media_batch_tasks = self._media_batch_state.tasks
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
-        self._approval_state: Dict[int, Dict[str, str]] = {}
+        self._approval_state: Dict[str, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
@@ -1991,7 +1991,9 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            approval_id = next(self._approval_counter)
+            approval_id = str((metadata or {}).get("approval_request_id") or "")
+            if not approval_id:
+                approval_id = uuid.uuid4().hex
             cmd_preview = command[:3000] + "..." if len(command) > 3000 else command
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
@@ -2040,6 +2042,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "request_id": approval_id,
                 }
             return result
         except Exception as exc:
@@ -2840,7 +2843,13 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(state["session_key"], choice)
+            request_id = state.get("request_id")
+            if request_id:
+                count = resolve_gateway_approval(
+                    state["session_key"], choice, request_id=request_id
+                )
+            else:
+                count = resolve_gateway_approval(state["session_key"], choice)
             logger.info(
                 "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count, state["session_key"], choice, user_name,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -309,11 +309,13 @@ class _MatrixApprovalPrompt:
         session_key: str,
         chat_id: str,
         message_id: str,
+        request_id: str = "",
         resolved: bool = False,
         requester_user_id: str | None = None,
         expires_at: float | None = None,
     ):
         self.session_key = session_key
+        self.request_id = request_id
         self.chat_id = chat_id
         self.message_id = message_id
         self.resolved = resolved
@@ -2006,6 +2008,7 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         requester_user_id = str((metadata or {}).get("requester_user_id") or "") or None
+        request_id = str((metadata or {}).get("approval_request_id") or "")
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
         text = (
             "⚠️ **Dangerous command requires approval**\n"
@@ -2024,6 +2027,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         prompt = _MatrixApprovalPrompt(
             session_key=session_key,
+            request_id=request_id,
             chat_id=chat_id,
             message_id=result.message_id,
             requester_user_id=requester_user_id,
@@ -3265,7 +3269,12 @@ class MatrixAdapter(BasePlatformAdapter):
                 try:
                     from tools.approval import resolve_gateway_approval
 
-                    count = resolve_gateway_approval(prompt.session_key, choice)
+                    if prompt.request_id:
+                        count = resolve_gateway_approval(
+                            prompt.session_key, choice, request_id=prompt.request_id
+                        )
+                    else:
+                        count = resolve_gateway_approval(prompt.session_key, choice)
                     if count:
                         prompt.resolved = True
                         self._approval_prompts_by_event.pop(reacts_to, None)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Any, Tuple, List
 
@@ -452,6 +453,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
+        self._approval_state: Dict[str, str] = {}
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -3254,6 +3256,9 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            request_id = str((metadata or {}).get("approval_request_id") or "")
+            if not request_id:
+                request_id = uuid.uuid4().hex
             thread_ts = self._resolve_thread_ts(None, metadata)
 
             # Slack hard-caps a section block's text at 3000 chars; an
@@ -3284,26 +3289,26 @@ class SlackAdapter(BasePlatformAdapter):
                             "text": {"type": "plain_text", "text": "Allow Once"},
                             "style": "primary",
                             "action_id": "hermes_approve_once",
-                            "value": session_key,
+                            "value": request_id,
                         },
                         {
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Allow Session"},
                             "action_id": "hermes_approve_session",
-                            "value": session_key,
+                            "value": request_id,
                         },
                         {
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Always Allow"},
                             "action_id": "hermes_approve_always",
-                            "value": session_key,
+                            "value": request_id,
                         },
                         {
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Deny"},
                             "style": "danger",
                             "action_id": "hermes_deny",
-                            "value": session_key,
+                            "value": request_id,
                         },
                     ],
                 },
@@ -3321,6 +3326,7 @@ class SlackAdapter(BasePlatformAdapter):
             msg_ts = result.get("ts", "")
             if msg_ts:
                 self._approval_resolved[msg_ts] = False
+                self._approval_state[request_id] = session_key
 
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
@@ -3575,7 +3581,8 @@ class SlackAdapter(BasePlatformAdapter):
         await ack()
 
         action_id = action.get("action_id", "")
-        session_key = action.get("value", "")
+        request_id = action.get("value", "")
+        session_key = self._approval_state.get(request_id, request_id)
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
@@ -3666,7 +3673,10 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             from tools.approval import resolve_gateway_approval
 
-            count = resolve_gateway_approval(session_key, choice)
+            if request_id in self._approval_state:
+                count = resolve_gateway_approval(session_key, choice, request_id=request_id)
+            else:
+                count = resolve_gateway_approval(session_key, choice)
             logger.info(
                 "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count,
@@ -3679,7 +3689,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "Failed to resolve gateway approval from Slack button: %s", exc
             )
 
-        # (approval state already consumed by atomic pop above)
+        self._approval_state.pop(request_id, None)
 
     # ----- Thread context fetching -----
 

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -27,6 +27,7 @@ import html
 import json
 import logging
 import os
+import uuid
 from typing import Any, Dict, Optional
 from urllib.parse import quote
 
@@ -1006,8 +1007,9 @@ class TeamsAdapter(BasePlatformAdapter):
         data = action.data or {}
         hermes_action = data.get("hermes_action", "")
         session_key = data.get("session_key", "")
+        request_id = data.get("request_id", "")
 
-        if not hermes_action or not session_key:
+        if not hermes_action or not session_key or not request_id:
             return InvokeResponse(
                 status=200,
                 body=AdaptiveCardActionMessageResponse(value="Unknown action."),
@@ -1066,7 +1068,11 @@ class TeamsAdapter(BasePlatformAdapter):
                 ),
             )
 
-        resolve_gateway_approval(session_key, choice)
+        if not resolve_gateway_approval(session_key, choice, request_id=request_id):
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionMessageResponse(value="Approval already resolved or expired."),
+            )
 
         label_map = {
             "once": "✅ Allowed (once)",
@@ -1104,9 +1110,13 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Teams app not initialized")
 
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
+        request_id = str((metadata or {}).get("approval_request_id") or "")
+        if not request_id:
+            request_id = uuid.uuid4().hex
         # Truncated for button data payload — just enough to reconstruct the card body.
         btn_data_base = {
             "session_key": session_key,
+            "request_id": request_id,
             "cmd": command[:200] + "..." if len(command) > 200 else command,
             "desc": description,
         }

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -16,6 +16,7 @@ import os
 import html as _html
 import re
 import threading
+import uuid
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -644,7 +645,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        self._approval_state: Dict[str, Dict[str, str]] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -4588,22 +4589,18 @@ class TelegramAdapter(BasePlatformAdapter):
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
 
-            # We'll use the message_id as part of callback_data to look up session_key
-            # Send a placeholder first, then update — or use a counter.
-            # Simpler: use a monotonic counter to generate short IDs.
-            import itertools
-            if not hasattr(self, "_approval_counter"):
-                self._approval_counter = itertools.count(1)
-            approval_id = next(self._approval_counter)
+            request_id = str((metadata or {}).get("approval_request_id") or "")
+            if not request_id:
+                request_id = uuid.uuid4().hex
 
             keyboard = InlineKeyboardMarkup([
                 [
-                    InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}"),
-                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}"),
+                    InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{request_id}"),
+                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{request_id}"),
                 ],
                 [
-                    InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}"),
-                    InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"),
+                    InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{request_id}"),
+                    InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{request_id}"),
                 ],
             ])
 
@@ -4629,7 +4626,7 @@ class TelegramAdapter(BasePlatformAdapter):
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
             # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            self._approval_state[request_id] = {"session_key": session_key}
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -5352,11 +5349,7 @@ class TelegramAdapter(BasePlatformAdapter):
             parts = data.split(":", 2)
             if len(parts) == 3:
                 choice = parts[1]  # once, session, always, deny
-                try:
-                    approval_id = int(parts[2])
-                except (ValueError, IndexError):
-                    await query.answer(text="Invalid approval data.")
-                    return
+                request_id = parts[2]
 
                 # Only authorized users may click approval buttons.
                 caller_id = str(getattr(query.from_user, "id", ""))
@@ -5370,8 +5363,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
-                if not session_key:
+                state = self._approval_state.get(request_id)
+                if state is None and request_id.isdigit():
+                    state = self._approval_state.get(int(request_id))
+                if not state:
                     await query.answer(text="This approval has already been resolved.")
                     return
 
@@ -5400,7 +5395,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Resolve the approval — unblocks the agent thread
                 try:
                     from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
+                    if isinstance(state, dict):
+                        session_key = state["session_key"]
+                        count = resolve_gateway_approval(
+                            session_key, choice, request_id=request_id
+                        )
+                    else:
+                        session_key = state
+                        count = resolve_gateway_approval(session_key, choice)
                     logger.info(
                         "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                         count, session_key, choice, user_display,
@@ -5408,6 +5410,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
                     count = 0
+                finally:
+                    self._approval_state.pop(request_id, None)
+                    if request_id.isdigit():
+                        self._approval_state.pop(int(request_id), None)
 
                 # Resume the typing indicator — paused when the approval was
                 # sent (gateway/run.py).  The text /approve and /deny paths

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -155,6 +155,24 @@ class TestBlockingGatewayApproval:
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
 
+    def test_resolve_specific_request_id(self):
+        """Interactive buttons should resolve the intended queued approval."""
+        from tools.approval import (
+            resolve_gateway_approval, pending_approval_count,
+            _ApprovalEntry, _gateway_queues,
+        )
+        session_key = "test-targeted"
+        e1 = _ApprovalEntry({"command": "first", "request_id": "req-first"})
+        e2 = _ApprovalEntry({"command": "second", "request_id": "req-second"})
+        _gateway_queues[session_key] = [e1, e2]
+
+        count = resolve_gateway_approval(session_key, "deny", request_id="req-second")
+        assert count == 1
+        assert not e1.event.is_set()
+        assert e2.event.is_set()
+        assert e2.result == "deny"
+        assert pending_approval_count(session_key) == 1
+
     def test_unregister_signals_all_entries(self):
         """unregister_gateway_notify signals all waiting entries to prevent hangs."""
         from tools.approval import (

--- a/tests/gateway/test_discord_exec_approval_content.py
+++ b/tests/gateway/test_discord_exec_approval_content.py
@@ -33,10 +33,12 @@ async def test_exec_approval_prompt_uses_visible_content_with_command_and_reason
         command=command,
         session_key="discord:555",
         description="script execution via -c flag",
+        metadata={"approval_request_id": "req-discord"},
     )
 
     assert result.success is True
     assert sent["view"] is not None
+    assert sent["view"].request_id == "req-discord"
     assert sent["embed"] is not None
 
     prompt_text = sent["content"]

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -22,11 +22,13 @@ class TestMatrixExecApprovalReactions:
             command="rm -rf /tmp/test",
             session_key="sess-1",
             description="dangerous",
+            metadata={"approval_request_id": "req-matrix"},
         )
 
         assert result.success is True
         assert adapter._approval_prompt_by_session["sess-1"] == "$evt1"
         assert adapter._approval_prompts_by_event["$evt1"].session_key == "sess-1"
+        assert adapter._approval_prompts_by_event["$evt1"].request_id == "req-matrix"
         assert adapter._send_reaction.await_count == 3
         emojis = [call.args[2] for call in adapter._send_reaction.await_args_list]
         assert emojis == ["✅", "♾️", "❌"]
@@ -40,7 +42,8 @@ class TestMatrixExecApprovalReactions:
         # Resolve user_id so _is_self_sender doesn't defensively drop all traffic (#15763).
         adapter._user_id = "@bot:example.org"
         adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
-            session_key="sess-1", chat_id="!room:example.org", message_id="$target"
+            session_key="sess-1", chat_id="!room:example.org", message_id="$target",
+            request_id="req-matrix",
         )
         adapter._approval_prompt_by_session["sess-1"] = "$target"
 
@@ -55,6 +58,6 @@ class TestMatrixExecApprovalReactions:
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._on_reaction(event)
 
-        mock_resolve.assert_called_once_with("sess-1", "once")
+        mock_resolve.assert_called_once_with("sess-1", "once", request_id="req-matrix")
         assert "$target" not in adapter._approval_prompts_by_event
         assert "sess-1" not in adapter._approval_prompt_by_session

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1794,11 +1794,12 @@ class TestSendExecApproval:
             command="rm -rf /tmp/demo",
             session_key="sess:abc",
             description="delete temp dir",
+            metadata={"approval_request_id": "req-qq"},
         )
         assert result.success
         assert len(calls) == 1
         req = calls[0]["req"]
-        assert req.session_key == "sess:abc"
+        assert req.session_key == "req-qq"
         assert req.command_preview == "rm -rf /tmp/demo"
         assert req.description == "delete temp dir"
         assert calls[0]["reply_to"] == "inbound-42"

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -95,6 +95,7 @@ class TestSlackExecApproval:
             command="rm -rf /important",
             session_key="agent:main:slack:group:C1:1111",
             description="dangerous deletion",
+            metadata={"approval_request_id": "req-slack"},
         )
 
         assert result.success is True
@@ -117,9 +118,9 @@ class TestSlackExecApproval:
         assert "hermes_approve_session" in action_ids
         assert "hermes_approve_always" in action_ids
         assert "hermes_deny" in action_ids
-        # Each button carries the session key as value
+        # Each button carries the exact pending request ID.
         for e in elements:
-            assert e["value"] == "agent:main:slack:group:C1:1111"
+            assert e["value"] == "req-slack"
 
     @pytest.mark.asyncio
     async def test_sends_in_thread(self):

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -118,10 +118,10 @@ class TestTelegramExecApproval:
             session_key="my-session-key",
         )
 
-        # The approval_id should map to the session_key
+        # The request_id should map to the pending approval metadata
         assert len(adapter._approval_state) == 1
-        approval_id = list(adapter._approval_state.keys())[0]
-        assert adapter._approval_state[approval_id] == "my-session-key"
+        request_id = list(adapter._approval_state.keys())[0]
+        assert adapter._approval_state[request_id]["session_key"] == "my-session-key"
 
     @pytest.mark.asyncio
     async def test_sends_in_thread(self):
@@ -242,14 +242,19 @@ class TestTelegramApprovalCallback:
     async def test_resolves_approval_on_click(self):
         adapter = _make_adapter()
         # Set up approval state
-        adapter._approval_state[1] = "agent:main:telegram:group:12345:99"
+        adapter._approval_state["req-1"] = {
+            "session_key": "agent:main:telegram:group:12345:99",
+        }
 
         # Mock callback query
         query = AsyncMock()
-        query.data = "ea:once:1"
+        query.data = "ea:once:req-1"
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "group"
         query.from_user = MagicMock()
+        query.from_user.id = 10
         query.from_user.first_name = "Norbert"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
@@ -263,12 +268,16 @@ class TestTelegramApprovalCallback:
             with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
                 await adapter._handle_callback_query(update, context)
 
-        mock_resolve.assert_called_once_with("agent:main:telegram:group:12345:99", "once")
+        mock_resolve.assert_called_once_with(
+            "agent:main:telegram:group:12345:99",
+            "once",
+            request_id="req-1",
+        )
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
 
         # State should be cleaned up
-        assert 1 not in adapter._approval_state
+        assert "req-1" not in adapter._approval_state
 
     @pytest.mark.asyncio
     async def test_resume_typing_after_inline_approval(self):
@@ -362,13 +371,16 @@ class TestTelegramApprovalCallback:
     @pytest.mark.asyncio
     async def test_deny_button(self):
         adapter = _make_adapter()
-        adapter._approval_state[2] = "some-session"
+        adapter._approval_state["req-2"] = {"session_key": "some-session"}
 
         query = AsyncMock()
-        query.data = "ea:deny:2"
+        query.data = "ea:deny:req-2"
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "group"
         query.from_user = MagicMock()
+        query.from_user.id = 11
         query.from_user.first_name = "Alice"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
@@ -382,7 +394,7 @@ class TestTelegramApprovalCallback:
             with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
                 await adapter._handle_callback_query(update, context)
 
-        mock_resolve.assert_called_once_with("some-session", "deny")
+        mock_resolve.assert_called_once_with("some-session", "deny", request_id="req-2")
         edit_kwargs = query.edit_message_text.call_args[1]
         assert "Denied" in edit_kwargs["text"]
 
@@ -427,7 +439,7 @@ class TestTelegramApprovalCallback:
         # No state for approval_id 99 — already resolved
 
         query = AsyncMock()
-        query.data = "ea:once:99"
+        query.data = "ea:once:req-missing"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
@@ -448,6 +460,34 @@ class TestTelegramApprovalCallback:
         # Should still ack with "already resolved" message
         query.answer.assert_called_once()
         assert "already been resolved" in query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_click_does_not_resolve(self):
+        adapter = _make_adapter()
+        adapter._approval_state["req-auth"] = {"session_key": "some-session"}
+        adapter.set_approval_authorizer(lambda source: False)
+
+        query = AsyncMock()
+        query.data = "ea:once:req-auth"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "group"
+        query.from_user = MagicMock()
+        query.from_user.id = 12
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+        assert "req-auth" in adapter._approval_state
+        assert "not authorized" in query.answer.call_args[1]["text"]
 
     @pytest.mark.asyncio
     async def test_model_picker_callback_not_affected(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1722,6 +1722,7 @@ class TestSendExecApprovalButtons:
             command="rm -rf /tmp/foo",
             session_key="sess-app-1",
             description="cleanup script",
+            metadata={"approval_request_id": "req-whatsapp"},
         )
 
         assert result.success
@@ -1740,7 +1741,10 @@ class TestSendExecApprovalButtons:
         body = payload["interactive"]["body"]["text"]
         assert "rm -rf /tmp/foo" in body
         assert "cleanup script" in body
-        assert adapter._exec_approval_state[approval_id] == "sess-app-1"
+        assert adapter._exec_approval_state[approval_id] == {
+            "session_key": "sess-app-1",
+            "request_id": "req-whatsapp",
+        }
 
     @pytest.mark.asyncio
     async def test_long_command_is_truncated(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -1444,11 +1445,13 @@ _permanent_approved: set = set()
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "request_id", "result", "reason")
 
     def __init__(self, data: dict):
+        self.data = dict(data or {})
+        self.request_id = str(self.data.get("request_id") or uuid.uuid4().hex)
+        self.data["request_id"] = self.request_id
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -1487,13 +1490,14 @@ def unregister_gateway_notify(session_key: str) -> None:
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             request_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
     When *resolve_all* is True every pending approval in the session is
     resolved at once (``/approve all``).  Otherwise only the oldest one
-    is resolved (FIFO).
+    is resolved (FIFO), unless *request_id* targets one exact entry.
 
     *reason* is an optional free-text explanation attached to an explicit
     deny (``/deny <reason>``).  It is relayed back to the agent in the
@@ -1508,6 +1512,14 @@ def resolve_gateway_approval(session_key: str, choice: str,
         if resolve_all:
             targets = list(queue)
             queue.clear()
+        elif request_id:
+            targets = []
+            for index, entry in enumerate(queue):
+                if entry.request_id == request_id:
+                    targets = [queue.pop(index)]
+                    break
+            if not targets:
+                return 0
         else:
             targets = [queue.pop(0)]
         if not queue:
@@ -1525,6 +1537,12 @@ def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
         return bool(_gateway_queues.get(session_key))
+
+
+def pending_approval_count(session_key: str) -> int:
+    """Return the number of pending approval entries for a session."""
+    with _lock:
+        return len(_gateway_queues.get(session_key, ()))
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -2487,7 +2505,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
-        notify_cb(approval_data)
+        notify_cb(entry.data)
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
         _drop_entry()


### PR DESCRIPTION
## What does this PR do?

Previously the interactive exec approval adapters reused the session-wide FIFO `/approve` resolver too literally. When a session had multiple pending approvals, a button click could resolve the wrong queued request, and some adapters bypassed the gateway's approval authorization check. This change binds each interactive prompt to a stable approval request id and reuses the gateway auth check before resolving the queue entry, so the button UI now matches the request the user actually clicked.

## Related Issue

Related to #3915 and #503.

Hardens interactive approval integrity in the gateway button flows and also addresses the same general approval-routing/auth concerns seen in #1888.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add request-bound approval entries in `tools/approval.py` and targeted `resolve_gateway_approval(..., request_id=...)` support
- Thread approval request IDs and the runner's approval authorizer through `gateway/run.py` and `gateway/platforms/base.py`
- Update Slack, Telegram, and Feishu approval handlers to store request-bound state and reject unauthorized button clicks
- Extend the interactive approval tests to cover exact request binding and auth failures

## How to Test

1. Run `uv run --with pytest --with pytest-asyncio python -m pytest -o addopts='' tests/gateway/test_approve_deny_commands.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_feishu_approval_buttons.py -q`
2. Confirm the suite passes (`70 passed`)
3. Verify that button clicks resolve the intended pending approval and unauthorized button clicks are rejected

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
