### PR TITLE
fix(gateway): enumerate Matrix rooms in channel directory

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -73,6 +73,8 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 platforms["discord"] = _build_discord(adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = _build_slack(adapter)
+            elif platform == Platform.MATRIX:
+                platforms["matrix"] = _build_matrix(adapter)
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
@@ -137,6 +139,35 @@ def _build_slack(adapter) -> List[Dict[str, str]]:
 
     # Fallback to session data
     return _build_from_sessions("slack")
+
+
+def _build_matrix(adapter) -> List[Dict[str, str]]:
+    """Enumerate joined Matrix rooms from the nio client."""
+    channels: List[Dict[str, str]] = []
+    client = getattr(adapter, "_client", None)
+    if not client:
+        return _build_from_sessions("matrix")
+    try:
+        rooms = getattr(client, "rooms", {}) or {}
+        for room_id, room in rooms.items():
+            alias = getattr(room, "canonical_alias", None) or ""
+            # Prefer alias localpart (e.g. "ws-researcher" from "#ws-researcher:localhost")
+            # so resolve_channel_name's lstrip("#")+lower path matches caller queries
+            # like "#ws-researcher".
+            if alias:
+                name = alias.lstrip("#").split(":", 1)[0]
+            else:
+                name = getattr(room, "display_name", None) or room_id
+            channels.append({
+                "id": room_id,
+                "name": name,
+                "alias": alias,
+                "type": "room",
+            })
+    except Exception as e:
+        logger.debug("Matrix channel enumeration failed: %s", e)
+    channels.extend(_build_from_sessions("matrix"))
+    return channels
 
 
 def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:


### PR DESCRIPTION
## Summary

- `build_channel_directory()` has no `Platform.MATRIX` branch, so Matrix gateways get a channel directory with zero entries.
- Any caller of `send_message(target=\"matrix:#some-room\")` then fails with `Could not resolve '#some-room' on matrix` — even when the bot is joined to the room.
- Adds a `_build_matrix(adapter)` helper that enumerates joined rooms from `nio.AsyncClient.rooms`, exposing alias localpart as the channel `name` so `resolve_channel_name` matches cleanly whether the caller passes `#ws-researcher`, `ws-researcher`, or the full alias.
- Falls back to `_build_from_sessions(\"matrix\")` during early startup, mirroring the Discord/Slack helpers.

## Test plan

- [x] Verified a Matrix gateway's channel directory populates with all joined rooms on startup.
- [x] `send_message(target=\"matrix:#ws-researcher\")` now resolves and delivers (previously returned \"Could not resolve\").
- [x] Room IDs, aliases, and localpart-style queries all resolve.
- [ ] CI