### PR TITLE
feat(custom): prompt and persist explicit api_mode for custom providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1422,6 +1422,21 @@ def _model_flow_custom(config):
         if probe.get("suggested_base_url"):
             print(f"  If this server expects /v1, try base URL: {probe['suggested_base_url']}")
 
+    # Prompt for API compatibility mode explicitly so codex-compatible custom
+    # providers don't silently fall back to chat_completions.
+    current_model_cfg = config.get("model")
+    current_api_mode = ""
+    if isinstance(current_model_cfg, dict):
+        current_api_mode = str(current_model_cfg.get("api_mode") or "").strip()
+    api_mode = _prompt_custom_api_mode_selection(
+        effective_url,
+        current_api_mode=current_api_mode,
+    )
+    if api_mode:
+        print(f"  API mode: {api_mode}")
+    else:
+        print("  API mode: auto-detect")
+
     # Select model — use probe results when available, fall back to manual input
     model_name = ""
     detected_models = probe.get("models") or []
@@ -1473,7 +1488,10 @@ def _model_flow_custom(config):
         model["base_url"] = effective_url
         if effective_key:
             model["api_key"] = effective_key
-        model.pop("api_mode", None)  # let runtime auto-detect from URL
+        if api_mode:
+            model["api_mode"] = api_mode
+        else:
+            model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 
@@ -1496,19 +1514,98 @@ def _model_flow_custom(config):
         _caller_model["base_url"] = effective_url
         if effective_key:
             _caller_model["api_key"] = effective_key
-        _caller_model.pop("api_mode", None)
+        if api_mode:
+            _caller_model["api_mode"] = api_mode
+        else:
+            _caller_model.pop("api_mode", None)
         config["model"] = _caller_model
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
 
     # Auto-save to custom_providers so it appears in the menu next time
-    _save_custom_provider(effective_url, effective_key, model_name or "", context_length=context_length)
+    _save_custom_provider(
+        effective_url,
+        effective_key,
+        model_name or "",
+        context_length=context_length,
+        api_mode=api_mode,
+    )
 
 
-def _save_custom_provider(base_url, api_key="", model="", context_length=None):
+def _prompt_custom_api_mode_selection(base_url: str, current_api_mode: str = "") -> Optional[str]:
+    """Prompt for a custom provider API mode.
+
+    Returns an explicit mode string, or None to keep auto-detect behavior.
+    """
+    from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+    detected_mode = _detect_api_mode_for_url(base_url)
+    normalized_current = str(current_api_mode or "").strip().lower()
+    default_mode = normalized_current or detected_mode or ""
+
+    mode_options = [
+        (
+            "",
+            "Auto-detect",
+            "Use Hermes URL heuristics; best for standard OpenAI-compatible endpoints.",
+        ),
+        (
+            "chat_completions",
+            "Chat Completions",
+            "Use /chat/completions for standard OpenAI-compatible servers.",
+        ),
+        (
+            "codex_responses",
+            "Responses / Codex",
+            "Use /responses for Codex-compatible tool-calling backends.",
+        ),
+        (
+            "anthropic_messages",
+            "Anthropic Messages",
+            "Use /v1/messages for Anthropic-compatible endpoints.",
+        ),
+    ]
+
+    print()
+    print("Select API compatibility mode:")
+    for idx, (value, label, description) in enumerate(mode_options, 1):
+        markers = []
+        if value == detected_mode:
+            markers.append("detected")
+        if value == default_mode:
+            markers.append("current")
+        suffix = f" [{' / '.join(markers)}]" if markers else ""
+        print(f"  {idx}. {label}{suffix}")
+        print(f"     {description}")
+
+    try:
+        raw = input(
+            "Choice [1-4, Enter to keep current/detected]: "
+        ).strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        print("\nCancelled.")
+        raise
+
+    if not raw:
+        return default_mode or None
+
+    if raw in {"1", "auto", "detect", "auto-detect"}:
+        return None
+    if raw in {"2", "chat", "chat_completions", "completions"}:
+        return "chat_completions"
+    if raw in {"3", "responses", "codex", "codex_responses"}:
+        return "codex_responses"
+    if raw in {"4", "anthropic", "anthropic_messages", "messages"}:
+        return "anthropic_messages"
+
+    print(f"Invalid API mode choice: {raw}. Falling back to auto-detect.")
+    return None
+
+
+def _save_custom_provider(base_url, api_key="", model="", context_length=None, api_mode=None):
     """Save a custom endpoint to custom_providers in config.yaml.
 
     Deduplicates by base_url — if the URL already exists, updates the
-    model name and context_length but doesn't add a duplicate entry.
+    model name, context_length, and api_mode but doesn't add a duplicate entry.
     Auto-generates a display name from the URL hostname.
     """
     from hermes_cli.config import load_config, save_config
