### PR TITLE
fix(security) sanitize persisted tool result paths

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -14,6 +14,7 @@ from tools.tool_result_storage import (
     PERSISTED_OUTPUT_TAG,
     PERSISTED_OUTPUT_CLOSING_TAG,
     STORAGE_DIR,
+    _remote_result_path,
     _build_persisted_message,
     _heredoc_marker,
     _write_to_sandbox,
@@ -76,6 +77,18 @@ class TestHeredocMarker:
         assert marker != HEREDOC_MARKER
         assert marker.startswith("HERMES_PERSIST_")
         assert marker not in content
+
+
+class TestRemoteResultPath:
+    def test_safe_tool_use_id_keeps_stable_filename(self):
+        assert _remote_result_path("tc_456") == f"{STORAGE_DIR}/tc_456.txt"
+
+    def test_unsafe_tool_use_id_is_sanitized(self):
+        path = _remote_result_path("../../escape; touch /tmp/pwned")
+        assert path.startswith(f"{STORAGE_DIR}/")
+        assert ".." not in path
+        assert ";" not in path
+        assert "touch /tmp/pwned" not in path
 
 
 # ── _write_to_sandbox ─────────────────────────────────────────────────
@@ -354,6 +367,29 @@ class TestMaybePersistToolResult:
         )
         # Any non-empty content with threshold=0 should be persisted
         assert PERSISTED_OUTPUT_TAG in result
+
+    def test_unsafe_tool_use_id_does_not_reach_shell_command(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        content = "x" * 60_000
+        tool_use_id = "../../escape; touch /tmp/pwned"
+
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id=tool_use_id,
+            env=env,
+            threshold=30_000,
+        )
+
+        shell_line = env.execute.call_args[0][0].splitlines()[0]
+        safe_path = _remote_result_path(tool_use_id)
+
+        assert PERSISTED_OUTPUT_TAG in result
+        assert f"Full output saved to: {safe_path}" in result
+        assert tool_use_id not in shell_line
+        assert "touch /tmp/pwned" not in shell_line
+        assert safe_path in shell_line
 
 
 # ── enforce_turn_budget ───────────────────────────────────────────────

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -9,9 +9,10 @@ Defense against context-window overflow operates at three levels:
 2. **Per-result persistence** (maybe_persist_tool_result): After a tool
    returns, if its output exceeds the tool's registered threshold
    (registry.get_max_result_size), the full output is written INTO THE
-   SANDBOX at /tmp/hermes-results/{tool_use_id}.txt via env.execute().
-   The in-context content is replaced with a preview + file path reference.
-   The model can read_file to access the full output on any backend.
+   SANDBOX under /tmp/hermes-results/ using a deterministic sanitized
+   filename derived from the tool_use_id. The in-context content is
+   replaced with a preview + file path reference. The model can read_file
+   to access the full output on any backend.
 
 3. **Per-turn aggregate budget** (enforce_turn_budget): After all tool
    results in a single assistant turn are collected, if the total exceeds
@@ -20,7 +21,11 @@ Defense against context-window overflow operates at three levels:
    where many medium-sized results combine to overflow context.
 """
 
+import hashlib
 import logging
+import posixpath
+import re
+import shlex
 import uuid
 
 from tools.budget_config import (
@@ -35,6 +40,8 @@ PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+_SAFE_TOOL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_UNSAFE_TOOL_ID_CHARS_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
@@ -55,11 +62,31 @@ def _heredoc_marker(content: str) -> str:
     return f"HERMES_PERSIST_{uuid.uuid4().hex[:8]}"
 
 
+def _safe_tool_result_basename(tool_use_id: str) -> str:
+    """Return a deterministic shell-safe basename for persisted tool output."""
+    raw = str(tool_use_id or "").strip()
+    if raw and raw not in {".", ".."} and _SAFE_TOOL_ID_RE.fullmatch(raw):
+        return raw
+
+    digest_source = raw or "result"
+    digest = hashlib.sha256(
+        digest_source.encode("utf-8", errors="replace")
+    ).hexdigest()[:12]
+    slug = _UNSAFE_TOOL_ID_CHARS_RE.sub("_", raw).strip("._-") if raw else ""
+    slug = (slug or "result")[:48]
+    return f"{slug}_{digest}"
+
+
+def _remote_result_path(tool_use_id: str) -> str:
+    """Build the sandbox path for a persisted tool result."""
+    return posixpath.join(STORAGE_DIR, f"{_safe_tool_result_basename(tool_use_id)}.txt")
+
+
 def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     """Write content into the sandbox via env.execute(). Returns True on success."""
     marker = _heredoc_marker(content)
     cmd = (
-        f"mkdir -p {STORAGE_DIR} && cat > {remote_path} << '{marker}'\n"
+        f"mkdir -p {shlex.quote(STORAGE_DIR)} && cat > {shlex.quote(remote_path)} << '{marker}'\n"
         f"{content}\n"
         f"{marker}"
     )
@@ -125,7 +152,7 @@ def maybe_persist_tool_result(
     if len(content) <= effective_threshold:
         return content
 
-    remote_path = f"{STORAGE_DIR}/{tool_use_id}.txt"
+    remote_path = _remote_result_path(tool_use_id)
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
     if env is not None:


### PR DESCRIPTION
## What changed and why

This change prevents untrusted `tool_call_id` values from being used directly in persisted output paths and shell write commands.

Previously, provider-originated tool call IDs could flow into the persisted filename and shell-side write path without normalization. A crafted value containing traversal segments or shell metacharacters could therefore influence where large tool outputs were written, or how the shell command was constructed, especially on local backends.

This patch keeps the fix intentionally small and local to `tools/tool_result_storage.py`:
- sanitize `tool_use_id` into a deterministic safe basename before deriving the persisted path
- keep storage rooted under `STORAGE_DIR`
- quote the shell-side write path with `shlex.quote()`
- add focused regression tests for traversal and shell-metacharacter inputs

## How to test

Run:

```bash
pytest tests/tools/test_tool_result_storage.py -v