### PR TITLE
feat(matrix): add LLM-callable Matrix tools with sync-to-async bridge

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -349,6 +349,15 @@ PLATFORM_HINTS = {
         "only — no markdown, no formatting. SMS messages are limited to ~1600 "
         "characters, so be brief and direct."
     ),
+    "matrix": (
+        "You are connected via Matrix, a decentralized encrypted messaging protocol. "
+        "You have Matrix-specific tools available: matrix_send_reaction (react with emoji), "
+        "matrix_redact_message (delete messages), matrix_create_room (create new rooms), "
+        "matrix_invite_user (invite users to rooms), matrix_fetch_history (read room history), "
+        "and matrix_set_presence (set your online status). "
+        "Messages support full HTML formatting via org.matrix.custom.html. "
+        "Use markdown naturally — it will be converted to proper HTML."
+    ),
 }
 
 CONTEXT_FILE_MAX_CHARS = 20_000

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -387,12 +387,28 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Start the sync loop.
         self._sync_task = asyncio.create_task(self._sync_loop())
+
+        # Wire Matrix tools adapter reference so LLM-callable tools can
+        # reach the adapter's async methods from sync handlers.
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(self)
+        except ImportError:
+            pass
+
         self._mark_connected()
         return True
 
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
         self._closing = True
+
+        # Clear Matrix tools adapter reference.
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(None)
+        except ImportError:
+            pass
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()

--- a/model_tools.py
+++ b/model_tools.py
@@ -158,6 +158,7 @@ def _discover_tools():
         "tools.send_message_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
+        "tools.matrix_tools",
     ]
     import importlib
     for mod_name in _modules:

