### PR TITLE
fix(discord): keep members intent opt-in for stability

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -514,16 +514,14 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Set up intents.
             # Message Content is required for normal text replies.
-            # Server Members is only needed when the allowlist contains usernames
-            # that must be resolved to numeric IDs. Requesting privileged intents
-            # that aren't enabled in the Discord Developer Portal can prevent the
-            # bot from coming online at all, so avoid requesting members intent
-            # unless it is actually necessary.
+            # Members intent is optional and often disabled in the Discord portal.
+            # Default to off unless explicitly enabled by env so the bot can still
+            # connect on setups where privileged intents are not enabled.
             intents = Intents.default()
             intents.message_content = True
             intents.dm_messages = True
             intents.guild_messages = True
-            intents.members = any(not entry.isdigit() for entry in self._allowed_user_ids)
+            intents.members = os.getenv("DISCORD_ENABLE_MEMBERS_INTENT", "false").lower() in {"1", "true", "yes", "on"}
             intents.voice_states = True
 
             # Create bot
@@ -1252,7 +1250,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 pass
 
     def _is_allowed_user(self, user_id: str) -> bool:
-        """Check if user is in DISCORD_ALLOWED_USERS."""
+        """Check Discord adapter-level authorization."""
+        if os.getenv("DISCORD_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes"):
+            return True
         if not self._allowed_user_ids:
             return True
         return user_id in self._allowed_user_ids
@@ -1482,6 +1482,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 to_resolve.add(entry.lower())
 
         if not to_resolve:
+            return
+
+        if not getattr(getattr(self._client, "intents", None), "members", False):
+            logger.info(
+                "[%s] Skipping username resolution for DISCORD_ALLOWED_USERS because members intent is disabled",
+                self.name,
+            )
             return
 
         print(f"[{self.name}] Resolving {len(to_resolve)} username(s): {', '.join(to_resolve)}")

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -998,17 +998,42 @@ class TestDiscordVoiceChannelMethods:
 
     def test_is_allowed_user_empty_list(self):
         adapter = self._make_adapter()
-        assert adapter._is_allowed_user("42") is True
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("DISCORD_ALLOW_ALL_USERS", None)
+            assert adapter._is_allowed_user("42") is True
 
     def test_is_allowed_user_in_list(self):
         adapter = self._make_adapter()
         adapter._allowed_user_ids = {"42", "99"}
-        assert adapter._is_allowed_user("42") is True
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("DISCORD_ALLOW_ALL_USERS", None)
+            assert adapter._is_allowed_user("42") is True
 
     def test_is_allowed_user_not_in_list(self):
         adapter = self._make_adapter()
         adapter._allowed_user_ids = {"99"}
-        assert adapter._is_allowed_user("42") is False
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("DISCORD_ALLOW_ALL_USERS", None)
+            assert adapter._is_allowed_user("42") is False
+
+    def test_is_allowed_user_honors_allow_all_env(self):
+        adapter = self._make_adapter()
+        adapter._allowed_user_ids = {"99"}
+        with patch.dict("os.environ", {"DISCORD_ALLOW_ALL_USERS": "true"}, clear=False):
+            assert adapter._is_allowed_user("42") is True
+
+    @pytest.mark.asyncio
+    async def test_resolve_allowed_usernames_skips_when_members_intent_disabled(self):
+        adapter = self._make_adapter()
+        adapter._allowed_user_ids = {"timerway", "42"}
+        adapter._client = MagicMock()
+        adapter._client.intents = SimpleNamespace(members=False)
+        adapter._client.guilds = [MagicMock()]
+
+        await adapter._resolve_allowed_usernames()
+
+        assert adapter._allowed_user_ids == {"timerway", "42"}
+        adapter._client.guilds[0].fetch_members.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_process_voice_input_success(self):


### PR DESCRIPTION
## Summary
- keep Discord members intent opt-in via `DISCORD_ENABLE_MEMBERS_INTENT` instead of auto-enabling it from allowlist contents
- respect `DISCORD_ALLOW_ALL_USERS` in the adapter-level allow check so gateway and adapter auth stay consistent
- skip username resolution when members intent is disabled to avoid triggering privileged-intent-dependent paths
- add regression tests covering allow-all behavior and disabled-members-intent username resolution

## Why
Tim's runtime uses Discord without the privileged Members intent enabled in the developer portal. Auto-requesting members intent causes `PrivilegedIntentsRequired`, connection timeouts, and reconnect loops. This patch keeps the bot online in that configuration while preserving an explicit opt-in for installations that do want members intent.

## Validation
- `pytest tests/gateway/test_voice_command.py -q`
- `python3 -m py_compile gateway/platforms/discord.py run_agent.py`
- `hermes gateway restart`
- verified Discord reconnects successfully on macOS local runtime
- verified ChatGPT Codex `gpt-5.4` still responds after update
