### PR TITLE
fix(honcho): respect HOME-anchored default-profile fallback

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from hermes_cli.profiles import _get_default_hermes_home
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -68,7 +69,7 @@ def resolve_config_path() -> Path:
         return local_path
 
     # Default profile's config — host blocks accumulate here via setup/clone
-    default_path = Path.home() / ".hermes" / "honcho.json"
+    default_path = _get_default_hermes_home() / "honcho.json"
     if default_path != local_path and default_path.exists():
         return default_path
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from hermes_cli.profiles import _get_default_hermes_home
+
 import pytest
 
 from plugins.memory.honcho.client import (
@@ -305,18 +307,22 @@ class TestResolveConfigPath:
             result = resolve_config_path()
         assert result == local_cfg
 
-    def test_falls_back_to_global_when_no_local(self, tmp_path):
+    def test_falls_back_to_default_profile_when_no_local(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
-        # No honcho.json in HERMES_HOME — also isolate ~/.hermes so
-        # the default-profile fallback doesn't hit the real filesystem.
         fake_home = tmp_path / "fakehome"
         fake_home.mkdir()
+        default_cfg = fake_home / ".hermes" / "honcho.json"
+        default_cfg.parent.mkdir(parents=True)
+        default_cfg.write_text('{"apiKey": "default-key"}')
 
-        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
-             patch.object(Path, "home", return_value=fake_home):
-            result = resolve_config_path()
-        assert result == GLOBAL_CONFIG_PATH
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        result = resolve_config_path()
+
+        assert _get_default_hermes_home() == fake_home / ".hermes"
+        assert result == default_cfg
 
     def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
         fake_home = tmp_path / "fakehome"
@@ -327,6 +333,26 @@ class TestResolveConfigPath:
             os.environ.pop("HERMES_HOME", None)
             result = resolve_config_path()
         assert result == GLOBAL_CONFIG_PATH
+
+    def test_from_global_config_uses_default_profile_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        default_cfg = fake_home / ".hermes" / "honcho.json"
+        default_cfg.parent.mkdir(parents=True)
+        default_cfg.write_text(json.dumps({
+            "apiKey": "default-key",
+            "workspace": "default-ws",
+        }))
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = HonchoClientConfig.from_global_config()
+
+        assert config.api_key == "default-key"
+        assert config.workspace_id == "default-ws"
 
     def test_from_global_config_uses_local_path(self, tmp_path):
         hermes_home = tmp_path / "hermes"


### PR DESCRIPTION
## Summary
- make Honcho's default-profile config fallback use the central HOME-anchored helper instead of a local `Path.home() / ".hermes"` reconstruction
- keep Honcho aligned with the project's profile-path convention: active instance via `get_hermes_home()`, default profile via `_get_default_hermes_home()`
- add regression coverage for both path resolution and actual config loading through the default-profile fallback

## Testing
- `source venv/bin/activate && python -m pytest tests/honcho_plugin/test_client.py -q`

Closes #4308
