### PR TITLE
feat: add /spawn for background child sessions from current context

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3455,10 +3455,11 @@ class HermesCLI:
         except Exception:
             pass
 
-        # Create the new session with parent link
+        # Create the new session with parent link and copied transcript
         try:
-            self._session_db.create_session(
-                session_id=new_session_id,
+            self._session_db.clone_session(
+                source_session_id=parent_session_id,
+                new_session_id=new_session_id,
                 source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 model=self.model,
                 model_config={
@@ -3466,31 +3467,12 @@ class HermesCLI:
                     "reasoning_config": self.reasoning_config,
                 },
                 parent_session_id=parent_session_id,
+                title=branch_title,
+                messages=self.conversation_history,
             )
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")
             return
-
-        # Copy conversation history to the new session
-        for msg in self.conversation_history:
-            try:
-                self._session_db.append_message(
-                    session_id=new_session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                    reasoning=msg.get("reasoning"),
-                )
-            except Exception:
-                pass  # Best-effort copy
-
-        # Set title on the branch
-        try:
-            self._session_db.set_session_title(new_session_id, branch_title)
-        except Exception:
-            pass
 
         # Switch to the new session
         self.session_id = new_session_id
@@ -3521,6 +3503,170 @@ class HermesCLI:
         )
         _cprint(f"  Original session: {parent_session_id}")
         _cprint(f"  Branch session:   {new_session_id}")
+
+    def _handle_spawn_command(self, cmd: str):
+        """Handle /spawn <prompt> — run a prompt in a child session clone."""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /spawn <prompt>")
+            _cprint("  Example: /spawn Continue this research in the background")
+            _cprint("  Clones the current session, keeps you here, and runs the prompt in the child.")
+            return
+
+        if not self.conversation_history:
+            _cprint("  No conversation to spawn from — send a message first.")
+            return
+
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start spawn task: no valid credentials.")
+            return
+
+        prompt = parts[1].strip()
+        history_snapshot = list(self.conversation_history)
+        parent_session_id = self.session_id
+        now = datetime.now()
+        new_session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+
+        current_title = self._session_db.get_session_title(parent_session_id)
+        base_title = current_title or "spawn"
+        child_title = self._session_db.get_next_title_in_lineage(base_title)
+
+        try:
+            self._session_db.clone_session(
+                source_session_id=parent_session_id,
+                new_session_id=new_session_id,
+                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                model=None,
+                model_config={
+                    "max_iterations": self.max_turns,
+                    "reasoning_config": self.reasoning_config,
+                },
+                parent_session_id=parent_session_id,
+                title=child_title,
+                messages=history_snapshot,
+            )
+        except Exception as e:
+            _cprint(f"  Failed to create spawn session: {e}")
+            return
+
+        self._background_task_counter += 1
+        task_num = self._background_task_counter
+        task_id = f"spawn_{now.strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        _cprint(f'  🪄 Spawn task #{task_num} started: "{preview}"')
+        _cprint(f"  Task ID:         {task_id}")
+        _cprint(f"  Parent session:  {parent_session_id}")
+        _cprint(f"  Child session:   {new_session_id}")
+        _cprint("  You stay on the current session — results will appear here when done.\n")
+
+        turn_route = self._resolve_turn_agent_config(prompt)
+
+        def run_spawn():
+            try:
+                spawn_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=self.enabled_toolsets,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=new_session_id,
+                    platform="cli",
+                    session_db=self._session_db,
+                    reasoning_config=self.reasoning_config,
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    fallback_model=self._fallback_model,
+                    pass_session_id=False,
+                )
+                spawn_agent._print_fn = lambda *_a, **_kw: None
+
+                def _spawn_thinking(text: str) -> None:
+                    if not self._agent_running:
+                        self._spinner_text = text
+                        if self._app:
+                            self._app.invalidate()
+
+                spawn_agent.thinking_callback = _spawn_thinking
+                result = spawn_agent.run_conversation(
+                    user_message=prompt,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                )
+
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                _cprint(f"  ✅ Spawn task #{task_num} complete")
+                _cprint(f"  Prompt: \"{preview}\"")
+                _cprint(f"  Child session: {new_session_id}")
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _skin = get_active_skin()
+                        label = _skin.get_branding("response_label", "⚕ Hermes")
+                        _resp_color = _skin.get_color("response_border", "#CD7F32")
+                        _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+                    except Exception:
+                        label = "⚕ Hermes"
+                        _resp_color = "#CD7F32"
+                        _resp_text = "#FFF8DC"
+
+                    _chat_console = ChatConsole()
+                    _chat_console.print(Panel(
+                        _rich_text_from_ansi(response),
+                        title=f"[{_resp_color} bold]{label} (spawn #{task_num})[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        style=_resp_text,
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 2),
+                    ))
+                else:
+                    _cprint("  (No response generated)")
+
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+
+            except Exception as e:
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                _cprint(f"  ❌ Spawn task #{task_num} failed: {e}")
+            finally:
+                self._background_tasks.pop(task_id, None)
+                if not self._agent_running:
+                    self._spinner_text = ""
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_spawn, daemon=True, name=f"spawn-task-{task_id}")
+        self._background_tasks[task_id] = thread
+        thread.start()
 
     def reset_conversation(self):
         """Reset the conversation by starting a new session."""
@@ -4428,6 +4574,8 @@ class HermesCLI:
             self.undo_last()
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
+        elif canonical == "spawn":
+            self._handle_spawn_command(cmd_original)
         elif canonical == "save":
             self.save_conversation()
         elif canonical == "cron":

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1119,13 +1119,13 @@ class BasePlatformAdapter(ABC):
                     logger.error("[%s] Approval dispatch failed: %s", self.name, e, exc_info=True)
                 return
 
