### PR TITLE
[codex] fix(plan): enforce exact /plan write target

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -16,6 +16,13 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _PLAN_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_PLAN_RUNTIME_NOTE_PREFIX = (
+    "Save the markdown plan with write_file to this exact relative path "
+    "inside the active workspace/backend cwd: "
+)
+_PLAN_RUNTIME_NOTE_RE = re.compile(
+    re.escape(f"[Runtime note: {_PLAN_RUNTIME_NOTE_PREFIX}") + r"(?P<path>[^\]\n]+)\]"
+)
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -40,6 +47,22 @@ def build_plan_path(
     slug = slug or "conversation-plan"
     timestamp = (now or datetime.now()).strftime("%Y-%m-%d_%H%M%S")
     return Path(".hermes") / "plans" / f"{timestamp}-{slug}.md"
+
+
+def build_plan_runtime_note(plan_path: Path | str) -> str:
+    """Return the runtime note that tells the model where /plan output must go."""
+    return f"{_PLAN_RUNTIME_NOTE_PREFIX}{plan_path}"
+
+
+def extract_plan_write_target(message: str) -> str | None:
+    """Extract the exact /plan write target from a skill runtime note, if present."""
+    if not message:
+        return None
+    match = _PLAN_RUNTIME_NOTE_RE.search(message)
+    if not match:
+        return None
+    target = match.group("path").strip()
+    return target or None
 
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:

--- a/cli.py
+++ b/cli.py
@@ -1202,6 +1202,7 @@ from agent.skill_commands import (
     scan_skill_commands,
     build_skill_invocation_message,
     build_plan_path,
+    build_plan_runtime_note,
     build_preloaded_skills_prompt,
 )
 
@@ -4764,10 +4765,7 @@ class HermesCLI:
             "/plan",
             user_instruction,
             task_id=self.session_id,
-            runtime_note=(
-                "Save the markdown plan with write_file to this exact relative path "
-                f"inside the active workspace/backend cwd: {plan_path}"
-            ),
+            runtime_note=build_plan_runtime_note(plan_path),
         )
 
         if not msg:
@@ -6592,7 +6590,14 @@ class HermesCLI:
                 if _msn:
                     agent_message = _msn + "\n\n" + agent_message
                     self._pending_model_switch_note = None
+                plan_write_target = None
                 try:
+                    from agent.skill_commands import extract_plan_write_target
+                    from tools.file_tools import clear_exact_write_target, register_exact_write_target
+
+                    plan_write_target = extract_plan_write_target(agent_message)
+                    if plan_write_target:
+                        register_exact_write_target(self.session_id, plan_write_target)
                     result = self.agent.run_conversation(
                         user_message=agent_message,
                         conversation_history=self.conversation_history[:-1],  # Exclude the message we just added
@@ -6611,6 +6616,9 @@ class HermesCLI:
                         "failed": True,
                         "error": _summary,
                     }
+                finally:
+                    if plan_write_target:
+                        clear_exact_write_target(self.session_id)
 
             # Start agent in background thread
             agent_thread = threading.Thread(target=run_agent)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2079,7 +2079,11 @@ class GatewayRunner:
 
         if canonical == "plan":
             try:
-                from agent.skill_commands import build_plan_path, build_skill_invocation_message
+                from agent.skill_commands import (
+                    build_plan_path,
+                    build_plan_runtime_note,
+                    build_skill_invocation_message,
+                )
 
                 user_instruction = event.get_command_args().strip()
                 plan_path = build_plan_path(user_instruction)
@@ -2087,10 +2091,7 @@ class GatewayRunner:
                     "/plan",
                     user_instruction,
                     task_id=_quick_key,
-                    runtime_note=(
-                        "Save the markdown plan with write_file to this exact relative path "
-                        f"inside the active workspace/backend cwd: {plan_path}"
-                    ),
+                    runtime_note=build_plan_runtime_note(plan_path),
                 )
                 if not event.text:
                     return "Failed to load the bundled /plan skill."
@@ -6875,9 +6876,18 @@ class GatewayRunner:
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            plan_write_target = None
             try:
+                from agent.skill_commands import extract_plan_write_target
+                from tools.file_tools import clear_exact_write_target, register_exact_write_target
+
+                plan_write_target = extract_plan_write_target(message)
+                if plan_write_target:
+                    register_exact_write_target(session_id, plan_write_target)
                 result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             finally:
+                if plan_write_target:
+                    clear_exact_write_target(session_id)
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_plan_path,
+    build_plan_runtime_note,
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    extract_plan_write_target,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -393,10 +395,7 @@ class TestPlanSkillHelpers:
             msg = build_skill_invocation_message(
                 "/plan",
                 "Add a /plan command",
-                runtime_note=(
-                    "Save the markdown plan with write_file to this exact relative path inside "
-                    "the active workspace/backend cwd: .hermes/plans/plan.md"
-                ),
+                runtime_note=build_plan_runtime_note(".hermes/plans/plan.md"),
             )
 
         assert msg is not None
@@ -405,3 +404,14 @@ class TestPlanSkillHelpers:
         assert "Add a /plan command" in msg
         assert ".hermes/plans/plan.md" in msg
         assert "Runtime note:" in msg
+
+    def test_extract_plan_write_target_returns_runtime_path(self):
+        runtime_note = build_plan_runtime_note(".hermes/plans/plan.md")
+        message = f"Plan mode skill\n\n[Runtime note: {runtime_note}]"
+
+        assert extract_plan_write_target(message) == ".hermes/plans/plan.md"
+
+    def test_extract_plan_write_target_ignores_other_runtime_notes(self):
+        message = "[Runtime note: Use patch for edits and read_file before writing.]"
+
+        assert extract_plan_write_target(message) is None

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -14,6 +14,8 @@ from tools.file_tools import (
     WRITE_FILE_SCHEMA,
     PATCH_SCHEMA,
     SEARCH_FILES_SCHEMA,
+    clear_exact_write_target,
+    register_exact_write_target,
 )
 
 
@@ -74,6 +76,9 @@ class TestReadFileHandler:
 
 
 class TestWriteFileHandler:
+    def teardown_method(self):
+        clear_exact_write_target()
+
     @patch("tools.file_tools._get_file_ops")
     def test_writes_content(self, mock_get):
         mock_ops = MagicMock()
@@ -109,8 +114,47 @@ class TestWriteFileHandler:
         assert result["error"] == "boom"
         assert any("write_file error" in r.getMessage() for r in caplog.records)
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_exact_write_target_allows_expected_plan_path(self, mock_get):
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/workspace"
+        mock_ops._expand_path.side_effect = lambda path: path
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import write_file_tool
+
+        register_exact_write_target("sess-1", ".hermes/plans/plan.md")
+        result = json.loads(write_file_tool(".hermes/plans/plan.md", "plan", task_id="sess-1"))
+
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once_with(".hermes/plans/plan.md", "plan")
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_exact_write_target_rejects_home_escaped_plan_path(self, mock_get):
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/workspace"
+        mock_ops._expand_path.side_effect = (
+            lambda path: "/root/.hermes/plans/plan.md" if path.startswith("~") else path
+        )
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import write_file_tool
+
+        register_exact_write_target("sess-1", ".hermes/plans/plan.md")
+        result = json.loads(write_file_tool("~/.hermes/plans/plan.md", "plan", task_id="sess-1"))
+
+        assert "error" in result
+        assert "exact path" in result["error"]
+        mock_ops.write_file.assert_not_called()
+
 
 class TestPatchHandler:
+    def teardown_method(self):
+        clear_exact_write_target()
+
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_calls_patch_replace(self, mock_get):
         mock_ops = MagicMock()
@@ -177,6 +221,30 @@ class TestPatchHandler:
         result = json.loads(patch_tool(mode="invalid_mode"))
         assert "error" in result
         assert "Unknown mode" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_exact_write_target_rejects_patch_to_other_path(self, mock_get):
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/workspace"
+        mock_ops._expand_path.side_effect = lambda path: path
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+
+        register_exact_write_target("sess-1", ".hermes/plans/plan.md")
+        result = json.loads(
+            patch_tool(
+                mode="replace",
+                path="README.md",
+                old_string="old",
+                new_string="new",
+                task_id="sess-1",
+            )
+        )
+
+        assert "error" in result
+        assert "exact path" in result["error"]
+        mock_ops.patch_replace.assert_not_called()
 
 
 class TestSearchHandler:
@@ -309,6 +377,5 @@ class TestSearchHints:
         raw = search_tool(pattern="foo", offset=50, limit=50)
         assert "[Hint:" in raw
         assert "offset=100" in raw
-
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -145,6 +145,8 @@ _file_ops_cache: dict = {}
 #                      by the same task don't trigger false warnings.
 _read_tracker_lock = threading.Lock()
 _read_tracker: dict = {}
+_exact_write_target_lock = threading.Lock()
+_exact_write_targets: dict[str, str] = {}
 
 
 def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
@@ -481,6 +483,49 @@ def clear_read_tracker(task_id: str = None):
             _read_tracker.clear()
 
 
