### PR TITLE
fix(gateway): preserve speaker attribution in shared room sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -232,6 +232,7 @@ from gateway.session import (
     build_session_context,
     build_session_context_prompt,
     build_session_key,
+    _hash_sender_id,
 )
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
@@ -246,6 +247,44 @@ def _normalize_whatsapp_identifier(value: str) -> str:
         .split(":", 1)[0]
         .split("@", 1)[0]
     )
+
+
+def _prefix_shared_session_sender(
+    message_text: str,
+    source: SessionSource,
+    *,
+    group_sessions_per_user: bool,
+    thread_sessions_per_user: bool,
+) -> str:
+    """Prefix shared-session messages with stable sender attribution."""
+    is_shared_session = (
+        source.chat_type != "dm"
+        and (
+            (
+                source.thread_id
+                and not thread_sessions_per_user
+            )
+            or (
+                not source.thread_id
+                and not group_sessions_per_user
+            )
+        )
+    )
+    if not is_shared_session:
+        return message_text
+
+    sender_id = source.user_id_alt or source.user_id
+    sender_parts = []
+    if source.user_name:
+        sender_parts.append(source.user_name)
+    if sender_id:
+        hashed_sender_id = _hash_sender_id(str(sender_id))
+        if hashed_sender_id not in sender_parts:
+            sender_parts.append(hashed_sender_id)
+    if not sender_parts:
+        return message_text
+
+    return f"[{' | '.join(sender_parts)}] {message_text}"
 
 
 def _expand_whatsapp_auth_aliases(identifier: str) -> set:
@@ -2716,20 +2755,19 @@ class GatewayRunner:
         message_text = event.text or ""
 
         # -----------------------------------------------------------------
-        # Sender attribution for shared thread sessions.
+        # Sender attribution for shared sessions.
         #
-        # When multiple users share a single thread session (the default for
-        # threads), prefix each message with [sender name] so the agent can
-        # tell participants apart.  Skip for DMs (single-user by nature) and
-        # when per-user thread isolation is explicitly enabled.
+        # When multiple users share a single room/thread session, prefix each
+        # message with [sender name | sender id] so the agent can tell
+        # participants apart across the retained transcript. Skip for DMs
+        # (single-user by nature) and when per-user isolation is enabled.
         # -----------------------------------------------------------------
