### PR TITLE
fix(clipboard): normalize Wayland clipboard images to real PNG files

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 # Cache WSL detection (checked once per process)
 _wsl_detected: bool | None = None
@@ -343,10 +344,13 @@ def _wayland_save(dest: Path) -> bool:
             dest.unlink(missing_ok=True)
             return False
 
-        # BMP needs conversion to PNG (common in WSLg where only BMP
-        # is bridged from Windows clipboard via RDP).
-        if mime == "image/bmp":
-            return _convert_to_png(dest)
+        # save_clipboard_image() promises a PNG output path. Wayland can offer
+        # JPEG/GIF/WebP/BMP payloads, so normalize every non-PNG result before
+        # returning success.
+        if mime != "image/png":
+            if not _convert_to_png(dest) or not _is_png_file(dest):
+                dest.unlink(missing_ok=True)
+                return False
 
         return True
 
@@ -396,6 +400,14 @@ def _convert_to_png(path: Path) -> bool:
 
     # Can't convert — BMP is still usable as-is for most APIs
     return path.exists() and path.stat().st_size > 0
+
+
+def _is_png_file(path: Path) -> bool:
+    """Return True when *path* starts with the PNG file signature."""
+    try:
+        return path.read_bytes().startswith(_PNG_SIGNATURE)
+    except OSError:
+        return False
 
 
 # ── X11 (xclip) ─────────────────────────────────────────────────────────

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -38,6 +38,7 @@ from hermes_cli.clipboard import (
 
 FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
 FAKE_BMP = b"BM" + b"\x00" * 100
+FAKE_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 100
 
 
 # ═════════════════════════════════════════════════════════════════════════
@@ -353,9 +354,53 @@ class TestWaylandSave:
             if "stdout" in kw and hasattr(kw["stdout"], "write"):
                 kw["stdout"].write(FAKE_BMP)
             return MagicMock(returncode=0)
+
+        def fake_convert(path):
+            assert path == dest
+            path.write_bytes(FAKE_PNG)
+            return True
+
+        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+            with patch("hermes_cli.clipboard._convert_to_png", side_effect=fake_convert):
+                assert _wayland_save(dest) is True
+
+    def test_jpeg_extraction_converts_to_real_png(self, tmp_path):
+        dest = tmp_path / "out.png"
+
+        def fake_run(cmd, **kw):
+            if "--list-types" in cmd:
+                return MagicMock(stdout="image/jpeg\ntext/plain\n", returncode=0)
+            if "stdout" in kw and hasattr(kw["stdout"], "write"):
+                kw["stdout"].write(FAKE_JPEG)
+            return MagicMock(returncode=0)
+
+        def fake_convert(path):
+            assert path == dest
+            path.write_bytes(FAKE_PNG)
+            return True
+
+        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+            with patch("hermes_cli.clipboard._convert_to_png", side_effect=fake_convert) as mock_convert:
+                assert _wayland_save(dest) is True
+
+        mock_convert.assert_called_once_with(dest)
+        assert dest.read_bytes() == FAKE_PNG
+
+    def test_non_png_conversion_failure_cleans_up(self, tmp_path):
+        dest = tmp_path / "out.png"
+
+        def fake_run(cmd, **kw):
+            if "--list-types" in cmd:
+                return MagicMock(stdout="image/jpeg\n", returncode=0)
+            if "stdout" in kw and hasattr(kw["stdout"], "write"):
+                kw["stdout"].write(FAKE_JPEG)
+            return MagicMock(returncode=0)
+
         with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
             with patch("hermes_cli.clipboard._convert_to_png", return_value=True):
-                assert _wayland_save(dest) is True
+                assert _wayland_save(dest) is False
+
+        assert not dest.exists()
 
     def test_no_image_types(self, tmp_path):
         dest = tmp_path / "out.png"


### PR DESCRIPTION
Summary
This fixes a clipboard paste bug in the CLI on Wayland sessions.

save_clipboard_image() writes clipboard images to a .png destination, but the Wayland path could previously accept non-PNG payloads such as image/jpeg, image/gif, or image/webp without normalizing them first. That produced files with a .png extension whose contents were not actually PNG, which could break downstream image handling.

What changed
Updated the Wayland clipboard flow in hermes_cli/clipboard.py
Normalized every non-PNG Wayland image payload to a real PNG before returning success
Added a PNG signature check to ensure the saved file is actually PNG
Cleaned up the output file when conversion succeeds superficially but the result is still not a valid PNG
Why
The clipboard helper promises a PNG output path, and downstream code treats these files as PNGs. Returning success for a JPEG/GIF/WebP/BMP payload that was only renamed to .png creates inconsistent behavior and can cause follow-on failures in multimodal or MIME-sensitive flows.

This keeps the behavior strict, predictable, and aligned with the existing function contract.

Tests
Added targeted regression coverage in tests/tools/test_clipboard.py for:

BMP extraction followed by conversion to a real PNG
JPEG extraction that must be converted before success is returned
Failed/non-effective conversion cleanup when the output is still not actually PNG
Validation
Ran targeted local verification for the affected regression cases:

python -m pytest tests/tools/test_clipboard.py -q -n0 -k "test_bmp_extraction_with_pillow_convert or test_jpeg_extraction_converts_to_real_png or test_non_png_conversion_failure_cleans_up"
Result: 3 passed

Platforms considered
Linux / Wayland: fixed path
WSLg / BMP clipboard bridging: preserved and covered
macOS: no behavior change
Windows: no behavior change
X11: no behavior change