### PR TITLE
feat(matrix): add thinking fields, approval buttons, and model picker

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -172,6 +172,18 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_REACTIONS", "true"
         ).lower() not in ("false", "0", "no")
 
+        # Thinking / agentic collapsible fields
+        self._thinking_enabled: bool = config.extra.get(
+            "thinking_fields_enabled",
+            os.getenv("MATRIX_THINKING_FIELDS_ENABLED", "true").lower()
+            in ("true", "1", "yes"),
+        )
+        self._thinking_manager: Optional[Any] = None
+
+        # Pending approval and model picker state (keyed by event_id)
+        self._approval_state: Dict[str, Dict[str, Any]] = {}
+        self._model_picker_state: Dict[str, Dict[str, Any]] = {}
+
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
         if not event_id:
@@ -393,6 +405,13 @@ class MatrixAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
         self._closing = True
+
+        # Abort any active thinking fields before shutdown.
+        if self._thinking_manager:
+            try:
+                await self._thinking_manager.abort_all("Gateway restarting")
+            except Exception as exc:
+                logger.debug("Matrix: could not abort active introspection fields: %s", exc)
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()
@@ -1410,18 +1429,52 @@ class MatrixAdapter(BasePlatformAdapter):
         )
 
     async def _on_reaction(self, room: Any, event: Any) -> None:
-        """Handle incoming reaction events."""
+        """Handle incoming reaction events.
+
+        Dispatches to approval and model picker state machines when the
+        reacted-to event has pending interactive state.  Otherwise logs.
+        """
         if event.sender == self._user_id:
             return
         if self._is_duplicate_event(getattr(event, "event_id", None)):
             return
-        # Log for now; future: trigger agent actions based on emoji.
+
         reacts_to = getattr(event, "reacts_to", "")
         key = getattr(event, "key", "")
         logger.info(
             "Matrix: reaction %s from %s on %s in %s",
             key, event.sender, reacts_to, room.room_id,
         )
