### PR TITLE
fix(profile): prevent recursive clone-all copies

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -418,8 +418,21 @@ def create_profile(
             )
 
     if clone_all and source_dir:
-        # Full copy of source profile
-        shutil.copytree(source_dir, profile_dir)
+        # Full copy of source profile.
+        # Guard against recursive self-copy when cloning from the default profile
+        # (~/.hermes) into a named profile (~/.hermes/profiles/<name>), because the
+        # destination lives inside the source tree. Exclude the nested profiles dir
+        # from the copy to preserve profile isolation and avoid infinite recursion.
+        copy_ignore = None
+        try:
+            source_resolved = source_dir.resolve()
+            dest_resolved = profile_dir.resolve(strict=False)
+            if source_resolved in dest_resolved.parents:
+                copy_ignore = shutil.ignore_patterns("profiles")
+        except Exception:
+            copy_ignore = None
+
+        shutil.copytree(source_dir, profile_dir, ignore=copy_ignore)
         # Strip runtime files
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -171,6 +171,19 @@ class TestCreateProfile:
         assert not (profile_dir / "gateway_state.json").exists()
         assert not (profile_dir / "processes.json").exists()
 
+    def test_clone_all_from_default_does_not_recursively_copy_profiles_dir(self, profile_env):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        nested_existing = default_home / "profiles" / "existing"
+        nested_existing.mkdir(parents=True, exist_ok=True)
+        (nested_existing / "config.yaml").write_text("model: stale")
+        (default_home / "config.yaml").write_text("model: gpt-4")
+
+        profile_dir = create_profile("coder", clone_all=True, no_alias=True)
+
+        assert (profile_dir / "config.yaml").read_text() == "model: gpt-4"
+        assert not (profile_dir / "profiles").exists()
+
     def test_clone_config_missing_files_skipped(self, profile_env):
         """Clone config gracefully skips files that don't exist in source."""
         profile_dir = create_profile("coder", clone_config=True, no_alias=True)


### PR DESCRIPTION
## Summary
- prevent `hermes profile create --clone-all` from recursively copying the `profiles/` directory when cloning from the default profile
- detect when the destination lives inside the source tree and exclude nested profiles from the copy
- add a regression test covering clone-all from the default `~/.hermes` profile

## Testing
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_profiles.py -q`

Closes #4306
