### PR TITLE
fix(tools): register "messaging" toolset so send_message reaches platform sessions

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -85,6 +85,7 @@ CONFIGURABLE_TOOLSETS = [
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
+    ("messaging",       "📨 Cross-platform Messaging", "send_message"),
 ]
 
 # Toolsets that are OFF by default for new installs.


### PR DESCRIPTION
## Summary

- The `send_message` tool lives in the `messaging` toolset, but `messaging` is not listed in `CONFIGURABLE_TOOLSETS` in `hermes_cli/tools_config.py`.
- As a result, the subset-match collapse in `_get_platform_tools()` silently drops `send_message` from matrix/discord/slack/telegram sessions. The tool loads at cold start, then vanishes after the first toolset reconciliation.
- Two-line fix: add the `("messaging", …)` entry so the collapse keeps it. No runtime behavior changes beyond "the tool is now reachable".

Refs #5991.

## Test plan

- [x] Restarted a matrix gateway session and confirmed `send_message` is present in the resolved toolset after reconciliation (previously absent).
- [x] Sent a real cross-room message via `send_message` end-to-end.
- [ ] CI