### PR TITLE
Fix Windows gateway process discovery when WMIC is unavailable

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -28,6 +28,104 @@ from hermes_cli.colors import Colors, color
 # Process Management (for manual gateway runs)
 # =============================================================================
 
+_GATEWAY_PROCESS_PATTERNS = (
+    "hermes_cli.main gateway",
+    "hermes_cli/main.py gateway",
+    "hermes gateway",
+    "gateway/run.py",
+)
+
+_WINDOWS_PROCESS_QUERY_COMMANDS = (
+    ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
+    [
+        "powershell",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        (
+            "Get-CimInstance Win32_Process | ForEach-Object { "
+            "if ($_.CommandLine) { "
+            "Write-Output ('CommandLine=' + $_.CommandLine); "
+            "Write-Output ('ProcessId=' + $_.ProcessId); "
+            "Write-Output '' "
+            "} }"
+        ),
+    ],
+    [
+        "pwsh",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        (
+            "Get-CimInstance Win32_Process | ForEach-Object { "
+            "if ($_.CommandLine) { "
+            "Write-Output ('CommandLine=' + $_.CommandLine); "
+            "Write-Output ('ProcessId=' + $_.ProcessId); "
+            "Write-Output '' "
+            "} }"
+        ),
+    ],
+)
+
+
+def _parse_windows_gateway_pids(output: str, *, exclude_pids: set[int] | None = None) -> list[int]:
+    """Parse Windows process-list output and return matching gateway PIDs."""
+    pids: list[int] = []
+    excluded = exclude_pids or set()
+    current_cmd = ""
+
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if line.startswith("CommandLine="):
+            current_cmd = line[len("CommandLine="):]
+            continue
+        if not line.startswith("ProcessId="):
+            continue
+
+        pid_str = line[len("ProcessId="):]
+        if not any(pattern in current_cmd for pattern in _GATEWAY_PROCESS_PATTERNS):
+            current_cmd = ""
+            continue
+
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            current_cmd = ""
+            continue
+
+        if pid != os.getpid() and pid not in excluded and pid not in pids:
+            pids.append(pid)
+        current_cmd = ""
+
+    return pids
+
+
+def _find_gateway_pids_windows(exclude_pids: set[int] | None = None) -> list[int]:
+    """Find gateway PIDs on Windows, falling back when WMIC is unavailable."""
+    for command in _WINDOWS_PROCESS_QUERY_COMMANDS:
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        except Exception:
+            continue
+
+        if result.returncode != 0:
+            continue
+
+        return _parse_windows_gateway_pids(
+            result.stdout,
+            exclude_pids=exclude_pids,
+        )
+
+    return []
+
+
 def _get_service_pids() -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
@@ -100,36 +198,10 @@ def find_gateway_pids(exclude_pids: set | None = None) -> list:
     """
     pids = []
     _exclude = exclude_pids or set()
-    patterns = [
-        "hermes_cli.main gateway",
-        "hermes_cli/main.py gateway",
-        "hermes gateway",
-        "gateway/run.py",
-    ]
 
     try:
         if is_windows():
-            # Windows: use wmic to search command lines
-            result = subprocess.run(
-                ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
-                capture_output=True, text=True, timeout=10
-            )
-            # Parse WMIC LIST output: blocks of "CommandLine=...\nProcessId=...\n"
-            current_cmd = ""
-            for line in result.stdout.split('\n'):
-                line = line.strip()
-                if line.startswith("CommandLine="):
-                    current_cmd = line[len("CommandLine="):]
-                elif line.startswith("ProcessId="):
-                    pid_str = line[len("ProcessId="):]
-                    if any(p in current_cmd for p in patterns):
-                        try:
-                            pid = int(pid_str)
-                            if pid != os.getpid() and pid not in pids and pid not in _exclude:
-                                pids.append(pid)
-                        except ValueError:
-                            pass
-                    current_cmd = ""
+            return _find_gateway_pids_windows(exclude_pids=_exclude)
         else:
             result = subprocess.run(
                 ["ps", "aux"],
@@ -141,7 +213,7 @@ def find_gateway_pids(exclude_pids: set | None = None) -> list:
                 # Skip grep and current process
                 if 'grep' in line or str(os.getpid()) in line:
                     continue
-                for pattern in patterns:
+                for pattern in _GATEWAY_PROCESS_PATTERNS:
                     if pattern in line:
                         parts = line.split()
                         if len(parts) > 1:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -252,3 +252,60 @@ class TestWaitForGatewayExit:
 
         # Should not raise — ProcessLookupError means it's already gone.
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=2.0)
+
+
+class TestFindGatewayPidsWindows:
+    def test_falls_back_to_powershell_when_wmic_missing(self, monkeypatch):
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway.os, "getpid", lambda: 999)
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[0] == "wmic":
+                raise FileNotFoundError
+            assert cmd[0] == "powershell"
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python gateway/run.py\n"
+                    "ProcessId=123\n\n"
+                    "CommandLine=python -m hermes_cli.main gateway\n"
+                    "ProcessId=456\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+        assert gateway.find_gateway_pids() == [123, 456]
+        assert calls[0][0] == "wmic"
+        assert calls[1][0] == "powershell"
+
+    def test_windows_fallback_skips_excluded_current_and_non_matching_pids(self, monkeypatch):
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway.os, "getpid", lambda: 456)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "wmic":
+                return SimpleNamespace(returncode=1, stdout="", stderr="wmic unavailable")
+            assert cmd[0] == "powershell"
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python gateway/run.py\n"
+                    "ProcessId=123\n\n"
+                    "CommandLine=python gateway/run.py\n"
+                    "ProcessId=456\n\n"
+                    "CommandLine=python gateway/run.py\n"
+                    "ProcessId=789\n\n"
+                    "CommandLine=python unrelated.py\n"
+                    "ProcessId=321\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+        assert gateway.find_gateway_pids(exclude_pids={789}) == [123]


### PR DESCRIPTION
## Summary

This fixes a Windows compatibility bug in `hermes_cli.gateway.find_gateway_pids()`.

On newer Windows installations, `wmic` is often unavailable. When that happened, Hermes silently returned no gateway PIDs, which meant stop/restart flows could miss already-running manual gateway processes.

## What changed

- kept the existing `wmic` path for backward compatibility
- added a Windows fallback that queries `Win32_Process` via PowerShell/CIM when `wmic` is missing or fails
- reused the same command-line pattern matching so behavior stays consistent with the existing implementation
- added regression tests covering:
  - fallback to PowerShell when `wmic` is unavailable
  - filtering of excluded PIDs, the current process, and unrelated processes

## Why this change

This is a small, focused cross-platform fix with direct user impact:
- improves reliability of `hermes gateway stop` / restart flows on modern Windows
- preserves existing behavior on systems where `wmic` still exists
- avoids a larger refactor by only touching the Windows process-discovery path

## How it was tested

Added targeted tests in `tests/hermes_cli/test_gateway.py` for:
- `wmic` missing -> PowerShell fallback returns matching gateway PIDs
- fallback output parsing respects `exclude_pids` and ignores non-gateway processes

## Platforms considered

- Windows: primary affected platform; now supports both legacy `wmic` and modern PowerShell/CIM discovery
- Linux/macOS: unchanged code path