+
+        # Dispatch: approval buttons
+        if reacts_to in self._approval_state and key in self._APPROVAL_REACTIONS:
+            state = self._approval_state.pop(reacts_to)
+            choice = self._APPROVAL_REACTIONS[key]
+            try:
+                from tools.approval import resolve_gateway_approval
+                resolve_gateway_approval(state["session_key"], choice)
+                # Edit the approval message to show the decision
+                choice_labels = {
+                    "once": "✅ Allowed once",
+                    "session": "🔁 Allowed for session",
+                    "always": "♾️ Allowed always",
+                    "deny": "❌ Denied",
+                }
+                label = choice_labels.get(choice, choice)
+                await self.edit_message(
+                    state["chat_id"], reacts_to,
+                    f"{label} by {event.sender}\n\n```\n{state['command']}\n```",
+                )
+            except Exception as exc:
+                logger.error("Matrix: approval resolution failed: %s", exc)
+            return
+
+        # Dispatch: model picker
+        if reacts_to in self._model_picker_state:
+            await self._handle_model_picker_reaction(
+                reacts_to, key, room.room_id, event.sender,
+            )
+            return
 
     async def _on_unknown_event(self, room: Any, event: Any) -> None:
         """Fallback handler for events not natively parsed by matrix-nio.
@@ -1706,6 +1759,294 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(resp))
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
+
+    # ------------------------------------------------------------------
+    # Thinking / introspection fields
+    # ------------------------------------------------------------------
+
+    def _get_thinking_manager(self):
+        """Lazy-init the ThinkingManager."""
+        if self._thinking_manager is None:
+            from gateway.platforms.matrix_thinking import ThinkingManager
+            self._thinking_manager = ThinkingManager(self)
+        return self._thinking_manager
+
+    async def start_thinking(
+        self, room_id: str, task_id: str,
+        initial_summary: str = "Processing request...",
+        *, model_label: str = "", initial_content_md: str = "",
+    ) -> Optional[str]:
+        """Start a collapsible thinking field in a Matrix room."""
+        if not self._thinking_enabled:
+            return None
+        return await self._get_thinking_manager().start(
+            room_id, task_id, initial_summary,
+            field_kind="thinking", model_label=model_label,
+            initial_content_md=initial_content_md,
+        )
+
+    async def update_thinking(
+        self, task_id: str, step_info: str, content_md: str = "",
+        *, model_label: Optional[str] = None, append_line: bool = True,
+    ) -> None:
+        """Update the active thinking field with new content."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.update(
+            task_id, step_info, content_md, field_kind="thinking",
+            model_label=model_label, append_line=append_line,
+        )
+
+    async def finalize_thinking(
+        self, task_id: str, final_summary: str = "Task complete",
+        collapse: bool = True, *, model_label: Optional[str] = None,
+    ) -> None:
+        """Finalize and collapse the thinking field."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.finalize(
+            task_id, final_summary, collapse,
+            field_kind="thinking", model_label=model_label,
+        )
+
+    async def abort_thinking(
+        self, task_id: str, reason: str = "Aborted",
+        *, model_label: Optional[str] = None,
+    ) -> None:
+        """Abort the thinking field, preserving buffered content."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.abort(
+            task_id, reason, field_kind="thinking", model_label=model_label,
+        )
+
+    async def start_tool_activity(
+        self, room_id: str, task_id: str,
+        initial_summary: str = "Running tools...",
+        *, model_label: str = "", initial_content_md: str = "",
+    ) -> Optional[str]:
+        """Start a collapsible tool activity field in a Matrix room."""
+        if not self._thinking_enabled:
+            return None
+        return await self._get_thinking_manager().start(
+            room_id, task_id, initial_summary,
+            field_kind="tools", model_label=model_label,
+            initial_content_md=initial_content_md,
+        )
+
+    async def update_tool_activity(
+        self, task_id: str, step_info: str, content_md: str = "",
+        *, model_label: Optional[str] = None, append_line: bool = True,
+    ) -> None:
+        """Update the active tool activity field with new content."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.update(
+            task_id, step_info, content_md, field_kind="tools",
+            model_label=model_label, append_line=append_line,
+        )
+
+    async def finalize_tool_activity(
+        self, task_id: str, final_summary: str = "Tools complete",
+        collapse: bool = True, *, model_label: Optional[str] = None,
+    ) -> None:
+        """Finalize and collapse the tool activity field."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.finalize(
+            task_id, final_summary, collapse,
+            field_kind="tools", model_label=model_label,
+        )
+
+    async def abort_tool_activity(
+        self, task_id: str, reason: str = "Aborted",
+        *, model_label: Optional[str] = None,
+    ) -> None:
+        """Abort the tool activity field, preserving buffered content."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.abort(
+            task_id, reason, field_kind="tools", model_label=model_label,
+        )
+
+    # ------------------------------------------------------------------
+    # Approval buttons via reactions
+    # ------------------------------------------------------------------
+
+    _APPROVAL_REACTIONS = {
+        "✅": "once",
+        "🔁": "session",
+        "♾️": "always",
+        "❌": "deny",
+    }
+
+    async def send_exec_approval(
+        self, chat_id: str, command: str, session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "SendResult":
+        """Send an interactive approval prompt using reactions.
+
+        Posts a message describing the command, then reacts with the 4
+        approval emoji.  When the user reacts back, ``_on_reaction``
+        resolves the approval via the gateway's approval mechanism.
+        """
+        prompt_lines = [
+            f"⚠️ **Approval Required** — {description}",
+            "",
+            f"```\n{command}\n```",
+            "",
+            "React to approve:",
+            "✅ Allow once · 🔁 Allow for session · ♾️ Allow always · ❌ Deny",
+        ]
+        result = await self.send(chat_id, "\n".join(prompt_lines), metadata=metadata)
+        if not result.success:
+            return result
+
+        msg_id = result.message_id
+        for emoji in self._APPROVAL_REACTIONS:
+            try:
+                await self._send_reaction(chat_id, msg_id, emoji)
+            except Exception as exc:
+                logger.debug("Matrix: approval reaction %s failed: %s", emoji, exc)
+
+        self._approval_state[msg_id] = {
+            "session_key": session_key,
+            "command": command,
+            "chat_id": chat_id,
+        }
+        return result
+
+    # ------------------------------------------------------------------
+    # Interactive model picker via reactions
+    # ------------------------------------------------------------------
+
+    async def send_model_picker(
+        self, chat_id: str, providers: list, current_model: str,
+        current_provider: str, session_key: str, on_model_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "SendResult":
+        """Send an interactive model picker using numbered reactions.
+
+        Shows a numbered list of providers.  The user reacts with the
+        corresponding number emoji to select.  Then the message is edited
+        to show models for that provider with a second set of numbers.
+        """
+        _NUM_EMOJI = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"]
+        display_providers = providers[:9]
+        lines = [
+            f"🔄 **Model Picker** (current: `{current_model}` on `{current_provider}`)",
+            "", "Select a provider:",
+        ]
+        for i, p in enumerate(display_providers):
+            name = p.get("name", p.get("slug", "unknown"))
+            lines.append(f"{_NUM_EMOJI[i]} {name}")
+        lines.extend(["", "❌ Cancel"])
+
+        result = await self.send(chat_id, "\n".join(lines), metadata=metadata)
+        if not result.success:
+            return result
+
+        msg_id = result.message_id
+        for i in range(len(display_providers)):
+            try:
+                await self._send_reaction(chat_id, msg_id, _NUM_EMOJI[i])
+            except Exception:
+                pass
+        try:
+            await self._send_reaction(chat_id, msg_id, "❌")
+        except Exception:
+            pass
+
+        self._model_picker_state[msg_id] = {
+            "stage": "provider", "providers": display_providers,
+            "session_key": session_key, "chat_id": chat_id,
+            "on_model_selected": on_model_selected,
+            "current_model": current_model, "current_provider": current_provider,
+            "metadata": metadata,
+        }
+        return result
+
+    async def _handle_model_picker_reaction(
+        self, event_id: str, emoji: str, room_id: str, sender: str,
+    ) -> None:
+        """Process a reaction on a model picker message."""
+        _NUM_EMOJI = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"]
+        state = self._model_picker_state.get(event_id)
+        if not state:
+            return
+
+        if emoji == "❌":
+            self._model_picker_state.pop(event_id, None)
+            try:
+                await self.edit_message(state["chat_id"], event_id, "🔄 Model selection cancelled.")
+            except Exception:
+                pass
+            return
+
+        idx = _NUM_EMOJI.index(emoji) if emoji in _NUM_EMOJI else -1
+        if idx < 0:
+            return
+
+        if state["stage"] == "provider":
+            providers = state["providers"]
+            if idx >= len(providers):
+                return
+            selected = providers[idx]
+            models = selected.get("models", [])
+            if not models:
+                self._model_picker_state.pop(event_id, None)
+                try:
+                    await self.edit_message(
+                        state["chat_id"], event_id,
+                        f"❌ No models available for {selected.get('name', '?')}.",
+                    )
+                except Exception:
+                    pass
+                return
+
+            display_models = models[:9]
+            state["stage"] = "model"
+            state["selected_provider"] = selected
+            state["display_models"] = display_models
+
+            lines = [f"🔄 **Select model** from {selected.get('name', '?')}:", ""]
+            for i, m in enumerate(display_models):
+                mid = m.get("id", m) if isinstance(m, dict) else str(m)
+                lines.append(f"{_NUM_EMOJI[i]} `{mid}`")
+            lines.extend(["", "❌ Cancel"])
+            try:
+                await self.edit_message(state["chat_id"], event_id, "\n".join(lines))
+            except Exception:
+                pass
+
+        elif state["stage"] == "model":
+            display_models = state.get("display_models", [])
+            if idx >= len(display_models):
+                return
+            sel = display_models[idx]
+            model_id = sel.get("id", sel) if isinstance(sel, dict) else str(sel)
+            provider_slug = state["selected_provider"].get(
+                "slug", state["selected_provider"].get("name", ""),
+            )
+            self._model_picker_state.pop(event_id, None)
+            callback = state.get("on_model_selected")
+            if callback:
+                try:
+                    msg = await callback(state["chat_id"], model_id, provider_slug)
+                    await self.edit_message(
+                        state["chat_id"], event_id,
+                        msg or f"✅ Switched to `{model_id}`",
+                    )
+                except Exception as exc:
+                    logger.error("Matrix: model picker callback failed: %s", exc)
+                    try:
+                        await self.edit_message(
+                            state["chat_id"], event_id,
+                            f"❌ Failed to switch model: {exc}",
+                        )
+                    except Exception:
+                        pass
 
     # ------------------------------------------------------------------
     # Helpers

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -1,0 +1,522 @@
+"""Matrix collapsible introspection fields for agent reasoning and tool activity.
+
+Lossless, reviewable, rate-limited live introspection for Matrix agent runs.
+Uses stable Matrix primitives only:
+  - m.room.message with org.matrix.custom.html + <details><summary>
+  - Live message edits via m.replace relation + m.new_content
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from gateway.platforms.matrix import MatrixAdapter
+
+logger = logging.getLogger(__name__)
+
+_MIN_EDIT_INTERVAL = 3.0
+_MAX_BODY_SIZE = 60_000
+
+
+@dataclass
+class ThinkingSession:
+    """Tracks one active introspection field per task/kind."""
+
+    room_id: str
+    event_id: str
+    task_id: str
+    started_at: float
+    last_update: float
+    step_count: int = 0
+    content_lines: list = field(default_factory=list)
+    finalized: bool = False
+    field_kind: str = "thinking"
+    title: str = "Hermes Agent"
+    summary: str = ""
+    model_label: str = ""
+    dirty: bool = False
+    flush_task: Optional[asyncio.Task] = None
+
+
+class ThinkingManager:
+    """Manages buffered Matrix introspection fields.
+
+    Supports two lossless buffered field types:
+      - thinking
+      - tools
+    """
+
+    def __init__(self, adapter: "MatrixAdapter"):
+        self._adapter = adapter
+        self._sessions: Dict[str, ThinkingSession] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def start(
+        self,
+        room_id: str,
+        task_id: str,
+        initial_summary: str = "Processing request...",
+        *,
+        field_kind: str = "thinking",
+        model_label: str = "",
+        initial_content_md: str = "",
+    ) -> Optional[str]:
+        """Send initial field and return event_id, or None on failure."""
+        import nio
+
+        key = self._session_key(task_id, field_kind)
+        async with self._lock:
+            _, existing = self._lookup_session_locked(task_id, field_kind)
+            if existing and not existing.finalized:
+                if model_label:
+                    existing.model_label = model_label
+                if initial_content_md:
+                    existing.content_lines.append(initial_content_md)
+                    existing.dirty = True
+                    self._ensure_flush_locked(key, existing, 0.0)
+                return existing.event_id
+
+        now = time.time()
+        title = self._field_title(field_kind)
+        initial_lines = [initial_content_md] if initial_content_md else []
+        html_body = self._build_html(
+            summary=initial_summary,
+            step=0,
+            ts=now,
+            content_html=self._lines_to_html(initial_lines),
+            open_tag=True,
+            field_kind=field_kind,
+            model_label=model_label,
+        )
+        plaintext = self._plaintext_summary(title, initial_summary, model_label=model_label)
+        content = self._msg_content(html_body, plaintext)
+
+        try:
+            resp = await asyncio.wait_for(
+                self._adapter._client.room_send(
+                    room_id,
+                    "m.room.message",
+                    content,
+                    ignore_unverified_devices=True,
+                ),
+                timeout=30,
+            )
+        except Exception as exc:
+            logger.error("Matrix introspection: failed to start %s in %s: %s", field_kind, room_id, exc)
+            return None
+
+        if not isinstance(resp, nio.RoomSendResponse):
+            logger.error(
+                "Matrix introspection: unexpected response %s",
+                getattr(resp, "message", resp),
+            )
+            return None
+
+        session = ThinkingSession(
+            room_id=room_id,
+            event_id=resp.event_id,
+            task_id=task_id,
+            started_at=now,
+            last_update=now,
+            field_kind=field_kind,
+            title=title,
+            summary=initial_summary,
+            model_label=model_label,
+            content_lines=initial_lines,
+        )
+        async with self._lock:
+            self._sessions[key] = session
+
+        logger.info(
+            "Matrix introspection started in %s (task=%s kind=%s event=%s)",
+            room_id,
+            task_id,
+            field_kind,
+            resp.event_id,
+        )
+        return resp.event_id
+
+    async def update(
+        self,
+        task_id: str,
+        step_info: str,
+        content_md: str = "",
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+        append_line: bool = True,
+    ) -> None:
+        """Append data losslessly and flush on a rate-limited schedule."""
+        key = self._session_key(task_id, field_kind)
+        snapshot = None
+
+        async with self._lock:
+            key, session = self._lookup_session_locked(task_id, field_kind)
+            if not session or session.finalized:
+                return
+
+            if step_info:
+                session.summary = step_info
+            if model_label:
+                session.model_label = model_label
+            if content_md and append_line:
+                session.content_lines.append(content_md)
+            session.step_count += 1
+            session.dirty = True
+
+            now = time.time()
+            elapsed = now - session.last_update
+            if elapsed >= _MIN_EDIT_INTERVAL and (session.flush_task is None or session.flush_task.done()):
+                snapshot = self._snapshot_locked(session)
+                session.last_update = now
+                session.dirty = False
+            else:
+                delay = max(0.0, _MIN_EDIT_INTERVAL - elapsed)
+                self._ensure_flush_locked(key, session, delay)
+
+        if snapshot:
+            await self._send_edit_snapshot(snapshot)
+
+    async def finalize(
+        self,
+        task_id: str,
+        final_summary: str = "Task complete",
+        collapse: bool = True,
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+    ) -> None:
+        """Flush all buffered data, then collapse the field."""
+        key = self._session_key(task_id, field_kind)
+        snapshot = None
+        flush_task = None
+
+        async with self._lock:
+            key, session = self._lookup_session_locked(task_id, field_kind)
+            if not session:
+                return
+            session.finalized = True
+            if field_kind == "thinking" and final_summary and not final_summary.startswith(("✅", "⚠️")):
+                session.summary = f"✅ {final_summary}"
+            else:
+                session.summary = final_summary
+            if model_label:
+                session.model_label = model_label
+            flush_task = session.flush_task
+            session.flush_task = None
+            snapshot = self._snapshot_locked(session)
+
+        if flush_task and not flush_task.done():
+            flush_task.cancel()
+            try:
+                await flush_task
+            except asyncio.CancelledError:
+                pass
+
+        await self._send_edit_snapshot(snapshot, final=True, collapse=collapse)
+
+        async with self._lock:
+            self._sessions.pop(key, None)
+
+    async def abort(
+        self,
+        task_id: str,
+        reason: str = "Aborted",
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+    ) -> None:
+        """Abort a field while preserving all buffered content."""
+        await self.finalize(
+            task_id,
+            f"⚠️ {reason}",
+            collapse=True,
+            field_kind=field_kind,
+            model_label=model_label,
+        )
+
+    def has_session(self, task_id: str, field_kind: str = "thinking") -> bool:
+        key = self._session_key(task_id, field_kind)
+        return key in self._sessions or (field_kind == "thinking" and task_id in self._sessions)
+
+    async def cleanup_stale(self, max_age: float = 1800) -> None:
+        now = time.time()
+        async with self._lock:
+            stale = [
+                key
+                for key, session in self._sessions.items()
+                if now - session.started_at > max_age
+            ]
+            for key in stale:
+                session = self._sessions.pop(key, None)
+                if session and session.flush_task and not session.flush_task.done():
+                    session.flush_task.cancel()
+                logger.warning("Matrix introspection: cleaned up stale session %s", key)
+
+    async def abort_all(self, reason: str = "Gateway restarting") -> None:
+        """Abort all active fields before shutdown/restart to avoid dangling blocks."""
+        async with self._lock:
+            snapshots = [
+                (key, session.task_id, session.field_kind, session.flush_task)
+                for key, session in self._sessions.items()
+            ]
+
+        for _key, task_id, field_kind, flush_task in snapshots:
+            if flush_task and not flush_task.done():
+                flush_task.cancel()
+                try:
+                    await flush_task
+                except asyncio.CancelledError:
+                    pass
+            await self.abort(task_id, reason, field_kind=field_kind)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _session_key(task_id: str, field_kind: str) -> str:
+        return f"{task_id}:{field_kind}"
+
+    def _lookup_session_locked(
+        self, task_id: str, field_kind: str
+    ) -> tuple[str, Optional[ThinkingSession]]:
+        key = self._session_key(task_id, field_kind)
+        session = self._sessions.get(key)
+        if session is None and field_kind == "thinking":
+            session = self._sessions.get(task_id)
+            if session is not None:
+                key = task_id
+        return key, session
+
+    @staticmethod
+    def _field_title(field_kind: str) -> str:
+        return "Tool Activity" if field_kind == "tools" else "Hermes Agent"
+
+    @staticmethod
+    def _field_icon(field_kind: str) -> str:
+        return "🛠️" if field_kind == "tools" else "🤔"
+
+    def _snapshot_locked(self, session: ThinkingSession) -> Dict[str, Any]:
+        return {
+            "room_id": session.room_id,
+            "event_id": session.event_id,
+            "task_id": session.task_id,
+            "started_at": session.started_at,
+            "step": session.step_count,
+            "summary": session.summary,
+            "content_lines": list(session.content_lines),
+            "field_kind": session.field_kind,
+            "title": session.title,
+            "model_label": session.model_label,
+        }
+
+    def _ensure_flush_locked(self, key: str, session: ThinkingSession, delay: float) -> None:
+        if session.flush_task is None or session.flush_task.done():
+            session.flush_task = asyncio.create_task(self._delayed_flush(key, delay))
+
+    async def _delayed_flush(self, key: str, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+            await self._flush(key)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("Matrix introspection: delayed flush failed for %s: %s", key, exc)
+
+    async def _flush(self, key: str) -> None:
+        snapshot = None
+        async with self._lock:
+            session = self._sessions.get(key)
+            if not session or session.finalized:
+                return
+            session.flush_task = None
+            if not session.dirty:
+                return
+            snapshot = self._snapshot_locked(session)
+            session.last_update = time.time()
+            session.dirty = False
+
+        await self._send_edit_snapshot(snapshot)
+
+    async def _send_edit_snapshot(
+        self,
+        snapshot: Dict[str, Any],
+        *,
+        final: bool = False,
+        collapse: bool = True,
+    ) -> None:
+        elapsed = self._elapsed_str(snapshot["started_at"])
+        content_html = self._lines_to_html(snapshot["content_lines"])
+        summary = snapshot["summary"] or ("Complete" if final else "Working")
+        open_tag = not final or not collapse
+
+        html_body = self._build_html(
+            summary=summary,
+            step=snapshot["step"],
+            ts=time.time(),
+            content_html=content_html,
+            open_tag=open_tag,
+            elapsed=elapsed,
+            final=final,
+            field_kind=snapshot["field_kind"],
+            model_label=snapshot.get("model_label") or "",
+        )
+        plaintext = self._plaintext_summary(
+            snapshot["title"],
+            summary,
+            elapsed=elapsed,
+            model_label=snapshot.get("model_label") or "",
+        )
+        edit_content = self._edit_content(snapshot["event_id"], html_body, plaintext)
+
+        try:
+            await asyncio.wait_for(
+                self._adapter._client.room_send(
+                    snapshot["room_id"],
+                    "m.room.message",
+                    edit_content,
+                    ignore_unverified_devices=True,
+                ),
+                timeout=15,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Matrix introspection: edit failed for task %s kind %s: %s",
+                snapshot["task_id"],
+                snapshot["field_kind"],
+                exc,
+            )
+            # Mark dirty again for non-final sessions so later updates/finalization retry.
+            if not final:
+                key = self._session_key(snapshot["task_id"], snapshot["field_kind"])
+                async with self._lock:
+                    session = self._sessions.get(key)
+                    if session and not session.finalized:
+                        session.dirty = True
+                        self._ensure_flush_locked(key, session, _MIN_EDIT_INTERVAL)
+
+    # ------------------------------------------------------------------
+    # HTML generation
+    # ------------------------------------------------------------------
+
+    # Shared inline style for both thinking and tool activity <details> blocks.
+    # Ensures both expand to fill available width identically.
+    _DETAILS_STYLE = (
+        "width:100%;max-width:100%;box-sizing:border-box;"
+        "overflow-x:auto;display:block"
+    )
+
+    def _build_html(
+        self,
+        summary: str,
+        step: int,
+        ts: float,
+        content_html: str,
+        open_tag: bool = True,
+        elapsed: str = "",
+        final: bool = False,
+        field_kind: str = "thinking",
+        model_label: str = "",
+    ) -> str:
+        open_attr = " open" if open_tag else ""
+        timestamp = time.strftime("%H:%M:%S", time.localtime(ts))
+        step_info = f"Step {step}" if step > 0 else "Starting"
+        elapsed_info = f" • {elapsed}" if elapsed else ""
+        icon = self._field_icon(field_kind)
+        title = self._field_title(field_kind)
+
+        if len(content_html.encode("utf-8")) > _MAX_BODY_SIZE:
+            content_html = content_html[:_MAX_BODY_SIZE] + "\n… (truncated)"
+
+        meta_html = (
+            f"<p><em>Model: {html.escape(model_label)}</em></p>" if model_label else ""
+        )
+        details_body = meta_html
+        if content_html:
+            details_body += (
+                f'<pre style="white-space:pre-wrap;word-break:break-word;'
+                f'overflow-x:auto;max-width:100%">'
+                f"<code>{content_html}</code></pre>"
+            )
+
+        return (
+            f'<details{open_attr} style="{self._DETAILS_STYLE}">'
+            f"<summary>{icon} <strong>{html.escape(title)}</strong> "
+            f"({step_info}{elapsed_info} • {timestamp}) — "
+            f"{html.escape(summary)}</summary>"
+            f"{details_body}"
+            f"</details>"
+        )
+
+    def _lines_to_html(self, lines: list) -> str:
+        if not lines:
+            return ""
+        return "\n".join(html.escape(line) for line in lines)
+
+    @staticmethod
+    def _elapsed_str(started_at: float) -> str:
+        elapsed = time.time() - started_at
+        if elapsed < 60:
+            return f"{elapsed:.0f}s"
+        minutes = int(elapsed // 60)
+        seconds = int(elapsed % 60)
+        return f"{minutes}m{seconds}s"
+
+    def _plaintext_summary(
+        self,
+        title: str,
+        summary: str,
+        *,
+        elapsed: str = "",
+        model_label: str = "",
+    ) -> str:
+        icon = "🛠️" if title == "Tool Activity" else "🤔"
+        parts = [f"{icon} {title} — {summary}"]
+        if elapsed:
+            parts.append(f"({elapsed})")
+        if model_label:
+            parts.append(f"[{model_label}]")
+        return " ".join(parts)
+
+    # ------------------------------------------------------------------
+    # Message content builders
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _msg_content(html_body: str, plaintext: str) -> Dict[str, Any]:
+        return {
+            "msgtype": "m.text",
+            "body": plaintext,
+            "format": "org.matrix.custom.html",
+            "formatted_body": html_body,
+        }
+
+    @staticmethod
+    def _edit_content(original_event_id: str, html_body: str, plaintext: str) -> Dict[str, Any]:
+        new_content = {
+            "msgtype": "m.text",
+            "body": plaintext,
+            "format": "org.matrix.custom.html",
+            "formatted_body": html_body,
+        }
+        return {
+            **new_content,
+            "body": f"* {plaintext}",
+            "formatted_body": f"* {html_body}",
+            "m.new_content": new_content,
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": original_event_id,
+            },
+        }

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -169,8 +169,13 @@ class ThinkingManager:
                 session.summary = step_info
             if model_label:
                 session.model_label = model_label
-            if content_md and append_line:
-                session.content_lines.append(content_md)
+            if content_md:
+                if append_line:
+                    session.content_lines.append(content_md)
+                elif session.content_lines:
+                    session.content_lines[-1] += content_md
+                else:
+                    session.content_lines.append(content_md)
             session.step_count += 1
             session.dirty = True
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6567,48 +6567,6 @@ class GatewayRunner:
                     f"{model_name} via {provider_name}" if provider_name else model_name
                 )
 
