### PR TITLE
fix(run_agent): pool socket walk descends into HTTPConnection wrapper

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3567,6 +3567,63 @@ class AIAgent:
         return client
 
     @staticmethod
+    def _iter_pool_sockets(client: Any):
+        """Yield raw socket objects from an httpx client's connection pool.
+
+        Walks: client._client._transport._pool._{connections,pool} -> each
+        ``HTTPConnection`` wrapper -> its inner ``HTTP11/2Connection`` (at
+        ``_connection``) -> ``_network_stream`` -> raw socket. Handles both
+        the sync httpcore backend (``stream._sock``) and the anyio async
+        backend (``stream._stream.extra(SocketAttribute.raw_socket)``).
+
+        Pre-fix versions of this code only checked ``conn._network_stream``,
+        which doesn't exist on httpcore >=1.0 wrapper objects, so the walk
+        silently yielded nothing and CLOSE-WAIT cleanup was a no-op.
+        """
+        try:
+            http_client = getattr(client, "_client", None)
+            if http_client is None:
+                return
+            transport = getattr(http_client, "_transport", None)
+            if transport is None:
+                return
+            pool = getattr(transport, "_pool", None)
+            if pool is None:
+                return
+            connections = (
+                getattr(pool, "_connections", None)
+                or getattr(pool, "_pool", None)
+                or []
+            )
+            for conn in list(connections):
+                # httpcore HTTPConnection wraps the real HTTP11/2Connection
+                # at ._connection; descend if present.
+                inner = getattr(conn, "_connection", None) or conn
+                stream = getattr(inner, "_network_stream", None) or getattr(
+                    inner, "_stream", None
+                )
+                if stream is None:
+                    continue
+                sock = getattr(stream, "_sock", None)
+                if sock is None:
+                    # AnyIO async backend: stream._stream is an anyio
+                    # SocketStream; get the raw fd via .extra().
+                    inner_stream = getattr(stream, "_stream", None)
+                    if inner_stream is not None:
+                        try:
+                            from anyio.abc import SocketAttribute  # type: ignore
+                            sock = inner_stream.extra(
+                                SocketAttribute.raw_socket, None
+                            )
+                        except Exception:
+                            sock = getattr(inner_stream, "_sock", None)
+                if sock is None:
+                    continue
+                yield sock
+        except Exception as exc:
+            logger.debug("Pool socket walk error: %s", exc)
+
+    @staticmethod
     def _force_close_tcp_sockets(client: Any) -> int:
         """Force-close underlying TCP sockets to prevent CLOSE-WAIT accumulation.
 
@@ -3581,48 +3638,16 @@ class AIAgent:
         import socket as _socket
 
         closed = 0
-        try:
-            http_client = getattr(client, "_client", None)
-            if http_client is None:
-                return 0
-            transport = getattr(http_client, "_transport", None)
-            if transport is None:
-                return 0
-            pool = getattr(transport, "_pool", None)
-            if pool is None:
-                return 0
-            # httpx uses httpcore connection pools; connections live in
-            # _connections (list) or _pool (list) depending on version.
-            connections = (
-                getattr(pool, "_connections", None)
-                or getattr(pool, "_pool", None)
-                or []
-            )
-            for conn in list(connections):
-                stream = (
-                    getattr(conn, "_network_stream", None)
-                    or getattr(conn, "_stream", None)
-                )
-                if stream is None:
-                    continue
-                sock = getattr(stream, "_sock", None)
-                if sock is None:
-                    sock = getattr(stream, "stream", None)
-                    if sock is not None:
-                        sock = getattr(sock, "_sock", None)
-                if sock is None:
-                    continue
-                try:
-                    sock.shutdown(_socket.SHUT_RDWR)
-                except OSError:
-                    pass
-                try:
-                    sock.close()
-                except OSError:
-                    pass
-                closed += 1
-        except Exception as exc:
-            logger.debug("Force-close TCP sockets sweep error: %s", exc)
+        for sock in AIAgent._iter_pool_sockets(client):
+            try:
+                sock.shutdown(_socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                sock.close()
+            except OSError:
+                pass
+            closed += 1
         return closed
 
     def _close_openai_client(self, client: Any, *, reason: str, shared: bool) -> None:
@@ -3695,38 +3720,9 @@ class AIAgent:
         if client is None:
             return False
         try:
-            http_client = getattr(client, "_client", None)
-            if http_client is None:
-                return False
-            transport = getattr(http_client, "_transport", None)
-            if transport is None:
-                return False
-            pool = getattr(transport, "_pool", None)
-            if pool is None:
-                return False
-            connections = (
-                getattr(pool, "_connections", None)
-                or getattr(pool, "_pool", None)
-                or []
-            )
+            import socket as _socket
             dead_count = 0
-            for conn in list(connections):
-                # Check for connections that are idle but have closed sockets
-                stream = (
-                    getattr(conn, "_network_stream", None)
-                    or getattr(conn, "_stream", None)
-                )
-                if stream is None:
-                    continue
-                sock = getattr(stream, "_sock", None)
-                if sock is None:
-                    sock = getattr(stream, "stream", None)
-                    if sock is not None:
-                        sock = getattr(sock, "_sock", None)
-                if sock is None:
-                    continue
-                # Probe socket health with a non-blocking recv peek
-                import socket as _socket
+            for sock in AIAgent._iter_pool_sockets(client):
                 try:
                     sock.setblocking(False)
                     data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)


### PR DESCRIPTION
## Problem

The CLOSE-WAIT cleanup added in #4481 (`_force_close_tcp_sockets`,
`_cleanup_dead_connections`) walks the httpx pool looking for
`conn._network_stream` on each pool entry. In **httpcore >= 1.0** the
pool contains `HTTPConnection` wrapper objects whose `_network_stream`
attribute does not exist — the real stream lives one level deeper at
`conn._connection._network_stream`, inside the wrapped
`HTTP11Connection` / `HTTP2Connection` (see
[`httpcore/_sync/connection.py`](https://github.com/encode/httpcore/blob/master/httpcore/_sync/connection.py)
line ~64 and [`http11.py`](https://github.com/encode/httpcore/blob/master/httpcore/_sync/http11.py) line ~54).

So the walk silently yields zero sockets and **both cleanup functions
become no-ops** under any httpx >= 0.25 / httpcore >= 1.0 install. The
log line `tcp_force_closed=N` always reports 0; pool rebuilds happen
on retry but no surgical socket shutdown ever runs.

## Symptom we hit in production

Long-lived gateway processes pointed at a local LLM proxy accumulated
CLOSE-WAIT sockets until httpx's pool handed a dead socket to a new
request. Write succeeded (into kernel send buffer), read hung until
`HERMES_STREAM_READ_TIMEOUT`, the agent surfaced the
"⚠️ Connection to provider dropped (ReadTimeout). Reconnecting..."
warning every few minutes, and recovery required restarting the
gateway. Exactly the failure #4481 was supposed to prevent.

## Fix

- Add `_iter_pool_sockets`, a single helper that descends through
  `conn._connection` when present, then unwraps the network stream's
  raw socket. Handles **both** the sync httpcore backend
  (`stream._sock`) **and** the anyio async backend
  (`stream._stream.extra(SocketAttribute.raw_socket)`).
- Rewrite `_force_close_tcp_sockets` and `_cleanup_dead_connections`
  to consume the helper. Behavior is otherwise unchanged.

## Verification

Reproduced live against `openai.OpenAI(base_url="http://localhost:3456/v1")`
on `httpx 0.28.1` / `httpcore 1.0.9`:

```
upstream walk found: 0    # pre-fix code from main
sockets found: 1          # this PR
```

The recovered socket is the actual `socket.socket` object backing the
client's keep-alive connection — `shutdown(SHUT_RDWR)` + `close()`
on it now does what the original commit message promised.

## Notes

- No behavior change when the walk *did* work (older httpcore, exotic
  transports) — the helper falls back to the same attribute names the
  original code tried.
- No new dependency on anyio: the import is inside a `try` block, only
  attempted when the sync `_sock` path returns nothing.