### PR TITLE
feat: deep-memory plugin — reasoning-based memory with semantic recall

### DIFF
--- a/docs/plugins/deep-memory.md
+++ b/docs/plugins/deep-memory.md
@@ -1,0 +1,84 @@
+# Deep Memory Plugin
+
+Reasoning-based memory system inspired by [Honcho](https://docs.honcho.dev). Provides structured reasoning over conversations, entity tracking, and hybrid semantic + keyword search — all running locally with zero external hosting.
+
+## Install
+
+```bash
+pip install hermes-agent[deep-memory]
+# or standalone:
+pip install deep-memory
+```
+
+For semantic search (recommended):
+```bash
+pip install sentence-transformers sqlite-vec
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `recall` | Search deep memory for insights — hybrid semantic + keyword search |
+| `learn` | Store structured insights (explicit, deductive, inductive, abductive) |
+| `entities` | Manage entity profiles (people, projects, concepts) |
+
+## How It Works
+
+### Automatic Post-Session Reasoning
+After each conversation, deep-memory automatically:
+1. Extracts structured insights from the conversation
+2. Classifies them (explicit → deductive → inductive → abductive)
+3. Stores with embeddings for future semantic recall
+4. Updates entity profiles mentioned in the conversation
+
+### System Prompt Injection
+Each turn, relevant deep memory context is injected into the system prompt:
+- Entity profile cards for known participants
+- High-confidence insights from past sessions
+
+### Embedding Auto-Config
+Deep-memory automatically detects the best embedding backend:
+
+| Priority | Backend | Condition | Model | Dimension |
+|----------|---------|-----------|-------|-----------|
+| 1 | Config | `deep_memory.embedding_backend` set | — | — |
+| 2 | Local | `sentence-transformers` installed | all-MiniLM-L6-v2 | 384 |
+| 3 | OpenAI | `OPENAI_API_KEY` set | text-embedding-3-small | 1536 |
+| 4 | FTS-only | Fallback | — | — |
+
+## Configuration (Optional)
+
+```yaml
+# ~/.hermes/config.yaml
+deep_memory:
+  embedding_backend: auto  # auto | local | openai | none
+```
+
+No configuration is required — auto-detection handles everything.
+
+## Data Storage
+
+All data lives in a single SQLite file:
+```
+~/.hermes/deep_memory/memory.db
+```
+
+Tables:
+- `entities` — People, projects, concepts (equivalent to Honcho Peers)
+- `conclusions` — Structured insights with embeddings (equivalent to Honcho Representations)
+- `summaries` — Compressed session digests
+
+## Diagnostics
+
+```python
+from deep_memory.embedding import diagnose
+print(diagnose())
+# {'sentence_transformers_available': True, 'openai_api_key_set': False,
+#  'sqlite_vec_available': True, 'configured_backend': None, 'auto_detected': 'local'}
+```
+
+## Source
+
+- Repository: [github.com/RichardHojunJang/deep-memory](https://github.com/RichardHojunJang/deep-memory)
+- License: AGPL-3.0 (same as Hermes Agent)

--- a/model_tools.py
+++ b/model_tools.py
@@ -159,6 +159,11 @@ def _discover_tools():
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
     ]
+    # Deep Memory (external package — optional)
+    try:
+        import deep_memory.hermes_integration  # noqa: F401
+    except ImportError:
+        pass
     import importlib
     for mod_name in _modules:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ pty = [
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
 ]
 honcho = ["honcho-ai>=2.0.1,<3"]
+deep-memory = ["deep-memory @ git+https://github.com/RichardHojunJang/deep-memory.git"]
 mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
@@ -87,6 +88,7 @@ all = [
   "hermes-agent[slack]",
   "hermes-agent[pty]",
   "hermes-agent[honcho]",
+  "hermes-agent[deep-memory]",
   "hermes-agent[mcp]",
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",

--- a/run_agent.py
+++ b/run_agent.py
@@ -2516,6 +2516,20 @@ class AIAgent:
             except Exception:
                 pass
 
+        # Deep Memory — reasoning-based insights (optional, requires deep-memory package)
+        if any(t in self.valid_tool_names for t in ("recall", "learn", "entities")):
+            try:
+                from deep_memory.hermes_integration import build_deep_memory_context
+                # Use platform user ID or session metadata to find the right entity
+                _dm_entity = getattr(self, "_deep_memory_entity_id", None)
+                _dm_block = build_deep_memory_context(_dm_entity)
+                if _dm_block:
+                    prompt_parts.append(_dm_block)
+            except ImportError:
+                pass
+            except Exception as _dm_exc:
+                logger.debug("Deep memory context injection failed: %s", _dm_exc)
+
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:
             avail_toolsets = {
@@ -8730,6 +8744,19 @@ class AIAgent:
             )
         except Exception as exc:
             logger.warning("on_session_end hook failed: %s", exc)
+
+        # Deep Memory — async post-session reasoning (fire-and-forget)
+        if any(t in self.valid_tool_names for t in ("recall", "learn", "entities")):
+            try:
+                from deep_memory.session_hook import process_session_async
+                process_session_async(
+                    session_id=self.session_id,
+                    messages=messages,
+                )
+            except ImportError:
+                pass
+            except Exception as _dm_exc:
+                logger.debug("Deep memory post-session reasoning failed: %s", _dm_exc)
 
         return result
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -50,6 +50,8 @@ _HERMES_CORE_TOOLS = [
     "text_to_speech",
     # Planning & memory
     "todo", "memory",
+    # Deep memory (reasoning-based insights — optional, requires deep-memory package)
+    "recall", "learn", "entities",
     # Session history search
     "session_search",
     # Clarifying questions
@@ -196,6 +198,12 @@ TOOLSETS = {
 
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
+
+    "deep_memory": {
+        "description": "Reasoning-based memory with entity tracking and semantic recall",
+        "tools": ["recall", "learn", "entities"],
+        "includes": []
+    },
 
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",


### PR DESCRIPTION
## Summary

Adds [deep-memory](https://github.com/RichardHojunJang/deep-memory) as an optional plugin toolset. Inspired by [Honcho](https://docs.honcho.dev), deep-memory provides structured reasoning over conversations, entity tracking, and hybrid semantic + keyword search — all running locally with zero external hosting (SQLite + FTS5 + sqlite-vec).

## New Tools

| Tool | Description |
|------|-------------|
| `recall` | Hybrid semantic + keyword search over past insights |
| `learn` | Store structured insights (explicit/deductive/inductive/abductive) |
| `entities` | Track people, projects, concepts with evolving profile cards |

## Features
- **Post-session reasoning** — Automatically extracts insights after each conversation
- **System prompt injection** — Surfaces relevant deep memory context each turn
- **Embedding auto-config** — Detects best backend: local (sentence-transformers) → OpenAI → FTS-only

## Install
```bash
pip install hermes-agent[deep-memory]
```
No config needed — auto-detection handles everything.

## Changes (5 files, +126 lines)

| File | Lines | Purpose |
|------|-------|---------|
| `pyproject.toml` | +3 | Optional dependency |
| `model_tools.py` | +5 | Plugin import in `_discover_tools()` |
| `toolsets.py` | +9 | Tool names + toolset definition |
| `run_agent.py` | +26 | Prompt injection + session hook |
| `docs/plugins/deep-memory.md` | +83 | Usage guide |

## Zero Impact When Not Installed
All imports are guarded by `try/except ImportError`. If deep-memory is not installed, Hermes behaves exactly as before — no errors, no warnings.

## Tests
- deep-memory: 78 tests passing
- hermes-agent: 2047 passed (3 pre-existing failures unrelated to this PR)