### PR TITLE
fix: respect explicit HERMES_HOME in CLI

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -97,7 +97,12 @@ def _apply_profile_override() -> None:
             consume = 1
             break
 
-    # 2. If no flag, check ~/.hermes/active_profile
+    # 2. If no explicit flag and HERMES_HOME is already set, respect it.
+    explicit_home = os.environ.get("HERMES_HOME", "").strip()
+    if profile_name is None and explicit_home:
+        return
+
+    # 3. Otherwise, if no flag, check ~/.hermes/active_profile
     if profile_name is None:
         try:
             active_path = Path.home() / ".hermes" / "active_profile"
@@ -109,7 +114,7 @@ def _apply_profile_override() -> None:
         except (UnicodeDecodeError, OSError):
             pass  # corrupted file, skip
 
-    # 3. If we found a profile, resolve and set HERMES_HOME
+    # 4. If we found a profile, resolve and set HERMES_HOME
     if profile_name is not None:
         try:
             from hermes_cli.profiles import resolve_profile_env
@@ -634,8 +639,16 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
-    # Import and run the CLI
-    from cli import main as cli_main
+    # Import and run the local CLI module explicitly from the repo source tree.
+    import importlib.util
+    from pathlib import Path
+    cli_path = Path(__file__).resolve().parent.parent / "cli.py"
+    spec = importlib.util.spec_from_file_location("hermes_local_cli", cli_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load local CLI module from {cli_path}")
+    cli_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli_module)
+    cli_main = cli_module.main
     
     # Build kwargs from args
     kwargs = {


### PR DESCRIPTION
This fixes a profile/skills-loading bug in the Hermes CLI launcher.

Problem:
- `hermes chat --skills ...` could fail to find valid skills when `HERMES_HOME` was explicitly set in the environment.
- `hermes_cli.main` was still overriding `HERMES_HOME` from `~/.hermes/active_profile` when no `--profile` flag was passed.
- That made the launcher search the wrong profile's skills directory.

Example failure:
- `HERMES_HOME=/path/to/profile hermes chat --skills openclaw-lane-autopilot ...`
- launcher silently switched to another active profile
- valid skill reported as unknown

Changes:
- If `HERMES_HOME` is already explicitly set and no `--profile` flag is passed, respect that environment value and do not override it from the sticky active-profile file.
- In `cmd_chat`, load the local repo `cli.py` explicitly from the source tree before delegation, so the standard launcher path uses the same local CLI module behavior as direct `cli.py` invocation.

Why this matters:
- fixes skill preloading for profile-scoped workflows
- makes `hermes chat --skills ...` consistent with direct `cli.py --skills ...`
- prevents explicit environment configuration from being unexpectedly ignored