-        _is_shared_thread = (
-            source.chat_type != "dm"
-            and source.thread_id
-            and not getattr(self.config, "thread_sessions_per_user", False)
+        message_text = _prefix_shared_session_sender(
+            message_text,
+            source,
+            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
+            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
         )
-        if _is_shared_thread and source.user_name:
-            message_text = f"[{source.user_name}] {message_text}"
 
         if event.media_urls:
             image_paths = []

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -174,6 +174,8 @@ class SessionContext:
     session_id: str = ""
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    shared_session: bool = False
+    shared_session_kind: Optional[str] = None
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -255,19 +257,16 @@ def build_session_context_prompt(
         lines.append(f"**Channel Topic:** {context.source.chat_topic}")
 
     # User identity.
-    # In shared thread sessions (non-DM with thread_id), multiple users
-    # contribute to the same conversation.  Don't pin a single user name
-    # in the system prompt — it changes per-turn and would bust the prompt
-    # cache.  Instead, note that this is a multi-user thread; individual
-    # sender names are prefixed on each user message by the gateway.
-    _is_shared_thread = (
-        context.source.chat_type != "dm"
-        and context.source.thread_id
-    )
-    if _is_shared_thread:
+    # In shared sessions, multiple users contribute to the same conversation.
+    # Don't pin a single user name in the system prompt — it changes per-turn
+    # and would bust the prompt cache. Instead, note that this is a shared
+    # session; individual sender names/IDs are prefixed on each user message
+    # by the gateway.
+    if context.shared_session:
+        session_kind = "Multi-user thread" if context.shared_session_kind == "thread" else "Shared room"
         lines.append(
-            "**Session type:** Multi-user thread — messages are prefixed "
-            "with [sender name]. Multiple users may participate."
+            f"**Session type:** {session_kind} — messages are prefixed "
+            "with [sender name | sender id]. Multiple users may participate."
         )
     elif context.source.user_name:
         lines.append(f"**User:** {context.source.user_name}")
@@ -1071,6 +1070,13 @@ def build_session_context(
         connected_platforms=connected,
         home_channels=home_channels,
     )
+    if source.chat_type != "dm":
+        if source.thread_id and not getattr(config, "thread_sessions_per_user", False):
+            context.shared_session = True
+            context.shared_session_kind = "thread"
+        elif not source.thread_id and not getattr(config, "group_sessions_per_user", True):
+            context.shared_session = True
+            context.shared_session_kind = "room"
     
     if session_entry:
         context.session_key = session_entry.session_key

--- a/tests/gateway/test_run_shared_sender_prefix.py
+++ b/tests/gateway/test_run_shared_sender_prefix.py
@@ -1,0 +1,98 @@
+from gateway.config import Platform
+from gateway.run import _prefix_shared_session_sender
+from gateway.session import SessionSource, _hash_sender_id
+
+
+def test_shared_non_thread_group_prefixes_name_and_hashed_id():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="guild:channel",
+        chat_type="group",
+        user_id="1234567890",
+        user_name="Alice",
+    )
+
+    result = _prefix_shared_session_sender(
+        "hello",
+        source,
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+
+    assert result == f"[Alice | {_hash_sender_id('1234567890')}] hello"
+
+
+def test_shared_thread_prefixes_name_and_hashed_id():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="guild:channel",
+        chat_type="group",
+        thread_id="thread-1",
+        user_id="thread-user",
+        user_name="Bob",
+    )
+
+    result = _prefix_shared_session_sender(
+        "reply",
+        source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+
+    assert result == f"[Bob | {_hash_sender_id('thread-user')}] reply"
+
+
+def test_non_shared_group_is_unchanged():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="guild:channel",
+        chat_type="group",
+        user_id="1234567890",
+        user_name="Alice",
+    )
+
+    result = _prefix_shared_session_sender(
+        "hello",
+        source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+
+    assert result == "hello"
+
+
+def test_dm_is_unchanged():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="dm-1",
+        chat_type="dm",
+        user_id="1234567890",
+        user_name="Alice",
+    )
+
+    result = _prefix_shared_session_sender(
+        "hello",
+        source,
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+
+    assert result == "hello"
+
+
+def test_name_only_shared_message_skips_missing_id():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="guild:channel",
+        chat_type="group",
+        user_name="Alice",
+    )
+
+    result = _prefix_shared_session_sender(
+        "hello",
+        source,
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+
+    assert result == "[Alice] hello"

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -310,7 +310,7 @@ class TestBuildSessionContextPrompt:
         prompt = build_session_context_prompt(ctx)
 
         assert "Multi-user thread" in prompt
-        assert "[sender name]" in prompt
+        assert "[sender name | sender id]" in prompt
         # Should NOT show a specific **User:** line (would bust cache)
         assert "**User:** Alice" not in prompt
 
@@ -333,6 +333,29 @@ class TestBuildSessionContextPrompt:
 
         assert "**User:** Alice" in prompt
         assert "Multi-user thread" not in prompt
+
+    def test_shared_non_thread_group_hides_user_line(self):
+        """Shared non-thread group sessions should avoid pinning one user."""
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake"),
+            },
+            group_sessions_per_user=False,
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1002285219667",
+            chat_name="Test Group",
+            chat_type="group",
+            user_id="12345",
+            user_name="Alice",
+        )
+        ctx = build_session_context(source, config)
+        prompt = build_session_context_prompt(ctx)
+
+        assert "Shared room" in prompt
+        assert "[sender name | sender id]" in prompt
+        assert "**User:** Alice" not in prompt
 
     def test_dm_thread_shows_user_not_multi(self):
         """DM threads are single-user and should show User, not multi-user note."""


### PR DESCRIPTION
## What does this PR do?

This fixes speaker attribution in shared gateway sessions.

Hermes already prefixes sender names in shared thread sessions, but shared non-thread rooms created with `group_sessions_per_user: false` did not preserve per-message speaker identity in the retained transcript. That made multi-user shared rooms much more ambiguous than shared threads.

This patch extends shared-session speaker attribution to non-thread rooms, keeps the session prompt aligned with that behavior, and avoids leaking raw sender IDs by hashing them before they are included in message text.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added shared-session sender prefixing for non-thread rooms in `gateway/run.py`
- Kept shared-thread attribution behavior aligned with the same formatting path
- Hashed sender IDs before including them in message text instead of exposing raw platform IDs
- Extended `gateway/session.py` so shared non-thread rooms are described as shared sessions in the dynamic session prompt
- Added regression coverage in `tests/gateway/test_session.py`
- Added direct attribution tests in `tests/gateway/test_run_shared_sender_prefix.py`

## How to Test

1. Run:
   `python -m pytest -o addopts= tests/gateway/test_run_shared_sender_prefix.py tests/gateway/test_session.py -q`
2. Configure a gateway room with `group_sessions_per_user: false`
3. Send messages from multiple participants in the same non-thread room and confirm the shared-session transcript preserves speaker attribution
4. Repeat in a shared thread and confirm existing shared-thread behavior still works
5. Verify sender IDs are rendered as hashed identifiers instead of raw platform IDs

## Tested on

- Windows 11 host
- Linux Docker container
- Manual Discord verification in shared non-thread and shared thread rooms