### PR TITLE
fix(cli): support Windows-style path autocomplete

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -680,16 +680,32 @@ class SlashCommandCompleter(Completer):
         if not word:
             return None
         # Only trigger path completion for path-like tokens
-        if word.startswith(("./", "../", "~/", "/")) or "/" in word:
+        if SlashCommandCompleter._looks_like_path_word(word):
             return word
         return None
+
+    @staticmethod
+    def _looks_like_path_word(word: str) -> bool:
+        """Return True when *word* looks like a Unix or Windows path."""
+        if not word:
+            return False
+        if word.startswith(("./", "../", "~/", "/", ".\\", "..\\", "~\\", "\\")):
+            return True
+        if "/" in word or "\\" in word:
+            return True
+        return len(word) >= 3 and word[1] == ":" and word[2] in ("/", "\\")
+
+    @staticmethod
+    def _ends_with_path_sep(path: str) -> bool:
+        """Return True when *path* ends with either supported path separator."""
+        return path.endswith(("/", "\\"))
 
     @staticmethod
     def _path_completions(word: str, limit: int = 30):
         """Yield Completion objects for file paths matching *word*."""
         expanded = os.path.expanduser(word)
         # Split into directory part and prefix to match inside it
-        if expanded.endswith("/"):
+        if SlashCommandCompleter._ends_with_path_sep(expanded):
             search_dir = expanded
             prefix = ""
         else:
@@ -782,7 +798,7 @@ class SlashCommandCompleter(Completer):
             if word.startswith(prefix):
                 path_part = word[len(prefix):] or "."
                 expanded = os.path.expanduser(path_part)
-                if expanded.endswith("/"):
+                if SlashCommandCompleter._ends_with_path_sep(expanded):
                     search_dir, match_prefix = expanded, ""
                 else:
                     search_dir = os.path.dirname(expanded) or "."
@@ -822,7 +838,7 @@ class SlashCommandCompleter(Completer):
             search_dir, match_prefix = ".", ""
         else:
             expanded = os.path.expanduser(query)
-            if expanded.endswith("/"):
+            if SlashCommandCompleter._ends_with_path_sep(expanded):
                 search_dir, match_prefix = expanded, ""
             else:
                 search_dir = os.path.dirname(expanded) or "."

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -59,6 +59,12 @@ class TestExtractPathWord:
     def test_just_tilde_slash(self):
         assert SlashCommandCompleter._extract_path_word("~/") == "~/"
 
+    def test_windows_relative_path(self):
+        assert SlashCommandCompleter._extract_path_word(r"edit .\src\main.py") == r".\src\main.py"
+
+    def test_windows_absolute_path(self):
+        assert SlashCommandCompleter._extract_path_word(r"open C:\Users\Simba\notes.txt") == r"C:\Users\Simba\notes.txt"
+
 
 class TestPathCompletions:
     def test_lists_current_directory(self, tmp_path):
@@ -101,6 +107,8 @@ class TestPathCompletions:
 
     def test_home_expansion(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
+        if os.name == "nt":
+            monkeypatch.setenv("USERPROFILE", str(tmp_path))
         (tmp_path / "testfile.md").touch()
 
         completions = list(SlashCommandCompleter._path_completions("~/test"))
@@ -155,13 +163,29 @@ class TestIntegration:
         completions = list(completer.get_completions(doc, event))
         assert completions == []
 
-    def test_absolute_path_triggers_completion(self, completer):
-        doc = Document("check /etc/hos", cursor_position=14)
+    def test_absolute_path_triggers_completion(self, completer, tmp_path):
+        file_path = tmp_path / "hosts.txt"
+        file_path.touch()
+        typed = str(file_path.parent / "hos")
+        doc = Document(f"check {typed}", cursor_position=len(f"check {typed}"))
         event = MagicMock()
         completions = list(completer.get_completions(doc, event))
         names = _display_names(completions)
-        # /etc/hosts should exist on Linux
-        assert any("host" in n.lower() for n in names)
+        assert "hosts.txt" in names
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows path syntax")
+    def test_windows_relative_path_triggers_completion(self, completer, tmp_path):
+        (tmp_path / "test.py").touch()
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            doc = Document(r"edit .\te", cursor_position=len(r"edit .\te"))
+            event = MagicMock()
+            completions = list(completer.get_completions(doc, event))
+            names = _display_names(completions)
+            assert "test.py" in names
+        finally:
+            os.chdir(old_cwd)
 
 
 class TestFileSizeLabel:


### PR DESCRIPTION
Windows path autocomplete is currently much stricter than the paths Windows users actually type.

Right now, completion only kicks in reliably for Unix-like path shapes. That means inputs like `.\foo`, `..\bar`, `~\baz`, `C:\work\repo`, or `\\server\share` can pass through the CLI without ever being recognized as path candidates, so autocomplete never starts.

This patch widens the path-detection heuristics used by CLI completion so Windows-native prefixes are treated as valid path input too. It also handles prefixes ending in `\` as directory-like prefixes, which lets completion continue naturally while navigating nested paths.

The change is intentionally small and localized:
- no command dispatch changes
- no registry/alias behavior changes
- no completion engine redesign
- only path-shape recognition is expanded

A regression test was added to cover Windows-style path extraction and to verify that completion is triggered for `.\...` input. Existing path completion expectations for other path styles were also kept covered so the broader heuristic does not regress current behavior.

Why this is worth fixing:
Windows users are entering legitimate paths and getting no completion at all, which makes the feature feel broken even though the completion pipeline itself is fine. This patch closes that gap without changing the rest of the command system.


Result:

`29 passed`