### PR TITLE
fix(agent): coerce args on direct agent-loop tool dispatch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2185,6 +2185,12 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     except Exception as _mw_err:
         logger.debug("tool_request middleware error: %s", _mw_err)
 
+    # Registry-dispatched tools get their args coerced in handle_function_call;
+    # this direct agent-loop path doesn't, so string scalars like todo's
+    # merge="false" would arrive raw and read as truthy. Coerce here too.
+    from model_tools import coerce_tool_args
+    function_args = coerce_tool_args(function_name, function_args)
+
     # Check plugin hooks for a block or approval directive before executing.
     block_message: Optional[str] = None
     if not pre_tool_block_checked:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1095,6 +1095,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_call_id=getattr(tool_call, "id", "") or "",
         )
 
+        # Registry-dispatched tools get their args coerced in handle_function_call;
+        # this direct agent-loop path doesn't, so string scalars like todo's
+        # merge="false" would arrive raw and read as truthy. Coerce here too.
+        from model_tools import coerce_tool_args
+        function_args = coerce_tool_args(function_name, function_args)
+
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None
         _block_error_type = "plugin_block"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2448,6 +2448,56 @@ class TestExecuteToolCalls:
         assert "Rate limit reached" not in output
 
 
+class TestAgentLoopArgCoercion:
+    """Direct agent-loop dispatch must coerce string-encoded scalar args the
+    same way the registry path does. Regression for todo's ``merge`` flag: the
+    string ``"false"`` used to be forwarded raw and read as a truthy merge,
+    silently turning a full replace into an update-by-id merge."""
+
+    @staticmethod
+    def _replace_with_new_item():
+        # ``merge`` arrives as the string "false" — the raw shape a model emits.
+        return {
+            "todos": [
+                {"id": "new", "content": "replacement item", "status": "pending"}
+            ],
+            "merge": "false",
+        }
+
+    def test_invoke_tool_coerces_todo_merge_flag(self, agent):
+        """Concurrent dispatch entry: _invoke_tool -> invoke_tool."""
+        agent._todo_store.write(
+            [{"id": "old", "content": "existing item", "status": "pending"}]
+        )
+
+        result = json.loads(
+            agent._invoke_tool("todo", self._replace_with_new_item(), "task-1")
+        )
+
+        expected = [{"id": "new", "content": "replacement item", "status": "pending"}]
+        assert result["todos"] == expected
+        assert agent._todo_store.read() == expected
+
+    def test_sequential_dispatch_coerces_todo_merge_flag(self, agent):
+        """Sequential executor path: _execute_tool_calls_sequential."""
+        agent._todo_store.write(
+            [{"id": "old", "content": "existing item", "status": "pending"}]
+        )
+        tool_call = _mock_tool_call(
+            name="todo",
+            arguments=json.dumps(self._replace_with_new_item()),
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert agent._todo_store.read() == [
+            {"id": "new", "content": "replacement item", "status": "pending"}
+        ]
+
+
 class TestRetryAfterCap:
     """#26293: the conversation loop owns rate-limit backoff and honors the
     Retry-After header up to a 600s ceiling (was 120s, which retried before


### PR DESCRIPTION
## What does this PR do?

Direct agent-loop tools were bypassing the same schema coercion that registry-dispatched tools already use.

That showed up most clearly in `todo`: a call like `"merge": "false"` was treated as truthy, so a replace could quietly turn into a merge and leave stale items behind.

This patch just reuses `coerce_tool_args()` in the direct agent-loop paths. It keeps the sequential and concurrent paths in line with the existing registry behavior without adding a second coercion layer.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reused `coerce_tool_args()` in `run_agent.py` before direct `_invoke_tool()` dispatch
- Applied the same normalization in the sequential and concurrent agent-loop parsing paths
- Added two regression tests that cover the direct and sequential `todo` paths with `"merge": "false"`

## How to Test

1. Run `uv run pytest -q -n 0 tests/run_agent/test_run_agent.py -k 'merge_flag'`.
2. Confirm both regression tests pass.
3. Optionally pre-populate the todo list, call `todo` with `"merge": "false"`, and verify the list is replaced rather than merged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

- `uv run pytest -q -n 0 tests/run_agent/test_run_agent.py -k 'merge_flag'` ✅
- `uv run python -m py_compile run_agent.py tests/run_agent/test_run_agent.py` ✅
- `uv run pytest tests/ -q` ❌ fails in this environment with unrelated `OSError: [Errno 24] Too many open files` errors across the wider suite