-            # /status must also bypass the active-session guard so it always
-            # returns a system-generated response instead of being queued as
-            # user text and passed to the agent (#5046).
-            if cmd == "status":
+            # /status and /spawn must also bypass the active-session guard so
+            # they always return a system-generated response instead of being
+            # queued as user text and passed to the agent.
+            if cmd in ("status", "spawn"):
                 logger.debug(
-                    "[%s] Status command bypassing active-session guard for %s",
-                    self.name, session_key,
+                    "[%s] Command '/%s' bypassing active-session guard for %s",
+                    self.name, cmd, session_key,
                 )
                 try:
                     _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
@@ -1138,7 +1138,7 @@ class BasePlatformAdapter(ABC):
                             metadata=_thread_meta,
                         )
                 except Exception as e:
-                    logger.error("[%s] Status dispatch failed: %s", self.name, e, exc_info=True)
+                    logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
                 return
 
             # Special case: photo bursts/albums frequently arrive as multiple near-

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4483,6 +4483,46 @@ class GatewayRunner:
                 exc,
             )
 
+    async def _deliver_spawn_result(
+        self,
+        adapter,
+        source: "SessionSource",
+        content: str,
+        *,
+        metadata: dict | None = None,
+        parent_session_id: str | None = None,
+    ):
+        """Persist a /spawn result to the parent transcript and deliver it with retry."""
+        self._persist_spawn_result_to_parent(parent_session_id, content)
+
+        send_with_retry = getattr(adapter, "_send_with_retry", None)
+        if callable(send_with_retry):
+            result = await send_with_retry(
+                chat_id=source.chat_id,
+                content=content,
+                metadata=metadata,
+            )
+        else:
+            result = await adapter.send(
+                chat_id=source.chat_id,
+                content=content,
+                metadata=metadata,
+            )
+
+        if not getattr(result, "success", True):
+            error_detail = getattr(result, "error", None) or "unknown send failure"
+            logger.error(
+                "Failed to deliver /spawn result for task chat=%s parent=%s: %s",
+                source.chat_id,
+                parent_session_id,
+                error_detail,
+            )
+            self._persist_spawn_result_to_parent(
+                parent_session_id,
+                f"⚠️ Spawn result delivery to chat failed after retry: {error_detail}",
+            )
+        return result
+
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str
     ) -> None:
@@ -4635,11 +4675,12 @@ class GatewayRunner:
             runtime_kwargs = _resolve_runtime_agent_kwargs()
             if not runtime_kwargs.get("api_key"):
                 error_content = f"❌ Spawn task {task_id} failed: no provider credentials configured."
-                self._persist_spawn_result_to_parent(parent_session_id, error_content)
-                await adapter.send(
-                    source.chat_id,
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
                     error_content,
                     metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
                 )
                 return
 
@@ -4701,21 +4742,14 @@ class GatewayRunner:
             if response:
                 media_files, response = adapter.extract_media(response)
                 images, text_content = adapter.extract_images(response)
-                persisted_text = header + (text_content or "(See attached media)")
-                self._persist_spawn_result_to_parent(parent_session_id, persisted_text)
-
-                if text_content:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + text_content,
-                        metadata=_thread_metadata,
-                    )
-                elif not images and not media_files:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + "(No response generated)",
-                        metadata=_thread_metadata,
-                    )
+                delivery_text = header + (text_content or "(See attached media)")
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
+                    delivery_text,
+                    metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
+                )
 
                 for image_url, alt_text in (images or []):
                     try:
@@ -4736,25 +4770,24 @@ class GatewayRunner:
                     except Exception:
                         pass
             else:
-                self._persist_spawn_result_to_parent(
-                    parent_session_id,
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
                     header + "(No response generated)",
-                )
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=header + "(No response generated)",
                     metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
                 )
 
         except Exception as e:
             logger.exception("Spawn task %s failed", task_id)
             try:
                 error_content = f"❌ Spawn task {task_id} failed: {e}"
-                self._persist_spawn_result_to_parent(parent_session_id, error_content)
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=error_content,
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
+                    error_content,
                     metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
                 )
             except Exception:
                 pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1856,9 +1856,13 @@ class GatewayRunner:
         if _quick_key in self._running_agents and _stale_ts:
             _stale_age = time.time() - _stale_ts
             _stale_agent = self._running_agents.get(_quick_key)
-            _stale_idle = float("inf")  # assume idle if we can't check
+            _stale_idle = None
             _stale_detail = ""
-            if _stale_agent and hasattr(_stale_agent, "get_activity_summary"):
+            if (
+                _stale_agent
+                and _stale_agent is not _AGENT_PENDING_SENTINEL
+                and hasattr(_stale_agent, "get_activity_summary")
+            ):
                 try:
                     _sa = _stale_agent.get_activity_summary()
                     _stale_idle = _sa.get("seconds_since_activity", float("inf"))
@@ -1869,12 +1873,14 @@ class GatewayRunner:
                     )
                 except Exception:
                     pass
-            # Evict if: agent is idle beyond timeout, OR wall-clock age is
-            # extreme (10x timeout or 2h, whichever is larger — catches
-            # cases where the agent object was garbage-collected).
+            # Evict if: agent is idle beyond timeout (only when we have a real
+            # activity tracker), OR wall-clock age is extreme (10x timeout or
+            # 2h, whichever is larger — catches leaked entries / dead objects).
+            # Do not treat the pending sentinel as idle=inf; it has no activity
+            # tracker by design and must be allowed to survive normal startup.
             _wall_ttl = max(_raw_stale_timeout * 10, 7200) if _raw_stale_timeout > 0 else float("inf")
             _should_evict = (
-                (_raw_stale_timeout > 0 and _stale_idle >= _raw_stale_timeout)
+                (_raw_stale_timeout > 0 and _stale_idle is not None and _stale_idle >= _raw_stale_timeout)
                 or _stale_age > _wall_ttl
             )
             if _should_evict:
@@ -1966,6 +1972,11 @@ class GatewayRunner:
                 if _cmd_def_inner.name == "approve":
                     return await self._handle_approve_command(event)
                 return await self._handle_deny_command(event)
