### PR TITLE
fix: simplify ACP approval bridging

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -1,10 +1,11 @@
-"""ACP permission bridging — maps ACP approval requests to hermes approval callbacks."""
+"""ACP permission bridging for Hermes dangerous-command approvals."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
 from concurrent.futures import TimeoutError as FutureTimeout
+from itertools import count
 from typing import Callable
 
 from acp.schema import (
@@ -14,13 +15,65 @@ from acp.schema import (
 
 logger = logging.getLogger(__name__)
 
-# Maps ACP PermissionOptionKind -> hermes approval result strings
-_KIND_TO_HERMES = {
+_OPTION_ID_TO_HERMES = {
     "allow_once": "once",
+    "allow_session": "session",
     "allow_always": "always",
-    "reject_once": "deny",
-    "reject_always": "deny",
+    "deny": "deny",
 }
+
+_PERMISSION_REQUEST_IDS = count(1)
+
+
+def _build_permission_options(*, allow_permanent: bool) -> list[PermissionOption]:
+    """Return ACP options that match Hermes approval semantics."""
+    options = [
+        PermissionOption(option_id="allow_once", kind="allow_once", name="Allow once"),
+        PermissionOption(
+            option_id="allow_session",
+            # ACP has no session-scoped kind, so use the closest persistent
+            # hint while keeping Hermes semantics in the option id.
+            kind="allow_always",
+            name="Allow for session",
+        ),
+    ]
+    if allow_permanent:
+        options.append(
+            PermissionOption(
+                option_id="allow_always",
+                kind="allow_always",
+                name="Allow always",
+            ),
+        )
+    options.append(PermissionOption(option_id="deny", kind="reject_once", name="Deny"))
+    return options
+
+
+def _build_permission_tool_call(command: str, description: str):
+    """Return the ACP tool-call update attached to a permission request."""
+    import acp as _acp
+
+    tool_call_id = f"perm-check-{next(_PERMISSION_REQUEST_IDS)}"
+    return _acp.update_tool_call(
+        tool_call_id,
+        title=description,
+        kind="execute",
+        status="pending",
+        content=[_acp.tool_content(_acp.text_block(f"$ {command}"))],
+        raw_input={"command": command, "description": description},
+    )
+
+
+def _map_outcome_to_hermes(outcome: object, *, allowed_option_ids: set[str]) -> str:
+    """Map an ACP permission outcome into Hermes approval strings."""
+    if not isinstance(outcome, AllowedOutcome):
+        return "deny"
+
+    option_id = outcome.option_id
+    if option_id not in allowed_option_ids:
+        logger.warning("Permission request returned unknown option_id: %s", option_id)
+        return "deny"
+    return _OPTION_ID_TO_HERMES.get(option_id, "deny")
 
 
 def make_approval_callback(
@@ -28,50 +81,44 @@ def make_approval_callback(
     loop: asyncio.AbstractEventLoop,
     session_id: str,
     timeout: float = 60.0,
-) -> Callable[[str, str], str]:
+) -> Callable[..., str]:
     """
-    Return a hermes-compatible ``approval_callback(command, description) -> str``
-    that bridges to the ACP client's ``request_permission`` call.
+    Return a Hermes-compatible approval callback that bridges to ACP.
 
