### PR TITLE
fix(hindsight): ignore redacted local-mode secret placeholders

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -80,6 +80,18 @@ def _run_sync(coro, timeout: float = 120.0):
     return future.result(timeout=timeout)
 
 
+def _resolve_secret(config_value: str | None, env_var: str) -> str:
+    """Prefer env secrets when config only contains a redacted placeholder."""
+    candidates = [
+        str(config_value or "").strip(),
+        str(os.environ.get(env_var, "") or "").strip(),
+    ]
+    for candidate in candidates:
+        if candidate and set(candidate) != {"*"}:
+            return candidate
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -254,7 +266,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=self._config.get("llm_provider", ""),
-                    llm_api_key=self._config.get("llmApiKey") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=_resolve_secret(self._config.get("llmApiKey"), "HINDSIGHT_LLM_API_KEY"),
                     llm_model=self._config.get("llm_model", ""),
                 )
             else:
@@ -311,7 +323,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     # If the config changed and the daemon is running, stop it.
                     from pathlib import Path as _Path
                     profile_env = _Path.home() / ".hindsight" / "profiles" / f"{profile}.env"
-                    current_key = self._config.get("llmApiKey") or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+                    current_key = _resolve_secret(self._config.get("llmApiKey"), "HINDSIGHT_LLM_API_KEY")
                     current_provider = self._config.get("llm_provider", "")
                     current_model = self._config.get("llm_model", "")
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1,0 +1,79 @@
+import sys
+import types
+
+from plugins.memory.hindsight import HindsightMemoryProvider
+
+
+class FakeEmbeddedClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._manager = FakeManager()
+        self.started = False
+
+    def _ensure_started(self):
+        self.started = True
+
+
+class InlineThread:
+    def __init__(self, target=None, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        if self._target is not None:
+            self._target()
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+class FakeManager:
+    def is_running(self, profile):
+        return False
+
+    def stop(self, profile):
+        return None
+
+
+def test_initialize_local_uses_real_env_key_when_config_secret_is_placeholder(monkeypatch, tmp_path):
+    fake_hindsight = types.ModuleType("hindsight")
+    fake_hindsight.HindsightEmbedded = FakeEmbeddedClient
+    monkeypatch.setitem(sys.modules, "hindsight", fake_hindsight)
+    fake_daemon_manager = types.ModuleType("hindsight_embed.daemon_embed_manager")
+    fake_daemon_manager.console = None
+    monkeypatch.setitem(sys.modules, "hindsight_embed", types.ModuleType("hindsight_embed"))
+    monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", fake_daemon_manager)
+
+    fake_rich_console = types.ModuleType("rich.console")
+
+    class FakeConsole:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_rich_console.Console = FakeConsole
+    monkeypatch.setitem(sys.modules, "rich", types.ModuleType("rich"))
+    monkeypatch.setitem(sys.modules, "rich.console", fake_rich_console)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HINDSIGHT_LLM_API_KEY", "real-secret")
+    monkeypatch.setattr("plugins.memory.hindsight._load_config", lambda: {
+        "mode": "local",
+        "profile": "demo",
+        "llm_provider": "openai",
+        "llm_model": "gpt-4o-mini",
+        "llmApiKey": "***",
+    })
+    monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path / ".hermes")
+    monkeypatch.setattr("plugins.memory.hindsight.threading.Thread", InlineThread)
+
+    provider = HindsightMemoryProvider()
+    provider.initialize("session-1")
+
+    profile_env = tmp_path / ".hindsight" / "profiles" / "demo.env"
+    contents = profile_env.read_text()
+    assert provider._client.kwargs["llm_api_key"] == "real-secret"
+    assert "HINDSIGHT_API_LLM_API_KEY=real-secret" in contents
+    assert "***" not in contents
+    assert provider._client.started is True


### PR DESCRIPTION
## What does this PR do?

Fixes Hindsight local mode so redacted placeholder secrets like `***` do not override a real `HINDSIGHT_LLM_API_KEY`.

In local mode, the plugin reads `llmApiKey` from Hindsight config and uses it both when constructing `HindsightEmbedded` and when writing the daemon profile env file. If that config contains a redacted placeholder such as `***`, Hermes treats it as a real secret and writes it back into `~/.hindsight/profiles/<profile>.env`.

This change adds a small helper that treats all-asterisk values as redacted placeholders and falls back to `HINDSIGHT_LLM_API_KEY` instead.

## Related Issue

None

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_resolve_secret()` in `plugins/memory/hindsight/__init__.py`
- Used it when creating `HindsightEmbedded` in local mode
- Used it when writing `~/.hindsight/profiles/<profile>.env` for the embedded daemon
- Added a regression test in `tests/plugins/memory/test_hindsight_provider.py`

## How to Test

1. Configure Hindsight local mode with `llmApiKey` set to `***` in config and `HINDSIGHT_LLM_API_KEY` set to a real value in the environment.
2. Initialize the Hindsight provider.
3. Verify that the embedded client receives the real env key and that the generated profile env file contains the real key, not `***`.

Automated regression check:

```bash
uv run --extra dev pytest -q -n 0 tests/plugins/memory/test_hindsight_provider.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

Notes:
- `uvx ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` passes.
- `uv run --extra dev pytest -q -n 0 tests/plugins/memory/test_hindsight_provider.py` passes.
- `pytest tests/ -q` did not pass cleanly in this environment. Without the optional `acp` extra it fails during collection, and with `--extra acp` the suite shows unrelated failures outside this change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression check:

```bash
uv run --extra dev pytest -q -n 0 tests/plugins/memory/test_hindsight_provider.py
.
1 passed, 1 warning in 0.06s
```