+
+            # /spawn must bypass the running-agent interrupt path so the child
+            # session can clone the latest in-memory snapshot immediately.
+            if _cmd_def_inner and _cmd_def_inner.name == "spawn":
+                return await self._handle_spawn_command(event)
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
@@ -4397,7 +4408,14 @@ class GatewayRunner:
 
         source = event.source
         current_entry = self.session_store.get_or_create_session(source)
-        history = self.session_store.load_transcript(current_entry.session_id)
+        session_key = self._session_key_for_source(source)
+        running_agent = self._running_agents.get(session_key)
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            history = list(getattr(running_agent, "_session_messages", []) or [])
+        else:
+            history = []
+        if not history:
+            history = self.session_store.load_transcript(current_entry.session_id)
         if not history:
             return "No conversation to spawn from — send a message first."
 
@@ -4422,7 +4440,14 @@ class GatewayRunner:
             return f"Failed to create spawn session: {e}"
 
         _task = asyncio.create_task(
-            self._run_spawn_task(prompt, source, task_id, new_session_id, history)
+            self._run_spawn_task(
+                prompt,
+                source,
+                task_id,
+                new_session_id,
+                history,
+                parent_session_id=current_entry.session_id,
+            )
         )
         self._background_tasks.add(_task)
         _task.add_done_callback(self._background_tasks.discard)
@@ -4435,6 +4460,28 @@ class GatewayRunner:
             f"Child session: {new_session_id}\n"
             "You stay on the current session — results will appear here when done."
         )
+
+    def _persist_spawn_result_to_parent(self, parent_session_id: str | None, content: str) -> None:
+        """Append the final /spawn result to the parent session transcript."""
+        if not parent_session_id or not content:
+            return
+        try:
+            self.session_store.append_to_transcript(
+                parent_session_id,
+                {
+                    "role": "assistant",
+                    "content": content,
+                    "timestamp": datetime.now().isoformat(),
+                    "mirror": True,
+                    "mirror_source": "spawn",
+                },
+            )
+        except Exception as exc:
+            logger.debug(
+                "Failed to persist /spawn result to parent session %s: %s",
+                parent_session_id,
+                exc,
+            )
 
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str
@@ -4572,6 +4619,7 @@ class GatewayRunner:
         task_id: str,
         child_session_id: str,
         history_snapshot: list[dict],
+        parent_session_id: str | None = None,
     ) -> None:
         """Execute a cloned-session background task and deliver the result."""
         from run_agent import AIAgent
@@ -4586,9 +4634,11 @@ class GatewayRunner:
         try:
             runtime_kwargs = _resolve_runtime_agent_kwargs()
             if not runtime_kwargs.get("api_key"):
+                error_content = f"❌ Spawn task {task_id} failed: no provider credentials configured."
+                self._persist_spawn_result_to_parent(parent_session_id, error_content)
                 await adapter.send(
                     source.chat_id,
-                    f"❌ Spawn task {task_id} failed: no provider credentials configured.",
+                    error_content,
                     metadata=_thread_metadata,
                 )
                 return
@@ -4651,6 +4701,8 @@ class GatewayRunner:
             if response:
                 media_files, response = adapter.extract_media(response)
                 images, text_content = adapter.extract_images(response)
