### PR TITLE
fix(hindsight): fail early when required dependencies are missing

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -23,11 +23,11 @@ import json
 import logging
 import os
 import threading
-
-from hermes_constants import get_hermes_home
+from importlib.util import find_spec
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
+from hermes_constants import get_hermes_home
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_CLOUD_CLIENT_MODULE = "hindsight_client"
+_LOCAL_DEPENDENCIES = ("hindsight", "hindsight_embed")
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -78,6 +80,57 @@ def _run_sync(coro, timeout: float = 120.0):
     loop = _get_loop()
     future = asyncio.run_coroutine_threadsafe(coro, loop)
     return future.result(timeout=timeout)
+
+
+def _missing_modules(module_names: tuple[str, ...]) -> list[str]:
+    """Return any modules that are unavailable in the current environment."""
+    missing = []
+    for module_name in module_names:
+        try:
+            if find_spec(module_name) is None:
+                missing.append(module_name)
+        except (ImportError, ModuleNotFoundError, ValueError):
+            missing.append(module_name)
+    return missing
+
+
+def _missing_local_dependencies() -> list[str]:
+    """Return any missing packages required for local embedded mode."""
+    return _missing_modules(_LOCAL_DEPENDENCIES)
+
+
+def _local_dependency_error(missing: list[str] | None = None) -> str:
+    """Build a clear error for unavailable local embedded mode."""
+    if missing is None:
+        missing = _missing_local_dependencies()
+    missing_list = ", ".join(missing)
+    required_list = ", ".join(_LOCAL_DEPENDENCIES)
+    return (
+        "Hindsight local mode requires embedded dependencies "
+        f"({required_list}). Missing: {missing_list}. "
+        "Run `hermes memory setup` to install the local provider dependencies."
+    )
+
+
+def _require_local_dependencies() -> None:
+    """Raise a clear error when local embedded mode is unavailable."""
+    missing = _missing_local_dependencies()
+    if missing:
+        raise RuntimeError(_local_dependency_error(missing))
+
+
+def _has_cloud_client() -> bool:
+    """Return True when the cloud client dependency is importable."""
+    return not _missing_modules((_CLOUD_CLIENT_MODULE,))
+
+
+def _require_cloud_client() -> None:
+    """Raise a clear error when cloud mode is unavailable."""
+    if not _has_cloud_client():
+        raise RuntimeError(
+            f"Hindsight cloud mode requires the `{_CLOUD_CLIENT_MODULE}` package. "
+            "Run `hermes memory setup` to install the provider dependencies."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -205,10 +258,10 @@ class HindsightMemoryProvider(MemoryProvider):
             cfg = _load_config()
             mode = cfg.get("mode", "cloud")
             if mode == "local":
-                return True
+                return not _missing_local_dependencies()
             has_key = bool(cfg.get("apiKey") or os.environ.get("HINDSIGHT_API_KEY", ""))
             has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
-            return has_key or has_url
+            return (has_key or has_url) and _has_cloud_client()
         except Exception:
             return False
 
@@ -246,6 +299,7 @@ class HindsightMemoryProvider(MemoryProvider):
         """Return the cached Hindsight client (created once, reused)."""
         if self._client is None:
             if self._mode == "local":
+                _require_local_dependencies()
                 from hindsight import HindsightEmbedded
                 # Disable __del__ on the class to prevent "attached to a
                 # different loop" errors during GC — we handle cleanup in
@@ -258,6 +312,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     llm_model=self._config.get("llm_model", ""),
                 )
             else:
+                _require_cloud_client()
                 from hindsight_client import Hindsight
                 kwargs = {"base_url": self._api_url, "timeout": 30.0}
                 if self._api_key:
@@ -282,6 +337,11 @@ class HindsightMemoryProvider(MemoryProvider):
 
         prefetch_method = self._config.get("prefetch_method", "recall")
         self._prefetch_method = prefetch_method if prefetch_method in ("recall", "reflect") else "recall"
+
+        if self._mode == "local":
+            _require_local_dependencies()
+        else:
+            _require_cloud_client()
 
         logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s",
                      self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._prefetch_method)