--- a/tests/gateway/test_matrix_tools.py
+++ b/tests/gateway/test_matrix_tools.py
@@ -1,0 +1,395 @@
+"""Tests for Matrix LLM-callable tools (tools/matrix_tools.py).
+
+Covers all 6 tool handlers, input validation, adapter availability checks,
+toolset registration, and platform hint configuration.
+"""
+
+import asyncio
+import json
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ===========================================================================
+# Tool handler tests
+# ===========================================================================
+
+class TestMatrixToolsSendReaction:
+    """Tests for the matrix_send_reaction tool handler."""
+
+    def setup_method(self):
+        from tools.matrix_tools import set_matrix_adapter, _handle_send_reaction
+        self.handler = _handle_send_reaction
+        self.adapter = MagicMock()
+        self.adapter._send_reaction = AsyncMock(return_value=True)
+        self.adapter._loop = asyncio.new_event_loop()
+        set_matrix_adapter(self.adapter)
+
+    def teardown_method(self):
+        from tools.matrix_tools import set_matrix_adapter
+        set_matrix_adapter(None)
+        if hasattr(self, "adapter") and hasattr(self.adapter, "_loop"):
+            self.adapter._loop.close()
+
+    def test_valid_reaction(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "$evt123",
+            "emoji": "👍",
+        }))
+        assert result["success"] is True
+
+    def test_missing_room_id(self):
+        result = json.loads(self.handler({
+            "room_id": "",
+            "event_id": "$evt123",
+            "emoji": "👍",
+        }))
+        assert "error" in result
+
+    def test_invalid_room_id_prefix(self):
+        result = json.loads(self.handler({
+            "room_id": "bad_room",
+            "event_id": "$evt123",
+            "emoji": "👍",
+        }))
+        assert "error" in result
+        assert "!" in result["error"]
+
+    def test_missing_event_id(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "",
+            "emoji": "👍",
+        }))
+        assert "error" in result
+
+    def test_invalid_event_id_prefix(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "not_an_event",
+            "emoji": "👍",
+        }))
+        assert "error" in result
+
+    def test_missing_emoji(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "$evt123",
+            "emoji": "",
+        }))
+        assert "error" in result
+
+    def test_emoji_too_long(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "$evt123",
+            "emoji": "x" * 33,
+        }))
+        assert "error" in result
+
+    def test_adapter_error_handled(self):
+        self.adapter._send_reaction = AsyncMock(side_effect=RuntimeError("network"))
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "$evt123",
+            "emoji": "👍",
+        }))
+        assert "error" in result
+
+
+class TestMatrixToolsRedactMessage:
+    def setup_method(self):
+        from tools.matrix_tools import set_matrix_adapter, _handle_redact_message
+        self.handler = _handle_redact_message
+        self.adapter = MagicMock()
+        self.adapter.redact_message = AsyncMock(return_value=True)
+        self.adapter._loop = asyncio.new_event_loop()
+        set_matrix_adapter(self.adapter)
+
+    def teardown_method(self):
+        from tools.matrix_tools import set_matrix_adapter
+        set_matrix_adapter(None)
+        if hasattr(self, "adapter") and hasattr(self.adapter, "_loop"):
+            self.adapter._loop.close()
+
+    def test_valid_redact(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "$evt123",
+        }))
+        assert result["success"] is True
+
+    def test_with_reason(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "$evt123",
+            "reason": "spam",
+        }))
+        assert result["success"] is True
+
+    def test_long_reason_truncated(self):
+        self.handler({
+            "room_id": "!room:example.org",
+            "event_id": "$evt123",
+            "reason": "x" * 600,
+        })
+        call_args = self.adapter.redact_message.call_args
+        assert len(call_args.kwargs.get("reason", "")) <= 500
+
+
+class TestMatrixToolsCreateRoom:
+    def setup_method(self):
+        from tools.matrix_tools import set_matrix_adapter, _handle_create_room
+        self.handler = _handle_create_room
+        self.adapter = MagicMock()
+        self.adapter.create_room = AsyncMock(return_value="!new:example.org")
+        self.adapter._loop = asyncio.new_event_loop()
+        set_matrix_adapter(self.adapter)
+
+    def teardown_method(self):
+        from tools.matrix_tools import set_matrix_adapter
+        set_matrix_adapter(None)
+        if hasattr(self, "adapter") and hasattr(self.adapter, "_loop"):
+            self.adapter._loop.close()
+
+    def test_create_private_room(self):
+        result = json.loads(self.handler({
+            "name": "Test Room",
+            "preset": "private_chat",
+        }))
+        assert result["success"] is True
+        assert result["room_id"] == "!new:example.org"
+
+    def test_invalid_preset(self):
+        result = json.loads(self.handler({
+            "name": "Test",
+            "preset": "bad_preset",
+        }))
+        assert "error" in result
+
+    @patch.dict("os.environ", {"MATRIX_ALLOW_PUBLIC_ROOMS": "false"})
+    def test_public_room_blocked_by_default(self):
+        result = json.loads(self.handler({
+            "name": "Public",
+            "preset": "public_chat",
+        }))
+        assert "error" in result
+        assert "disabled" in result["error"].lower()
+
+    @patch.dict("os.environ", {"MATRIX_ALLOW_PUBLIC_ROOMS": "true"})
+    def test_public_room_allowed_with_env(self):
+        result = json.loads(self.handler({
+            "name": "Public",
+            "preset": "public_chat",
+        }))
+        assert result["success"] is True
+
+    def test_invalid_invite_list_entry(self):
+        result = json.loads(self.handler({
+            "invite": ["not_a_user"],
+        }))
+        assert "error" in result
+
+    def test_valid_invite_list(self):
+        result = json.loads(self.handler({
+            "invite": ["@user:example.org"],
+        }))
+        assert result["success"] is True
+
+    def test_room_creation_failure(self):
+        self.adapter.create_room = AsyncMock(return_value=None)
+        result = json.loads(self.handler({"name": "fail"}))
+        assert result["success"] is False
+
+
+class TestMatrixToolsInviteUser:
+    def setup_method(self):
+        from tools.matrix_tools import set_matrix_adapter, _handle_invite_user
+        self.handler = _handle_invite_user
+        self.adapter = MagicMock()
+        self.adapter.invite_user = AsyncMock(return_value=True)
+        self.adapter._loop = asyncio.new_event_loop()
+        set_matrix_adapter(self.adapter)
+
+    def teardown_method(self):
+        from tools.matrix_tools import set_matrix_adapter
+        set_matrix_adapter(None)
+        if hasattr(self, "adapter") and hasattr(self.adapter, "_loop"):
+            self.adapter._loop.close()
+
+    def test_valid_invite(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "user_id": "@user:example.org",
+        }))
+        assert result["success"] is True
+
+    def test_invalid_user_id(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "user_id": "bad_user",
+        }))
+        assert "error" in result
+
+    def test_missing_room_id(self):
+        result = json.loads(self.handler({
+            "room_id": "",
+            "user_id": "@user:example.org",
+        }))
+        assert "error" in result
+
+
+class TestMatrixToolsFetchHistory:
+    def setup_method(self):
+        from tools.matrix_tools import set_matrix_adapter, _handle_fetch_history
+        self.handler = _handle_fetch_history
+        self.adapter = MagicMock()
+        self.adapter.fetch_room_history = AsyncMock(return_value=[
+            {"sender": "@alice:ex.org", "body": "hello", "timestamp": 12345},
+        ])
+        self.adapter._loop = asyncio.new_event_loop()
+        set_matrix_adapter(self.adapter)
+
+    def teardown_method(self):
+        from tools.matrix_tools import set_matrix_adapter
+        set_matrix_adapter(None)
+        if hasattr(self, "adapter") and hasattr(self.adapter, "_loop"):
+            self.adapter._loop.close()
+
+    def test_fetch_history(self):
+        result = json.loads(self.handler({
+            "room_id": "!room:example.org",
+            "limit": 10,
+        }))
+        assert result["count"] == 1
+        assert len(result["messages"]) == 1
+
+    def test_limit_clamped_to_200(self):
+        self.handler({"room_id": "!room:example.org", "limit": 500})
+        call_args = self.adapter.fetch_room_history.call_args
+        assert call_args.kwargs.get("limit", 200) <= 200
+
+    def test_negative_limit_defaults(self):
+        self.handler({"room_id": "!room:example.org", "limit": -1})
+        call_args = self.adapter.fetch_room_history.call_args
+        assert call_args.kwargs.get("limit", 50) == 50
+
+
+class TestMatrixToolsSetPresence:
+    def setup_method(self):
+        from tools.matrix_tools import set_matrix_adapter, _handle_set_presence
+        self.handler = _handle_set_presence
+        self.adapter = MagicMock()
+        self.adapter.set_presence = AsyncMock(return_value=True)
+        self.adapter._loop = asyncio.new_event_loop()
+        set_matrix_adapter(self.adapter)
+
+    def teardown_method(self):
+        from tools.matrix_tools import set_matrix_adapter
+        set_matrix_adapter(None)
+        if hasattr(self, "adapter") and hasattr(self.adapter, "_loop"):
+            self.adapter._loop.close()
+
+    def test_set_online(self):
+        result = json.loads(self.handler({"state": "online"}))
+        assert result["success"] is True
+
+    def test_set_offline(self):
+        result = json.loads(self.handler({"state": "offline"}))
+        assert result["success"] is True
+
+    def test_set_unavailable(self):
+        result = json.loads(self.handler({"state": "unavailable"}))
+        assert result["success"] is True
+
+    def test_invalid_state(self):
+        result = json.loads(self.handler({"state": "busy"}))
+        assert "error" in result
+
+    def test_status_msg_truncated(self):
+        self.handler({"state": "online", "status_msg": "x" * 300})
+        call_args = self.adapter.set_presence.call_args
+        assert len(call_args.kwargs.get("status_msg", "")) <= 255
+
+
+class TestMatrixToolsAvailabilityCheck:
+    """Test that tools are unavailable when no adapter is connected."""
+
+    def test_unavailable_when_no_adapter(self):
+        from tools.matrix_tools import set_matrix_adapter, _check_matrix_available
+        set_matrix_adapter(None)
+        assert _check_matrix_available() is False
+
+    def test_available_when_adapter_set(self):
+        from tools.matrix_tools import set_matrix_adapter, _check_matrix_available
+        set_matrix_adapter(MagicMock())
+        assert _check_matrix_available() is True
+        set_matrix_adapter(None)
+
+    def test_adapter_not_connected_raises(self):
+        from tools.matrix_tools import set_matrix_adapter, _ensure_adapter
+        set_matrix_adapter(None)
+        with pytest.raises(RuntimeError, match="not connected"):
+            _ensure_adapter()
+
+
+# ===========================================================================
+# Registration tests
+# ===========================================================================
+
+class TestToolRegistration:
+    """Verify matrix tools are registered in the correct toolsets."""
+
+    def test_matrix_toolset_exists(self):
+        from toolsets import TOOLSETS
+        assert "matrix" in TOOLSETS
+
+    def test_matrix_toolset_has_all_tools(self):
+        from toolsets import TOOLSETS
+        tools = TOOLSETS["matrix"]["tools"]
+        expected = [
+            "matrix_send_reaction", "matrix_redact_message", "matrix_create_room",
+            "matrix_invite_user", "matrix_fetch_history", "matrix_set_presence",
+        ]
+        for name in expected:
+            assert name in tools, f"Missing tool: {name}"
+
+    def test_hermes_matrix_includes_matrix(self):
+        from toolsets import TOOLSETS
+        includes = TOOLSETS["hermes-matrix"]["includes"]
+        assert "matrix" in includes
+
+    def test_matrix_platform_hint_exists(self):
+        from agent.prompt_builder import PLATFORM_HINTS
+        assert "matrix" in PLATFORM_HINTS
+        hint = PLATFORM_HINTS["matrix"]
+        assert "matrix_send_reaction" in hint
+        assert "HTML" in hint
+
+    def test_matrix_tools_module_importable(self):
+        """tools.matrix_tools should be importable."""
+        import importlib
+        spec = importlib.util.find_spec("tools.matrix_tools")
+        assert spec is not None
+
+
+class TestAdapterWiring:
+    """Verify set_matrix_adapter is called in connect/disconnect."""
+
+    def test_connect_wires_adapter(self):
+        """connect() should call set_matrix_adapter(self)."""
+        from gateway.platforms.matrix import MatrixAdapter
+        config = PlatformConfig(
+            enabled=True, token="***",
+            extra={"homeserver": "https://matrix.example.org", "user_id": "@bot:example.org"},
+        )
+        adapter = MatrixAdapter(config)
+        # The actual connect() wiring is tested by checking the import
+        # Try/except pattern — just verify the code path exists
+        import inspect
+        source = inspect.getsource(adapter.connect)
+        assert "set_matrix_adapter" in source