+                persisted_text = header + (text_content or "(See attached media)")
+                self._persist_spawn_result_to_parent(parent_session_id, persisted_text)
 
                 if text_content:
                     await adapter.send(
@@ -4684,6 +4736,10 @@ class GatewayRunner:
                     except Exception:
                         pass
             else:
+                self._persist_spawn_result_to_parent(
+                    parent_session_id,
+                    header + "(No response generated)",
+                )
                 await adapter.send(
                     chat_id=source.chat_id,
                     content=header + "(No response generated)",
@@ -4693,9 +4749,11 @@ class GatewayRunner:
         except Exception as e:
             logger.exception("Spawn task %s failed", task_id)
             try:
+                error_content = f"❌ Spawn task {task_id} failed: {e}"
+                self._persist_spawn_result_to_parent(parent_session_id, error_content)
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f"❌ Spawn task {task_id} failed: {e}",
+                    content=error_content,
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2127,6 +2127,9 @@ class GatewayRunner:
         if canonical == "branch":
             return await self._handle_branch_command(event)
 
+        if canonical == "spawn":
+            return await self._handle_spawn_command(event)
+
         if canonical == "rollback":
             return await self._handle_rollback_command(event)
 
@@ -4379,6 +4382,60 @@ class GatewayRunner:
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
         return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting — results will appear when done.'
 
+    async def _handle_spawn_command(self, event: MessageEvent) -> str:
+        """Handle /spawn <prompt> — clone the current session and run a child task."""
+        prompt = event.get_command_args().strip()
+        if not prompt:
+            return (
+                "Usage: /spawn <prompt>\n"
+                "Example: /spawn Continue this research in the background\n\n"
+                "Clones the current session, keeps you here, and runs the prompt in the child session."
+            )
+
+        if not self._session_db:
+            return "Session database not available."
+
+        source = event.source
+        current_entry = self.session_store.get_or_create_session(source)
+        history = self.session_store.load_transcript(current_entry.session_id)
+        if not history:
+            return "No conversation to spawn from — send a message first."
+
+        now = datetime.now()
+        task_id = f"spawn_{now.strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        new_session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{os.urandom(3).hex()}"
+        current_title = self._session_db.get_session_title(current_entry.session_id)
+        child_title = self._session_db.get_next_title_in_lineage(current_title or "spawn")
+
+        try:
+            self._session_db.clone_session(
+                source_session_id=current_entry.session_id,
+                new_session_id=new_session_id,
+                source=source.platform.value if source.platform else "gateway",
+                model=None,
+                parent_session_id=current_entry.session_id,
+                title=child_title,
+                messages=history,
+            )
+        except Exception as e:
+            logger.error("Failed to create spawn session: %s", e)
+            return f"Failed to create spawn session: {e}"
+
+        _task = asyncio.create_task(
+            self._run_spawn_task(prompt, source, task_id, new_session_id, history)
+        )
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        return (
+            f'🪄 Spawn task started: "{preview}"\n'
+            f"Task ID: {task_id}\n"
+            f"Parent session: {current_entry.session_id}\n"
+            f"Child session: {new_session_id}\n"
+            "You stay on the current session — results will appear here when done."
+        )
+
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str
     ) -> None:
@@ -4503,6 +4560,142 @@ class GatewayRunner:
                 await adapter.send(
                     chat_id=source.chat_id,
                     content=f"❌ Background task {task_id} failed: {e}",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
+
+    async def _run_spawn_task(
+        self,
+        prompt: str,
+        source: "SessionSource",
+        task_id: str,
+        child_session_id: str,
+        history_snapshot: list[dict],
+    ) -> None:
+        """Execute a cloned-session background task and deliver the result."""
+        from run_agent import AIAgent
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            logger.warning("No adapter for platform %s in spawn task %s", source.platform, task_id)
+            return
+
+        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+
+        try:
+            runtime_kwargs = _resolve_runtime_agent_kwargs()
+            if not runtime_kwargs.get("api_key"):
+                await adapter.send(
+                    source.chat_id,
+                    f"❌ Spawn task {task_id} failed: no provider credentials configured.",
+                    metadata=_thread_metadata,
+                )
+                return
+
+            user_config = _load_gateway_config()
+            model = _resolve_gateway_model(user_config)
+            platform_key = _platform_config_key(source.platform)
+
+            from hermes_cli.tools_config import _get_platform_tools
+            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+
+            pr = self._provider_routing
+            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            reasoning_config = self._load_reasoning_config()
+            self._reasoning_config = reasoning_config
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+
+            def run_sync():
+                agent = AIAgent(
+                    model=turn_route["model"],
+                    **turn_route["runtime"],
+                    max_iterations=max_iterations,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    enabled_toolsets=enabled_toolsets,
+                    reasoning_config=reasoning_config,
+                    providers_allowed=pr.get("only"),
+                    providers_ignored=pr.get("ignore"),
+                    providers_order=pr.get("order"),
+                    provider_sort=pr.get("sort"),
+                    provider_require_parameters=pr.get("require_parameters", False),
+                    provider_data_collection=pr.get("data_collection"),
+                    session_id=child_session_id,
+                    platform=platform_key,
+                    session_db=self._session_db,
+                    fallback_model=self._fallback_model,
+                    pass_session_id=False,
+                )
+
+                return agent.run_conversation(
+                    user_message=prompt,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                )
+
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(None, run_sync)
+
+            response = result.get("final_response", "") if result else ""
+            if not response and result and result.get("error"):
+                response = f"Error: {result['error']}"
+
+            preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+            header = (
+                f'✅ Spawn task complete\n'
+                f'Prompt: "{preview}"\n'
+                f'Child session: {child_session_id}\n\n'
+            )
+
+            if response:
+                media_files, response = adapter.extract_media(response)
+                images, text_content = adapter.extract_images(response)
+
+                if text_content:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=header + text_content,
+                        metadata=_thread_metadata,
+                    )
+                elif not images and not media_files:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=header + "(No response generated)",
+                        metadata=_thread_metadata,
+                    )
+
+                for image_url, alt_text in (images or []):
+                    try:
+                        await adapter.send_image(
+                            chat_id=source.chat_id,
+                            image_url=image_url,
+                            caption=alt_text,
+                        )
+                    except Exception:
+                        pass
+
+                for media_path in (media_files or []):
+                    try:
+                        await adapter.send_document(
+                            chat_id=source.chat_id,
+                            file_path=media_path,
+                        )
+                    except Exception:
+                        pass
+            else:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=header + "(No response generated)",
+                    metadata=_thread_metadata,
+                )
+
+        except Exception as e:
+            logger.exception("Spawn task %s failed", task_id)
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"❌ Spawn task {task_id} failed: {e}",
                     metadata=_thread_metadata,
                 )
             except Exception:
@@ -5056,38 +5249,20 @@ class GatewayRunner:
 
         parent_session_id = current_entry.session_id
 
-        # Create the new session with parent link
+        # Create the new session with parent link and copied transcript
         try:
-            self._session_db.create_session(
-                session_id=new_session_id,
+            self._session_db.clone_session(
+                source_session_id=parent_session_id,
+                new_session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 parent_session_id=parent_session_id,
+                title=branch_title,
+                messages=history,
             )
         except Exception as e:
             logger.error("Failed to create branch session: %s", e)
             return f"Failed to create branch: {e}"
-
-        # Copy conversation history to the new session
-        for msg in history:
-            try:
-                self._session_db.append_message(
-                    session_id=new_session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                    reasoning=msg.get("reasoning"),
-                )
-            except Exception:
-                pass  # Best-effort copy
-
-        # Set title
-        try:
-            self._session_db.set_session_title(new_session_id, branch_title)
-        except Exception:
-            pass
 
         # Switch the session store entry to the new session
         new_entry = self.session_store.switch_session(session_key, new_session_id)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -59,6 +59,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",
                aliases=("fork",), args_hint="[name]"),
+    CommandDef("spawn", "Spawn a background child session from the current context", "Session",
+               args_hint="<prompt>"),
     CommandDef("compress", "Manually compress conversation context", "Session"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -24,7 +24,7 @@ import threading
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -382,6 +382,68 @@ class SessionDB:
             )
         self._execute_write(_do)
         return session_id
