### PR TITLE
fix(webhook): rate-limit only authenticated, non-duplicate deliveries

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -105,6 +105,20 @@ class WebhookAdapter(BasePlatformAdapter):
             config.extra.get("max_body_bytes", 1_048_576)
         )  # 1MB
 
+    def _consume_rate_limit(self, route_name: str, now: float) -> bool:
+        """Record an accepted delivery and report whether the route is limited.
+
+        Rate limiting happens only after authentication and duplicate detection.
+        That prevents unauthenticated floods and provider retries from burning
+        the quota for legitimate deliveries.
+        """
+        window = self._rate_counts.setdefault(route_name, [])
+        window[:] = [t for t in window if now - t < 60]
+        if len(window) >= self._rate_limit:
+            return True
+        window.append(now)
+        return False
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -285,16 +299,6 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"error": "Payload too large"}, status=413
             )
 
-        # ── Rate limiting ────────────────────────────────────────
-        now = time.time()
-        window = self._rate_counts.setdefault(route_name, [])
-        window[:] = [t for t in window if now - t < 60]
-        if len(window) >= self._rate_limit:
-            return web.json_response(
-                {"error": "Rate limit exceeded"}, status=429
-            )
-        window.append(now)
-
         # Read body
         try:
             raw_body = await request.read()
@@ -406,6 +410,13 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
+
+        # ── Rate limiting ────────────────────────────────────────
+        if self._consume_rate_limit(route_name, now):
+            return web.json_response(
+                {"error": "Rate limit exceeded"}, status=429
+            )
+
         self._seen_deliveries[delivery_id] = now
 
         # Use delivery_id in session key so concurrent webhooks on the

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -492,6 +492,69 @@ class TestRateLimiting:
             )
             assert resp.status == 202  # allowed again
 
+    @pytest.mark.asyncio
+    async def test_invalid_signature_does_not_consume_rate_limit(self):
+        """Unauthenticated requests must not exhaust the route budget."""
+        secret = "signed-route-secret"
+        routes = {"signed": {"secret": secret, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, rate_limit=1)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            body = json.dumps({"n": 1}).encode("utf-8")
+
+            invalid = await cli.post(
+                "/webhooks/signed",
+                data=body,
+                headers={"X-Hub-Signature-256": "sha256=deadbeef"},
+            )
+            assert invalid.status == 401
+            assert adapter._rate_counts.get("signed", []) == []
+
+            valid = await cli.post(
+                "/webhooks/signed",
+                data=body,
+                headers={
+                    "X-Hub-Signature-256": _github_signature(body, secret),
+                    "X-GitHub-Delivery": "signed-1",
+                    "Content-Type": "application/json",
+                },
+            )
+            assert valid.status == 202
+
+    @pytest.mark.asyncio
+    async def test_duplicate_delivery_does_not_consume_rate_limit(self):
+        """Provider retries should not burn quota for new deliveries."""
+        routes = {"limited": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, rate_limit=2)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/limited",
+                json={"n": 1},
+                headers={"X-GitHub-Delivery": "dup-1"},
+            )
+            assert first.status == 202
+
+            duplicate = await cli.post(
+                "/webhooks/limited",
+                json={"n": 1},
+                headers={"X-GitHub-Delivery": "dup-1"},
+            )
+            assert duplicate.status == 200
+            data = await duplicate.json()
+            assert data["status"] == "duplicate"
+
+            fresh = await cli.post(
+                "/webhooks/limited",
+                json={"n": 2},
+                headers={"X-GitHub-Delivery": "dup-2"},
+            )
+            assert fresh.status == 202
+
 
 # ===================================================================
 # Body size limit


### PR DESCRIPTION
## What does this PR do?

Fixes a webhook hardening bug where signed routes consumed per-route rate-limit budget before HMAC validation and before duplicate-delivery rejection.

That allowed invalid requests to exhaust the quota for legitimate webhook deliveries, and it also let provider retries burn budget that should be reserved for new events. This change moves rate-limit consumption to the accepted-delivery path and keeps the fixed-window behavior unchanged for real traffic.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Moved webhook rate-limit consumption in `gateway/platforms/webhook.py` to run after signature validation and duplicate-delivery checks.
- Added `_consume_rate_limit()` in `gateway/platforms/webhook.py` to keep the fixed-window logic centralized and explicit.
- Added regression coverage in `tests/gateway/test_webhook_adapter.py` for invalid-signature floods and duplicate delivery retries.

## How to Test

1. Run `source .venv/bin/activate && python -m pytest tests/gateway/test_webhook_adapter.py -q`
2. Run `source .venv/bin/activate && python -m pytest tests/gateway/test_webhook_dynamic_routes.py tests/hermes_cli/test_webhook_cli.py -q`
3. Manually verify a signed webhook route with a low `rate_limit`: a bad-signature request returns `401` without consuming quota, a valid request still returns `202`, and replaying the same delivery ID returns `200 duplicate` without blocking a fresh delivery.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`source .venv/bin/activate && python -m pytest tests/gateway/test_webhook_adapter.py -q`
`38 passed, 16 warnings in 1.98s`

`source .venv/bin/activate && python -m pytest tests/gateway/test_webhook_dynamic_routes.py tests/hermes_cli/test_webhook_cli.py -q`
`24 passed, 24 warnings in 1.71s`
