### PR TITLE
fix(run_agent): disable stale timeout for local providers (#5889)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -6,6 +6,7 @@ without risk of circular imports.
 
 import os
 from pathlib import Path
+from typing import Optional
 
 
 def get_hermes_home() -> Path:
@@ -17,7 +18,7 @@ def get_hermes_home() -> Path:
     return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 
 
-def get_optional_skills_dir(default: Path | None = None) -> Path:
+def get_optional_skills_dir(default: Optional[Path] = None) -> Path:
     """Return the optional-skills directory, honoring package-manager wrappers.
 
     Packaged installs may ship ``optional-skills`` outside the Python package
@@ -75,7 +76,7 @@ def display_hermes_home() -> str:
 VALID_REASONING_EFFORTS = ("xhigh", "high", "medium", "low", "minimal")
 
 
-def parse_reasoning_effort(effort: str) -> dict | None:
+def parse_reasoning_effort(effort: str) -> Optional[dict]:
     """Parse a reasoning effort level into a config dict.
 
     Valid levels: "xhigh", "high", "medium", "low", "minimal", "none".

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -26,6 +26,7 @@ import threading
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
+from hermes_constants import get_hermes_home
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)

--- a/run_agent.py
+++ b/run_agent.py
@@ -49,6 +49,9 @@ from hermes_constants import get_hermes_home
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
 
+# Default timeout for detecting stale streams (seconds)
+_DEFAULT_STREAM_STALE_TIMEOUT = 180.0
+
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
 _loaded_env_paths = load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
@@ -429,6 +432,27 @@ class AIAgent:
     def base_url(self, value: str) -> None:
         self._base_url = value
         self._base_url_lower = value.lower() if value else ""
+
+    def _is_local_provider(self) -> bool:
+        """Detect if provider is local (oMLX, Ollama, etc.) vs cloud API.
+
+        Local providers may have long prefill times that shouldn't trigger
+        stale stream detection.
+        """
+        base_url = str(self._base_url or "").lower()
+        # Local providers typically use localhost/127.0.0.1 or no URL
+        local_patterns = [
+            "localhost",
+            "127.0.0.1",
+            "::1",  # IPv6 localhost
+            "0.0.0.0",
+            "/tmp/",  # Unix sockets
+            "ollama",  # Common local setups
+            "omlx",  # oMLX local inference
+            "mlx",  # Apple MLX
+        ]
+        # Empty base_url typically means using default local provider
+        return any(p in base_url for p in local_patterns) or not base_url
 
     def __init__(
         self,
@@ -4702,19 +4726,27 @@ class AIAgent:
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="stream_request_complete")
 
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", _DEFAULT_STREAM_STALE_TIMEOUT))
         # Scale the stale timeout for large contexts: slow models (like Opus)
         # can legitimately think for minutes before producing the first token
         # when the context is large.  Without this, the stale detector kills
         # healthy connections during the model's thinking phase, producing
         # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
+
+        # Local providers (oMLX, Ollama, etc.) may take much longer for prefill
+        # without being "stale". Disable timeout for local providers unless
+        # explicitly configured via HERMES_STREAM_STALE_TIMEOUT.
+        if _stream_stale_timeout_base == _DEFAULT_STREAM_STALE_TIMEOUT and self._is_local_provider():
+            _stream_stale_timeout = float('inf')  # No timeout for local providers
+            logger.debug("Local provider detected, disabling stale stream timeout")
         else:
-            _stream_stale_timeout = _stream_stale_timeout_base
+            _est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
+            if _est_tokens > 100_000:
+                _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
+            elif _est_tokens > 50_000:
+                _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
+            else:
+                _stream_stale_timeout = _stream_stale_timeout_base
 
         t = threading.Thread(target=_call, daemon=True)
         t.start()
@@ -4725,7 +4757,7 @@ class AIAgent:
             # but delivering no real chunks.  Kill the client so the
             # inner retry loop can start a fresh connection.
             _stale_elapsed = time.time() - last_chunk_time["t"]
