### PR TITLE
fix(gateway): claim pidfile before adapter startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7531,6 +7531,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logging.getLogger().setLevel(_stderr_level)
 
     runner = GatewayRunner(config)
+
+    # Write the PID file BEFORE adapter startup so concurrent `gateway run --replace`
+    # invocations cannot all slip past the duplicate-instance guard during the
+    # several-second connect window. If startup fails or exits cleanly, remove it.
+    import atexit
+    from gateway.status import write_pid_file, remove_pid_file
+    write_pid_file()
+    atexit.register(remove_pid_file)
     
     # Set up signal handlers
     def signal_handler():
@@ -7546,17 +7554,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Start the gateway
     success = await runner.start()
     if not success:
+        remove_pid_file()
         return False
     if runner.should_exit_cleanly:
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
+        remove_pid_file()
         return True
-    
-    # Write PID file so CLI can detect gateway is running
-    import atexit
-    from gateway.status import write_pid_file, remove_pid_file
-    write_pid_file()
-    atexit.register(remove_pid_file)
     
     # Start background cron ticker so scheduled jobs fire automatically.
     # Pass the event loop so cron delivery can use live adapters (E2EE support).

--- a/tests/gateway/test_gateway_startup_pidfile.py
+++ b/tests/gateway/test_gateway_startup_pidfile.py
@@ -1,0 +1,81 @@
+"""Regression tests for gateway startup PID-file timing."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import gateway.run as gateway_run
+
+
+class _FakeRunner:
+    should_exit_cleanly = False
+    should_exit_with_failure = False
+    exit_reason = None
+    adapters = {}
+
+    def __init__(self, config):
+        self.config = config
+
+    async def start(self):
+        return True
+
+    async def wait_for_shutdown(self):
+        return None
+
+    async def stop(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_writes_pid_before_runner_start(monkeypatch):
+    order = []
+
+    class Runner(_FakeRunner):
+        async def start(self):
+            order.append("start")
+            assert order and order[0] == "pid"
+            return True
+
+    monkeypatch.setattr(gateway_run, "GatewayRunner", Runner)
+
+    with patch("gateway.status.get_running_pid", return_value=None), \
+         patch("gateway.status.write_pid_file", side_effect=lambda: order.append("pid")), \
+         patch("gateway.status.remove_pid_file"), \
+         patch("hermes_logging.setup_logging", return_value=gateway_run._hermes_home / "logs"), \
+         patch("hermes_logging._add_rotating_handler"), \
+         patch("tools.skills_sync.sync_skills"), \
+         patch.object(gateway_run, "_start_cron_ticker"), \
+         patch.object(gateway_run.logging.getLogger(), "addHandler"):
+        result = await gateway_run.start_gateway(config=SimpleNamespace())
+
+    await asyncio.sleep(0)
+    assert result is True
+    assert order[0] == "pid"
+    assert "start" in order
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_removes_pid_on_clean_exit(monkeypatch):
+    class Runner(_FakeRunner):
+        should_exit_cleanly = True
+        exit_reason = "test clean exit"
+
+        async def start(self):
+            return True
+
+    monkeypatch.setattr(gateway_run, "GatewayRunner", Runner)
+    removed = []
+
+    with patch("gateway.status.get_running_pid", return_value=None), \
+         patch("gateway.status.write_pid_file"), \
+         patch("gateway.status.remove_pid_file", side_effect=lambda: removed.append(True)), \
+         patch("hermes_logging.setup_logging", return_value=gateway_run._hermes_home / "logs"), \
+         patch("hermes_logging._add_rotating_handler"), \
+         patch("tools.skills_sync.sync_skills"), \
+         patch.object(gateway_run.logging.getLogger(), "addHandler"):
+        result = await gateway_run.start_gateway(config=SimpleNamespace())
+
+    assert result is True
+    assert removed


### PR DESCRIPTION
## What does this PR do?

Fixes a duplicate-start race in the gateway lifecycle. `start_gateway()` previously checked for an existing `gateway.pid` before startup, but only wrote the pidfile after `runner.start()` had already connected adapters. That left a several-second window where concurrent `hermes gateway run --replace` invocations under the same `HERMES_HOME` could all pass the guard, all connect, and all process the same inbound events.

This PR writes `gateway.pid` immediately after constructing `GatewayRunner`, before adapter startup begins. It also removes the pidfile again on startup failure and on clean early exit.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Move `write_pid_file()` earlier in `gateway/run.py` so the duplicate-instance guard is claimed before adapters connect
- Remove the pidfile on startup failure and clean early exit
- Add `tests/gateway/test_gateway_startup_pidfile.py` regression coverage

## How to Test

1. Run `python -m pytest tests/gateway/test_gateway_startup_pidfile.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_runner_fatal_adapter.py tests/gateway/test_status.py -q -o addopts=''`
2. Start two `hermes gateway run --replace` invocations against the same `HERMES_HOME` and confirm only one successfully owns startup
3. Verify clean early exits do not leave a stale `gateway.pid` behind

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run targeted pytest coverage for the affected gateway startup paths
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific code added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted regression tests passed locally:

```bash
python -m pytest tests/gateway/test_gateway_startup_pidfile.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_runner_fatal_adapter.py tests/gateway/test_status.py -q -o addopts=''
# 15 passed
```