--- a/tools/matrix_tools.py
+++ b/tools/matrix_tools.py
@@ -1,0 +1,467 @@
+"""Matrix room management and interaction tools.
+
+Registers LLM-callable tools for controlling Matrix rooms and interactions:
+- ``matrix_send_reaction`` -- react to a message with an emoji
+- ``matrix_redact_message`` -- redact (delete) a message
+- ``matrix_create_room`` -- create a new Matrix room
+- ``matrix_invite_user`` -- invite a user to a room
+- ``matrix_fetch_history`` -- fetch recent message history from a room
+- ``matrix_set_presence`` -- set the bot's presence status
+
+The adapter instance is injected at runtime via ``set_matrix_adapter()``.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Adapter reference (set at runtime by MatrixAdapter.connect)
+# ---------------------------------------------------------------------------
+
+_adapter: Optional[Any] = None
+_adapter_lock = threading.Lock()
+def set_matrix_adapter(adapter: Optional[Any]) -> None:
+    """Set (or clear) the running MatrixAdapter instance."""
+    global _adapter
+    with _adapter_lock:
+        _adapter = adapter
+
+
+def _check_matrix_available() -> bool:
+    """Tool is only available when a MatrixAdapter is connected."""
+    return _adapter is not None
+
+
+# ---------------------------------------------------------------------------
+# Async bridge (sync handler → async adapter methods)
+# ---------------------------------------------------------------------------
+
+_MAX_EMOJI_LEN = 32
+_MAX_REASON_LEN = 500
+_MAX_NAME_LEN = 255
+_MAX_TOPIC_LEN = 1000
+_MAX_STATUS_LEN = 255
+_ALLOWED_PRESETS = frozenset(("private_chat", "public_chat"))
+
+
+def _run_async(coro):
+    """Run an async coroutine from a sync handler.
+
+    Schedules the coroutine on the adapter's own event loop via
+    ``run_coroutine_threadsafe`` when possible, to avoid creating a
+    second event loop that can't share matrix-nio client state.
+    Falls back to ``asyncio.run()`` only when no loop is available.
+    """
+    # Prefer the adapter's event loop for nio client safety.
+    adapter_loop = getattr(_adapter, "_loop", None) if _adapter else None
+    if adapter_loop is not None and adapter_loop.is_running():
+        future = asyncio.run_coroutine_threadsafe(coro, adapter_loop)
+        try:
+            return future.result(timeout=30)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        # Schedule on the current running loop.
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        try:
+            return future.result(timeout=30)
+        except TimeoutError:
+            future.cancel()
+            raise
+    else:
+        return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def _ensure_adapter():
+    """Return the adapter or raise if unavailable."""
+    with _adapter_lock:
+        adapter = _adapter
+    if adapter is None:
+        raise RuntimeError("Matrix adapter is not connected")
+    return adapter
+
+
+def _handle_send_reaction(args: dict, **kw) -> str:
+    """Handler for matrix_send_reaction tool."""
+    room_id = args.get("room_id", "").strip()
+    event_id = args.get("event_id", "").strip()
+    emoji = args.get("emoji", "").strip()
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not event_id or not event_id.startswith("$"):
+        return json.dumps({"error": "event_id is required and must start with '$'"})
+    if not emoji:
+        return json.dumps({"error": "emoji is required and must be non-empty"})
+    if len(emoji) > _MAX_EMOJI_LEN:
+        return json.dumps({"error": f"emoji must be at most {_MAX_EMOJI_LEN} characters"})
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter._send_reaction(room_id, event_id, emoji))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_send_reaction error: %s", e)
+        return json.dumps({"error": f"Failed to send reaction: {e}"})
+
+
+def _handle_redact_message(args: dict, **kw) -> str:
+    """Handler for matrix_redact_message tool."""
+    room_id = args.get("room_id", "").strip()
+    event_id = args.get("event_id", "").strip()
+    reason = args.get("reason", "")
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not event_id or not event_id.startswith("$"):
+        return json.dumps({"error": "event_id is required and must start with '$'"})
+    if len(reason) > _MAX_REASON_LEN:
+        reason = reason[:_MAX_REASON_LEN]
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter.redact_message(room_id, event_id, reason=reason))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_redact_message error: %s", e)
+        return json.dumps({"error": f"Failed to redact message: {e}"})
+
+
+def _handle_create_room(args: dict, **kw) -> str:
+    """Handler for matrix_create_room tool."""
+    name = args.get("name", "")
+    topic = args.get("topic", "")
+    invite = args.get("invite", [])
+    is_direct = args.get("is_direct", False)
+    preset = args.get("preset", "private_chat")
+
+    if name and len(name) > _MAX_NAME_LEN:
+        name = name[:_MAX_NAME_LEN]
+    if topic and len(topic) > _MAX_TOPIC_LEN:
+        topic = topic[:_MAX_TOPIC_LEN]
+    if invite and not isinstance(invite, list):
+        return json.dumps({"error": "invite must be a list of user IDs"})
+    for uid in (invite or []):
+        if not isinstance(uid, str) or not uid.startswith("@"):
+            return json.dumps({"error": f"Invalid user ID in invite list: {uid!r} (must start with '@')"})
+    if preset not in _ALLOWED_PRESETS:
+        return json.dumps({"error": f"Invalid preset: {preset!r}. Must be one of: {', '.join(sorted(_ALLOWED_PRESETS))}"})
+    if preset == "public_chat" and os.getenv("MATRIX_ALLOW_PUBLIC_ROOMS", "").lower() not in ("true", "1", "yes"):
+        return json.dumps({"error": "Public room creation is disabled by default. Set MATRIX_ALLOW_PUBLIC_ROOMS=true to allow."})
+
+    try:
+        adapter = _ensure_adapter()
+        room_id = _run_async(adapter.create_room(
+            name=name, topic=topic, invite=invite,
+            is_direct=is_direct, preset=preset,
+        ))
+        if room_id:
+            return json.dumps({"success": True, "room_id": room_id})
+        return json.dumps({"success": False, "error": "Room creation failed"})
+    except Exception as e:
+        logger.error("matrix_create_room error: %s", e)
+        return json.dumps({"error": f"Failed to create room: {e}"})
+
+
+def _handle_invite_user(args: dict, **kw) -> str:
+    """Handler for matrix_invite_user tool."""
+    room_id = args.get("room_id", "").strip()
+    user_id = args.get("user_id", "").strip()
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not user_id or not user_id.startswith("@"):
+        return json.dumps({"error": "user_id is required and must start with '@'"})
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter.invite_user(room_id, user_id))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_invite_user error: %s", e)
+        return json.dumps({"error": f"Failed to invite user: {e}"})
+
+
+def _handle_fetch_history(args: dict, **kw) -> str:
+    """Handler for matrix_fetch_history tool."""
+    room_id = args.get("room_id", "").strip()
+    limit = args.get("limit", 50)
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not isinstance(limit, int) or limit < 1:
+        limit = 50
+    if limit > 200:
+        limit = 200
+
+    try:
+        adapter = _ensure_adapter()
+        messages = _run_async(adapter.fetch_room_history(room_id, limit=limit))
+        return json.dumps({"count": len(messages), "messages": messages})
+    except Exception as e:
+        logger.error("matrix_fetch_history error: %s", e)
+        return json.dumps({"error": f"Failed to fetch history: {e}"})
+
+
+def _handle_set_presence(args: dict, **kw) -> str:
+    """Handler for matrix_set_presence tool."""
+    state = args.get("state", "").strip().lower()
+    status_msg = args.get("status_msg", "")
+
+    if state not in ("online", "offline", "unavailable"):
+        return json.dumps({"error": f"Invalid state: {state!r}. Must be 'online', 'offline', or 'unavailable'"})
+    if len(status_msg) > _MAX_STATUS_LEN:
+        status_msg = status_msg[:_MAX_STATUS_LEN]
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter.set_presence(state=state, status_msg=status_msg))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_set_presence error: %s", e)
+        return json.dumps({"error": f"Failed to set presence: {e}"})
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+MATRIX_SEND_REACTION_SCHEMA = {
+    "name": "matrix_send_reaction",
+    "description": (
+        "Send an emoji reaction to a message in a Matrix room. "
+        "Requires the room_id and event_id of the target message."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": (
+                    "The Matrix room ID (starts with '!', e.g. '!abc123:matrix.org')."
+                ),
+            },
+            "event_id": {
+                "type": "string",
+                "description": (
+                    "The event ID of the message to react to (starts with '$')."
+                ),
+            },
+            "emoji": {
+                "type": "string",
+                "description": "The emoji to react with (e.g. '👍', '❤️', '🎉').",
+            },
+        },
+        "required": ["room_id", "event_id", "emoji"],
+    },
+}
+
+MATRIX_REDACT_MESSAGE_SCHEMA = {
+    "name": "matrix_redact_message",
+    "description": (
+        "Redact (delete) a message or event from a Matrix room. "
+        "The message content will be removed but a tombstone remains."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "The Matrix room ID (starts with '!').",
+            },
+            "event_id": {
+                "type": "string",
+                "description": "The event ID of the message to redact (starts with '$').",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional reason for the redaction.",
+            },
+        },
+        "required": ["room_id", "event_id"],
+    },
+}
+
+MATRIX_CREATE_ROOM_SCHEMA = {
+    "name": "matrix_create_room",
+    "description": (
+        "Create a new Matrix room. Returns the room_id on success. "
+        "Can optionally set a name, topic, invite users, and configure visibility."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Human-readable room name.",
+            },
+            "topic": {
+                "type": "string",
+                "description": "Room topic/description.",
+            },
+            "invite": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of Matrix user IDs to invite (e.g. ['@user:matrix.org'])."
+                ),
+            },
+            "is_direct": {
+                "type": "boolean",
+                "description": "Mark as a direct message room. Default: false.",
+            },
+            "preset": {
+                "type": "string",
+                "description": (
+                    "Room preset: 'private_chat' (default), 'public_chat', "
+                    "or see allowed presets."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+MATRIX_INVITE_USER_SCHEMA = {
+    "name": "matrix_invite_user",
+    "description": "Invite a user to a Matrix room.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "The Matrix room ID (starts with '!').",
+            },
+            "user_id": {
+                "type": "string",
+                "description": (
+                    "The Matrix user ID to invite (starts with '@', "
+                    "e.g. '@user:matrix.org')."
+                ),
+            },
+        },
+        "required": ["room_id", "user_id"],
+    },
+}
+
+MATRIX_FETCH_HISTORY_SCHEMA = {
+    "name": "matrix_fetch_history",
+    "description": (
+        "Fetch recent message history from a Matrix room. "
+        "Returns messages in chronological order with sender, body, and timestamp."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "The Matrix room ID (starts with '!').",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of messages to fetch (default: 50, max: 200).",
+            },
+        },
+        "required": ["room_id"],
+    },
+}
+
+MATRIX_SET_PRESENCE_SCHEMA = {
+    "name": "matrix_set_presence",
+    "description": (
+        "Set the bot's presence status on Matrix. "
+        "Controls whether the bot appears as online, offline, or unavailable."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "state": {
+                "type": "string",
+                "description": "Presence state: 'online', 'offline', or 'unavailable'.",
+            },
+            "status_msg": {
+                "type": "string",
+                "description": "Optional human-readable status message.",
+            },
+        },
+        "required": ["state"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry
+
+registry.register(
+    name="matrix_send_reaction",
+    toolset="matrix",
+    schema=MATRIX_SEND_REACTION_SCHEMA,
+    handler=_handle_send_reaction,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_redact_message",
+    toolset="matrix",
+    schema=MATRIX_REDACT_MESSAGE_SCHEMA,
+    handler=_handle_redact_message,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_create_room",
+    toolset="matrix",
+    schema=MATRIX_CREATE_ROOM_SCHEMA,
+    handler=_handle_create_room,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_invite_user",
+    toolset="matrix",
+    schema=MATRIX_INVITE_USER_SCHEMA,
+    handler=_handle_invite_user,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_fetch_history",
+    toolset="matrix",
+    schema=MATRIX_FETCH_HISTORY_SCHEMA,
+    handler=_handle_fetch_history,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_set_presence",
+    toolset="matrix",
+    schema=MATRIX_SET_PRESENCE_SCHEMA,
+    handler=_handle_set_presence,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -329,10 +329,17 @@ TOOLSETS = {
         "includes": []
     },
 
+    "matrix": {
+        "description": "Matrix protocol tools - reactions, moderation, room management, history, presence",
+        "tools": ["matrix_send_reaction", "matrix_redact_message", "matrix_create_room",
+                  "matrix_invite_user", "matrix_fetch_history", "matrix_set_presence"],
+        "includes": []
+    },
+
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": ["matrix"]
     },
 
     "hermes-dingtalk": {


### PR DESCRIPTION
## Summary

Adds 6 LLM-callable tools that expose existing MatrixAdapter methods to the agent, bridging the gap between adapter capabilities and agent tool access.

## Tools Added

| Tool | Description |
|---|---|
| `matrix_send_reaction` | React to messages with emoji |
| `matrix_redact_message` | Delete/redact messages |
| `matrix_create_room` | Create rooms (with `MATRIX_ALLOW_PUBLIC_ROOMS` env guard) |
| `matrix_invite_user` | Invite users to rooms |
| `matrix_fetch_history` | Fetch up to 200 messages from a room |
| `matrix_set_presence` | Set bot presence (online/offline/unavailable) |

## Architecture

- **`tools/matrix_tools.py`**: Tool handlers with input validation and sync-to-async bridge via `run_coroutine_threadsafe` on the adapter's event loop
- **`set_matrix_adapter()`**: Wired in `connect()`/`disconnect()` for runtime adapter injection
- **Registration**: Added to `model_tools.py` discover list; new `matrix` toolset in `toolsets.py` included by `hermes-matrix`
- **Platform hint**: Added `matrix` entry to `PLATFORM_HINTS` in `prompt_builder.py`

## Testing

- 38 new tests covering all handlers, input validation, error handling, availability checks, toolset registration, platform hint, and adapter wiring
- All 120 existing Matrix tests pass (no regressions)

## How to Test

```bash
pytest tests/gateway/test_matrix_tools.py -v
pytest tests/gateway/test_matrix.py -v  # regression check
```

Tested on: Linux (Ubuntu)