### PR TITLE
fix(cli): route quick command output through session console

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4668,13 +4668,13 @@ class HermesCLI:
                             if output:
                                 self.console.print(_rich_text_from_ansi(output))
                             else:
-                                ChatConsole().print("[dim]Command returned no output[/]")
+                                self.console.print("[dim]Command returned no output[/]")
                         except subprocess.TimeoutExpired:
-                            ChatConsole().print("[bold red]Quick command timed out (30s)[/]")
+                            self.console.print("[bold red]Quick command timed out (30s)[/]")
                         except Exception as e:
-                            ChatConsole().print(f"[bold red]Quick command error: {e}[/]")
+                            self.console.print(f"[bold red]Quick command error: {e}[/]")
                     else:
-                        ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
+                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
                 elif qcmd.get("type") == "alias":
                     target = qcmd.get("target", "").strip()
                     if target:
@@ -4683,9 +4683,9 @@ class HermesCLI:
                         aliased_command = f"{target} {user_args}".strip()
                         return self.process_command(aliased_command)
                     else:
-                        ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
+                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
                 else:
-                    ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
+                    self.console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import get_plugin_command_handler


### PR DESCRIPTION
Part 1 of 4 in a coordinated PR stack.

Goal
- Make the upstream test suite green again for the failures introduced on upstream main.
- This PR removes the quick-command CLI regression; the later PRs in the stack remove the remaining failures.

Full stack
- 1/4: #6219 fix(cli): route quick command output through session console <- this PR
- 2/4: #6220 fix(aux): normalize vision main provider and dynamic auth path
- 3/4: #6221 fix(docker): honor explicit env passthrough allowlist
- 4/4: #6222 fix(metadata): sync HF context length keys

Please review/merge in stack order.

What this fixes
- Route all quick-command fallback/error output through `self.console.print`
- Restore testability and consistent CLI console behavior for:
  - no output fallback
  - timeout
  - generic error
  - missing command
  - missing alias target
  - unsupported type

CI context
- Original upstream failing job: https://github.com/NousResearch/hermes-agent/actions/runs/24134173160/job/70417917731
- Tests this PR fixes are confirmed green in the stack-top verification job: https://github.com/NousResearch/hermes-agent/actions/runs/24148333281/job/70468134347
- Tests flipped green by this PR:
  - `tests/cli/test_quick_commands.py::TestCLIQuickCommands::test_exec_command_no_output_shows_fallback`
  - `tests/cli/test_quick_commands.py::TestCLIQuickCommands::test_alias_no_target_shows_error`
  - `tests/cli/test_quick_commands.py::TestCLIQuickCommands::test_unsupported_type_shows_error`
  - `tests/cli/test_quick_commands.py::TestCLIQuickCommands::test_missing_command_field_shows_error`
  - `tests/cli/test_quick_commands.py::TestCLIQuickCommands::test_timeout_shows_error`

Why
- The failing code path used `ChatConsole().print` instead of the session console, which bypassed the mockable output channel and broke the quick-command CLI tests.

Validation
- Local targeted: `pytest -q tests/cli/test_quick_commands.py`
- Stack-top verification job: https://github.com/NousResearch/hermes-agent/actions/runs/24148333281