+def register_exact_write_target(task_id: str, path: str) -> None:
+    """Require writes for a task to target one exact path until cleared."""
+    if not task_id or not path:
+        return
+    with _exact_write_target_lock:
+        _exact_write_targets[task_id] = path
+
+
+def clear_exact_write_target(task_id: str | None = None) -> None:
+    """Clear exact write-target constraints for one task or all tasks."""
+    with _exact_write_target_lock:
+        if task_id:
+            _exact_write_targets.pop(task_id, None)
+        else:
+            _exact_write_targets.clear()
+
+
+def _normalize_tool_path_for_task(path: str, file_ops: ShellFileOperations) -> str:
+    """Normalize a tool path the same way the active backend resolves it."""
+    expanded = file_ops._expand_path(path)
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(file_ops.cwd or "/", expanded)
+    return os.path.normpath(expanded)
+
+
+def _check_exact_write_targets(paths: list[str], task_id: str, file_ops: ShellFileOperations) -> str | None:
+    """Return an error if a task-scoped exact write target is active and violated."""
+    with _exact_write_target_lock:
+        expected_path = _exact_write_targets.get(task_id)
+    if not expected_path:
+        return None
+
+    expected_resolved = _normalize_tool_path_for_task(expected_path, file_ops)
+    for path in paths:
+        candidate_resolved = _normalize_tool_path_for_task(path, file_ops)
+        if candidate_resolved != expected_resolved:
+            return (
+                f"This task must write the plan to the exact path: {expected_path}. "
+                f"Refusing to write to: {path}"
+            )
+    return None
+
+
 def reset_file_dedup(task_id: str = None):
     """Clear the deduplication cache for file reads.
 
@@ -574,8 +619,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     if sensitive_err:
         return tool_error(sensitive_err)
     try:
-        stale_warning = _check_file_staleness(path, task_id)
         file_ops = _get_file_ops(task_id)
+        exact_target_err = _check_exact_write_targets([path], task_id, file_ops)
+        if exact_target_err:
+            return tool_error(exact_target_err)
+        stale_warning = _check_file_staleness(path, task_id)
         result = file_ops.write_file(path, content)
         result_dict = result.to_dict()
         if stale_warning:
@@ -609,27 +657,32 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         if sensitive_err:
             return tool_error(sensitive_err)
     try:
+        if mode == "replace":
+            if not path:
+                return tool_error("path required")
+            if old_string is None or new_string is None:
+                return tool_error("old_string and new_string required")
+        elif mode == "patch":
+            if not patch:
+                return tool_error("patch content required")
+        else:
+            return tool_error(f"Unknown mode: {mode}")
+
+        file_ops = _get_file_ops(task_id)
+        exact_target_err = _check_exact_write_targets(_paths_to_check, task_id, file_ops)
+        if exact_target_err:
+            return tool_error(exact_target_err)
         # Check staleness for all files this patch will touch.
         stale_warnings = []
         for _p in _paths_to_check:
             _sw = _check_file_staleness(_p, task_id)
             if _sw:
                 stale_warnings.append(_sw)
-
-        file_ops = _get_file_ops(task_id)
         
         if mode == "replace":
-            if not path:
-                return tool_error("path required")
-            if old_string is None or new_string is None:
-                return tool_error("old_string and new_string required")
             result = file_ops.patch_replace(path, old_string, new_string, replace_all)
         elif mode == "patch":
-            if not patch:
-                return tool_error("patch content required")
             result = file_ops.patch_v4a(patch)
-        else:
-            return tool_error(f"Unknown mode: {mode}")
         
         result_dict = result.to_dict()
         if stale_warnings:


### PR DESCRIPTION
## Summary
- enforce a task-scoped exact write target for `/plan` output instead of relying on prompt compliance alone
- register that exact target for the current CLI or gateway turn and clear it after the run completes
- add regression coverage for runtime-note parsing and file-tool enforcement

## Root Cause
PR #1381 changed `/plan` to prefer workspace-relative `.hermes/plans/...`, but the actual write target was only communicated through a runtime note. If the model called `write_file` with `~/.hermes/plans/...`, `tools/file_operations.py` expanded `~` against `$HOME`, which let Docker sessions write plans into `/root/.hermes/plans/...` instead of the active workspace.

## What Changed
- added shared `/plan` runtime-note helpers so the exact target can be generated and parsed consistently
- enforced exact-path matching in `write_file` and `patch` when a task has an active `/plan` target
- wired CLI and gateway runs to activate that constraint only for the relevant turn
- added focused regression tests for helper parsing and write/patch enforcement

## Validation
- `uv run --extra dev python -m pytest -q -n0 tests/agent/test_skill_commands.py tests/tools/test_file_tools.py tests/cli/test_cli_plan_command.py tests/gateway/test_plan_command.py`

Fixes #6203
