### PR TITLE
fix: zsh completion script crashes outside completion context

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1043,7 +1043,7 @@ _hermes() {
     esac
 }
 
-_hermes "$@"
+compdef _hermes hermes
 '''
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -688,6 +688,12 @@ class TestCompletion:
         script = generate_zsh_completion()
         assert "_hermes" in script
 
+    def test_zsh_completion_uses_compdef_not_direct_call(self):
+        """Regression test for #6122: _hermes "$@" crashes outside completion context."""
+        script = generate_zsh_completion()
+        assert 'compdef _hermes hermes' in script
+        assert '_hermes "$@"' not in script
+
 
 # ===================================================================
 # TestGetProfilesRoot / TestGetDefaultHermesHome (internal helpers)


### PR DESCRIPTION
## Summary

Fixes #6122 — `eval "$(hermes completion zsh)"` in `~/.zshrc` triggers:

```
_arguments:comparguments:327: can only be called from completion function
```

**Root cause**: The generated script ends with `_hermes "$@"`, which immediately calls `_arguments` at eval time — outside a completion context.

**Fix**: Replace `_hermes "$@"` with `compdef _hermes hermes`, the standard lazy-registration pattern used by `uv`, `kubectl`, `skaffold`, and other tools.

## Changes

- `hermes_cli/profiles.py`: `_hermes "$@"` → `compdef _hermes hermes` in `generate_zsh_completion()`
- `tests/hermes_cli/test_profiles.py`: regression test asserting `compdef _hermes hermes` present and `_hermes "$@"` absent

## Test plan

- [x] Regression test added (`test_zsh_completion_uses_compdef_not_direct_call`)
- [ ] Manual: `eval "$(hermes completion zsh)"` no longer errors on shell startup
- [ ] Manual: `hermes <TAB>` still shows subcommands and `-p` still completes profile names