-    Args:
-        request_permission_fn: The ACP connection's ``request_permission`` coroutine.
-        loop: The event loop on which the ACP connection lives.
-        session_id: Current ACP session id.
-        timeout: Seconds to wait for a response before auto-denying.
+    The callback accepts ``command`` and ``description`` plus optional
+    keyword arguments such as ``allow_permanent`` used by
+    ``tools.approval.prompt_dangerous_approval()``.
     """
 
-    def _callback(command: str, description: str) -> str:
-        options = [
-            PermissionOption(option_id="allow_once", kind="allow_once", name="Allow once"),
-            PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always"),
-            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
-        ]
-        import acp as _acp
+    def _callback(
+        command: str,
+        description: str,
+        *,
+        allow_permanent: bool = True,
+        **_: object,
+    ) -> str:
+        options = _build_permission_options(allow_permanent=allow_permanent)
 
-        tool_call = _acp.start_tool_call("perm-check", command, kind="execute")
-
-        coro = request_permission_fn(
-            session_id=session_id,
-            tool_call=tool_call,
-            options=options,
-        )
-
+        future = None
         try:
+            tool_call = _build_permission_tool_call(command, description)
+            coro = request_permission_fn(
+                session_id=session_id,
+                tool_call=tool_call,
+                options=options,
+            )
             future = asyncio.run_coroutine_threadsafe(coro, loop)
             response = future.result(timeout=timeout)
         except (FutureTimeout, Exception) as exc:
+            if future is not None:
+                future.cancel()
             logger.warning("Permission request timed out or failed: %s", exc)
             return "deny"
 
-        outcome = response.outcome
-        if isinstance(outcome, AllowedOutcome):
-            option_id = outcome.option_id
-            # Look up the kind from our options list
-            for opt in options:
-                if opt.option_id == option_id:
-                    return _KIND_TO_HERMES.get(opt.kind, "deny")
-            return "once"  # fallback for unknown option_id
-        else:
-            return "deny"
+        allowed_option_ids = {option.option_id for option in options}
+        return _map_outcome_to_hermes(
+            response.outcome,
+            allowed_option_ids=allowed_option_ids,
+        )
 
     return _callback

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -386,8 +386,6 @@ class HermesACPAgent(acp.Agent):
             state.cancel_event.clear()
 
         tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
-        previous_approval_cb = None
-
         if conn:
             tool_progress_cb = make_tool_progress_cb(conn, session_id, loop, tool_call_ids)
             thinking_cb = make_thinking_cb(conn, session_id, loop)
@@ -407,16 +405,13 @@ class HermesACPAgent(acp.Agent):
         agent.step_callback = step_cb
         agent.message_callback = message_cb
 
-        if approval_cb:
-            try:
-                from tools import terminal_tool as _terminal_tool
-                previous_approval_cb = getattr(_terminal_tool, "_approval_callback", None)
-                _terminal_tool.set_approval_callback(approval_cb)
-            except Exception:
-                logger.debug("Could not set ACP approval callback", exc_info=True)
-
         def _run_agent() -> dict:
+            previous_approval_cb = None
             try:
+                if approval_cb:
+                    from tools import terminal_tool as _terminal_tool
+                    previous_approval_cb = _terminal_tool.get_approval_callback()
+                    _terminal_tool.set_approval_callback(approval_cb)
                 result = agent.run_conversation(
                     user_message=user_text,
                     conversation_history=state.history,

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -1,75 +1,146 @@
-"""Tests for acp_adapter.permissions — ACP approval bridging."""
+"""Tests for acp_adapter.permissions."""
 
 import asyncio
+import inspect
 from concurrent.futures import Future
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from acp.schema import (
     AllowedOutcome,
     DeniedOutcome,
     RequestPermissionResponse,
 )
+
 from acp_adapter.permissions import make_approval_callback
+from tools.approval import prompt_dangerous_approval
 
 
 def _make_response(outcome):
-    """Helper to build a RequestPermissionResponse with the given outcome."""
     return RequestPermissionResponse(outcome=outcome)
 
 
-def _setup_callback(outcome, timeout=60.0):
-    """
-    Create a callback wired to a mock request_permission coroutine
-    that resolves to the given outcome.
-
-    Returns:
-        (callback, mock_request_permission_fn)
-    """
+def _invoke_callback(
+    outcome,
+    *,
+    allow_permanent=True,
+    timeout=60.0,
+    use_prompt_path=False,
+):
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
-    mock_rp = MagicMock(name="request_permission")
-
-    response = _make_response(outcome)
-
-    # Patch asyncio.run_coroutine_threadsafe so it returns a future
-    # that immediately yields the response.
+    request_permission = AsyncMock(name="request_permission")
     future = MagicMock(spec=Future)
-    future.result.return_value = response
+    future.result.return_value = _make_response(outcome)
 
-    with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
-        cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=timeout)
-        result = cb("rm -rf /", "dangerous command")
+    scheduled = {}
 
-    return result
+    def _schedule(coro, passed_loop):
+        scheduled["coro"] = coro
+        scheduled["loop"] = passed_loop
+        return future
+
+    with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", side_effect=_schedule):
+        cb = make_approval_callback(request_permission, loop, session_id="s1", timeout=timeout)
+        if use_prompt_path:
+            result = prompt_dangerous_approval(
+                "rm -rf /",
+                "dangerous command",
+                allow_permanent=allow_permanent,
+                approval_callback=cb,
+            )
+        else:
+            result = cb(
+                "rm -rf /",
+                "dangerous command",
+                allow_permanent=allow_permanent,
+            )
+
+    scheduled["coro"].close()
+    _, kwargs = request_permission.call_args
+    return result, kwargs, scheduled, future, loop
 
 
-class TestApprovalMapping:
-    def test_approval_allow_once_maps_correctly(self):
-        outcome = AllowedOutcome(option_id="allow_once", outcome="selected")
-        result = _setup_callback(outcome)
+class TestApprovalBridge:
+    def test_bridge_schedules_request_on_the_given_loop(self):
+        result, kwargs, scheduled, _, loop = _invoke_callback(
+            AllowedOutcome(option_id="allow_once", outcome="selected"),
+        )
+
+        tool_call = kwargs["tool_call"]
+        option_ids = [option.option_id for option in kwargs["options"]]
+
         assert result == "once"
+        assert scheduled["loop"] is loop
+        assert inspect.iscoroutine(scheduled["coro"])
+        assert kwargs["session_id"] == "s1"
+        assert tool_call.session_update == "tool_call_update"
+        assert tool_call.tool_call_id.startswith("perm-check-")
+        assert tool_call.kind == "execute"
+        assert tool_call.status == "pending"
+        assert tool_call.title == "dangerous command"
+        assert tool_call.raw_input == {
+            "command": "rm -rf /",
+            "description": "dangerous command",
+        }
+        assert option_ids == ["allow_once", "allow_session", "allow_always", "deny"]
 
-    def test_approval_allow_always_maps_correctly(self):
-        outcome = AllowedOutcome(option_id="allow_always", outcome="selected")
-        result = _setup_callback(outcome)
+    def test_tool_call_ids_are_unique(self):
+        _, first_kwargs, _, _, _ = _invoke_callback(
+            AllowedOutcome(option_id="allow_once", outcome="selected"),
+        )
+        _, second_kwargs, _, _, _ = _invoke_callback(
+            AllowedOutcome(option_id="allow_once", outcome="selected"),
+        )
+
+        assert first_kwargs["tool_call"].tool_call_id != second_kwargs["tool_call"].tool_call_id
+
+    def test_prompt_path_keeps_session_option_when_permanent_disabled(self):
+        result, kwargs, _, _, _ = _invoke_callback(
+            AllowedOutcome(option_id="allow_session", outcome="selected"),
+            allow_permanent=False,
+            use_prompt_path=True,
+        )
+
+        option_ids = [option.option_id for option in kwargs["options"]]
+
+        assert result == "session"
+        assert option_ids == ["allow_once", "allow_session", "deny"]
+
+    def test_allow_always_maps_correctly(self):
+        result, _, _, _, _ = _invoke_callback(
+            AllowedOutcome(option_id="allow_always", outcome="selected"),
+            use_prompt_path=True,
+        )
+
         assert result == "always"
 
-    def test_approval_deny_maps_correctly(self):
-        outcome = DeniedOutcome(outcome="cancelled")
-        result = _setup_callback(outcome)
-        assert result == "deny"
+    def test_denied_and_unknown_outcomes_deny(self):
+        denied_result, _, _, _, _ = _invoke_callback(DeniedOutcome(outcome="cancelled"))
+        unknown_result, _, _, _, _ = _invoke_callback(
+            AllowedOutcome(option_id="unexpected", outcome="selected"),
+        )
 
-    def test_approval_timeout_returns_deny(self):
-        """When the future times out, the callback should return 'deny'."""
+        assert denied_result == "deny"
+        assert unknown_result == "deny"
+
+    def test_timeout_returns_deny_and_cancels_future(self):
         loop = MagicMock(spec=asyncio.AbstractEventLoop)
-        mock_rp = MagicMock(name="request_permission")
-
+        request_permission = AsyncMock(name="request_permission")
         future = MagicMock(spec=Future)
         future.result.side_effect = TimeoutError("timed out")
 
-        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
-            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=0.01)
-            result = cb("rm -rf /", "dangerous")
+        scheduled = {}
+
+        def _schedule(coro, passed_loop):
+            scheduled["coro"] = coro
+            scheduled["loop"] = passed_loop
+            return future
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", side_effect=_schedule):
+            cb = make_approval_callback(request_permission, loop, session_id="s1", timeout=0.01)
+            result = cb("rm -rf /", "dangerous command")
+
+        scheduled["coro"].close()
 
         assert result == "deny"
+        assert scheduled["loop"] is loop
+        assert future.cancel.call_count == 1

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -714,5 +714,3 @@ class TestNormalizationBypass:
         cmd = "\uff4c\uff53 -\uff4c\uff41 /tmp"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
-
-

--- a/tests/tools/test_terminal_tool_callbacks.py
+++ b/tests/tools/test_terminal_tool_callbacks.py
@@ -1,0 +1,39 @@
+import threading
+
+import tools.terminal_tool as terminal_tool_module
+
+
+def test_approval_callback_is_thread_local():
+    main_cb = object()
+    worker_cb = object()
+    ready = threading.Event()
+    release = threading.Event()
+    seen = {}
+
+    terminal_tool_module.set_approval_callback(main_cb)
+
+    def worker():
+        terminal_tool_module.set_approval_callback(worker_cb)
+        seen["worker_before"] = terminal_tool_module.get_approval_callback()
+        ready.set()
+        release.wait(timeout=5)
+        seen["worker_after"] = terminal_tool_module.get_approval_callback()
+        terminal_tool_module.set_approval_callback(None)
+
+    thread = threading.Thread(target=worker)
+    try:
+        thread.start()
+        assert ready.wait(timeout=5)
+        seen["main"] = terminal_tool_module.get_approval_callback()
+        terminal_tool_module.set_approval_callback(None)
+        release.set()
+        thread.join(timeout=5)
+    finally:
+        terminal_tool_module.set_approval_callback(None)
+        release.set()
+        thread.join(timeout=5)
+
+    assert seen["main"] is main_cb
+    assert seen["worker_before"] is worker_cb
+    assert seen["worker_after"] is worker_cb
+    assert terminal_tool_module.get_approval_callback() is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -115,9 +115,10 @@ _cached_sudo_password: str = ""
 # instead of the default /dev/tty or input() readers. The CLI registers these
 # so prompts route through prompt_toolkit's event loop.
 #   _sudo_password_callback() -> str  (return password or "" to skip)
-#   _approval_callback(command, description) -> str  ("once"/"session"/"always"/"deny")
+#   current-thread approval callback(command, description, **kwargs) -> str
+#       ("once"/"session"/"always"/"deny")
 _sudo_password_callback = None
-_approval_callback = None
+_approval_callback_state = threading.local()
 
 
 def set_sudo_password_callback(cb):
@@ -128,8 +129,12 @@ def set_sudo_password_callback(cb):
 
 def set_approval_callback(cb):
     """Register a callback for dangerous command approval prompts (used by CLI)."""
-    global _approval_callback
-    _approval_callback = cb
+    _approval_callback_state.callback = cb
+
+
+def get_approval_callback():
+    """Return the approval callback for the current thread, if any."""
+    return getattr(_approval_callback_state, "callback", None)
 
 # =============================================================================
 # Dangerous Command Approval System
@@ -145,7 +150,7 @@ from tools.approval import (
 def _check_all_guards(command: str, env_type: str) -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
-                                  approval_callback=_approval_callback)
+                                  approval_callback=get_approval_callback())
 
 
 # Allowlist: characters that can legitimately appear in directory paths.


### PR DESCRIPTION
## What does this PR do?

This fixes ACP dangerous-command approvals by simplifying the bridge between Hermes approval prompts and ACP permission requests.

Previously this path mixed an invalid ACP request payload shape with partial Hermes option mapping, and it stored the approval callback in process-global state. This version builds ACP permission requests with `update_tool_call`, preserves Hermes `once / session / always / deny` semantics in both approval modes, fails closed on unknown outcomes or request failures, and scopes approval callbacks to the current worker thread so concurrent ACP sessions do not cross wires.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace ACP permission request construction in `acp_adapter/permissions.py` with a smaller helper-based bridge that uses `update_tool_call`, unique `perm-check-*` ids, and explicit option-id mapping.
- Preserve Hermes approval semantics for both `allow_permanent=False` and `allow_permanent=True` so ACP users see `session` in both relevant paths.
- Fail closed on unknown option ids, timeouts, and request-construction failures.
- Move ACP approval callback registration into the executor worker and read it from thread-local state in `tools/terminal_tool.py`.
- Consolidate ACP bridge coverage in `tests/acp/test_permissions.py`, remove duplicated ACP-specific assertions from `tests/tools/test_approval.py`, and add `tests/tools/test_terminal_tool_callbacks.py` for the thread-local callback behavior.

## How to Test

1. Run `uv run --extra dev --extra acp pytest tests/acp/test_permissions.py tests/tools/test_terminal_tool_callbacks.py tests/tools/test_approval.py -q -n 0`.
2. Run `uv run --extra dev --extra acp pytest tests/acp/test_server.py -q -n 0`.
3. In an ACP client session, trigger dangerous commands in both `allow_permanent=False` and `allow_permanent=True` flows and verify the approval options match Hermes semantics while overlapping ACP sessions keep approvals bound to the correct session.

Validated locally with:
- `uv run --extra dev --extra acp pytest tests/acp/test_permissions.py tests/tools/test_terminal_tool_callbacks.py tests/tools/test_approval.py -q -n 0` -> `107 passed`
- `uv run --extra dev --extra acp pytest tests/acp/test_server.py -q -n 0` -> `51 passed`
- `PYTHONPATH=. .venv/bin/python -m py_compile acp_adapter/permissions.py acp_adapter/server.py tools/terminal_tool.py tests/acp/test_permissions.py tests/tools/test_approval.py tests/tools/test_terminal_tool_callbacks.py`

## Checklist

### Code

- [ ] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I have updated `cli-config.yaml.example` if I added or changed config keys, or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the compatibility guide, or N/A
- [x] I have updated tool descriptions or schemas if I changed tool behavior, or N/A

## Screenshots / Logs

N/A