### PR TITLE
fix(cli): remove conflicting /q alias for queue

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -72,7 +72,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("btw", "Ephemeral side question using session context (no tools, not persisted)", "Session",
                args_hint="<question>"),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
-               aliases=("q",), args_hint="<prompt>"),
+               args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session",
                gateway_only=True),
     CommandDef("profile", "Show active profile name and home directory", "Info"),

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -63,6 +63,16 @@ class TestCommandRegistry:
                     assert resolve_command(alias).name == cmd.name or alias == cmd.name, \
                         f"Alias '{alias}' of '{cmd.name}' shadows canonical '{target.name}'"
 
+    def test_no_duplicate_aliases(self):
+        """Each alias should resolve unambiguously to a single command."""
+        seen: dict[str, str] = {}
+        for cmd in COMMAND_REGISTRY:
+            for alias in cmd.aliases:
+                previous = seen.setdefault(alias, cmd.name)
+                assert previous == cmd.name, (
+                    f"Alias '{alias}' is shared by both '{previous}' and '{cmd.name}'"
+                )
+
     def test_every_entry_has_valid_category(self):
         valid_categories = {"Session", "Configuration", "Tools & Skills", "Info", "Exit"}
         for cmd in COMMAND_REGISTRY:
@@ -99,6 +109,12 @@ class TestResolveCommand:
     def test_unknown_returns_none(self):
         assert resolve_command("nonexistent") is None
         assert resolve_command("") is None
+
+    def test_queue_has_no_conflicting_short_alias(self):
+        assert resolve_command("queue").name == "queue"
+        assert "q" not in next(
+            cmd.aliases for cmd in COMMAND_REGISTRY if cmd.name == "queue"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This fixes a slash-command registry alias collision where `q` was assigned to both `/queue` and `/quit`.

Because the central command lookup uses a plain dict, the later registration won and silently shadowed the earlier alias. That left the registry metadata and actual command resolution out of sync.

## Problem

In `hermes_cli/commands.py`, `q` was defined as an alias for both `queue` and `quit`.

At runtime, resolving `q` mapped to `quit`, while the registry still advertised `queue` as if it also owned that alias. This created ambiguous command metadata and inconsistent behavior across help, autocomplete, and dispatch-related surfaces.

## Fix

- removed the conflicting `q` alias from `queue`
- kept `q` as the short alias for `quit`
- added a regression test to ensure aliases stay globally unique
- added a targeted test asserting that `queue` no longer exposes the conflicting short alias

## Why this approach

This is the smallest and lowest-risk fix:

- no dispatch refactor
- no broader registry redesign
- no behavioral change beyond removing an ambiguous alias
- straightforward to review and verify

## Behavior impact

- `/q` now resolves unambiguously to `quit`
- `/queue` remains available via its canonical command
- registry/help/autocomplete data no longer carries a silent alias collision

This intentionally favors explicitness over preserving an ambiguous shorthand.

## Testing

Ran:

`python -m pytest tests/hermes_cli/test_commands.py -q`

Result:

- 100 passed
- 20 warnings

## Files changed

- `hermes_cli/commands.py`
- `tests/hermes_cli/test_commands.py`