--- a/tests/plugins/memory/test_hindsight.py
+++ b/tests/plugins/memory/test_hindsight.py
@@ -1,0 +1,71 @@
+import pytest
+
+import plugins.memory.hindsight as hindsight_module
+from plugins.memory.hindsight import HindsightMemoryProvider
+
+
+def _set_config(monkeypatch, config):
+    monkeypatch.setattr(hindsight_module, "_load_config", lambda: config)
+
+
+def _mark_local_deps_missing(monkeypatch):
+    monkeypatch.setattr(
+        hindsight_module,
+        "_missing_local_dependencies",
+        lambda: ["hindsight", "hindsight_embed"],
+        raising=False,
+    )
+
+
+def _mark_cloud_client_missing(monkeypatch):
+    monkeypatch.setattr(hindsight_module, "_has_cloud_client", lambda: False, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("config", "mark_missing"),
+    [
+        ({"mode": "local"}, _mark_local_deps_missing),
+        ({"mode": "cloud", "apiKey": "test-key"}, _mark_cloud_client_missing),
+    ],
+)
+def test_is_available_false_when_required_dependency_missing(monkeypatch, config, mark_missing):
+    _set_config(monkeypatch, config)
+    mark_missing(monkeypatch)
+
+    provider = HindsightMemoryProvider()
+
+    assert provider.is_available() is False
+
+
+def test_initialize_raises_before_starting_local_thread_when_embedded_deps_missing(monkeypatch):
+    _set_config(monkeypatch, {"mode": "local"})
+    _mark_local_deps_missing(monkeypatch)
+
+    started = False
+
+    class FakeThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            nonlocal started
+            started = True
+
+    monkeypatch.setattr(hindsight_module.threading, "Thread", FakeThread)
+
+    provider = HindsightMemoryProvider()
+
+    with pytest.raises(RuntimeError, match="Run `hermes memory setup`"):
+        provider.initialize("session-1")
+
+    assert started is False
+
+
+def test_initialize_raises_when_cloud_client_missing(monkeypatch):
+    _set_config(monkeypatch, {"mode": "cloud", "apiKey": "test-key"})
+    _mark_cloud_client_missing(monkeypatch)
+
+    provider = HindsightMemoryProvider()
+
+    with pytest.raises(RuntimeError, match="hindsight_client"):
+        provider.initialize("session-1")


### PR DESCRIPTION
## What does this PR do?

This fixes a few Hindsight startup and availability bugs.

Before this change, the provider could report itself as available and finish `initialize()`, then fail later when it first tried to import its runtime dependencies. That happened in both local mode and cloud mode.

This patch makes Hindsight fail early instead:

- local mode now checks for `hindsight` and `hindsight_embed`
- cloud mode now checks for `hindsight_client`
- `is_available()` now returns `False` when the required package set is missing
- `initialize()` now raises a clear error instead of letting the provider fail later
- the local daemon startup path now has `get_hermes_home` available at module scope

## Related Issue

No linked issue.

Reviewed related open PRs:
- #6107
- #5962
- #5634

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `plugins/memory/hindsight/__init__.py`
- Added local dependency checks for `hindsight` and `hindsight_embed`
- Added cloud dependency checks for `hindsight_client`
- Changed `is_available()` to fail closed when required packages are missing
- Changed `initialize()` to raise early in both modes
- Added a regression test file at `tests/plugins/memory/test_hindsight.py`

## How to Test

1. Run:
   ```bash
   uv run --extra dev pytest -q -n 0 tests/plugins/memory/test_hindsight.py
   ```
2. Run:
   ```bash
   uv run --extra dev pytest -q -n 0 tests/plugins/memory
   ```
3. Run:
   ```bash
   uvx ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight.py
   ```
4. Verify behavior manually if needed:
   - local mode with missing embedded deps should return unavailable and raise during init
   - cloud mode with missing `hindsight_client` should return unavailable and raise during init

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
uv run --extra dev pytest -q -n 0 tests/plugins/memory/test_hindsight.py
4 passed

uv run --extra dev pytest -q -n 0 tests/plugins/memory
48 passed

uvx ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight.py
All checks passed!

uv run --extra dev pytest tests/ -q
20 failed, 8860 passed, 88 skipped, 1 xfailed, 187 errors
```

The full suite still has unrelated failures in the current repo state, so the full-suite checkbox is left unchecked.
