### PR TITLE
[fix] Skip installer post-setup chat handoff on macOS

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2839,6 +2839,11 @@ def run_setup_wizard(args):
 def _offer_launch_chat():
     """Prompt the user to jump straight into chat after setup."""
     print()
+    if os.environ.get("HERMES_SKIP_POST_SETUP_CHAT") == "1":
+        print_info(
+            "Skipping immediate launch into chat for this setup session."
+        )
+        return
     if prompt_yes_no("Launch hermes chat now?", True):
         from hermes_cli.main import cmd_chat
         from types import SimpleNamespace

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -949,10 +949,12 @@ run_setup_wizard() {
 
     # Run hermes setup using the venv Python directly (no activation needed).
     # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
+    # Skip the immediate handoff into chat: prompt_toolkit can fail on macOS
+    # when setup itself was started with stdin redirected from /dev/tty.
     if [ "$USE_VENV" = true ]; then
-        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
+        HERMES_SKIP_POST_SETUP_CHAT=1 "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
     else
-        python -m hermes_cli.main setup < /dev/tty
+        HERMES_SKIP_POST_SETUP_CHAT=1 python -m hermes_cli.main setup < /dev/tty
     fi
 }
 

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -137,3 +137,17 @@ class TestNonInteractiveSetup:
 
         terminal_section.assert_called_once_with(config)
         tts_section.assert_not_called()
+
+    def test_offer_launch_chat_skips_when_installer_requests_it(self, monkeypatch, capsys):
+        """Installer-launched setup should be able to skip the in-process chat handoff."""
+        from hermes_cli import setup as setup_mod
+
+        monkeypatch.setenv("HERMES_SKIP_POST_SETUP_CHAT", "1")
+
+        with patch.object(
+            setup_mod, "prompt_yes_no", side_effect=AssertionError("prompt should not be called")
+        ):
+            setup_mod._offer_launch_chat()
+
+        out = capsys.readouterr().out
+        assert "Skipping immediate launch into chat" in out


### PR DESCRIPTION
Summary
This prevents the installer-driven setup flow from immediately handing off into hermes chat when setup was launched with stdin redirected from /dev/tty.

Why
On macOS, the install script runs setup as:

... -m hermes_cli.main setup < /dev/tty

That setup flow can complete successfully, but the final _offer_launch_chat() handoff then starts the prompt_toolkit chat UI in a context where the input fd is not usable as a normal interactive terminal. The result is the KeyError: '0 is not registered' / OSError: [Errno 22] Invalid argument crash reported in #5884.

What changed
Add an installer-only environment guard in _offer_launch_chat() so setup can skip the in-process chat handoff when requested.
Set that guard from scripts/install.sh when launching the setup wizard via /dev/tty.
Add a regression test covering the skip behavior.
Impact
hermes setup still offers to launch chat in normal interactive use.
The install script no longer crashes at the end of setup on the affected macOS path.
Users can still start Hermes normally after setup by running hermes directly.
Validation
Ran:

PYTHONDONTWRITEBYTECODE=1 PYTHONPYCACHEPREFIX=/tmp/hermes-pycache \
/Users/yulei/.hermes/hermes-agent/venv/bin/pytest -p no:cacheprovider \
/Users/yulei/.hermes/hermes-agent/tests/hermes_cli/test_setup_noninteractive.py \
-k launch_chat
Result: 1 passed