### PR TITLE
feat(skills): add Slack API skill for bot integration

### DIFF
--- a/skills/productivity/slack-api/SKILL.md
+++ b/skills/productivity/slack-api/SKILL.md
@@ -72,13 +72,31 @@ curl -s -H "Authorization: Bearer $TOKEN" "https://slack.com/api/users.list?limi
 `search.messages` requires a **User token** (not bot token) — it returns `not_allowed_token_type` with bot tokens. Instead, iterate channels and grep history.
 
 ## Scanning All Channels for Mentions (Pattern)
-Use `execute_code` for reliability (avoids terminal timeout on large workspaces):
+Use `execute_code` or a standalone script for reliability (terminal times out on large workspaces):
 1. `conversations.list` with pagination to get all channels
-2. `conversations.join` each channel
-3. `conversations.history` with limit=200 per channel
-4. Filter messages containing `<@USER_ID>`
-5. `users.info` to resolve mentioned user IDs to names
-6. Rate limit: `time.sleep(0.2-0.3)` between API calls
+2. **Skip** `conversations.join` for channels where `is_member=true` (from the list response) — this avoids the Tier 2 rate limit bottleneck
+3. Only join channels where `is_member=false`, with 3s pause every 20 joins
+4. `conversations.history` with limit=200 per channel
+5. Filter messages containing `<@USER_ID>`
+6. `users.info` to resolve mentioned user IDs to names
+
+### HTTP 429 Retry Pattern
+All Slack API wrappers should handle rate limits:
+```python
+def _slack_request(req, retries=3):
+    for attempt in range(retries):
+        try:
+            return json.loads(urllib.request.urlopen(req).read())
+        except urllib.error.HTTPError as e:
+            if e.code == 429:
+                retry_after = int(e.headers.get("Retry-After", 30))
+                time.sleep(retry_after + 1)
+                req = urllib.request.Request(req.full_url,
+                    data=req.data, headers=dict(req.headers), method=req.get_method())
+                continue
+            raise
+    return {"ok": False, "error": "rate_limited_exhausted"}
+```
 
 ## Recommended Bot Scopes
 Comprehensive set for a fully capable bot:
@@ -126,23 +144,6 @@ curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
 ```
 To find a message to delete, use `conversations.history` and match on text content or bot_id.
 
-## Diagnosing Socket Mode Hijacking (OpenClaw / Other Bots)
-If the gateway stops responding on Slack but `hermes gateway status` shows it running:
-1. Check `gateway.log` — if no recent Slack entries, the socket was stolen
-2. On this server: `ps aux | grep -i "openclaw\|claw\|node.*slack" | grep -v grep`
-3. Check macOS: `launchctl list | grep -i claw` — OpenClaw installs as `ai.openclaw.gateway` launchd service
-4. To remove on macOS:
-   ```bash
-   kill <PID>                                          # kill the process
-   launchctl remove ai.openclaw.gateway                # remove the service (more reliable than bootout)
-   rm ~/Library/LaunchAgents/ai.openclaw.gateway.plist  # prevent restart on reboot
-   launchctl list | grep claw                           # verify it's gone
-   ```
-   Note: `launchctl bootout` often fails with I/O errors — use `launchctl remove` instead.
-5. Then restart the Hermes gateway to reclaim the socket connection
-6. OpenClaw is installed via Homebrew (`which openclaw` → `/opt/homebrew/bin/openclaw`), config in `~/.openclaw/`
-7. **`ps | grep claw` false positive** — `grep` matches itself in the process list. If the only match is `grep --color=auto claw`, there is no OpenClaw process running.
-
 ## Downloading and Forwarding Slack Files (Images, Documents)
 
 Slack file URLs (`files.slack.com/files-pri/...`) are **private** — they require the bot token to access. They cannot be embedded directly in external services (Linear, GitHub, etc.).
@@ -172,14 +173,104 @@ with open(local_path, "wb") as f:
 - `linear issue attach` fails with spaces in filenames — always sanitize first
 - Use `execute_code` for bulk operations to avoid terminal timeouts
 
+## Block Kit Rich Formatting
+
+Slack does NOT render markdown tables. For rich formatting, use Block Kit with `chat.postMessage`. Post blocks as JSON via the API:
+
+```python
+import json, urllib.request
+data = json.dumps({"channel": "CHANNEL_ID", "blocks": [...], "text": "fallback"}).encode()
+req = urllib.request.Request("https://slack.com/api/chat.postMessage",
+    data=data, headers={"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"})
+resp = json.loads(urllib.request.urlopen(req).read())
+```
+
+### Available Block Types (Messages)
+- **header** — large bold text: `{"type": "header", "text": {"type": "plain_text", "text": "Title", "emoji": true}}`
+- **section** — mrkdwn text (bold `*x*`, italic `_x_`, code `` `x` ``): `{"type": "section", "text": {"type": "mrkdwn", "text": "..."}}`
+- **divider** — horizontal line: `{"type": "divider"}`
+- **context** — small grey text/images: `{"type": "context", "elements": [{"type": "mrkdwn", "text": "..."}]}`
+- **rich_text** — structured text with lists, bold, italic, code, emoji, links
+- **table** — actual table with rows, columns, alignment (see below)
+- **image** — `{"type": "image", "image_url": "...", "alt_text": "..."}`
+
+### Table Block
+Only ONE table per message (appended at bottom). Rows are arrays of cells:
+```json
+{
+    "type": "table",
+    "column_settings": [
+        {"align": "left"},
+        {"align": "left", "is_wrapped": true},
+        {"align": "left"}
+    ],
+    "rows": [
+        [
+            {"type": "raw_text", "text": "Time"},
+            {"type": "raw_text", "text": "Meeting"},
+            {"type": "raw_text", "text": "Status"}
+        ],
+        [
+            {"type": "raw_text", "text": "11:15"},
+            {"type": "raw_text", "text": "Dmitri / Thomas"},
+            {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [
+                {"type": "emoji", "name": "warning"},
+                {"type": "text", "text": " Declined"}
+            ]}]}
+        ]
+    ]
+}
+```
+Cell types: `raw_text` (plain string) or `rich_text` (with bold, emoji, links).
+Max: 100 rows, 20 columns. First row is treated as header.
+
+### Rich Text Block
+For structured lists and formatted text without a table:
+```json
+{
+    "type": "rich_text",
+    "elements": [
+        {
+            "type": "rich_text_list",
+            "style": "bullet",
+            "elements": [
+                {"type": "rich_text_section", "elements": [
+                    {"type": "text", "text": "Bold text", "style": {"bold": true}},
+                    {"type": "text", "text": " normal text"},
+                    {"type": "emoji", "name": "rocket"}
+                ]}
+            ]
+        }
+    ]
+}
+```
+Rich text element types: `text` (with style: bold/italic/code/strike), `emoji` (by name), `link` (with url), `user` (mention by ID).
+
+### Cron Job Block Kit Delivery
+The gateway's automatic cron delivery sends plain text only. For Block Kit formatting in cron jobs, have the agent post the message itself via the Slack API using terminal/execute_code, then return a short confirmation as the final response. Note: the cron prompt cannot contain `curl` commands directly (blocked by security filter) — use Python `urllib` instead.
+
+### Key Constraints
+- Max 50 blocks per message
+- Only 1 table block per message
+- Section block mrkdwn max 3000 chars
+- `text` field is required as fallback even when using blocks
+
 ## Pitfalls
 1. **`search.messages` is user-token only** — bot tokens get `not_allowed_token_type`. Must iterate channels manually.
 2. **Bot must join channel before reading history** — otherwise get `not_in_channel` error (not a scope issue).
 3. **`conversations.open` for DMs requires `im:write`** — easy to miss, not included in basic bot templates.
 4. **Bot profile (name/image) can't be set via API** — must be configured in Slack App settings under Display Information.
-5. **Rate limits** — Slack Tier 3 methods allow ~50 req/min. Add 200-300ms delays when iterating many channels.
+5. **Rate limits are per-tier, not global.** Key limits:
+   - Tier 1 (1/min): `chat.delete`, `conversations.open`
+   - Tier 2 (20/min): `conversations.join`, `users.info`
+   - Tier 3 (50/min): `conversations.list`, `conversations.history`
+   - Tier 4 (100/min): `auth.test`
+   When scanning many channels: skip `conversations.join` for channels where `is_member=true` (from conversations.list response). This avoids the Tier 2 bottleneck entirely for already-joined channels. Handle 429 responses by reading the `Retry-After` header.
 6. **Large workspaces timeout in terminal** — use `execute_code` instead for bulk operations across 100+ channels.
 7. **Scope changes require app reinstall** — after adding scopes in OAuth & Permissions, must reinstall from "Install App" page (not OAuth page, which may fail with `redirect_uri` error for Socket Mode apps).
-8. **Socket Mode only allows ONE active connection per app token** — if another process (e.g., an old OpenClaw bot) connects with the same `SLACK_APP_TOKEN`, it silently steals the connection. The gateway log will stop showing Slack messages but the process stays alive. Diagnose by checking if `gateway.log` has recent Slack entries. Fix: find and kill the other process, or create a new Slack app with fresh tokens.
+8. **Socket Mode only allows ONE active connection per app token** — if another process connects with the same `SLACK_APP_TOKEN`, it silently steals the connection. The gateway log will stop showing Slack messages but the process stays alive. Diagnose by checking if `gateway.log` has recent Slack entries. Fix: find and kill the other process, or create a new Slack app with fresh tokens.
 9. **Slack scope picker is virtualized** — the dropdown only renders visible items. Scopes like `channels:history` won't appear until you scroll up or type in the search filter. Always use the search box.
 10. **Check bot scopes via response header** — `curl -sI ... auth.test | grep x-oauth-scopes` is the fastest way to see what scopes are active, rather than checking the Slack app settings page.
+11. **Cron `deliver: slack` needs explicit channel** — if no Slack home channel is configured, delivery silently fails. Use `deliver: slack:CHANNEL_ID` (e.g., `slack:D0AFQA1V2GP` for a DM) instead of bare `slack`.
+12. **Cron scripts run in the Hermes venv** — packages installed via system `pip` aren't available. Install into the venv: `~/.hermes/hermes-agent/venv/bin/python -m pip install <package>`.
+13. **himalaya email flags** — JSON output uses `flags` as a list. `"Seen"` = read, empty list = unread. The table view uses `*` for "flagged", which is different from "seen/unseen".

--- a/skills/productivity/slack-api/SKILL.md
+++ b/skills/productivity/slack-api/SKILL.md
@@ -119,34 +119,6 @@ Returns all messages in a thread given the parent message's `ts` (thread_ts).
 
 The thread_ts is typically available from the message metadata. If not, use `conversations.history` on the channel and look for the parent message.
 
-### Handling File Attachments (Images, Documents)
-Slack messages often contain file attachments (screenshots, documents). These appear in the `files` array of each message. **File URLs require the bot token to access** — they are NOT public URLs.
-
-To download a Slack file:
-```python
-import urllib.request
-req = urllib.request.Request(
-    file["url_private"],
-    headers={"Authorization": f"Bearer {TOKEN}"}
-)
-data = urllib.request.urlopen(req).read()
-```
-
-**IMPORTANT — Cross-platform content transfer:** When creating issues (Linear, GitHub, etc.) from Slack threads that contain images, you MUST handle the files explicitly. The text content alone loses critical visual context. Steps:
-1. Fetch the thread via `conversations.replies` — each message has a `files` array
-2. Download each file using `url_private` + bot token auth
-3. Upload to the target platform (e.g. Linear attachment API, GitHub issue, imgur) or use `url_private_download` with the token
-4. Embed the uploaded URLs as markdown images in the issue body
-
-If you skip file handling, flag it explicitly to the user: "Note: N screenshots from the thread were not included — Slack file URLs require authentication and can't be directly embedded."
-
-Common file fields:
-- `url_private` — authenticated download URL
-- `url_private_download` — forces download (vs browser preview)
-- `name` — original filename
-- `mimetype` — e.g. `image/png`
-- `thumb_*` — thumbnail URLs (also require auth)
-
 ### Delete a Bot Message (requires `chat:write` — bot can only delete its own)
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \

--- a/skills/productivity/slack-api/SKILL.md
+++ b/skills/productivity/slack-api/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: slack-api
+description: Interact with Slack workspaces via the Bot Token and Web API — read channels, send messages, scan for mentions, resolve users, manage DMs. Use when the user asks to read/send Slack messages, search channels, or audit mentions.
+tags: [slack, messaging, api, workspace]
+---
+
+# Slack API via Bot Token
+
+## When to Use
+- User asks to read Slack channel messages
+- User asks to send messages/DMs via Slack
+- User asks to scan channels for mentions or keywords
+- User asks to check bot permissions or channel access
+
+## Setup
+Bot token is in `~/.hermes/.env` as `SLACK_BOT_TOKEN`. Load it:
+```bash
+TOKEN=$(grep SLACK_BOT_TOKEN ~/.hermes/.env | cut -d= -f2)
+```
+
+## Key Patterns
+
+### Check Current Bot Scopes
+The `x-oauth-scopes` response header reveals all granted scopes — much more reliable than trial-and-error:
+```bash
+curl -sI -H "Authorization: Bearer $TOKEN" "https://slack.com/api/auth.test" | grep -i x-oauth-scopes
+```
+
+### List Public Channels
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://slack.com/api/conversations.list?types=public_channel&limit=200&exclude_archived=true"
+```
+Paginate with `cursor` from `response_metadata.next_cursor`.
+
+### Join a Channel (requires `channels:join`)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"channel":"CHANNEL_ID"}' "https://slack.com/api/conversations.join"
+```
+Bot must join before reading history. Joining via API may not show the bot in the member list visibly.
+
+### Read Channel History (requires `channels:history` + bot in channel)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://slack.com/api/conversations.history?channel=CHANNEL_ID&limit=100"
+```
+
+### Send a Message (requires `chat:write`)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"channel":"CHANNEL_ID","text":"Hello!"}' "https://slack.com/api/chat.postMessage"
+```
+
+### Open a DM with a User (requires `im:write`)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"users":"USER_ID"}' "https://slack.com/api/conversations.open"
+```
+Returns a DM channel ID. For group DMs, comma-separate user IDs.
+
+### Resolve User IDs to Names (requires `users:read`)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://slack.com/api/users.info?user=USER_ID"
+```
+Access `user.real_name` or `user.name` from response.
+
+### List All Users
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://slack.com/api/users.list?limit=200"
+```
+
+### Search Messages
+`search.messages` requires a **User token** (not bot token) — it returns `not_allowed_token_type` with bot tokens. Instead, iterate channels and grep history.
+
+## Scanning All Channels for Mentions (Pattern)
+Use `execute_code` for reliability (avoids terminal timeout on large workspaces):
+1. `conversations.list` with pagination to get all channels
+2. `conversations.join` each channel
+3. `conversations.history` with limit=200 per channel
+4. Filter messages containing `<@USER_ID>`
+5. `users.info` to resolve mentioned user IDs to names
+6. Rate limit: `time.sleep(0.2-0.3)` between API calls
+
+## Recommended Bot Scopes
+Comprehensive set for a fully capable bot:
+- `app_mentions:read` — respond to @mentions
+- `channels:history` — read public channel messages
+- `channels:join` — join public channels
+- `channels:read` — list public channels
+- `chat:write` — send messages
+- `chat:write.public` — post to channels without joining
+- `connections:write` — Socket Mode
+- `files:read` / `files:write` — view and upload files
+- `groups:history` / `groups:read` — private channel access (when invited)
+- `im:history` / `im:read` / `im:write` — DM access
+- `mpim:history` / `mpim:read` — group DM access
+- `pins:read` / `pins:write` — pinned messages
+- `reactions:read` / `reactions:write` — emoji reactions
+- `users:read` / `users:read.email` — user lookups
+
+## Daily Mentions Briefing (Cron Pattern)
+A reusable script exists at `~/.hermes/scripts/slack_mentions.py` that:
+1. Scans all public channels for `<@USER_ID>` mentions in the last 24 hours
+2. Checks DMs and group DMs for new messages (skips own messages and subtypes)
+3. Resolves user IDs to real names
+4. Outputs structured text for agent summarization
+
+Set up as a cron job with `script: slack_mentions.py` and a prompt that categorizes mentions into questions, action items, FYIs, and kudos. Deliver to `slack` for Slack DM delivery.
+
+### Scanning DMs and Group DMs
+Use `conversations.list?types=im` and `conversations.list?types=mpim` to enumerate DM/group DM channels, then `conversations.history` on each. Filter out the bot's own user ID and subtype messages (joins, etc.).
+
+### Read Thread Replies (requires `channels:history`)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://slack.com/api/conversations.replies?channel=CHANNEL_ID&ts=THREAD_TS&limit=100"
+```
+Returns all messages in a thread given the parent message's `ts` (thread_ts).
+
+**IMPORTANT — Gateway thread context:** When running as a Slack gateway bot and a user @mentions you in a thread, the gateway only passes the single mention message — it does NOT include the rest of the thread. If the user's request references "the message above", "this thread", or seems to lack context, **use your tools to call `conversations.replies`** to fetch the full thread. Do not say you can't see thread messages — you can always fetch them via the API.
+
+The thread_ts is typically available from the message metadata. If not, use `conversations.history` on the channel and look for the parent message.
+
+### Handling File Attachments (Images, Documents)
+Slack messages often contain file attachments (screenshots, documents). These appear in the `files` array of each message. **File URLs require the bot token to access** — they are NOT public URLs.
+
+To download a Slack file:
+```python
+import urllib.request
+req = urllib.request.Request(
+    file["url_private"],
+    headers={"Authorization": f"Bearer {TOKEN}"}
+)
+data = urllib.request.urlopen(req).read()
+```
+
+**IMPORTANT — Cross-platform content transfer:** When creating issues (Linear, GitHub, etc.) from Slack threads that contain images, you MUST handle the files explicitly. The text content alone loses critical visual context. Steps:
+1. Fetch the thread via `conversations.replies` — each message has a `files` array
+2. Download each file using `url_private` + bot token auth
+3. Upload to the target platform (e.g. Linear attachment API, GitHub issue, imgur) or use `url_private_download` with the token
+4. Embed the uploaded URLs as markdown images in the issue body
+
+If you skip file handling, flag it explicitly to the user: "Note: N screenshots from the thread were not included — Slack file URLs require authentication and can't be directly embedded."
+
+Common file fields:
+- `url_private` — authenticated download URL
+- `url_private_download` — forces download (vs browser preview)
+- `name` — original filename
+- `mimetype` — e.g. `image/png`
+- `thumb_*` — thumbnail URLs (also require auth)
+
+### Delete a Bot Message (requires `chat:write` — bot can only delete its own)
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"channel":"CHANNEL_ID","ts":"MESSAGE_TIMESTAMP"}' "https://slack.com/api/chat.delete"
+```
+To find a message to delete, use `conversations.history` and match on text content or bot_id.
+
+## Diagnosing Socket Mode Hijacking (OpenClaw / Other Bots)
+If the gateway stops responding on Slack but `hermes gateway status` shows it running:
+1. Check `gateway.log` — if no recent Slack entries, the socket was stolen
+2. On this server: `ps aux | grep -i "openclaw\|claw\|node.*slack" | grep -v grep`
+3. Check macOS: `launchctl list | grep -i claw` — OpenClaw installs as `ai.openclaw.gateway` launchd service
+4. To remove on macOS:
+   ```bash
+   kill <PID>                                          # kill the process
+   launchctl remove ai.openclaw.gateway                # remove the service (more reliable than bootout)
+   rm ~/Library/LaunchAgents/ai.openclaw.gateway.plist  # prevent restart on reboot
+   launchctl list | grep claw                           # verify it's gone
+   ```
+   Note: `launchctl bootout` often fails with I/O errors — use `launchctl remove` instead.
+5. Then restart the Hermes gateway to reclaim the socket connection
+6. OpenClaw is installed via Homebrew (`which openclaw` → `/opt/homebrew/bin/openclaw`), config in `~/.openclaw/`
+7. **`ps | grep claw` false positive** — `grep` matches itself in the process list. If the only match is `grep --color=auto claw`, there is no OpenClaw process running.
+
+## Downloading and Forwarding Slack Files (Images, Documents)
+
+Slack file URLs (`files.slack.com/files-pri/...`) are **private** — they require the bot token to access. They cannot be embedded directly in external services (Linear, GitHub, etc.).
+
+### Pattern: Slack Files → Linear Issues
+When creating Linear issues from Slack threads that contain images:
+
+1. **Fetch thread** via `conversations.replies` to get all messages with `files` arrays
+2. **Download each file** using the bot token for auth:
+```python
+req = urllib.request.Request(file["url_private"], 
+    headers={"Authorization": f"Bearer {TOKEN}"})
+data = urllib.request.urlopen(req).read()
+with open(local_path, "wb") as f:
+    f.write(data)
+```
+3. **Rename files** to remove spaces (breaks CLI tools): `fname.replace(" ", "_")`
+4. **Upload to Linear** via CLI: `linear issue attach ISSUE-ID /path/to/file -t "Title"`
+5. **Get attachment URLs** from `linear issue view ISSUE-ID --json` → `attachments[].url`
+6. **Embed in description** as markdown images: `![description](attachment_url)`
+7. **Update the issue** with `linear issue update ISSUE-ID --description "..."`
+
+### Key Details
+- Slack file objects have: `url_private` (needs auth), `name`, `mimetype`, `filetype`
+- Each Slack message can have multiple files in its `files` array
+- Linear attachments get public URLs (`public.linear.app/...`) after upload
+- `linear issue attach` fails with spaces in filenames — always sanitize first
+- Use `execute_code` for bulk operations to avoid terminal timeouts
+
+## Pitfalls
+1. **`search.messages` is user-token only** — bot tokens get `not_allowed_token_type`. Must iterate channels manually.
+2. **Bot must join channel before reading history** — otherwise get `not_in_channel` error (not a scope issue).
+3. **`conversations.open` for DMs requires `im:write`** — easy to miss, not included in basic bot templates.
+4. **Bot profile (name/image) can't be set via API** — must be configured in Slack App settings under Display Information.
+5. **Rate limits** — Slack Tier 3 methods allow ~50 req/min. Add 200-300ms delays when iterating many channels.
+6. **Large workspaces timeout in terminal** — use `execute_code` instead for bulk operations across 100+ channels.
+7. **Scope changes require app reinstall** — after adding scopes in OAuth & Permissions, must reinstall from "Install App" page (not OAuth page, which may fail with `redirect_uri` error for Socket Mode apps).
+8. **Socket Mode only allows ONE active connection per app token** — if another process (e.g., an old OpenClaw bot) connects with the same `SLACK_APP_TOKEN`, it silently steals the connection. The gateway log will stop showing Slack messages but the process stays alive. Diagnose by checking if `gateway.log` has recent Slack entries. Fix: find and kill the other process, or create a new Slack app with fresh tokens.
+9. **Slack scope picker is virtualized** — the dropdown only renders visible items. Scopes like `channels:history` won't appear until you scroll up or type in the search filter. Always use the search box.
+10. **Check bot scopes via response header** — `curl -sI ... auth.test | grep x-oauth-scopes` is the fastest way to see what scopes are active, rather than checking the Slack app settings page.


