### PR TITLE
fix(metadata): sync HF context length keys

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -130,7 +130,10 @@ _NOUS_FREE_TIER_VISION_MODEL = "xiaomi/mimo-v2-omni"
 _NOUS_FREE_TIER_AUX_MODEL = "xiaomi/mimo-v2-pro"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
-_AUTH_JSON_PATH = get_hermes_home() / "auth.json"
+
+
+def _auth_json_path() -> Path:
+    return get_hermes_home() / "auth.json"
 
 # Codex fallback: uses the Responses API (the only endpoint the Codex
 # OAuth token can access) with a fast model for auxiliary tasks.
@@ -603,9 +606,10 @@ def _read_nous_auth() -> Optional[dict]:
         }
 
     try:
-        if not _AUTH_JSON_PATH.is_file():
+        auth_json_path = _auth_json_path()
+        if not auth_json_path.is_file():
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text())
+        data = json.loads(auth_json_path.read_text())
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})
@@ -834,7 +838,11 @@ def _read_main_provider() -> str:
         if isinstance(model_cfg, dict):
             provider = model_cfg.get("provider", "")
             if isinstance(provider, str) and provider.strip():
-                return _normalize_aux_provider(provider)
+                normalized_provider = provider.strip().lower()
+                if normalized_provider.startswith("custom:"):
+                    suffix = normalized_provider.split(":", 1)[1].strip()
+                    return f"custom:{suffix}" if suffix else "custom"
+                return _normalize_aux_provider(normalized_provider)
     except Exception:
         pass
     return ""
@@ -1425,6 +1433,9 @@ def get_async_text_auxiliary_client(task: str = ""):
 _VISION_AUTO_PROVIDER_ORDER = (
     "openrouter",
     "nous",
+    "openai-codex",
+    "anthropic",
+    "custom",
 )
 
 
@@ -1470,20 +1481,17 @@ def _preferred_main_vision_provider() -> Optional[str]:
 def get_available_vision_backends() -> List[str]:
     """Return the currently available vision backends in auto-selection order.
 
-    Order: OpenRouter → Nous → active provider.  This is the single source
-    of truth for setup, tool gating, and runtime auto-routing of vision tasks.
+    This is the single source of truth for setup, tool gating, and runtime
+    auto-routing of vision tasks. The selected main provider is preferred when
+    it is also a known-good vision backend; otherwise Hermes falls back through
+    the standard conservative order.
     """
