### PR TITLE
fix(gateway): make Slack thread follow-up mentions configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -550,6 +550,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "thread_followups_require_mention" in platform_cfg:
+                    bridged["thread_followups_require_mention"] = platform_cfg["thread_followups_require_mention"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -695,6 +695,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "thread_followups_require_mention" in platform_cfg:
+                    bridged["thread_followups_require_mention"] = platform_cfg["thread_followups_require_mention"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "dm_policy" in platform_cfg:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -114,6 +114,17 @@ class SlackAdapter(BasePlatformAdapter):
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
 
+    def _slack_thread_followups_require_mention(self) -> bool:
+        """Return whether channel thread follow-ups must always @mention the bot."""
+        configured = self.config.extra.get("thread_followups_require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv(
+            "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION", "false"
+        ).lower() in ("true", "1", "yes", "on")
+
     async def connect(self) -> bool:
         """Connect to Slack via Socket Mode."""
         if not SLACK_AVAILABLE:
@@ -1007,13 +1018,19 @@ class SlackAdapter(BasePlatformAdapter):
         #   0. Channel is in free_response_channels, OR require_mention is
         #      disabled — always process regardless of mention.
         #   1. The bot is @mentioned in this message, OR
-        #   2. The message is a reply in a thread the bot started/participated in, OR
-        #   3. The message is in a thread where the bot was previously @mentioned, OR
-        #   4. There's an existing session for this thread (survives restarts)
+        #   2. thread_followups_require_mention is false AND the message is a
+        #      reply in a thread the bot started/participated in, OR
+        #   3. thread_followups_require_mention is false AND the message is in
+        #      a thread where the bot was previously @mentioned, OR
+        #   4. thread_followups_require_mention is false AND there's an active
+        #      session for this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         is_mentioned = bot_uid and f"<@{bot_uid}>" in text
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        thread_followups_require_mention = (
+            self._slack_thread_followups_require_mention()
+        )
 
         if not is_dm and bot_uid:
             if channel_id in self._slack_free_response_channels():
@@ -1022,14 +1039,18 @@ class SlackAdapter(BasePlatformAdapter):
                 pass  # Mention requirement disabled globally for Slack
             elif not is_mentioned:
                 reply_to_bot_thread = (
-                    is_thread_reply and event_thread_ts in self._bot_message_ts
+                    is_thread_reply
+                    and not thread_followups_require_mention
+                    and event_thread_ts in self._bot_message_ts
                 )
                 in_mentioned_thread = (
                     event_thread_ts is not None
+                    and not thread_followups_require_mention
                     and event_thread_ts in self._mentioned_threads
                 )
                 has_session = (
                     is_thread_reply
+                    and not thread_followups_require_mention
                     and self._has_active_session_for_thread(
                         channel_id=channel_id,
                         thread_ts=event_thread_ts,

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -368,6 +368,17 @@ class SlackAdapter(BasePlatformAdapter):
             )
         return None
 
+    def _slack_thread_followups_require_mention(self) -> bool:
+        """Return whether channel thread follow-ups must always @mention the bot."""
+        configured = self.config.extra.get("thread_followups_require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv(
+            "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION", "false"
+        ).lower() in ("true", "1", "yes", "on")
+
     async def connect(self) -> bool:
         """Connect to Slack via Socket Mode."""
         if not SLACK_AVAILABLE:
@@ -1685,14 +1696,20 @@ class SlackAdapter(BasePlatformAdapter):
         #   0. Channel is in free_response_channels, OR require_mention is
         #      disabled — always process regardless of mention.
         #   1. The bot is @mentioned in this message, OR
-        #   2. The message is a reply in a thread the bot started/participated in, OR
-        #   3. The message is in a thread where the bot was previously @mentioned, OR
-        #   4. There's an existing session for this thread (survives restarts)
+        #   2. thread_followups_require_mention is false AND the message is a
+        #      reply in a thread the bot started/participated in, OR
+        #   3. thread_followups_require_mention is false AND the message is in
+        #      a thread where the bot was previously @mentioned, OR
+        #   4. thread_followups_require_mention is false AND there's an active
+        #      session for this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         routing_text = original_text or ""
         is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        thread_followups_require_mention = (
+            self._slack_thread_followups_require_mention()
+        )
 
         if not is_dm and bot_uid:
             if channel_id in self._slack_free_response_channels():
@@ -1703,14 +1720,18 @@ class SlackAdapter(BasePlatformAdapter):
                 return  # Strict mode: ignore until @-mentioned again
             elif not is_mentioned:
                 reply_to_bot_thread = (
-                    is_thread_reply and event_thread_ts in self._bot_message_ts
+                    is_thread_reply
+                    and not thread_followups_require_mention
+                    and event_thread_ts in self._bot_message_ts
                 )
                 in_mentioned_thread = (
                     event_thread_ts is not None
+                    and not thread_followups_require_mention
                     and event_thread_ts in self._mentioned_threads
                 )
                 has_session = (
                     is_thread_reply
+                    and not thread_followups_require_mention
                     and self._has_active_session_for_thread(
                         channel_id=channel_id,
                         thread_ts=event_thread_ts,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1008,6 +1008,14 @@ DEFAULT_CONFIG = {
         "server_actions": "",
     },
 
+    # Slack platform settings (gateway mode)
+    "slack": {
+        # If true, channel thread replies must @mention the bot every time.
+        # Default false preserves the existing behavior where active bot
+        # threads/sessions continue without repeated mentions.
+        "thread_followups_require_mention": False,
+    },
+
     # WhatsApp platform settings (gateway mode)
     "whatsapp": {
         # Reply prefix prepended to every outgoing WhatsApp message.
@@ -1221,6 +1229,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    13: ["SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1929,6 +1938,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Slack App Token (xapp-...)",
         "url": "https://api.slack.com/apps",
         "password": True,
+        "category": "messaging",
+    },
+    "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION": {
+        "description": "Require @mention on every Slack channel thread reply. Default: false "
+                       "(active bot threads continue without repeated mentions).",
+        "prompt": "Require @mention for Slack thread follow-ups",
+        "url": None,
+        "password": False,
         "category": "messaging",
     },
     "MATTERMOST_URL": {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -701,6 +701,14 @@ DEFAULT_CONFIG = {
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
     },
 
+    # Slack platform settings (gateway mode)
+    "slack": {
+        # If true, channel thread replies must @mention the bot every time.
+        # Default false preserves the existing behavior where active bot
+        # threads/sessions continue without repeated mentions.
+        "thread_followups_require_mention": False,
+    },
+
     # WhatsApp platform settings (gateway mode)
     "whatsapp": {
         # Reply prefix prepended to every outgoing WhatsApp message.
@@ -795,6 +803,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    13: ["SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1338,6 +1347,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Slack App Token (xapp-...)",
         "url": "https://api.slack.com/apps",
         "password": True,
+        "category": "messaging",
+    },
+    "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION": {
+        "description": "Require @mention on every Slack channel thread reply. Default: false "
+                       "(active bot threads continue without repeated mentions).",
+        "prompt": "Require @mention for Slack thread follow-ups",
+        "url": None,
+        "password": False,
         "category": "messaging",
     },
     "MATTERMOST_URL": {

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1739,6 +1739,48 @@ class TestThreadReplyHandling:
         assert msg_event.text == "Follow-up question"
 
     @pytest.mark.asyncio
+    async def test_thread_reply_without_mention_with_session_ignored_when_configured(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """thread_followups_require_mention=true should force mentions on thread replies."""
+        adapter_with_session_store.config.extra["thread_followups_require_mention"] = True
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {session_key: MagicMock()}
+
+        event = {
+            "text": "Follow-up question",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+        adapter_with_session_store.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_with_mention_still_processed_when_configured(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Explicit mentions should still work when thread follow-ups require mention."""
+        adapter_with_session_store.config.extra["thread_followups_require_mention"] = True
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {session_key: MagicMock()}
+
+        event = {
+            "text": "<@U_BOT> Follow-up question",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+        adapter_with_session_store.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_thread_reply_with_mention_strips_bot_id(
         self, adapter_with_session_store, mock_session_store
     ):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1109,6 +1109,48 @@ class TestThreadReplyHandling:
         assert msg_event.text == "Follow-up question"
 
     @pytest.mark.asyncio
+    async def test_thread_reply_without_mention_with_session_ignored_when_configured(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """thread_followups_require_mention=true should force mentions on thread replies."""
+        adapter_with_session_store.config.extra["thread_followups_require_mention"] = True
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {session_key: MagicMock()}
+
+        event = {
+            "text": "Follow-up question",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+        adapter_with_session_store.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_with_mention_still_processed_when_configured(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Explicit mentions should still work when thread follow-ups require mention."""
+        adapter_with_session_store.config.extra["thread_followups_require_mention"] = True
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {session_key: MagicMock()}
+
+        event = {
+            "text": "<@U_BOT> Follow-up question",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+        adapter_with_session_store.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_thread_reply_with_mention_strips_bot_id(
         self, adapter_with_session_store, mock_session_store
     ):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -410,6 +410,24 @@ class TestOptionalEnvVarsRegistry:
             all_vars.extend(vars_list)
         assert "TAVILY_API_KEY" in all_vars
 
+    def test_slack_thread_followups_require_mention_registered(self):
+        """SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION is listed in OPTIONAL_ENV_VARS."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION" in OPTIONAL_ENV_VARS
+
+    def test_slack_thread_followups_require_mention_is_messaging_category(self):
+        """SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION is in the messaging category."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION"]["category"] == "messaging"
+
+    def test_slack_thread_followups_require_mention_in_env_vars_by_version(self):
+        """SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION is listed in ENV_VARS_BY_VERSION."""
+        from hermes_cli.config import ENV_VARS_BY_VERSION
+        all_vars = []
+        for vars_list in ENV_VARS_BY_VERSION.values():
+            all_vars.extend(vars_list)
+        assert "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION" in all_vars
+
 
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -393,6 +393,24 @@ class TestOptionalEnvVarsRegistry:
             all_vars.extend(vars_list)
         assert "TAVILY_API_KEY" in all_vars
 
+    def test_slack_thread_followups_require_mention_registered(self):
+        """SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION is listed in OPTIONAL_ENV_VARS."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION" in OPTIONAL_ENV_VARS
+
+    def test_slack_thread_followups_require_mention_is_messaging_category(self):
+        """SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION is in the messaging category."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION"]["category"] == "messaging"
+
+    def test_slack_thread_followups_require_mention_in_env_vars_by_version(self):
+        """SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION is listed in ENV_VARS_BY_VERSION."""
+        from hermes_cli.config import ENV_VARS_BY_VERSION
+        all_vars = []
+        for vars_list in ENV_VARS_BY_VERSION.values():
+            all_vars.extend(vars_list)
+        assert "SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION" in all_vars
+
 
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -253,6 +253,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_ALLOW_MENTION_REPLIED_USER` | Ping the author when replying to their message (default: `true`). |
 | `SLACK_BOT_TOKEN` | Slack bot token (`xoxb-...`) |
 | `SLACK_APP_TOKEN` | Slack app-level token (`xapp-...`, required for Socket Mode) |
+| `SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION` | Require `@mention` on every Slack channel thread reply (default: `false`) |
 | `SLACK_ALLOWED_USERS` | Comma-separated Slack user IDs |
 | `SLACK_HOME_CHANNEL` | Default Slack channel for cron delivery |
 | `SLACK_HOME_CHANNEL_NAME` | Display name for the Slack home channel |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -184,6 +184,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all` |
 | `SLACK_BOT_TOKEN` | Slack bot token (`xoxb-...`) |
 | `SLACK_APP_TOKEN` | Slack app-level token (`xapp-...`, required for Socket Mode) |
+| `SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION` | Require `@mention` on every Slack channel thread reply (default: `false`) |
 | `SLACK_ALLOWED_USERS` | Comma-separated Slack user IDs |
 | `SLACK_HOME_CHANNEL` | Default Slack channel for cron delivery |
 | `SLACK_HOME_CHANNEL_NAME` | Display name for the Slack home channel |

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -342,10 +342,10 @@ Set to `false` if you want a collaborative mode where the entire channel shares 
 
 ```yaml
 slack:
-  # Require @mention in channels (this is the default behavior;
-  # the Slack adapter enforces @mention gating in channels regardless,
-  # but you can set this explicitly for consistency with other platforms)
-  require_mention: true
+  # Require @mention on every thread follow-up in channels.
+  # Default false preserves Slack's current behavior:
+  # once Hermes is active in a thread, follow-ups can omit the mention.
+  thread_followups_require_mention: false
 
   # Prevent thread auto-engagement: only reply to channel messages that
   # contain an explicit @mention. With this OFF (default), Slack can
@@ -370,7 +370,7 @@ Set this to `true` in busy workspaces where Slack's default "the bot remembers t
 :::
 
 :::info
-Slack supports both patterns: `@mention` required to start a conversation by default, but you can opt specific channels out via `SLACK_FREE_RESPONSE_CHANNELS` (comma-separated channel IDs) or `slack.free_response_channels` in `config.yaml`. Once the bot has an active session in a thread, subsequent thread replies do not require a mention. In DMs the bot always responds without needing a mention.
+Slack supports both patterns: `@mention` required to start a conversation by default, but you can opt specific channels out via `SLACK_FREE_RESPONSE_CHANNELS` (comma-separated channel IDs) or `slack.free_response_channels` in `config.yaml`. Once the bot has an active session in a thread, subsequent thread replies do not require a mention. Set `slack.thread_followups_require_mention: true` or `SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION=true` if you want every thread reply to explicitly mention the bot. In DMs the bot always responds without needing a mention.
 :::
 
 ### Unauthorized User Handling
@@ -410,7 +410,7 @@ stt_enabled: true
 
 # Slack-specific settings
 slack:
-  require_mention: true
+  thread_followups_require_mention: false
   unauthorized_dm_behavior: "pair"
 
 # Platform config

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -267,10 +267,10 @@ Set to `false` if you want a collaborative mode where the entire channel shares 
 
 ```yaml
 slack:
-  # Require @mention in channels (this is the default behavior;
-  # the Slack adapter enforces @mention gating in channels regardless,
-  # but you can set this explicitly for consistency with other platforms)
-  require_mention: true
+  # Require @mention on every thread follow-up in channels.
+  # Default false preserves Slack's current behavior:
+  # once Hermes is active in a thread, follow-ups can omit the mention.
+  thread_followups_require_mention: false
 
   # Custom mention patterns that trigger the bot
   # (in addition to the default @mention detection)
@@ -283,7 +283,7 @@ slack:
 ```
 
 :::info
-Unlike Discord and Telegram, Slack does not have a `free_response_channels` equivalent. The Slack adapter requires `@mention` to start a conversation in channels. However, once the bot has an active session in a thread, subsequent thread replies do not require a mention. In DMs, the bot always responds without needing a mention.
+Slack does not have a `free_response_channels` equivalent. By default, Hermes requires `@mention` to start a conversation in channels, but once Hermes is active in a thread, subsequent thread replies do not require a mention. Set `slack.thread_followups_require_mention: true` or `SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION=true` if you want every thread reply to explicitly mention the bot. In DMs, the bot always responds without needing a mention.
 :::
 
 ### Unauthorized User Handling
@@ -323,7 +323,7 @@ stt_enabled: true
 
 # Slack-specific settings
 slack:
-  require_mention: true
+  thread_followups_require_mention: false
   unauthorized_dm_behavior: "pair"
 
 # Platform config


### PR DESCRIPTION
## What does this PR do?

Adds a Slack gateway setting to make thread follow-up mentions configurable.

Today, Slack channel conversations require an `@mention` to start, but once Hermes is active in a thread it will continue responding to follow-ups without repeated mentions. This PR keeps that behavior as the default, while adding a toggle for deployments that want every thread reply to explicitly mention the bot.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `slack.thread_followups_require_mention` to the gateway config path and Slack adapter behavior.
- Add `SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION` to the env var registry and config migration metadata.
- Add Slack adapter tests for both the default behavior and the stricter mention-required mode.
- Update the Slack messaging docs and environment variable reference.

## How to Test

1. Run `source venv/bin/activate && python -m pytest tests/gateway/test_slack.py tests/hermes_cli/test_config.py -q`
2. In Slack, verify that thread follow-ups without `@mention` still work by default after the bot has joined the thread.
3. Set `slack.thread_followups_require_mention: true` or `SLACK_THREAD_FOLLOWUPS_REQUIRE_MENTION=true`, restart the gateway, and verify that thread follow-ups are ignored unless they explicitly mention the bot.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