### PR DESCRIPTION
## Summary

Adds a comprehensive Slack API skill (`skills/productivity/slack-api/SKILL.md`) covering bot token-based Slack Web API usage.

### What's included

- **Channel operations** — listing, joining, reading history
- **Messaging** — sending to channels, DMs, and group DMs
- **Thread context** — fetching thread replies via `conversations.replies` (critical for gateway bots that only receive the @mention message, not surrounding thread context)
- **File handling** — downloading authenticated Slack files and forwarding to external services (e.g., Linear issues with inline images)
- **User resolution** — mapping user IDs to real names
- **Daily mentions briefing** — reusable cron pattern with a scanner script
- **Bot scope reference** — comprehensive list of recommended OAuth scopes
- **Diagnostics** — Socket Mode hijacking detection (e.g., OpenClaw stealing connections)
- **10 documented pitfalls** from production use

### Motivation

When running Hermes as a Slack gateway bot, several non-obvious issues come up:
1. The gateway adapter passes only the @mention message to the agent — thread context must be fetched via API
2. Slack file URLs are private and require bot token auth to download
3. Socket Mode only allows one connection per app token — competing bots silently steal the connection
4. `search.messages` requires user tokens, not bot tokens — must iterate channels manually
5. Scope changes require app reinstall, and the OAuth page may fail for Socket Mode apps

This skill captures all of these learnings so future Slack gateway users don't have to rediscover them.

### Testing

All patterns in this skill were tested against a live Normal Computing Slack workspace running Hermes v0.7.0 as a gateway bot.