### PR TITLE
fix(gateway): suppress "(empty)" visible replies on chat surfaces

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -74,6 +74,19 @@ def _safe_url_for_log(url: str, max_len: int = 80) -> str:
     return f"{safe[:max_len - 3]}..."
 
 
+def _is_silent_response(response: Optional[str]) -> bool:
+    """Return True when a handler result should not be sent to the user.
+
+    Hermes core can surface a reasoning-only completion as the literal string
+    ``"(empty)"``. Treat that sentinel the same as a true empty/None response
+    at the messaging boundary so it behaves like "no reply".
+    """
+    if response is None:
+        return True
+    normalized = str(response).strip()
+    return not normalized or normalized == "(empty)"
+
+
 # ---------------------------------------------------------------------------
 # Image cache utilities
 #
@@ -1227,12 +1240,14 @@ class BasePlatformAdapter(ABC):
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
             
-            # Send response if any.  A None/empty response is normal when
-            # streaming already delivered the text (already_sent=True) or
-            # when the message was queued behind an active agent.  Log at
-            # DEBUG to avoid noisy warnings for expected behavior.
-            if not response:
+            # Send response if any. A None/empty response is normal when
+            # streaming already delivered the text (already_sent=True), when
+            # the message was queued behind an active agent, or when the core
+            # completed with the "(empty)" sentinel for "no visible reply".
+            # Log at DEBUG to avoid noisy warnings for expected behavior.
+            if _is_silent_response(response):
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+                response = None
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,6 +1,7 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
 import os
+import pytest
 from unittest.mock import patch
 
 from gateway.platforms.base import (
@@ -8,8 +9,11 @@ from gateway.platforms.base import (
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     MessageType,
+    SendResult,
     _safe_url_for_log,
 )
+from gateway.session import SessionSource
+from gateway.config import Platform, PlatformConfig
 
 
 class TestSecretCaptureGuidance:
@@ -448,3 +452,80 @@ class TestGetHumanDelay:
         with patch.dict(os.environ, env):
             delay = BasePlatformAdapter._get_human_delay()
             assert 0.1 <= delay <= 0.2
+
+
+class _SilentResponseAdapter(BasePlatformAdapter):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent_messages.append(content)
+        return SendResult(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+class TestSilentResponseSuppression:
+    def _adapter(self):
+        adapter = _SilentResponseAdapter(
+            config=PlatformConfig(enabled=True, token="test"),
+            platform=Platform.DISCORD,
+        )
+        adapter.sent_messages = []
+        return adapter
+
+    def _event(self, text="hello"):
+        return MessageEvent(
+            text=text,
+            source=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="chat-1",
+                chat_type="channel",
+                user_id="user-1",
+                user_name="sd",
+            ),
+            message_id="msg-1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_sentinel_is_not_sent(self):
+        adapter = self._adapter()
+
+        async def handler(_event):
+            return "(empty)"
+
+        adapter.set_message_handler(handler)
+
+        await adapter._process_message_background(self._event(), "chat-1")
+
+        assert adapter.sent_messages == []
+
+    @pytest.mark.asyncio
+    async def test_whitespace_wrapped_empty_sentinel_is_not_sent(self):
+        adapter = self._adapter()
+
+        async def handler(_event):
+            return "  (empty) \n"
+
+        adapter.set_message_handler(handler)
+
+        await adapter._process_message_background(self._event(), "chat-1")
+
+        assert adapter.sent_messages == []
+
+    @pytest.mark.asyncio
+    async def test_regular_response_still_sends(self):
+        adapter = self._adapter()
+
+        async def handler(_event):
+            return "hello back"
+
+        adapter.set_message_handler(handler)
+
+        await adapter._process_message_background(self._event(), "chat-1")
+
+        assert adapter.sent_messages == ["hello back"]


### PR DESCRIPTION
## What does this PR do?

This prevents Hermes from sending the literal string `"(empty)"` to messaging platforms when a reasoning-only completion produces no visible user-facing text.

Core Hermes intentionally stores reasoning-only completions with `content = "(empty)"` so providers and session history keep a non-empty assistant message. That behavior is useful internally, but it leaks a confusing placeholder into Discord and other chat surfaces.

This patch keeps the core/session-history behavior unchanged and only suppresses `"(empty)"` at the messaging boundary, making it behave like "no reply" for platform delivery.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added `_is_silent_response(...)` in `gateway/platforms/base.py`
- Treat `"(empty)"` the same as `None`/empty at the platform delivery boundary
- Kept core `run_agent.py` behavior unchanged, preserving the semantics introduced by #5278
- Added regression tests in `tests/gateway/test_platform_base.py` for:
  - exact `"(empty)"`
  - whitespace-wrapped `"(empty)"`
  - normal visible responses still sending normally

## How to Test

1. Run:
   `python -m pytest -o addopts= tests/gateway/test_platform_base.py -q`
2. Trigger a reasoning-only completion that would otherwise surface `"(empty)"`
3. Confirm no visible chat message is sent
4. Confirm regular non-empty replies still send normally

## Tested on

- Windows 11 host
- Linux Docker container
- Manual Discord verification that reasoning-only completions no longer surface `"(empty)"`