-        def _matrix_tool_progress_sync(tool_name: str, preview: str = None, args: dict = None, **kwargs):
-            """Route tool progress into Matrix collapsible tool-activity field."""
-            if not (_matrix_thinking_active and _status_adapter):
-                return
-            event_type = kwargs.get("event_type", "tool.started")
-            if event_type not in ("tool.started",):
-                return
-            try:
-                from agent.display import get_tool_emoji
-                emoji = get_tool_emoji(tool_name, default="⚙️")
-                if preview:
-                    msg = f"{emoji} {tool_name}: \"{preview}\""
-                elif args:
-                    msg = f"{emoji} {tool_name}({list(args.keys())})"
-                else:
-                    msg = f"{emoji} {tool_name}"
-
-                if not _tool_field_started[0]:
-                    _tool_field_started[0] = True
-                    asyncio.run_coroutine_threadsafe(
-                        _status_adapter.start_tool_activity(
-                            _status_chat_id,
-                            _thinking_task_id,
-                            "Tool activity",
-                            model_label=_model_label_holder[0] or "",
-                            initial_content_md=msg,
-                        ),
-                        _loop_for_step,
-                    ).result(timeout=10)
-                else:
-                    asyncio.run_coroutine_threadsafe(
-                        _status_adapter.update_tool_activity(
-                            _thinking_task_id,
-                            tool_name,
-                            msg,
-                            model_label=_model_label_holder[0],
-                        ),
-                        _loop_for_step,
-                    )
-            except Exception as _e:
-                logger.debug("matrix_tool_progress error: %s", _e)
-
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
                 return
