### PR TITLE
fix(send_message): accept Matrix room IDs and user MXIDs as explicit targets

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -232,6 +232,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return match.group(1), match.group(2), True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
+    # Matrix room IDs (start with !) and user IDs (start with @) are explicit
+    if platform_name == "matrix" and (target_ref.startswith("!") or target_ref.startswith("@")):
+        return target_ref, None, True
     return None, None, False
 
 


### PR DESCRIPTION
## Summary

- `_parse_target_ref` has explicit-reference branches for Telegram, Feishu, and numeric IDs, but none for Matrix.
- Callers of `send_message(target=\"matrix:!roomid:server\")` or `send_message(target=\"matrix:@user:server\")` fall through and the tool errors out — even though a raw Matrix room ID or MXID is the most unambiguous possible target.
- Three-line fix: recognize `!…` as a room ID and `@…` as a user MXID when platform is \`matrix\`. Alias-based targets (`#…`) continue to go through the normal resolve path.

## Test plan

- [x] `send_message(target=\"matrix:!WuHuerZkrItIfKxjPf:localhost\")` now delivers (previously errored).
- [x] `send_message(target=\"matrix:@user:localhost\")` resolves to a DM.
- [x] `send_message(target=\"matrix:#ws-researcher\")` still resolves via the normal alias path.
- [ ] CI