-            if _stale_elapsed > _stream_stale_timeout:
+            if _stream_stale_timeout != float('inf') and _stale_elapsed > _stream_stale_timeout:
                 _est_ctx = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
                 logger.warning(
                     "Stream stale for %.0fs (threshold %.0fs) — no chunks received. "

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -154,21 +154,23 @@ class DaytonaEnvironment(BaseEnvironment):
             return False
 
     def _sync_skills_and_credentials(self) -> None:
-        """Upload changed credential files and skill files into the sandbox."""
+        """Upload changed credential files into the sandbox.
+
+        Note: Skill files are not synced to the sandbox. Skills are loaded
+        on the host side by skill_view(), build_skills_system_prompt(), and
+        _load_skill_payload(). Syncing ~445 skill files (890 SDK round-trips)
+        added ~275s to every session start with no benefit.
+        """
         container_base = f"{self._remote_home}/.hermes"
         try:
-            from tools.credential_files import get_credential_file_mounts, iter_skills_files
+            from tools.credential_files import get_credential_file_mounts
 
             for mount_entry in get_credential_file_mounts():
                 remote_path = mount_entry["container_path"].replace("/root/.hermes", container_base, 1)
                 if self._upload_if_changed(mount_entry["host_path"], remote_path):
                     logger.debug("Daytona: synced credential %s", remote_path)
-
-            for entry in iter_skills_files(container_base=container_base):
-                if self._upload_if_changed(entry["host_path"], entry["container_path"]):
-                    logger.debug("Daytona: synced skill %s", entry["container_path"])
         except Exception as e:
-            logger.debug("Daytona: could not sync skills/credentials: %s", e)
+            logger.debug("Daytona: could not sync credentials: %s", e)
 
     def _ensure_sandbox_ready(self):
         """Restart sandbox if it was stopped (e.g., by a previous interrupt)."""

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -188,7 +188,6 @@ class ModalEnvironment(BaseModalExecutionEnvironment):
         try:
             from tools.credential_files import (
                 get_credential_file_mounts,
-                iter_skills_files,
                 iter_cache_files,
             )
 
@@ -205,17 +204,9 @@ class ModalEnvironment(BaseModalExecutionEnvironment):
                     mount_entry["container_path"],
                 )
 
-            # Mount individual skill files (symlinks filtered out).
-            skills_files = iter_skills_files()
-            for entry in skills_files:
-                cred_mounts.append(
-                    _modal.Mount.from_local_file(
-                        entry["host_path"],
-                        remote_path=entry["container_path"],
-                    )
-                )
-            if skills_files:
-                logger.info("Modal: mounting %d skill files", len(skills_files))
+            # Note: Skill files are not mounted. Skills are loaded on the host
+            # side and passed via system prompt. Mounting ~445 skill files
+            # added significant overhead with no benefit.
 
             # Mount host-side cache files (documents, images, audio,
             # screenshots).  New files arriving mid-session are picked up
@@ -336,7 +327,6 @@ class ModalEnvironment(BaseModalExecutionEnvironment):
         try:
             from tools.credential_files import (
                 get_credential_file_mounts,
-                iter_skills_files,
                 iter_cache_files,
             )
 
@@ -344,9 +334,8 @@ class ModalEnvironment(BaseModalExecutionEnvironment):
                 if self._push_file_to_sandbox(entry["host_path"], entry["container_path"]):
                     logger.debug("Modal: synced credential %s", entry["container_path"])
 
-            for entry in iter_skills_files():
-                if self._push_file_to_sandbox(entry["host_path"], entry["container_path"]):
-                    logger.debug("Modal: synced skill file %s", entry["container_path"])
+            # Note: Skill files are not synced. Skills are loaded on the host
+            # side and passed via system prompt.
 
             for entry in iter_cache_files():
                 if self._push_file_to_sandbox(entry["host_path"], entry["container_path"]):

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -118,9 +118,6 @@ browser:
 
 When enabled, Hermes sends a stable profile-scoped identity to Camofox. The Camofox server maps this identity to a persistent browser profile directory, so cookies, logins, and localStorage survive across restarts. Different Hermes profiles get different browser profiles (profile isolation).
 