@@ -6651,19 +6609,15 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
-        # ── Matrix thinking field state ────────────────────────────────
-        _thinking_started = [False]
-        _tool_field_started = [False]
-        _thinking_task_id = session_key or session_id or ""
-        _model_label_holder = [None]
-
         def _matrix_tool_progress_sync(tool_name: str, preview: str = None, args: dict = None, **kw):
             """Tool progress callback that renders into Matrix <details> blocks."""
             if not (_matrix_thinking_active and _status_adapter):
                 return
+            event_type = kw.get("event_type", "tool.started")
+            if event_type not in ("tool.started",):
+                return
             try:
                 from agent.display import get_tool_emoji
-                import json as _json
 
                 emoji = get_tool_emoji(tool_name, default="⚙️")
                 if args:
@@ -7478,57 +7432,6 @@ class GatewayRunner:
                     "history_offset": 0,
                     "failed": True,
                 }
-
-            # ── Finalize Matrix thinking fields ─────────────────────────
-            if _matrix_thinking_active and _status_adapter:
-                _final_model_label = _model_label_holder[0] or ""
-                _is_error = (response or {}).get("failed") or (response or {}).get("error")
-
-                if _thinking_started[0]:
-                    try:
-                        if _is_error:
-                            asyncio.run_coroutine_threadsafe(
-                                _status_adapter.abort_thinking(
-                                    _thinking_task_id,
-                                    str((response or {}).get("error", "Agent error")),
-                                    model_label=_final_model_label,
-                                ),
-                                _loop_for_step,
-                            ).result(timeout=10)
-                        else:
-                            asyncio.run_coroutine_threadsafe(
-                                _status_adapter.finalize_thinking(
-                                    _thinking_task_id,
-                                    "Complete",
-                                    model_label=_final_model_label,
-                                ),
-                                _loop_for_step,
-                            ).result(timeout=10)
-                    except Exception as _e:
-                        logger.debug("thinking finalize error: %s", _e)
-
-                if _tool_field_started[0]:
-                    try:
-                        if _is_error:
-                            asyncio.run_coroutine_threadsafe(
-                                _status_adapter.abort_tool_activity(
-                                    _thinking_task_id,
-                                    str((response or {}).get("error", "Agent error")),
-                                    model_label=_final_model_label,
-                                ),
-                                _loop_for_step,
-                            ).result(timeout=10)
-                        else:
-                            asyncio.run_coroutine_threadsafe(
-                                _status_adapter.finalize_tool_activity(
-                                    _thinking_task_id,
-                                    "Complete",
-                                    model_label=_final_model_label,
-                                ),
-                                _loop_for_step,
-                            ).result(timeout=10)
-                    except Exception as _e:
-                        logger.debug("tool_activity finalize error: %s", _e)
 
             # Track fallback model state: if the agent switched to a
             # fallback model during this run, persist it so /model shows

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7479,6 +7479,57 @@ class GatewayRunner:
                     "failed": True,
                 }
 
