### PR TITLE
fix(gateway): init memory store for flush agent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -667,7 +667,7 @@ class GatewayRunner:
                 model=model,
                 max_iterations=8,
                 quiet_mode=True,
-                skip_memory=True,  # Flush agent — no memory provider
+                skip_memory=False,  # Must init _memory_store so memory tool works
                 enabled_toolsets=["memory", "skills"],
                 session_id=old_session_id,
             )

--- a/tests/gateway/test_flush_memory_store.py
+++ b/tests/gateway/test_flush_memory_store.py
@@ -1,0 +1,45 @@
+"""Regression test for #6157: flush agent must init _memory_store.
+
+The gateway pre-reset memory flush creates a temporary AIAgent.  If that
+agent is created with ``skip_memory=True``, the memory tool is available
+(it's in ``enabled_toolsets``) but ``_memory_store`` is ``None``, so every
+call returns ``{"success": False, "error": "Memory is not available."}``.
+
+This test verifies that ``skip_memory=False`` is passed so the store is
+properly initialised.
+"""
+
+import ast
+from pathlib import Path
+
+
+def test_flush_agent_skip_memory_is_false():
+    """Parse gateway/run.py AST to verify skip_memory=False in flush agent.
+
+    A static check avoids importing the full dependency tree while
+    ensuring the fix for #6157 doesn't regress.
+    """
+    src = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    tree = ast.parse(src.read_text())
+
+    # Find the _flush_memories_for_session method
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_flush_memories_for_session":
+            # Find the AIAgent(...) call inside it
+            for child in ast.walk(node):
+                if isinstance(child, ast.Call):
+                    # Look for keyword skip_memory in any Call node
+                    for kw in child.keywords:
+                        if kw.arg == "skip_memory":
+                            # Must be False (NameConstant or Constant)
+                            if isinstance(kw.value, ast.Constant):
+                                assert kw.value.value is False, (
+                                    f"skip_memory must be False to init _memory_store, "
+                                    f"got {kw.value.value!r} (#6157)"
+                                )
+                                return
+                            raise AssertionError(
+                                f"skip_memory is not a constant: {ast.dump(kw.value)}"
+                            )
+            raise AssertionError("skip_memory keyword not found in _flush_memories_for_session")
+    raise AssertionError("_flush_memories_for_session function not found in gateway/run.py")


### PR DESCRIPTION
## Summary

Fixes #6157 — the gateway pre-reset memory flush created a temporary `AIAgent` with `skip_memory=True`, which prevented `_memory_store` from being initialised. Since the memory tool was still in `enabled_toolsets`, the model could call it but every call returned `"Memory is not available."` — making the flush path completely non-functional for all messaging platform sessions (Telegram, Discord, Matrix, etc.).

## Changes

- **gateway/run.py**: `skip_memory=True` → `skip_memory=False` (1 line)
- **tests/gateway/test_flush_memory_store.py**: AST-based regression test that verifies `skip_memory=False` in the flush agent constructor

## Root cause

```python
tmp_agent = AIAgent(
    ...
    skip_memory=True,   # ← prevents _memory_store initialization
    enabled_toolsets=["memory", "skills"],  # ← memory tool IS available
)
```

When `skip_memory=True`, `run_agent.py:977-992` skips `MemoryStore(...)` creation, leaving `_memory_store = None`. The memory tool at `memory_tool.py:452` then returns an error on every call.

## Test plan

- [x] Regression test passes (`pytest tests/gateway/test_flush_memory_store.py`)
- [ ] Manual: trigger a session reset on a messaging platform, verify memory flush produces writes