### PR TITLE
fix(config): drop stale placeholder secrets from .env writes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2086,14 +2086,14 @@ def _sanitize_env_lines(lines: list) -> list:
     # Done inside the function so OPTIONAL_ENV_VARS is guaranteed to be defined.
     known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
 
-    sanitized: list[str] = []
+    split_lines: list[str] = []
     for line in lines:
         raw = line.rstrip("\r\n")
         stripped = raw.strip()
 
         # Preserve blank lines and comments
         if not stripped or stripped.startswith("#"):
-            sanitized.append(raw + "\n")
+            split_lines.append(raw + "\n")
             continue
 
         # Detect concatenated KEY=VALUE pairs on one line.
@@ -2114,11 +2114,46 @@ def _sanitize_env_lines(lines: list) -> list:
                 end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
                 part = stripped[pos:end].strip()
                 if part:
-                    sanitized.append(part + "\n")
+                    split_lines.append(part + "\n")
         else:
-            sanitized.append(stripped + "\n")
+            split_lines.append(stripped + "\n")
 
-    return sanitized
+    placeholder_secret_suffixes = (
+        "_API_KEY",
+        "_TOKEN",
+        "_SECRET",
+        "_PASSWORD",
+        "_SSH_KEY",
+        "_ENCRYPT_KEY",
+        "_VERIFICATION_TOKEN",
+    )
+
+    def _is_placeholder_secret(key: str, value: str) -> bool:
+        normalized_value = value.strip().strip('"\'')
+        if normalized_value != "***":
+            return False
+        return OPTIONAL_ENV_VARS.get(key, {}).get("password") or key.endswith(placeholder_secret_suffixes)
+
+    sanitized: list[str | None] = []
+    seen_keys: dict[str, int] = {}
+
+    for line in split_lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            sanitized.append(line)
+            continue
+
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        if _is_placeholder_secret(key, value):
+            continue
+
+        if key in seen_keys:
+            sanitized[seen_keys[key]] = None
+        seen_keys[key] = len(sanitized)
+        sanitized.append(f"{key}={value.strip()}\n")
+
+    return [line for line in sanitized if line is not None]
 
 
 def sanitize_env_file() -> int:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -335,6 +335,18 @@ class TestSanitizeEnvLines:
             assert "OPENAI_BASE_URL=https://api.openai.com/v1" in lines
             assert "MESSAGING_CWD=/tmp" in lines
 
+    def test_save_env_value_removes_stale_placeholder_duplicates(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "OPENAI_API_KEY=real-key\n"
+            "OPENAI_API_KEY=***\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("OPENAI_API_KEY", "new-key")
+
+            assert env_file.read_text() == "OPENAI_API_KEY=new-key\n"
+            assert load_env()["OPENAI_API_KEY"] == "new-key"
+
     def test_sanitize_env_file_returns_fix_count(self, tmp_path):
         """sanitize_env_file reports how many entries were fixed."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## What does this PR do?

Fixes `.env` persistence so stale placeholder secrets like `KEY=***` do not survive later writes and override real values.

Today `save_env_value()` sanitizes the file before writing, but `_sanitize_env_lines()` only repairs concatenated `KEY=VALUE` lines. It does not remove placeholder-only secret entries or collapse duplicate keys. That leaves cases like:

```text
OPENAI_API_KEY=new-key
OPENAI_API_KEY=***
```

In that state, `load_env()` still resolves the stale trailing value because it keeps the last matching entry.

This change makes `_sanitize_env_lines()` drop placeholder-only secret lines and keep a single canonical entry per key before writes are persisted.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Update `hermes_cli/config.py` so `_sanitize_env_lines()` removes `KEY=***` placeholder secret entries
- Collapse duplicate `KEY=` entries during sanitization so stale trailing values cannot shadow the current value
- Add a regression test in `tests/hermes_cli/test_config.py` that reproduces the bug through `save_env_value()` and `load_env()`

## How to Test

1. Run `uv run pytest -q -n 0 tests/hermes_cli/test_config.py`
2. Confirm `test_save_env_value_removes_stale_placeholder_duplicates` passes
3. Confirm the full test file passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
uv run pytest -q -n 0 tests/hermes_cli/test_config.py
41 passed, 1 warning in 0.33s
```