+            # ── Finalize Matrix thinking fields ─────────────────────────
+            if _matrix_thinking_active and _status_adapter:
+                _final_model_label = _model_label_holder[0] or ""
+                _is_error = (response or {}).get("failed") or (response or {}).get("error")
+
+                if _thinking_started[0]:
+                    try:
+                        if _is_error:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.abort_thinking(
+                                    _thinking_task_id,
+                                    str((response or {}).get("error", "Agent error")),
+                                    model_label=_final_model_label,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                        else:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.finalize_thinking(
+                                    _thinking_task_id,
+                                    "Complete",
+                                    model_label=_final_model_label,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                    except Exception as _e:
+                        logger.debug("thinking finalize error: %s", _e)
+
+                if _tool_field_started[0]:
+                    try:
+                        if _is_error:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.abort_tool_activity(
+                                    _thinking_task_id,
+                                    str((response or {}).get("error", "Agent error")),
+                                    model_label=_final_model_label,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                        else:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.finalize_tool_activity(
+                                    _thinking_task_id,
+                                    "Complete",
+                                    model_label=_final_model_label,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                    except Exception as _e:
+                        logger.debug("tool_activity finalize error: %s", _e)
+
             # Track fallback model state: if the agent switched to a
             # fallback model during this run, persist it so /model shows
             # the actually-active model instead of the config default.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6553,10 +6553,93 @@ class GatewayRunner:
         _status_chat_id = source.chat_id
         _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
 
+        # Matrix thinking field state
+        _thinking_started = [False]
+        _tool_field_started = [False]
+        _thinking_task_id = session_key or session_id or ""
+        _model_label_holder = [None]
+
+        def _set_model_label(model_name: str = "", provider_name: str = "") -> None:
+            model_name = (model_name or "").strip()
+            provider_name = (provider_name or "").strip()
+            if model_name:
+                _model_label_holder[0] = (
+                    f"{model_name} via {provider_name}" if provider_name else model_name
+                )
+
+        def _matrix_tool_progress_sync(tool_name: str, preview: str = None, args: dict = None, **kwargs):
+            """Route tool progress into Matrix collapsible tool-activity field."""
+            if not (_matrix_thinking_active and _status_adapter):
+                return
+            event_type = kwargs.get("event_type", "tool.started")
+            if event_type not in ("tool.started",):
+                return
+            try:
+                from agent.display import get_tool_emoji
+                emoji = get_tool_emoji(tool_name, default="⚙️")
+                if preview:
+                    msg = f"{emoji} {tool_name}: \"{preview}\""
+                elif args:
+                    msg = f"{emoji} {tool_name}({list(args.keys())})"
+                else:
+                    msg = f"{emoji} {tool_name}"
+
+                if not _tool_field_started[0]:
+                    _tool_field_started[0] = True
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.start_tool_activity(
+                            _status_chat_id,
+                            _thinking_task_id,
+                            "Tool activity",
+                            model_label=_model_label_holder[0] or "",
+                            initial_content_md=msg,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=10)
+                else:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.update_tool_activity(
+                            _thinking_task_id,
+                            tool_name,
+                            msg,
+                            model_label=_model_label_holder[0],
+                        ),
+                        _loop_for_step,
+                    )
+            except Exception as _e:
+                logger.debug("matrix_tool_progress error: %s", _e)
+
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
                 return
             try:
+                # When Matrix thinking is active, route status messages into
+                # the thinking field instead of sending them as standalone msgs.
+                if _matrix_thinking_active:
+                    if message and not _thinking_started[0]:
+                        _thinking_started[0] = True
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.start_thinking(
+                                _status_chat_id,
+                                _thinking_task_id,
+                                message,
+                                model_label=_model_label_holder[0] or "",
+                                initial_content_md=message,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=10)
+                    elif message:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.update_thinking(
+                                _thinking_task_id,
+                                message,
+                                message,
+                                model_label=_model_label_holder[0],
+                            ),
+                            _loop_for_step,
+                        )
+                    return
+
                 asyncio.run_coroutine_threadsafe(
                     _status_adapter.send(
                         _status_chat_id,
@@ -6567,6 +6650,55 @@ class GatewayRunner:
                 )
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
+
+        # ── Matrix thinking field state ────────────────────────────────
+        _thinking_started = [False]
+        _tool_field_started = [False]
+        _thinking_task_id = session_key or session_id or ""
+        _model_label_holder = [None]
+
+        def _matrix_tool_progress_sync(tool_name: str, preview: str = None, args: dict = None, **kw):
+            """Tool progress callback that renders into Matrix <details> blocks."""
+            if not (_matrix_thinking_active and _status_adapter):
+                return
+            try:
+                from agent.display import get_tool_emoji
+                import json as _json
+
+                emoji = get_tool_emoji(tool_name, default="⚙️")
+                if args:
+                    _top = list(args.items())[:2]
+                    _parts = ", ".join(f"{k}={repr(v)[:60]}" for k, v in _top)
+                    msg = f"{emoji} {tool_name}({_parts})"
+                elif preview:
+                    msg = f'{emoji} {tool_name}: "{preview}"'
+                else:
+                    msg = f"{emoji} {tool_name}"
+
+                if not _tool_field_started[0]:
+                    _tool_field_started[0] = True
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.start_tool_activity(
+                            _status_chat_id,
+                            _thinking_task_id,
+                            "Tool activity",
+                            model_label=_model_label_holder[0] or "",
+                            initial_content_md=msg,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=10)
+                else:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.update_tool_activity(
+                            _thinking_task_id,
+                            tool_name,
+                            msg,
+                            model_label=_model_label_holder[0],
+                        ),
+                        _loop_for_step,
+                    )
+            except Exception as _e:
+                logger.debug("matrix_tool_progress error: %s", _e)
 
         def run_sync():
             # The conditional re-assignment of `message` further below
@@ -6698,11 +6830,76 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            agent.tool_progress_callback = (
+                _matrix_tool_progress_sync
+                if _matrix_thinking_active
+                else (progress_callback if tool_progress_enabled else None)
+            )
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
+
+            # Wire thinking field callbacks for Matrix (collapsible <details> blocks).
+            # These bridge the sync agent thread → async Matrix adapter via
+            # run_coroutine_threadsafe, matching the pattern of _step_callback_sync.
+            _thinking_adapter = self.adapters.get(source.platform)
+
+            if (
+                source.platform == Platform.MATRIX
+                and _thinking_adapter
+                and getattr(_thinking_adapter, "_thinking_enabled", False)
+            ):
+                def _thinking_callback_sync(text: str) -> None:
+                    """Called by agent when thinking state changes."""
+                    try:
+                        if text and not _thinking_started[0]:
+                            _thinking_started[0] = True
+                            asyncio.run_coroutine_threadsafe(
+                                _thinking_adapter.start_thinking(
+                                    source.chat_id,
+                                    _thinking_task_id,
+                                    "Processing…",
+                                    model_label=_model_label_holder[0] or "",
+                                    initial_content_md=text,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                        elif text and _thinking_started[0]:
+                            asyncio.run_coroutine_threadsafe(
+                                _thinking_adapter.update_thinking(
+                                    _thinking_task_id,
+                                    "Reasoning…",
+                                    text,
+                                    model_label=_model_label_holder[0],
+                                ),
+                                _loop_for_step,
+                            )
+                    except Exception as _e:
+                        logger.debug("thinking_callback error: %s", _e)
+
+                def _reasoning_callback_sync(text: str) -> None:
+                    """Called by agent with reasoning trace deltas."""
+                    if not _thinking_started[0] or not text:
+                        return
+                    try:
+                        asyncio.run_coroutine_threadsafe(
+                            _thinking_adapter.update_thinking(
+                                _thinking_task_id,
+                                "Reasoning…",
+                                text,
+                                model_label=_model_label_holder[0],
+                            ),
+                            _loop_for_step,
+                        )
+                    except Exception as _e:
+                        logger.debug("reasoning_callback error: %s", _e)
+
+                agent.thinking_callback = _thinking_callback_sync
+                agent.reasoning_callback = _reasoning_callback_sync
+            else:
+                agent.thinking_callback = None
+                agent.reasoning_callback = None
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:
@@ -6885,7 +7082,49 @@ class GatewayRunner:
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
                 _stream_consumer.finish()
-            
+
+            # ── Finalize Matrix thinking fields ──────────────────────────
+            if _matrix_thinking_active and _status_adapter:
+                _final_model_label = _model_label_holder[0]
+                _is_error = result.get("failed") or result.get("error")
+                if _thinking_started[0]:
+                    try:
+                        if _is_error:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.abort_thinking(
+                                    _thinking_task_id,
+                                    str(result.get("error", "Agent error")),
+                                    model_label=_final_model_label,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                        else:
+                            _steps = result.get("api_calls", 0)
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.finalize_thinking(
+                                    _thinking_task_id,
+                                    f"Complete ({_steps} API calls)",
+                                    collapse=True,
+                                    model_label=_final_model_label,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                    except Exception as _e:
+                        logger.debug("thinking finalize error: %s", _e)
+                if _tool_field_started[0]:
+                    try:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.finalize_tool_activity(
+                                _thinking_task_id,
+                                "Tools complete",
+                                collapse=True,
+                                model_label=_final_model_label,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=10)
+                    except Exception as _e:
+                        logger.debug("tool activity finalize error: %s", _e)
+
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
 
@@ -7057,6 +7296,21 @@ class GatewayRunner:
         
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
 
+        # ── Eager Matrix thinking-field start ─────────────────────────
+        # Show a "Processing request…" indicator immediately when the turn
+        # starts, before the agent thread even makes its first API call.
+        if _matrix_thinking_active and _status_adapter and not _thinking_started[0]:
+            try:
+                await _status_adapter.start_thinking(
+                    source.chat_id,
+                    _thinking_task_id,
+                    "Processing request…",
+                    model_label=_model_label_holder[0] or "",
+                )
+                _thinking_started[0] = True
+            except Exception as _e:
+                logger.debug("eager start_thinking error: %s", _e)
+
         # Periodic "still working" notifications for long-running tasks.
         # Fires every 10 minutes so the user knows the agent hasn't died.
         _NOTIFY_INTERVAL = 600  # 10 minutes
@@ -7170,6 +7424,26 @@ class GatewayRunner:
                 # pool worker is freed.
                 if _timed_out_agent and hasattr(_timed_out_agent, "interrupt"):
                     _timed_out_agent.interrupt("Execution timed out (inactivity)")
+
+                # ── Matrix thinking-field cleanup on timeout ───────────
+                if _matrix_thinking_active and _status_adapter:
+                    _timeout_model = _model_label_holder[0]
+                    if _thinking_started[0]:
+                        try:
+                            await _status_adapter.abort_thinking(
+                                _thinking_task_id, "Timed out",
+                                model_label=_timeout_model,
+                            )
+                        except Exception as _e:
+                            logger.debug("thinking abort (timeout) error: %s", _e)
+                    if _tool_field_started[0]:
+                        try:
+                            await _status_adapter.abort_tool_activity(
+                                _thinking_task_id, "Timed out",
+                                model_label=_timeout_model,
+                            )
+                        except Exception as _e:
+                            logger.debug("tool activity abort (timeout) error: %s", _e)
 
                 _timeout_mins = int(_agent_timeout // 60) or 1
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6558,6 +6558,11 @@ class GatewayRunner:
         _tool_field_started = [False]
         _thinking_task_id = session_key or session_id or ""
         _model_label_holder = [None]
+        _matrix_thinking_active = (
+            source.platform == Platform.MATRIX
+            and _status_adapter is not None
+            and getattr(_status_adapter, "_thinking_enabled", False)
+        )
 
         def _set_model_label(model_name: str = "", provider_name: str = "") -> None:
             model_name = (model_name or "").strip()
@@ -6843,6 +6848,7 @@ class GatewayRunner:
                                 "Reasoning…",
                                 text,
                                 model_label=_model_label_holder[0],
+                                append_line=False,
                             ),
                             _loop_for_step,
                         )

--- a/tests/gateway/test_matrix_interactive.py
+++ b/tests/gateway/test_matrix_interactive.py
@@ -1,0 +1,388 @@
+"""Tests for Matrix interactive features — thinking fields, approval buttons, model picker.
+
+Covers:
+  - matrix_thinking.py — ThinkingManager for collapsible introspection fields
+  - matrix.py — thinking methods, send_exec_approval, send_model_picker,
+    _on_reaction dispatch for approval and model selection
+"""
+
+import asyncio
+import importlib
+import re
+import sys
+import time
+import types
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _make_fake_nio():
+    """Create a lightweight fake ``nio`` module for isinstance checks."""
+    mod = types.ModuleType("nio")
+
+    class RoomSendResponse:
+        def __init__(self, event_id="$fake_event"):
+            self.event_id = event_id
+
+    class RoomRedactResponse:
+        pass
+
+    mod.RoomSendResponse = RoomSendResponse
+    mod.RoomRedactResponse = RoomRedactResponse
+    return mod
+
+
+def _make_adapter():
+    """Create a MatrixAdapter with mocked config for testing."""
+    from gateway.platforms.matrix import MatrixAdapter
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+        },
+    )
+    return MatrixAdapter(config)
+
+
+# ===========================================================================
+# ThinkingManager lifecycle tests
+# ===========================================================================
+
+class TestThinkingManager:
+    """Tests for the collapsible introspection field manager."""
+
+    def setup_method(self):
+        self.nio = _make_fake_nio()
+        self._nio_patcher = patch.dict("sys.modules", {"nio": self.nio})
+        self._nio_patcher.start()
+        if "gateway.platforms.matrix_thinking" in sys.modules:
+            importlib.reload(sys.modules["gateway.platforms.matrix_thinking"])
+        self.adapter = MagicMock()
+        self.adapter._client = MagicMock()
+        self.adapter._client.room_send = AsyncMock(
+            return_value=self.nio.RoomSendResponse("$thinking_evt")
+        )
+
+    def teardown_method(self):
+        self._nio_patcher.stop()
+
+    def _make_manager(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+        return ThinkingManager(self.adapter)
+
+    @pytest.mark.asyncio
+    async def test_start_creates_session(self):
+        mgr = self._make_manager()
+        evt_id = await mgr.start("!room:ex", "task1", "Working...")
+        assert evt_id == "$thinking_evt"
+        assert mgr.has_session("task1")
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self):
+        mgr = self._make_manager()
+        evt1 = await mgr.start("!room:ex", "task1")
+        evt2 = await mgr.start("!room:ex", "task1")
+        assert evt1 == evt2
+        assert self.adapter._client.room_send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_finalize_removes_session(self):
+        mgr = self._make_manager()
+        await mgr.start("!room:ex", "task1")
+        await mgr.finalize("task1", "Done")
+        assert not mgr.has_session("task1")
+
+    @pytest.mark.asyncio
+    async def test_abort_marks_warning(self):
+        mgr = self._make_manager()
+        await mgr.start("!room:ex", "task1")
+        await mgr.abort("task1", "Timed out")
+        assert not mgr.has_session("task1")
+        assert self.adapter._client.room_send.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_update_increments_step(self):
+        mgr = self._make_manager()
+        await mgr.start("!room:ex", "task1")
+        await mgr.update("task1", "Step 1", "doing stuff")
+        key = mgr._session_key("task1", "thinking")
+        session = mgr._sessions.get(key)
+        assert session is not None
+        assert session.step_count == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_activity_field_kind(self):
+        mgr = self._make_manager()
+        evt_id = await mgr.start("!room:ex", "task1", field_kind="tools")
+        assert evt_id == "$thinking_evt"
+        assert mgr.has_session("task1", "tools")
+
+    @pytest.mark.asyncio
+    async def test_abort_all(self):
+        mgr = self._make_manager()
+        self.adapter._client.room_send = AsyncMock(
+            side_effect=[
+                self.nio.RoomSendResponse("$evt1"),
+                self.nio.RoomSendResponse("$evt2"),
+                self.nio.RoomSendResponse("$edit1"),
+                self.nio.RoomSendResponse("$edit2"),
+            ]
+        )
+        await mgr.start("!room:ex", "task1", field_kind="thinking")
+        await mgr.start("!room:ex", "task1", field_kind="tools")
+        await mgr.abort_all("shutdown")
+        assert len(mgr._sessions) == 0
+
+    @pytest.mark.asyncio
+    async def test_cleanup_stale(self):
+        mgr = self._make_manager()
+        await mgr.start("!room:ex", "task1")
+        key = mgr._session_key("task1", "thinking")
+        mgr._sessions[key].started_at = time.time() - 3600
+        await mgr.cleanup_stale(max_age=1800)
+        assert not mgr.has_session("task1")
+
+
+# ===========================================================================
+# ThinkingManager HTML generation
+# ===========================================================================
+
+class TestThinkingManagerHtml:
+    """Tests for HTML generation — especially width parity fix."""
+
+    def _make_manager(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+        return ThinkingManager(MagicMock())
+
+    def test_details_has_width_style(self):
+        mgr = self._make_manager()
+        html = mgr._build_html("test", 1, time.time(), "content")
+        assert 'style="' in html
+        assert "width:100%" in html
+
+    def test_thinking_and_tools_same_style(self):
+        """Both field kinds must have identical width styling."""
+        mgr = self._make_manager()
+        thinking = mgr._build_html("test", 1, time.time(), "content", field_kind="thinking")
+        tools = mgr._build_html("test", 1, time.time(), "content", field_kind="tools")
+        thinking_style = re.search(r'style="([^"]*)"', thinking)
+        tools_style = re.search(r'style="([^"]*)"', tools)
+        assert thinking_style and tools_style
+        assert thinking_style.group(1) == tools_style.group(1)
+
+    def test_pre_has_overflow_style(self):
+        mgr = self._make_manager()
+        html = mgr._build_html("test", 1, time.time(), "some code")
+        assert "overflow-x:auto" in html
+        assert "max-width:100%" in html
+
+    def test_model_label_shown(self):
+        mgr = self._make_manager()
+        html = mgr._build_html("test", 1, time.time(), "", model_label="gpt-5.4")
+        assert "gpt-5.4" in html
+
+    def test_truncation_at_max_body(self):
+        mgr = self._make_manager()
+        html = mgr._build_html("test", 1, time.time(), "x" * 70_000)
+        assert "truncated" in html
+
+
+# ===========================================================================
+# MatrixAdapter — thinking method wiring
+# ===========================================================================
+
+class TestAdapterThinkingWiring:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    @pytest.mark.asyncio
+    async def test_thinking_disabled(self):
+        self.adapter._thinking_enabled = False
+        result = await self.adapter.start_thinking("!room:ex", "task1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_thinking_enabled_lazy_init(self):
+        self.adapter._thinking_enabled = True
+        with patch("gateway.platforms.matrix_thinking.ThinkingManager") as MockMgr:
+            mock_mgr = MagicMock()
+            mock_mgr.start = AsyncMock(return_value="$evt")
+            MockMgr.return_value = mock_mgr
+            result = await self.adapter.start_thinking("!room:ex", "task1")
+            assert result == "$evt"
+            assert self.adapter._thinking_manager is mock_mgr
+
+    @pytest.mark.asyncio
+    async def test_abort_thinking_noop_when_no_manager(self):
+        self.adapter._thinking_enabled = True
+        self.adapter._thinking_manager = None
+        await self.adapter.abort_thinking("task1")  # should not raise
+
+
+# ===========================================================================
+# MatrixAdapter — approval buttons
+# ===========================================================================
+
+class TestAdapterApprovalButtons:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_send_approval_posts_message(self):
+        from gateway.platforms.matrix import SendResult
+        with patch.object(self.adapter, "send", new_callable=AsyncMock) as mock_send, \
+             patch.object(self.adapter, "_send_reaction", new_callable=AsyncMock):
+            mock_send.return_value = SendResult(success=True, message_id="$approval_msg")
+            result = await self.adapter.send_exec_approval(
+                chat_id="!room:ex", command="rm -rf /",
+                session_key="session_123", description="destructive command",
+            )
+            assert result.success is True
+            assert "$approval_msg" in self.adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_approval_state_tracks_session_key(self):
+        from gateway.platforms.matrix import SendResult
+        with patch.object(self.adapter, "send", new_callable=AsyncMock) as mock_send, \
+             patch.object(self.adapter, "_send_reaction", new_callable=AsyncMock):
+            mock_send.return_value = SendResult(success=True, message_id="$msg1")
+            await self.adapter.send_exec_approval(
+                chat_id="!room:ex", command="echo test", session_key="sess_abc",
+            )
+            state = self.adapter._approval_state["$msg1"]
+            assert state["session_key"] == "sess_abc"
+
+    @pytest.mark.asyncio
+    async def test_reaction_resolves_approval(self):
+        self.adapter._approval_state["$target_evt"] = {
+            "session_key": "sess_xyz", "command": "dangerous cmd", "chat_id": "!room:ex",
+        }
+        event = MagicMock(sender="@user:example.org", event_id="$react_evt",
+                          reacts_to="$target_evt", key="✅")
+        room = MagicMock(room_id="!room:ex")
+
+        with patch.object(self.adapter, "_is_duplicate_event", return_value=False), \
+             patch("tools.approval.resolve_gateway_approval") as mock_resolve, \
+             patch.object(self.adapter, "edit_message", new_callable=AsyncMock):
+            self.adapter._user_id = "@bot:example.org"
+            await self.adapter._on_reaction(room, event)
+            mock_resolve.assert_called_once_with("sess_xyz", "once")
+            assert "$target_evt" not in self.adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_deny_reaction(self):
+        self.adapter._approval_state["$target_evt"] = {
+            "session_key": "sess_xyz", "command": "bad cmd", "chat_id": "!room:ex",
+        }
+        event = MagicMock(sender="@user:example.org", event_id="$react_evt2",
+                          reacts_to="$target_evt", key="❌")
+        room = MagicMock(room_id="!room:ex")
+
+        with patch.object(self.adapter, "_is_duplicate_event", return_value=False), \
+             patch("tools.approval.resolve_gateway_approval") as mock_resolve, \
+             patch.object(self.adapter, "edit_message", new_callable=AsyncMock):
+            self.adapter._user_id = "@bot:example.org"
+            await self.adapter._on_reaction(room, event)
+            mock_resolve.assert_called_once_with("sess_xyz", "deny")
+
+    @pytest.mark.asyncio
+    async def test_send_approval_reacts_with_4_emoji(self):
+        from gateway.platforms.matrix import SendResult
+        with patch.object(self.adapter, "send", new_callable=AsyncMock) as mock_send, \
+             patch.object(self.adapter, "_send_reaction", new_callable=AsyncMock) as mock_react:
+            mock_send.return_value = SendResult(success=True, message_id="$msg")
+            await self.adapter.send_exec_approval(
+                chat_id="!room:ex", command="test", session_key="s1",
+            )
+            assert mock_react.call_count == 4
+
+
+# ===========================================================================
+# MatrixAdapter — model picker
+# ===========================================================================
+
+class TestAdapterModelPicker:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_send_picker_posts_numbered_list(self):
+        from gateway.platforms.matrix import SendResult
+        providers = [
+            {"name": "OpenAI", "slug": "openai", "models": [{"id": "gpt-5.4"}]},
+            {"name": "Anthropic", "slug": "anthropic", "models": [{"id": "claude-4"}]},
+        ]
+        with patch.object(self.adapter, "send", new_callable=AsyncMock) as mock_send, \
+             patch.object(self.adapter, "_send_reaction", new_callable=AsyncMock):
+            mock_send.return_value = SendResult(success=True, message_id="$picker_msg")
+            result = await self.adapter.send_model_picker(
+                chat_id="!room:ex", providers=providers,
+                current_model="gpt-5.4", current_provider="openai",
+                session_key="sess_123", on_model_selected=AsyncMock(),
+            )
+            assert result.success is True
+            assert "$picker_msg" in self.adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_cancel_picker(self):
+        self.adapter._model_picker_state["$picker"] = {
+            "stage": "provider", "providers": [{"name": "Test"}],
+            "session_key": "s1", "chat_id": "!room:ex",
+            "on_model_selected": AsyncMock(),
+            "current_model": "m1", "current_provider": "p1", "metadata": None,
+        }
+        with patch.object(self.adapter, "edit_message", new_callable=AsyncMock):
+            await self.adapter._handle_model_picker_reaction(
+                "$picker", "❌", "!room:ex", "@user:ex",
+            )
+        assert "$picker" not in self.adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_provider_selection_advances_to_model_stage(self):
+        self.adapter._model_picker_state["$picker"] = {
+            "stage": "provider",
+            "providers": [{"name": "OpenAI", "slug": "openai", "models": [{"id": "gpt-5.4"}]}],
+            "session_key": "s1", "chat_id": "!room:ex",
+            "on_model_selected": AsyncMock(),
+            "current_model": "m1", "current_provider": "p1", "metadata": None,
+        }
+        with patch.object(self.adapter, "edit_message", new_callable=AsyncMock):
+            await self.adapter._handle_model_picker_reaction(
+                "$picker", "1️⃣", "!room:ex", "@user:ex",
+            )
+        assert self.adapter._model_picker_state["$picker"]["stage"] == "model"
+
+    @pytest.mark.asyncio
+    async def test_model_selection_calls_callback(self):
+        callback = AsyncMock(return_value="Switched!")
+        self.adapter._model_picker_state["$picker"] = {
+            "stage": "model",
+            "selected_provider": {"name": "OpenAI", "slug": "openai"},
+            "display_models": [{"id": "gpt-5.4"}],
+            "session_key": "s1", "chat_id": "!room:ex",
+            "on_model_selected": callback,
+            "current_model": "m1", "current_provider": "p1",
+            "metadata": None, "providers": [],
+        }
+        with patch.object(self.adapter, "edit_message", new_callable=AsyncMock):
+            await self.adapter._handle_model_picker_reaction(
+                "$picker", "1️⃣", "!room:ex", "@user:ex",
+            )
+        callback.assert_called_once_with("!room:ex", "gpt-5.4", "openai")
+        assert "$picker" not in self.adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_unknown_reaction_ignored(self):
+        """Reactions not matching any state should be silently ignored."""
+        event = MagicMock(sender="@user:ex", event_id="$evt",
+                          reacts_to="$unknown", key="🎉")
+        room = MagicMock(room_id="!room:ex")
+        with patch.object(self.adapter, "_is_duplicate_event", return_value=False):
+            self.adapter._user_id = "@bot:example.org"
+            await self.adapter._on_reaction(room, event)  # should not raise

--- a/tests/gateway/test_matrix_run_regression.py
+++ b/tests/gateway/test_matrix_run_regression.py
@@ -1,0 +1,153 @@
+"""Regression tests for Matrix gateway run-loop wiring."""
+
+import importlib
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class MatrixThinkingCaptureAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.MATRIX)
+        self._thinking_enabled = True
+        self.started = []
+        self.finalized = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="$msg")
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def start_thinking(self, chat_id, task_id, summary="Processing…", model_label="", initial_content_md=""):
+        self.started.append({
+            "chat_id": chat_id,
+            "task_id": task_id,
+            "summary": summary,
+            "model_label": model_label,
+            "initial_content_md": initial_content_md,
+        })
+        return "$thinking"
+
+    async def update_thinking(self, task_id, summary, content_md, model_label=None, append_line=True):
+        return None
+
+    async def finalize_thinking(self, task_id, summary, collapse=True, model_label=None):
+        self.finalized.append({
+            "task_id": task_id,
+            "summary": summary,
+            "collapse": collapse,
+            "model_label": model_label,
+        })
+        return None
+
+    async def start_tool_activity(self, chat_id, task_id, summary="Tool activity", model_label="", initial_content_md=""):
+        return "$tools"
+
+    async def update_tool_activity(self, task_id, tool_name, content_md, model_label=None, append_line=True):
+        return None
+
+    async def finalize_tool_activity(self, task_id, summary, collapse=True, model_label=None):
+        return None
+
+
+class FakeMatrixAgent:
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.thinking_callback = None
+        self.reasoning_callback = None
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.status_callback:
+            self.status_callback("status", "Preparing response")
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {Platform.MATRIX: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agent_started_at = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._effective_model = None
+    runner._effective_provider = None
+    runner._get_or_create_gateway_honcho = lambda sk: (None, {})
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=None)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_matrix_thinking_enabled_does_not_raise_nameerror(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeMatrixAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = MatrixThinkingCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    runner._load_reasoning_config = lambda: {"enabled": False}
+
+    source = SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:example.org",
+        chat_type="room",
+        user_id="@chris:example.org",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-matrix-1",
+        session_key="agent:main:matrix:room:!room:example.org",
+    )
+
+    assert result["final_response"] == "ok"
+    assert adapter.started
+    assert adapter.finalized
+    assert adapter.started[0]["task_id"] == "agent:main:matrix:room:!room:example.org"
+    assert adapter.finalized[0]["summary"] == "Complete (1 API calls)"

--- a/tests/gateway/test_matrix_thinking_delta_merge.py
+++ b/tests/gateway/test_matrix_thinking_delta_merge.py
@@ -1,0 +1,44 @@
+"""Regression tests for Matrix thinking delta coalescing."""
+
+import importlib
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_fake_nio():
+    mod = types.ModuleType("nio")
+
+    class RoomSendResponse:
+        def __init__(self, event_id="$evt"):
+            self.event_id = event_id
+
+    mod.RoomSendResponse = RoomSendResponse
+    return mod
+
+
+class _Adapter:
+    def __init__(self, nio_mod):
+        self._client = MagicMock()
+        self._client.room_send = AsyncMock(return_value=nio_mod.RoomSendResponse())
+
+
+@pytest.mark.asyncio
+async def test_update_with_append_line_false_merges_into_last_line():
+    nio = _make_fake_nio()
+    with patch.dict(sys.modules, {"nio": nio}):
+        if "gateway.platforms.matrix_thinking" in sys.modules:
+            importlib.reload(sys.modules["gateway.platforms.matrix_thinking"])
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _Adapter(nio)
+        mgr = ThinkingManager(adapter)
+
+        await mgr.start("!room:example", "task1", initial_content_md="Hello")
+        await mgr.update("task1", "Reasoning…", " world", append_line=False)
+        await mgr.update("task1", "Reasoning…", "!", append_line=False)
+
+        session = mgr._sessions[mgr._session_key("task1", "thinking")]
+        assert session.content_lines == ["Hello world!"]


### PR DESCRIPTION
## What does this PR do?

Adds interactive Matrix UX features and the follow-up hardening required to make them work reliably in the gateway run loop.

This PR now includes:
- Collapsible thinking/tool-activity fields rendered via `matrix_thinking.py`
- Approval buttons and model picker via reactions
- Gateway run-loop wiring for Matrix thinking/status/tool callbacks
- Follow-up fixes for a Matrix `NameError` in `_run_agent()` (`_matrix_thinking_active` initialization)
- Reasoning-delta coalescing so early thinking text does not render as one fragment per line
- Regression tests for the run-loop wiring and delta-merging behavior

## Live validation findings

Live Matrix testing surfaced two follow-up issues that are now fixed in this PR:
- A Matrix turn could crash in `gateway/run.py` with `NameError: name '_matrix_thinking_active' is not defined`
- Early streamed reasoning text could render as fragmented line-by-line output in the collapsible thinking field because reasoning deltas were newline-appended instead of coalesced

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `gateway/platforms/matrix_thinking.py` for live editable `<details>` introspection blocks
- Extend `gateway/platforms/matrix.py` with thinking/tool activity methods, approval reactions, and model picker support
- Wire Matrix thinking lifecycle, reasoning, status, and tool progress callbacks in `gateway/run.py`
- Initialize `_matrix_thinking_active` in `_run_agent()` so Matrix turns cannot crash with `NameError`
- Merge streamed reasoning deltas into the active line when `append_line=False` to avoid one-word-per-line rendering in Matrix
- Add `tests/gateway/test_matrix_interactive.py`
- Add `tests/gateway/test_matrix_run_regression.py`
- Add `tests/gateway/test_matrix_thinking_delta_merge.py`

## How to Test

1. Run:
   - `python -m pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_interactive.py tests/gateway/test_matrix_run_regression.py tests/gateway/test_matrix_thinking_delta_merge.py -q -o addopts=''`
2. Start the Matrix gateway and send a message in Matrix
3. Verify exactly one thinking field appears, tool activity behaves correctly, and early reasoning text wraps normally instead of rendering one fragment per line
4. Exercise approval reactions and model picker reactions in Matrix

## Potential reviewer questions

- Why is this in `gateway/run.py` instead of adapter-only code?
  - Because the agent callbacks are wired in the gateway orchestration layer, not in the adapter
- Why is delta merging necessary?
  - Reasoning arrives as fragments; newline-appending each fragment in Matrix `<pre>` output causes visibly broken rendering
- Is this tested?
  - Yes:
    - `test_matrix_interactive.py`
    - `test_matrix_run_regression.py`
    - `test_matrix_thinking_delta_merge.py`
    - plus `test_matrix.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature/fix
- [x] I've run targeted pytest coverage for the affected Matrix and gateway paths
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — behavior is Matrix-specific and uses existing cross-platform Python primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted regression tests passed locally:

```bash
python -m pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_interactive.py tests/gateway/test_matrix_run_regression.py tests/gateway/test_matrix_thinking_delta_merge.py -q -o addopts=''
# 148 passed
```
