### PR TITLE
security: fix path traversal vulnerability in profile alias command

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4045,11 +4045,8 @@ def cmd_profile(args):
             if collision:
                 print(f"Error: {collision}")
                 sys.exit(1)
-            wrapper_path = create_wrapper_script(alias_name)
+            wrapper_path = create_wrapper_script(alias_name, profile_name=name)
             if wrapper_path:
-                # If custom name, write the profile name into the wrapper
-                if custom_name:
-                    wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
                 print(f"✓ Alias created: {wrapper_path}")
                 if not _is_wrapper_dir_in_path():
                     print(f"⚠ {_get_wrapper_dir()} is not in your PATH.")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -22,6 +22,7 @@ Usage::
 import json
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -152,6 +153,15 @@ def validate_profile_name(name: str) -> None:
         )
 
 
+def validate_alias_name(name: str) -> None:
+    """Raise ``ValueError`` if *name* is not a safe wrapper alias."""
+    if not _PROFILE_ID_RE.match(name):
+        raise ValueError(
+            f"Invalid alias name {name!r}. Must match "
+            f"[a-z0-9][a-z0-9_-]{{0,63}}"
+        )
+
+
 def get_profile_dir(name: str) -> Path:
     """Resolve a profile name to its HERMES_HOME directory."""
     if name == "default":
@@ -175,6 +185,11 @@ def check_alias_collision(name: str) -> Optional[str]:
 
     Checks: reserved names, hermes subcommands, existing binaries in PATH.
     """
+    try:
+        validate_alias_name(name)
+    except ValueError as exc:
+        return str(exc)
+
     if name in _RESERVED_NAMES:
         return f"'{name}' is a reserved name"
     if name in _HERMES_SUBCOMMANDS:
@@ -209,7 +224,23 @@ def _is_wrapper_dir_in_path() -> bool:
     return wrapper_dir in os.environ.get("PATH", "").split(os.pathsep)
 
 
-def create_wrapper_script(name: str) -> Optional[Path]:
+def _resolve_wrapper_path(name: str) -> Path:
+    """Resolve a wrapper alias to a path inside the wrapper directory."""
+    validate_alias_name(name)
+    wrapper_dir = _get_wrapper_dir().resolve()
+    wrapper_path = (wrapper_dir / name).resolve(strict=False)
+    if not wrapper_path.is_relative_to(wrapper_dir):
+        raise ValueError(f"Alias path escapes wrapper directory: {name!r}")
+    return wrapper_path
+
+
+def _build_wrapper_script(profile_name: str) -> str:
+    """Return the shell wrapper content for *profile_name*."""
+    validate_profile_name(profile_name)
+    return f'#!/bin/sh\nexec hermes -p {shlex.quote(profile_name)} "$@"\n'
+
+
+def create_wrapper_script(name: str, profile_name: Optional[str] = None) -> Optional[Path]:
     """Create a shell wrapper script at ~/.local/bin/<name>.
 
     Returns the path to the created wrapper, or None if creation failed.
@@ -221,9 +252,10 @@ def create_wrapper_script(name: str) -> Optional[Path]:
         print(f"⚠ Could not create {wrapper_dir}: {e}")
         return None
 
-    wrapper_path = wrapper_dir / name
+    wrapper_path = _resolve_wrapper_path(name)
+    target_profile = profile_name or name
     try:
-        wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
+        wrapper_path.write_text(_build_wrapper_script(target_profile), encoding="utf-8")
         wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
         return wrapper_path
     except OSError as e:
@@ -233,11 +265,14 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
 def remove_wrapper_script(name: str) -> bool:
     """Remove the wrapper script for a profile. Returns True if removed."""
-    wrapper_path = _get_wrapper_dir() / name
+    try:
+        wrapper_path = _resolve_wrapper_path(name)
+    except ValueError:
+        return False
     if wrapper_path.exists():
         try:
             # Verify it's our wrapper before removing
-            content = wrapper_path.read_text()
+            content = wrapper_path.read_text(encoding="utf-8")
             if "hermes -p" in content:
                 wrapper_path.unlink()
                 return True

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -18,6 +18,7 @@ from hermes_cli.profiles import (
     validate_profile_name,
     get_profile_dir,
     create_profile,
+    create_wrapper_script,
     delete_profile,
     list_profiles,
     set_active_profile,
@@ -26,6 +27,7 @@ from hermes_cli.profiles import (
     resolve_profile_env,
     check_alias_collision,
     rename_profile,
+    remove_wrapper_script,
     export_profile,
     import_profile,
     generate_bash_completion,
@@ -356,6 +358,40 @@ class TestAliasCollision:
         result = check_alias_collision("default")
         assert result is not None
         assert "reserved" in result.lower()
+
+    def test_invalid_alias_name_rejected_before_path_lookup(self, profile_env):
+        with patch("subprocess.run") as mock_run:
+            result = check_alias_collision("../../.bashrc")
+        assert result is not None
+        assert "invalid alias name" in result.lower()
+        mock_run.assert_not_called()
+
+
+class TestWrapperScriptSecurity:
+    """Security-focused tests for alias wrapper creation/removal."""
+
+    def test_create_wrapper_rejects_path_traversal(self, profile_env):
+        tmp_path = profile_env
+        sentinel = tmp_path / ".bashrc"
+        sentinel.write_text("keep", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Invalid alias name"):
+            create_wrapper_script("../../.bashrc", profile_name="coder")
+
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+
+    def test_remove_wrapper_rejects_path_traversal(self, profile_env):
+        tmp_path = profile_env
+        sentinel = tmp_path / ".bashrc"
+        sentinel.write_text("keep", encoding="utf-8")
+
+        assert remove_wrapper_script("../../.bashrc") is False
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+
+    def test_custom_alias_wrapper_uses_target_profile(self, profile_env):
+        wrapper = create_wrapper_script("mybot", profile_name="coder")
+        assert wrapper is not None
+        assert wrapper.read_text(encoding="utf-8") == '#!/bin/sh\nexec hermes -p coder "$@"\n'
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
Prevent path traversal and arbitrary file clobber in `hermes profile alias --name`.

## What changed
- validate custom alias names with the same safe identifier rules used for profiles
- enforce wrapper path containment under `~/.local/bin`
- centralize wrapper script generation in a single safe helper
- update CLI alias flow to use the safe helper directly
- add regression tests for traversal rejection and custom alias wrapper behavior

## Impact
Previously, a crafted alias name like `../../.bashrc` could escape the wrapper directory and overwrite or delete arbitrary local files reachable by the current user.

## Testing
- `python -m pytest tests/hermes_cli/test_profiles.py -q`
- `python -m pytest tests/hermes_cli/test_profiles.py -q -k "invalid_alias_name_rejected_before_path_lookup or WrapperScriptSecurity"`

