### PR TITLE
fix(gateway): clear stale session env between messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5908,19 +5908,25 @@ class GatewayRunner:
 
     def _set_session_env(self, context: SessionContext) -> None:
         """Set environment variables for the current session."""
-        os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
-        os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
-        if context.source.chat_name:
-            os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
-        if context.source.thread_id:
-            os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
-    
+        source = context.source
+        self._clear_session_env()
+        os.environ["HERMES_SESSION_PLATFORM"] = source.platform.value
+        os.environ["HERMES_SESSION_CHAT_ID"] = source.chat_id
+        if source.chat_name:
+            os.environ["HERMES_SESSION_CHAT_NAME"] = source.chat_name
+        if source.thread_id:
+            os.environ["HERMES_SESSION_THREAD_ID"] = str(source.thread_id)
+
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
-            if var in os.environ:
-                del os.environ[var]
-    
+        for var in (
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_CHAT_NAME",
+            "HERMES_SESSION_THREAD_ID",
+        ):
+            os.environ.pop(var, None)
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -43,3 +43,44 @@ def test_clear_session_env_removes_thread_id(monkeypatch):
     assert os.getenv("HERMES_SESSION_CHAT_ID") is None
     assert os.getenv("HERMES_SESSION_CHAT_NAME") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None
+
+
+def test_set_session_env_clears_stale_optional_values(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+
+    threaded_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="Group",
+        chat_type="group",
+        thread_id="17585",
+    )
+    plain_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+
+    threaded_context = SessionContext(
+        source=threaded_source,
+        connected_platforms=[],
+        home_channels={},
+    )
+    plain_context = SessionContext(
+        source=plain_source,
+        connected_platforms=[],
+        home_channels={},
+    )
+
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+
+    runner._set_session_env(threaded_context)
+    runner._set_session_env(plain_context)
+
+    assert os.getenv("HERMES_SESSION_PLATFORM") == "telegram"
+    assert os.getenv("HERMES_SESSION_CHAT_ID") == "12345"
+    assert os.getenv("HERMES_SESSION_CHAT_NAME") is None
+    assert os.getenv("HERMES_SESSION_THREAD_ID") is None


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway bug where session environment variables could carry optional values from one message into the next.

`GatewayRunner._set_session_env()` only wrote `HERMES_SESSION_CHAT_NAME` and `HERMES_SESSION_THREAD_ID` when those fields were present. If a threaded group message was followed by a plain DM, the old values stayed in `os.environ` and could be seen later in the same process.

This patch clears the session env before setting the current message context, so each turn only exposes values from the active session.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Update `gateway/run.py` so `_set_session_env()` clears any previous session env before setting the current values
- Make `_clear_session_env()` idempotent with `os.environ.pop(..., None)`
- Add a regression test in `tests/gateway/test_session_env.py` that reproduces the stale-value case by calling `_set_session_env()` twice with different session contexts

## How to Test

1. Run `uv run pytest -q -n 0 tests/gateway/test_session_env.py`
2. Confirm `test_set_session_env_clears_stale_optional_values` passes
3. Confirm the full test file passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
uv run pytest -q -n 0 tests/gateway/test_session_env.py
3 passed, 1 warning in 0.10s
```

## Notes

I also ran `uv run pytest tests/ -q`, but the full suite did not complete cleanly because of unrelated existing failures, and the run hit `OSError: [Errno 24] Too many open files`. I left the full-suite checkbox unchecked for that reason.