-    available = [p for p in _VISION_AUTO_PROVIDER_ORDER
-                 if _strict_vision_backend_available(p)]
-    # Also check the user's active provider (may be DeepSeek, Alibaba, named
-    # custom, etc.) — resolve_provider_client handles all provider types.
-    main_provider = _read_main_provider()
-    if (main_provider and main_provider not in ("auto", "")
-            and main_provider not in available):
-        client, _ = resolve_provider_client(main_provider, _read_main_model())
-        if client is not None:
-            available.append(main_provider)
-    return available
+    ordered = list(_VISION_AUTO_PROVIDER_ORDER)
+    preferred = _preferred_main_vision_provider()
+    if preferred in ordered:
+        ordered.remove(preferred)
+        ordered.insert(0, preferred)
+    return [provider for provider in ordered if _strict_vision_backend_available(provider)]
 
 
 def resolve_vision_provider_client(
@@ -1528,30 +1536,16 @@ def resolve_vision_provider_client(
         return "custom", client, final_model
 
     if requested == "auto":
-        # Vision auto-detection order:
-        #   1. OpenRouter  (known vision-capable default model)
-        #   2. Nous Portal (known vision-capable default model)
-        #   3. Active provider + model (user's main chat config)
-        #   4. Stop
-        for candidate in _VISION_AUTO_PROVIDER_ORDER:
+        ordered = list(_VISION_AUTO_PROVIDER_ORDER)
+        preferred = _preferred_main_vision_provider()
+        if preferred in ordered:
+            ordered.remove(preferred)
+            ordered.insert(0, preferred)
+
+        for candidate in ordered:
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)
-
-        # Fall back to the user's active provider + model.
-        main_provider = _read_main_provider()
-        main_model = _read_main_model()
-        if main_provider and main_provider not in ("auto", ""):
-            sync_client, resolved_model = resolve_provider_client(
-                main_provider, main_model)
-            if sync_client is not None:
-                logger.info(
-                    "Vision auto-detect: using active provider %s (%s)",
-                    main_provider, resolved_model or main_model,
-                )
-                return _finalize(
-                    main_provider, sync_client, resolved_model or main_model)
-
         logger.debug("Auxiliary vision client: none available")
         return None, None, None
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1542,10 +1542,22 @@ def resolve_vision_provider_client(
             ordered.remove(preferred)
             ordered.insert(0, preferred)
 
+        main_provider = _read_main_provider()
+        main_model = _read_main_model()
+        if main_provider and main_provider not in ("auto", "") and main_provider not in ordered:
+            client, final_model = resolve_provider_client(
+                main_provider,
+                model=main_model or resolved_model,
+                async_mode=async_mode,
+            )
+            if client is not None:
+                return main_provider, client, final_model or main_model
+
         for candidate in ordered:
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)
+
         logger.debug("Auxiliary vision client: none available")
         return None, None, None
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -134,7 +134,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek-ai/DeepSeek-V3.2": 65536,
     "moonshotai/Kimi-K2.5": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
-    "minimaxai/minimax-m2.5": 1048576,
+    "MiniMaxAI/MiniMax-M2.5": 1048576,
     "XiaomiMiMo/MiMo-V2-Flash": 32768,
     "mimo-v2-pro": 1048576,
     "mimo-v2-omni": 1048576,

--- a/cli.py
+++ b/cli.py
@@ -4668,13 +4668,13 @@ class HermesCLI:
                             if output:
                                 self.console.print(_rich_text_from_ansi(output))
                             else:
-                                ChatConsole().print("[dim]Command returned no output[/]")
+                                self.console.print("[dim]Command returned no output[/]")
                         except subprocess.TimeoutExpired:
-                            ChatConsole().print("[bold red]Quick command timed out (30s)[/]")
+                            self.console.print("[bold red]Quick command timed out (30s)[/]")
                         except Exception as e:
-                            ChatConsole().print(f"[bold red]Quick command error: {e}[/]")
+                            self.console.print(f"[bold red]Quick command error: {e}[/]")
                     else:
-                        ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
+                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
                 elif qcmd.get("type") == "alias":
                     target = qcmd.get("target", "").strip()
                     if target:
@@ -4683,9 +4683,9 @@ class HermesCLI:
                         aliased_command = f"{target} {user_args}".strip()
                         return self.process_command(aliased_command)
                     else:
-                        ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
+                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
                 else:
-                    ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
+                    self.console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import get_plugin_command_handler

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -505,14 +505,17 @@ class DockerEnvironment(BaseEnvironment):
         # (dynamic from host process).  Forward values take precedence.
         exec_env: dict[str, str] = dict(self._env)
 
-        forward_keys = set(self._forward_env)
+        explicit_forward_keys = set(self._forward_env)
+        passthrough_keys: set[str] = set()
         try:
             from tools.env_passthrough import get_all_passthrough
-            forward_keys |= get_all_passthrough()
+            passthrough_keys = set(get_all_passthrough())
         except Exception:
             pass
-        # Strip Hermes-managed secrets so they never leak into the container.
-        forward_keys -= _HERMES_PROVIDER_ENV_BLOCKLIST
+        # Explicit docker_forward_env entries are an intentional opt-in and must
+        # win over the generic Hermes secret blocklist. Only implicit passthrough
+        # keys are filtered.
+        forward_keys = explicit_forward_keys | (passthrough_keys - _HERMES_PROVIDER_ENV_BLOCKLIST)
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):
             value = os.getenv(key)


### PR DESCRIPTION
Part 4 of 4 in a coordinated PR stack.

Goal
- Finish the CI recovery for the upstream main failures and get the stack to a green test run.
- At this point the `Tests` workflow is green on this PR.

Full stack
- 1/4: #6219 fix(cli): route quick command output through session console
- 2/4: #6220 fix(aux): normalize vision main provider and dynamic auth path
- 3/4: #6221 fix(docker): honor explicit env passthrough allowlist
- 4/4: #6222 fix(metadata): sync HF context length keys <- this PR

Please review/merge in stack order.

What this fixes
- Sync the Hugging Face context-length metadata key with the canonical model ID used in `hermes_cli.models`

CI context
- Original upstream failing job: https://github.com/NousResearch/hermes-agent/actions/runs/24134173160/job/70417917731
- Tests workflow now green on this PR: https://github.com/NousResearch/hermes-agent/actions/runs/24148333281/job/70468134347
- Full PR checks page: https://github.com/NousResearch/hermes-agent/actions/runs/24148333281
- Test flipped green by this PR:
  - `tests/hermes_cli/test_api_key_providers.py::TestHuggingFaceModels::test_model_metadata_has_context_lengths`
- Status note:
  - `Tests` is green on this PR.
  - `Docker Build and Publish` was still in progress at last check, so this is not yet a claim of full-CI green until that job completes.

Why
- The provider model list uses `MiniMaxAI/MiniMax-M2.5` while metadata still used a mismatched lowercase key.

Validation
- Local targeted: `pytest -q tests/hermes_cli/test_api_key_providers.py::TestHuggingFaceModels::test_model_metadata_has_context_lengths`
- Stack-top local verification:
  - `pytest -q tests/cli/test_quick_commands.py tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_auxiliary_client.py::TestAuxiliaryPoolAwareness::test_vision_auto_uses_named_custom_as_active_provider tests/tools/test_vision_tools.py::TestVisionRequirements::test_check_requirements_accepts_codex_auth tests/tools/test_docker_environment.py tests/hermes_cli/test_api_key_providers.py::TestHuggingFaceModels::test_model_metadata_has_context_lengths`