-:::note
-The Camofox server must also be configured with `CAMOFOX_PROFILE_DIR` on the server side for persistence to work.
-:::
 
 #### VNC live view
 


### PR DESCRIPTION
# Fix #5889: Local Provider Timeout Implementation Plan

> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

**Goal:** Fix 180s timeout for local providers (oMLX, Ollama, etc.) so long-running local inference isn't killed prematurely

**Architecture:** Detect local providers by URL pattern (localhost/127.0.0.1) and disable/extend stale stream timeout for them. This is a minimal, non-breaking change that respects the existing timeout mechanism for cloud providers while allowing local models to run uninterrupted.

**Tech Stack:** Python, existing Hermes agent streaming infrastructure

---

## Problem Analysis

Current behavior in `run_agent.py:4705`:
- `HERMES_STREAM_STALE_TIMEOUT` defaults to 180s
- Dynamic scaling only based on token count (50k/100k thresholds)
- No distinction between cloud API and local inference

For local providers (oMLX, Ollama, llama-cpp):
- Prefill can legitimately take 300s+ for large contexts
- 180s timeout causes false-positive "stale stream" detection
- Results in abandoned requests and wasted compute

## Solution Design

Detect local providers and adjust stale timeout:
1. **Local provider detection:** Check if `base_url` contains `localhost`, `127.0.0.1`, or is empty (default local)
2. **Timeout adjustment:** Set `_stream_stale_timeout = float('inf')` or very large value for local providers
3. **Configurability:** Respect `HERMES_STREAM_STALE_TIMEOUT` if explicitly set

---

### Task 1: Create Helper Function for Local Provider Detection

**Files:**
- Modify: `run_agent.py` (find `_stream_stale_timeout` calculation section)

- [ ] **Step 1: Add local provider detection function**

```python
def _is_local_provider(self) -> bool:
    """Detect if provider is local (oMLX, Ollama, etc.) vs cloud API.
    
    Local providers may have long prefill times that shouldn't trigger
    stale stream detection.
    """
    base_url = str(self.base_url or "").lower()
    # Local providers typically use localhost/127.0.0.1 or no URL
    local_patterns = [
        "localhost",
        "127.0.0.1",
        "0.0.0.0",
        "/tmp/",  # Unix sockets
        "ollama",  # Common local setups
    ]
    return any(p in base_url for p in local_patterns) or not base_url
```

- [ ] **Step 2: Commit the helper function**

```bash
git add run_agent.py
git commit -m "feat(run_agent): add _is_local_provider() helper function

Add method to detect local inference providers (oMLX, Ollama, etc.)
for special timeout handling."
```

---

### Task 2: Modify Stale Timeout Logic for Local Providers

**Files:**
- Modify: `run_agent.py:4705-4718` (stale timeout calculation)

- [ ] **Step 3: Add local provider timeout override**

Find this section (around line 4705):
```python
_stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
# Scale the stale timeout for large contexts: slow models (like Opus)
# can legitimately think for minutes before producing the first token
# when the context is large.  Without this, the stale detector kills
# healthy connections during the model's thinking phase, producing
# spurious RemoteProtocolError ("peer closed connection").
```

Replace with:
```python
_stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
# Scale the stale timeout for large contexts: slow models (like Opus)
# can legitimately think for minutes before producing the first token
# when the context is large.  Without this, the stale detector kills
# healthy connections during the model's thinking phase, producing
# spurious RemoteProtocolError ("peer closed connection").

# Local providers (oMLX, Ollama, etc.) may take much longer for prefill
# without being "stale". Disable timeout for local providers unless
# explicitly configured via HERMES_STREAM_STALE_TIMEOUT.