@@ -1531,6 +1628,13 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
                     models_cfg = {}
                 models_cfg[model] = {"context_length": context_length}
                 entry["models"] = models_cfg
+                changed = True
+            if api_mode:
+                if entry.get("api_mode") != api_mode:
+                    entry["api_mode"] = api_mode
+                    changed = True
+            elif "api_mode" in entry:
+                entry.pop("api_mode", None)
                 changed = True
             if changed:
                 cfg["custom_providers"] = providers
@@ -1557,6 +1661,8 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
         entry["api_key"] = api_key
     if model:
         entry["model"] = model
+    if api_mode:
+        entry["api_mode"] = api_mode
     if model and context_length:
         entry["models"] = {model: {"context_length": context_length}}
 
@@ -1635,6 +1741,7 @@ def _model_flow_named_custom(config, provider_info):
     base_url = provider_info["base_url"]
     api_key = provider_info.get("api_key", "")
     saved_model = provider_info.get("model", "")
+    api_mode = str(provider_info.get("api_mode") or "").strip()
 
     # If a model is saved, just activate immediately — no probing needed
     if saved_model:
@@ -1649,6 +1756,10 @@ def _model_flow_named_custom(config, provider_info):
         model["base_url"] = base_url
         if api_key:
             model["api_key"] = api_key
+        if api_mode:
+            model["api_mode"] = api_mode
+        else:
+            model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 
@@ -1722,11 +1833,15 @@ def _model_flow_named_custom(config, provider_info):
     model["base_url"] = base_url
     if api_key:
         model["api_key"] = api_key
+    if api_mode:
+        model["api_mode"] = api_mode
+    else:
+        model.pop("api_mode", None)
     save_config(cfg)
     deactivate_provider()
 
     # Save model name to the custom_providers entry for next time
-    _save_custom_provider(base_url, api_key, model_name)
+    _save_custom_provider(base_url, api_key, model_name, api_mode=api_mode)
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -577,7 +577,7 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
 
     # After the probe detects a single model ("llm"), the flow asks
     # "Use this model? [Y/n]:" — confirm with Enter, then context length.