+
+    def clone_session(
+        self,
+        source_session_id: str,
+        new_session_id: str,
+        *,
+        source: str,
+        title: str | None = None,
+        model: str = None,
+        model_config: Dict[str, Any] = None,
+        system_prompt: str = None,
+        user_id: str = None,
+        parent_session_id: str | None = None,
+        messages: Iterable[Dict[str, Any]] | None = None,
+    ) -> str:
+        """Clone a session's transcript into a new child session.
+
+        Creates the child session record, copies the provided messages (or loads
+        them from ``source_session_id`` when omitted), preserves the parent
+        linkage, and optionally sets a title. It does not end or switch the
+        source session.
+        """
+        parent_id = parent_session_id or source_session_id
+        self.create_session(
+            session_id=new_session_id,
+            source=source,
+            model=model,
+            model_config=model_config,
+            system_prompt=system_prompt,
+            user_id=user_id,
+            parent_session_id=parent_id,
+        )
+
+        source_messages = (
+            list(messages)
+            if messages is not None
+            else self.get_messages_as_conversation(source_session_id)
+        )
+        for msg in source_messages:
+            try:
+                self.append_message(
+                    session_id=new_session_id,
+                    role=msg.get("role", "user"),
+                    content=msg.get("content"),
+                    tool_name=msg.get("tool_name") or msg.get("name"),
+                    tool_calls=msg.get("tool_calls"),
+                    tool_call_id=msg.get("tool_call_id"),
+                    finish_reason=msg.get("finish_reason"),
+                    reasoning=msg.get("reasoning"),
+                    reasoning_details=msg.get("reasoning_details"),
+                    codex_reasoning_items=msg.get("codex_reasoning_items"),
+                )
+            except Exception:
+                pass  # Best-effort copy
+
+        if title:
+            try:
+                self.set_session_title(new_session_id, title)
+            except Exception:
+                pass
+
+        return new_session_id
 
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended."""

--- a/tests/gateway/test_branch_command.py
+++ b/tests/gateway/test_branch_command.py
@@ -1,0 +1,98 @@
+"""Tests for gateway /branch command regression coverage."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    os.environ["HERMES_HOME"] = str(tmp_path / ".hermes")
+    os.makedirs(tmp_path / ".hermes", exist_ok=True)
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / ".hermes" / "test_sessions.db")
+    yield db
+    db.close()
+
+
+def _make_event(text="/branch", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(session_db):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = session_db
+    runner._running_agents = {}
+    runner.config = {"model": {"default": "anthropic/claude-sonnet-4.6"}}
+
+    current_session_id = "20260408_091500_parent"
+    session_db.create_session(
+        session_id=current_session_id,
+        source="telegram",
+        model="anthropic/claude-sonnet-4.6",
+    )
+    session_db.set_session_title(current_session_id, "Gateway Session")
+
+    history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+        {"role": "user", "content": "Explore option B"},
+        {"role": "assistant", "content": "Sure"},
+    ]
+    for msg in history:
+        session_db.append_message(
+            session_id=current_session_id,
+            role=msg["role"],
+            content=msg["content"],
+        )
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = SimpleNamespace(session_id=current_session_id)
+    mock_store.load_transcript.return_value = history
+    mock_store.switch_session.side_effect = lambda session_key, target_session_id: SimpleNamespace(session_id=target_session_id)
+    runner.session_store = mock_store
+    runner._session_key_for_source = MagicMock(return_value="telegram:67890")
+    runner._evict_cached_agent = MagicMock()
+    return runner, current_session_id, history
+
+
+def _find_child_sessions(session_db, parent_session_id):
+    cursor = session_db._conn.execute(
+        "SELECT id FROM sessions WHERE parent_session_id = ? ORDER BY started_at",
+        (parent_session_id,),
+    )
+    return [row["id"] for row in cursor.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_gateway_branch_clones_history_and_switches_session(session_db):
+    runner, parent_id, history = _make_runner(session_db)
+
+    event = _make_event(text="/branch branch idea")
+    result = await runner._handle_branch_command(event)
+
+    child_sessions = _find_child_sessions(session_db, parent_id)
+    assert len(child_sessions) == 1
+    child_id = child_sessions[0]
+    assert len(session_db.get_messages_as_conversation(child_id)) == len(history)
+    assert session_db.get_session(child_id)["parent_session_id"] == parent_id
+    runner.session_store.switch_session.assert_called_once_with("telegram:67890", child_id)
+    runner._evict_cached_agent.assert_called_once_with("telegram:67890")
+    assert "Branched to **branch idea**" in result
+    assert parent_id in result
+    assert child_id in result

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -36,11 +36,14 @@ def _make_runner():
     )
     runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
     runner._running_agents = {}
+    runner._running_agents_ts = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._voice_mode = {}
     runner._background_tasks = set()
     runner._is_user_authorized = lambda _source: True
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
     return runner
 
 

