### PR TITLE
fix(nix): export HERMES_HOME system-wide when addToSystemPackages is true

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -464,7 +464,11 @@
       addToSystemPackages = mkOption {
         type = types.bool;
         default = false;
-        description = "Add hermes CLI to environment.systemPackages.";
+        description = ''
+          Add the hermes CLI to environment.systemPackages and export
+          HERMES_HOME system-wide (via environment.variables) so interactive
+          shells share state with the gateway service.
+        '';
       };
 
       # ── OCI Container (opt-in) ──────────────────────────────────────────
@@ -545,8 +549,12 @@
       })
 
       # ── Host CLI ──────────────────────────────────────────────────────
+      # Add the hermes CLI to system PATH and export HERMES_HOME system-wide
+      # so interactive shells share state (sessions, skills, cron) with the
+      # gateway service instead of creating a separate ~/.hermes/.
       (lib.mkIf cfg.addToSystemPackages {
         environment.systemPackages = [ cfg.package ];
+        environment.variables.HERMES_HOME = "${cfg.stateDir}/.hermes";
       })
 
       # ── Directories ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #6044.

`services.hermes-agent.addToSystemPackages` is documented (both in its option description and in the `:::tip addToSystemPackages` block of `website/docs/getting-started/nix-setup.md`) as doing two things:

1. Adding the `hermes` CLI to system PATH
2. Setting `HERMES_HOME` system-wide so interactive shells share state (sessions, skills, cron) with the gateway service

But the module only did #1 — `nix/nixosModules.nix` simply added `cfg.package` to `environment.systemPackages`. With no `HERMES_HOME` exported for interactive shells, running `hermes` from a user shell silently created a separate `~/.hermes/` directory, defeating the entire point of the option.

This is the same mismatch @iacker called out on the issue:

> `nix/nixosModules.nix` only adds `cfg.package` to `environment.systemPackages` when `addToSystemPackages = true`. I do not see a matching export of `HERMES_HOME` for interactive shells.

## Changes

- `nix/nixosModules.nix`: in the `addToSystemPackages` `mkIf` block, also set `environment.variables.HERMES_HOME = "${cfg.stateDir}/.hermes"` so the variable is exported in `/etc/profile` for all interactive shells.
- Updated the `addToSystemPackages` option description to match the actual (now-implemented) behavior.

## Why implement instead of just amending the docs

Either approach closes the issue, but the docs are clearly the intent — the `:::tip` block explains *why* you'd want this (shared state with the gateway). Weakening the docs would force every NixOS user who wants the documented behavior to manually add `environment.variables.HERMES_HOME = ...` themselves. One line in the module gets every user the behavior they expected.

## Test plan

- [ ] `nixos-rebuild switch` on a host with `addToSystemPackages = true`
- [ ] `echo \$HERMES_HOME` in a fresh login shell — should print `/var/lib/hermes/.hermes`
- [ ] `hermes config` from that shell — should read the gateway-managed config