-    answers = iter(["http://localhost:8000", "local-key", "", ""])
+    answers = iter(["http://localhost:8000", "local-key", "", "", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
     monkeypatch.setattr("getpass.getpass", lambda _prompt="": next(answers))
 
@@ -589,6 +589,61 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"
+
+
+def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
+    saved_cfg = {"model": {"default": "", "provider": "custom", "base_url": ""}}
+    captured_provider = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value",
+        lambda key: "" if key in {"OPENAI_BASE_URL", "OPENAI_API_KEY"} else "",
+    )
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": [],
+            "probed_url": f"{base_url.rstrip('/')}/models",
+            "resolved_base_url": None,
+            "suggested_base_url": None,
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: saved_cfg)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
+    monkeypatch.setattr(
+        "hermes_cli.main._save_custom_provider",
+        lambda base_url, api_key="", model="", context_length=None, api_mode=None: captured_provider.update(
+            {
+                "base_url": base_url,
+                "api_key": api_key,
+                "model": model,
+                "context_length": context_length,
+                "api_mode": api_mode,
+            }
+        ),
+    )
+
+    answers = iter(
+        [
+            "https://codex.example.com/v1",
+            "3",
+            "chosen-model",
+            "",
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "test-key")
+
+    hermes_main._model_flow_custom({"model": {"provider": "custom"}})
+
+    assert saved_cfg["model"]["provider"] == "custom"
+    assert saved_cfg["model"]["base_url"] == "https://codex.example.com/v1"
+    assert saved_cfg["model"]["api_key"] == "test-key"
+    assert saved_cfg["model"]["api_mode"] == "codex_responses"
+    assert captured_provider["api_mode"] == "codex_responses"
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -149,6 +149,31 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("api_mode") == "codex_responses"
         assert config["agent"]["reasoning_effort"] == "high"
 
+    def test_named_custom_provider_preserves_explicit_api_mode(self, config_home):
+        """Named custom providers should re-activate with their saved api_mode."""
+        import yaml
+
+        from hermes_cli.main import _model_flow_named_custom
+
+        provider_info = {
+            "name": "Packy",
+            "base_url": "https://packy.example.com/v1",
+            "api_key": "sk-test",
+            "model": "gpt-5.4",
+            "api_mode": "codex_responses",
+        }
+
+        with patch("hermes_cli.auth._save_model_choice"), \
+             patch("hermes_cli.auth.deactivate_provider"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("provider") == "custom"
+        assert model.get("base_url") == "https://packy.example.com/v1"
+        assert model.get("api_mode") == "codex_responses"
+
     def test_copilot_acp_provider_saved_when_selected(self, config_home):
         """_model_flow_copilot_acp should persist provider/base_url/model together."""
         from hermes_cli.main import _model_flow_copilot_acp


### PR DESCRIPTION
## Summary

This PR improves the `custom` provider setup flow by prompting for an explicit `api_mode` and persisting it in config.

Previously, the custom provider flow silently removed `api_mode` and relied entirely on URL heuristics to infer the transport. That works for some standard endpoints, but it is not reliable for third-party backends that are fully compatible with Codex / Responses API semantics.

## Problem

The current `custom` provider configuration flow defaults to URL-based auto-detection and often falls back to `chat_completions`.

This creates a poor experience for third-party providers that are fully compatible with the Responses API but are hosted on non-OpenAI domains. In those cases, Hermes may configure the provider as `chat_completions` even when `codex_responses` is the correct transport.

## What changed

- Added an explicit API compatibility mode prompt to the `hermes model -> custom` flow
- Added support for choosing one of:
  - `Auto-detect`
  - `chat_completions`
  - `codex_responses`
  - `anthropic_messages`
- Persist the selected `api_mode` to `model`
- Persist the selected `api_mode` to `custom_providers`
- Preserve and restore `api_mode` when re-activating a named custom provider

## Why this approach

This is a focused and low-risk improvement:

- It avoids over-expanding transport auto-detection heuristics
- It gives users an explicit way to describe backend compatibility
- It improves support for Codex-compatible third-party providers without changing the runtime execution path
- It keeps the fix small, understandable, and easy to review

## Validation

Ran targeted local tests after installing the project in the repo virtualenv:

- `2 passed, 23 deselected`

Test command:
```bash
source "venv/bin/activate"
pytest -q -o addopts='' "tests/cli/test_cli_provider_resolution.py" -k "model_flow_custom" "tests/hermes_cli/test_model_provider_persistence.py" -k "custom_provider_preserves_explicit_api_mode or copilot_provider_saved_when_selected"
```

## Files changed

- `hermes_cli/main.py`
- `tests/cli/test_cli_provider_resolution.py`
- `tests/hermes_cli/test_model_provider_persistence.py`

## Notes

This PR does **not** claim that custom providers previously lacked Responses API support entirely.

Instead, it addresses a configuration UX gap: the custom provider flow did not clearly guide users to select and persist the correct `api_mode` for responses-compatible backends.
