### PR TITLE
fix(tools): skip camofox auto-cleanup when managed persistence is enabled

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -101,7 +101,8 @@ def _managed_persistence_enabled() -> bool:
     """
     try:
         camofox_cfg = load_config().get("browser", {}).get("camofox", {})
-    except Exception:
+    except Exception as exc:
+        logger.warning("managed_persistence check failed, defaulting to disabled: %s", exc)
         return False
     return bool(camofox_cfg.get("managed_persistence"))
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1935,11 +1935,18 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
     if task_id is None:
         task_id = "default"
     
-    # Also clean up Camofox session if running in Camofox mode
+    # Also clean up Camofox session if running in Camofox mode.
+    # Skip cleanup when managed persistence is enabled — the whole point
+    # is that the browser profile (and its session cookies) survives across
+    # agent tasks.  The inactivity reaper still frees idle resources.
     if _is_camofox_mode():
         try:
-            from tools.browser_camofox import camofox_close
-            camofox_close(task_id)
+            from tools.browser_camofox import camofox_close, _managed_persistence_enabled, _drop_session
+            if _managed_persistence_enabled():
+                _drop_session(task_id)
+                logger.debug("Camofox cleanup skipped for task %s (managed persistence)", task_id)
+            else:
+                camofox_close(task_id)
         except Exception as e:
             logger.debug("Camofox cleanup for task %s: %s", task_id, e)
 


### PR DESCRIPTION
## Summary

- When `managed_persistence` is enabled, `cleanup_browser()` was calling `camofox_close()` after every agent task, destroying the Camofox browser context and killing login sessions. This broke cookie persistence across cron runs.
- Skip `camofox_close()` for managed-persistence sessions; call `_drop_session()` instead to free the in-memory entry without destroying the server-side browser context. The inactivity reaper still handles idle resource cleanup.
- Surface a `logger.warning()` when `_managed_persistence_enabled()` fails to load config, replacing a silent `except Exception: return False`.

## Test plan

- [ ] Enable `browser.camofox.managed_persistence: true` in config
- [ ] Run a browser-using skill/cron job, verify browser context survives after task ends
- [ ] Log in to a site via VNC, run another task, verify login session persists
- [ ] Disable managed persistence, verify `camofox_close()` still fires normally
- [ ] Break config loading temporarily, verify warning appears in logs