### PR TITLE
fix(hindsight): add missing get_hermes_home import and remove incorrect docs

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -26,6 +26,7 @@ import threading
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
+from hermes_constants import get_hermes_home
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -118,9 +118,6 @@ browser:
 
 When enabled, Hermes sends a stable profile-scoped identity to Camofox. The Camofox server maps this identity to a persistent browser profile directory, so cookies, logins, and localStorage survive across restarts. Different Hermes profiles get different browser profiles (profile isolation).
 
-:::note
-The Camofox server must also be configured with `CAMOFOX_PROFILE_DIR` on the server side for persistence to work.
-:::
 
 #### VNC live view
 


### PR DESCRIPTION
## Summary

This PR fixes two issues:

### Fix #6098: Add missing `get_hermes_home` import in hindsight plugin

The `hindsight` memory plugin was using `get_hermes_home()` in the `initialize()` method (line 294), but the import was only defined inside `_load_config()` function. This could cause a `NameError` if `initialize()` was called before `_load_config()`.

**Fix:** Added `from hermes_constants import get_hermes_home` at the top of the file.

### Fix #6087: Remove incorrect `CAMOFOX_PROFILE_DIR` documentation

The browser documentation mentioned that `CAMOFOX_PROFILE_DIR` needs to be configured on the Camofox server side. However, this environment variable does not exist in the [camofox-browser](https://github.com/jo-inc/camofox-browser) repository.

**Fix:** Removed the incorrect note about `CAMOFOX_PROFILE_DIR`.

## Changes
- `plugins/memory/hindsight/__init__.py`: Add missing import
- `website/docs/user-guide/features/browser.md`: Remove incorrect documentation

## Testing
- [x] Import statement is now at module level
- [x] Documentation no longer references non-existent env var