### PR TITLE
feat: add tested Termux install path and EOF-aware gh auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
-Works on Linux, macOS, and WSL2. The installer handles everything — Python, Node.js, dependencies, and the `hermes` command. No prerequisites except git.
+Works on Linux, macOS, WSL2, and Android via Termux. The installer handles the platform-specific setup for you.
 
+> **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
+>
 > **Windows:** Native Windows is not supported. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command above.
 
 After installation:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -79,7 +79,7 @@ CUSTOM_POOL_PREFIX = "custom:"
 _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
-    "agent_key_obtained_at", "tls",
+    "agent_key_obtained_at", "session_token", "tls",
 })
 
 

--- a/cli.py
+++ b/cli.py
@@ -8707,6 +8707,7 @@ def main(
                     route_label=turn_route["label"],
                 ):
                     cli.agent.quiet_mode = True
+                    cli.agent.suppress_status_output = True
                     result = cli.agent.run_conversation(
                         user_message=query,
                         conversation_history=cli.conversation_history,

--- a/cli.py
+++ b/cli.py
@@ -1894,7 +1894,26 @@ class HermesCLI:
             return 0
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
 
+    def _get_voice_status_fragments(self, width: Optional[int] = None):
+        """Return the voice status bar fragments for the interactive TUI."""
+        width = width or self._get_tui_terminal_width()
+        compact = self._use_minimal_tui_chrome(width=width)
+        if self._voice_recording:
+            if compact:
+                return [("class:voice-status-recording", " ● REC ")]
+            return [("class:voice-status-recording", " ● REC  Ctrl+B to stop ")]
+        if self._voice_processing:
+            if compact:
+                return [("class:voice-status", " ◉ STT ")]
+            return [("class:voice-status", " ◉ Transcribing... ")]
+        if compact:
+            return [("class:voice-status", " 🎤 Ctrl+B ")]
+        tts = " | TTS on" if self._voice_tts else ""
+        cont = " | Continuous" if self._voice_continuous else ""
+        return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  Ctrl+B to record ")]
+
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
+        """Return a compact one-line session status string for the TUI footer."""
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
@@ -5991,6 +6010,13 @@ class HermesCLI:
         reqs = check_voice_requirements()
         if not reqs["audio_available"]:
             if _is_termux_environment():
+                details = reqs.get("details", "")
+                if "Termux:API Android app is not installed" in details:
+                    raise RuntimeError(
+                        "Termux:API command package detected, but the Android app is missing.\n"
+                        "Install/update the Termux:API Android app, then retry /voice on.\n"
+                        "Fallback: pkg install python-numpy portaudio && python -m pip install sounddevice"
+                    )
                 raise RuntimeError(
                     "Voice mode requires either Termux:API microphone access or Python audio libraries.\n"
                     "Option 1: pkg install termux-api and install the Termux:API Android app\n"
@@ -8321,13 +8347,7 @@ class HermesCLI:
 
         # Persistent voice mode status bar (visible only when voice mode is on)
         def _get_voice_status():
-            if cli_ref._voice_recording:
-                return [('class:voice-status-recording', ' ● REC  Ctrl+B to stop ')]
-            if cli_ref._voice_processing:
-                return [('class:voice-status', ' ◉ Transcribing... ')]
-            tts = " | TTS on" if cli_ref._voice_tts else ""
-            cont = " | Continuous" if cli_ref._voice_continuous else ""
-            return [('class:voice-status', f' 🎤 Voice mode{tts}{cont}  —  Ctrl+B to record ')]
+            return cli_ref._get_voice_status_fragments()
 
         voice_status_bar = ConditionalContainer(
             Window(

--- a/cli.py
+++ b/cli.py
@@ -1022,6 +1022,20 @@ def _is_termux_environment() -> bool:
     return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
 
 
+def _termux_example_image_path(filename: str = "cat.png") -> str:
+    """Return a realistic example media path for the current Termux setup."""
+    candidates = [
+        os.path.expanduser("~/storage/shared"),
+        "/sdcard",
+        "/storage/emulated/0",
+        "/storage/self/primary",
+    ]
+    for root in candidates:
+        if os.path.isdir(root):
+            return os.path.join(root, "Pictures", filename)
+    return os.path.join("~/storage/shared", "Pictures", filename)
+
+
 def _split_path_input(raw: str) -> tuple[str, str]:
     """Split a leading file path token from trailing free-form text.
 
@@ -3121,7 +3135,7 @@ class HermesCLI:
             _cprint(
                 f"  {_DIM}Clipboard image paste is not available on Termux — "
                 f"use /image <path> or paste a local image path like "
-                f"~/storage/shared/Pictures/cat.png{_RST}"
+                f"{_termux_example_image_path()}{_RST}"
             )
             return
 
@@ -3139,7 +3153,7 @@ class HermesCLI:
         """Handle /image <path> — attach a local image file for the next prompt."""
         raw_args = (cmd_original.split(None, 1)[1].strip() if " " in cmd_original else "")
         if not raw_args:
-            hint = "~/storage/shared/Pictures/cat.png" if _is_termux_environment() else "/path/to/image.png"
+            hint = _termux_example_image_path() if _is_termux_environment() else "/path/to/image.png"
             _cprint(f"  {_DIM}Usage: /image <path>  e.g. /image {hint}{_RST}")
             return
 
@@ -3157,7 +3171,7 @@ class HermesCLI:
         if _remainder:
             _cprint(f"  {_DIM}Now type your prompt (or use --image in single-query mode): {_remainder}{_RST}")
         elif _is_termux_environment():
-            _cprint(f"  {_DIM}Tip: type your next message, or run hermes chat -q --image {image_path} \"What do you see?\"{_RST}")
+            _cprint(f"  {_DIM}Tip: type your next message, or run hermes chat -q --image {_termux_example_image_path(image_path.name)} \"What do you see?\"{_RST}")
 
     def _preprocess_images_with_vision(self, text: str, images: list, *, announce: bool = True) -> str:
         """Analyze attached images via the vision tool and return enriched text.
@@ -3312,7 +3326,7 @@ class HermesCLI:
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
         if _is_termux_environment():
-            _cprint(f"  {_DIM}Attach image: /image ~/storage/shared/Pictures/cat.png or start your prompt with a local image path{_RST}\n")
+            _cprint(f"  {_DIM}Attach image: /image {_termux_example_image_path()} or start your prompt with a local image path{_RST}\n")
         else:
             _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
     
@@ -6241,8 +6255,11 @@ class HermesCLI:
             for line in reqs["details"].split("\n"):
                 _cprint(f"  {_DIM}{line}{_RST}")
             if reqs["missing_packages"]:
-                _cprint(f"\n  {_BOLD}Install: pip install {' '.join(reqs['missing_packages'])}{_RST}")
-                _cprint(f"  {_DIM}Or: pip install hermes-agent[voice]{_RST}")
+                if _is_termux_environment():
+                    _cprint(f"\n  {_BOLD}Install: pkg install python-numpy portaudio && python -m pip install sounddevice{_RST}")
+                else:
+                    _cprint(f"\n  {_BOLD}Install: pip install {' '.join(reqs['missing_packages'])}{_RST}")
+                    _cprint(f"  {_DIM}Or: pip install hermes-agent[voice]{_RST}")
             return
 
         with self._voice_lock:

--- a/cli.py
+++ b/cli.py
@@ -1840,15 +1840,51 @@ class HermesCLI:
             width += ch_width
         return "".join(out).rstrip() + ellipsis
 
+    @staticmethod
+    def _get_tui_terminal_width(default: tuple[int, int] = (80, 24)) -> int:
+        """Return the live prompt_toolkit width, falling back to ``shutil``.
+
+        The TUI layout can be narrower than ``shutil.get_terminal_size()`` reports,
+        especially on Termux/mobile shells, so prefer prompt_toolkit's width whenever
+        an app is active.
+        """
+        try:
+            from prompt_toolkit.application import get_app
+            return get_app().output.get_size().columns
+        except Exception:
+            return shutil.get_terminal_size(default).columns
+
+    def _use_minimal_tui_chrome(self, width: Optional[int] = None) -> bool:
+        """Hide low-value chrome on narrow/mobile terminals to preserve rows."""
+        if width is None:
+            width = self._get_tui_terminal_width()
+        return width < 64
+
+    def _tui_input_rule_height(self, position: str, width: Optional[int] = None) -> int:
+        """Return the visible height for the top/bottom input separator rules."""
+        if position not in {"top", "bottom"}:
+            raise ValueError(f"Unknown input rule position: {position}")
+        if position == "top":
+            return 1
+        return 0 if self._use_minimal_tui_chrome(width=width) else 1
+
+    def _agent_spacer_height(self, width: Optional[int] = None) -> int:
+        """Return the spacer height shown above the status bar while the agent runs."""
+        if not getattr(self, "_agent_running", False):
+            return 0
+        return 0 if self._use_minimal_tui_chrome(width=width) else 1
+
+    def _spinner_widget_height(self, width: Optional[int] = None) -> int:
+        """Return the visible height for the spinner/status text line above the status bar."""
+        if not getattr(self, "_spinner_text", ""):
+            return 0
+        return 0 if self._use_minimal_tui_chrome(width=width) else 1
+
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
-                try:
-                    from prompt_toolkit.application import get_app
-                    width = get_app().output.get_size().columns
-                except Exception:
-                    width = shutil.get_terminal_size((80, 24)).columns
+                width = self._get_tui_terminal_width()
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
@@ -1884,11 +1920,7 @@ class HermesCLI:
             # values (especially on SSH) that differ from what prompt_toolkit
             # actually renders, causing the fragments to overflow to a second
             # line and produce duplicated status bar rows over long sessions.
-            try:
-                from prompt_toolkit.application import get_app
-                width = get_app().output.get_size().columns
-            except Exception:
-                width = shutil.get_terminal_size((80, 24)).columns
+            width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
 
             if width < 52:
@@ -8011,9 +8043,9 @@ class HermesCLI:
         def get_hint_height():
             if cli_ref._sudo_state or cli_ref._secret_state or cli_ref._approval_state or cli_ref._clarify_state or cli_ref._command_running:
                 return 1
-            # Keep a 1-line spacer while agent runs so output doesn't push
-            # right up against the top rule of the input area
-            return 1 if cli_ref._agent_running else 0
+            # Keep a spacer while the agent runs on roomy terminals, but reclaim
+            # the row on narrow/mobile screens where every line matters.
+            return cli_ref._agent_spacer_height()
 
         def get_spinner_text():
             txt = cli_ref._spinner_text
@@ -8022,7 +8054,7 @@ class HermesCLI:
             return [('class:hint', f'  {txt}')]
 
         def get_spinner_height():
-            return 1 if cli_ref._spinner_text else 0
+            return cli_ref._spinner_widget_height()
 
         spinner_widget = Window(
             content=FormattedTextControl(get_spinner_text),
@@ -8213,18 +8245,17 @@ class HermesCLI:
             filter=Condition(lambda: cli_ref._approval_state is not None),
         )
 
-        # Horizontal rules above and below the input (bronze, 1 line each).
-        # The bottom rule moves down as the TextArea grows with newlines.
-        # Using char='─' instead of hardcoded repetition so the rule
-        # always spans the full terminal width on any screen size.
+        # Horizontal rules above and below the input.
+        # On narrow/mobile terminals we keep the top separator for structure but
+        # hide the bottom one to recover a full row for conversation content.
         input_rule_top = Window(
             char='─',
-            height=1,
+            height=lambda: cli_ref._tui_input_rule_height("top"),
             style='class:input-rule',
         )
         input_rule_bot = Window(
             char='─',
-            height=1,
+            height=lambda: cli_ref._tui_input_rule_height("bottom"),
             style='class:input-rule',
         )
 

--- a/cli.py
+++ b/cli.py
@@ -1008,7 +1008,7 @@ def _cprint(text: str):
 
 
 # ---------------------------------------------------------------------------
-# File-drop detection — extracted as a pure function for testability.
+# File-drop / local attachment detection — extracted as pure helpers for tests.
 # ---------------------------------------------------------------------------
 
 _IMAGE_EXTENSIONS = frozenset({
@@ -1017,12 +1017,91 @@ _IMAGE_EXTENSIONS = frozenset({
 })
 
 
-def _detect_file_drop(user_input: str) -> "dict | None":
-    """Detect if *user_input* is a dragged/pasted file path, not a slash command.
+def _is_termux_environment() -> bool:
+    prefix = os.getenv("PREFIX", "")
+    return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
 
-    When a user drags a file into the terminal, macOS pastes the absolute path
-    (e.g. ``/Users/roland/Desktop/file.png``) which starts with ``/`` and would
-    otherwise be mistaken for a slash command.
+
+def _split_path_input(raw: str) -> tuple[str, str]:
+    """Split a leading file path token from trailing free-form text.
+
+    Supports quoted paths and backslash-escaped spaces so callers can accept
+    inputs like:
+      /tmp/pic.png describe this
+      ~/storage/shared/My\ Photos/cat.png what is this?
+      "/storage/emulated/0/DCIM/Camera/cat 1.png" summarize
+    """
+    raw = str(raw or "").strip()
+    if not raw:
+        return "", ""
+
+    if raw[0] in {'"', "'"}:
+        quote = raw[0]
+        pos = 1
+        while pos < len(raw):
+            ch = raw[pos]
+            if ch == '\\' and pos + 1 < len(raw):
+                pos += 2
+                continue
+            if ch == quote:
+                token = raw[1:pos]
+                remainder = raw[pos + 1 :].strip()
+                return token, remainder
+            pos += 1
+        return raw[1:], ""
+
+    pos = 0
+    while pos < len(raw):
+        ch = raw[pos]
+        if ch == '\\' and pos + 1 < len(raw) and raw[pos + 1] == ' ':
+            pos += 2
+        elif ch == ' ':
+            break
+        else:
+            pos += 1
+
+    token = raw[:pos].replace('\\ ', ' ')
+    remainder = raw[pos:].strip()
+    return token, remainder
+
+
+def _resolve_attachment_path(raw_path: str) -> Path | None:
+    """Resolve a user-supplied local attachment path.
+
+    Accepts quoted or unquoted paths, expands ``~`` and env vars, and resolves
+    relative paths from ``TERMINAL_CWD`` when set (matching terminal tool cwd).
+    Returns ``None`` when the path does not resolve to an existing file.
+    """
+    token = str(raw_path or "").strip()
+    if not token:
+        return None
+
+    if (token.startswith('"') and token.endswith('"')) or (token.startswith("'") and token.endswith("'")):
+        token = token[1:-1].strip()
+    if not token:
+        return None
+
+    expanded = os.path.expandvars(os.path.expanduser(token))
+    path = Path(expanded)
+    if not path.is_absolute():
+        base_dir = Path(os.getenv("TERMINAL_CWD", os.getcwd()))
+        path = base_dir / path
+
+    try:
+        resolved = path.resolve()
+    except Exception:
+        resolved = path
+
+    if not resolved.exists() or not resolved.is_file():
+        return None
+    return resolved
+
+
+def _detect_file_drop(user_input: str) -> "dict | None":
+    """Detect if *user_input* starts with a real local file path.
+
+    This catches dragged/pasted paths before they are mistaken for slash
+    commands, and also supports Termux-friendly paths like ``~/storage/...``.
 
     Returns a dict on match::
 
@@ -1034,34 +1113,99 @@ def _detect_file_drop(user_input: str) -> "dict | None":
 
     Returns ``None`` when the input is not a real file path.
     """
-    if not isinstance(user_input, str) or not user_input.startswith("/"):
+    if not isinstance(user_input, str):
         return None
 
-    # Walk the string absorbing backslash-escaped spaces ("\ ").
-    raw = user_input
-    pos = 0
-    while pos < len(raw):
-        ch = raw[pos]
-        if ch == '\\' and pos + 1 < len(raw) and raw[pos + 1] == ' ':
-            pos += 2  # skip escaped space
-        elif ch == ' ':
-            break
-        else:
-            pos += 1
-
-    first_token_raw = raw[:pos]
-    first_token = first_token_raw.replace('\\ ', ' ')
-    drop_path = Path(first_token)
-
-    if not drop_path.exists() or not drop_path.is_file():
+    stripped = user_input.strip()
+    if not stripped:
         return None
 
-    remainder = raw[pos:].strip()
+    starts_like_path = (
+        stripped.startswith("/")
+        or stripped.startswith("~")
+        or stripped.startswith("./")
+        or stripped.startswith("../")
+        or stripped.startswith('"/')
+        or stripped.startswith('"~')
+        or stripped.startswith("'/")
+        or stripped.startswith("'~")
+    )
+    if not starts_like_path:
+        return None
+
+    first_token, remainder = _split_path_input(stripped)
+    drop_path = _resolve_attachment_path(first_token)
+    if drop_path is None:
+        return None
+
     return {
         "path": drop_path,
         "is_image": drop_path.suffix.lower() in _IMAGE_EXTENSIONS,
         "remainder": remainder,
     }
+
+
+def _format_image_attachment_badges(attached_images: list[Path], image_counter: int, width: int | None = None) -> str:
+    """Format the attached-image badge row for the interactive CLI.
+
+    Narrow terminals such as Termux should get a compact summary that fits on a
+    single row, while wider terminals can show the classic per-image badges.
+    """
+    if not attached_images:
+        return ""
+
+    width = width or shutil.get_terminal_size((80, 24)).columns
+
+    def _trunc(name: str, limit: int) -> str:
+        return name if len(name) <= limit else name[: max(1, limit - 3)] + "..."
+
+    if width < 52:
+        if len(attached_images) == 1:
+            return f"[📎 {_trunc(attached_images[0].name, 20)}]"
+        return f"[📎 {len(attached_images)} images attached]"
+
+    if width < 80:
+        if len(attached_images) == 1:
+            return f"[📎 {_trunc(attached_images[0].name, 32)}]"
+        first = _trunc(attached_images[0].name, 20)
+        extra = len(attached_images) - 1
+        return f"[📎 {first}] [+{extra}]"
+
+    base = image_counter - len(attached_images) + 1
+    return " ".join(
+        f"[📎 Image #{base + i}]"
+        for i in range(len(attached_images))
+    )
+
+
+def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
+    """Collect local image attachments for single-query CLI flows."""
+    message = query or ""
+    images: list[Path] = []
+
+    if isinstance(message, str):
+        dropped = _detect_file_drop(message)
+        if dropped and dropped.get("is_image"):
+            images.append(dropped["path"])
+            message = dropped["remainder"] or f"[User attached image: {dropped['path'].name}]"
+
+    if image_arg:
+        explicit_path = _resolve_attachment_path(image_arg)
+        if explicit_path is None:
+            raise ValueError(f"Image file not found: {image_arg}")
+        if explicit_path.suffix.lower() not in _IMAGE_EXTENSIONS:
+            raise ValueError(f"Not a supported image file: {explicit_path}")
+        images.append(explicit_path)
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for img in images:
+        key = str(img)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(img)
+    return message, deduped
 
 
 class ChatConsole:
@@ -2941,6 +3085,14 @@ class HermesCLI:
         doesn't fire for image-only clipboard content (e.g., VSCode terminal,
         Windows Terminal with WSL2).
         """
+        if _is_termux_environment():
+            _cprint(
+                f"  {_DIM}Clipboard image paste is not available on Termux — "
+                f"use /image <path> or paste a local image path like "
+                f"~/storage/shared/Pictures/cat.png{_RST}"
+            )
+            return
+
         from hermes_cli.clipboard import has_clipboard_image
         if has_clipboard_image():
             if self._try_attach_clipboard_image():
@@ -2951,7 +3103,31 @@ class HermesCLI:
         else:
             _cprint(f"  {_DIM}(._.) No image found in clipboard{_RST}")
 
-    def _preprocess_images_with_vision(self, text: str, images: list) -> str:
+    def _handle_image_command(self, cmd_original: str):
+        """Handle /image <path> — attach a local image file for the next prompt."""
+        raw_args = (cmd_original.split(None, 1)[1].strip() if " " in cmd_original else "")
+        if not raw_args:
+            hint = "~/storage/shared/Pictures/cat.png" if _is_termux_environment() else "/path/to/image.png"
+            _cprint(f"  {_DIM}Usage: /image <path>  e.g. /image {hint}{_RST}")
+            return
+
+        path_token, _remainder = _split_path_input(raw_args)
+        image_path = _resolve_attachment_path(path_token)
+        if image_path is None:
+            _cprint(f"  {_DIM}(>_<) File not found: {path_token}{_RST}")
+            return
+        if image_path.suffix.lower() not in _IMAGE_EXTENSIONS:
+            _cprint(f"  {_DIM}(._.) Not a supported image file: {image_path.name}{_RST}")
+            return
+
+        self._attached_images.append(image_path)
+        _cprint(f"  📎 Attached image: {image_path.name}")
+        if _remainder:
+            _cprint(f"  {_DIM}Now type your prompt (or use --image in single-query mode): {_remainder}{_RST}")
+        elif _is_termux_environment():
+            _cprint(f"  {_DIM}Tip: type your next message, or run hermes chat -q --image {image_path} \"What do you see?\"{_RST}")
+
+    def _preprocess_images_with_vision(self, text: str, images: list, *, announce: bool = True) -> str:
         """Analyze attached images via the vision tool and return enriched text.
 
         Instead of embedding raw base64 ``image_url`` content parts in the
@@ -2978,7 +3154,8 @@ class HermesCLI:
             if not img_path.exists():
                 continue
             size_kb = img_path.stat().st_size // 1024
-            _cprint(f"  {_DIM}👁️  analyzing {img_path.name} ({size_kb}KB)...{_RST}")
+            if announce:
+                _cprint(f"  {_DIM}👁️  analyzing {img_path.name} ({size_kb}KB)...{_RST}")
             try:
                 result_json = _asyncio.run(
                     vision_analyze_tool(image_url=str(img_path), user_prompt=analysis_prompt)
@@ -2991,21 +3168,24 @@ class HermesCLI:
                         f"[If you need a closer look, use vision_analyze with "
                         f"image_url: {img_path}]"
                     )
-                    _cprint(f"  {_DIM}✓ image analyzed{_RST}")
+                    if announce:
+                        _cprint(f"  {_DIM}✓ image analyzed{_RST}")
                 else:
                     enriched_parts.append(
                         f"[The user attached an image but it couldn't be analyzed. "
                         f"You can try examining it with vision_analyze using "
                         f"image_url: {img_path}]"
                     )
-                    _cprint(f"  {_DIM}⚠ vision analysis failed — path included for retry{_RST}")
+                    if announce:
+                        _cprint(f"  {_DIM}⚠ vision analysis failed — path included for retry{_RST}")
             except Exception as e:
                 enriched_parts.append(
                     f"[The user attached an image but analysis failed ({e}). "
                     f"You can try examining it with vision_analyze using "
                     f"image_url: {img_path}]"
                 )
-                _cprint(f"  {_DIM}⚠ vision analysis error — path included for retry{_RST}")
+                if announce:
+                    _cprint(f"  {_DIM}⚠ vision analysis error — path included for retry{_RST}")
 
         # Combine: vision descriptions first, then the user's original text
         user_text = text if isinstance(text, str) and text else ""
@@ -3099,7 +3279,10 @@ class HermesCLI:
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
-        _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
+        if _is_termux_environment():
+            _cprint(f"  {_DIM}Attach image: /image ~/storage/shared/Pictures/cat.png or start your prompt with a local image path{_RST}\n")
+        else:
+            _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
@@ -4599,6 +4782,8 @@ class HermesCLI:
             self._show_insights(cmd_original)
         elif canonical == "paste":
             self._handle_paste_command()
+        elif canonical == "image":
+            self._handle_image_command(cmd_original)
         elif canonical == "reload-mcp":
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._reload_mcp()
@@ -8049,10 +8234,9 @@ class HermesCLI:
         def _get_image_bar():
             if not cli_ref._attached_images:
                 return []
-            base = cli_ref._image_counter - len(cli_ref._attached_images) + 1
-            badges = " ".join(
-                f"[📎 Image #{base + i}]"
-                for i in range(len(cli_ref._attached_images))
+            badges = _format_image_attachment_badges(
+                cli_ref._attached_images,
+                cli_ref._image_counter,
             )
             return [("class:image-badge", f" {badges} ")]
 
@@ -8525,6 +8709,7 @@ class HermesCLI:
 def main(
     query: str = None,
     q: str = None,
+    image: str = None,
     toolsets: str = None,
     skills: str | list[str] | tuple[str, ...] = None,
     model: str = None,
@@ -8550,6 +8735,7 @@ def main(
     Args:
         query: Single query to execute (then exit). Alias: -q
         q: Shorthand for --query
+        image: Optional local image path to attach to a single query
         toolsets: Comma-separated list of toolsets to enable (e.g., "web,terminal")
         skills: Comma-separated or repeated list of skills to preload for the session
         model: Model to use (default: anthropic/claude-opus-4-20250514)
@@ -8570,6 +8756,7 @@ def main(
         python cli.py --toolsets web,terminal    # Use specific toolsets
         python cli.py --skills hermes-agent-dev,github-auth
         python cli.py -q "What is Python?"       # Single query mode
+        python cli.py -q "Describe this" --image ~/storage/shared/Pictures/cat.png
         python cli.py --list-tools               # List tools and exit
         python cli.py --resume 20260225_143052_a1b2c3  # Resume session
         python cli.py -w                         # Start in isolated git worktree
@@ -8692,13 +8879,21 @@ def main(
     atexit.register(_run_cleanup)
     
     # Handle single query mode
-    if query:
+    if query or image:
+        query, single_query_images = _collect_query_images(query, image)
         if quiet:
             # Quiet mode: suppress banner, spinner, tool previews.
             # Only print the final response and parseable session info.
             cli.tool_progress_mode = "off"
             if cli._ensure_runtime_credentials():
-                turn_route = cli._resolve_turn_agent_config(query)
+                effective_query = query
+                if single_query_images:
+                    effective_query = cli._preprocess_images_with_vision(
+                        query,
+                        single_query_images,
+                        announce=False,
+                    )
+                turn_route = cli._resolve_turn_agent_config(effective_query)
                 if turn_route["signature"] != cli._active_agent_route_signature:
                     cli.agent = None
                 if cli._init_agent(
@@ -8709,7 +8904,7 @@ def main(
                     cli.agent.quiet_mode = True
                     cli.agent.suppress_status_output = True
                     result = cli.agent.run_conversation(
-                        user_message=query,
+                        user_message=effective_query,
                         conversation_history=cli.conversation_history,
                     )
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
@@ -8724,8 +8919,10 @@ def main(
             sys.exit(1)
         else:
             cli.show_banner()
-            cli.console.print(f"[bold blue]Query:[/] {query}")
-            cli.chat(query)
+            _query_label = query or ("[image attached]" if single_query_images else "")
+            if _query_label:
+                cli.console.print(f"[bold blue]Query:[/] {_query_label}")
+            cli.chat(query, images=single_query_images or None)
             cli._print_exit_summary()
         return
     

--- a/cli.py
+++ b/cli.py
@@ -5986,10 +5986,16 @@ class HermesCLI:
         """Start capturing audio from the microphone."""
         if getattr(self, '_should_exit', False):
             return
-        from tools.voice_mode import AudioRecorder, check_voice_requirements
+        from tools.voice_mode import create_audio_recorder, check_voice_requirements
 
         reqs = check_voice_requirements()
         if not reqs["audio_available"]:
+            if _is_termux_environment():
+                raise RuntimeError(
+                    "Voice mode requires either Termux:API microphone access or Python audio libraries.\n"
+                    "Option 1: pkg install termux-api and install the Termux:API Android app\n"
+                    "Option 2: pkg install python-numpy portaudio && python -m pip install sounddevice"
+                )
             raise RuntimeError(
                 "Voice mode requires sounddevice and numpy.\n"
                 "Install with: pip install sounddevice numpy\n"
@@ -6018,7 +6024,7 @@ class HermesCLI:
             pass
 
         if self._voice_recorder is None:
-            self._voice_recorder = AudioRecorder()
+            self._voice_recorder = create_audio_recorder()
 
         # Apply config-driven silence params
         self._voice_recorder._silence_threshold = voice_cfg.get("silence_threshold", 200)
@@ -6047,7 +6053,13 @@ class HermesCLI:
             with self._voice_lock:
                 self._voice_recording = False
             raise
-        _cprint(f"\n{_GOLD}● Recording...{_RST} {_DIM}(auto-stops on silence | Ctrl+B to stop & exit continuous){_RST}")
+        if getattr(self._voice_recorder, "supports_silence_autostop", True):
+            _recording_hint = "auto-stops on silence | Ctrl+B to stop & exit continuous"
+        elif _is_termux_environment():
+            _recording_hint = "Termux:API capture | Ctrl+B to stop"
+        else:
+            _recording_hint = "Ctrl+B to stop"
+        _cprint(f"\n{_GOLD}● Recording...{_RST} {_DIM}({_recording_hint}){_RST}")
 
         # Periodically refresh prompt to update audio level indicator
         def _refresh_level():
@@ -6256,7 +6268,9 @@ class HermesCLI:
                 _cprint(f"  {_DIM}{line}{_RST}")
             if reqs["missing_packages"]:
                 if _is_termux_environment():
-                    _cprint(f"\n  {_BOLD}Install: pkg install python-numpy portaudio && python -m pip install sounddevice{_RST}")
+                    _cprint(f"\n  {_BOLD}Option 1: pkg install termux-api{_RST}")
+                    _cprint(f"  {_DIM}Then install/update the Termux:API Android app for microphone capture{_RST}")
+                    _cprint(f"  {_BOLD}Option 2: pkg install python-numpy portaudio && python -m pip install sounddevice{_RST}")
                 else:
                     _cprint(f"\n  {_BOLD}Install: pip install {' '.join(reqs['missing_packages'])}{_RST}")
                     _cprint(f"  {_DIM}Or: pip install hermes-agent[voice]{_RST}")
@@ -7183,27 +7197,39 @@ class HermesCLI:
     def _get_tui_prompt_fragments(self):
         """Return the prompt_toolkit fragments for the current interactive state."""
         symbol, state_suffix = self._get_tui_prompt_symbols()
+        compact = self._use_minimal_tui_chrome(width=self._get_tui_terminal_width())
+
+        def _state_fragment(style: str, icon: str, extra: str = ""):
+            if compact:
+                text = icon
+                if extra:
+                    text = f"{text} {extra.strip()}".rstrip()
+                return [(style, text + " ")]
+            if extra:
+                return [(style, f"{icon} {extra} {state_suffix}")]
+            return [(style, f"{icon} {state_suffix}")]
+
         if self._voice_recording:
             bar = self._audio_level_bar()
-            return [("class:voice-recording", f"● {bar} {state_suffix}")]
+            return _state_fragment("class:voice-recording", "●", bar)
         if self._voice_processing:
-            return [("class:voice-processing", f"◉ {state_suffix}")]
+            return _state_fragment("class:voice-processing", "◉")
         if self._sudo_state:
-            return [("class:sudo-prompt", f"🔐 {state_suffix}")]
+            return _state_fragment("class:sudo-prompt", "🔐")
         if self._secret_state:
-            return [("class:sudo-prompt", f"🔑 {state_suffix}")]
+            return _state_fragment("class:sudo-prompt", "🔑")
         if self._approval_state:
-            return [("class:prompt-working", f"⚠ {state_suffix}")]
+            return _state_fragment("class:prompt-working", "⚠")
         if self._clarify_freetext:
-            return [("class:clarify-selected", f"✎ {state_suffix}")]
+            return _state_fragment("class:clarify-selected", "✎")
         if self._clarify_state:
-            return [("class:prompt-working", f"? {state_suffix}")]
+            return _state_fragment("class:prompt-working", "?")
         if self._command_running:
-            return [("class:prompt-working", f"{self._command_spinner_frame()} {state_suffix}")]
+            return _state_fragment("class:prompt-working", self._command_spinner_frame())
         if self._agent_running:
-            return [("class:prompt-working", f"⚕ {state_suffix}")]
+            return _state_fragment("class:prompt-working", "⚕")
         if self._voice_mode:
-            return [("class:voice-prompt", f"🎤 {state_suffix}")]
+            return _state_fragment("class:voice-prompt", "🎤")
         return [("class:prompt", symbol)]
 
     def _get_tui_prompt_text(self) -> str:

--- a/constraints-termux.txt
+++ b/constraints-termux.txt
@@ -1,0 +1,15 @@
+# Termux / Android dependency constraints for Hermes Agent.
+#
+# Usage:
+#   python -m pip install -e '.[termux]' -c constraints-termux.txt
+#
+# These pins keep the tested Android install path stable when upstream packages
+# move faster than Termux-compatible wheels / sdists.
+
+ipython<10
+jedi>=0.18.1,<0.20
+parso>=0.8.4,<0.9
+stack-data>=0.6,<0.7
+pexpect>4.3,<5
+matplotlib-inline>=0.1.7,<0.2
+asttokens>=2.1,<3

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2222,16 +2222,27 @@ def get_chatgpt_web_auth_status() -> Dict[str, Any]:
         if pool and pool.has_credentials():
             entry = pool.select()
             if entry is not None:
-                api_key = (
+                api_key = str(
                     getattr(entry, "runtime_api_key", None)
                     or getattr(entry, "access_token", "")
-                )
+                    or ""
+                ).strip()
+                session_token = str(getattr(entry, "session_token", "") or "").strip()
                 if api_key and not _codex_access_token_is_expiring(api_key, 0):
                     return {
                         "logged_in": True,
                         "auth_store": str(_auth_file_path()),
                         "last_refresh": getattr(entry, "last_refresh", None),
                         "auth_mode": getattr(entry, "auth_type", None) or "oauth",
+                        "source": f"pool:{getattr(entry, 'label', 'unknown')}",
+                        "api_key": api_key,
+                    }
+                if session_token:
+                    return {
+                        "logged_in": True,
+                        "auth_store": str(_auth_file_path()),
+                        "last_refresh": getattr(entry, "last_refresh", None),
+                        "auth_mode": "session_token",
                         "source": f"pool:{getattr(entry, 'label', 'unknown')}",
                         "api_key": api_key,
                     }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2195,7 +2195,8 @@ def get_codex_auth_status() -> Dict[str, Any]:
 def get_chatgpt_web_auth_status() -> Dict[str, Any]:
     """Status snapshot for ChatGPT Web auth.
 
-    Reuses Codex OAuth credentials when no explicit ChatGPT web env vars are set.
+    Prefers explicit ChatGPT Web credentials, then ChatGPT Web pool entries,
+    then falls back to Codex OAuth credentials.
     """
     access_token = os.getenv("CHATGPT_WEB_ACCESS_TOKEN", "").strip()
     session_token = os.getenv("CHATGPT_WEB_SESSION_TOKEN", "").strip()
@@ -2213,6 +2214,29 @@ def get_chatgpt_web_auth_status() -> Dict[str, Any]:
             "source": "env:CHATGPT_WEB_SESSION_TOKEN",
             "api_key": "",
         }
+
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("chatgpt-web")
+        if pool and pool.has_credentials():
+            entry = pool.select()
+            if entry is not None:
+                api_key = (
+                    getattr(entry, "runtime_api_key", None)
+                    or getattr(entry, "access_token", "")
+                )
+                if api_key and not _codex_access_token_is_expiring(api_key, 0):
+                    return {
+                        "logged_in": True,
+                        "auth_store": str(_auth_file_path()),
+                        "last_refresh": getattr(entry, "last_refresh", None),
+                        "auth_mode": getattr(entry, "auth_type", None) or "oauth",
+                        "source": f"pool:{getattr(entry, 'label', 'unknown')}",
+                        "api_key": api_key,
+                    }
+    except Exception:
+        pass
 
     codex_status = get_codex_auth_status()
     if codex_status.get("logged_in"):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -67,6 +67,7 @@ DEFAULT_AGENT_KEY_MIN_TTL_SECONDS = 30 * 60  # 30 minutes
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+DEFAULT_CHATGPT_WEB_BASE_URL = "https://chatgpt.com/backend-api/f"
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
@@ -115,6 +116,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="OpenAI Codex",
         auth_type="oauth_external",
         inference_base_url=DEFAULT_CODEX_BASE_URL,
+    ),
+    "chatgpt-web": ProviderConfig(
+        id="chatgpt-web",
+        name="ChatGPT Web",
+        auth_type="oauth_external",
+        inference_base_url=DEFAULT_CHATGPT_WEB_BASE_URL,
     ),
     "qwen-oauth": ProviderConfig(
         id="qwen-oauth",
@@ -2185,6 +2192,38 @@ def get_codex_auth_status() -> Dict[str, Any]:
         }
 
 
+def get_chatgpt_web_auth_status() -> Dict[str, Any]:
+    """Status snapshot for ChatGPT Web auth.
+
+    Reuses Codex OAuth credentials when no explicit ChatGPT web env vars are set.
+    """
+    access_token = os.getenv("CHATGPT_WEB_ACCESS_TOKEN", "").strip()
+    session_token = os.getenv("CHATGPT_WEB_SESSION_TOKEN", "").strip()
+    if access_token:
+        return {
+            "logged_in": True,
+            "auth_mode": "access_token",
+            "source": "env:CHATGPT_WEB_ACCESS_TOKEN",
+            "api_key": access_token,
+        }
+    if session_token:
+        return {
+            "logged_in": True,
+            "auth_mode": "session_token",
+            "source": "env:CHATGPT_WEB_SESSION_TOKEN",
+            "api_key": "",
+        }
+
+    codex_status = get_codex_auth_status()
+    if codex_status.get("logged_in"):
+        return {
+            **codex_status,
+            "auth_mode": "codex_oauth",
+            "source": codex_status.get("source") or "codex-oauth",
+        }
+    return codex_status
+
+
 def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
@@ -2253,6 +2292,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_nous_auth_status()
     if target == "openai-codex":
         return get_codex_auth_status()
+    if target == "chatgpt-web":
+        return get_chatgpt_web_auth_status()
     if target == "qwen-oauth":
         return get_qwen_auth_status()
     if target == "copilot-acp":

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -147,7 +147,7 @@ def auth_add_command(args) -> None:
         if provider.startswith(CUSTOM_POOL_PREFIX):
             requested_type = AUTH_TYPE_API_KEY
         else:
-            requested_type = AUTH_TYPE_OAUTH if provider in {"anthropic", "nous", "openai-codex", "qwen-oauth"} else AUTH_TYPE_API_KEY
+            requested_type = AUTH_TYPE_OAUTH if provider in {"anthropic", "nous", "openai-codex", "chatgpt-web", "qwen-oauth"} else AUTH_TYPE_API_KEY
 
     pool = load_pool(provider)
 
@@ -244,6 +244,28 @@ def auth_add_command(args) -> None:
             access_token=creds["tokens"]["access_token"],
             refresh_token=creds["tokens"].get("refresh_token"),
             base_url=creds.get("base_url"),
+            last_refresh=creds.get("last_refresh"),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider == "chatgpt-web":
+        creds = auth_mod._codex_device_code_login()
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            creds["tokens"]["access_token"],
+            _oauth_default_label(provider, len(pool.entries()) + 1),
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:device_code",
+            access_token=creds["tokens"]["access_token"],
+            refresh_token=creds["tokens"].get("refresh_token"),
+            base_url=_provider_base_url(provider),
             last_refresh=creds.get("last_refresh"),
         )
         pool.add_entry(entry)
@@ -420,7 +442,7 @@ def _interactive_add() -> None:
         raise SystemExit(f"Unknown provider: {provider}")
 
     # For OAuth-capable providers, ask which type
-    if provider in _OAUTH_CAPABLE_PROVIDERS:
+    if provider in _OAUTH_CAPABLE_PROVIDERS or provider == "chatgpt-web":
         print(f"\n{provider} supports both API keys and OAuth login.")
         print("  1. API key (paste a key from the provider dashboard)")
         print("  2. OAuth login (authenticate via browser)")

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -696,6 +696,8 @@ def auth_browser_command(args) -> None:
             ca_bundle=None,
         ))
         print("Stored chatgpt-web credential from Termux browser.")
+        print(f'Added it to the credential pool as "{label}".')
+        print("Verify with: hermes auth list")
     finally:
         if not keep_open:
             _terminate_process(proc)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -105,6 +105,10 @@ def _api_key_default_label(count: int) -> str:
     return f"api-key-{count}"
 
 
+def _looks_like_jwt(token: str) -> bool:
+    return isinstance(token, str) and token.count(".") == 2
+
+
 def _display_source(source: str) -> str:
     return source.split(":", 1)[1] if source.startswith("manual:") else source
 
@@ -153,6 +157,54 @@ def auth_add_command(args) -> None:
 
     if requested_type == AUTH_TYPE_API_KEY:
         token = (getattr(args, "api_key", None) or "").strip()
+        if provider == "chatgpt-web":
+            token_mode = str(getattr(args, "token_mode", "") or "").strip().lower()
+            if not token:
+                if token_mode == "session_token":
+                    token = getpass("Paste your ChatGPT Web session token: ").strip()
+                elif token_mode == "access_token":
+                    token = getpass("Paste your ChatGPT Web API key or access token: ").strip()
+                else:
+                    token = getpass("Paste your ChatGPT Web access token or session token: ").strip()
+            if not token:
+                raise SystemExit("No ChatGPT Web token provided.")
+            default_label = _api_key_default_label(len(pool.entries()) + 1)
+            label = (getattr(args, "label", None) or "").strip()
+            if not label:
+                label = input(f"Label (optional, default: {default_label}): ").strip() or default_label
+
+            source = SOURCE_MANUAL
+            access_token = token
+            extra = {}
+            should_exchange_session = (
+                token_mode == "session_token"
+                or (token_mode not in {"access_token", "session_token"} and not _looks_like_jwt(token))
+            )
+            if should_exchange_session:
+                from hermes_cli.chatgpt_web import _fetch_chatgpt_web_access_token_from_session
+
+                try:
+                    access_token = _fetch_chatgpt_web_access_token_from_session(token)
+                except Exception as exc:
+                    raise SystemExit(f"Could not exchange ChatGPT Web session token: {exc}") from exc
+                source = f"{SOURCE_MANUAL}:session_token"
+                extra["session_token"] = token
+
+            entry = PooledCredential(
+                provider=provider,
+                id=uuid.uuid4().hex[:6],
+                label=label,
+                auth_type=AUTH_TYPE_API_KEY,
+                priority=0,
+                source=source,
+                access_token=access_token,
+                base_url=_provider_base_url(provider),
+                extra=extra,
+            )
+            pool.add_entry(entry)
+            print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')
+            return
+
         if not token:
             token = getpass("Paste your API key: ").strip()
         if not token:
@@ -442,7 +494,25 @@ def _interactive_add() -> None:
         raise SystemExit(f"Unknown provider: {provider}")
 
     # For OAuth-capable providers, ask which type
-    if provider in _OAUTH_CAPABLE_PROVIDERS or provider == "chatgpt-web":
+    token_mode = None
+    if provider == "chatgpt-web":
+        print(f"\n{provider} supports API keys/access tokens, OAuth login, and session tokens.")
+        print("  1. API key / access token")
+        print("  2. OAuth login (authenticate via browser/device code)")
+        print("  3. Session token (paste __Secure-next-auth.session-token)")
+        try:
+            type_choice = input("Type [1/2/3]: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return
+        if type_choice == "2":
+            auth_type = "oauth"
+        elif type_choice == "3":
+            auth_type = "api_key"
+            token_mode = "session_token"
+        else:
+            auth_type = "api_key"
+            token_mode = "access_token"
+    elif provider in _OAUTH_CAPABLE_PROVIDERS:
         print(f"\n{provider} supports both API keys and OAuth login.")
         print("  1. API key (paste a key from the provider dashboard)")
         print("  2. OAuth login (authenticate via browser)")
@@ -469,6 +539,7 @@ def _interactive_add() -> None:
         provider=provider, auth_type=auth_type, label=label, api_key=None,
         portal_url=None, inference_url=None, client_id=None, scope=None,
         no_browser=False, timeout=None, insecure=False, ca_bundle=None,
+        token_mode=token_mode,
     ))
 
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 from getpass import getpass
+import json
 import math
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
 import time
 from types import SimpleNamespace
+import urllib.request
 import uuid
 
 from agent.credential_pool import (
@@ -28,7 +36,12 @@ from agent.credential_pool import (
 )
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import PROVIDER_REGISTRY
-from hermes_constants import OPENROUTER_BASE_URL
+from hermes_constants import OPENROUTER_BASE_URL, get_hermes_home
+
+try:
+    import websockets
+except ImportError:
+    websockets = None  # type: ignore[assignment]
 
 
 # Providers that support OAuth login in addition to API keys.
@@ -432,6 +445,263 @@ def auth_reset_command(args) -> None:
     print(f"Reset status on {count} {provider} credentials")
 
 
+def _is_termux() -> bool:
+    prefix = os.getenv("PREFIX", "")
+    return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
+
+
+def _termux_x11_android_app_installed() -> bool:
+    pm_command = "/system/bin/pm"
+    if not Path(pm_command).exists():
+        return False
+    result = subprocess.run(
+        [pm_command, "list", "packages", "com.termux.x11"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={k: v for k, v in os.environ.items() if k != "LD_PRELOAD"},
+    )
+    return "package:com.termux.x11" in (result.stdout or "")
+
+
+def _find_termux_x11_command() -> str | None:
+    return shutil.which("termux-x11")
+
+
+def _find_chromium_browser_command() -> str | None:
+    return shutil.which("chromium-browser") or shutil.which("chromium")
+
+
+def _write_chatgpt_web_browser_launch_scripts(
+    base_dir: Path,
+    termux_x11_command: str,
+    browser_command: str,
+    debug_port: int,
+) -> tuple[Path, Path]:
+    base_dir.mkdir(parents=True, exist_ok=True)
+    startup_script = base_dir / "startup.sh"
+    launcher_script = base_dir / "launch.sh"
+
+    startup_script.write_text(
+        "#!/data/data/com.termux/files/usr/bin/bash\n"
+        "set -euo pipefail\n\n"
+        f"BASE_DIR={shlex.quote(str(base_dir))}\n"
+        "PROFILE_DIR=\"$BASE_DIR/profile\"\n"
+        "LOG_DIR=\"$BASE_DIR/logs\"\n"
+        "mkdir -p \"$PROFILE_DIR\" \"$LOG_DIR\"\n\n"
+        "export DISPLAY=\"${DISPLAY:-:0}\"\n"
+        "export XDG_RUNTIME_DIR=\"${TMPDIR:-$PREFIX/tmp}\"\n"
+        f"exec {shlex.quote(browser_command)} \\\n"
+        "  --no-sandbox \\\n"
+        "  --password-store=basic \\\n"
+        "  --user-data-dir=\"$PROFILE_DIR\" \\\n"
+        "  --remote-debugging-address=127.0.0.1 \\\n"
+        f"  --remote-debugging-port={int(debug_port)} \\\n"
+        "  --no-first-run \\\n"
+        "  --no-default-browser-check \\\n"
+        "  --disable-fre \\\n"
+        "  --disable-crash-reporter \\\n"
+        "  --disable-session-crashed-bubble \\\n"
+        "  --window-size=1280,900 \\\n"
+        "  https://chatgpt.com \\\n"
+        "  >>\"$LOG_DIR/chromium.log\" 2>&1\n",
+        encoding="utf-8",
+    )
+
+    launcher_script.write_text(
+        "#!/data/data/com.termux/files/usr/bin/bash\n"
+        "set -euo pipefail\n\n"
+        f"BASE_DIR={shlex.quote(str(base_dir))}\n"
+        "DISPLAY_FILE=\"$BASE_DIR/display\"\n"
+        "mkdir -p \"$BASE_DIR\"\n"
+        "rm -f \"$DISPLAY_FILE\"\n\n"
+        "exec 3<>\"$DISPLAY_FILE\"\n"
+        f"exec {shlex.quote(termux_x11_command)} -displayfd 3 -noreset -xstartup {shlex.quote(str(startup_script))}\n",
+        encoding="utf-8",
+    )
+
+    startup_script.chmod(0o755)
+    launcher_script.chmod(0o755)
+    return launcher_script, startup_script
+
+
+def _launch_chatgpt_web_browser(launcher_script: Path, base_dir: Path):
+    log_path = base_dir / "termux-x11.log"
+    with log_path.open("ab") as handle:
+        return subprocess.Popen(
+            [str(launcher_script)],
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(base_dir),
+            start_new_session=True,
+        )
+
+
+def _wait_for_debugger(debug_base: str, timeout: float = 30.0) -> None:
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{debug_base}/json/version", timeout=5) as response:
+                if response.status == 200:
+                    return
+        except Exception as exc:
+            last_error = exc
+        time.sleep(1)
+    raise SystemExit(f"Timed out waiting for Chromium DevTools at {debug_base}: {last_error}")
+
+
+async def _get_chatgpt_web_session_token(debug_base: str) -> str | None:
+    if websockets is None:
+        raise SystemExit("Python package 'websockets' is required for browser auth.")
+
+    with urllib.request.urlopen(f"{debug_base}/json/list", timeout=5) as response:
+        pages = json.load(response)
+
+    page = None
+    for item in pages:
+        if item.get("type") == "page" and "chatgpt.com" in str(item.get("url") or ""):
+            page = item
+            break
+    if page is None:
+        return None
+
+    ws_url = str(page.get("webSocketDebuggerUrl") or "").strip()
+    if not ws_url:
+        return None
+
+    async with websockets.connect(ws_url, max_size=20_000_000) as ws:
+        next_id = 1
+
+        async def send(method: str, params: dict | None = None):
+            nonlocal next_id
+            payload = {"id": next_id, "method": method}
+            if params is not None:
+                payload["params"] = params
+            await ws.send(json.dumps(payload))
+            my_id = next_id
+            next_id += 1
+            while True:
+                message = json.loads(await ws.recv())
+                if message.get("id") == my_id:
+                    return message
+
+        await send("Network.enable")
+        result = await send("Network.getCookies", {"urls": ["https://chatgpt.com/"]})
+        cookies = result.get("result", {}).get("cookies", [])
+        for cookie in cookies:
+            if cookie.get("name") == "__Secure-next-auth.session-token":
+                value = str(cookie.get("value") or "").strip()
+                if value:
+                    return value
+    return None
+
+
+def _wait_for_chatgpt_web_session_token(
+    debug_base: str,
+    *,
+    timeout_seconds: int = 15 * 60,
+    poll_seconds: int = 5,
+) -> str | None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            token = asyncio.run(_get_chatgpt_web_session_token(debug_base))
+        except Exception:
+            token = None
+        if token:
+            return token
+        print("waiting for ChatGPT login in Termux browser...")
+        time.sleep(poll_seconds)
+    return None
+
+
+def _terminate_process(proc, timeout: float = 5.0) -> None:
+    if proc is None:
+        return
+    try:
+        if proc.poll() is not None:
+            return
+    except Exception:
+        pass
+    try:
+        proc.terminate()
+        proc.wait(timeout=timeout)
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+def auth_browser_command(args) -> None:
+    provider = _normalize_provider(getattr(args, "provider", "") or "chatgpt-web")
+    if provider != "chatgpt-web":
+        raise SystemExit("Browser auth currently supports only chatgpt-web.")
+    if not _is_termux():
+        raise SystemExit("Browser auth currently supports only Termux/Android.")
+    if websockets is None:
+        raise SystemExit("Python package 'websockets' is required for browser auth.")
+    if not _termux_x11_android_app_installed():
+        raise SystemExit("Termux:X11 Android app (com.termux.x11) is not installed.")
+
+    termux_x11_command = _find_termux_x11_command()
+    if not termux_x11_command:
+        raise SystemExit("termux-x11 command not found. Install `termux-x11-nightly`.")
+
+    browser_command = _find_chromium_browser_command()
+    if not browser_command:
+        raise SystemExit("Chromium command not found. Install `chromium`.")
+
+    label = (getattr(args, "label", None) or "termux-x11-browser").strip() or "termux-x11-browser"
+    timeout_seconds = max(30, int(getattr(args, "timeout", None) or 15 * 60))
+    debug_port = max(1024, int(getattr(args, "debug_port", None) or 9222))
+    keep_open = bool(getattr(args, "keep_open", False))
+    debug_base = f"http://127.0.0.1:{debug_port}"
+    base_dir = get_hermes_home() / "chatgpt-web-browser"
+
+    shutil.rmtree(base_dir, ignore_errors=True)
+    launcher_script, _startup_script = _write_chatgpt_web_browser_launch_scripts(
+        base_dir,
+        termux_x11_command,
+        browser_command,
+        debug_port,
+    )
+    proc = _launch_chatgpt_web_browser(launcher_script, base_dir)
+    print("Started local Termux browser for ChatGPT Web auth.")
+    print("Open the Termux:X11 Android app manually, then finish logging into ChatGPT in Chromium.")
+
+    try:
+        _wait_for_debugger(debug_base, timeout=min(60.0, float(timeout_seconds)))
+        session_token = _wait_for_chatgpt_web_session_token(
+            debug_base,
+            timeout_seconds=timeout_seconds,
+        )
+        if not session_token:
+            raise SystemExit("Timed out waiting for __Secure-next-auth.session-token from Chromium.")
+
+        auth_add_command(SimpleNamespace(
+            provider="chatgpt-web",
+            auth_type="api-key",
+            api_key=session_token,
+            label=label,
+            token_mode="session_token",
+            portal_url=None,
+            inference_url=None,
+            client_id=None,
+            scope=None,
+            no_browser=False,
+            timeout=None,
+            insecure=False,
+            ca_bundle=None,
+        ))
+        print("Stored chatgpt-web credential from Termux browser.")
+    finally:
+        if not keep_open:
+            _terminate_process(proc)
+            shutil.rmtree(base_dir, ignore_errors=True)
+
+
 def _interactive_auth() -> None:
     """Interactive credential pool management when `hermes auth` is called bare."""
     # Show current pool status first
@@ -626,6 +896,9 @@ def auth_command(args) -> None:
         return
     if action == "reset":
         auth_reset_command(args)
+        return
+    if action == "browser":
+        auth_browser_command(args)
         return
     # No subcommand — launch interactive mode
     _interactive_auth()

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -766,12 +766,13 @@ def _interactive_add() -> None:
     # For OAuth-capable providers, ask which type
     token_mode = None
     if provider == "chatgpt-web":
-        print(f"\n{provider} supports API keys/access tokens, OAuth login, and session tokens.")
+        print(f"\n{provider} supports API keys/access tokens, OAuth login, session tokens, and local browser bootstrap.")
         print("  1. API key / access token")
         print("  2. OAuth login (authenticate via browser/device code)")
         print("  3. Session token (paste __Secure-next-auth.session-token)")
+        print("  4. Termux browser bootstrap (launch Chromium in Termux:X11 and capture the session automatically)")
         try:
-            type_choice = input("Type [1/2/3]: ").strip()
+            type_choice = input("Type [1/2/3/4]: ").strip()
         except (EOFError, KeyboardInterrupt):
             return
         if type_choice == "2":
@@ -779,6 +780,8 @@ def _interactive_add() -> None:
         elif type_choice == "3":
             auth_type = "api_key"
             token_mode = "session_token"
+        elif type_choice == "4":
+            auth_type = "browser"
         else:
             auth_type = "api_key"
             token_mode = "access_token"
@@ -804,6 +807,16 @@ def _interactive_add() -> None:
         return
     if typed_label:
         label = typed_label
+
+    if auth_type == "browser":
+        auth_browser_command(SimpleNamespace(
+            provider=provider,
+            label=label,
+            timeout=None,
+            debug_port=None,
+            keep_open=False,
+        ))
+        return
 
     auth_add_command(SimpleNamespace(
         provider=provider, auth_type=auth_type, label=label, api_key=None,

--- a/hermes_cli/chatgpt_web.py
+++ b/hermes_cli/chatgpt_web.py
@@ -301,19 +301,52 @@ def _format_initial_message(
     for item in messages:
         if not isinstance(item, dict):
             continue
-        role = str(item.get("role") or "").strip()
-        content = str(item.get("content") or "")
+        role = str(item.get("role") or "").strip().lower()
+        raw_content = item.get("content")
+        content = str(raw_content or "")
+        rendered = ""
+
         if role == "user":
             latest_user = content
-        if role in {"user", "assistant"} and content.strip():
-            transcript_lines.append(f"{role.title()}: {content.strip()}")
+            rendered = content.strip()
+        elif role == "assistant":
+            rendered_parts: list[str] = []
+            if content.strip():
+                rendered_parts.append(content.strip())
+            tool_calls = item.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    function = tool_call.get("function") if isinstance(tool_call.get("function"), dict) else {}
+                    name = str(function.get("name") or "").strip()
+                    if not name:
+                        continue
+                    arguments = function.get("arguments", {})
+                    if isinstance(arguments, str):
+                        try:
+                            arguments = json.loads(arguments)
+                        except Exception:
+                            pass
+                    rendered_parts.append(
+                        "<tool_call>\n"
+                        + json.dumps({"name": name, "arguments": arguments}, ensure_ascii=False)
+                        + "\n</tool_call>"
+                    )
+            rendered = "\n".join(part for part in rendered_parts if part).strip()
+        elif role == "tool":
+            if content.strip():
+                rendered = f"<tool_response>\n{content.strip()}\n</tool_response>"
+
+        if rendered:
+            transcript_lines.append(f"{role.title()}:\n{rendered}")
 
     if has_remote_thread:
         return latest_user.strip()
 
     prompt_parts: list[str] = []
     if instructions.strip():
-        prompt_parts.append(f"System instructions:\n{instructions.strip()}")
+        prompt_parts.append(f"Developer instructions (higher priority than the conversation below):\n{instructions.strip()}")
     if transcript_lines:
         prompt_parts.append("Conversation so far:\n" + "\n".join(transcript_lines))
     return "\n\n".join(part for part in prompt_parts if part).strip()

--- a/hermes_cli/chatgpt_web.py
+++ b/hermes_cli/chatgpt_web.py
@@ -348,6 +348,17 @@ def _decode_json_pointer(path: str) -> list[str]:
     return [token.replace("~1", "/").replace("~0", "~") for token in tokens]
 
 
+def _looks_like_message_patch_list(value: Any) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    return any(
+        isinstance(item, dict)
+        and str(item.get("p") or "").startswith("/message/")
+        and str(item.get("o") or "").strip().lower() in {"append", "add", "replace"}
+        for item in value
+    )
+
+
 def _apply_message_patch(message: dict[str, Any], patch_op: dict[str, Any]) -> bool:
     path = str(patch_op.get("p") or "")
     op = str(patch_op.get("o") or "").strip().lower()
@@ -584,7 +595,12 @@ def stream_chatgpt_web_completion(
                                     on_delta(delta)
                         continue
 
-                    if str(event.get("o") or "").strip().lower() == "patch" and isinstance(event.get("v"), list):
+                    patch_ops = event.get("v") if isinstance(event.get("v"), list) else None
+                    is_patch_event = (
+                        str(event.get("o") or "").strip().lower() == "patch"
+                        or _looks_like_message_patch_list(patch_ops)
+                    )
+                    if is_patch_event and patch_ops is not None:
                         if assistant_message is None:
                             assistant_message = {
                                 "id": assistant_message_id,
@@ -592,7 +608,7 @@ def stream_chatgpt_web_completion(
                                 "content": {"content_type": "text", "parts": [""]},
                                 "metadata": {},
                             }
-                        for patch_op in event.get("v") or []:
+                        for patch_op in patch_ops:
                             if not isinstance(patch_op, dict):
                                 continue
                             if not _apply_message_patch(assistant_message, patch_op):

--- a/hermes_cli/chatgpt_web.py
+++ b/hermes_cli/chatgpt_web.py
@@ -134,19 +134,23 @@ def resolve_chatgpt_web_runtime_credentials(*, force_refresh: bool = False) -> d
 
     try:
         from agent.credential_pool import load_pool
+        from hermes_cli.auth import _codex_access_token_is_expiring
 
         pool = load_pool("chatgpt-web")
         if pool and pool.has_credentials():
             entry = pool.select()
             if entry is not None:
-                pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
+                pool_api_key = str(getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "") or "").strip()
+                pool_session_token = str(getattr(entry, "session_token", "") or "").strip()
+                if pool_session_token and (not pool_api_key or _codex_access_token_is_expiring(pool_api_key, 0)):
+                    pool_api_key = _fetch_chatgpt_web_access_token_from_session(pool_session_token)
                 if pool_api_key:
                     return {
                         "provider": "chatgpt-web",
-                        "api_key": str(pool_api_key).strip(),
+                        "api_key": pool_api_key,
                         "base_url": (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", "") or DEFAULT_CHATGPT_WEB_BASE_URL).rstrip("/"),
                         "source": f"pool:{getattr(entry, 'label', 'unknown')}",
-                        "session_token": "",
+                        "session_token": pool_session_token,
                     }
     except Exception:
         pass

--- a/hermes_cli/chatgpt_web.py
+++ b/hermes_cli/chatgpt_web.py
@@ -1,0 +1,451 @@
+"""Helpers for ChatGPT.com web-model access and streaming conversation transport."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import random
+import time
+import uuid
+from contextlib import nullcontext
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Callable, Optional
+
+import httpx
+
+DEFAULT_CHATGPT_WEB_BASE_URL = "https://chatgpt.com/backend-api/f"
+DEFAULT_CHATGPT_WEB_MODELS = [
+    "gpt-5-thinking",
+    "gpt-5-instant",
+    "gpt-5",
+    "gpt-4o",
+    "gpt-4.1",
+    "o3",
+    "o4-mini",
+]
+DEFAULT_CHATGPT_WEB_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+
+def _default_user_agent() -> str:
+    return os.getenv("CHATGPT_WEB_USER_AGENT", "").strip() or DEFAULT_CHATGPT_WEB_USER_AGENT
+
+
+def _default_device_id() -> str:
+    return os.getenv("CHATGPT_WEB_DEVICE_ID", "").strip() or str(uuid.uuid4())
+
+
+def _build_cookie_header(*, session_token: str = "", device_id: str = "") -> str:
+    parts: list[str] = []
+    if session_token:
+        parts.append(f"__Secure-next-auth.session-token={session_token}")
+    if device_id:
+        parts.append(f"oai-did={device_id}")
+    return "; ".join(parts)
+
+
+def _build_chatgpt_web_headers(
+    *,
+    access_token: str,
+    session_token: str = "",
+    user_agent: str = "",
+    device_id: str = "",
+    accept: str = "application/json",
+) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": accept,
+        "User-Agent": user_agent or _default_user_agent(),
+        "Content-Type": "application/json",
+        "Oai-Device-Id": device_id or _default_device_id(),
+        "Referer": "https://chatgpt.com/",
+        "Origin": "https://chatgpt.com",
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Dest": "empty",
+    }
+    cookie_header = _build_cookie_header(
+        session_token=session_token,
+        device_id=headers["Oai-Device-Id"],
+    )
+    if cookie_header:
+        headers["Cookie"] = cookie_header
+    return headers
+
+
+def _fetch_chatgpt_web_access_token_from_session(
+    session_token: str,
+    *,
+    user_agent: str = "",
+    device_id: str = "",
+    timeout: float = 15.0,
+) -> str:
+    session_token = (session_token or "").strip()
+    if not session_token:
+        raise ValueError("ChatGPT web session token is required")
+
+    did = device_id or _default_device_id()
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": user_agent or _default_user_agent(),
+        "Oai-Device-Id": did,
+        "Cookie": _build_cookie_header(session_token=session_token, device_id=did),
+    }
+    response = httpx.get(
+        "https://chatgpt.com/api/auth/session",
+        headers=headers,
+        timeout=timeout,
+        follow_redirects=True,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    access_token = str(payload.get("accessToken") or "").strip()
+    if not access_token:
+        raise ValueError("ChatGPT session exchange did not return an accessToken")
+    return access_token
+
+
+def resolve_chatgpt_web_runtime_credentials(*, force_refresh: bool = False) -> dict[str, Any]:
+    del force_refresh  # reserved for future provider-specific refresh logic
+
+    access_token = os.getenv("CHATGPT_WEB_ACCESS_TOKEN", "").strip()
+    session_token = os.getenv("CHATGPT_WEB_SESSION_TOKEN", "").strip()
+    if access_token:
+        return {
+            "provider": "chatgpt-web",
+            "api_key": access_token,
+            "base_url": DEFAULT_CHATGPT_WEB_BASE_URL,
+            "source": "access-token",
+            "session_token": session_token,
+        }
+    if session_token:
+        return {
+            "provider": "chatgpt-web",
+            "api_key": _fetch_chatgpt_web_access_token_from_session(session_token),
+            "base_url": DEFAULT_CHATGPT_WEB_BASE_URL,
+            "source": "session-token",
+            "session_token": session_token,
+        }
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    creds = resolve_codex_runtime_credentials(force_refresh=False, refresh_if_expiring=True)
+    return {
+        "provider": "chatgpt-web",
+        "api_key": str(creds.get("api_key") or "").strip(),
+        "base_url": DEFAULT_CHATGPT_WEB_BASE_URL,
+        "source": "codex-oauth",
+        "session_token": "",
+    }
+
+
+def fetch_chatgpt_web_model_ids(
+    access_token: Optional[str] = None,
+    *,
+    session_token: str = "",
+    user_agent: str = "",
+    device_id: str = "",
+    timeout: float = 15.0,
+) -> list[str]:
+    token = (access_token or "").strip()
+    resolved_session = (session_token or os.getenv("CHATGPT_WEB_SESSION_TOKEN", "")).strip()
+    if not token:
+        token = resolve_chatgpt_web_runtime_credentials().get("api_key", "")
+    if not token:
+        return list(DEFAULT_CHATGPT_WEB_MODELS)
+
+    headers = _build_chatgpt_web_headers(
+        access_token=token,
+        session_token=resolved_session,
+        user_agent=user_agent,
+        device_id=device_id,
+    )
+    try:
+        response = httpx.get(
+            "https://chatgpt.com/backend-api/models",
+            headers=headers,
+            timeout=timeout,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception:
+        return list(DEFAULT_CHATGPT_WEB_MODELS)
+
+    raw_models = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(raw_models, list):
+        return list(DEFAULT_CHATGPT_WEB_MODELS)
+
+    model_ids: list[str] = []
+    for item in raw_models:
+        if not isinstance(item, dict):
+            continue
+        slug = str(item.get("slug") or item.get("id") or item.get("name") or item.get("model") or "").strip()
+        if not slug:
+            continue
+        visibility = str(item.get("visibility") or "").strip().lower()
+        if visibility in {"hidden", "hide"}:
+            continue
+        if slug not in model_ids:
+            model_ids.append(slug)
+    return model_ids or list(DEFAULT_CHATGPT_WEB_MODELS)
+
+
+def _generate_proof_token(seed: str, difficulty: str, user_agent: str) -> str:
+    prefix = "gAAAAAB"
+    now_utc = datetime.now(timezone.utc)
+    config = [
+        random.randint(1000, 3000),
+        now_utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
+        None,
+        0,
+        user_agent,
+    ]
+    diff_len = len(difficulty or "")
+    for attempt in range(100000):
+        config[3] = attempt
+        answer = base64.b64encode(json.dumps(config).encode()).decode()
+        candidate = hashlib.sha3_512((seed + answer).encode()).hexdigest()
+        if candidate[:diff_len] <= difficulty:
+            return prefix + answer
+    fallback_base = base64.b64encode(seed.encode()).decode()
+    return prefix + "wQ8Lk5FbGpA2NcR9dShT6gYjU7VxZ4D" + fallback_base
+
+
+def _prepare_conversation(
+    client: httpx.Client,
+    *,
+    headers: dict[str, str],
+    model: str,
+    conversation_id: Optional[str],
+    parent_message_id: str,
+    history_and_training_disabled: bool,
+) -> str:
+    payload: dict[str, Any] = {
+        "action": "next",
+        "parent_message_id": parent_message_id,
+        "model": model,
+        "conversation_mode": {"kind": "primary_assistant"},
+        "supports_buffering": True,
+        "supported_encodings": ["v1"],
+        "system_hints": [],
+    }
+    if history_and_training_disabled:
+        payload["history_and_training_disabled"] = True
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+
+    response = client.post(
+        "https://chatgpt.com/backend-api/f/conversation/prepare",
+        headers=headers,
+        json=payload,
+    )
+    if response.status_code >= 400:
+        return ""
+    data = response.json()
+    return str(data.get("conduit_token") or "").strip()
+
+
+def _chat_requirements(
+    client: httpx.Client,
+    *,
+    headers: dict[str, str],
+) -> dict[str, Any]:
+    response = client.post(
+        "https://chatgpt.com/backend-api/sentinel/chat-requirements",
+        headers=headers,
+        json={},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload if isinstance(payload, dict) else {}
+
+
+def _format_initial_message(
+    *,
+    instructions: str,
+    messages: list[dict[str, Any]],
+    has_remote_thread: bool,
+) -> str:
+    latest_user = ""
+    transcript_lines: list[str] = []
+    for item in messages:
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("role") or "").strip()
+        content = str(item.get("content") or "")
+        if role == "user":
+            latest_user = content
+        if role in {"user", "assistant"} and content.strip():
+            transcript_lines.append(f"{role.title()}: {content.strip()}")
+
+    if has_remote_thread:
+        return latest_user.strip()
+
+    prompt_parts: list[str] = []
+    if instructions.strip():
+        prompt_parts.append(f"System instructions:\n{instructions.strip()}")
+    if transcript_lines:
+        prompt_parts.append("Conversation so far:\n" + "\n".join(transcript_lines))
+    return "\n\n".join(part for part in prompt_parts if part).strip()
+
+
+def stream_chatgpt_web_completion(
+    *,
+    access_token: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    instructions: str = "",
+    conversation_id: Optional[str] = None,
+    parent_message_id: Optional[str] = None,
+    session_token: str = "",
+    on_delta: Optional[Callable[[str], None]] = None,
+    timeout: float = 1800.0,
+    history_and_training_disabled: bool = False,
+    user_agent: str = "",
+    device_id: str = "",
+    client: Optional[httpx.Client] = None,
+) -> dict[str, Any]:
+    token = (access_token or "").strip()
+    if not token:
+        raise ValueError("ChatGPT web access token is required")
+
+    ua = user_agent or _default_user_agent()
+    did = device_id or _default_device_id()
+    convo_id = (conversation_id or "").strip() or None
+    parent_id = (parent_message_id or "").strip() or str(uuid.uuid4())
+    prompt_text = _format_initial_message(
+        instructions=instructions,
+        messages=messages,
+        has_remote_thread=bool(convo_id),
+    )
+    if not prompt_text:
+        raise ValueError("ChatGPT web prompt is empty")
+
+    base_headers = _build_chatgpt_web_headers(
+        access_token=token,
+        session_token=session_token,
+        user_agent=ua,
+        device_id=did,
+    )
+
+    client_ctx = nullcontext(client) if client is not None else httpx.Client(timeout=timeout, follow_redirects=True)
+    with client_ctx as client:
+        conduit_token = _prepare_conversation(
+            client,
+            headers=base_headers,
+            model=model,
+            conversation_id=convo_id,
+            parent_message_id=parent_id,
+            history_and_training_disabled=history_and_training_disabled,
+        )
+        chat_requirements = _chat_requirements(client, headers=base_headers)
+        requirement_token = str(chat_requirements.get("token") or "").strip()
+        proof_token = ""
+        proof = chat_requirements.get("proofofwork")
+        if isinstance(proof, dict):
+            seed = str(proof.get("seed") or "")
+            difficulty = str(proof.get("difficulty") or "")
+            if seed and difficulty:
+                proof_token = _generate_proof_token(seed, difficulty, ua)
+
+        payload: dict[str, Any] = {
+            "action": "next",
+            "messages": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": [prompt_text]},
+                    "metadata": {},
+                }
+            ],
+            "parent_message_id": parent_id,
+            "model": model,
+            "conversation_mode": {"kind": "primary_assistant"},
+            "enable_message_followups": True,
+            "supports_buffering": True,
+            "supported_encodings": ["v1"],
+            "system_hints": [],
+            "history_and_training_disabled": history_and_training_disabled,
+        }
+        if convo_id:
+            payload["conversation_id"] = convo_id
+
+        headers = {
+            **base_headers,
+            "Accept": "text/event-stream",
+            "openai-sentinel-chat-requirements-token": requirement_token,
+        }
+        if conduit_token:
+            headers["x-conduit-token"] = conduit_token
+        if proof_token:
+            headers["openai-sentinel-proof-token"] = proof_token
+
+        final_text = ""
+        assistant_message_id = parent_id
+        final_conversation_id = convo_id
+        with client.stream(
+            "POST",
+            "https://chatgpt.com/backend-api/f/conversation",
+            headers=headers,
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8", "ignore")
+                if not isinstance(line, str) or not line.startswith("data: "):
+                    continue
+                raw = line[6:].strip()
+                if not raw or raw == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(raw)
+                except Exception:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                event_conversation_id = str(event.get("conversation_id") or "").strip()
+                if event_conversation_id:
+                    final_conversation_id = event_conversation_id
+                message = event.get("message")
+                if not isinstance(message, dict):
+                    continue
+                author = message.get("author") if isinstance(message.get("author"), dict) else {}
+                if author.get("role") != "assistant":
+                    continue
+                message_id = str(message.get("id") or "").strip()
+                if message_id:
+                    assistant_message_id = message_id
+                content = message.get("content") if isinstance(message.get("content"), dict) else {}
+                if content.get("content_type") != "text":
+                    continue
+                parts = content.get("parts")
+                if not isinstance(parts, list) or not parts:
+                    continue
+                text = str(parts[0] or "")
+                if not text:
+                    continue
+                delta = text[len(final_text):] if text.startswith(final_text) else text
+                final_text = text
+                if delta and on_delta is not None:
+                    on_delta(delta)
+
+    if not final_text.strip():
+        raise RuntimeError("ChatGPT web transport returned no assistant text")
+
+    return {
+        "content": final_text.strip(),
+        "conversation_id": final_conversation_id,
+        "parent_message_id": assistant_message_id,
+        "message_id": assistant_message_id,
+        "model": model,
+        "finish_reason": "stop",
+    }

--- a/hermes_cli/chatgpt_web.py
+++ b/hermes_cli/chatgpt_web.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import hashlib
 import json
 import os
@@ -318,6 +319,117 @@ def _format_initial_message(
     return "\n\n".join(part for part in prompt_parts if part).strip()
 
 
+def _extract_event_message(event: dict[str, Any]) -> Optional[dict[str, Any]]:
+    message = event.get("message")
+    if isinstance(message, dict):
+        return message
+    nested = event.get("v")
+    if isinstance(nested, dict):
+        message = nested.get("message")
+        if isinstance(message, dict):
+            return message
+    return None
+
+
+def _extract_message_text(message: dict[str, Any]) -> str:
+    content = message.get("content") if isinstance(message.get("content"), dict) else {}
+    if content.get("content_type") != "text":
+        return ""
+    parts = content.get("parts")
+    if not isinstance(parts, list) or not parts:
+        return ""
+    return str(parts[0] or "")
+
+
+def _decode_json_pointer(path: str) -> list[str]:
+    if not isinstance(path, str) or not path.startswith("/"):
+        return []
+    tokens = path.split("/")[1:]
+    return [token.replace("~1", "/").replace("~0", "~") for token in tokens]
+
+
+def _apply_message_patch(message: dict[str, Any], patch_op: dict[str, Any]) -> bool:
+    path = str(patch_op.get("p") or "")
+    op = str(patch_op.get("o") or "").strip().lower()
+    value = patch_op.get("v")
+
+    tokens = _decode_json_pointer(path)
+    if not tokens or tokens[0] != "message":
+        return False
+    tokens = tokens[1:]
+    if not tokens:
+        return False
+
+    current: Any = message
+    for idx, token in enumerate(tokens[:-1]):
+        next_token = tokens[idx + 1]
+        next_is_index = next_token.isdigit()
+        if isinstance(current, dict):
+            child = current.get(token)
+            if child is None:
+                child = [] if next_is_index else {}
+                current[token] = child
+            current = child
+            continue
+        if isinstance(current, list):
+            if not token.isdigit():
+                return False
+            list_index = int(token)
+            while len(current) <= list_index:
+                current.append([] if next_is_index else {})
+            child = current[list_index]
+            if child is None:
+                child = [] if next_is_index else {}
+                current[list_index] = child
+            current = child
+            continue
+        return False
+
+    leaf = tokens[-1]
+    if isinstance(current, dict):
+        existing = current.get(leaf)
+        if op == "append":
+            if existing is None:
+                current[leaf] = value
+            elif isinstance(existing, str) and isinstance(value, str):
+                current[leaf] = existing + value
+            elif isinstance(existing, list):
+                existing.append(value)
+            elif isinstance(existing, dict) and isinstance(value, dict):
+                existing.update(value)
+            else:
+                current[leaf] = value
+            return True
+        if op in {"add", "replace"}:
+            current[leaf] = value
+            return True
+        return False
+
+    if isinstance(current, list):
+        if not leaf.isdigit():
+            return False
+        list_index = int(leaf)
+        while len(current) <= list_index:
+            current.append(None)
+        existing = current[list_index]
+        if op == "append":
+            if existing is None:
+                current[list_index] = value
+            elif isinstance(existing, str) and isinstance(value, str):
+                current[list_index] = existing + value
+            elif isinstance(existing, list):
+                existing.append(value)
+            elif isinstance(existing, dict) and isinstance(value, dict):
+                existing.update(value)
+            else:
+                current[list_index] = value
+            return True
+        if op in {"add", "replace"}:
+            current[list_index] = value
+            return True
+    return False
+
+
 def stream_chatgpt_web_completion(
     *,
     access_token: str,
@@ -412,6 +524,8 @@ def stream_chatgpt_web_completion(
         final_text = ""
         assistant_message_id = parent_id
         final_conversation_id = convo_id
+        assistant_message: Optional[dict[str, Any]] = None
+        saw_stream_complete = False
         with client.stream(
             "POST",
             "https://chatgpt.com/backend-api/f/conversation",
@@ -419,47 +533,80 @@ def stream_chatgpt_web_completion(
             json=payload,
         ) as response:
             response.raise_for_status()
-            for line in response.iter_lines():
-                if not line:
-                    continue
-                if isinstance(line, bytes):
-                    line = line.decode("utf-8", "ignore")
-                if not isinstance(line, str) or not line.startswith("data: "):
-                    continue
-                raw = line[6:].strip()
-                if not raw or raw == "[DONE]":
-                    continue
-                try:
-                    event = json.loads(raw)
-                except Exception:
-                    continue
-                if not isinstance(event, dict):
-                    continue
-                event_conversation_id = str(event.get("conversation_id") or "").strip()
-                if event_conversation_id:
-                    final_conversation_id = event_conversation_id
-                message = event.get("message")
-                if not isinstance(message, dict):
-                    continue
-                author = message.get("author") if isinstance(message.get("author"), dict) else {}
-                if author.get("role") != "assistant":
-                    continue
-                message_id = str(message.get("id") or "").strip()
-                if message_id:
-                    assistant_message_id = message_id
-                content = message.get("content") if isinstance(message.get("content"), dict) else {}
-                if content.get("content_type") != "text":
-                    continue
-                parts = content.get("parts")
-                if not isinstance(parts, list) or not parts:
-                    continue
-                text = str(parts[0] or "")
-                if not text:
-                    continue
-                delta = text[len(final_text):] if text.startswith(final_text) else text
-                final_text = text
-                if delta and on_delta is not None:
-                    on_delta(delta)
+            try:
+                for line in response.iter_lines():
+                    if not line:
+                        continue
+                    if isinstance(line, bytes):
+                        line = line.decode("utf-8", "ignore")
+                    if not isinstance(line, str) or not line.startswith("data: "):
+                        continue
+                    raw = line[6:].strip()
+                    if not raw:
+                        continue
+                    if raw == "[DONE]":
+                        break
+                    try:
+                        event = json.loads(raw)
+                    except Exception:
+                        continue
+                    if not isinstance(event, dict):
+                        continue
+
+                    event_conversation_id = str(event.get("conversation_id") or "").strip()
+                    if not event_conversation_id:
+                        nested_v = event.get("v")
+                        if isinstance(nested_v, dict):
+                            event_conversation_id = str(nested_v.get("conversation_id") or "").strip()
+                    if event_conversation_id:
+                        final_conversation_id = event_conversation_id
+
+                    if str(event.get("type") or "").strip() == "message_stream_complete":
+                        saw_stream_complete = True
+
+                    marker_message_id = str(event.get("message_id") or "").strip()
+                    if marker_message_id:
+                        assistant_message_id = marker_message_id
+
+                    message = _extract_event_message(event)
+                    if isinstance(message, dict):
+                        author = message.get("author") if isinstance(message.get("author"), dict) else {}
+                        if author.get("role") == "assistant":
+                            assistant_message = copy.deepcopy(message)
+                            message_id = str(message.get("id") or "").strip()
+                            if message_id:
+                                assistant_message_id = message_id
+                            text = _extract_message_text(assistant_message)
+                            if text:
+                                delta = text[len(final_text):] if text.startswith(final_text) else text
+                                final_text = text
+                                if delta and on_delta is not None:
+                                    on_delta(delta)
+                        continue
+
+                    if str(event.get("o") or "").strip().lower() == "patch" and isinstance(event.get("v"), list):
+                        if assistant_message is None:
+                            assistant_message = {
+                                "id": assistant_message_id,
+                                "author": {"role": "assistant"},
+                                "content": {"content_type": "text", "parts": [""]},
+                                "metadata": {},
+                            }
+                        for patch_op in event.get("v") or []:
+                            if not isinstance(patch_op, dict):
+                                continue
+                            if not _apply_message_patch(assistant_message, patch_op):
+                                continue
+                            text = _extract_message_text(assistant_message)
+                            if not text:
+                                continue
+                            delta = text[len(final_text):] if text.startswith(final_text) else text
+                            final_text = text
+                            if delta and on_delta is not None:
+                                on_delta(delta)
+            except httpx.RemoteProtocolError:
+                if not final_text.strip() and not saw_stream_complete:
+                    raise
 
     if not final_text.strip():
         raise RuntimeError("ChatGPT web transport returned no assistant text")

--- a/hermes_cli/chatgpt_web.py
+++ b/hermes_cli/chatgpt_web.py
@@ -132,6 +132,25 @@ def resolve_chatgpt_web_runtime_credentials(*, force_refresh: bool = False) -> d
             "session_token": session_token,
         }
 
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("chatgpt-web")
+        if pool and pool.has_credentials():
+            entry = pool.select()
+            if entry is not None:
+                pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
+                if pool_api_key:
+                    return {
+                        "provider": "chatgpt-web",
+                        "api_key": str(pool_api_key).strip(),
+                        "base_url": (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", "") or DEFAULT_CHATGPT_WEB_BASE_URL).rstrip("/"),
+                        "source": f"pool:{getattr(entry, 'label', 'unknown')}",
+                        "session_token": "",
+                    }
+    except Exception:
+        pass
+
     from hermes_cli.auth import resolve_codex_runtime_credentials
 
     creds = resolve_codex_runtime_credentials(force_refresh=False, refresh_if_expiring=True)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -136,6 +136,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, aliases=("gateway",)),
     CommandDef("paste", "Check clipboard for an image and attach it", "Info",
                cli_only=True),
+    CommandDef("image", "Attach a local image file for your next prompt", "Info",
+               cli_only=True, args_hint="<path>"),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -71,6 +71,17 @@ def _system_package_install_cmd(pkg: str) -> str:
     return f"sudo apt install {pkg}"
 
 
+def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
+    steps: list[str] = []
+    step = 1
+    if not node_installed:
+        steps.append(f"{step}) pkg install nodejs")
+        step += 1
+    steps.append(f"{step}) npm install -g agent-browser")
+    steps.append(f"{step + 1}) agent-browser install")
+    return steps
+
+
 def _has_provider_env_config(content: str) -> bool:
     """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
     return any(key in content for key in _PROVIDER_ENV_HINTS)
@@ -597,12 +608,18 @@ def run_doctor(args):
             if _is_termux():
                 check_info("agent-browser is not installed (expected in the tested Termux path)")
                 check_info("Install it manually later with: npm install -g agent-browser && agent-browser install")
+                check_info("Termux browser setup:")
+                for step in _termux_browser_setup_steps(node_installed=True):
+                    check_info(step)
             else:
                 check_warn("agent-browser not installed", "(run: npm install)")
     else:
         if _is_termux():
             check_info("Node.js not found (browser tools are optional in the tested Termux path)")
             check_info("Install Node.js on Termux with: pkg install nodejs")
+            check_info("Termux browser setup:")
+            for step in _termux_browser_setup_steps(node_installed=False):
+                check_info(step)
         else:
             check_warn("Node.js not found", "(optional, needed for browser tools)")
     

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -54,6 +54,23 @@ _PROVIDER_ENV_HINTS = (
 )
 
 
+def _is_termux() -> bool:
+    prefix = os.getenv("PREFIX", "")
+    return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
+
+
+def _python_install_cmd() -> str:
+    return "python -m pip install" if _is_termux() else "uv pip install"
+
+
+def _system_package_install_cmd(pkg: str) -> str:
+    if _is_termux():
+        return f"pkg install {pkg}"
+    if sys.platform == "darwin":
+        return f"brew install {pkg}"
+    return f"sudo apt install {pkg}"
+
+
 def _has_provider_env_config(content: str) -> bool:
     """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
     return any(key in content for key in _PROVIDER_ENV_HINTS)
@@ -200,7 +217,7 @@ def run_doctor(args):
             check_ok(name)
         except ImportError:
             check_fail(name, "(missing)")
-            issues.append(f"Install {name}: uv pip install {module}")
+            issues.append(f"Install {name}: {_python_install_cmd()} {module}")
     
     for module, name in optional_packages:
         try:
@@ -503,7 +520,7 @@ def run_doctor(args):
         check_ok("ripgrep (rg)", "(faster file search)")
     else:
         check_warn("ripgrep (rg) not found", "(file search uses grep fallback)")
-        check_info("Install for faster search: sudo apt install ripgrep")
+        check_info(f"Install for faster search: {_system_package_install_cmd('ripgrep')}")
     
     # Docker (optional)
     terminal_env = os.getenv("TERMINAL_ENV", "local")
@@ -577,6 +594,8 @@ def run_doctor(args):
             check_warn("agent-browser not installed", "(run: npm install)")
     else:
         check_warn("Node.js not found", "(optional, needed for browser tools)")
+        if _is_termux():
+            check_info("Install Node.js on Termux with: pkg install nodejs")
     
     # npm audit for all Node.js packages
     if shutil.which("npm"):
@@ -739,8 +758,9 @@ def run_doctor(args):
                 __import__("tinker_atropos")
                 check_ok("tinker-atropos", "(RL training backend)")
             except ImportError:
-                check_warn("tinker-atropos found but not installed", "(run: uv pip install -e ./tinker-atropos)")
-                issues.append("Install tinker-atropos: uv pip install -e ./tinker-atropos")
+                install_cmd = f"{_python_install_cmd()} -e ./tinker-atropos"
+                check_warn("tinker-atropos found but not installed", f"(run: {install_cmd})")
+                issues.append(f"Install tinker-atropos: {install_cmd}")
         else:
             check_warn("tinker-atropos requires Python 3.11+", f"(current: {py_version.major}.{py_version.minor})")
     else:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -543,7 +543,10 @@ def run_doctor(args):
         if shutil.which("docker"):
             check_ok("docker", "(optional)")
         else:
-            check_warn("docker not found", "(optional)")
+            if _is_termux():
+                check_info("Docker backend is not available inside Termux (expected on Android)")
+            else:
+                check_warn("docker not found", "(optional)")
     
     # SSH (if using ssh backend)
     if terminal_env == "ssh":
@@ -591,11 +594,17 @@ def run_doctor(args):
         if agent_browser_path.exists():
             check_ok("agent-browser (Node.js)", "(browser automation)")
         else:
-            check_warn("agent-browser not installed", "(run: npm install)")
+            if _is_termux():
+                check_info("agent-browser is not installed (expected in the tested Termux path)")
+                check_info("Install it manually later with: npm install")
+            else:
+                check_warn("agent-browser not installed", "(run: npm install)")
     else:
-        check_warn("Node.js not found", "(optional, needed for browser tools)")
         if _is_termux():
+            check_info("Node.js not found (browser tools are optional in the tested Termux path)")
             check_info("Install Node.js on Termux with: pkg install nodejs")
+        else:
+            check_warn("Node.js not found", "(optional, needed for browser tools)")
     
     # npm audit for all Node.js packages
     if shutil.which("npm"):

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -596,7 +596,7 @@ def run_doctor(args):
         else:
             if _is_termux():
                 check_info("agent-browser is not installed (expected in the tested Termux path)")
-                check_info("Install it manually later with: npm install")
+                check_info("Install it manually later with: npm install -g agent-browser && agent-browser install")
             else:
                 check_warn("agent-browser not installed", "(run: npm install)")
     else:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -39,7 +39,7 @@ def _get_service_pids() -> set:
     pids: set = set()
 
     # --- systemd (Linux): user and system scopes ---
-    if is_linux():
+    if supports_systemd_services():
         for scope_args in [["systemctl", "--user"], ["systemctl"]]:
             try:
                 result = subprocess.run(
@@ -224,6 +224,16 @@ def stop_profile_gateway() -> bool:
 
 def is_linux() -> bool:
     return sys.platform.startswith('linux')
+
+
+def is_termux() -> bool:
+    prefix = os.getenv("PREFIX", "")
+    return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
+
+
+def supports_systemd_services() -> bool:
+    return is_linux() and not is_termux()
+
 
 def is_macos() -> bool:
     return sys.platform == 'darwin'
@@ -477,13 +487,15 @@ def install_linux_gateway_from_setup(force: bool = False) -> tuple[str | None, b
 
 
 def get_systemd_linger_status() -> tuple[bool | None, str]:
-    """Return whether systemd user lingering is enabled for the current user.
+    """Return systemd linger status for the current user.
 
     Returns:
         (True, "") when linger is enabled.
         (False, "") when linger is disabled.
         (None, detail) when the status could not be determined.
     """
+    if is_termux():
+        return None, "not supported in Termux"
     if not is_linux():
         return None, "not supported on this platform"
 
@@ -766,7 +778,7 @@ def _print_linger_enable_warning(username: str, detail: str | None = None) -> No
 
 def _ensure_linger_enabled() -> None:
     """Enable linger when possible so the user gateway survives logout."""
-    if not is_linux():
+    if is_termux() or not is_linux():
         return
 
     import getpass
@@ -1773,7 +1785,7 @@ def _setup_whatsapp():
 
 def _is_service_installed() -> bool:
     """Check if the gateway is installed as a system service."""
-    if is_linux():
+    if supports_systemd_services():
         return get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()
     elif is_macos():
         return get_launchd_plist_path().exists()
@@ -1782,7 +1794,7 @@ def _is_service_installed() -> bool:
 
 def _is_service_running() -> bool:
     """Check if the gateway service is currently running."""
-    if is_linux():
+    if supports_systemd_services():
         user_unit_exists = get_systemd_unit_path(system=False).exists()
         system_unit_exists = get_systemd_unit_path(system=True).exists()
 
@@ -1955,7 +1967,7 @@ def gateway_setup():
     service_installed = _is_service_installed()
     service_running = _is_service_running()
 
-    if is_linux() and has_conflicting_systemd_units():
+    if supports_systemd_services() and has_conflicting_systemd_units():
         print_systemd_scope_conflict_warning()
         print()
 
@@ -1965,7 +1977,7 @@ def gateway_setup():
         print_warning("Gateway service is installed but not running.")
         if prompt_yes_no("  Start it now?", True):
             try:
-                if is_linux():
+                if supports_systemd_services():
                     systemd_start()
                 elif is_macos():
                     launchd_start()
@@ -2016,7 +2028,7 @@ def gateway_setup():
         if service_running:
             if prompt_yes_no("  Restart the gateway to pick up changes?", True):
                 try:
-                    if is_linux():
+                    if supports_systemd_services():
                         systemd_restart()
                     elif is_macos():
                         launchd_restart()
@@ -2028,7 +2040,7 @@ def gateway_setup():
         elif service_installed:
             if prompt_yes_no("  Start the gateway service?", True):
                 try:
-                    if is_linux():
+                    if supports_systemd_services():
                         systemd_start()
                     elif is_macos():
                         launchd_start()
@@ -2036,13 +2048,13 @@ def gateway_setup():
                     print_error(f"  Start failed: {e}")
         else:
             print()
-            if is_linux() or is_macos():
-                platform_name = "systemd" if is_linux() else "launchd"
+            if supports_systemd_services() or is_macos():
+                platform_name = "systemd" if supports_systemd_services() else "launchd"
                 if prompt_yes_no(f"  Install the gateway as a {platform_name} service? (runs in background, starts on boot)", True):
                     try:
                         installed_scope = None
                         did_install = False
-                        if is_linux():
+                        if supports_systemd_services():
                             installed_scope, did_install = install_linux_gateway_from_setup(force=False)
                         else:
                             launchd_install(force=False)
@@ -2050,7 +2062,7 @@ def gateway_setup():
                         print()
                         if did_install and prompt_yes_no("  Start the service now?", True):
                             try:
-                                if is_linux():
+                                if supports_systemd_services():
                                     systemd_start(system=installed_scope == "system")
                                 else:
                                     launchd_start()
@@ -2061,12 +2073,18 @@ def gateway_setup():
                         print_info("  You can try manually: hermes gateway install")
                 else:
                     print_info("  You can install later: hermes gateway install")
-                    if is_linux():
+                    if supports_systemd_services():
                         print_info("  Or as a boot-time service: sudo hermes gateway install --system")
                     print_info("  Or run in foreground:  hermes gateway")
             else:
-                print_info("  Service install not supported on this platform.")
-                print_info("  Run in foreground: hermes gateway")
+                if is_termux():
+                    from hermes_constants import display_hermes_home as _dhh
+                    print_info("  Termux does not use systemd/launchd services.")
+                    print_info("  Run in foreground: hermes gateway")
+                    print_info(f"  Or start it manually in the background (best effort): nohup hermes gateway >{_dhh()}/logs/gateway.log 2>&1 &")
+                else:
+                    print_info("  Service install not supported on this platform.")
+                    print_info("  Run in foreground: hermes gateway")
     else:
         print()
         print_info("No platforms configured. Run 'hermes gateway setup' when ready.")
@@ -2102,7 +2120,11 @@ def gateway_command(args):
         force = getattr(args, 'force', False)
         system = getattr(args, 'system', False)
         run_as_user = getattr(args, 'run_as_user', None)
-        if is_linux():
+        if is_termux():
+            print("Gateway service installation is not supported on Termux.")
+            print("Run manually: hermes gateway")
+            sys.exit(1)
+        if supports_systemd_services():
             systemd_install(force=force, system=system, run_as_user=run_as_user)
         elif is_macos():
             launchd_install(force)
@@ -2116,7 +2138,11 @@ def gateway_command(args):
             managed_error("uninstall gateway service (managed by NixOS)")
             return
         system = getattr(args, 'system', False)
-        if is_linux():
+        if is_termux():
+            print("Gateway service uninstall is not supported on Termux because there is no managed service to remove.")
+            print("Stop manual runs with: hermes gateway stop")
+            sys.exit(1)
+        if supports_systemd_services():
             systemd_uninstall(system=system)
         elif is_macos():
             launchd_uninstall()
@@ -2126,7 +2152,11 @@ def gateway_command(args):
     
     elif subcmd == "start":
         system = getattr(args, 'system', False)
-        if is_linux():
+        if is_termux():
+            print("Gateway service start is not supported on Termux because there is no system service manager.")
+            print("Run manually: hermes gateway")
+            sys.exit(1)
+        if supports_systemd_services():
             systemd_start(system=system)
         elif is_macos():
             launchd_start()
@@ -2141,7 +2171,7 @@ def gateway_command(args):
         if stop_all:
             # --all: kill every gateway process on the machine
             service_available = False
-            if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
                 try:
                     systemd_stop(system=system)
                     service_available = True
@@ -2162,7 +2192,7 @@ def gateway_command(args):
         else:
             # Default: stop only the current profile's gateway
             service_available = False
-            if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
                 try:
                     systemd_stop(system=system)
                     service_available = True
@@ -2190,7 +2220,7 @@ def gateway_command(args):
         system = getattr(args, 'system', False)
         service_configured = False
         
-        if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+        if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
             service_configured = True
             try:
                 systemd_restart(system=system)
@@ -2207,7 +2237,7 @@ def gateway_command(args):
         
         if not service_available:
             # systemd/launchd restart failed — check if linger is the issue
-            if is_linux():
+            if supports_systemd_services():
                 linger_ok, _detail = get_systemd_linger_status()
                 if linger_ok is not True:
                     import getpass
@@ -2244,7 +2274,7 @@ def gateway_command(args):
         system = getattr(args, 'system', False)
         
         # Check for service first
-        if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+        if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
             systemd_status(deep, system=system)
         elif is_macos() and get_launchd_plist_path().exists():
             launchd_status(deep)
@@ -2261,9 +2291,13 @@ def gateway_command(args):
                     for line in runtime_lines:
                         print(f"  {line}")
                 print()
-                print("To install as a service:")
-                print("  hermes gateway install")
-                print("  sudo hermes gateway install --system")
+                if is_termux():
+                    print("Termux note:")
+                    print("  Android may stop background jobs when Termux is suspended")
+                else:
+                    print("To install as a service:")
+                    print("  hermes gateway install")
+                    print("  sudo hermes gateway install --system")
             else:
                 print("✗ Gateway is not running")
                 runtime_lines = _runtime_health_lines()
@@ -2275,5 +2309,8 @@ def gateway_command(args):
                 print()
                 print("To start:")
                 print("  hermes gateway          # Run in foreground")
-                print("  hermes gateway install  # Install as user service")
-                print("  sudo hermes gateway install --system  # Install as boot-time system service")
+                if is_termux():
+                    print("  nohup hermes gateway > ~/.hermes/logs/gateway.log 2>&1 &  # Best-effort background start")
+                else:
+                    print("  hermes gateway install  # Install as user service")
+                    print("  sudo hermes gateway install --system  # Install as boot-time system service")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3750,7 +3750,7 @@ def cmd_update(args):
         # running gateway needs restarting to pick up the new code.
         try:
             from hermes_cli.gateway import (
-                is_macos, is_linux, _ensure_user_systemd_env,
+                is_macos, supports_systemd_services, _ensure_user_systemd_env,
                 find_gateway_pids,
                 _get_service_pids,
             )
@@ -3761,7 +3761,7 @@ def cmd_update(args):
 
             # --- Systemd services (Linux) ---
             # Discover all hermes-gateway* units (default + profiles)
-            if is_linux():
+            if supports_systemd_services():
                 try:
                     _ensure_user_systemd_env()
                 except Exception:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4350,7 +4350,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "chatgpt-web", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -646,6 +646,7 @@ def cmd_chat(args):
         "verbose": args.verbose,
         "quiet": getattr(args, "quiet", False),
         "query": args.query,
+        "image": getattr(args, "image", None),
         "resume": getattr(args, "resume", None),
         "worktree": getattr(args, "worktree", False),
         "checkpoints": getattr(args, "checkpoints", False),
@@ -4277,6 +4278,10 @@ For more help on a command:
     chat_parser.add_argument(
         "-q", "--query",
         help="Single query (non-interactive mode)"
+    )
+    chat_parser.add_argument(
+        "--image",
+        help="Optional local image path to attach to a single query"
     )
     chat_parser.add_argument(
         "-m", "--model",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4650,6 +4650,12 @@ For more help on a command:
     auth_remove.add_argument("target", help="Credential index, entry id, or exact label")
     auth_reset = auth_subparsers.add_parser("reset", help="Clear exhaustion status for all credentials for a provider")
     auth_reset.add_argument("provider", help="Provider id")
+    auth_browser = auth_subparsers.add_parser("browser", help="Bootstrap auth by launching a local browser session")
+    auth_browser.add_argument("provider", nargs="?", default="chatgpt-web", choices=["chatgpt-web"], help="Provider id (currently only chatgpt-web)")
+    auth_browser.add_argument("--label", help="Optional display label for the stored credential")
+    auth_browser.add_argument("--timeout", type=int, default=15 * 60, help="How long to wait for the browser login flow in seconds")
+    auth_browser.add_argument("--debug-port", type=int, default=9222, help="Local Chromium remote-debugging port")
+    auth_browser.add_argument("--keep-open", action="store_true", help="Leave the browser/X11 session running after auth completes")
     auth_parser.set_defaults(func=cmd_auth)
 
     # =========================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -919,6 +919,7 @@ def select_provider_and_model(args=None):
         "openrouter": "OpenRouter",
         "nous": "Nous Portal",
         "openai-codex": "OpenAI Codex",
+        "chatgpt-web": "ChatGPT Web",
         "qwen-oauth": "Qwen OAuth",
         "copilot-acp": "GitHub Copilot ACP",
         "copilot": "GitHub Copilot",
@@ -949,6 +950,7 @@ def select_provider_and_model(args=None):
         ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
         ("anthropic", "Anthropic (Claude models — API key or Claude Code)"),
         ("openai-codex", "OpenAI Codex"),
+        ("chatgpt-web", "ChatGPT Web (ChatGPT.com web-app models)"),
         ("qwen-oauth", "Qwen OAuth (reuses local Qwen CLI login)"),
         ("copilot", "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
         ("huggingface", "Hugging Face Inference Providers (20+ open models)"),
@@ -1046,6 +1048,8 @@ def select_provider_and_model(args=None):
         _model_flow_nous(config, current_model, args=args)
     elif selected_provider == "openai-codex":
         _model_flow_openai_codex(config, current_model)
+    elif selected_provider == "chatgpt-web":
+        _model_flow_chatgpt_web(config, current_model)
     elif selected_provider == "qwen-oauth":
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "copilot-acp":
@@ -1362,6 +1366,53 @@ def _model_flow_openai_codex(config, current_model=""):
     else:
         print("No change.")
 
+
+def _model_flow_chatgpt_web(config, current_model=""):
+    """ChatGPT Web provider: reuse ChatGPT auth, then pick a web-app model slug."""
+    from hermes_cli.auth import (
+        get_chatgpt_web_auth_status,
+        _prompt_model_selection,
+        _save_model_choice,
+        _update_config_for_provider,
+        _login_openai_codex,
+        PROVIDER_REGISTRY,
+    )
+    from hermes_cli.chatgpt_web import (
+        DEFAULT_CHATGPT_WEB_BASE_URL,
+        fetch_chatgpt_web_model_ids,
+        resolve_chatgpt_web_runtime_credentials,
+    )
+    import argparse
+
+    status = get_chatgpt_web_auth_status()
+    if not status.get("logged_in"):
+        print("Not logged into ChatGPT Web. Starting OpenAI login...")
+        print()
+        try:
+            mock_args = argparse.Namespace()
+            _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
+        except SystemExit:
+            print("Login cancelled or failed.")
+            return
+        except Exception as exc:
+            print(f"Login failed: {exc}")
+            return
+
+    access_token = None
+    try:
+        creds = resolve_chatgpt_web_runtime_credentials()
+        access_token = creds.get("api_key")
+    except Exception:
+        pass
+
+    web_models = fetch_chatgpt_web_model_ids(access_token=access_token)
+    selected = _prompt_model_selection(web_models, current_model=current_model)
+    if selected:
+        _save_model_choice(selected)
+        _update_config_for_provider("chatgpt-web", DEFAULT_CHATGPT_WEB_BASE_URL)
+        print(f"Default model set to: {selected} (via ChatGPT Web)")
+    else:
+        print("No change.")
 
 
 _DEFAULT_QWEN_PORTAL_MODELS = [
@@ -4514,7 +4565,7 @@ For more help on a command:
     )
     login_parser.add_argument(
         "--provider",
-        choices=["nous", "openai-codex"],
+        choices=["nous", "openai-codex", "chatgpt-web"],
         default=None,
         help="Provider to authenticate with (default: nous)"
     )
@@ -4568,7 +4619,7 @@ For more help on a command:
     )
     logout_parser.add_argument(
         "--provider",
-        choices=["nous", "openai-codex"],
+        choices=["nous", "openai-codex", "chatgpt-web"],
         default=None,
         help="Provider to log out from (default: active provider)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -92,6 +92,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-5.1-codex-mini",
         "gpt-5.1-codex-max",
     ],
+    "chatgpt-web": [
+        "gpt-5-thinking",
+        "gpt-5-instant",
+        "gpt-5",
+        "gpt-4o",
+        "gpt-4.1",
+        "o3",
+        "o4-mini",
+    ],
     "copilot-acp": [
         "copilot-acp",
     ],
@@ -468,6 +477,7 @@ def check_nous_free_tier() -> bool:
 _PROVIDER_LABELS = {
     "openrouter": "OpenRouter",
     "openai-codex": "OpenAI Codex",
+    "chatgpt-web": "ChatGPT Web",
     "copilot-acp": "GitHub Copilot ACP",
     "nous": "Nous Portal",
     "copilot": "GitHub Copilot",
@@ -493,6 +503,9 @@ _PROVIDER_ALIASES = {
     "z-ai": "zai",
     "z.ai": "zai",
     "zhipu": "zai",
+    "chatgpt": "chatgpt-web",
+    "chatgpt.com": "chatgpt-web",
+    "openai-chatgpt": "chatgpt-web",
     "github": "copilot",
     "github-copilot": "copilot",
     "github-models": "copilot",
@@ -766,7 +779,7 @@ def list_available_providers() -> list[dict[str, str]]:
     """
     # Canonical providers in display order
     _PROVIDER_ORDER = [
-        "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+        "openrouter", "nous", "openai-codex", "chatgpt-web", "copilot", "copilot-acp",
         "gemini", "huggingface",
         "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "qwen-oauth",
@@ -1041,6 +1054,19 @@ def provider_model_ids(provider: Optional[str]) -> list[str]:
         from hermes_cli.codex_models import get_codex_model_ids
 
         return get_codex_model_ids()
+    if normalized == "chatgpt-web":
+        try:
+            from hermes_cli.chatgpt_web import (
+                fetch_chatgpt_web_model_ids,
+                resolve_chatgpt_web_runtime_credentials,
+            )
+
+            creds = resolve_chatgpt_web_runtime_credentials()
+            live = fetch_chatgpt_web_model_ids(access_token=creds.get("api_key", ""))
+            if live:
+                return live
+        except Exception:
+            pass
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -242,6 +242,7 @@ ALIASES: Dict[str, str] = {
 _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
+    "chatgpt-web": "ChatGPT Web",
     "copilot-acp": "GitHub Copilot ACP",
     "local": "Local endpoint",
 }
@@ -364,6 +365,7 @@ LABELS: Dict[str, str] = {
     "openrouter": "OpenRouter",
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
+    "chatgpt-web": "ChatGPT Web",
     "copilot-acp": "GitHub Copilot ACP",
     "github-copilot": "GitHub Copilot",
     "anthropic": "Anthropic",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class HermesOverlay:
     """Hermes-specific provider metadata layered on top of models.dev."""
 
-    transport: str = "openai_chat"        # openai_chat | anthropic_messages | codex_responses
+    transport: str = "openai_chat"        # openai_chat | anthropic_messages | codex_responses | chatgpt_web
     is_aggregator: bool = False
     auth_type: str = "api_key"            # api_key | oauth_device_code | oauth_external | external_process
     extra_env_vars: Tuple[str, ...] = ()  # env vars models.dev doesn't list
@@ -57,6 +57,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="codex_responses",
         auth_type="oauth_external",
         base_url_override="https://chatgpt.com/backend-api/codex",
+    ),
+    "chatgpt-web": HermesOverlay(
+        transport="chatgpt_web",
+        auth_type="oauth_external",
+        extra_env_vars=("CHATGPT_WEB_ACCESS_TOKEN", "CHATGPT_WEB_SESSION_TOKEN"),
+        base_url_override="https://chatgpt.com/backend-api/f",
     ),
     "qwen-oauth": HermesOverlay(
         transport="openai_chat",
@@ -247,6 +253,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "openai_chat": "chat_completions",
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
+    "chatgpt_web": "chatgpt_web",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,6 +14,7 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_CHATGPT_WEB_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
     format_auth_error,
@@ -25,6 +26,7 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
+from hermes_cli.chatgpt_web import resolve_chatgpt_web_runtime_credentials
 from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
 
@@ -40,6 +42,8 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     tool calls with reasoning (chat/completions returns 400).
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
+    if "chatgpt.com/backend-api/f" in normalized or "chatgpt.com/backend-anon/f" in normalized:
+        return "chatgpt_web"
     if "api.openai.com" in normalized and "openrouter" not in normalized:
         return "codex_responses"
     return None
@@ -123,7 +127,7 @@ def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
         return "chat_completions"
 
 
-_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages"}
+_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages", "chatgpt_web"}
 
 
 def _parse_api_mode(raw: Any) -> Optional[str]:
@@ -150,6 +154,9 @@ def _resolve_runtime_from_pool_entry(
     if provider == "openai-codex":
         api_mode = "codex_responses"
         base_url = base_url or DEFAULT_CODEX_BASE_URL
+    elif provider == "chatgpt-web":
+        api_mode = "chatgpt_web"
+        base_url = base_url or DEFAULT_CHATGPT_WEB_BASE_URL
     elif provider == "qwen-oauth":
         api_mode = "chat_completions"
         base_url = base_url or DEFAULT_QWEN_BASE_URL
@@ -694,6 +701,23 @@ def resolve_runtime_provider(
             # Auto-detected Codex but credentials are stale/revoked —
             # fall through to env-var providers (e.g. OpenRouter).
             logger.info("Auto-detected Codex provider but credentials failed; "
+                        "falling through to next provider.")
+
+    if provider == "chatgpt-web":
+        try:
+            creds = resolve_chatgpt_web_runtime_credentials()
+            return {
+                "provider": "chatgpt-web",
+                "api_mode": "chatgpt_web",
+                "base_url": (creds.get("base_url") or DEFAULT_CHATGPT_WEB_BASE_URL).rstrip("/"),
+                "api_key": creds.get("api_key", ""),
+                "source": creds.get("source", "codex-oauth"),
+                "requested_provider": requested_provider,
+            }
+        except AuthError:
+            if requested_provider != "auto":
+                raise
+            logger.info("Auto-detected ChatGPT Web provider but credentials failed; "
                         "falling through to next provider.")
 
     if provider == "qwen-oauth":

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -79,6 +79,11 @@ def _effective_provider_label() -> str:
     return provider_label(effective)
 
 
+def _is_termux() -> bool:
+    prefix = os.getenv("PREFIX", "")
+    return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
+
+
 def show_status(args):
     """Show status of all Hermes Agent components."""
     show_all = getattr(args, 'all', False)
@@ -324,7 +329,25 @@ def show_status(args):
     print()
     print(color("◆ Gateway Service", Colors.CYAN, Colors.BOLD))
     
-    if sys.platform.startswith('linux'):
+    if _is_termux():
+        try:
+            from hermes_cli.gateway import find_gateway_pids
+            gateway_pids = find_gateway_pids()
+        except Exception:
+            gateway_pids = []
+        is_running = bool(gateway_pids)
+        print(f"  Status:       {check_mark(is_running)} {'running' if is_running else 'stopped'}")
+        print("  Manager:      Termux / manual process")
+        if gateway_pids:
+            rendered = ", ".join(str(pid) for pid in gateway_pids[:3])
+            if len(gateway_pids) > 3:
+                rendered += ", ..."
+            print(f"  PID(s):       {rendered}")
+        else:
+            print("  Start with:   hermes gateway")
+            print("  Note:         Android may stop background jobs when Termux is suspended")
+
+    elif sys.platform.startswith('linux'):
         try:
             from hermes_cli.gateway import get_service_name
             _gw_svc = get_service_name()
@@ -338,7 +361,7 @@ def show_status(args):
                 timeout=5
             )
             is_active = result.stdout.strip() == "active"
-        except subprocess.TimeoutExpired:
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             is_active = False
         print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
         print("  Manager:      systemd (user)")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -158,13 +158,20 @@ def show_status(args):
     print(color("◆ Auth Providers", Colors.CYAN, Colors.BOLD))
 
     try:
-        from hermes_cli.auth import get_nous_auth_status, get_codex_auth_status, get_qwen_auth_status
+        from hermes_cli.auth import (
+            get_chatgpt_web_auth_status,
+            get_codex_auth_status,
+            get_nous_auth_status,
+            get_qwen_auth_status,
+        )
         nous_status = get_nous_auth_status()
         codex_status = get_codex_auth_status()
+        chatgpt_web_status = get_chatgpt_web_auth_status()
         qwen_status = get_qwen_auth_status()
     except Exception:
         nous_status = {}
         codex_status = {}
+        chatgpt_web_status = {}
         qwen_status = {}
 
     nous_logged_in = bool(nous_status.get("logged_in"))
@@ -195,6 +202,26 @@ def show_status(args):
         print(f"    Refreshed:  {codex_last_refresh}")
     if codex_status.get("error") and not codex_logged_in:
         print(f"    Error:      {codex_status.get('error')}")
+
+    chatgpt_web_logged_in = bool(chatgpt_web_status.get("logged_in"))
+    print(
+        f"  {'ChatGPT Web':<12}  {check_mark(chatgpt_web_logged_in)} "
+        f"{'logged in' if chatgpt_web_logged_in else 'not logged in (run: hermes model)'}"
+    )
+    chatgpt_web_source = chatgpt_web_status.get("source")
+    if chatgpt_web_source:
+        print(f"    Source:     {chatgpt_web_source}")
+    chatgpt_web_mode = chatgpt_web_status.get("auth_mode")
+    if chatgpt_web_mode:
+        print(f"    Mode:       {chatgpt_web_mode}")
+    chatgpt_web_auth_file = chatgpt_web_status.get("auth_store")
+    if chatgpt_web_auth_file:
+        print(f"    Auth file:  {chatgpt_web_auth_file}")
+    chatgpt_web_last_refresh = _format_iso_timestamp(chatgpt_web_status.get("last_refresh"))
+    if chatgpt_web_status.get("last_refresh"):
+        print(f"    Refreshed:  {chatgpt_web_last_refresh}")
+    if chatgpt_web_status.get("error") and not chatgpt_web_logged_in:
+        print(f"    Error:      {chatgpt_web_status.get('error')}")
 
     qwen_logged_in = bool(qwen_status.get("logged_in"))
     print(

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -122,6 +122,10 @@ def uninstall_gateway_service():
     
     if platform.system() != "Linux":
         return False
+
+    prefix = os.getenv("PREFIX", "")
+    if os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix:
+        return False
     
     try:
         from hermes_cli.gateway import get_service_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,17 @@ homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
 acp = ["agent-client-protocol>=0.9.0,<1.0"]
 mistral = ["mistralai>=2.3.0,<3"]
+termux = [
+  # Tested Android / Termux path: keeps the core CLI feature-rich while
+  # avoiding extras that currently depend on non-Android wheels (notably
+  # faster-whisper -> ctranslate2 via the voice extra).
+  "hermes-agent[cron]",
+  "hermes-agent[cli]",
+  "hermes-agent[pty]",
+  "hermes-agent[mcp]",
+  "hermes-agent[honcho]",
+  "hermes-agent[acp]",
+]
 dingtalk = ["dingtalk-stream>=0.1.0,<1"]
 feishu = ["lark-oapi>=1.5.3,<2"]
 rl = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "python-dotenv>=1.2.1,<2",
   "fire>=0.7.1,<1",
   "httpx>=0.28.1,<1",
+  "websockets>=15.0.1,<16",
   "rich>=14.3.3,<15",
   "tenacity>=9.1.4,<10",
   "pyyaml>=6.0.2,<7",

--- a/run_agent.py
+++ b/run_agent.py
@@ -20,6 +20,7 @@ Usage:
     response = agent.run_conversation("Tell me about the latest Python updates")
 """
 
+import ast
 import asyncio
 import base64
 import concurrent.futures
@@ -107,6 +108,88 @@ from agent.trajectory import (
 )
 from utils import atomic_json_write, env_var_enabled
 
+
+_XML_TOOL_CALL_BLOCK_RE = re.compile(r"(?:['\"]?<?)tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL | re.IGNORECASE)
+
+
+def _extract_xml_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:
+    if not isinstance(text, str) or not text.strip():
+        return [], ""
+
+    extracted: list[SimpleNamespace] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _load_tool_call_object(raw_json: str) -> Optional[dict[str, Any]]:
+        for loader in (json.loads, ast.literal_eval):
+            try:
+                loaded = loader(raw_json)
+            except Exception:
+                continue
+            if isinstance(loaded, dict):
+                return loaded
+        return None
+
+    def _try_add_tool_call(raw_json: str) -> None:
+        obj = _load_tool_call_object(raw_json)
+        if not isinstance(obj, dict):
+            return
+
+        function_block = obj.get("function") if isinstance(obj.get("function"), dict) else None
+        if function_block is not None:
+            function_name = function_block.get("name")
+            function_args = function_block.get("arguments", "{}")
+        else:
+            function_name = obj.get("name")
+            function_args = obj.get("arguments", {})
+
+        if not isinstance(function_name, str) or not function_name.strip():
+            return
+        if not isinstance(function_args, str):
+            function_args = json.dumps(function_args, ensure_ascii=False)
+
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"chatgpt_web_call_{len(extracted) + 1}"
+
+        extracted.append(
+            SimpleNamespace(
+                id=call_id,
+                call_id=call_id,
+                response_item_id=None,
+                type="function",
+                function=SimpleNamespace(
+                    name=function_name.strip(),
+                    arguments=function_args,
+                ),
+            )
+        )
+
+    for match in _XML_TOOL_CALL_BLOCK_RE.finditer(text):
+        _try_add_tool_call(match.group(1))
+        consumed_spans.append((match.start(), match.end()))
+
+    if not consumed_spans:
+        return extracted, text.strip()
+
+    consumed_spans.sort()
+    merged_spans: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged_spans or start > merged_spans[-1][1]:
+            merged_spans.append((start, end))
+        else:
+            merged_spans[-1] = (merged_spans[-1][0], max(merged_spans[-1][1], end))
+
+    remaining_parts: list[str] = []
+    cursor = 0
+    for start, end in merged_spans:
+        if cursor < start:
+            remaining_parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        remaining_parts.append(text[cursor:])
+
+    cleaned = "\n".join(part.strip() for part in remaining_parts if isinstance(part, str) and part.strip()).strip()
+    return extracted, cleaned
 
 
 class _SafeWriter:
@@ -629,6 +712,7 @@ class AIAgent:
         self.suppress_status_output = False
         self._chatgpt_web_conversation_id = None
         self._chatgpt_web_parent_message_id = None
+        self._chatgpt_web_forced_tool_call = None
         self.thinking_callback = thinking_callback
         self.reasoning_callback = reasoning_callback
         self._reasoning_deltas_fired = False  # Set by _fire_reasoning_delta, reset per API call
@@ -2029,6 +2113,210 @@ class AIAgent:
         
         return json.dumps(formatted_tools, ensure_ascii=False)
     
+    @staticmethod
+    def _compact_chatgpt_web_schema(value: Any) -> Any:
+        if isinstance(value, dict):
+            cleaned: dict[str, Any] = {}
+            for key, inner in value.items():
+                if key in {"description", "title", "default", "examples", "$schema"}:
+                    continue
+                compact = AIAgent._compact_chatgpt_web_schema(inner)
+                if compact in ({}, [], None, ""):
+                    continue
+                cleaned[key] = compact
+            return cleaned
+        if isinstance(value, list):
+            items = [AIAgent._compact_chatgpt_web_schema(item) for item in value]
+            return [item for item in items if item not in ({}, [], None, "")]
+        return value
+
+    @staticmethod
+    def _compact_chatgpt_web_description(text: str) -> str:
+        if not isinstance(text, str) or not text.strip():
+            return ""
+        first_paragraph = text.strip().split("\n\n", 1)[0].strip()
+        first_sentence = re.split(r"(?<=[.!?])\s+", first_paragraph, maxsplit=1)[0].strip()
+        return first_sentence[:220]
+
+    def _select_chatgpt_web_tools(self, payload_messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not self.tools:
+            return []
+
+        tools_by_name = {
+            str(tool.get("function", {}).get("name") or "").strip(): tool
+            for tool in self.tools
+            if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+        }
+        tools_by_name = {name: tool for name, tool in tools_by_name.items() if name}
+        if not tools_by_name:
+            return []
+
+        user_text = "\n".join(
+            str(msg.get("content") or "")
+            for msg in payload_messages
+            if isinstance(msg, dict) and msg.get("role") == "user"
+        )
+        used_tool_count = sum(
+            1 for msg in payload_messages
+            if isinstance(msg, dict) and msg.get("role") == "tool"
+        )
+
+        explicit_pattern = re.compile(
+            r"\b(" + "|".join(re.escape(name) for name in sorted(tools_by_name, key=len, reverse=True)) + r")\b",
+            re.IGNORECASE,
+        )
+        explicit_sequence = [match.group(1) for match in explicit_pattern.finditer(user_text)]
+        if explicit_sequence:
+            next_index = min(used_tool_count, len(explicit_sequence) - 1)
+            next_name = explicit_sequence[next_index]
+            for candidate_name, tool in tools_by_name.items():
+                if candidate_name.lower() == next_name.lower():
+                    return [tool]
+
+        lowered = user_text.lower()
+        heuristic_names: list[str] = []
+        if any(keyword in lowered for keyword in ("working directory", "pwd", "current directory", "date", "time", "port", "process")):
+            heuristic_names.append("terminal")
+        if any(keyword in lowered for keyword in ("python", "script", "calculate", "math", "compute", "sum", "product", "multiply")):
+            heuristic_names.append("execute_code")
+        if any(keyword in lowered for keyword in ("find", "search", "grep", "file", "files", "path", "repo", "symbol")):
+            heuristic_names.extend(["search_files", "read_file"])
+        if any(keyword in lowered for keyword in ("shell", "command", "run ")):
+            heuristic_names.append("terminal")
+        if any(keyword in lowered for keyword in ("edit", "modify", "change", "patch", "fix", "write")):
+            heuristic_names.extend(["patch", "write_file"])
+
+        for name in heuristic_names:
+            tool = tools_by_name.get(name)
+            if tool is not None:
+                return [tool]
+
+        for name in ("search_files", "read_file", "execute_code", "terminal"):
+            tool = tools_by_name.get(name)
+            if tool is not None:
+                return [tool]
+
+        return [next(iter(tools_by_name.values()))]
+
+    def _chatgpt_web_tool_args(self, tool_name: str, payload_messages: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            return None
+        user_text = "\n".join(
+            str(msg.get("content") or "")
+            for msg in payload_messages
+            if isinstance(msg, dict) and msg.get("role") == "user"
+        )
+        lowered = user_text.lower()
+
+        if tool_name == "search_files":
+            path_match = re.search(r"([A-Za-z0-9_./-]+\.[A-Za-z0-9_]+)", user_text)
+            symbol_match = re.search(r"\bfor\s+([A-Za-z_][A-Za-z0-9_]*)", user_text)
+            if ("grep" in lowered or "symbol" in lowered or "search" in lowered) and path_match and symbol_match:
+                return {
+                    "pattern": symbol_match.group(1),
+                    "target": "content",
+                    "path": path_match.group(1),
+                }
+            if "find" in lowered or "file named" in lowered or "named" in lowered:
+                filename = path_match.group(1) if path_match else "*.py"
+                return {
+                    "pattern": filename,
+                    "target": "files",
+                    "path": ".",
+                    "output_mode": "files_only",
+                    "limit": 20,
+                }
+
+        if tool_name == "execute_code":
+            expr_match = re.search(r"([0-9][0-9\s\+\-\*\/\(\)]*[\+\-\*\/][0-9\s\+\-\*\/\(\)]*)", user_text)
+            if expr_match:
+                expr = expr_match.group(1).strip()
+                return {"code": f"print({expr})"}
+
+        if tool_name == "terminal":
+            if "working directory" in lowered or "pwd" in lowered:
+                return {"command": "pwd"}
+            if "date" in lowered or "time" in lowered:
+                return {"command": "date"}
+
+        return None
+
+    def _chatgpt_web_tool_hint(self, tool_name: str, payload_messages: list[dict[str, Any]]) -> str:
+        args = self._chatgpt_web_tool_args(tool_name, payload_messages)
+        if args is None:
+            return ""
+        return "Use these exact arguments for this turn: " + json.dumps(args, ensure_ascii=False)
+
+    def _chatgpt_web_tool_call_example(self, tool_name: str, payload_messages: list[dict[str, Any]]) -> str:
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            return ""
+        args = self._chatgpt_web_tool_args(tool_name, payload_messages)
+        if args is None:
+            return ""
+        return (
+            "<tool_call>\n"
+            + json.dumps({"name": tool_name, "arguments": args}, ensure_ascii=False)
+            + "\n</tool_call>"
+        )
+
+    def _format_tools_for_chatgpt_web(self, tools: Optional[list[dict[str, Any]]] = None) -> str:
+        selected_tools = tools if tools is not None else self.tools
+        if not selected_tools:
+            return "[]"
+        formatted_tools = []
+        for tool in selected_tools:
+            func = tool.get("function") if isinstance(tool, dict) else None
+            if not isinstance(func, dict):
+                continue
+            name = str(func.get("name") or "").strip()
+            if not name:
+                continue
+            schema = self._compact_chatgpt_web_schema(func.get("parameters", {}))
+            if not isinstance(schema, dict) or not schema:
+                schema = {"type": "object"}
+            formatted_tools.append({
+                "name": name,
+                "description": self._compact_chatgpt_web_description(func.get("description", "")),
+                "parameters": schema,
+            })
+        return json.dumps(formatted_tools, ensure_ascii=False)
+
+    def _chatgpt_web_tool_protocol(self, tools: Optional[list[dict[str, Any]]] = None) -> str:
+        selected_tools = tools if tools is not None else self.tools
+        if not selected_tools:
+            return ""
+        tool_names = [
+            str(tool.get("function", {}).get("name") or "").strip()
+            for tool in selected_tools
+            if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+        ]
+        tool_names = [name for name in tool_names if name]
+        if len(tool_names) == 1:
+            tool_label = tool_names[0]
+            return (
+                f"You have access to exactly one tool in this turn: {tool_label}. "
+                f"That tool is available right now. Do not say tools are unavailable. "
+                f"Ignore any later steps for now and focus only on using {tool_label} in this response. "
+                f"If the user's request needs {tool_label}, your next response must be EXACTLY ONE <tool_call>...</tool_call> block and nothing else. "
+                "After you receive a <tool_response>, continue the task and either make the next tool call or give the final answer.\n"
+                f"<tools>\n{self._format_tools_for_chatgpt_web(selected_tools)}\n</tools>\n"
+                "Tool call schema: {'name': <function-name>, 'arguments': <args-dict>}\n"
+                f"Example:\n<tool_call>\n{{\"name\": \"{tool_label}\", \"arguments\": {{}}}}\n</tool_call>"
+            )
+        return (
+            "You are running inside Hermes Agent's local tool loop over ChatGPT Web. "
+            "If the user asks for live filesystem inspection, file search, command execution, Python/code execution, calculations, or current system/repo facts, you MUST call Hermes tools before answering. "
+            "Never claim that tools are unavailable, inaccessible, or unsupported here. They ARE available through this local tool loop. "
+            "Do not claim that a tool failed unless you actually emitted a <tool_call> block and were given a failing <tool_response>. "
+            "For multi-step tasks, work iteratively: make the single best next tool call now, wait for the <tool_response>, then make the next tool call or provide the final answer. "
+            "When a tool is needed, respond with EXACTLY ONE <tool_call>...</tool_call> block and no surrounding commentary. "
+            "After tool execution, you will receive tool outputs inside <tool_response>...</tool_response> blocks and should then continue the task.\n"
+            f"<tools>\n{self._format_tools_for_chatgpt_web(selected_tools)}\n</tools>\n"
+            "For each function call return a JSON object with this schema: {'name': <function-name>, 'arguments': <args-dict>}. "
+            "Each function call must be enclosed within <tool_call> </tool_call> XML tags.\n"
+            "Example:\n<tool_call>\n{\"name\": \"search_files\", \"arguments\": {\"pattern\": \"chatgpt_web\", \"target\": \"content\", \"path\": \"hermes_cli/chatgpt_web.py\"}}\n</tool_call>"
+        )
+
     def _convert_to_trajectory_format(self, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
         """
         Convert internal message format to trajectory format for saving.
@@ -4244,7 +4532,7 @@ class AIAgent:
             self._try_refresh_anthropic_client_credentials()
         return self._anthropic_client.messages.create(**api_kwargs)
 
-    def _chatgpt_web_messages(self, api_messages: list) -> tuple[str, list[dict[str, Any]]]:
+    def _chatgpt_web_messages(self, api_messages: list) -> tuple[str, list[dict[str, Any]], bool]:
         instructions = ""
         payload_messages = api_messages
         if api_messages and api_messages[0].get("role") == "system":
@@ -4252,25 +4540,111 @@ class AIAgent:
             payload_messages = api_messages[1:]
         if not instructions:
             instructions = DEFAULT_AGENT_IDENTITY
-        if self.tools:
-            instructions = (
-                instructions.rstrip()
-                + "\n\nImportant runtime limitation: this ChatGPT Web transport currently does not support Hermes tool calls. "
-                  "Never claim to have run a tool or accessed live system state through a tool."
+
+        self._chatgpt_web_forced_tool_call = None
+        uses_local_tool_loop = bool(self.tools)
+        if uses_local_tool_loop:
+            payload_messages = copy.deepcopy(payload_messages)
+            selected_tools = self._select_chatgpt_web_tools(payload_messages)
+            used_tool_count = sum(
+                1 for item in payload_messages
+                if isinstance(item, dict) and item.get("role") == "tool"
             )
-        if self._chatgpt_web_conversation_id and payload_messages:
+            tool_protocol = self._chatgpt_web_tool_protocol(selected_tools).strip()
+            base_instructions = instructions.strip() or DEFAULT_AGENT_IDENTITY
+            instructions = f"{base_instructions}\n\n{tool_protocol}" if tool_protocol else base_instructions
+            selected_tool_names = [
+                str(tool.get("function", {}).get("name") or "").strip()
+                for tool in selected_tools
+                if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+            ]
+            selected_tool_names = [name for name in selected_tool_names if name]
+            selected_tool_text = ", ".join(selected_tool_names)
+            selected_tool_args = self._chatgpt_web_tool_args(selected_tool_names[0], payload_messages) if selected_tool_names else None
+            selected_tool_hint = (
+                "Use these exact arguments for this turn: " + json.dumps(selected_tool_args, ensure_ascii=False)
+                if selected_tool_args is not None else ""
+            )
+            selected_tool_example = (
+                "<tool_call>\n"
+                + json.dumps({"name": selected_tool_names[0], "arguments": selected_tool_args}, ensure_ascii=False)
+                + "\n</tool_call>"
+                if selected_tool_names and selected_tool_args is not None else ""
+            )
+            if used_tool_count == 0 and selected_tool_names and selected_tool_args is not None:
+                self._chatgpt_web_forced_tool_call = {
+                    "name": selected_tool_names[0],
+                    "arguments": selected_tool_args,
+                }
+            for item in reversed(payload_messages):
+                if isinstance(item, dict) and item.get("role") == "user":
+                    original = str(item.get("content") or "").strip()
+                    marker = "Original user request:\n"
+                    if marker in original:
+                        original = original.split(marker, 1)[1].strip()
+                        original = original.split("\n\nRuntime reminder:", 1)[0].strip()
+                    if original:
+                        reminder_lines = [f"The tool available for this turn is: {selected_tool_text}."] if selected_tool_text else []
+                        if used_tool_count == 0:
+                            reminder_lines.extend([
+                                "Hermes has already determined that this turn requires a tool call.",
+                                "Do not answer the user yet.",
+                                "Your next reply must be EXACTLY ONE <tool_call>...</tool_call> block with no explanatory prose before or after it.",
+                            ])
+                            if selected_tool_hint:
+                                reminder_lines.append(selected_tool_hint)
+                            if selected_tool_example:
+                                reminder_lines.append("Reply now with this exact structure:")
+                                reminder_lines.append(selected_tool_example)
+                        else:
+                            reminder_lines.extend([
+                                "You have already received at least one <tool_response>.",
+                                "If another tool is still required, emit EXACTLY ONE <tool_call>...</tool_call> block.",
+                                "Otherwise, give the final answer directly with no extra tool-call markup.",
+                                "When you give the final answer, follow the original user's requested output format exactly, including any 'answer only' constraint.",
+                            ])
+                            if selected_tool_hint:
+                                reminder_lines.append(selected_tool_hint)
+                        item["content"] = (
+                            f"Original user request:\n{original}\n\nRuntime reminder:\n"
+                            + "\n".join(reminder_lines)
+                        )
+                    break
+
+        if self._chatgpt_web_conversation_id and payload_messages and not uses_local_tool_loop:
             latest_user = None
             for item in reversed(payload_messages):
                 if isinstance(item, dict) and item.get("role") == "user":
                     latest_user = item
                     break
             payload_messages = [latest_user] if latest_user else payload_messages[-1:]
-        return instructions, payload_messages
+        return instructions, payload_messages, uses_local_tool_loop
 
     def _wrap_chatgpt_web_response(self, result: dict[str, Any]):
         message_text = str(result.get("content") or "")
         finish_reason = str(result.get("finish_reason") or "stop")
-        assistant_message = SimpleNamespace(content=message_text, tool_calls=None, role="assistant")
+        tool_calls = None
+        forced_tool_call = self._chatgpt_web_forced_tool_call
+        self._chatgpt_web_forced_tool_call = None
+        if self.tools and message_text:
+            extracted_tool_calls, cleaned_text = _extract_xml_tool_calls_from_text(message_text)
+            if extracted_tool_calls:
+                tool_calls = extracted_tool_calls
+                message_text = cleaned_text
+            elif isinstance(forced_tool_call, dict):
+                synthetic_block = (
+                    "<tool_call>\n"
+                    + json.dumps({
+                        "name": forced_tool_call.get("name"),
+                        "arguments": forced_tool_call.get("arguments", {}),
+                    }, ensure_ascii=False)
+                    + "\n</tool_call>"
+                )
+                extracted_tool_calls, _ = _extract_xml_tool_calls_from_text(synthetic_block)
+                if extracted_tool_calls:
+                    tool_calls = extracted_tool_calls
+                    message_text = ""
+        assistant_message = SimpleNamespace(content=message_text, tool_calls=tool_calls, role="assistant")
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
         return SimpleNamespace(
             id=result.get("message_id") or result.get("parent_message_id") or str(uuid.uuid4()),
@@ -5540,15 +5914,15 @@ class AIAgent:
             return kwargs
 
         if self.api_mode == "chatgpt_web":
-            instructions, payload_messages = self._chatgpt_web_messages(api_messages)
+            instructions, payload_messages, uses_local_tool_loop = self._chatgpt_web_messages(api_messages)
             return {
                 "model": self.model,
                 "instructions": instructions,
                 "messages": payload_messages,
-                "conversation_id": self._chatgpt_web_conversation_id,
-                "parent_message_id": self._chatgpt_web_parent_message_id,
+                "conversation_id": None if uses_local_tool_loop else self._chatgpt_web_conversation_id,
+                "parent_message_id": None if uses_local_tool_loop else self._chatgpt_web_parent_message_id,
                 "timeout": float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
-                "history_and_training_disabled": False,
+                "history_and_training_disabled": bool(uses_local_tool_loop),
             }
 
         sanitized_messages = api_messages

--- a/run_agent.py
+++ b/run_agent.py
@@ -4454,7 +4454,20 @@ class AIAgent:
             finally:
                 self._codex_on_first_delta = None
         if self.api_mode == "chatgpt_web":
-            self._chatgpt_web_on_delta = on_first_delta or self._fire_stream_delta
+            first_delta_fired = {"done": False}
+
+            def _chatgpt_web_stream_callback(text: str):
+                if not text:
+                    return
+                if not first_delta_fired["done"] and on_first_delta:
+                    first_delta_fired["done"] = True
+                    try:
+                        on_first_delta()
+                    except Exception:
+                        pass
+                self._fire_stream_delta(text)
+
+            self._chatgpt_web_on_delta = _chatgpt_web_stream_callback
             try:
                 return self._interruptible_api_call(api_kwargs)
             finally:

--- a/run_agent.py
+++ b/run_agent.py
@@ -620,6 +620,7 @@ class AIAgent:
         self.tool_progress_callback = tool_progress_callback
         self.tool_start_callback = tool_start_callback
         self.tool_complete_callback = tool_complete_callback
+        self.suppress_status_output = False
         self.thinking_callback = thinking_callback
         self.reasoning_callback = reasoning_callback
         self._reasoning_deltas_fired = False  # Set by _fire_reasoning_delta, reset per API call
@@ -1454,7 +1455,14 @@ class AIAgent:
         After the main response has been delivered and the remaining tool
         calls are post-response housekeeping (``_mute_post_response``),
         all non-forced output is suppressed.
+
+        ``suppress_status_output`` is a stricter CLI automation mode used by
+        parseable single-query flows such as ``hermes chat -q``. In that mode,
+        all status/diagnostic prints routed through ``_vprint`` are suppressed
+        so stdout stays machine-readable.
         """
+        if getattr(self, "suppress_status_output", False):
+            return
         if not force and getattr(self, "_mute_post_response", False):
             return
         if not force and self._has_stream_consumers() and not self._executing_tools:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1480,6 +1480,17 @@ class AIAgent:
         except (AttributeError, ValueError, OSError):
             return False
 
+    def _should_emit_quiet_tool_messages(self) -> bool:
+        """Return True when quiet-mode tool summaries should print directly.
+
+        When the caller provides ``tool_progress_callback`` (for example the CLI
+        TUI or a gateway progress renderer), that callback owns progress display.
+        Emitting quiet-mode summary lines here duplicates progress and leaks tool
+        previews into flows that are expected to stay silent, such as
+        ``hermes chat -q``.
+        """
+        return self.quiet_mode and not self.tool_progress_callback
+
     def _emit_status(self, message: str) -> None:
         """Emit a lifecycle status message to both CLI and gateway channels.
 
@@ -6294,7 +6305,7 @@ class AIAgent:
 
         # Start spinner for CLI mode (skip when TUI handles tool progress)
         spinner = None
-        if self.quiet_mode and not self.tool_progress_callback and self._should_start_quiet_spinner():
+        if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
             face = random.choice(KawaiiSpinner.KAWAII_WAITING)
             spinner = KawaiiSpinner(f"{face} ⚡ running {num_tools} tools concurrently", spinner_type='dots', print_fn=self._print_fn)
             spinner.start()
@@ -6344,7 +6355,7 @@ class AIAgent:
                     logging.debug(f"Tool result ({len(function_result)} chars): {function_result}")
 
             # Print cute message per tool
-            if self.quiet_mode:
+            if self._should_emit_quiet_tool_messages():
                 cute_msg = _get_cute_tool_message_impl(name, args, tool_duration, result=function_result)
                 self._safe_print(f"  {cute_msg}")
             elif not self.quiet_mode:
@@ -6501,7 +6512,7 @@ class AIAgent:
                     store=self._todo_store,
                 )
                 tool_duration = time.time() - tool_start_time
-                if self.quiet_mode:
+                if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
             elif function_name == "session_search":
                 if not self._session_db:
@@ -6516,7 +6527,7 @@ class AIAgent:
                         current_session_id=self.session_id,
                     )
                 tool_duration = time.time() - tool_start_time
-                if self.quiet_mode:
+                if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
             elif function_name == "memory":
                 target = function_args.get("target", "memory")
@@ -6529,7 +6540,7 @@ class AIAgent:
                     store=self._memory_store,
                 )
                 tool_duration = time.time() - tool_start_time
-                if self.quiet_mode:
+                if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
             elif function_name == "clarify":
                 from tools.clarify_tool import clarify_tool as _clarify_tool
@@ -6539,7 +6550,7 @@ class AIAgent:
                     callback=self.clarify_callback,
                 )
                 tool_duration = time.time() - tool_start_time
-                if self.quiet_mode:
+                if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
             elif function_name == "delegate_task":
                 from tools.delegate_tool import delegate_task as _delegate_task
@@ -6550,7 +6561,7 @@ class AIAgent:
                     goal_preview = (function_args.get("goal") or "")[:30]
                     spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
                 spinner = None
-                if self.quiet_mode and not self.tool_progress_callback and self._should_start_quiet_spinner():
+                if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
                     face = random.choice(KawaiiSpinner.KAWAII_WAITING)
                     spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots', print_fn=self._print_fn)
                     spinner.start()
@@ -6572,13 +6583,13 @@ class AIAgent:
                     cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
                     if spinner:
                         spinner.stop(cute_msg)
-                    elif self.quiet_mode:
+                    elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.
                 spinner = None
-                if self.quiet_mode and not self.tool_progress_callback:
+                if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
                     face = random.choice(KawaiiSpinner.KAWAII_WAITING)
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
@@ -6596,11 +6607,11 @@ class AIAgent:
                     cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
                     if spinner:
                         spinner.stop(cute_msg)
-                    elif self.quiet_mode:
+                    elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
             elif self.quiet_mode:
                 spinner = None
-                if not self.tool_progress_callback:
+                if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
                     face = random.choice(KawaiiSpinner.KAWAII_WAITING)
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
@@ -6623,7 +6634,7 @@ class AIAgent:
                     cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
                     if spinner:
                         spinner.stop(cute_msg)
-                    else:
+                    elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
             else:
                 try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -44,6 +44,7 @@ from datetime import datetime
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from hermes_cli import chatgpt_web as _chatgpt_web
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -584,13 +585,18 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "chatgpt_web"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
+        elif self.provider == "chatgpt-web":
+            self.api_mode = "chatgpt_web"
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self._base_url_lower:
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
+        elif (provider_name is None) and "chatgpt.com/backend-api/f" in self._base_url_lower:
+            self.api_mode = "chatgpt_web"
+            self.provider = "chatgpt-web"
         elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self._base_url_lower):
             self.api_mode = "anthropic_messages"
             self.provider = "anthropic"
@@ -621,6 +627,8 @@ class AIAgent:
         self.tool_start_callback = tool_start_callback
         self.tool_complete_callback = tool_complete_callback
         self.suppress_status_output = False
+        self._chatgpt_web_conversation_id = None
+        self._chatgpt_web_parent_message_id = None
         self.thinking_callback = thinking_callback
         self.reasoning_callback = reasoning_callback
         self._reasoning_deltas_fired = False  # Set by _fire_reasoning_delta, reset per API call
@@ -4236,6 +4244,65 @@ class AIAgent:
             self._try_refresh_anthropic_client_credentials()
         return self._anthropic_client.messages.create(**api_kwargs)
 
+    def _chatgpt_web_messages(self, api_messages: list) -> tuple[str, list[dict[str, Any]]]:
+        instructions = ""
+        payload_messages = api_messages
+        if api_messages and api_messages[0].get("role") == "system":
+            instructions = str(api_messages[0].get("content") or "").strip()
+            payload_messages = api_messages[1:]
+        if not instructions:
+            instructions = DEFAULT_AGENT_IDENTITY
+        if self.tools:
+            instructions = (
+                instructions.rstrip()
+                + "\n\nImportant runtime limitation: this ChatGPT Web transport currently does not support Hermes tool calls. "
+                  "Never claim to have run a tool or accessed live system state through a tool."
+            )
+        if self._chatgpt_web_conversation_id and payload_messages:
+            latest_user = None
+            for item in reversed(payload_messages):
+                if isinstance(item, dict) and item.get("role") == "user":
+                    latest_user = item
+                    break
+            payload_messages = [latest_user] if latest_user else payload_messages[-1:]
+        return instructions, payload_messages
+
+    def _wrap_chatgpt_web_response(self, result: dict[str, Any]):
+        message_text = str(result.get("content") or "")
+        finish_reason = str(result.get("finish_reason") or "stop")
+        assistant_message = SimpleNamespace(content=message_text, tool_calls=None, role="assistant")
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        return SimpleNamespace(
+            id=result.get("message_id") or result.get("parent_message_id") or str(uuid.uuid4()),
+            model=result.get("model") or self.model,
+            choices=[choice],
+            usage=None,
+        )
+
+    def _run_chatgpt_web_completion(self, api_kwargs: dict, *, client=None):
+        def _on_delta(text: str):
+            if not text:
+                return
+            callback = getattr(self, "_chatgpt_web_on_delta", None)
+            if callback is not None:
+                callback(text)
+
+        result = _chatgpt_web.stream_chatgpt_web_completion(
+            access_token=self.api_key,
+            model=api_kwargs.get("model") or self.model,
+            messages=api_kwargs.get("messages") or [],
+            instructions=api_kwargs.get("instructions") or DEFAULT_AGENT_IDENTITY,
+            conversation_id=api_kwargs.get("conversation_id") or None,
+            parent_message_id=api_kwargs.get("parent_message_id") or None,
+            timeout=api_kwargs.get("timeout") or float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
+            history_and_training_disabled=bool(api_kwargs.get("history_and_training_disabled", False)),
+            on_delta=_on_delta,
+            client=client,
+        )
+        self._chatgpt_web_conversation_id = result.get("conversation_id") or self._chatgpt_web_conversation_id
+        self._chatgpt_web_parent_message_id = result.get("parent_message_id") or self._chatgpt_web_parent_message_id
+        return self._wrap_chatgpt_web_response(result)
+
     def _interruptible_api_call(self, api_kwargs: dict):
         """
         Run the API call in a background thread so the main conversation loop
@@ -4256,6 +4323,17 @@ class AIAgent:
                         api_kwargs,
                         client=request_client_holder["client"],
                         on_first_delta=getattr(self, "_codex_on_first_delta", None),
+                    )
+                elif self.api_mode == "chatgpt_web":
+                    import httpx as _httpx
+
+                    request_client_holder["client"] = _httpx.Client(
+                        timeout=api_kwargs.get("timeout") or float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
+                        follow_redirects=True,
+                    )
+                    result["response"] = self._run_chatgpt_web_completion(
+                        api_kwargs,
+                        client=request_client_holder["client"],
                     )
                 elif self.api_mode == "anthropic_messages":
                     result["response"] = self._anthropic_messages_create(api_kwargs)
@@ -4375,6 +4453,12 @@ class AIAgent:
                 return self._interruptible_api_call(api_kwargs)
             finally:
                 self._codex_on_first_delta = None
+        if self.api_mode == "chatgpt_web":
+            self._chatgpt_web_on_delta = on_first_delta or self._fire_stream_delta
+            try:
+                return self._interruptible_api_call(api_kwargs)
+            finally:
+                self._chatgpt_web_on_delta = None
 
         result = {"response": None, "error": None}
         request_client_holder = {"client": None}
@@ -5441,6 +5525,18 @@ class AIAgent:
                 kwargs["max_output_tokens"] = self.max_tokens
 
             return kwargs
+
+        if self.api_mode == "chatgpt_web":
+            instructions, payload_messages = self._chatgpt_web_messages(api_messages)
+            return {
+                "model": self.model,
+                "instructions": instructions,
+                "messages": payload_messages,
+                "conversation_id": self._chatgpt_web_conversation_id,
+                "parent_message_id": self._chatgpt_web_parent_message_id,
+                "timeout": float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
+                "history_and_training_disabled": False,
+            }
 
         sanitized_messages = api_messages
         needs_sanitization = False

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@
 # ============================================================================
 # Hermes Agent Installer
 # ============================================================================
-# Installation script for Linux and macOS.
-# Uses uv for fast Python provisioning and package management.
+# Installation script for Linux, macOS, and Android/Termux.
+# Uses uv for desktop/server installs and Python's stdlib venv + pip on Termux.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
@@ -117,6 +117,10 @@ log_error() {
     echo -e "${RED}✗${NC} $1"
 }
 
+is_termux() {
+    [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
+}
+
 # ============================================================================
 # System detection
 # ============================================================================
@@ -124,12 +128,17 @@ log_error() {
 detect_os() {
     case "$(uname -s)" in
         Linux*)
-            OS="linux"
-            if [ -f /etc/os-release ]; then
-                . /etc/os-release
-                DISTRO="$ID"
+            if is_termux; then
+                OS="android"
+                DISTRO="termux"
             else
-                DISTRO="unknown"
+                OS="linux"
+                if [ -f /etc/os-release ]; then
+                    . /etc/os-release
+                    DISTRO="$ID"
+                else
+                    DISTRO="unknown"
+                fi
             fi
             ;;
         Darwin*)
@@ -158,6 +167,12 @@ detect_os() {
 # ============================================================================
 
 install_uv() {
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Termux detected — using Python's stdlib venv + pip instead of uv"
+        UV_CMD=""
+        return 0
+    fi
+
     log_info "Checking for uv package manager..."
 
     # Check common locations for uv
@@ -209,6 +224,25 @@ install_uv() {
 }
 
 check_python() {
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Checking Termux Python..."
+        if command -v python >/dev/null 2>&1; then
+            PYTHON_PATH="$(command -v python)"
+            if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+                PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+                log_success "Python found: $PYTHON_FOUND_VERSION"
+                return 0
+            fi
+        fi
+
+        log_info "Installing Python via pkg..."
+        pkg install -y python >/dev/null
+        PYTHON_PATH="$(command -v python)"
+        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        log_success "Python installed: $PYTHON_FOUND_VERSION"
+        return 0
+    fi
+
     log_info "Checking Python $PYTHON_VERSION..."
 
     # Let uv handle Python — it can download and manage Python versions
@@ -243,6 +277,17 @@ check_git() {
     fi
 
     log_error "Git not found"
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Installing Git via pkg..."
+        pkg install -y git >/dev/null
+        if command -v git >/dev/null 2>&1; then
+            GIT_VERSION=$(git --version | awk '{print $3}')
+            log_success "Git $GIT_VERSION installed"
+            return 0
+        fi
+    fi
+
     log_info "Please install Git:"
 
     case "$OS" in
@@ -261,6 +306,9 @@ check_git() {
                     log_info "  Use your package manager to install git"
                     ;;
             esac
+            ;;
+        android)
+            log_info "  pkg install git"
             ;;
         macos)
             log_info "  xcode-select --install"
@@ -290,11 +338,29 @@ check_node() {
         return 0
     fi
 
-    log_info "Node.js not found — installing Node.js $NODE_VERSION LTS..."
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Node.js not found — installing Node.js via pkg..."
+    else
+        log_info "Node.js not found — installing Node.js $NODE_VERSION LTS..."
+    fi
     install_node
 }
 
 install_node() {
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Installing Node.js via pkg..."
+        if pkg install -y nodejs >/dev/null; then
+            local installed_ver
+            installed_ver=$(node --version 2>/dev/null)
+            log_success "Node.js $installed_ver installed via pkg"
+            HAS_NODE=true
+        else
+            log_warn "Failed to install Node.js via pkg"
+            HAS_NODE=false
+        fi
+        return 0
+    fi
+
     local arch=$(uname -m)
     local node_arch
     case "$arch" in
@@ -411,6 +477,30 @@ install_system_packages() {
         HAS_FFMPEG=true
     else
         need_ffmpeg=true
+    fi
+
+    # Termux always needs the Android build toolchain for the tested pip path,
+    # even when ripgrep/ffmpeg are already present.
+    if [ "$DISTRO" = "termux" ]; then
+        local termux_pkgs=(clang rust make pkg-config libffi openssl)
+        if [ "$need_ripgrep" = true ]; then
+            termux_pkgs+=("ripgrep")
+        fi
+        if [ "$need_ffmpeg" = true ]; then
+            termux_pkgs+=("ffmpeg")
+        fi
+
+        log_info "Installing Termux packages: ${termux_pkgs[*]}"
+        if pkg install -y "${termux_pkgs[@]}" >/dev/null; then
+            [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
+            [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+            log_success "Termux build dependencies installed"
+            return 0
+        fi
+
+        log_warn "Could not auto-install all Termux packages"
+        log_info "Install manually: pkg install ${termux_pkgs[*]}"
+        return 0
     fi
 
     # Nothing to install — done
@@ -550,6 +640,9 @@ show_manual_install_hint() {
                 *)             log_info "  Use your package manager or visit the project homepage" ;;
             esac
             ;;
+        android)
+            log_info "  pkg install $pkg"
+            ;;
         macos) log_info "  brew install $pkg" ;;
     esac
 }
@@ -646,6 +739,19 @@ setup_venv() {
         return 0
     fi
 
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Creating virtual environment with Termux Python..."
+
+        if [ -d "venv" ]; then
+            log_info "Virtual environment already exists, recreating..."
+            rm -rf venv
+        fi
+
+        "$PYTHON_PATH" -m venv venv
+        log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null))"
+        return 0
+    fi
+
     log_info "Creating virtual environment with Python $PYTHON_VERSION..."
 
     if [ -d "venv" ]; then
@@ -661,6 +767,46 @@ setup_venv() {
 
 install_deps() {
     log_info "Installing dependencies..."
+
+    if [ "$DISTRO" = "termux" ]; then
+        if [ "$USE_VENV" = true ]; then
+            export VIRTUAL_ENV="$INSTALL_DIR/venv"
+            PIP_PYTHON="$INSTALL_DIR/venv/bin/python"
+        else
+            PIP_PYTHON="$PYTHON_PATH"
+        fi
+
+        if [ -z "${ANDROID_API_LEVEL:-}" ]; then
+            ANDROID_API_LEVEL="$(getprop ro.build.version.sdk 2>/dev/null || true)"
+            if [ -z "$ANDROID_API_LEVEL" ]; then
+                ANDROID_API_LEVEL=24
+            fi
+            export ANDROID_API_LEVEL
+            log_info "Using ANDROID_API_LEVEL=$ANDROID_API_LEVEL for Android wheel builds"
+        fi
+
+        "$PIP_PYTHON" -m pip install --upgrade pip setuptools wheel >/dev/null
+        if ! "$PIP_PYTHON" -m pip install -e '.[termux]' -c constraints-termux.txt; then
+            log_warn "Termux feature install (.[termux]) failed, trying base install..."
+            if ! "$PIP_PYTHON" -m pip install -e '.' -c constraints-termux.txt; then
+                log_error "Package installation failed on Termux."
+                log_info "Ensure these packages are installed: pkg install clang rust make pkg-config libffi openssl"
+                log_info "Then re-run: cd $INSTALL_DIR && python -m pip install -e '.[termux]' -c constraints-termux.txt"
+                exit 1
+            fi
+        fi
+
+        log_success "Main package installed"
+        log_info "Termux note: browser/WhatsApp tooling is not installed by default; see the Termux guide for optional follow-up steps."
+
+        if [ -d "tinker-atropos" ] && [ -f "tinker-atropos/pyproject.toml" ]; then
+            log_info "tinker-atropos submodule found — skipping install (optional, for RL training)"
+            log_info "  To install later: $PIP_PYTHON -m pip install -e \"./tinker-atropos\""
+        fi
+
+        log_success "All dependencies installed"
+        return 0
+    fi
 
     if [ "$USE_VENV" = true ]; then
         # Tell uv to install into our venv (no need to activate)
@@ -743,7 +889,11 @@ setup_path() {
     if [ ! -x "$HERMES_BIN" ]; then
         log_warn "hermes entry point not found at $HERMES_BIN"
         log_info "This usually means the pip install didn't complete successfully."
-        log_info "Try: cd $INSTALL_DIR && uv pip install -e '.[all]'"
+        if [ "$DISTRO" = "termux" ]; then
+            log_info "Try: cd $INSTALL_DIR && python -m pip install -e '.[termux]' -c constraints-termux.txt"
+        else
+            log_info "Try: cd $INSTALL_DIR && uv pip install -e '.[all]'"
+        fi
         return 0
     fi
 
@@ -875,6 +1025,13 @@ SOUL_EOF
 install_node_deps() {
     if [ "$HAS_NODE" = false ]; then
         log_info "Skipping Node.js dependencies (Node not installed)"
+        return 0
+    fi
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Skipping automatic Node/browser dependency setup on Termux"
+        log_info "Browser automation and WhatsApp bridge are not part of the tested Termux install path yet."
+        log_info "If you want to experiment manually later, run: cd $INSTALL_DIR && npm install"
         return 0
     fi
 
@@ -1090,7 +1247,11 @@ print_success() {
         echo -e "${YELLOW}"
         echo "Note: Node.js could not be installed automatically."
         echo "Browser tools need Node.js. Install manually:"
-        echo "  https://nodejs.org/en/download/"
+        if [ "$DISTRO" = "termux" ]; then
+            echo "  pkg install nodejs"
+        else
+            echo "  https://nodejs.org/en/download/"
+        fi
         echo -e "${NC}"
     fi
 
@@ -1099,7 +1260,11 @@ print_success() {
         echo -e "${YELLOW}"
         echo "Note: ripgrep (rg) was not found. File search will use"
         echo "grep as a fallback. For faster search in large codebases,"
-        echo "install ripgrep: sudo apt install ripgrep (or brew install ripgrep)"
+        if [ "$DISTRO" = "termux" ]; then
+            echo "install ripgrep: pkg install ripgrep"
+        else
+            echo "install ripgrep: sudo apt install ripgrep (or brew install ripgrep)"
+        fi
         echo -e "${NC}"
     fi
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,6 +121,32 @@ is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
 
+get_command_link_dir() {
+    if is_termux && [ -n "${PREFIX:-}" ]; then
+        echo "$PREFIX/bin"
+    else
+        echo "$HOME/.local/bin"
+    fi
+}
+
+get_command_link_display_dir() {
+    if is_termux && [ -n "${PREFIX:-}" ]; then
+        echo '$PREFIX/bin'
+    else
+        echo '~/.local/bin'
+    fi
+}
+
+get_hermes_command_path() {
+    local link_dir
+    link_dir="$(get_command_link_dir)"
+    if [ -x "$link_dir/hermes" ]; then
+        echo "$link_dir/hermes"
+    else
+        echo "hermes"
+    fi
+}
+
 # ============================================================================
 # System detection
 # ============================================================================
@@ -897,15 +923,27 @@ setup_path() {
         return 0
     fi
 
-    # Create symlink in ~/.local/bin (standard user binary location, usually on PATH)
-    mkdir -p "$HOME/.local/bin"
-    ln -sf "$HERMES_BIN" "$HOME/.local/bin/hermes"
-    log_success "Symlinked hermes → ~/.local/bin/hermes"
+    local command_link_dir
+    local command_link_display_dir
+    command_link_dir="$(get_command_link_dir)"
+    command_link_display_dir="$(get_command_link_display_dir)"
+
+    # Create a user-facing shim for the hermes command.
+    mkdir -p "$command_link_dir"
+    ln -sf "$HERMES_BIN" "$command_link_dir/hermes"
+    log_success "Symlinked hermes → $command_link_display_dir/hermes"
+
+    if [ "$DISTRO" = "termux" ]; then
+        export PATH="$command_link_dir:$PATH"
+        log_info "$command_link_display_dir is the native Termux command path"
+        log_success "hermes command ready"
+        return 0
+    fi
 
     # Check if ~/.local/bin is on PATH; if not, add it to shell config.
     # Detect the user's actual login shell (not the shell running this script,
     # which is always bash when piped from curl).
-    if ! echo "$PATH" | tr ':' '\n' | grep -q "^$HOME/.local/bin$"; then
+    if ! echo "$PATH" | tr ':' '\n' | grep -q "^$command_link_dir$"; then
         SHELL_CONFIGS=()
         LOGIN_SHELL="$(basename "${SHELL:-/bin/bash}")"
         case "$LOGIN_SHELL" in
@@ -951,7 +989,7 @@ setup_path() {
     fi
 
     # Export for current session so hermes works immediately
-    export PATH="$HOME/.local/bin:$PATH"
+    export PATH="$command_link_dir:$PATH"
 
     log_success "hermes command ready"
 }
@@ -1149,8 +1187,7 @@ maybe_start_gateway() {
             read -p "Pair WhatsApp now? [Y/n] " -n 1 -r
             echo
             if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
-                HERMES_CMD="$HOME/.local/bin/hermes"
-                [ ! -x "$HERMES_CMD" ] && HERMES_CMD="hermes"
+                HERMES_CMD="$(get_hermes_command_path)"
                 $HERMES_CMD whatsapp || true
             fi
         else
@@ -1164,16 +1201,17 @@ maybe_start_gateway() {
     fi
 
     echo ""
-    read -p "Would you like to install the gateway as a background service? [Y/n] " -n 1 -r < /dev/tty
+    if [ "$DISTRO" = "termux" ]; then
+        read -p "Would you like to start the gateway in the background? [Y/n] " -n 1 -r < /dev/tty
+    else
+        read -p "Would you like to install the gateway as a background service? [Y/n] " -n 1 -r < /dev/tty
+    fi
     echo
 
     if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
-        HERMES_CMD="$HOME/.local/bin/hermes"
-        if [ ! -x "$HERMES_CMD" ]; then
-            HERMES_CMD="hermes"
-        fi
+        HERMES_CMD="$(get_hermes_command_path)"
 
-        if command -v systemctl &> /dev/null; then
+        if [ "$DISTRO" != "termux" ] && command -v systemctl &> /dev/null; then
             log_info "Installing systemd service..."
             if $HERMES_CMD gateway install 2>/dev/null; then
                 log_success "Gateway service installed"
@@ -1186,12 +1224,19 @@ maybe_start_gateway() {
                 log_warn "Systemd install failed. You can start manually: hermes gateway"
             fi
         else
-            log_info "systemd not available — starting gateway in background..."
+            if [ "$DISTRO" = "termux" ]; then
+                log_info "Termux detected — starting gateway in best-effort background mode..."
+            else
+                log_info "systemd not available — starting gateway in background..."
+            fi
             nohup $HERMES_CMD gateway > "$HERMES_HOME/logs/gateway.log" 2>&1 &
             GATEWAY_PID=$!
             log_success "Gateway started (PID $GATEWAY_PID). Logs: ~/.hermes/logs/gateway.log"
             log_info "To stop: kill $GATEWAY_PID"
             log_info "To restart later: hermes gateway"
+            if [ "$DISTRO" = "termux" ]; then
+                log_warn "Android may stop background processes when Termux is suspended or the system reclaims resources."
+            fi
         fi
     else
         log_info "Skipped. Start the gateway later with: hermes gateway"
@@ -1230,17 +1275,22 @@ print_success() {
 
     echo -e "${CYAN}─────────────────────────────────────────────────────────${NC}"
     echo ""
-    echo -e "${YELLOW}⚡ Reload your shell to use 'hermes' command:${NC}"
-    echo ""
-    LOGIN_SHELL="$(basename "${SHELL:-/bin/bash}")"
-    if [ "$LOGIN_SHELL" = "zsh" ]; then
-        echo "   source ~/.zshrc"
-    elif [ "$LOGIN_SHELL" = "bash" ]; then
-        echo "   source ~/.bashrc"
+    if [ "$DISTRO" = "termux" ]; then
+        echo -e "${YELLOW}⚡ 'hermes' was linked into $(get_command_link_display_dir), which is already on PATH in Termux.${NC}"
+        echo ""
     else
-        echo "   source ~/.bashrc   # or ~/.zshrc"
+        echo -e "${YELLOW}⚡ Reload your shell to use 'hermes' command:${NC}"
+        echo ""
+        LOGIN_SHELL="$(basename "${SHELL:-/bin/bash}")"
+        if [ "$LOGIN_SHELL" = "zsh" ]; then
+            echo "   source ~/.zshrc"
+        elif [ "$LOGIN_SHELL" = "bash" ]; then
+            echo "   source ~/.bashrc"
+        else
+            echo "   source ~/.bashrc   # or ~/.zshrc"
+        fi
+        echo ""
     fi
-    echo ""
 
     # Show Node.js warning if auto-install failed
     if [ "$HAS_NODE" = false ]; then

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -3,17 +3,17 @@
 # Hermes Agent Setup Script
 # ============================================================================
 # Quick setup for developers who cloned the repo manually.
-# Uses uv for fast Python provisioning and package management.
+# Uses uv for desktop/server setup and Python's stdlib venv + pip on Termux.
 #
 # Usage:
 #   ./setup-hermes.sh
 #
 # This script:
-# 1. Installs uv if not present
-# 2. Creates a virtual environment with Python 3.11 via uv
-# 3. Installs all dependencies (main package + submodules)
+# 1. Detects desktop/server vs Android/Termux setup path
+# 2. Creates a Python 3.11 virtual environment
+# 3. Installs the appropriate dependency set for the platform
 # 4. Creates .env from template (if not exists)
-# 5. Symlinks the 'hermes' CLI command into ~/.local/bin
+# 5. Symlinks the 'hermes' CLI command into a user-facing bin dir
 # 6. Runs the setup wizard (optional)
 # ============================================================================
 
@@ -31,6 +31,26 @@ cd "$SCRIPT_DIR"
 
 PYTHON_VERSION="3.11"
 
+is_termux() {
+    [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
+}
+
+get_command_link_dir() {
+    if is_termux && [ -n "${PREFIX:-}" ]; then
+        echo "$PREFIX/bin"
+    else
+        echo "$HOME/.local/bin"
+    fi
+}
+
+get_command_link_display_dir() {
+    if is_termux && [ -n "${PREFIX:-}" ]; then
+        echo '$PREFIX/bin'
+    else
+        echo '~/.local/bin'
+    fi
+}
+
 echo ""
 echo -e "${CYAN}⚕ Hermes Agent Setup${NC}"
 echo ""
@@ -42,36 +62,40 @@ echo ""
 echo -e "${CYAN}→${NC} Checking for uv..."
 
 UV_CMD=""
-if command -v uv &> /dev/null; then
-    UV_CMD="uv"
-elif [ -x "$HOME/.local/bin/uv" ]; then
-    UV_CMD="$HOME/.local/bin/uv"
-elif [ -x "$HOME/.cargo/bin/uv" ]; then
-    UV_CMD="$HOME/.cargo/bin/uv"
-fi
-
-if [ -n "$UV_CMD" ]; then
-    UV_VERSION=$($UV_CMD --version 2>/dev/null)
-    echo -e "${GREEN}✓${NC} uv found ($UV_VERSION)"
+if is_termux; then
+    echo -e "${CYAN}→${NC} Termux detected — using Python's stdlib venv + pip instead of uv"
 else
-    echo -e "${CYAN}→${NC} Installing uv..."
-    if curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null; then
-        if [ -x "$HOME/.local/bin/uv" ]; then
-            UV_CMD="$HOME/.local/bin/uv"
-        elif [ -x "$HOME/.cargo/bin/uv" ]; then
-            UV_CMD="$HOME/.cargo/bin/uv"
-        fi
-        
-        if [ -n "$UV_CMD" ]; then
-            UV_VERSION=$($UV_CMD --version 2>/dev/null)
-            echo -e "${GREEN}✓${NC} uv installed ($UV_VERSION)"
+    if command -v uv &> /dev/null; then
+        UV_CMD="uv"
+    elif [ -x "$HOME/.local/bin/uv" ]; then
+        UV_CMD="$HOME/.local/bin/uv"
+    elif [ -x "$HOME/.cargo/bin/uv" ]; then
+        UV_CMD="$HOME/.cargo/bin/uv"
+    fi
+
+    if [ -n "$UV_CMD" ]; then
+        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        echo -e "${GREEN}✓${NC} uv found ($UV_VERSION)"
+    else
+        echo -e "${CYAN}→${NC} Installing uv..."
+        if curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null; then
+            if [ -x "$HOME/.local/bin/uv" ]; then
+                UV_CMD="$HOME/.local/bin/uv"
+            elif [ -x "$HOME/.cargo/bin/uv" ]; then
+                UV_CMD="$HOME/.cargo/bin/uv"
+            fi
+
+            if [ -n "$UV_CMD" ]; then
+                UV_VERSION=$($UV_CMD --version 2>/dev/null)
+                echo -e "${GREEN}✓${NC} uv installed ($UV_VERSION)"
+            else
+                echo -e "${RED}✗${NC} uv installed but not found. Add ~/.local/bin to PATH and retry."
+                exit 1
+            fi
         else
-            echo -e "${RED}✗${NC} uv installed but not found. Add ~/.local/bin to PATH and retry."
+            echo -e "${RED}✗${NC} Failed to install uv. Visit https://docs.astral.sh/uv/"
             exit 1
         fi
-    else
-        echo -e "${RED}✗${NC} Failed to install uv. Visit https://docs.astral.sh/uv/"
-        exit 1
     fi
 fi
 
@@ -81,16 +105,34 @@ fi
 
 echo -e "${CYAN}→${NC} Checking Python $PYTHON_VERSION..."
 
-if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
-    PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-    PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
-    echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found"
+if is_termux; then
+    if command -v python >/dev/null 2>&1; then
+        PYTHON_PATH="$(command -v python)"
+        if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+            PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+            echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found"
+        else
+            echo -e "${RED}✗${NC} Termux Python must be 3.11+"
+            echo "    Run: pkg install python"
+            exit 1
+        fi
+    else
+        echo -e "${RED}✗${NC} Python not found in Termux"
+        echo "    Run: pkg install python"
+        exit 1
+    fi
 else
-    echo -e "${CYAN}→${NC} Python $PYTHON_VERSION not found, installing via uv..."
-    $UV_CMD python install "$PYTHON_VERSION"
-    PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-    PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
-    echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION installed"
+    if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
+        PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
+        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found"
+    else
+        echo -e "${CYAN}→${NC} Python $PYTHON_VERSION not found, installing via uv..."
+        $UV_CMD python install "$PYTHON_VERSION"
+        PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
+        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION installed"
+    fi
 fi
 
 # ============================================================================
@@ -104,11 +146,16 @@ if [ -d "venv" ]; then
     rm -rf venv
 fi
 
-$UV_CMD venv venv --python "$PYTHON_VERSION"
-echo -e "${GREEN}✓${NC} venv created (Python $PYTHON_VERSION)"
+if is_termux; then
+    "$PYTHON_PATH" -m venv venv
+    echo -e "${GREEN}✓${NC} venv created with stdlib venv"
+else
+    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    echo -e "${GREEN}✓${NC} venv created (Python $PYTHON_VERSION)"
+fi
 
-# Tell uv to install into this venv (no activation needed for uv)
 export VIRTUAL_ENV="$SCRIPT_DIR/venv"
+SETUP_PYTHON="$SCRIPT_DIR/venv/bin/python"
 
 # ============================================================================
 # Dependencies
@@ -116,19 +163,34 @@ export VIRTUAL_ENV="$SCRIPT_DIR/venv"
 
 echo -e "${CYAN}→${NC} Installing dependencies..."
 
-# Prefer uv sync with lockfile (hash-verified installs) when available,
-# fall back to pip install for compatibility or when lockfile is stale.
-if [ -f "uv.lock" ]; then
-    echo -e "${CYAN}→${NC} Using uv.lock for hash-verified installation..."
-    UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --all-extras --locked 2>/dev/null && \
-        echo -e "${GREEN}✓${NC} Dependencies installed (lockfile verified)" || {
-        echo -e "${YELLOW}⚠${NC} Lockfile install failed (may be outdated), falling back to pip install..."
+if is_termux; then
+    export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk 2>/dev/null || printf '%s' "${ANDROID_API_LEVEL:-}")"
+    echo -e "${CYAN}→${NC} Termux detected — installing the tested Android bundle"
+    "$SETUP_PYTHON" -m pip install --upgrade pip setuptools wheel
+    if [ -f "constraints-termux.txt" ]; then
+        "$SETUP_PYTHON" -m pip install -e ".[termux]" -c constraints-termux.txt || {
+            echo -e "${YELLOW}⚠${NC} Termux bundle install failed, falling back to base install..."
+            "$SETUP_PYTHON" -m pip install -e "." -c constraints-termux.txt
+        }
+    else
+        "$SETUP_PYTHON" -m pip install -e ".[termux]" || "$SETUP_PYTHON" -m pip install -e "."
+    fi
+    echo -e "${GREEN}✓${NC} Dependencies installed"
+else
+    # Prefer uv sync with lockfile (hash-verified installs) when available,
+    # fall back to pip install for compatibility or when lockfile is stale.
+    if [ -f "uv.lock" ]; then
+        echo -e "${CYAN}→${NC} Using uv.lock for hash-verified installation..."
+        UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --all-extras --locked 2>/dev/null && \
+            echo -e "${GREEN}✓${NC} Dependencies installed (lockfile verified)" || {
+            echo -e "${YELLOW}⚠${NC} Lockfile install failed (may be outdated), falling back to pip install..."
+            $UV_CMD pip install -e ".[all]" || $UV_CMD pip install -e "."
+            echo -e "${GREEN}✓${NC} Dependencies installed"
+        }
+    else
         $UV_CMD pip install -e ".[all]" || $UV_CMD pip install -e "."
         echo -e "${GREEN}✓${NC} Dependencies installed"
-    }
-else
-    $UV_CMD pip install -e ".[all]" || $UV_CMD pip install -e "."
-    echo -e "${GREEN}✓${NC} Dependencies installed"
+    fi
 fi
 
 # ============================================================================
@@ -138,7 +200,9 @@ fi
 echo -e "${CYAN}→${NC} Installing optional submodules..."
 
 # tinker-atropos (RL training backend)
-if [ -d "tinker-atropos" ] && [ -f "tinker-atropos/pyproject.toml" ]; then
+if is_termux; then
+    echo -e "${CYAN}→${NC} Skipping tinker-atropos on Termux (not part of the tested Android path)"
+elif [ -d "tinker-atropos" ] && [ -f "tinker-atropos/pyproject.toml" ]; then
     $UV_CMD pip install -e "./tinker-atropos" && \
         echo -e "${GREEN}✓${NC} tinker-atropos installed" || \
         echo -e "${YELLOW}⚠${NC} tinker-atropos install failed (RL tools may not work)"
@@ -160,34 +224,42 @@ else
     echo
     if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
         INSTALLED=false
-        
-        # Check if sudo is available
-        if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
-            if command -v apt &> /dev/null; then
-                sudo apt install -y ripgrep && INSTALLED=true
-            elif command -v dnf &> /dev/null; then
-                sudo dnf install -y ripgrep && INSTALLED=true
+
+        if is_termux; then
+            pkg install -y ripgrep && INSTALLED=true
+        else
+            # Check if sudo is available
+            if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
+                if command -v apt &> /dev/null; then
+                    sudo apt install -y ripgrep && INSTALLED=true
+                elif command -v dnf &> /dev/null; then
+                    sudo dnf install -y ripgrep && INSTALLED=true
+                fi
+            fi
+
+            # Try brew (no sudo needed)
+            if [ "$INSTALLED" = false ] && command -v brew &> /dev/null; then
+                brew install ripgrep && INSTALLED=true
+            fi
+
+            # Try cargo (no sudo needed)
+            if [ "$INSTALLED" = false ] && command -v cargo &> /dev/null; then
+                echo -e "${CYAN}→${NC} Trying cargo install (no sudo required)..."
+                cargo install ripgrep && INSTALLED=true
             fi
         fi
-        
-        # Try brew (no sudo needed)
-        if [ "$INSTALLED" = false ] && command -v brew &> /dev/null; then
-            brew install ripgrep && INSTALLED=true
-        fi
-        
-        # Try cargo (no sudo needed)
-        if [ "$INSTALLED" = false ] && command -v cargo &> /dev/null; then
-            echo -e "${CYAN}→${NC} Trying cargo install (no sudo required)..."
-            cargo install ripgrep && INSTALLED=true
-        fi
-        
+
         if [ "$INSTALLED" = true ]; then
             echo -e "${GREEN}✓${NC} ripgrep installed"
         else
             echo -e "${YELLOW}⚠${NC} Auto-install failed. Install options:"
-            echo "    sudo apt install ripgrep     # Debian/Ubuntu"
-            echo "    brew install ripgrep         # macOS"
-            echo "    cargo install ripgrep        # With Rust (no sudo)"
+            if is_termux; then
+                echo "    pkg install ripgrep          # Termux / Android"
+            else
+                echo "    sudo apt install ripgrep     # Debian/Ubuntu"
+                echo "    brew install ripgrep         # macOS"
+                echo "    cargo install ripgrep        # With Rust (no sudo)"
+            fi
             echo "    https://github.com/BurntSushi/ripgrep#installation"
         fi
     fi
@@ -207,49 +279,56 @@ else
 fi
 
 # ============================================================================
-# PATH setup — symlink hermes into ~/.local/bin
+# PATH setup — symlink hermes into a user-facing bin dir
 # ============================================================================
 
 echo -e "${CYAN}→${NC} Setting up hermes command..."
 
 HERMES_BIN="$SCRIPT_DIR/venv/bin/hermes"
-mkdir -p "$HOME/.local/bin"
-ln -sf "$HERMES_BIN" "$HOME/.local/bin/hermes"
-echo -e "${GREEN}✓${NC} Symlinked hermes → ~/.local/bin/hermes"
+COMMAND_LINK_DIR="$(get_command_link_dir)"
+COMMAND_LINK_DISPLAY_DIR="$(get_command_link_display_dir)"
+mkdir -p "$COMMAND_LINK_DIR"
+ln -sf "$HERMES_BIN" "$COMMAND_LINK_DIR/hermes"
+echo -e "${GREEN}✓${NC} Symlinked hermes → $COMMAND_LINK_DISPLAY_DIR/hermes"
 
-# Determine the appropriate shell config file
-SHELL_CONFIG=""
-if [[ "$SHELL" == *"zsh"* ]]; then
-    SHELL_CONFIG="$HOME/.zshrc"
-elif [[ "$SHELL" == *"bash"* ]]; then
-    SHELL_CONFIG="$HOME/.bashrc"
-    [ ! -f "$SHELL_CONFIG" ] && SHELL_CONFIG="$HOME/.bash_profile"
+if is_termux; then
+    export PATH="$COMMAND_LINK_DIR:$PATH"
+    echo -e "${GREEN}✓${NC} $COMMAND_LINK_DISPLAY_DIR is already on PATH in Termux"
 else
-    # Fallback to checking existing files
-    if [ -f "$HOME/.zshrc" ]; then
+    # Determine the appropriate shell config file
+    SHELL_CONFIG=""
+    if [[ "$SHELL" == *"zsh"* ]]; then
         SHELL_CONFIG="$HOME/.zshrc"
-    elif [ -f "$HOME/.bashrc" ]; then
+    elif [[ "$SHELL" == *"bash"* ]]; then
         SHELL_CONFIG="$HOME/.bashrc"
-    elif [ -f "$HOME/.bash_profile" ]; then
-        SHELL_CONFIG="$HOME/.bash_profile"
-    fi
-fi
-
-if [ -n "$SHELL_CONFIG" ]; then
-    # Touch the file just in case it doesn't exist yet but was selected
-    touch "$SHELL_CONFIG" 2>/dev/null || true
-    
-    if ! echo "$PATH" | tr ':' '\n' | grep -q "^$HOME/.local/bin$"; then
-        if ! grep -q '\.local/bin' "$SHELL_CONFIG" 2>/dev/null; then
-            echo "" >> "$SHELL_CONFIG"
-            echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG"
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_CONFIG"
-            echo -e "${GREEN}✓${NC} Added ~/.local/bin to PATH in $SHELL_CONFIG"
-        else
-            echo -e "${GREEN}✓${NC} ~/.local/bin already in $SHELL_CONFIG"
-        fi
+        [ ! -f "$SHELL_CONFIG" ] && SHELL_CONFIG="$HOME/.bash_profile"
     else
-        echo -e "${GREEN}✓${NC} ~/.local/bin already on PATH"
+        # Fallback to checking existing files
+        if [ -f "$HOME/.zshrc" ]; then
+            SHELL_CONFIG="$HOME/.zshrc"
+        elif [ -f "$HOME/.bashrc" ]; then
+            SHELL_CONFIG="$HOME/.bashrc"
+        elif [ -f "$HOME/.bash_profile" ]; then
+            SHELL_CONFIG="$HOME/.bash_profile"
+        fi
+    fi
+
+    if [ -n "$SHELL_CONFIG" ]; then
+        # Touch the file just in case it doesn't exist yet but was selected
+        touch "$SHELL_CONFIG" 2>/dev/null || true
+
+        if ! echo "$PATH" | tr ':' '\n' | grep -q "^$HOME/.local/bin$"; then
+            if ! grep -q '\.local/bin' "$SHELL_CONFIG" 2>/dev/null; then
+                echo "" >> "$SHELL_CONFIG"
+                echo "# Hermes Agent — ensure ~/.local/bin is on PATH" >> "$SHELL_CONFIG"
+                echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_CONFIG"
+                echo -e "${GREEN}✓${NC} Added ~/.local/bin to PATH in $SHELL_CONFIG"
+            else
+                echo -e "${GREEN}✓${NC} ~/.local/bin already in $SHELL_CONFIG"
+            fi
+        else
+            echo -e "${GREEN}✓${NC} ~/.local/bin already on PATH"
+        fi
     fi
 fi
 
@@ -281,18 +360,31 @@ echo -e "${GREEN}✓ Setup complete!${NC}"
 echo ""
 echo "Next steps:"
 echo ""
-echo "  1. Reload your shell:"
-echo "     source $SHELL_CONFIG"
-echo ""
-echo "  2. Run the setup wizard to configure API keys:"
-echo "     hermes setup"
-echo ""
-echo "  3. Start chatting:"
-echo "     hermes"
-echo ""
+if is_termux; then
+    echo "  1. Run the setup wizard to configure API keys:"
+    echo "     hermes setup"
+    echo ""
+    echo "  2. Start chatting:"
+    echo "     hermes"
+    echo ""
+else
+    echo "  1. Reload your shell:"
+    echo "     source $SHELL_CONFIG"
+    echo ""
+    echo "  2. Run the setup wizard to configure API keys:"
+    echo "     hermes setup"
+    echo ""
+    echo "  3. Start chatting:"
+    echo "     hermes"
+    echo ""
+fi
 echo "Other commands:"
 echo "  hermes status        # Check configuration"
-echo "  hermes gateway install # Install gateway service (messaging + cron)"
+if is_termux; then
+    echo "  hermes gateway       # Run gateway in foreground"
+else
+    echo "  hermes gateway install # Install gateway service (messaging + cron)"
+fi
 echo "  hermes cron list     # View scheduled jobs"
 echo "  hermes doctor        # Diagnose issues"
 echo ""

--- a/tests/cli/test_cli_file_drop.py
+++ b/tests/cli/test_cli_file_drop.py
@@ -147,6 +147,20 @@ class TestEscapedSpaces:
         assert result["path"] == tmp_image_with_spaces
         assert result["remainder"] == "what is this?"
 
+    def test_tilde_prefixed_path(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        img = home / "storage" / "shared" / "Pictures" / "cat.png"
+        img.parent.mkdir(parents=True, exist_ok=True)
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        monkeypatch.setenv("HOME", str(home))
+
+        result = _detect_file_drop("~/storage/shared/Pictures/cat.png what is this?")
+
+        assert result is not None
+        assert result["path"] == img
+        assert result["is_image"] is True
+        assert result["remainder"] == "what is this?"
+
 
 # ---------------------------------------------------------------------------
 # Tests: edge cases

--- a/tests/cli/test_cli_image_command.py
+++ b/tests/cli/test_cli_image_command.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from cli import (
+    HermesCLI,
+    _collect_query_images,
+    _format_image_attachment_badges,
+)
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._attached_images = []
+    return cli_obj
+
+
+def _make_image(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    return path
+
+
+class TestImageCommand:
+    def test_handle_image_command_attaches_local_image(self, tmp_path):
+        img = _make_image(tmp_path / "photo.png")
+        cli_obj = _make_cli()
+
+        with patch("cli._cprint"):
+            cli_obj._handle_image_command(f"/image {img}")
+
+        assert cli_obj._attached_images == [img]
+
+    def test_handle_image_command_supports_quoted_path_with_spaces(self, tmp_path):
+        img = _make_image(tmp_path / "my photo.png")
+        cli_obj = _make_cli()
+
+        with patch("cli._cprint"):
+            cli_obj._handle_image_command(f'/image "{img}"')
+
+        assert cli_obj._attached_images == [img]
+
+    def test_handle_image_command_rejects_non_image_file(self, tmp_path):
+        file_path = tmp_path / "notes.txt"
+        file_path.write_text("hello\n", encoding="utf-8")
+        cli_obj = _make_cli()
+
+        with patch("cli._cprint") as mock_print:
+            cli_obj._handle_image_command(f"/image {file_path}")
+
+        assert cli_obj._attached_images == []
+        rendered = " ".join(str(arg) for call in mock_print.call_args_list for arg in call.args)
+        assert "Not a supported image file" in rendered
+
+
+class TestCollectQueryImages:
+    def test_collect_query_images_accepts_explicit_image_arg(self, tmp_path):
+        img = _make_image(tmp_path / "diagram.png")
+
+        message, images = _collect_query_images("describe this", str(img))
+
+        assert message == "describe this"
+        assert images == [img]
+
+    def test_collect_query_images_extracts_leading_path(self, tmp_path):
+        img = _make_image(tmp_path / "camera.png")
+
+        message, images = _collect_query_images(f"{img} what do you see?")
+
+        assert message == "what do you see?"
+        assert images == [img]
+
+    def test_collect_query_images_supports_tilde_paths(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        img = _make_image(home / "storage" / "shared" / "Pictures" / "cat.png")
+        monkeypatch.setenv("HOME", str(home))
+
+        message, images = _collect_query_images("describe this", "~/storage/shared/Pictures/cat.png")
+
+        assert message == "describe this"
+        assert images == [img]
+
+
+class TestImageBadgeFormatting:
+    def test_compact_badges_use_filename_on_narrow_terminals(self, tmp_path):
+        img = _make_image(tmp_path / "Screenshot 2026-04-09 at 11.22.33 AM.png")
+
+        badges = _format_image_attachment_badges([img], image_counter=1, width=40)
+
+        assert badges.startswith("[📎 ")
+        assert "Image #1" not in badges
+
+    def test_compact_badges_summarize_multiple_images(self, tmp_path):
+        img1 = _make_image(tmp_path / "one.png")
+        img2 = _make_image(tmp_path / "two.png")
+
+        badges = _format_image_attachment_badges([img1, img2], image_counter=2, width=45)
+
+        assert badges == "[📎 2 images attached]"

--- a/tests/cli/test_cli_image_command.py
+++ b/tests/cli/test_cli_image_command.py
@@ -5,6 +5,7 @@ from cli import (
     HermesCLI,
     _collect_query_images,
     _format_image_attachment_badges,
+    _termux_example_image_path,
 )
 
 
@@ -78,6 +79,16 @@ class TestCollectQueryImages:
 
         assert message == "describe this"
         assert images == [img]
+
+
+class TestTermuxImageHints:
+    def test_termux_example_image_path_prefers_real_shared_storage_root(self, monkeypatch):
+        existing = {"/sdcard", "/storage/emulated/0"}
+        monkeypatch.setattr("cli.os.path.isdir", lambda path: path in existing)
+
+        hint = _termux_example_image_path()
+
+        assert hint == "/sdcard/Pictures/cat.png"
 
 
 class TestImageBadgeFormatting:

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -49,6 +49,25 @@ class TestCliSkinPromptIntegration:
         set_active_skin("ares")
         assert cli._get_tui_prompt_fragments() == [("class:sudo-prompt", "🔑 ❯ ")]
 
+    def test_narrow_terminals_compact_voice_prompt_fragments(self):
+        cli = _make_cli_stub()
+        cli._voice_mode = True
+
+        with patch.object(HermesCLI, "_get_tui_terminal_width", return_value=50):
+            assert cli._get_tui_prompt_fragments() == [("class:voice-prompt", "🎤 ")]
+
+    def test_narrow_terminals_compact_voice_recording_prompt_fragments(self):
+        cli = _make_cli_stub()
+        cli._voice_recording = True
+        cli._voice_recorder = SimpleNamespace(current_rms=3000)
+
+        with patch.object(HermesCLI, "_get_tui_terminal_width", return_value=50):
+            frags = cli._get_tui_prompt_fragments()
+
+        assert frags[0][0] == "class:voice-recording"
+        assert frags[0][1].startswith("●")
+        assert "❯" not in frags[0][1]
+
     def test_icon_only_skin_symbol_still_visible_in_special_states(self):
         cli = _make_cli_stub()
         cli._secret_state = {"response_queue": object()}

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -205,6 +205,37 @@ class TestCLIStatusBar:
         assert "⚕" in text
         assert "claude-sonnet-4-20250514" in text
 
+    def test_minimal_tui_chrome_threshold(self):
+        cli_obj = _make_cli()
+
+        assert cli_obj._use_minimal_tui_chrome(width=63) is True
+        assert cli_obj._use_minimal_tui_chrome(width=64) is False
+
+    def test_bottom_input_rule_hides_on_narrow_terminals(self):
+        cli_obj = _make_cli()
+
+        assert cli_obj._tui_input_rule_height("top", width=50) == 1
+        assert cli_obj._tui_input_rule_height("bottom", width=50) == 0
+        assert cli_obj._tui_input_rule_height("bottom", width=90) == 1
+
+    def test_agent_spacer_reclaimed_on_narrow_terminals(self):
+        cli_obj = _make_cli()
+        cli_obj._agent_running = True
+
+        assert cli_obj._agent_spacer_height(width=50) == 0
+        assert cli_obj._agent_spacer_height(width=90) == 1
+        cli_obj._agent_running = False
+        assert cli_obj._agent_spacer_height(width=90) == 0
+
+    def test_spinner_line_hidden_on_narrow_terminals(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "thinking"
+
+        assert cli_obj._spinner_widget_height(width=50) == 0
+        assert cli_obj._spinner_widget_height(width=90) == 1
+        cli_obj._spinner_text = ""
+        assert cli_obj._spinner_widget_height(width=90) == 0
+
 
 class TestCLIUsageReport:
     def test_show_usage_includes_estimated_cost(self, capsys):

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -236,6 +236,28 @@ class TestCLIStatusBar:
         cli_obj._spinner_text = ""
         assert cli_obj._spinner_widget_height(width=90) == 0
 
+    def test_voice_status_bar_compacts_on_narrow_terminals(self):
+        cli_obj = _make_cli()
+        cli_obj._voice_mode = True
+        cli_obj._voice_recording = False
+        cli_obj._voice_processing = False
+        cli_obj._voice_tts = True
+        cli_obj._voice_continuous = True
+
+        fragments = cli_obj._get_voice_status_fragments(width=50)
+
+        assert fragments == [("class:voice-status", " 🎤 Ctrl+B ")]
+
+    def test_voice_recording_status_bar_compacts_on_narrow_terminals(self):
+        cli_obj = _make_cli()
+        cli_obj._voice_mode = True
+        cli_obj._voice_recording = True
+        cli_obj._voice_processing = False
+
+        fragments = cli_obj._get_voice_status_fragments(width=50)
+
+        assert fragments == [("class:voice-status-recording", " ● REC ")]
+
 
 class TestCLIUsageReport:
     def test_show_usage_includes_estimated_cost(self, capsys):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -253,7 +253,7 @@ def test_auth_add_chatgpt_web_session_token_persists_pool_entry(tmp_path, monkey
     assert entry["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
 
 
-def test_auth_browser_command_bootstraps_chatgpt_web_from_termux_browser(tmp_path, monkeypatch):
+def test_auth_browser_command_bootstraps_chatgpt_web_from_termux_browser(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
 
     from hermes_cli import auth_commands as auth_commands_mod
@@ -301,12 +301,16 @@ def test_auth_browser_command_bootstraps_chatgpt_web_from_termux_browser(tmp_pat
         keep_open = False
 
     auth_commands_mod.auth_browser_command(_Args())
+    output = capsys.readouterr().out
 
     assert captured["args"].provider == "chatgpt-web"
     assert captured["args"].auth_type == "api-key"
     assert captured["args"].token_mode == "session_token"
     assert captured["args"].api_key == "session-cookie"
     assert captured["args"].label == "termux-x11-browser"
+    assert "Stored chatgpt-web credential from Termux browser" in output
+    assert "credential pool" in output.lower()
+    assert "hermes auth list" in output
     assert fake_proc.terminated is True
     assert fake_proc.killed is False
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -253,6 +253,78 @@ def test_auth_add_chatgpt_web_session_token_persists_pool_entry(tmp_path, monkey
     assert entry["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
 
 
+def test_auth_browser_command_bootstraps_chatgpt_web_from_termux_browser(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli import auth_commands as auth_commands_mod
+
+    captured = {}
+
+    class _FakeProc:
+        pid = 12345
+
+        def __init__(self):
+            self.terminated = False
+            self.killed = False
+            self.wait_calls = []
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            self.wait_calls.append(timeout)
+            return 0
+
+        def kill(self):
+            self.killed = True
+
+    fake_proc = _FakeProc()
+
+    monkeypatch.setattr(auth_commands_mod, "_is_termux", lambda: True)
+    monkeypatch.setattr(auth_commands_mod, "_termux_x11_android_app_installed", lambda: True)
+    monkeypatch.setattr(auth_commands_mod, "_find_termux_x11_command", lambda: "/usr/bin/termux-x11")
+    monkeypatch.setattr(auth_commands_mod, "_find_chromium_browser_command", lambda: "/usr/bin/chromium-browser")
+    monkeypatch.setattr(auth_commands_mod, "_wait_for_debugger", lambda *args, **kwargs: None)
+    monkeypatch.setattr(auth_commands_mod, "_wait_for_chatgpt_web_session_token", lambda *args, **kwargs: "session-cookie")
+    monkeypatch.setattr(auth_commands_mod, "_launch_chatgpt_web_browser", lambda *args, **kwargs: fake_proc)
+    monkeypatch.setattr(
+        auth_commands_mod,
+        "auth_add_command",
+        lambda args: captured.setdefault("args", args),
+    )
+
+    class _Args:
+        provider = "chatgpt-web"
+        label = "termux-x11-browser"
+        timeout = 30
+        debug_port = 9222
+        keep_open = False
+
+    auth_commands_mod.auth_browser_command(_Args())
+
+    assert captured["args"].provider == "chatgpt-web"
+    assert captured["args"].auth_type == "api-key"
+    assert captured["args"].token_mode == "session_token"
+    assert captured["args"].api_key == "session-cookie"
+    assert captured["args"].label == "termux-x11-browser"
+    assert fake_proc.terminated is True
+    assert fake_proc.killed is False
+
+
+def test_auth_browser_command_rejects_unsupported_provider():
+    from hermes_cli import auth_commands as auth_commands_mod
+
+    class _Args:
+        provider = "openai-codex"
+        label = None
+        timeout = 30
+        debug_port = 9222
+        keep_open = False
+
+    with pytest.raises(SystemExit, match="chatgpt-web"):
+        auth_commands_mod.auth_browser_command(_Args())
+
+
 def test_interactive_add_chatgpt_web_selects_access_token(monkeypatch):
     from hermes_cli import auth_commands as auth_commands_mod
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -184,6 +184,64 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+def test_auth_add_chatgpt_web_oauth_persists_pool_entry(tmp_path, monkeypatch):
+    from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("chatgpt-web@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "refresh-token",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-03-23T10:00:00Z",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "chatgpt-web"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["chatgpt-web"]
+    entry = next(item for item in entries if item["source"] == "manual:device_code")
+    assert entry["label"] == "chatgpt-web@example.com"
+    assert entry["source"] == "manual:device_code"
+    assert entry["refresh_token"] == "refresh-token"
+    assert entry["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
+
+
+def test_interactive_add_chatgpt_web_selects_oauth(monkeypatch):
+    from hermes_cli import auth_commands as auth_commands_mod
+
+    captured = {}
+    monkeypatch.setattr(auth_commands_mod, "_pick_provider", lambda prompt="Provider": "chatgpt-web")
+
+    answers = iter(["2", "web-account"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    monkeypatch.setattr(
+        auth_commands_mod,
+        "auth_add_command",
+        lambda args: captured.setdefault("args", args),
+    )
+
+    auth_commands_mod._interactive_add()
+
+    assert captured["args"].provider == "chatgpt-web"
+    assert captured["args"].auth_type == "oauth"
+    assert captured["args"].label == "web-account"
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -221,6 +221,60 @@ def test_auth_add_chatgpt_web_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
 
 
+def test_auth_add_chatgpt_web_session_token_persists_pool_entry(tmp_path, monkeypatch):
+    from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("chatgpt-session@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web._fetch_chatgpt_web_access_token_from_session",
+        lambda session_token, **kwargs: token,
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "chatgpt-web"
+        auth_type = "api-key"
+        api_key = "session-cookie"
+        label = "cookie-login"
+        token_mode = "session_token"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["chatgpt-web"]
+    entry = next(item for item in entries if item["source"] == "manual:session_token")
+    assert entry["label"] == "cookie-login"
+    assert entry["auth_type"] == "api_key"
+    assert entry["access_token"] == token
+    assert entry["session_token"] == "session-cookie"
+    assert entry["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
+
+
+def test_interactive_add_chatgpt_web_selects_access_token(monkeypatch):
+    from hermes_cli import auth_commands as auth_commands_mod
+
+    captured = {}
+    monkeypatch.setattr(auth_commands_mod, "_pick_provider", lambda prompt="Provider": "chatgpt-web")
+
+    answers = iter(["1", "web-account"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    monkeypatch.setattr(
+        auth_commands_mod,
+        "auth_add_command",
+        lambda args: captured.setdefault("args", args),
+    )
+
+    auth_commands_mod._interactive_add()
+
+    assert captured["args"].provider == "chatgpt-web"
+    assert captured["args"].auth_type == "api_key"
+    assert captured["args"].token_mode == "access_token"
+    assert captured["args"].label == "web-account"
+
+
 def test_interactive_add_chatgpt_web_selects_oauth(monkeypatch):
     from hermes_cli import auth_commands as auth_commands_mod
 
@@ -240,6 +294,28 @@ def test_interactive_add_chatgpt_web_selects_oauth(monkeypatch):
     assert captured["args"].provider == "chatgpt-web"
     assert captured["args"].auth_type == "oauth"
     assert captured["args"].label == "web-account"
+
+
+def test_interactive_add_chatgpt_web_selects_session_token(monkeypatch):
+    from hermes_cli import auth_commands as auth_commands_mod
+
+    captured = {}
+    monkeypatch.setattr(auth_commands_mod, "_pick_provider", lambda prompt="Provider": "chatgpt-web")
+
+    answers = iter(["3", "cookie-account"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    monkeypatch.setattr(
+        auth_commands_mod,
+        "auth_add_command",
+        lambda args: captured.setdefault("args", args),
+    )
+
+    auth_commands_mod._interactive_add()
+
+    assert captured["args"].provider == "chatgpt-web"
+    assert captured["args"].auth_type == "api_key"
+    assert captured["args"].token_mode == "session_token"
+    assert captured["args"].label == "cookie-account"
 
 
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -390,6 +390,29 @@ def test_interactive_add_chatgpt_web_selects_session_token(monkeypatch):
     assert captured["args"].label == "cookie-account"
 
 
+def test_interactive_add_chatgpt_web_selects_termux_browser_bootstrap(monkeypatch):
+    from hermes_cli import auth_commands as auth_commands_mod
+
+    captured = {}
+    monkeypatch.setattr(auth_commands_mod, "_pick_provider", lambda prompt="Provider": "chatgpt-web")
+
+    answers = iter(["4", "browser-account"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    monkeypatch.setattr(
+        auth_commands_mod,
+        "auth_browser_command",
+        lambda args: captured.setdefault("args", args),
+    )
+
+    auth_commands_mod._interactive_add()
+
+    assert captured["args"].provider == "chatgpt-web"
+    assert captured["args"].label == "browser-account"
+    assert captured["args"].timeout is None
+    assert captured["args"].debug_port is None
+    assert captured["args"].keep_open is False
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources

--- a/tests/hermes_cli/test_chat_skills_flag.py
+++ b/tests/hermes_cli/test_chat_skills_flag.py
@@ -49,6 +49,30 @@ def test_chat_subcommand_accepts_skills_flag(monkeypatch):
     }
 
 
+def test_chat_subcommand_accepts_image_flag(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_chat(args):
+        captured["query"] = args.query
+        captured["image"] = args.image
+
+    monkeypatch.setattr(main_mod, "cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "chat", "-q", "hello", "--image", "~/storage/shared/Pictures/cat.png"],
+    )
+
+    main_mod.main()
+
+    assert captured == {
+        "query": "hello",
+        "image": "~/storage/shared/Pictures/cat.png",
+    }
+
+
 def test_continue_worktree_and_skills_flags_work_together(monkeypatch):
     import hermes_cli.main as main_mod
 

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -2,6 +2,7 @@ import sys
 from unittest.mock import patch
 
 from hermes_cli.models import normalize_provider, provider_model_ids
+from hermes_cli.providers import get_label
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 
@@ -138,3 +139,23 @@ def test_main_accepts_chatgpt_web_for_login_and_logout(monkeypatch):
     hermes_main.main()
 
     assert seen == [("login", "chatgpt-web"), ("logout", "chatgpt-web")]
+
+
+def test_main_accepts_chatgpt_web_for_chat_provider(monkeypatch):
+    from hermes_cli import main as hermes_main
+
+    seen = []
+    monkeypatch.setattr(hermes_main, "cmd_chat", lambda args: seen.append(args.provider))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "chat", "--provider", "chatgpt-web", "-q", "hello"],
+    )
+    hermes_main.main()
+
+    assert seen == ["chatgpt-web"]
+
+
+def test_provider_label_chatgpt_web_is_human_readable():
+    assert get_label("chatgpt-web") == "ChatGPT Web"

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -359,6 +359,39 @@ def test_resolve_chatgpt_web_runtime_credentials_refreshes_pool_session_token(tm
     assert creds["session_token"] == "session-cookie-token"
 
 
+def test_format_initial_message_includes_tool_calls_and_tool_responses():
+    from hermes_cli.chatgpt_web import _format_initial_message
+
+    prompt = _format_initial_message(
+        instructions="Use tools when needed.",
+        has_remote_thread=False,
+        messages=[
+            {"role": "user", "content": "Find the file."},
+            {
+                "role": "assistant",
+                "content": "I will inspect the repo.",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "search_files",
+                            "arguments": '{"pattern": "chatgpt_web.py"}',
+                        }
+                    }
+                ],
+            },
+            {"role": "tool", "content": '{"matches":["hermes_cli/chatgpt_web.py"]}'},
+            {"role": "user", "content": "Continue."},
+        ],
+    )
+
+    assert "Developer instructions (higher priority than the conversation below):" in prompt
+    assert "<tool_call>" in prompt
+    assert "search_files" in prompt
+    assert "<tool_response>" in prompt
+    assert "hermes_cli/chatgpt_web.py" in prompt
+
+
+
 def test_stream_chatgpt_web_completion_parses_patch_events(monkeypatch):
     from hermes_cli.chatgpt_web import stream_chatgpt_web_completion
 

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -2,6 +2,8 @@ import json
 import sys
 from unittest.mock import patch
 
+import httpx
+
 from hermes_cli.models import normalize_provider, provider_model_ids
 from hermes_cli.providers import get_label
 from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -355,3 +357,131 @@ def test_resolve_chatgpt_web_runtime_credentials_refreshes_pool_session_token(tm
     assert creds["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
     assert creds["source"] == "pool:session-cookie"
     assert creds["session_token"] == "session-cookie-token"
+
+
+def test_stream_chatgpt_web_completion_parses_patch_events(monkeypatch):
+    from hermes_cli.chatgpt_web import stream_chatgpt_web_completion
+
+    deltas = []
+
+    class _JSONResponse:
+        def __init__(self, payload, status_code=200):
+            self._payload = payload
+            self.status_code = status_code
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError("boom", request=None, response=None)
+
+        def json(self):
+            return self._payload
+
+    class _StreamResponse:
+        def __init__(self, lines):
+            self._lines = lines
+            self.status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            yield from self._lines
+
+    class _Client:
+        def post(self, url, headers=None, json=None):
+            if url.endswith("/conversation/prepare"):
+                return _JSONResponse({"conduit_token": "conduit-123"})
+            if url.endswith("/sentinel/chat-requirements"):
+                return _JSONResponse({"token": "req-token", "proofofwork": {}})
+            raise AssertionError(f"unexpected POST {url}")
+
+        def stream(self, method, url, headers=None, json=None):
+            assert method == "POST"
+            assert url.endswith("/conversation")
+            return _StreamResponse([
+                'data: "v1"',
+                'data: {"conversation_id":"conv_123","type":"resume_conversation_token"}',
+                'data: {"v":{"message":{"id":"msg_123","author":{"role":"assistant"},"content":{"content_type":"text","parts":[""]},"status":"in_progress","metadata":{}}}}',
+                'data: {"o":"patch","v":[{"p":"/message/content/parts/0","o":"append","v":"Hel"},{"p":"/message/content/parts/0","o":"append","v":"lo"},{"p":"/message/status","o":"replace","v":"finished_successfully"}]}',
+                'data: {"type":"message_stream_complete","conversation_id":"conv_123"}',
+                'data: [DONE]',
+            ])
+
+    result = stream_chatgpt_web_completion(
+        access_token="chatgpt-web-token",
+        model="gpt-5-thinking",
+        messages=[{"role": "user", "content": "hello"}],
+        on_delta=deltas.append,
+        client=_Client(),
+        history_and_training_disabled=True,
+    )
+
+    assert result["content"] == "Hello"
+    assert result["conversation_id"] == "conv_123"
+    assert result["message_id"] == "msg_123"
+    assert deltas == ["Hel", "lo"]
+
+
+
+def test_stream_chatgpt_web_completion_tolerates_protocol_close_after_completion(monkeypatch):
+    from hermes_cli.chatgpt_web import stream_chatgpt_web_completion
+
+    class _JSONResponse:
+        def __init__(self, payload, status_code=200):
+            self._payload = payload
+            self.status_code = status_code
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError("boom", request=None, response=None)
+
+        def json(self):
+            return self._payload
+
+    class _StreamResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            yield 'data: {"conversation_id":"conv_456","type":"resume_conversation_token"}'
+            yield 'data: {"v":{"message":{"id":"msg_456","author":{"role":"assistant"},"content":{"content_type":"text","parts":[""]},"status":"in_progress","metadata":{}}}}'
+            yield 'data: {"o":"patch","v":[{"p":"/message/content/parts/0","o":"append","v":"OK"}]}'
+            yield 'data: {"type":"message_stream_complete","conversation_id":"conv_456"}'
+            raise httpx.RemoteProtocolError("incomplete chunked read")
+
+    class _Client:
+        def post(self, url, headers=None, json=None):
+            if url.endswith("/conversation/prepare"):
+                return _JSONResponse({"conduit_token": "conduit-456"})
+            if url.endswith("/sentinel/chat-requirements"):
+                return _JSONResponse({"token": "req-token", "proofofwork": {}})
+            raise AssertionError(f"unexpected POST {url}")
+
+        def stream(self, method, url, headers=None, json=None):
+            assert method == "POST"
+            assert url.endswith("/conversation")
+            return _StreamResponse()
+
+    result = stream_chatgpt_web_completion(
+        access_token="chatgpt-web-token",
+        model="gpt-5-thinking",
+        messages=[{"role": "user", "content": "hello"}],
+        client=_Client(),
+        history_and_training_disabled=True,
+    )
+
+    assert result["content"] == "OK"
+    assert result["conversation_id"] == "conv_456"
+    assert result["message_id"] == "msg_456"

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -202,6 +202,46 @@ def test_get_chatgpt_web_auth_status_prefers_chatgpt_web_pool(tmp_path, monkeypa
     assert status["api_key"] == "chatgpt-web-token"
 
 
+def test_get_chatgpt_web_auth_status_accepts_pool_session_token(tmp_path, monkeypatch):
+    from hermes_cli.auth import get_chatgpt_web_auth_status
+    from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("CHATGPT_WEB_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("CHATGPT_WEB_SESSION_TOKEN", raising=False)
+
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "chatgpt-web": [
+                        {
+                            "id": "cred-web",
+                            "label": "session-cookie",
+                            "auth_type": "api_key",
+                            "priority": 0,
+                            "source": "manual:session_token",
+                            "access_token": "",
+                            "session_token": "session-cookie-token",
+                            "base_url": DEFAULT_CHATGPT_WEB_BASE_URL,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    status = get_chatgpt_web_auth_status()
+
+    assert status["logged_in"] is True
+    assert status["auth_mode"] == "session_token"
+    assert status["source"] == "pool:session-cookie"
+    assert status["api_key"] == ""
+
+
 def test_resolve_chatgpt_web_runtime_credentials_prefers_pool_entry(tmp_path, monkeypatch):
     from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL, resolve_chatgpt_web_runtime_credentials
 
@@ -239,3 +279,47 @@ def test_resolve_chatgpt_web_runtime_credentials_prefers_pool_entry(tmp_path, mo
     assert creds["api_key"] == "chatgpt-web-token"
     assert creds["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
     assert creds["source"] == "pool:web-account"
+
+
+def test_resolve_chatgpt_web_runtime_credentials_refreshes_pool_session_token(tmp_path, monkeypatch):
+    from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL, resolve_chatgpt_web_runtime_credentials
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("CHATGPT_WEB_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("CHATGPT_WEB_SESSION_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web._fetch_chatgpt_web_access_token_from_session",
+        lambda session_token, **kwargs: "refreshed-web-access-token",
+    )
+
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "chatgpt-web": [
+                        {
+                            "id": "cred-web",
+                            "label": "session-cookie",
+                            "auth_type": "api_key",
+                            "priority": 0,
+                            "source": "manual:session_token",
+                            "access_token": "",
+                            "session_token": "session-cookie-token",
+                            "base_url": DEFAULT_CHATGPT_WEB_BASE_URL,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    creds = resolve_chatgpt_web_runtime_credentials()
+
+    assert creds["provider"] == "chatgpt-web"
+    assert creds["api_key"] == "refreshed-web-access-token"
+    assert creds["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
+    assert creds["source"] == "pool:session-cookie"
+    assert creds["session_token"] == "session-cookie-token"

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -1,0 +1,140 @@
+import sys
+from unittest.mock import patch
+
+from hermes_cli.models import normalize_provider, provider_model_ids
+from hermes_cli.runtime_provider import resolve_runtime_provider
+
+
+def test_normalize_provider_maps_chatgpt_aliases():
+    assert normalize_provider("chatgpt") == "chatgpt-web"
+    assert normalize_provider("chatgpt-web") == "chatgpt-web"
+    assert normalize_provider("chatgpt.com") == "chatgpt-web"
+
+
+def test_provider_model_ids_chatgpt_web_prefers_live_catalog(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.resolve_chatgpt_web_runtime_credentials",
+        lambda **kwargs: {"api_key": "chatgpt-web-token"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.fetch_chatgpt_web_model_ids",
+        lambda access_token=None, **kwargs: ["gpt-5-thinking", "gpt-5-instant", "gpt-5"],
+    )
+
+    assert provider_model_ids("chatgpt-web") == ["gpt-5-thinking", "gpt-5-instant", "gpt-5"]
+
+
+def test_resolve_runtime_provider_chatgpt_web_uses_chatgpt_web_mode(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_chatgpt_web_runtime_credentials",
+        lambda **kwargs: {
+            "provider": "chatgpt-web",
+            "api_key": "chatgpt-web-token",
+            "base_url": "https://chatgpt.com/backend-api/f",
+            "source": "codex-oauth",
+        },
+    )
+
+    runtime = resolve_runtime_provider(requested="chatgpt-web")
+
+    assert runtime["provider"] == "chatgpt-web"
+    assert runtime["api_mode"] == "chatgpt_web"
+    assert runtime["api_key"] == "chatgpt-web-token"
+    assert runtime["base_url"] == "https://chatgpt.com/backend-api/f"
+
+
+def test_model_flow_chatgpt_web_uses_runtime_access_token_for_model_list(monkeypatch):
+    from hermes_cli.main import _model_flow_chatgpt_web
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_chatgpt_web_auth_status",
+        lambda: {"logged_in": True},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.resolve_chatgpt_web_runtime_credentials",
+        lambda **kwargs: {"api_key": "chatgpt-web-token"},
+    )
+
+    def _fake_fetch(access_token=None, **kwargs):
+        captured["access_token"] = access_token
+        return ["gpt-5-thinking", "gpt-5-instant"]
+
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.fetch_chatgpt_web_model_ids",
+        _fake_fetch,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda model_ids, current_model="": None,
+    )
+
+    _model_flow_chatgpt_web({}, current_model="gpt-5-thinking")
+
+    assert captured["access_token"] == "chatgpt-web-token"
+
+
+def test_resolve_chatgpt_web_runtime_credentials_prefers_session_token_exchange(monkeypatch):
+    from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL, resolve_chatgpt_web_runtime_credentials
+
+    monkeypatch.setenv("CHATGPT_WEB_SESSION_TOKEN", "session-token")
+    monkeypatch.delenv("CHATGPT_WEB_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web._fetch_chatgpt_web_access_token_from_session",
+        lambda session_token, **kwargs: "access-from-session",
+    )
+
+    creds = resolve_chatgpt_web_runtime_credentials()
+
+    assert creds["provider"] == "chatgpt-web"
+    assert creds["api_key"] == "access-from-session"
+    assert creds["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
+    assert creds["source"] == "session-token"
+
+
+def test_select_provider_and_model_lists_chatgpt_web_in_top_menu(monkeypatch):
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "gpt-5", "provider": "openrouter"}},
+    )
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda requested, **kwargs: requested)
+
+    prompts = []
+    dispatched = {}
+
+    def _fake_prompt_provider_choice(choices, **kwargs):
+        prompts.append(list(choices))
+        return next(idx for idx, label in enumerate(choices) if "ChatGPT Web" in label)
+
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", _fake_prompt_provider_choice)
+    monkeypatch.setattr(
+        hermes_main,
+        "_model_flow_chatgpt_web",
+        lambda config, current_model="": dispatched.setdefault("args", (config, current_model)),
+    )
+
+    hermes_main.select_provider_and_model()
+
+    assert prompts
+    assert any("ChatGPT Web" in label for label in prompts[0])
+    assert dispatched["args"][1] == "gpt-5"
+
+
+def test_main_accepts_chatgpt_web_for_login_and_logout(monkeypatch):
+    from hermes_cli import main as hermes_main
+
+    seen = []
+    monkeypatch.setattr(hermes_main, "cmd_login", lambda args: seen.append(("login", args.provider)))
+    monkeypatch.setattr(hermes_main, "cmd_logout", lambda args: seen.append(("logout", args.provider)))
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "login", "--provider", "chatgpt-web"])
+    hermes_main.main()
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "logout", "--provider", "chatgpt-web"])
+    hermes_main.main()
+
+    assert seen == [("login", "chatgpt-web"), ("logout", "chatgpt-web")]

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from unittest.mock import patch
 
@@ -159,3 +160,82 @@ def test_main_accepts_chatgpt_web_for_chat_provider(monkeypatch):
 
 def test_provider_label_chatgpt_web_is_human_readable():
     assert get_label("chatgpt-web") == "ChatGPT Web"
+
+
+def test_get_chatgpt_web_auth_status_prefers_chatgpt_web_pool(tmp_path, monkeypatch):
+    from hermes_cli.auth import get_chatgpt_web_auth_status
+    from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("CHATGPT_WEB_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("CHATGPT_WEB_SESSION_TOKEN", raising=False)
+
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "chatgpt-web": [
+                        {
+                            "id": "cred-web",
+                            "label": "web-account",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "chatgpt-web-token",
+                            "base_url": DEFAULT_CHATGPT_WEB_BASE_URL,
+                            "last_refresh": "2026-03-23T10:00:00Z",
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    status = get_chatgpt_web_auth_status()
+
+    assert status["logged_in"] is True
+    assert status["auth_mode"] == "oauth"
+    assert status["source"] == "pool:web-account"
+    assert status["api_key"] == "chatgpt-web-token"
+
+
+def test_resolve_chatgpt_web_runtime_credentials_prefers_pool_entry(tmp_path, monkeypatch):
+    from hermes_cli.chatgpt_web import DEFAULT_CHATGPT_WEB_BASE_URL, resolve_chatgpt_web_runtime_credentials
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("CHATGPT_WEB_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("CHATGPT_WEB_SESSION_TOKEN", raising=False)
+
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "chatgpt-web": [
+                        {
+                            "id": "cred-web",
+                            "label": "web-account",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "chatgpt-web-token",
+                            "base_url": DEFAULT_CHATGPT_WEB_BASE_URL,
+                            "last_refresh": "2026-03-23T10:00:00Z",
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    creds = resolve_chatgpt_web_runtime_credentials()
+
+    assert creds["provider"] == "chatgpt-web"
+    assert creds["api_key"] == "chatgpt-web-token"
+    assert creds["base_url"] == DEFAULT_CHATGPT_WEB_BASE_URL
+    assert creds["source"] == "pool:web-account"

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -142,6 +142,38 @@ def test_main_accepts_chatgpt_web_for_login_and_logout(monkeypatch):
     assert seen == [("login", "chatgpt-web"), ("logout", "chatgpt-web")]
 
 
+def test_main_accepts_chatgpt_web_for_auth_browser(monkeypatch):
+    from hermes_cli import main as hermes_main
+
+    seen = []
+    monkeypatch.setattr(
+        hermes_main,
+        "cmd_auth",
+        lambda args: seen.append((args.auth_action, args.provider, args.label, args.timeout, args.debug_port, args.keep_open)),
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "auth",
+            "browser",
+            "chatgpt-web",
+            "--label",
+            "termux-x11-browser",
+            "--timeout",
+            "42",
+            "--debug-port",
+            "9333",
+            "--keep-open",
+        ],
+    )
+    hermes_main.main()
+
+    assert seen == [("browser", "chatgpt-web", "termux-x11-browser", 42, 9333, True)]
+
+
 def test_main_accepts_chatgpt_web_for_chat_provider(monkeypatch):
     from hermes_cli import main as hermes_main
 

--- a/tests/hermes_cli/test_chatgpt_web_provider.py
+++ b/tests/hermes_cli/test_chatgpt_web_provider.py
@@ -429,6 +429,72 @@ def test_stream_chatgpt_web_completion_parses_patch_events(monkeypatch):
 
 
 
+def test_stream_chatgpt_web_completion_parses_patch_events_without_outer_op(monkeypatch):
+    from hermes_cli.chatgpt_web import stream_chatgpt_web_completion
+
+    deltas = []
+
+    class _JSONResponse:
+        def __init__(self, payload, status_code=200):
+            self._payload = payload
+            self.status_code = status_code
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError("boom", request=None, response=None)
+
+        def json(self):
+            return self._payload
+
+    class _StreamResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            yield 'data: "v1"'
+            yield 'data: {"conversation_id":"conv_789","type":"resume_conversation_token"}'
+            yield 'data: {"v":{"message":{"id":"msg_789","author":{"role":"assistant"},"content":{"content_type":"text","parts":[""]},"status":"in_progress","metadata":{}}}}'
+            yield 'data: {"o":"patch","v":[{"p":"/message/content/parts/0","o":"append","v":"Yes,"}]}'
+            yield 'data: {"v":[{"p":"/message/content/parts/0","o":"append","v":" tools are active"}]}'
+            yield 'data: {"v":[{"p":"/message/content/parts/0","o":"append","v":" and ready."},{"p":"/message/status","o":"replace","v":"finished_successfully"}]}'
+            yield 'data: {"type":"message_stream_complete","conversation_id":"conv_789"}'
+            yield 'data: [DONE]'
+
+    class _Client:
+        def post(self, url, headers=None, json=None):
+            if url.endswith("/conversation/prepare"):
+                return _JSONResponse({"conduit_token": "conduit-789"})
+            if url.endswith("/sentinel/chat-requirements"):
+                return _JSONResponse({"token": "***", "proofofwork": {}})
+            raise AssertionError(f"unexpected POST {url}")
+
+        def stream(self, method, url, headers=None, json=None):
+            assert method == "POST"
+            assert url.endswith("/conversation")
+            return _StreamResponse()
+
+    result = stream_chatgpt_web_completion(
+        access_token="chatgpt-web-token",
+        model="gpt-5-thinking",
+        messages=[{"role": "user", "content": "hello"}],
+        on_delta=deltas.append,
+        client=_Client(),
+        history_and_training_disabled=True,
+    )
+
+    assert result["content"] == "Yes, tools are active and ready."
+    assert result["conversation_id"] == "conv_789"
+    assert result["message_id"] == "msg_789"
+    assert deltas == ["Yes,", " tools are active", " and ready."]
+
+
+
 def test_stream_chatgpt_web_completion_tolerates_protocol_close_after_completion(monkeypatch):
     from hermes_cli.chatgpt_web import stream_chatgpt_web_completion
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -223,3 +223,25 @@ class TestDoctorMemoryProviderSection:
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
+
+
+def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
+    helper = TestDoctorMemoryProviderSection()
+    monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+    monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+
+    real_which = doctor_mod.shutil.which
+
+    def fake_which(cmd):
+        if cmd in {"docker", "node", "npm"}:
+            return None
+        return real_which(cmd)
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+    out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+
+    assert "Docker backend is not available inside Termux" in out
+    assert "Node.js not found (browser tools are optional in the tested Termux path)" in out
+    assert "Install Node.js on Termux with: pkg install nodejs" in out
+    assert "docker not found (optional)" not in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -14,6 +14,23 @@ from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
 
 
+class TestDoctorPlatformHints:
+    def test_termux_package_hint(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        assert doctor._is_termux() is True
+        assert doctor._python_install_cmd() == "python -m pip install"
+        assert doctor._system_package_install_cmd("ripgrep") == "pkg install ripgrep"
+
+    def test_non_termux_package_hint_defaults_to_apt(self, monkeypatch):
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/usr")
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert doctor._is_termux() is False
+        assert doctor._python_install_cmd() == "uv pip install"
+        assert doctor._system_package_install_cmd("ripgrep") == "sudo apt install ripgrep"
+
+
 class TestProviderEnvDetection:
     def test_detects_openai_api_key(self):
         content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=***"

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -245,3 +245,46 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "Node.js not found (browser tools are optional in the tested Termux path)" in out
     assert "Install Node.js on Termux with: pkg install nodejs" in out
     assert "docker not found (optional)" not in out
+
+
+def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+    monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/data/data/com.termux/files/usr/bin/node" if cmd in {"node", "npm"} else None)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (["terminal"], [{"name": "browser", "env_vars": [], "tools": ["browser_navigate"]}]),
+        TOOLSET_REQUIREMENTS={
+            "terminal": {"name": "terminal"},
+            "browser": {"name": "browser"},
+        },
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "✓ browser" not in out
+    assert "browser" in out
+    assert "system dependency not met" in out
+    assert "agent-browser is not installed (expected in the tested Termux path)" in out
+    assert "npm install -g agent-browser && agent-browser install" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -244,6 +244,10 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "Docker backend is not available inside Termux" in out
     assert "Node.js not found (browser tools are optional in the tested Termux path)" in out
     assert "Install Node.js on Termux with: pkg install nodejs" in out
+    assert "Termux browser setup:" in out
+    assert "1) pkg install nodejs" in out
+    assert "2) npm install -g agent-browser" in out
+    assert "3) agent-browser install" in out
     assert "docker not found (optional)" not in out
 
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -10,6 +10,7 @@ import hermes_cli.gateway as gateway
 class TestSystemdLingerStatus:
     def test_reports_enabled(self, monkeypatch):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setenv("USER", "alice")
         monkeypatch.setattr(
             gateway.subprocess,
@@ -22,6 +23,7 @@ class TestSystemdLingerStatus:
 
     def test_reports_disabled(self, monkeypatch):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setenv("USER", "alice")
         monkeypatch.setattr(
             gateway.subprocess,
@@ -31,6 +33,11 @@ class TestSystemdLingerStatus:
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/loginctl")
 
         assert gateway.get_systemd_linger_status() == (False, "")
+
+    def test_reports_termux_as_not_supported(self, monkeypatch):
+        monkeypatch.setattr(gateway, "is_termux", lambda: True)
+
+        assert gateway.get_systemd_linger_status() == (None, "not supported in Termux")
 
 
 def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -8,6 +8,7 @@ import hermes_cli.gateway as gateway
 class TestEnsureLingerEnabled:
     def test_linger_already_enabled_via_file(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
         monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: True))
 
@@ -22,6 +23,7 @@ class TestEnsureLingerEnabled:
 
     def test_status_enabled_skips_enable(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
         monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (True, ""))
@@ -37,6 +39,7 @@ class TestEnsureLingerEnabled:
 
     def test_loginctl_success_enables_linger(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
         monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (False, ""))
@@ -59,6 +62,7 @@ class TestEnsureLingerEnabled:
 
     def test_missing_loginctl_shows_manual_guidance(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
         monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (None, "loginctl not found"))
@@ -76,6 +80,7 @@ class TestEnsureLingerEnabled:
 
     def test_loginctl_failure_shows_manual_guidance(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
         monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (False, ""))

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -109,7 +109,8 @@ class TestGatewayStopCleanup:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("unit\n", encoding="utf-8")
 
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
 
@@ -134,7 +135,8 @@ class TestGatewayStopCleanup:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("unit\n", encoding="utf-8")
 
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
 
@@ -256,7 +258,8 @@ class TestGatewayServiceDetection:
         user_unit = SimpleNamespace(exists=lambda: True)
         system_unit = SimpleNamespace(exists=lambda: True)
 
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(
             gateway_cli,
@@ -278,7 +281,8 @@ class TestGatewayServiceDetection:
 
 class TestGatewaySystemServiceRouting:
     def test_gateway_install_passes_system_flags(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
 
         calls = []
@@ -294,11 +298,30 @@ class TestGatewaySystemServiceRouting:
 
         assert calls == [(True, True, "alice")]
 
+    def test_gateway_install_reports_termux_manual_mode(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+
+        try:
+            gateway_cli.gateway_command(
+                SimpleNamespace(gateway_command="install", force=False, system=False, run_as_user=None)
+            )
+        except SystemExit as exc:
+            assert exc.code == 1
+        else:
+            raise AssertionError("Expected gateway_command to exit on unsupported Termux service install")
+
+        out = capsys.readouterr().out
+        assert "not supported on Termux" in out
+        assert "Run manually: hermes gateway" in out
+
     def test_gateway_status_prefers_system_service_when_only_system_unit_exists(self, monkeypatch):
         user_unit = SimpleNamespace(exists=lambda: False)
         system_unit = SimpleNamespace(exists=lambda: True)
 
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(
             gateway_cli,
@@ -312,6 +335,20 @@ class TestGatewaySystemServiceRouting:
         gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
 
         assert calls == [(False, False)]
+
+    def test_gateway_status_on_termux_shows_manual_guidance(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda exclude_pids=None: [])
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+
+        out = capsys.readouterr().out
+        assert "Gateway is not running" in out
+        assert "nohup hermes gateway" in out
+        assert "install as user service" not in out
 
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
@@ -513,12 +550,22 @@ class TestGeneratedUnitUsesDetectedVenv:
 class TestGeneratedUnitIncludesLocalBin:
     """~/.local/bin must be in PATH so uvx/pipx tools are discoverable."""
 
-    def test_user_unit_includes_local_bin_in_path(self):
+    def test_user_unit_includes_local_bin_in_path(self, monkeypatch):
+        home = Path.home()
+        monkeypatch.setattr(
+            gateway_cli,
+            "_build_user_local_paths",
+            lambda home_path, existing: [str(home / ".local" / "bin")],
+        )
         unit = gateway_cli.generate_systemd_unit(system=False)
-        home = str(Path.home())
         assert f"{home}/.local/bin" in unit
 
-    def test_system_unit_includes_local_bin_in_path(self):
+    def test_system_unit_includes_local_bin_in_path(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_build_user_local_paths",
+            lambda home_path, existing: [str(home_path / ".local" / "bin")],
+        )
         unit = gateway_cli.generate_systemd_unit(system=True)
         # System unit uses the resolved home dir from _system_service_identity
         assert "/.local/bin" in unit

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_SCRIPT = REPO_ROOT / "setup-hermes.sh"
+
+
+def test_setup_hermes_script_is_valid_shell():
+    result = subprocess.run(["bash", "-n", str(SETUP_SCRIPT)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_setup_hermes_script_has_termux_path():
+    content = SETUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "is_termux()" in content
+    assert ".[termux]" in content
+    assert "constraints-termux.txt" in content
+    assert "$PREFIX/bin" in content
+    assert "Skipping tinker-atropos on Termux" in content

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -12,3 +12,33 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+    monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    def _unexpected_systemctl(*args, **kwargs):
+        raise AssertionError("systemctl should not be called in the Termux status view")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", _unexpected_systemctl)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Manager:      Termux / manual process" in output
+    assert "Start with:   hermes gateway" in output
+    assert "systemd (user)" not in output

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -42,3 +42,40 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_includes_chatgpt_web_auth(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5-thinking"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "chatgpt-web", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "chatgpt-web", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "ChatGPT Web", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(
+        auth_mod,
+        "get_chatgpt_web_auth_status",
+        lambda: {
+            "logged_in": True,
+            "auth_mode": "codex_oauth",
+            "source": "codex-oauth",
+            "auth_store": str(tmp_path / "codex" / "auth.json"),
+            "last_refresh": "2026-03-23T10:00:00Z",
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "ChatGPT Web" in output
+    assert "logged in" in output
+    assert "Source:     codex-oauth" in output
+    assert "Mode:       codex_oauth" in output

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -368,6 +368,8 @@ class TestCmdUpdateLaunchdRestart:
         monkeypatch.setattr(
             gateway_cli, "is_macos", lambda: False,
         )
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",
@@ -426,7 +428,8 @@ class TestCmdUpdateSystemService:
     ):
         """When user systemd is inactive but a system service exists, restart via system scope."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",
@@ -455,7 +458,8 @@ class TestCmdUpdateSystemService:
     ):
         """When system service restart fails, show the failure message."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",
@@ -477,7 +481,8 @@ class TestCmdUpdateSystemService:
     ):
         """When both user and system services are active, both are restarted."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",
@@ -560,7 +565,8 @@ class TestServicePidExclusion:
     ):
         """After systemd restart, the sweep must exclude the service PID."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
 
         SERVICE_PID = 55000
 
@@ -639,7 +645,8 @@ class TestGetServicePids:
     """Unit tests for _get_service_pids()."""
 
     def test_returns_systemd_main_pid(self, monkeypatch):
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
 
         def fake_run(cmd, **kwargs):
@@ -688,7 +695,8 @@ class TestGetServicePids:
 
     def test_excludes_zero_pid(self, monkeypatch):
         """systemd returns MainPID=0 for stopped services; skip those."""
-        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
 
         def fake_run(cmd, **kwargs):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1061,6 +1061,35 @@ class TestExecuteToolCalls:
         assert len(messages[0]["content"]) < 150_000
         assert ("Truncated" in messages[0]["content"] or "<persisted-output>" in messages[0]["content"])
 
+    def test_quiet_tool_output_suppressed_when_progress_callback_present(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        agent.tool_progress_callback = lambda *args, **kwargs: None
+
+        with patch("run_agent.handle_function_call", return_value="search result"), \
+             patch.object(agent, "_safe_print") as mock_print:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        mock_print.assert_not_called()
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+
+    def test_quiet_tool_output_prints_without_progress_callback(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        agent.tool_progress_callback = None
+
+        with patch("run_agent.handle_function_call", return_value="search result"), \
+             patch.object(agent, "_safe_print") as mock_print:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        mock_print.assert_called_once()
+        assert "search" in str(mock_print.call_args.args[0]).lower()
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+
 
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1090,6 +1090,46 @@ class TestExecuteToolCalls:
         assert len(messages) == 1
         assert messages[0]["role"] == "tool"
 
+    def test_vprint_suppressed_in_parseable_quiet_mode(self, agent):
+        agent.suppress_status_output = True
+
+        with patch.object(agent, "_safe_print") as mock_print:
+            agent._vprint("status line", force=True)
+            agent._vprint("normal line")
+
+        mock_print.assert_not_called()
+
+    def test_run_conversation_suppresses_retry_noise_in_parseable_quiet_mode(self, agent):
+        class _RateLimitError(Exception):
+            status_code = 429
+
+            def __str__(self):
+                return "Error code: 429 - Rate limit exceeded."
+
+        responses = [_RateLimitError(), _mock_response(content="Recovered")]
+
+        def _fake_api_call(api_kwargs):
+            result = responses.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        agent.suppress_status_output = True
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+        agent._save_session_log = lambda *args, **kwargs: None
+
+        with patch("run_agent.time.sleep", return_value=None), \
+             patch.object(agent, "_vprint") as mock_vprint:
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        rendered = [" ".join(str(arg) for arg in call.args) for call in mock_vprint.call_args_list]
+        assert not any("API call failed" in line for line in rendered)
+        assert not any("Rate limit reached" in line for line in rendered)
+
 
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""

--- a/tests/run_agent/test_run_agent_chatgpt_web.py
+++ b/tests/run_agent/test_run_agent_chatgpt_web.py
@@ -1,0 +1,189 @@
+import sys
+import threading
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+
+
+DEFAULT_WEB_BASE = "https://chatgpt.com/backend-api/f"
+
+
+def _patch_agent_bootstrap(monkeypatch):
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: [])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+
+def _build_agent(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+
+    agent = run_agent.AIAgent(
+        model="gpt-5-thinking",
+        provider="chatgpt-web",
+        api_mode="chatgpt_web",
+        base_url=DEFAULT_WEB_BASE,
+        api_key="chatgpt-web-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._save_session_log = lambda messages: None
+    return agent
+
+
+def test_build_api_kwargs_chatgpt_web_carries_thread_state(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent._chatgpt_web_conversation_id = "conv_existing"
+    agent._chatgpt_web_parent_message_id = "msg_existing"
+
+    kwargs = agent._build_api_kwargs([
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Hello from Hermes."},
+    ])
+
+    assert kwargs["model"] == "gpt-5-thinking"
+    assert kwargs["conversation_id"] == "conv_existing"
+    assert kwargs["parent_message_id"] == "msg_existing"
+    assert kwargs["messages"][-1]["content"] == "Hello from Hermes."
+    assert "tools" not in kwargs
+
+
+def test_interruptible_api_call_chatgpt_web_returns_openai_like_response(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.stream_chatgpt_web_completion",
+        lambda **kwargs: {
+            "content": "Hello from ChatGPT web.",
+            "conversation_id": "conv_123",
+            "parent_message_id": "msg_456",
+            "message_id": "msg_456",
+            "model": "gpt-5-thinking",
+            "finish_reason": "stop",
+        },
+    )
+
+    response = agent._interruptible_api_call({
+        "model": "gpt-5-thinking",
+        "messages": [{"role": "user", "content": "hi"}],
+        "conversation_id": None,
+        "parent_message_id": None,
+        "instructions": "Be concise.",
+    })
+
+    assert response.choices[0].message.content == "Hello from ChatGPT web."
+    assert response.choices[0].finish_reason == "stop"
+    assert agent._chatgpt_web_conversation_id == "conv_123"
+    assert agent._chatgpt_web_parent_message_id == "msg_456"
+
+
+def test_interruptible_streaming_api_call_chatgpt_web_emits_deltas(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    deltas = []
+    agent.stream_delta_callback = deltas.append
+
+    def _fake_stream(**kwargs):
+        on_delta = kwargs.get("on_delta")
+        assert on_delta is not None
+        on_delta("Hel")
+        on_delta("lo")
+        return {
+            "content": "Hello",
+            "conversation_id": "conv_stream",
+            "parent_message_id": "msg_stream",
+            "message_id": "msg_stream",
+            "model": "gpt-5-thinking",
+            "finish_reason": "stop",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.stream_chatgpt_web_completion",
+        _fake_stream,
+    )
+
+    response = agent._interruptible_streaming_api_call({
+        "model": "gpt-5-thinking",
+        "messages": [{"role": "user", "content": "hi"}],
+        "conversation_id": None,
+        "parent_message_id": None,
+        "instructions": "Be concise.",
+    })
+
+    assert deltas == ["Hel", "lo"]
+    assert response.choices[0].message.content == "Hello"
+    assert agent._chatgpt_web_conversation_id == "conv_stream"
+    assert agent._chatgpt_web_parent_message_id == "msg_stream"
+
+
+def test_interruptible_api_call_chatgpt_web_closes_request_client_on_interrupt(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    entered = threading.Event()
+    close_seen = threading.Event()
+    created_clients = []
+    close_reasons = []
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+            close_seen.set()
+
+    def _fake_client_factory(*args, **kwargs):
+        client = _FakeClient(*args, **kwargs)
+        created_clients.append(client)
+        return client
+
+    def _fake_close_request_client(client, *, reason):
+        close_reasons.append(reason)
+        client.close()
+
+    def _fake_stream(**kwargs):
+        client = kwargs.get("client")
+        assert client is created_clients[0]
+        entered.set()
+        while not client.closed:
+            time.sleep(0.01)
+        raise RuntimeError("aborted")
+
+    monkeypatch.setattr("httpx.Client", _fake_client_factory)
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.stream_chatgpt_web_completion",
+        _fake_stream,
+    )
+    agent._close_request_openai_client = _fake_close_request_client
+
+    def _interrupt_once_stream_starts():
+        assert entered.wait(timeout=2)
+        agent._interrupt_requested = True
+
+    interrupter = threading.Thread(target=_interrupt_once_stream_starts, daemon=True)
+    interrupter.start()
+
+    with pytest.raises(InterruptedError, match="Agent interrupted during API call"):
+        agent._interruptible_api_call({
+            "model": "gpt-5-thinking",
+            "messages": [{"role": "user", "content": "hi"}],
+            "conversation_id": None,
+            "parent_message_id": None,
+            "instructions": "Be concise.",
+        })
+
+    assert close_seen.wait(timeout=2)
+    assert created_clients
+    assert "interrupt_abort" in close_reasons
+    time.sleep(0.05)
+    assert agent._chatgpt_web_conversation_id is None
+    assert agent._chatgpt_web_parent_message_id is None

--- a/tests/run_agent/test_run_agent_chatgpt_web.py
+++ b/tests/run_agent/test_run_agent_chatgpt_web.py
@@ -59,6 +59,210 @@ def test_build_api_kwargs_chatgpt_web_carries_thread_state(monkeypatch):
     assert "tools" not in kwargs
 
 
+def test_select_chatgpt_web_tools_prefers_explicit_sequence(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.tools = [
+        {"type": "function", "function": {"name": "search_files", "description": "Search files", "parameters": {"type": "object"}}},
+        {"type": "function", "function": {"name": "terminal", "description": "Run shell commands", "parameters": {"type": "object"}}},
+        {"type": "function", "function": {"name": "execute_code", "description": "Run Python code", "parameters": {"type": "object"}}},
+    ]
+
+    first = agent._select_chatgpt_web_tools([
+        {"role": "user", "content": "First use search_files, then terminal, then execute_code."},
+    ])
+    second = agent._select_chatgpt_web_tools([
+        {"role": "user", "content": "First use search_files, then terminal, then execute_code."},
+        {"role": "tool", "tool_name": "search_files", "content": "{}"},
+    ])
+    third = agent._select_chatgpt_web_tools([
+        {"role": "user", "content": "First use search_files, then terminal, then execute_code."},
+        {"role": "tool", "tool_name": "search_files", "content": "{}"},
+        {"role": "tool", "tool_name": "terminal", "content": "{}"},
+    ])
+
+    assert [tool["function"]["name"] for tool in first] == ["search_files"]
+    assert [tool["function"]["name"] for tool in second] == ["terminal"]
+    assert [tool["function"]["name"] for tool in third] == ["execute_code"]
+
+
+
+def test_select_chatgpt_web_tools_prefers_terminal_for_working_directory(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.tools = [
+        {"type": "function", "function": {"name": "search_files", "description": "Search files", "parameters": {"type": "object"}}},
+        {"type": "function", "function": {"name": "terminal", "description": "Run shell commands", "parameters": {"type": "object"}}},
+    ]
+
+    selected = agent._select_chatgpt_web_tools([
+        {"role": "user", "content": "Use Hermes tools to print the current working directory. Answer only the path."},
+    ])
+
+    assert [tool["function"]["name"] for tool in selected] == ["terminal"]
+
+
+
+def test_build_api_kwargs_chatgpt_web_with_tools_injects_protocol_and_disables_remote_thread(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent._chatgpt_web_conversation_id = "conv_existing"
+    agent._chatgpt_web_parent_message_id = "msg_existing"
+    agent.tools = [{
+        "type": "function",
+        "function": {
+            "name": "search_files",
+            "description": "Search files",
+            "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}}, "required": ["pattern"]},
+        },
+    }]
+
+    kwargs = agent._build_api_kwargs([
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Use Hermes tools to grep hermes_cli/chatgpt_web.py for stream_chatgpt_web_completion. Answer only yes/no and one matching path."},
+    ])
+
+    assert kwargs["conversation_id"] is None
+    assert kwargs["parent_message_id"] is None
+    assert kwargs["history_and_training_disabled"] is True
+    assert "Be concise." in kwargs["instructions"]
+    assert "<tool_call>" in kwargs["instructions"]
+    assert "<tool_response>" in kwargs["instructions"]
+    assert "search_files" in kwargs["instructions"]
+    assert "does not support Hermes tool calls" not in kwargs["instructions"]
+
+    rewritten_user = kwargs["messages"][-1]["content"]
+    assert rewritten_user.startswith("Original user request:\nUse Hermes tools to grep")
+    assert "Hermes has already determined that this turn requires a tool call." in rewritten_user
+    assert "Reply now with this exact structure:" in rewritten_user
+    assert '"name": "search_files"' in rewritten_user
+    assert '"pattern": "stream_chatgpt_web_completion"' in rewritten_user
+    assert '"path": "hermes_cli/chatgpt_web.py"' in rewritten_user
+
+
+def test_build_api_kwargs_chatgpt_web_refreshes_runtime_reminder_after_tool_response(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.tools = [{
+        "type": "function",
+        "function": {
+            "name": "execute_code",
+            "description": "Run Python code",
+            "parameters": {"type": "object", "properties": {"code": {"type": "string"}}, "required": ["code"]},
+        },
+    }]
+
+    kwargs = agent._build_api_kwargs([
+        {"role": "system", "content": "Be concise."},
+        {
+            "role": "user",
+            "content": (
+                "Original user request:\nUse Hermes tools to run Python that prints 6*7. Answer only the result.\n\n"
+                "Runtime reminder:\nThe tool available for this turn is: execute_code. "
+                "Hermes has already determined that this turn requires a tool call."
+            ),
+        },
+        {"role": "tool", "content": "42"},
+    ])
+
+    rewritten_user = kwargs["messages"][0]["content"]
+    assert rewritten_user.startswith("Original user request:\nUse Hermes tools to run Python")
+    assert "You have already received at least one <tool_response>." in rewritten_user
+    assert "Otherwise, give the final answer directly with no extra tool-call markup." in rewritten_user
+    assert "follow the original user's requested output format exactly" in rewritten_user
+    assert "Hermes has already determined that this turn requires a tool call." not in rewritten_user
+
+
+def test_wrap_chatgpt_web_response_extracts_xml_tool_calls(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.tools = [{
+        "type": "function",
+        "function": {
+            "name": "search_files",
+            "description": "Search files",
+            "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}}},
+        },
+    }]
+
+    response = agent._wrap_chatgpt_web_response({
+        "content": (
+            "I will inspect the repo.\n"
+            "<tool_call>\n"
+            '{"name":"search_files","arguments":{"pattern":"chatgpt_web"}}\n'
+            "</tool_call>"
+        ),
+        "message_id": "msg_tool_1",
+        "model": "gpt-5-thinking",
+        "finish_reason": "stop",
+    })
+
+    message = response.choices[0].message
+    assert "inspect the repo" in message.content
+    assert "<tool_call>" not in message.content
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.tool_calls[0].function.name == "search_files"
+    assert message.tool_calls[0].function.arguments == '{"pattern": "chatgpt_web"}'
+
+
+def test_wrap_chatgpt_web_response_extracts_tool_calls_with_missing_opening_angle(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.tools = [{
+        "type": "function",
+        "function": {
+            "name": "search_files",
+            "description": "Search files",
+            "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}}},
+        },
+    }]
+
+    response = agent._wrap_chatgpt_web_response({
+        "content": (
+            "tool_call>\n"
+            '{"name":"search_files","arguments":{"pattern":"run_agent.py","target":"files"}}\n'
+            "</tool_call>"
+        ),
+        "message_id": "msg_tool_2",
+        "model": "gpt-5-thinking",
+        "finish_reason": "stop",
+    })
+
+    message = response.choices[0].message
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.tool_calls[0].function.name == "search_files"
+    assert message.tool_calls[0].function.arguments == '{"pattern": "run_agent.py", "target": "files"}'
+
+
+
+def test_wrap_chatgpt_web_response_forces_selected_tool_when_model_refuses(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.tools = [{
+        "type": "function",
+        "function": {
+            "name": "search_files",
+            "description": "Search files",
+            "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}}},
+        },
+    }]
+    agent._chatgpt_web_forced_tool_call = {
+        "name": "search_files",
+        "arguments": {"pattern": "stream_chatgpt_web_completion", "target": "content", "path": "hermes_cli/chatgpt_web.py"},
+    }
+
+    response = agent._wrap_chatgpt_web_response({
+        "content": "I can't access the tool right now.",
+        "message_id": "msg_tool_3",
+        "model": "gpt-5-thinking",
+        "finish_reason": "stop",
+    })
+
+    message = response.choices[0].message
+    assert message.content == ""
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.tool_calls[0].function.name == "search_files"
+    assert message.tool_calls[0].function.arguments == '{"pattern": "stream_chatgpt_web_completion", "target": "content", "path": "hermes_cli/chatgpt_web.py"}'
+    assert agent._chatgpt_web_forced_tool_call is None
+
+
+
 def test_interruptible_api_call_chatgpt_web_returns_openai_like_response(monkeypatch):
     agent = _build_agent(monkeypatch)
 

--- a/tests/run_agent/test_run_agent_chatgpt_web.py
+++ b/tests/run_agent/test_run_agent_chatgpt_web.py
@@ -126,6 +126,47 @@ def test_interruptible_streaming_api_call_chatgpt_web_emits_deltas(monkeypatch):
     assert agent._chatgpt_web_parent_message_id == "msg_stream"
 
 
+def test_interruptible_streaming_api_call_chatgpt_web_fires_first_delta_without_text_arg(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    deltas = []
+    first_delta_calls = []
+    agent.stream_delta_callback = deltas.append
+
+    def _fake_stream(**kwargs):
+        on_delta = kwargs.get("on_delta")
+        assert on_delta is not None
+        on_delta("Hel")
+        on_delta("lo")
+        return {
+            "content": "Hello",
+            "conversation_id": "conv_first",
+            "parent_message_id": "msg_first",
+            "message_id": "msg_first",
+            "model": "gpt-5-thinking",
+            "finish_reason": "stop",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.chatgpt_web.stream_chatgpt_web_completion",
+        _fake_stream,
+    )
+
+    response = agent._interruptible_streaming_api_call(
+        {
+            "model": "gpt-5-thinking",
+            "messages": [{"role": "user", "content": "hi"}],
+            "conversation_id": None,
+            "parent_message_id": None,
+            "instructions": "Be concise.",
+        },
+        on_first_delta=lambda: first_delta_calls.append("fired"),
+    )
+
+    assert first_delta_calls == ["fired"]
+    assert deltas == ["Hel", "lo"]
+    assert response.choices[0].message.content == "Hello"
+
+
 def test_interruptible_api_call_chatgpt_web_closes_request_client_on_interrupt(monkeypatch):
     agent = _build_agent(monkeypatch)
     entered = threading.Event()

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -13,6 +13,7 @@ from tools.browser_tool import (
     _find_agent_browser,
     _run_browser_command,
     _SANE_PATH,
+    check_browser_requirements,
 )
 
 
@@ -147,6 +148,17 @@ class TestFindAgentBrowser:
              ):
             with pytest.raises(FileNotFoundError, match="agent-browser CLI not found"):
                 _find_agent_browser()
+
+
+class TestBrowserRequirements:
+    def test_termux_requires_real_agent_browser_install_not_npx_fallback(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: None)
+        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: "npx agent-browser")
+
+        assert check_browser_requirements() is False
 
 
 class TestRunBrowserCommandPathConstruction:

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -161,6 +161,20 @@ class TestBrowserRequirements:
         assert check_browser_requirements() is False
 
 
+class TestRunBrowserCommandTermuxFallback:
+    def test_termux_local_mode_rejects_bare_npx_fallback(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: "npx agent-browser")
+        monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: None)
+
+        result = _run_browser_command("task-1", "navigate", ["https://example.com"])
+
+        assert result["success"] is False
+        assert "bare npx fallback" in result["error"]
+        assert "agent-browser install" in result["error"]
+
+
 class TestRunBrowserCommandPathConstruction:
     """Verify _run_browser_command() includes Homebrew node dirs in subprocess PATH."""
 

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -44,6 +44,7 @@ from tools.code_execution_tool import (
     build_execute_code_schema,
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
+    _execute_remote,
 )
 
 
@@ -114,6 +115,48 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("def shell_quote(", src)
         self.assertIn("def retry(", src)
         self.assertIn("import json, os, socket, shlex, time", src)
+
+    def test_file_transport_uses_tempfile_fallback_for_rpc_dir(self):
+        src = generate_hermes_tools_module(["terminal"], transport="file")
+        self.assertIn("import json, os, shlex, tempfile, time", src)
+        self.assertIn("os.path.join(tempfile.gettempdir(), \"hermes_rpc\")", src)
+        self.assertNotIn('os.environ.get("HERMES_RPC_DIR", "/tmp/hermes_rpc")', src)
+
+
+class TestExecuteCodeRemoteTempDir(unittest.TestCase):
+    def test_execute_remote_uses_backend_temp_dir_for_sandbox(self):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def get_temp_dir(self):
+                return "/data/data/com.termux/files/usr/tmp"
+
+            def execute(self, command, cwd=None, timeout=None):
+                self.commands.append((command, cwd, timeout))
+                if "command -v python3" in command:
+                    return {"output": "OK\n"}
+                if "python3 script.py" in command:
+                    return {"output": "hello\n", "returncode": 0}
+                return {"output": ""}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
+             patch("tools.code_execution_tool._get_or_create_env", return_value=(env, "ssh")), \
+             patch("tools.code_execution_tool._ship_file_to_remote"), \
+             patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
+            result = json.loads(_execute_remote("print('hello')", "task-1", ["terminal"]))
+
+        self.assertEqual(result["status"], "success")
+        mkdir_cmd = env.commands[1][0]
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        cleanup_cmd = env.commands[-1][0]
+        self.assertIn("mkdir -p /data/data/com.termux/files/usr/tmp/hermes_exec_", mkdir_cmd)
+        self.assertIn("HERMES_RPC_DIR=/data/data/com.termux/files/usr/tmp/hermes_exec_", run_cmd)
+        self.assertIn("rm -rf /data/data/com.termux/files/usr/tmp/hermes_exec_", cleanup_cmd)
+        self.assertNotIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
 
 
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")

--- a/tests/tools/test_local_tempdir.py
+++ b/tests/tools/test_local_tempdir.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+from tools.environments.local import LocalEnvironment
+
+
+class TestLocalTempDir:
+    def test_uses_os_tmpdir_for_session_artifacts(self, monkeypatch):
+        monkeypatch.setenv("TMPDIR", "/data/data/com.termux/files/usr/tmp")
+        monkeypatch.delenv("TMP", raising=False)
+        monkeypatch.delenv("TEMP", raising=False)
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=".", timeout=10)
+
+        assert env.get_temp_dir() == "/data/data/com.termux/files/usr/tmp"
+        assert env._snapshot_path == f"/data/data/com.termux/files/usr/tmp/hermes-snap-{env._session_id}.sh"
+        assert env._cwd_file == f"/data/data/com.termux/files/usr/tmp/hermes-cwd-{env._session_id}.txt"
+
+    def test_prefers_backend_env_tmpdir_override(self, monkeypatch):
+        monkeypatch.delenv("TMPDIR", raising=False)
+        monkeypatch.delenv("TMP", raising=False)
+        monkeypatch.delenv("TEMP", raising=False)
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(
+                cwd=".",
+                timeout=10,
+                env={"TMPDIR": "/data/data/com.termux/files/home/.cache/hermes-tmp/"},
+            )
+
+        assert env.get_temp_dir() == "/data/data/com.termux/files/home/.cache/hermes-tmp"
+        assert env._snapshot_path == (
+            f"/data/data/com.termux/files/home/.cache/hermes-tmp/hermes-snap-{env._session_id}.sh"
+        )
+        assert env._cwd_file == (
+            f"/data/data/com.termux/files/home/.cache/hermes-tmp/hermes-cwd-{env._session_id}.txt"
+        )
+
+    def test_falls_back_to_tempfile_when_tmp_missing(self, monkeypatch):
+        monkeypatch.delenv("TMPDIR", raising=False)
+        monkeypatch.delenv("TMP", raising=False)
+        monkeypatch.delenv("TEMP", raising=False)
+
+        with patch("tools.environments.local.os.path.isdir", return_value=False), \
+             patch("tools.environments.local.os.access", return_value=False), \
+             patch("tools.environments.local.tempfile.gettempdir", return_value="/cache/tmp"), \
+             patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=".", timeout=10)
+            assert env.get_temp_dir() == "/cache/tmp"
+            assert env._snapshot_path == f"/cache/tmp/hermes-snap-{env._session_id}.sh"
+            assert env._cwd_file == f"/cache/tmp/hermes-cwd-{env._session_id}.txt"

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -136,6 +136,64 @@ class TestReadLog:
 
 
 # =========================================================================
+# Stdin helpers
+# =========================================================================
+
+class TestStdinHelpers:
+    def test_close_stdin_not_found(self, registry):
+        result = registry.close_stdin("nonexistent")
+        assert result["status"] == "not_found"
+
+    def test_close_stdin_pipe_mode(self, registry):
+        proc = MagicMock()
+        proc.stdin = MagicMock()
+        s = _make_session()
+        s.process = proc
+        registry._running[s.id] = s
+
+        result = registry.close_stdin(s.id)
+
+        proc.stdin.close.assert_called_once()
+        assert result["status"] == "ok"
+
+    def test_close_stdin_pty_mode(self, registry):
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+
+        result = registry.close_stdin(s.id)
+
+        pty.sendeof.assert_called_once()
+        assert result["status"] == "ok"
+
+    def test_close_stdin_allows_eof_driven_process_to_finish(self, registry, tmp_path):
+        session = registry.spawn_local(
+            'python3 -c "import sys; print(sys.stdin.read().strip())"',
+            cwd=str(tmp_path),
+            use_pty=False,
+        )
+
+        try:
+            time.sleep(0.5)
+            assert registry.submit_stdin(session.id, "hello")["status"] == "ok"
+            assert registry.close_stdin(session.id)["status"] == "ok"
+
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                poll = registry.poll(session.id)
+                if poll["status"] == "exited":
+                    assert poll["exit_code"] == 0
+                    assert "hello" in poll["output_preview"]
+                    return
+                time.sleep(0.2)
+
+            pytest.fail("process did not exit after stdin was closed")
+        finally:
+            registry.kill_process(session.id)
+
+
+# =========================================================================
 # List sessions
 # =========================================================================
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -340,6 +340,67 @@ class TestSpawnEnvSanitization:
         assert f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}TELEGRAM_BOT_TOKEN" not in env
         assert env["PYTHONUNBUFFERED"] == "1"
 
+    def test_spawn_via_env_uses_backend_temp_dir_for_artifacts(self, registry):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def get_temp_dir(self):
+                return "/data/data/com.termux/files/usr/tmp"
+
+            def execute(self, command, timeout=None):
+                self.commands.append((command, timeout))
+                return {"output": "4321\n"}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(env, "echo hello")
+
+        bg_command = env.commands[0][0]
+        assert session.pid == 4321
+        assert "/data/data/com.termux/files/usr/tmp/hermes_bg_" in bg_command
+        assert ".exit" in bg_command
+        assert "rc=$?;" in bg_command
+        assert " > /tmp/hermes_bg_" not in bg_command
+        assert "cat /tmp/hermes_bg_" not in bg_command
+        fake_thread.start.assert_called_once()
+
+    def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
+        session = _make_session(sid="proc_space")
+        session.exited = False
+
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+                self._responses = iter([
+                    {"output": "hello\n"},
+                    {"output": "1\n"},
+                    {"output": "0\n"},
+                ])
+
+            def execute(self, command, timeout=None):
+                self.commands.append((command, timeout))
+                return next(self._responses)
+
+        env = FakeEnv()
+
+        with patch("tools.process_registry.time.sleep", return_value=None), \
+            patch.object(registry, "_move_to_finished"):
+            registry._env_poller_loop(
+                session,
+                env,
+                "/path with spaces/hermes_bg.log",
+                "/path with spaces/hermes_bg.pid",
+                "/path with spaces/hermes_bg.exit",
+            )
+
+        assert env.commands[0][0] == "cat '/path with spaces/hermes_bg.log' 2>/dev/null"
+        assert env.commands[1][0] == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
+        assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
+
 
 # =========================================================================
 # Checkpoint

--- a/tests/tools/test_terminal_tool_pty_fallback.py
+++ b/tests/tools/test_terminal_tool_pty_fallback.py
@@ -1,0 +1,91 @@
+import json
+from types import SimpleNamespace
+
+import tools.terminal_tool as terminal_tool_module
+from tools import process_registry as process_registry_module
+
+
+def _base_config(tmp_path):
+    return {
+        "env_type": "local",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+        "cwd": str(tmp_path),
+        "timeout": 30,
+    }
+
+
+def test_command_requires_pipe_stdin_detects_gh_with_token():
+    assert terminal_tool_module._command_requires_pipe_stdin(
+        "gh auth login --hostname github.com --git-protocol https --with-token"
+    ) is True
+    assert terminal_tool_module._command_requires_pipe_stdin(
+        "gh auth login --web"
+    ) is False
+
+
+def test_terminal_background_disables_pty_for_gh_with_token(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(env={})
+    captured = {}
+
+    def fake_spawn_local(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id="proc_test", pid=1234, notify_on_complete=False)
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool_module, "_check_all_guards", lambda *_args, **_kwargs: {"approved": True})
+    monkeypatch.setattr(process_registry_module.process_registry, "spawn_local", fake_spawn_local)
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="gh auth login --hostname github.com --git-protocol https --with-token",
+                background=True,
+                pty=True,
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert captured["use_pty"] is False
+    assert result["session_id"] == "proc_test"
+    assert "PTY disabled" in result["pty_note"]
+
+
+def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(env={})
+    captured = {}
+
+    def fake_spawn_local(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id="proc_test", pid=1234, notify_on_complete=False)
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool_module, "_check_all_guards", lambda *_args, **_kwargs: {"approved": True})
+    monkeypatch.setattr(process_registry_module.process_registry, "spawn_local", fake_spawn_local)
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="python3 -c \"print(input())\"",
+                background=True,
+                pty=True,
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert captured["use_pty"] is True
+    assert "pty_note" not in result

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -16,6 +16,7 @@ from tools.tool_result_storage import (
     STORAGE_DIR,
     _build_persisted_message,
     _heredoc_marker,
+    _resolve_storage_dir,
     _write_to_sandbox,
     enforce_turn_budget,
     generate_preview,
@@ -114,6 +115,24 @@ class TestWriteToSandbox:
         env.execute.return_value = {"output": "", "returncode": 0}
         _write_to_sandbox("content", "/tmp/hermes-results/abc.txt", env)
         assert env.execute.call_args[1]["timeout"] == 30
+
+    def test_uses_parent_dir_of_remote_path(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        remote_path = "/data/data/com.termux/files/usr/tmp/hermes-results/abc.txt"
+        _write_to_sandbox("content", remote_path, env)
+        cmd = env.execute.call_args[0][0]
+        assert "mkdir -p /data/data/com.termux/files/usr/tmp/hermes-results" in cmd
+
+
+class TestResolveStorageDir:
+    def test_defaults_to_storage_dir_without_env(self):
+        assert _resolve_storage_dir(None) == STORAGE_DIR
+
+    def test_uses_env_temp_dir_when_available(self):
+        env = MagicMock()
+        env.get_temp_dir.return_value = "/data/data/com.termux/files/usr/tmp"
+        assert _resolve_storage_dir(env) == "/data/data/com.termux/files/usr/tmp/hermes-results"
 
 
 # ── _build_persisted_message ──────────────────────────────────────────
@@ -340,6 +359,22 @@ class TestMaybePersistToolResult:
             threshold=30_000,
         )
         assert "DISTINCTIVE_START_MARKER" in result
+
+    def test_env_temp_dir_changes_persisted_path(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        env.get_temp_dir.return_value = "/data/data/com.termux/files/usr/tmp"
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_termux",
+            env=env,
+            threshold=30_000,
+        )
+        assert "/data/data/com.termux/files/usr/tmp/hermes-results/tc_termux.txt" in result
+        cmd = env.execute.call_args[0][0]
+        assert "mkdir -p /data/data/com.termux/files/usr/tmp/hermes-results" in cmd
 
     def test_threshold_zero_forces_persist(self):
         env = MagicMock()

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -183,6 +183,21 @@ class TestDetectAudioEnvironment:
         assert result["available"] is False
         assert any("PortAudio" in w for w in result["warnings"])
 
+    def test_termux_import_error_shows_termux_install_guidance(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (_ for _ in ()).throw(ImportError("no audio libs")))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is False
+        assert any("pkg install python-numpy portaudio" in w for w in result["warnings"])
+        assert any("python -m pip install sounddevice" in w for w in result["warnings"])
+
 
 # ============================================================================
 # check_voice_requirements

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -199,11 +199,42 @@ class TestDetectAudioEnvironment:
         assert any("python -m pip install sounddevice" in w for w in result["warnings"])
 
 
+    def test_termux_api_microphone_allows_voice_without_sounddevice(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.setattr("tools.voice_mode.shutil.which", lambda cmd: "/data/data/com.termux/files/usr/bin/termux-microphone-record" if cmd == "termux-microphone-record" else None)
+        monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (_ for _ in ()).throw(ImportError("no audio libs")))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is True
+        assert any("Termux:API microphone recording available" in n for n in result.get("notices", []))
+        assert result["warnings"] == []
+
+
 # ============================================================================
 # check_voice_requirements
 # ============================================================================
 
 class TestCheckVoiceRequirements:
+    def test_termux_api_capture_counts_as_audio_available(self, monkeypatch):
+        monkeypatch.setattr("tools.voice_mode._audio_available", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode.detect_audio_environment", lambda: {"available": True, "warnings": [], "notices": ["Termux:API microphone recording available"]})
+        monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "openai")
+
+        from tools.voice_mode import check_voice_requirements
+        result = check_voice_requirements()
+
+        assert result["available"] is True
+        assert result["audio_available"] is True
+        assert result["missing_packages"] == []
+        assert "Termux:API microphone" in result["details"]
+
     def test_all_requirements_met(self, monkeypatch):
         monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
         monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
@@ -250,8 +281,71 @@ class TestCheckVoiceRequirements:
 # AudioRecorder
 # ============================================================================
 
-class TestAudioRecorderStart:
-    def test_start_raises_without_audio(self, monkeypatch):
+class TestCreateAudioRecorder:
+    def test_termux_uses_termux_audio_recorder_when_api_present(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+
+        from tools.voice_mode import create_audio_recorder, TermuxAudioRecorder
+        recorder = create_audio_recorder()
+
+        assert isinstance(recorder, TermuxAudioRecorder)
+        assert recorder.supports_silence_autostop is False
+
+
+class TestTermuxAudioRecorder:
+    def test_start_and_stop_use_termux_microphone_commands(self, monkeypatch, temp_voice_dir):
+        command_calls = []
+        output_path = Path(temp_voice_dir) / "recording_20260409_120000.aac"
+
+        def fake_run(cmd, **kwargs):
+            command_calls.append(cmd)
+            if cmd[1] == "-f":
+                Path(cmd[2]).write_bytes(b"aac-bytes")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode.time.strftime", lambda fmt: "20260409_120000")
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", fake_run)
+
+        from tools.voice_mode import TermuxAudioRecorder
+        recorder = TermuxAudioRecorder()
+        recorder.start()
+        recorder._start_time = time.monotonic() - 1.0
+        result = recorder.stop()
+
+        assert result == str(output_path)
+        assert command_calls[0][:2] == ["/data/data/com.termux/files/usr/bin/termux-microphone-record", "-f"]
+        assert command_calls[1] == ["/data/data/com.termux/files/usr/bin/termux-microphone-record", "-q"]
+
+    def test_cancel_removes_partial_termux_recording(self, monkeypatch, temp_voice_dir):
+        output_path = Path(temp_voice_dir) / "recording_20260409_120000.aac"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[1] == "-f":
+                Path(cmd[2]).write_bytes(b"aac-bytes")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode.time.strftime", lambda fmt: "20260409_120000")
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", fake_run)
+
+        from tools.voice_mode import TermuxAudioRecorder
+        recorder = TermuxAudioRecorder()
+        recorder.start()
+        recorder.cancel()
+
+        assert output_path.exists() is False
+        assert recorder.is_recording is False
+
+
+class TestAudioRecorder:
+    def test_start_raises_without_audio_libs(self, monkeypatch):
         def _fail_import():
             raise ImportError("no sounddevice")
         monkeypatch.setattr("tools.voice_mode._import_audio", _fail_import)

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -190,6 +190,7 @@ class TestDetectAudioEnvironment:
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.delenv("SSH_CONNECTION", raising=False)
         monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (_ for _ in ()).throw(ImportError("no audio libs")))
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: None)
 
         from tools.voice_mode import detect_audio_environment
         result = detect_audio_environment()
@@ -197,6 +198,22 @@ class TestDetectAudioEnvironment:
         assert result["available"] is False
         assert any("pkg install python-numpy portaudio" in w for w in result["warnings"])
         assert any("python -m pip install sounddevice" in w for w in result["warnings"])
+
+    def test_termux_api_package_without_android_app_blocks_voice(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (_ for _ in ()).throw(ImportError("no audio libs")))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is False
+        assert any("Termux:API Android app is not installed" in w for w in result["warnings"])
 
 
     def test_termux_api_microphone_allows_voice_without_sounddevice(self, monkeypatch):
@@ -206,6 +223,7 @@ class TestDetectAudioEnvironment:
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.delenv("SSH_CONNECTION", raising=False)
         monkeypatch.setattr("tools.voice_mode.shutil.which", lambda cmd: "/data/data/com.termux/files/usr/bin/termux-microphone-record" if cmd == "termux-microphone-record" else None)
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
         monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (_ for _ in ()).throw(ImportError("no audio libs")))
 
         from tools.voice_mode import detect_audio_environment
@@ -224,6 +242,7 @@ class TestCheckVoiceRequirements:
     def test_termux_api_capture_counts_as_audio_available(self, monkeypatch):
         monkeypatch.setattr("tools.voice_mode._audio_available", lambda: False)
         monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
         monkeypatch.setattr("tools.voice_mode.detect_audio_environment", lambda: {"available": True, "warnings": [], "notices": ["Termux:API microphone recording available"]})
         monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "openai")
 
@@ -286,12 +305,24 @@ class TestCreateAudioRecorder:
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
         monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
 
         from tools.voice_mode import create_audio_recorder, TermuxAudioRecorder
         recorder = create_audio_recorder()
 
         assert isinstance(recorder, TermuxAudioRecorder)
         assert recorder.supports_silence_autostop is False
+
+    def test_termux_without_android_app_falls_back_to_audio_recorder(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: False)
+
+        from tools.voice_mode import create_audio_recorder, AudioRecorder
+        recorder = create_audio_recorder()
+
+        assert isinstance(recorder, AudioRecorder)
 
 
 class TestTermuxAudioRecorder:
@@ -308,6 +339,7 @@ class TestTermuxAudioRecorder:
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
         monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
         monkeypatch.setattr("tools.voice_mode.time.strftime", lambda fmt: "20260409_120000")
         monkeypatch.setattr("tools.voice_mode.subprocess.run", fake_run)
 
@@ -332,6 +364,7 @@ class TestTermuxAudioRecorder:
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
         monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
         monkeypatch.setattr("tools.voice_mode.time.strftime", lambda fmt: "20260409_120000")
         monkeypatch.setattr("tools.voice_mode.subprocess.run", fake_run)
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -285,6 +285,17 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
     return _cached_cloud_provider
 
 
+def _is_termux_environment() -> bool:
+    prefix = os.getenv("PREFIX", "")
+    return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
+
+
+def _browser_install_hint() -> str:
+    if _is_termux_environment():
+        return "npm install -g agent-browser && agent-browser install"
+    return "npm install -g agent-browser && agent-browser install --with-deps"
+
+
 def _is_local_mode() -> bool:
     """Return True when the browser tool will use a local browser backend."""
     if _get_cdp_override():
@@ -796,7 +807,8 @@ def _find_agent_browser() -> str:
         return "npx agent-browser"
     
     raise FileNotFoundError(
-        "agent-browser CLI not found. Install it with: npm install -g agent-browser\n"
+        "agent-browser CLI not found. Install it with: "
+        f"{_browser_install_hint()}\n"
         "Or run 'npm install' in the repo root to install locally.\n"
         "Or ensure npx is available in your PATH."
     )
@@ -2040,8 +2052,15 @@ def check_browser_requirements() -> bool:
 
     # The agent-browser CLI is always required
     try:
-        _find_agent_browser()
+        browser_cmd = _find_agent_browser()
     except FileNotFoundError:
+        return False
+
+    # On Termux, the bare npx fallback is too fragile to treat as a satisfied
+    # local browser dependency. Require a real install (global or local) so the
+    # browser tool is not advertised as available when it will likely fail on
+    # first use.
+    if _is_termux_environment() and _is_local_mode() and browser_cmd.strip() == "npx agent-browser":
         return False
 
     # In cloud mode, also require provider credentials

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -296,6 +296,17 @@ def _browser_install_hint() -> str:
     return "npm install -g agent-browser && agent-browser install --with-deps"
 
 
+def _requires_real_termux_browser_install(browser_cmd: str) -> bool:
+    return _is_termux_environment() and _is_local_mode() and browser_cmd.strip() == "npx agent-browser"
+
+
+def _termux_browser_install_error() -> str:
+    return (
+        "Local browser automation on Termux cannot rely on the bare npx fallback. "
+        f"Install agent-browser explicitly first: {_browser_install_hint()}"
+    )
+
+
 def _is_local_mode() -> bool:
     """Return True when the browser tool will use a local browser backend."""
     if _get_cdp_override():
@@ -864,6 +875,11 @@ def _run_browser_command(
     except FileNotFoundError as e:
         logger.warning("agent-browser CLI not found: %s", e)
         return {"success": False, "error": str(e)}
+
+    if _requires_real_termux_browser_install(browser_cmd):
+        error = _termux_browser_install_error()
+        logger.warning("browser command blocked on Termux: %s", error)
+        return {"success": False, "error": error}
     
     from tools.interrupt import is_interrupted
     if is_interrupted():
@@ -2060,7 +2076,7 @@ def check_browser_requirements() -> bool:
     # local browser dependency. Require a real install (global or local) so the
     # browser tool is not advertised as available when it will likely fail on
     # first use.
-    if _is_termux_environment() and _is_local_mode() and browser_cmd.strip() == "npx agent-browser":
+    if _requires_real_termux_browser_install(browser_cmd):
         return False
 
     # In cloud mode, also require provider credentials
@@ -2092,10 +2108,13 @@ if __name__ == "__main__":
     else:
         print("❌ Missing requirements:")
         try:
-            _find_agent_browser()
+            browser_cmd = _find_agent_browser()
+            if _requires_real_termux_browser_install(browser_cmd):
+                print("   - bare npx fallback found (insufficient on Termux local mode)")
+                print(f"     Install: {_browser_install_hint()}")
         except FileNotFoundError:
             print("   - agent-browser CLI not found")
-            print("     Install: npm install -g agent-browser && agent-browser install --with-deps")
+            print(f"     Install: {_browser_install_hint()}")
         if _cp is not None and not _cp.is_configured():
             print(f"   - {_cp.provider_name()} credentials not configured")
             print("   Tip: set browser.cloud_provider to 'local' to use free local mode instead")

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import platform
+import shlex
 import signal
 import socket
 import subprocess
@@ -246,9 +247,9 @@ def _call(tool_name, args):
 
 _FILE_TRANSPORT_HEADER = '''\
 """Auto-generated Hermes tools RPC stubs (file-based transport)."""
-import json, os, shlex, time
+import json, os, shlex, tempfile, time
 
-_RPC_DIR = os.environ.get("HERMES_RPC_DIR", "/tmp/hermes_rpc")
+_RPC_DIR = os.environ.get("HERMES_RPC_DIR") or os.path.join(tempfile.gettempdir(), "hermes_rpc")
 _seq = 0
 ''' + _COMMON_HELPERS + '''\
 
@@ -536,11 +537,28 @@ def _ship_file_to_remote(env, remote_path: str, content: str) -> None:
     quotes are fine.
     """
     encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    quoted_remote_path = shlex.quote(remote_path)
     env.execute(
-        f"echo '{encoded}' | base64 -d > {remote_path}",
+        f"echo '{encoded}' | base64 -d > {quoted_remote_path}",
         cwd="/",
         timeout=30,
     )
+
+
+def _env_temp_dir(env: Any) -> str:
+    """Return a writable temp dir for env-backed execute_code sandboxes."""
+    get_temp_dir = getattr(env, "get_temp_dir", None)
+    if callable(get_temp_dir):
+        try:
+            temp_dir = get_temp_dir()
+            if isinstance(temp_dir, str) and temp_dir.startswith("/"):
+                return temp_dir.rstrip("/") or "/"
+        except Exception as exc:
+            logger.debug("Could not resolve execute_code env temp dir: %s", exc)
+    candidate = tempfile.gettempdir()
+    if isinstance(candidate, str) and candidate.startswith("/"):
+        return candidate.rstrip("/") or "/"
+    return "/tmp"
 
 
 def _rpc_poll_loop(
@@ -563,11 +581,12 @@ def _rpc_poll_loop(
 
     poll_interval = 0.1  # 100 ms
 
+    quoted_rpc_dir = shlex.quote(rpc_dir)
     while not stop_event.is_set():
         try:
             # List pending request files (skip .tmp partials)
             ls_result = env.execute(
-                f"ls -1 {rpc_dir}/req_* 2>/dev/null || true",
+                f"ls -1 {quoted_rpc_dir}/req_* 2>/dev/null || true",
                 cwd="/",
                 timeout=10,
             )
@@ -589,9 +608,10 @@ def _rpc_poll_loop(
 
                 call_start = time.monotonic()
 
+                quoted_req_file = shlex.quote(req_file)
                 # Read request
                 read_result = env.execute(
-                    f"cat {req_file}",
+                    f"cat {quoted_req_file}",
                     cwd="/",
                     timeout=10,
                 )
@@ -600,7 +620,7 @@ def _rpc_poll_loop(
                 except (json.JSONDecodeError, ValueError):
                     logger.debug("Malformed RPC request in %s", req_file)
                     # Remove bad request to avoid infinite retry
-                    env.execute(f"rm -f {req_file}", cwd="/", timeout=5)
+                    env.execute(f"rm -f {quoted_req_file}", cwd="/", timeout=5)
                     continue
 
                 tool_name = request.get("tool", "")
@@ -608,6 +628,7 @@ def _rpc_poll_loop(
                 seq = request.get("seq", 0)
                 seq_str = f"{seq:06d}"
                 res_file = f"{rpc_dir}/res_{seq_str}"
+                quoted_res_file = shlex.quote(res_file)
 
                 # Enforce allow-list
                 if tool_name not in allowed_tools:
@@ -665,14 +686,14 @@ def _rpc_poll_loop(
                     tool_result.encode("utf-8")
                 ).decode("ascii")
                 env.execute(
-                    f"echo '{encoded_result}' | base64 -d > {res_file}.tmp"
-                    f" && mv {res_file}.tmp {res_file}",
+                    f"echo '{encoded_result}' | base64 -d > {quoted_res_file}.tmp"
+                    f" && mv {quoted_res_file}.tmp {quoted_res_file}",
                     cwd="/",
                     timeout=60,
                 )
 
                 # Remove the request file
-                env.execute(f"rm -f {req_file}", cwd="/", timeout=5)
+                env.execute(f"rm -f {quoted_req_file}", cwd="/", timeout=5)
 
         except Exception as e:
             if not stop_event.is_set():
@@ -707,7 +728,10 @@ def _execute_remote(
     env, env_type = _get_or_create_env(effective_task_id)
 
     sandbox_id = uuid.uuid4().hex[:12]
-    sandbox_dir = f"/tmp/hermes_exec_{sandbox_id}"
+    temp_dir = _env_temp_dir(env)
+    sandbox_dir = f"{temp_dir}/hermes_exec_{sandbox_id}"
+    quoted_sandbox_dir = shlex.quote(sandbox_dir)
+    quoted_rpc_dir = shlex.quote(f"{sandbox_dir}/rpc")
 
     tool_call_log: list = []
     tool_call_counter = [0]
@@ -735,7 +759,7 @@ def _execute_remote(
 
         # Create sandbox directory on remote
         env.execute(
-            f"mkdir -p {sandbox_dir}/rpc", cwd="/", timeout=10,
+            f"mkdir -p {quoted_rpc_dir}", cwd="/", timeout=10,
         )
 
         # Generate and ship files
@@ -759,7 +783,7 @@ def _execute_remote(
 
         # Build environment variable prefix for the script
         env_prefix = (
-            f"HERMES_RPC_DIR={sandbox_dir}/rpc "
+            f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
             f"PYTHONDONTWRITEBYTECODE=1"
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
@@ -770,7 +794,7 @@ def _execute_remote(
         logger.info("Executing code on %s backend (task %s)...",
                      env_type, effective_task_id[:8])
         script_result = env.execute(
-            f"cd {sandbox_dir} && {env_prefix} python3 script.py",
+            f"cd {quoted_sandbox_dir} && {env_prefix} python3 script.py",
             timeout=timeout,
         )
 
@@ -807,7 +831,7 @@ def _execute_remote(
         # Clean up remote sandbox dir
         try:
             env.execute(
-                f"rm -rf {sandbox_dir}", cwd="/", timeout=15,
+                f"rm -rf {quoted_sandbox_dir}", cwd="/", timeout=15,
             )
         except Exception:
             logger.debug("Failed to clean up remote sandbox %s", sandbox_dir)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -226,14 +226,24 @@ class BaseEnvironment(ABC):
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
 
+    def get_temp_dir(self) -> str:
+        """Return the backend temp directory used for session artifacts.
+
+        Most sandboxed backends use ``/tmp`` inside the target environment.
+        LocalEnvironment overrides this on platforms like Termux where ``/tmp``
+        may be missing and ``TMPDIR`` is the portable writable location.
+        """
+        return "/tmp"
+
     def __init__(self, cwd: str, timeout: int, env: dict = None):
         self.cwd = cwd
         self.timeout = timeout
         self.env = env or {}
 
         self._session_id = uuid.uuid4().hex[:12]
-        self._snapshot_path = f"/tmp/hermes-snap-{self._session_id}.sh"
-        self._cwd_file = f"/tmp/hermes-cwd-{self._session_id}.txt"
+        temp_dir = self.get_temp_dir().rstrip("/") or "/"
+        self._snapshot_path = f"{temp_dir}/hermes-snap-{self._session_id}.sh"
+        self._cwd_file = f"{temp_dir}/hermes-cwd-{self._session_id}.txt"
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
         self._last_sync_time: float | None = (

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -5,6 +5,7 @@ import platform
 import shutil
 import signal
 import subprocess
+import tempfile
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 
@@ -208,6 +209,32 @@ class LocalEnvironment(BaseEnvironment):
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
         self.init_session()
+
+    def get_temp_dir(self) -> str:
+        """Return a shell-safe writable temp dir for local execution.
+
+        Termux does not provide /tmp by default, but exposes a POSIX TMPDIR.
+        Prefer POSIX-style env vars when available, keep using /tmp on regular
+        Unix systems, and only fall back to tempfile.gettempdir() when it also
+        resolves to a POSIX path.
+
+        Check the environment configured for this backend first so callers can
+        override the temp root explicitly (for example via terminal.env or a
+        custom TMPDIR), then fall back to the host process environment.
+        """
+        for env_var in ("TMPDIR", "TMP", "TEMP"):
+            candidate = self.env.get(env_var) or os.environ.get(env_var)
+            if candidate and candidate.startswith("/"):
+                return candidate.rstrip("/") or "/"
+
+        if os.path.isdir("/tmp") and os.access("/tmp", os.W_OK | os.X_OK):
+            return "/tmp"
+
+        candidate = tempfile.gettempdir()
+        if candidate.startswith("/"):
+            return candidate.rstrip("/") or "/"
+
+        return "/tmp"
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -700,6 +700,29 @@ class ProcessRegistry:
         """Send data + newline to a running process's stdin (like pressing Enter)."""
         return self.write_stdin(session_id, data + "\n")
 
+    def close_stdin(self, session_id: str) -> dict:
+        """Close a running process's stdin / send EOF without killing the process."""
+        session = self.get(session_id)
+        if session is None:
+            return {"status": "not_found", "error": f"No process with ID {session_id}"}
+        if session.exited:
+            return {"status": "already_exited", "error": "Process has already finished"}
+
+        if hasattr(session, '_pty') and session._pty:
+            try:
+                session._pty.sendeof()
+                return {"status": "ok", "message": "EOF sent"}
+            except Exception as e:
+                return {"status": "error", "error": str(e)}
+
+        if not session.process or not session.process.stdin:
+            return {"status": "error", "error": "Process stdin not available (non-local backend or stdin closed)"}
+        try:
+            session.process.stdin.close()
+            return {"status": "ok", "message": "stdin closed"}
+        except Exception as e:
+            return {"status": "error", "error": str(e)}
+
     def list_sessions(self, task_id: str = None) -> list:
         """List all running and recently-finished processes."""
         with self._lock:
@@ -915,14 +938,14 @@ PROCESS_SCHEMA = {
         "Actions: 'list' (show all), 'poll' (check status + new output), "
         "'log' (full output with pagination), 'wait' (block until done or timeout), "
         "'kill' (terminate), 'write' (send raw stdin data without newline), "
-        "'submit' (send data + Enter, for answering prompts)."
+        "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF)."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit"],
+                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit", "close"],
                 "description": "Action to perform on background processes"
             },
             "session_id": {
@@ -962,7 +985,7 @@ def _handle_process(args, **kw):
 
     if action == "list":
         return _json.dumps({"processes": process_registry.list_sessions(task_id=task_id)}, ensure_ascii=False)
-    elif action in ("poll", "log", "wait", "kill", "write", "submit"):
+    elif action in ("poll", "log", "wait", "kill", "write", "submit", "close"):
         if not session_id:
             return tool_error(f"session_id is required for {action}")
         if action == "poll":
@@ -978,7 +1001,9 @@ def _handle_process(args, **kw):
             return _json.dumps(process_registry.write_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
         elif action == "submit":
             return _json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
-    return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit")
+        elif action == "close":
+            return _json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
+    return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
 
 
 registry.register(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -172,6 +172,19 @@ class ProcessRegistry:
 
     # ----- Spawn -----
 
+    @staticmethod
+    def _env_temp_dir(env: Any) -> str:
+        """Return the writable sandbox temp dir for env-backed background tasks."""
+        get_temp_dir = getattr(env, "get_temp_dir", None)
+        if callable(get_temp_dir):
+            try:
+                temp_dir = get_temp_dir()
+                if isinstance(temp_dir, str) and temp_dir.startswith("/"):
+                    return temp_dir.rstrip("/") or "/"
+            except Exception as exc:
+                logger.debug("Could not resolve environment temp dir: %s", exc)
+        return "/tmp"
+
     def spawn_local(
         self,
         command: str,
@@ -316,12 +329,20 @@ class ProcessRegistry:
         )
 
         # Run the command in the sandbox with output capture
-        log_path = f"/tmp/hermes_bg_{session.id}.log"
-        pid_path = f"/tmp/hermes_bg_{session.id}.pid"
+        temp_dir = self._env_temp_dir(env)
+        log_path = f"{temp_dir}/hermes_bg_{session.id}.log"
+        pid_path = f"{temp_dir}/hermes_bg_{session.id}.pid"
+        exit_path = f"{temp_dir}/hermes_bg_{session.id}.exit"
         quoted_command = shlex.quote(command)
+        quoted_temp_dir = shlex.quote(temp_dir)
+        quoted_log_path = shlex.quote(log_path)
+        quoted_pid_path = shlex.quote(pid_path)
+        quoted_exit_path = shlex.quote(exit_path)
         bg_command = (
-            f"nohup bash -c {quoted_command} > {log_path} 2>&1 & "
-            f"echo $! > {pid_path} && cat {pid_path}"
+            f"mkdir -p {quoted_temp_dir} && "
+            f"( nohup bash -lc {quoted_command} > {quoted_log_path} 2>&1; "
+            f"rc=$?; printf '%s\\n' \"$rc\" > {quoted_exit_path} ) & "
+            f"echo $! > {quoted_pid_path} && cat {quoted_pid_path}"
         )
 
         try:
@@ -342,7 +363,7 @@ class ProcessRegistry:
             # Start a poller thread that periodically reads the log file
             reader = threading.Thread(
                 target=self._env_poller_loop,
-                args=(session, env, log_path, pid_path),
+                args=(session, env, log_path, pid_path, exit_path),
                 daemon=True,
                 name=f"proc-poller-{session.id}",
             )
@@ -386,14 +407,17 @@ class ProcessRegistry:
         self._move_to_finished(session)
 
     def _env_poller_loop(
-        self, session: ProcessSession, env: Any, log_path: str, pid_path: str
+        self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str
     ):
         """Background thread: poll a sandbox log file for non-local backends."""
+        quoted_log_path = shlex.quote(log_path)
+        quoted_pid_path = shlex.quote(pid_path)
+        quoted_exit_path = shlex.quote(exit_path)
         while not session.exited:
             time.sleep(2)  # Poll every 2 seconds
             try:
                 # Read new output from the log file
-                result = env.execute(f"cat {log_path} 2>/dev/null", timeout=10)
+                result = env.execute(f"cat {quoted_log_path} 2>/dev/null", timeout=10)
                 new_output = result.get("output", "")
                 if new_output:
                     with session._lock:
@@ -403,14 +427,14 @@ class ProcessRegistry:
 
                 # Check if process is still running
                 check = env.execute(
-                    f"kill -0 $(cat {pid_path} 2>/dev/null) 2>/dev/null; echo $?",
+                    f"kill -0 \"$(cat {quoted_pid_path} 2>/dev/null)\" 2>/dev/null; echo $?",
                     timeout=5,
                 )
                 check_output = check.get("output", "").strip()
                 if check_output and check_output.splitlines()[-1].strip() != "0":
-                    # Process has exited -- get exit code
+                    # Process has exited -- get exit code captured by the wrapper shell.
                     exit_result = env.execute(
-                        f"wait $(cat {pid_path} 2>/dev/null) 2>/dev/null; echo $?",
+                        f"cat {quoted_exit_path} 2>/dev/null",
                         timeout=5,
                     )
                     exit_str = exit_result.get("output", "").strip()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1023,6 +1023,21 @@ def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     return None
 
 
+def _command_requires_pipe_stdin(command: str) -> bool:
+    """Return True when PTY mode would break stdin-driven commands.
+
+    Some CLIs change behavior when stdin is a TTY. In particular,
+    `gh auth login --with-token` expects the token to arrive via piped stdin and
+    waits for EOF; when we launch it under a PTY, `process.submit()` only sends a
+    newline, so the command appears to hang forever with no visible progress.
+    """
+    normalized = " ".join(command.lower().split())
+    return (
+        normalized.startswith("gh auth login")
+        and "--with-token" in normalized
+    )
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -1243,6 +1258,17 @@ def terminal_tool(
                 }, ensure_ascii=False)
 
         # Prepare command for execution
+        pty_disabled_reason = None
+        effective_pty = pty
+        if pty and _command_requires_pipe_stdin(command):
+            effective_pty = False
+            pty_disabled_reason = (
+                "PTY disabled for this command because it expects piped stdin/EOF "
+                "(for example gh auth login --with-token). For local background "
+                "processes, call process(action='close') after writing so it receives "
+                "EOF."
+            )
+
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
@@ -1260,7 +1286,7 @@ def terminal_tool(
                         task_id=effective_task_id,
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
-                        use_pty=pty,
+                        use_pty=effective_pty,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -1280,6 +1306,8 @@ def terminal_tool(
                 }
                 if approval_note:
                     result_data["approval"] = approval_note
+                if pty_disabled_reason:
+                    result_data["pty_note"] = pty_disabled_reason
 
                 # Transparent timeout clamping note
                 max_timeout = effective_timeout

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -9,9 +9,11 @@ Defense against context-window overflow operates at three levels:
 2. **Per-result persistence** (maybe_persist_tool_result): After a tool
    returns, if its output exceeds the tool's registered threshold
    (registry.get_max_result_size), the full output is written INTO THE
-   SANDBOX at /tmp/hermes-results/{tool_use_id}.txt via env.execute().
-   The in-context content is replaced with a preview + file path reference.
-   The model can read_file to access the full output on any backend.
+   SANDBOX temp dir (for example /tmp/hermes-results/{tool_use_id}.txt on
+   standard Linux, or $TMPDIR/hermes-results/{tool_use_id}.txt on Termux)
+   via env.execute(). The in-context content is replaced with a preview +
+   file path reference. The model can read_file to access the full output
+   on any backend.
 
 3. **Per-turn aggregate budget** (enforce_turn_budget): After all tool
    results in a single assistant turn are collected, if the total exceeds
@@ -21,6 +23,7 @@ Defense against context-window overflow operates at three levels:
 """
 
 import logging
+import os
 import uuid
 
 from tools.budget_config import (
@@ -35,6 +38,22 @@ PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+
+
+def _resolve_storage_dir(env) -> str:
+    """Return the best temp-backed storage dir for this environment."""
+    if env is not None:
+        get_temp_dir = getattr(env, "get_temp_dir", None)
+        if callable(get_temp_dir):
+            try:
+                temp_dir = get_temp_dir()
+            except Exception as exc:
+                logger.debug("Could not resolve env temp dir: %s", exc)
+            else:
+                if temp_dir:
+                    temp_dir = temp_dir.rstrip("/") or "/"
+                    return f"{temp_dir}/hermes-results"
+    return STORAGE_DIR
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
@@ -58,8 +77,9 @@ def _heredoc_marker(content: str) -> str:
 def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     """Write content into the sandbox via env.execute(). Returns True on success."""
     marker = _heredoc_marker(content)
+    storage_dir = os.path.dirname(remote_path)
     cmd = (
-        f"mkdir -p {STORAGE_DIR} && cat > {remote_path} << '{marker}'\n"
+        f"mkdir -p {storage_dir} && cat > {remote_path} << '{marker}'\n"
         f"{content}\n"
         f"{marker}"
     )
@@ -125,7 +145,8 @@ def maybe_persist_tool_result(
     if len(content) <= effective_threshold:
         return content
 
-    remote_path = f"{STORAGE_DIR}/{tool_use_id}.txt"
+    storage_dir = _resolve_storage_dir(env)
+    remote_path = f"{storage_dir}/{tool_use_id}.txt"
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
     if env is not None:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -48,6 +48,17 @@ def _audio_available() -> bool:
         return False
 
 
+def _is_termux_environment() -> bool:
+    prefix = os.getenv("PREFIX", "")
+    return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
+
+
+def _voice_capture_install_hint() -> str:
+    if _is_termux_environment():
+        return "pkg install python-numpy portaudio && python -m pip install sounddevice"
+    return "pip install sounddevice numpy"
+
+
 def detect_audio_environment() -> dict:
     """Detect if the current environment supports audio I/O.
 
@@ -98,14 +109,21 @@ def detect_audio_environment() -> dict:
             else:
                 warnings.append("Audio subsystem error (PortAudio cannot query devices)")
     except ImportError:
-        warnings.append("Audio libraries not installed (pip install sounddevice numpy)")
+        warnings.append(f"Audio libraries not installed ({_voice_capture_install_hint()})")
     except OSError:
-        warnings.append(
-            "PortAudio system library not found -- install it first:\n"
-            "  Linux:  sudo apt-get install libportaudio2\n"
-            "  macOS:  brew install portaudio\n"
-            "Then retry /voice on."
-        )
+        if _is_termux_environment():
+            warnings.append(
+                "PortAudio system library not found -- install it first:\n"
+                "  Termux: pkg install portaudio\n"
+                "Then retry /voice on."
+            )
+        else:
+            warnings.append(
+                "PortAudio system library not found -- install it first:\n"
+                "  Linux:  sudo apt-get install libportaudio2\n"
+                "  macOS:  brew install portaudio\n"
+                "Then retry /voice on."
+            )
 
     return {
         "available": not warnings,
@@ -748,7 +766,7 @@ def check_voice_requirements() -> Dict[str, Any]:
     if has_audio:
         details_parts.append("Audio capture: OK")
     else:
-        details_parts.append("Audio capture: MISSING (pip install sounddevice numpy)")
+        details_parts.append(f"Audio capture: MISSING ({_voice_capture_install_hint()})")
 
     if not stt_enabled:
         details_parts.append("STT provider: DISABLED in config (stt.enabled: false)")

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -59,6 +59,22 @@ def _voice_capture_install_hint() -> str:
     return "pip install sounddevice numpy"
 
 
+def _termux_microphone_command() -> Optional[str]:
+    if not _is_termux_environment():
+        return None
+    return shutil.which("termux-microphone-record")
+
+
+def _termux_media_player_command() -> Optional[str]:
+    if not _is_termux_environment():
+        return None
+    return shutil.which("termux-media-player")
+
+
+def _termux_voice_capture_available() -> bool:
+    return _termux_microphone_command() is not None
+
+
 def detect_audio_environment() -> dict:
     """Detect if the current environment supports audio I/O.
 
@@ -68,6 +84,7 @@ def detect_audio_environment() -> dict:
     """
     warnings = []   # hard-fail: these block voice mode
     notices = []     # informational: logged but don't block
+    termux_capture = _termux_voice_capture_available()
 
     # SSH detection
     if any(os.environ.get(v) for v in ('SSH_CLIENT', 'SSH_TTY', 'SSH_CONNECTION')):
@@ -100,18 +117,28 @@ def detect_audio_environment() -> dict:
         try:
             devices = sd.query_devices()
             if not devices:
-                warnings.append("No audio input/output devices detected")
+                if termux_capture:
+                    notices.append("No PortAudio devices detected, but Termux:API microphone capture is available")
+                else:
+                    warnings.append("No audio input/output devices detected")
         except Exception:
             # In WSL with PulseAudio, device queries can fail even though
             # recording/playback works fine. Don't block if PULSE_SERVER is set.
             if os.environ.get('PULSE_SERVER'):
                 notices.append("Audio device query failed but PULSE_SERVER is set -- continuing")
+            elif termux_capture:
+                notices.append("PortAudio device query failed, but Termux:API microphone capture is available")
             else:
                 warnings.append("Audio subsystem error (PortAudio cannot query devices)")
     except ImportError:
-        warnings.append(f"Audio libraries not installed ({_voice_capture_install_hint()})")
+        if termux_capture:
+            notices.append("Termux:API microphone recording available (sounddevice not required)")
+        else:
+            warnings.append(f"Audio libraries not installed ({_voice_capture_install_hint()})")
     except OSError:
-        if _is_termux_environment():
+        if termux_capture:
+            notices.append("Termux:API microphone recording available (PortAudio not required)")
+        elif _is_termux_environment():
             warnings.append(
                 "PortAudio system library not found -- install it first:\n"
                 "  Termux: pkg install portaudio\n"
@@ -193,6 +220,129 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
 
 
 # ============================================================================
+# Termux Audio Recorder
+# ============================================================================
+class TermuxAudioRecorder:
+    """Recorder backend that uses Termux:API microphone capture commands."""
+
+    supports_silence_autostop = False
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._recording = False
+        self._start_time = 0.0
+        self._recording_path: Optional[str] = None
+        self._current_rms = 0
+
+    @property
+    def is_recording(self) -> bool:
+        return self._recording
+
+    @property
+    def elapsed_seconds(self) -> float:
+        if not self._recording:
+            return 0.0
+        return time.monotonic() - self._start_time
+
+    @property
+    def current_rms(self) -> int:
+        return self._current_rms
+
+    def start(self, on_silence_stop=None) -> None:
+        del on_silence_stop  # Termux:API does not expose live silence callbacks.
+        mic_cmd = _termux_microphone_command()
+        if not mic_cmd:
+            raise RuntimeError(
+                "Termux voice capture requires the termux-api package and app.\n"
+                "Install with: pkg install termux-api\n"
+                "Then install/update the Termux:API Android app."
+            )
+
+        with self._lock:
+            if self._recording:
+                return
+            os.makedirs(_TEMP_DIR, exist_ok=True)
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            self._recording_path = os.path.join(_TEMP_DIR, f"recording_{timestamp}.aac")
+
+        command = [
+            mic_cmd,
+            "-f", self._recording_path,
+            "-l", "0",
+            "-e", "aac",
+            "-r", str(SAMPLE_RATE),
+            "-c", str(CHANNELS),
+        ]
+        try:
+            subprocess.run(command, capture_output=True, text=True, timeout=15, check=True)
+        except subprocess.CalledProcessError as e:
+            details = (e.stderr or e.stdout or str(e)).strip()
+            raise RuntimeError(f"Termux microphone start failed: {details}") from e
+        except Exception as e:
+            raise RuntimeError(f"Termux microphone start failed: {e}") from e
+
+        with self._lock:
+            self._start_time = time.monotonic()
+            self._recording = True
+            self._current_rms = 0
+        logger.info("Termux voice recording started")
+
+    def _stop_termux_recording(self) -> None:
+        mic_cmd = _termux_microphone_command()
+        if not mic_cmd:
+            return
+        subprocess.run([mic_cmd, "-q"], capture_output=True, text=True, timeout=15, check=False)
+
+    def stop(self) -> Optional[str]:
+        with self._lock:
+            if not self._recording:
+                return None
+            self._recording = False
+            path = self._recording_path
+            self._recording_path = None
+            started_at = self._start_time
+            self._current_rms = 0
+
+        self._stop_termux_recording()
+        if not path or not os.path.isfile(path):
+            return None
+        if time.monotonic() - started_at < 0.3:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return None
+        if os.path.getsize(path) <= 0:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return None
+        logger.info("Termux voice recording stopped: %s", path)
+        return path
+
+    def cancel(self) -> None:
+        with self._lock:
+            path = self._recording_path
+            self._recording = False
+            self._recording_path = None
+            self._current_rms = 0
+        try:
+            self._stop_termux_recording()
+        except Exception:
+            pass
+        if path and os.path.isfile(path):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        logger.info("Termux voice recording cancelled")
+
+    def shutdown(self) -> None:
+        self.cancel()
+
+
+# ============================================================================
 # AudioRecorder
 # ============================================================================
 class AudioRecorder:
@@ -210,6 +360,8 @@ class AudioRecorder:
     If ``on_silence_stop`` is provided, recording automatically stops when
     the user is silent for ``silence_duration`` seconds and calls the callback.
     """
+
+    supports_silence_autostop = True
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -544,6 +696,13 @@ class AudioRecorder:
         return wav_path
 
 
+def create_audio_recorder() -> AudioRecorder | TermuxAudioRecorder:
+    """Return the best recorder backend for the current environment."""
+    if _termux_voice_capture_available():
+        return TermuxAudioRecorder()
+    return AudioRecorder()
+
+
 # ============================================================================
 # Whisper hallucination filter
 # ============================================================================
@@ -752,7 +911,8 @@ def check_voice_requirements() -> Dict[str, Any]:
     stt_available = stt_enabled and stt_provider != "none"
 
     missing: List[str] = []
-    has_audio = _audio_available()
+    termux_capture = _termux_voice_capture_available()
+    has_audio = _audio_available() or termux_capture
 
     if not has_audio:
         missing.extend(["sounddevice", "numpy"])
@@ -763,7 +923,9 @@ def check_voice_requirements() -> Dict[str, Any]:
     available = has_audio and stt_available and env_check["available"]
     details_parts = []
 
-    if has_audio:
+    if termux_capture:
+        details_parts.append("Audio capture: OK (Termux:API microphone)")
+    elif has_audio:
         details_parts.append("Audio capture: OK")
     else:
         details_parts.append(f"Audio capture: MISSING ({_voice_capture_install_hint()})")

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -71,8 +71,24 @@ def _termux_media_player_command() -> Optional[str]:
     return shutil.which("termux-media-player")
 
 
+def _termux_api_app_installed() -> bool:
+    if not _is_termux_environment():
+        return False
+    try:
+        result = subprocess.run(
+            ["pm", "list", "packages", "com.termux.api"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        return "package:com.termux.api" in (result.stdout or "")
+    except Exception:
+        return False
+
+
 def _termux_voice_capture_available() -> bool:
-    return _termux_microphone_command() is not None
+    return _termux_microphone_command() is not None and _termux_api_app_installed()
 
 
 def detect_audio_environment() -> dict:
@@ -84,7 +100,9 @@ def detect_audio_environment() -> dict:
     """
     warnings = []   # hard-fail: these block voice mode
     notices = []     # informational: logged but don't block
-    termux_capture = _termux_voice_capture_available()
+    termux_mic_cmd = _termux_microphone_command()
+    termux_app_installed = _termux_api_app_installed()
+    termux_capture = bool(termux_mic_cmd and termux_app_installed)
 
     # SSH detection
     if any(os.environ.get(v) for v in ('SSH_CLIENT', 'SSH_TTY', 'SSH_CONNECTION')):
@@ -133,11 +151,19 @@ def detect_audio_environment() -> dict:
     except ImportError:
         if termux_capture:
             notices.append("Termux:API microphone recording available (sounddevice not required)")
+        elif termux_mic_cmd and not termux_app_installed:
+            warnings.append(
+                "Termux:API Android app is not installed. Install/update the Termux:API app to use termux-microphone-record."
+            )
         else:
             warnings.append(f"Audio libraries not installed ({_voice_capture_install_hint()})")
     except OSError:
         if termux_capture:
             notices.append("Termux:API microphone recording available (PortAudio not required)")
+        elif termux_mic_cmd and not termux_app_installed:
+            warnings.append(
+                "Termux:API Android app is not installed. Install/update the Termux:API app to use termux-microphone-record."
+            )
         elif _is_termux_environment():
             warnings.append(
                 "PortAudio system library not found -- install it first:\n"
@@ -256,6 +282,11 @@ class TermuxAudioRecorder:
                 "Termux voice capture requires the termux-api package and app.\n"
                 "Install with: pkg install termux-api\n"
                 "Then install/update the Termux:API Android app."
+            )
+        if not _termux_api_app_installed():
+            raise RuntimeError(
+                "Termux voice capture requires the Termux:API Android app.\n"
+                "Install/update the Termux:API app, then retry /voice on."
             )
 
         with self._lock:

--- a/uv.lock
+++ b/uv.lock
@@ -1772,6 +1772,15 @@ slack = [
 sms = [
     { name = "aiohttp" },
 ]
+termux = [
+    { name = "agent-client-protocol" },
+    { name = "croniter" },
+    { name = "honcho-ai" },
+    { name = "mcp" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "pywinpty", marker = "sys_platform == 'win32'" },
+    { name = "simple-term-menu" },
+]
 tts-premium = [
     { name = "elevenlabs" },
 ]
@@ -1806,19 +1815,25 @@ requires-dist = [
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["cli"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["cron"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["daytona"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["dev"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["dingtalk"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["feishu"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["messaging"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["mistral"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["modal"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["pty"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["slack"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["tts-premium"], marker = "extra == 'all'" },
@@ -1861,7 +1876,7 @@ requires-dist = [
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "dingtalk", "feishu", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"

--- a/uv.lock
+++ b/uv.lock
@@ -1673,6 +1673,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "tenacity" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -1874,6 +1875,7 @@ requires-dist = [
     { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
+    { name = "websockets", specifier = ">=15.0.1,<16" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
 ]
 provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "rl", "yc-bench", "all"]

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Installation"
-description: "Install Hermes Agent on Linux, macOS, or WSL2"
+description: "Install Hermes Agent on Linux, macOS, WSL2, or Android via Termux"
 ---
 
 # Installation
@@ -15,6 +15,23 @@ Get Hermes Agent up and running in under two minutes with the one-line installer
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
+
+### Android / Termux
+
+Hermes now ships a Termux-aware installer path too:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+The installer detects Termux automatically and switches to a tested Android flow:
+- uses Termux `pkg` for system dependencies (`git`, `python`, `nodejs`, `ripgrep`, `ffmpeg`, build tools)
+- creates the virtualenv with `python -m venv`
+- exports `ANDROID_API_LEVEL` automatically for Android wheel builds
+- installs a curated `.[termux]` extra with `pip`
+- skips the untested browser / WhatsApp bootstrap by default
+
+If you want the fully explicit path, follow the dedicated [Termux guide](./termux.md).
 
 :::warning Windows
 Native Windows is **not supported**. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run Hermes Agent from there. The install command above works inside WSL2.
@@ -125,6 +142,7 @@ uv pip install -e "."
 | `tts-premium` | ElevenLabs premium voices | `uv pip install -e ".[tts-premium]"` |
 | `voice` | CLI microphone input + audio playback | `uv pip install -e ".[voice]"` |
 | `pty` | PTY terminal support | `uv pip install -e ".[pty]"` |
+| `termux` | Tested Android / Termux bundle (`cron`, `cli`, `pty`, `mcp`, `honcho`, `acp`) | `python -m pip install -e ".[termux]" -c constraints-termux.txt` |
 | `honcho` | AI-native memory (Honcho integration) | `uv pip install -e ".[honcho]"` |
 | `mcp` | Model Context Protocol support | `uv pip install -e ".[mcp]"` |
 | `homeassistant` | Home Assistant integration | `uv pip install -e ".[homeassistant]"` |
@@ -133,6 +151,10 @@ uv pip install -e "."
 | `dev` | pytest & test utilities | `uv pip install -e ".[dev]"` |
 
 You can combine extras: `uv pip install -e ".[messaging,cron]"`
+
+:::tip Termux users
+`.[all]` is not currently available on Android because the `voice` extra pulls `faster-whisper`, which depends on `ctranslate2` wheels that are not published for Android. Use `.[termux]` for the tested mobile install path, then add individual extras only as needed.
+:::
 
 </details>
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -13,9 +13,13 @@ This guide walks you through installing Hermes Agent, setting up a provider, and
 Run the one-line installer:
 
 ```bash
-# Linux / macOS / WSL2
+# Linux / macOS / WSL2 / Android (Termux)
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
+
+:::tip Android / Termux
+If you're installing on a phone, see the dedicated [Termux guide](./termux.md) for the tested manual path, supported extras, and current Android-specific limitations.
+:::
 
 :::tip Windows Users
 Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) first, then run the command above inside your WSL2 terminal.

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -51,6 +51,7 @@ On Termux, the installer automatically:
 - uses `pkg` for system packages
 - creates the venv with `python -m venv`
 - installs `.[termux]` with `pip`
+- links `hermes` into `$PREFIX/bin` so it stays on your Termux PATH
 - skips the untested browser / WhatsApp bootstrap
 
 If you want the explicit commands or need to debug a failed install, use the manual path below.
@@ -110,14 +111,22 @@ If you only want the minimal core agent, this also works:
 python -m pip install -e '.' -c constraints-termux.txt
 ```
 
-### 5. Verify the install
+### 5. Put `hermes` on your Termux PATH
+
+```bash
+ln -sf "$PWD/venv/bin/hermes" "$PREFIX/bin/hermes"
+```
+
+`$PREFIX/bin` is already on PATH in Termux, so this makes the `hermes` command persist across new shells without re-activating the venv every time.
+
+### 6. Verify the install
 
 ```bash
 hermes version
 hermes doctor
 ```
 
-### 6. Start Hermes
+### 7. Start Hermes
 
 ```bash
 hermes

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -1,0 +1,228 @@
+---
+sidebar_position: 3
+title: "Android / Termux"
+description: "Run Hermes Agent directly on an Android phone with Termux"
+---
+
+# Hermes on Android with Termux
+
+This is the tested path for running Hermes Agent directly on an Android phone through [Termux](https://termux.dev/).
+
+It gives you a working local CLI on the phone, plus the core extras that are currently known to install cleanly on Android.
+
+## What is supported in the tested path?
+
+The tested Termux bundle installs:
+- the Hermes CLI
+- cron support
+- PTY/background terminal support
+- MCP support
+- Honcho memory support
+- ACP support
+
+Concretely, it maps to:
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+## What is not part of the tested path yet?
+
+A few features still need desktop/server-style dependencies that are not published for Android, or have not been validated on phones yet:
+
+- `.[all]` is not supported on Android today
+- the `voice` extra is blocked by `faster-whisper -> ctranslate2`, and `ctranslate2` does not publish Android wheels
+- automatic browser / Playwright bootstrap is skipped in the Termux installer
+- Docker-based terminal isolation is not available inside Termux
+
+That does not stop Hermes from working well as a phone-native CLI agent — it just means the recommended mobile install is intentionally narrower than the desktop/server install.
+
+---
+
+## Option 1: One-line installer
+
+Hermes now ships a Termux-aware installer path:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+On Termux, the installer automatically:
+- uses `pkg` for system packages
+- creates the venv with `python -m venv`
+- installs `.[termux]` with `pip`
+- skips the untested browser / WhatsApp bootstrap
+
+If you want the explicit commands or need to debug a failed install, use the manual path below.
+
+---
+
+## Option 2: Manual install (fully explicit)
+
+### 1. Update Termux and install system packages
+
+```bash
+pkg update
+pkg install -y git python clang rust make pkg-config libffi openssl nodejs ripgrep ffmpeg
+```
+
+Why these packages?
+- `python` — runtime + venv support
+- `git` — clone/update the repo
+- `clang`, `rust`, `make`, `pkg-config`, `libffi`, `openssl` — needed to build a few Python dependencies on Android
+- `nodejs` — optional Node runtime for experiments beyond the tested core path
+- `ripgrep` — fast file search
+- `ffmpeg` — media / TTS conversions
+
+### 2. Clone Hermes
+
+```bash
+git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+```
+
+If you already cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+### 3. Create a virtual environment
+
+```bash
+python -m venv venv
+source venv/bin/activate
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+python -m pip install --upgrade pip setuptools wheel
+```
+
+`ANDROID_API_LEVEL` is important for Rust / maturin-based packages such as `jiter`.
+
+### 4. Install the tested Termux bundle
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+If you only want the minimal core agent, this also works:
+
+```bash
+python -m pip install -e '.' -c constraints-termux.txt
+```
+
+### 5. Verify the install
+
+```bash
+hermes version
+hermes doctor
+```
+
+### 6. Start Hermes
+
+```bash
+hermes
+```
+
+---
+
+## Recommended follow-up setup
+
+### Configure a model
+
+```bash
+hermes model
+```
+
+Or set keys directly in `~/.hermes/.env`.
+
+### Re-run the full interactive setup wizard later
+
+```bash
+hermes setup
+```
+
+### Install optional Node dependencies manually
+
+The tested Termux path skips Node/browser bootstrap on purpose. If you want to experiment later:
+
+```bash
+npm install
+```
+
+Treat browser / WhatsApp tooling on Android as experimental until documented otherwise.
+
+---
+
+## Troubleshooting
+
+### `No solution found` when installing `.[all]`
+
+Use the tested Termux bundle instead:
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+The blocker is currently the `voice` extra:
+- `voice` pulls `faster-whisper`
+- `faster-whisper` depends on `ctranslate2`
+- `ctranslate2` does not publish Android wheels
+
+### `uv pip install` fails on Android
+
+Use the Termux path with the stdlib venv + `pip` instead:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+### `jiter` / `maturin` complains about `ANDROID_API_LEVEL`
+
+Set the API level explicitly before installing:
+
+```bash
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+### `hermes doctor` says ripgrep or Node is missing
+
+Install them with Termux packages:
+
+```bash
+pkg install ripgrep nodejs
+```
+
+### Build failures while installing Python packages
+
+Make sure the build toolchain is installed:
+
+```bash
+pkg install clang rust make pkg-config libffi openssl
+```
+
+Then retry:
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+---
+
+## Known limitations on phones
+
+- Docker backend is unavailable
+- local voice transcription via `faster-whisper` is unavailable in the tested path
+- browser automation setup is intentionally skipped by the installer
+- some optional extras may work, but only `.[termux]` is currently documented as the tested Android bundle
+
+If you hit a new Android-specific issue, please open a GitHub issue with:
+- your Android version
+- `termux-info`
+- `python --version`
+- `hermes doctor`
+- the exact install command and full error output

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -36,6 +36,20 @@ Set your provider with `hermes model` or by editing `~/.hermes/.env`. See the [E
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
+### Does it work on Android / Termux?
+
+Yes — Hermes now has a tested Termux install path for Android phones.
+
+Quick install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+For the fully explicit manual steps, supported extras, and current limitations, see the [Termux guide](../getting-started/termux.md).
+
+Important caveat: the full `.[all]` extra is not currently available on Android because the `voice` extra depends on `faster-whisper` → `ctranslate2`, and `ctranslate2` does not publish Android wheels. Use the tested `.[termux]` extra instead.
+
 ### Is my data sent anywhere?
 
 API calls go **only to the LLM provider you configure** (e.g., OpenRouter, your local Ollama instance). Hermes Agent does not collect telemetry, usage data, or analytics. Your conversations, memory, and skills are stored locally in `~/.hermes/`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -9,6 +9,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'getting-started/quickstart',
         'getting-started/installation',
+        'getting-started/termux',
         'getting-started/nix-setup',
         'getting-started/updating',
         'getting-started/learning-path',


### PR DESCRIPTION
## Summary
- add a tested Android/Termux install path with a dedicated `.[termux]` extra and docs
- teach the installer and doctor command about Termux-specific package/runtime behavior
- fix background `gh auth login --with-token` flows by adding stdin close/EOF support and PTY fallback logic

## Validation
- `bash -n scripts/install.sh`
- `python3 -m pytest tests/hermes_cli/test_doctor.py tests/tools/test_terminal_tool_pty_fallback.py tests/tools/test_process_registry.py -q`
- fresh Termux install test: `python3.11 -m venv .tmp-termux-verify-venv && source .tmp-termux-verify-venv/bin/activate && export ANDROID_API_LEVEL=$(getprop ro.build.version.sdk) && python -m pip install -e '.[termux]' -c constraints-termux.txt`

## Notes
- The tested Termux path intentionally skips browser/WhatsApp bootstrap for now.
- `.[all]` remains unsupported on Android because `voice` depends on `faster-whisper -> ctranslate2`, which has no Android wheels.