--- a/tests/gateway/test_spawn_command.py
+++ b/tests/gateway/test_spawn_command.py
@@ -1,0 +1,180 @@
+"""Tests for /spawn gateway slash command."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    os.environ["HERMES_HOME"] = str(tmp_path / ".hermes")
+    os.makedirs(tmp_path / ".hermes", exist_ok=True)
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / ".hermes" / "test_sessions.db")
+    yield db
+    db.close()
+
+
+def _make_event(text="/spawn", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(session_db):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = session_db
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    runner.config = {"model": {"default": "anthropic/claude-sonnet-4.6"}}
+
+    current_session_id = "20260408_090000_parent"
+    session_db.create_session(
+        session_id=current_session_id,
+        source="telegram",
+        model="anthropic/claude-sonnet-4.6",
+    )
+    session_db.set_session_title(current_session_id, "Main Session")
+
+    history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+        {"role": "user", "content": "Investigate the bug"},
+        {"role": "assistant", "content": "On it"},
+    ]
+    for msg in history:
+        session_db.append_message(
+            session_id=current_session_id,
+            role=msg["role"],
+            content=msg["content"],
+        )
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = SimpleNamespace(session_id=current_session_id)
+    mock_store.load_transcript.return_value = history
+    runner.session_store = mock_store
+
+    from gateway.hooks import HookRegistry
+
+    runner.hooks = HookRegistry()
+    return runner, current_session_id, history
+
+
+def _find_child_sessions(session_db, parent_session_id):
+    cursor = session_db._conn.execute(
+        "SELECT id FROM sessions WHERE parent_session_id = ? ORDER BY started_at",
+        (parent_session_id,),
+    )
+    return [row["id"] for row in cursor.fetchall()]
+
+
+class TestHandleSpawnCommand:
+    @pytest.mark.asyncio
+    async def test_no_prompt_shows_usage(self, session_db):
+        runner, _, _ = _make_runner(session_db)
+        event = _make_event(text="/spawn")
+        result = await runner._handle_spawn_command(event)
+        assert "Usage:" in result
+        assert "/spawn" in result
+
+    @pytest.mark.asyncio
+    async def test_spawn_clones_child_session_without_switching(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            created_tasks.append(mock_task)
+            return mock_task
+
+        with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            event = _make_event(text="/spawn Continue in the background")
+            result = await runner._handle_spawn_command(event)
+
+        child_sessions = _find_child_sessions(session_db, parent_id)
+        assert len(child_sessions) == 1
+        child_id = child_sessions[0]
+        child = session_db.get_session(child_id)
+        assert child["parent_session_id"] == parent_id
+        assert len(session_db.get_messages_as_conversation(child_id)) == len(history)
+        runner.session_store.switch_session.assert_not_called()
+        assert "Spawn task started" in result
+        assert parent_id in result
+        assert child_id in result
+        assert len(created_tasks) == 1
+
+
+class TestRunSpawnTask:
+    @pytest.mark.asyncio
+    async def test_spawn_task_uses_child_session_and_disables_pass_session_id(self, session_db):
+        runner, _, history = _make_runner(session_db)
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "Spawned result", "messages": []}
+            MockAgent.return_value = mock_agent
+
+            await runner._run_spawn_task(
+                prompt="continue",
+                source=source,
+                task_id="spawn_test",
+                child_session_id="20260408_090001_child",
+                history_snapshot=history,
+            )
+
+        kwargs = MockAgent.call_args.kwargs
+        assert kwargs["session_id"] == "20260408_090001_child"
+        assert kwargs["pass_session_id"] is False
+        mock_agent.run_conversation.assert_called_once_with(
+            user_message="continue",
+            conversation_history=history,
+            task_id="spawn_test",
+        )
+        sent_content = mock_adapter.send.call_args.kwargs["content"]
+        assert "Spawn task complete" in sent_content
+        assert "20260408_090001_child" in sent_content
+
+
+class TestSpawnCommandRegistration:
+    def test_spawn_is_known_gateway_command(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+
+        assert "spawn" in GATEWAY_KNOWN_COMMANDS
+
+    def test_spawn_in_cli_commands(self):
+        from hermes_cli.commands import COMMANDS
+
+        assert "/spawn" in COMMANDS

--- a/tests/gateway/test_spawn_command.py
+++ b/tests/gateway/test_spawn_command.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource, build_session_key
 
 
@@ -235,7 +235,8 @@ class TestRunSpawnTask:
     async def test_spawn_task_uses_child_session_and_disables_pass_session_id(self, session_db):
         runner, _, history = _make_runner(session_db)
         mock_adapter = AsyncMock()
-        mock_adapter.send = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True))
         mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
         mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
@@ -269,7 +270,7 @@ class TestRunSpawnTask:
             conversation_history=history,
             task_id="spawn_test",
         )
-        sent_content = mock_adapter.send.call_args.kwargs["content"]
+        sent_content = mock_adapter._send_with_retry.call_args.kwargs["content"]
         assert "Spawn task complete" in sent_content
         assert "20260408_090001_child" in sent_content
 
@@ -278,7 +279,8 @@ class TestRunSpawnTask:
         runner, parent_id, history = _make_runner(session_db)
         runner.session_store.append_to_transcript = MagicMock()
         mock_adapter = AsyncMock()
-        mock_adapter.send = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True))
         mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
         mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
@@ -310,6 +312,45 @@ class TestRunSpawnTask:
         assert args[0] == parent_id
         assert "Spawn task complete" in args[1]["content"]
         assert "Spawned result" in args[1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_spawn_task_sends_text_callback_even_when_response_is_media_only(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+        runner.session_store.append_to_transcript = MagicMock()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter.send_document = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter.extract_media = MagicMock(return_value=([("/tmp/result.txt", False)], ""))
+        mock_adapter.extract_images = MagicMock(return_value=([], ""))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "MEDIA:/tmp/result.txt", "messages": []}
+            MockAgent.return_value = mock_agent
+
+            await runner._run_spawn_task(
+                prompt="continue",
+                source=source,
+                task_id="spawn_test",
+                child_session_id="20260408_090001_child",
+                history_snapshot=history,
+                parent_session_id=parent_id,
+            )
+
+        sent_content = mock_adapter._send_with_retry.call_args.kwargs["content"]
+        assert "Spawn task complete" in sent_content
+        assert "(See attached media)" in sent_content
+        mock_adapter.send_document.assert_awaited_once()
 
 
 class TestSpawnCommandRegistration:

--- a/tests/gateway/test_spawn_command.py
+++ b/tests/gateway/test_spawn_command.py
@@ -1,14 +1,15 @@
 """Tests for /spawn gateway slash command."""
 
+import asyncio
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
-from gateway.session import SessionSource
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
 
 
 @pytest.fixture
@@ -43,8 +44,12 @@ def _make_runner(session_db):
     runner._provider_routing = {}
     runner._fallback_model = None
     runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
     runner._background_tasks = set()
     runner.config = {"model": {"default": "anthropic/claude-sonnet-4.6"}}
+    runner._session_key_for_source = MagicMock(side_effect=build_session_key)
+    runner._is_user_authorized = MagicMock(return_value=True)
 
     current_session_id = "20260408_090000_parent"
     session_db.create_session(
@@ -123,6 +128,107 @@ class TestHandleSpawnCommand:
         assert child_id in result
         assert len(created_tasks) == 1
 
+    @pytest.mark.asyncio
+    async def test_spawn_prefers_running_agent_snapshot_over_transcript(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+
+        running_history = history + [
+            {"role": "user", "content": "Latest in-memory prompt"},
+            {"role": "assistant", "content": "Latest in-memory answer"},
+        ]
+        session_key = build_session_key(_make_event().source)
+        runner._running_agents[session_key] = SimpleNamespace(_session_messages=running_history)
+        runner.session_store.load_transcript.return_value = history
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            return mock_task
+
+        with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            event = _make_event(text="/spawn Continue in the background")
+            result = await runner._handle_spawn_command(event)
+
+        child_sessions = _find_child_sessions(session_db, parent_id)
+        assert len(child_sessions) == 1
+        child_id = child_sessions[0]
+        assert session_db.get_messages_as_conversation(child_id) == running_history
+        runner.session_store.load_transcript.assert_not_called()
+        assert child_id in result
+
+    @pytest.mark.asyncio
+    async def test_spawn_bypasses_running_agent_guard(self, session_db):
+        runner, _, _ = _make_runner(session_db)
+        event = _make_event(text="/spawn Continue in the background")
+        session_key = build_session_key(event.source)
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+        runner.adapters[Platform.TELEGRAM] = SimpleNamespace(
+            _pending_messages={},
+            get_pending_message=MagicMock(return_value=None),
+        )
+        runner._handle_spawn_command = AsyncMock(return_value="spawn handled")
+
+        result = await runner._handle_message(event)
+
+        assert result == "spawn handled"
+        runner._handle_spawn_command.assert_awaited_once_with(event)
+        running_agent.interrupt.assert_not_called()
+        assert runner.adapters[Platform.TELEGRAM]._pending_messages == {}
+
+    @pytest.mark.asyncio
+    async def test_spawn_bypasses_adapter_active_session_guard(self):
+        source = _make_event().source
+        session_key = build_session_key(source)
+        handler_called_with = []
+
+        async def fake_handler(event):
+            handler_called_with.append(event)
+            return "spawn handled"
+
+        class _ConcreteAdapter(BasePlatformAdapter):
+            platform = Platform.TELEGRAM
+
+            async def connect(self):
+                return None
+
+            async def disconnect(self):
+                return None
+
+            async def send(self, chat_id, content, **kwargs):
+                return None
+
+            async def get_chat_info(self, chat_id):
+                return {}
+
+        adapter = _ConcreteAdapter(
+            PlatformConfig(enabled=True, token="***"),
+            Platform.TELEGRAM,
+        )
+        adapter.set_message_handler(fake_handler)
+
+        sent = []
+
+        async def fake_send_with_retry(chat_id, content, reply_to=None, metadata=None):
+            sent.append(content)
+
+        adapter._send_with_retry = fake_send_with_retry
+        interrupt_event = asyncio.Event()
+        adapter._active_sessions[session_key] = interrupt_event
+
+        event = MessageEvent(
+            text="/spawn Continue in the background",
+            source=source,
+            message_id="m1",
+            message_type=MessageType.COMMAND,
+        )
+        await adapter.handle_message(event)
+
+        assert handler_called_with == [event]
+        assert sent == ["spawn handled"]
+        assert not interrupt_event.is_set()
+        assert session_key not in adapter._pending_messages
+
 
 class TestRunSpawnTask:
     @pytest.mark.asyncio
@@ -166,6 +272,44 @@ class TestRunSpawnTask:
         sent_content = mock_adapter.send.call_args.kwargs["content"]
         assert "Spawn task complete" in sent_content
         assert "20260408_090001_child" in sent_content
+
+    @pytest.mark.asyncio
+    async def test_spawn_task_persists_result_to_parent_session_context(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+        runner.session_store.append_to_transcript = MagicMock()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "Spawned result", "messages": []}
+            MockAgent.return_value = mock_agent
+
+            await runner._run_spawn_task(
+                prompt="continue",
+                source=source,
+                task_id="spawn_test",
+                child_session_id="20260408_090001_child",
+                history_snapshot=history,
+                parent_session_id=parent_id,
+            )
+
+        runner.session_store.append_to_transcript.assert_called_once()
+        args = runner.session_store.append_to_transcript.call_args.args
+        assert args[0] == parent_id
+        assert "Spawn task complete" in args[1]["content"]
+        assert "Spawned result" in args[1]["content"]
 
 
 class TestSpawnCommandRegistration:

--- a/tests/test_branch_command.py
+++ b/tests/test_branch_command.py
@@ -176,8 +176,98 @@ class TestBranchCommandCLI:
         assert result.name == "branch"
 
 
+def _find_child_sessions(session_db, parent_session_id):
+    cursor = session_db._conn.execute(
+        "SELECT id FROM sessions WHERE parent_session_id = ? ORDER BY started_at",
+        (parent_session_id,),
+    )
+    return [row["id"] for row in cursor.fetchall()]
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, daemon=None, name=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self.daemon = daemon
+        self.name = name
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+class TestSpawnCommandCLI:
+    """Test the /spawn command logic for the CLI."""
+
+    def _configure_spawn_cli(self, cli_instance):
+        cli_instance._background_task_counter = 0
+        cli_instance._background_tasks = {}
+        cli_instance.enabled_toolsets = ["terminal", "file"]
+        cli_instance._providers_only = None
+        cli_instance._providers_ignore = None
+        cli_instance._providers_order = None
+        cli_instance._provider_sort = None
+        cli_instance._provider_require_params = False
+        cli_instance._provider_data_collection = None
+        cli_instance._fallback_model = None
+        cli_instance._agent_running = False
+        cli_instance._spinner_text = ""
+        cli_instance._app = None
+        cli_instance.bell_on_complete = False
+        cli_instance._ensure_runtime_credentials = MagicMock(return_value=True)
+        cli_instance._resolve_turn_agent_config = MagicMock(
+            return_value={"model": cli_instance.model, "runtime": {}}
+        )
+
+    def test_spawn_creates_child_session_without_switching(self, cli_instance, session_db):
+        from cli import HermesCLI
+
+        self._configure_spawn_cli(cli_instance)
+        original_id = cli_instance.session_id
+
+        with patch("cli.threading.Thread", _ImmediateThread), \
+             patch("cli.AIAgent") as MockAgent, \
+             patch("cli.ChatConsole") as MockChatConsole:
+            MockAgent.return_value.run_conversation.return_value = {"final_response": ""}
+            MockChatConsole.return_value.print = MagicMock()
+            HermesCLI._handle_spawn_command(cli_instance, "/spawn Continue in the background")
+
+        child_sessions = _find_child_sessions(session_db, original_id)
+        assert len(child_sessions) == 1
+        child_id = child_sessions[0]
+        assert cli_instance.session_id == original_id
+        assert child_id != original_id
+        assert session_db.get_session(original_id)["end_reason"] is None
+        assert session_db.get_session(child_id)["parent_session_id"] == original_id
+        assert len(session_db.get_messages_as_conversation(child_id)) == 4
+
+    def test_spawn_runs_child_with_pass_session_id_disabled(self, cli_instance, session_db):
+        from cli import HermesCLI
+
+        self._configure_spawn_cli(cli_instance)
+        original_id = cli_instance.session_id
+
+        with patch("cli.threading.Thread", _ImmediateThread), \
+             patch("cli.AIAgent") as MockAgent, \
+             patch("cli.ChatConsole") as MockChatConsole:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": ""}
+            MockAgent.return_value = mock_agent
+            MockChatConsole.return_value.print = MagicMock()
+
+            HermesCLI._handle_spawn_command(cli_instance, "/spawn Continue in the background")
+
+        child_id = _find_child_sessions(session_db, original_id)[0]
+        kwargs = MockAgent.call_args.kwargs
+        assert kwargs["session_id"] == child_id
+        assert kwargs["pass_session_id"] is False
+        mock_agent.run_conversation.assert_called_once()
+        assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == cli_instance.conversation_history
+
+
 class TestBranchCommandDef:
-    """Test the CommandDef registration for /branch."""
+    """Test the CommandDef registration for /branch and /spawn."""
 
     def test_branch_in_registry(self):
         """The branch command should be in the command registry."""
@@ -196,3 +286,13 @@ class TestBranchCommandDef:
         from hermes_cli.commands import COMMAND_REGISTRY
         branch = next(c for c in COMMAND_REGISTRY if c.name == "branch")
         assert branch.category == "Session"
+
+    def test_spawn_in_registry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        names = [c.name for c in COMMAND_REGISTRY]
+        assert "spawn" in names
+
+    def test_spawn_in_session_category(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        spawn = next(c for c in COMMAND_REGISTRY if c.name == "spawn")
+        assert spawn.category == "Session"


### PR DESCRIPTION
## Summary
- add `/spawn <prompt>` as a background child-session command cloned from the current context
- make `/spawn` bypass active-session guards so it can fork from the current conversation immediately
- make spawned-result delivery more durable by mirroring the final result back into the parent transcript and retrying chat delivery when possible
- add regression coverage for `/spawn`, plus branch/background distinction coverage

## Why `/spawn` is needed
Hermes already had two related but different workflows:

- `/background` runs a detached async task in a separate session
- `/branch` clones the current session, but switches the user into that new branch immediately

What was missing was the third workflow:
- preserve the current conversation state like `/branch`
- run asynchronously like `/background`
- keep the user on the current session instead of switching away

That matters for real tasks such as:
- "continue this investigation in the background"
- "take the current context and explore one branch of it"
- "use everything we've discussed so far, but don't interrupt this chat"

Without `/spawn`, users have to choose between losing context (`/background`) and leaving the current session (`/branch`).

## Semantics and distinction from existing commands
### `/background`
`/background` is for detached async work:
- starts a separate background session
- does not clone the current session transcript into a child lineage
- returns results to the same chat, but is conceptually "run this separately"

### `/branch`
`/branch` is for interactive divergence:
- clones the current session
- switches the active session to the new branch immediately
- from that point on, the user is talking inside the branched session

### `/spawn`
`/spawn` is for delegated divergence from current context:
- clones the current session into a child session
- records parent/child lineage
- runs the follow-up prompt in the child session in the background
- keeps the user on the parent session
- delivers the result back to the same chat and mirrors it into the parent transcript

In short:
- `/background` = async detached task
- `/branch` = switch me into a cloned branch
- `/spawn` = clone current context into a child session, run it in the background, and keep me here

## `/spawn` behavior
When a user runs `/spawn <prompt>`, Hermes:
1. resolves the current session
2. snapshots the current context
   - if an agent is actively running, it prefers the latest in-memory session messages
   - otherwise it falls back to the persisted transcript
3. clones that snapshot into a child session
4. links the child to the parent via `parent_session_id`
5. starts a background task that runs the prompt inside the child session
6. keeps the user on the parent session
7. sends the child result back to the same chat when complete
8. mirrors the final result into the parent transcript for durable session history

## Why the guard bypass is intentional
`/spawn` is a session-control command, not ordinary user content.

If it were treated like a normal follow-up while a session is busy, it could:
- be queued behind the current run
- interrupt the current run
- miss the latest in-memory context snapshot
- stop being a reliable "fork from here now" operation

For that reason, `/spawn` intentionally bypasses the running-agent interrupt path and the adapter active-session guard, similar to other control-plane commands.

## Durability changes
This series also hardens result delivery for spawned tasks:
- spawned work runs with its own child `session_id`
- final delivery uses adapter retry when available
- the result is mirrored into the parent transcript even if live chat delivery later fails
- media-only results still emit a text completion callback so the parent session has a durable completion record

## Test plan
Focused tests run locally:

```bash
./.venv/bin/python -m pytest tests/gateway/test_spawn_command.py tests/gateway/test_session_race_guard.py tests/gateway/test_branch_command.py tests/cli/test_branch_command.py -q
```

Result:
- 38 passed
