### PR TITLE
fix(gateway): preserve async side-task attachment delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4377,69 +4377,97 @@ class GatewayRunner:
         text itself is already delivered — this only handles file attachments
         that the normal _process_message_background path would have caught.
         """
-        from pathlib import Path
-
         try:
             media_files, _ = adapter.extract_media(response)
             _, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
 
             _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
-
-            _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
-            _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
-            _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
-
-            for media_path, is_voice in media_files:
-                try:
-                    ext = Path(media_path).suffix.lower()
-                    if ext in _AUDIO_EXTS:
-                        await adapter.send_voice(
-                            chat_id=event.source.chat_id,
-                            audio_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
-                            chat_id=event.source.chat_id,
-                            video_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    elif ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
-                            chat_id=event.source.chat_id,
-                            image_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    else:
-                        await adapter.send_document(
-                            chat_id=event.source.chat_id,
-                            file_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                except Exception as e:
-                    logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
-
-            for file_path in local_files:
-                try:
-                    ext = Path(file_path).suffix.lower()
-                    if ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
-                            chat_id=event.source.chat_id,
-                            image_path=file_path,
-                            metadata=_thread_meta,
-                        )
-                    else:
-                        await adapter.send_document(
-                            chat_id=event.source.chat_id,
-                            file_path=file_path,
-                            metadata=_thread_meta,
-                        )
-                except Exception as e:
-                    logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
-
+            await self._deliver_extracted_attachments(
+                adapter=adapter,
+                chat_id=event.source.chat_id,
+                metadata=_thread_meta,
+                media_files=media_files,
+                local_files=local_files,
+            )
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
+
+    async def _deliver_extracted_attachments(
+        self,
+        *,
+        adapter,
+        chat_id: str,
+        metadata: Optional[dict] = None,
+        images: Optional[List[tuple[str, str]]] = None,
+        media_files: Optional[List[tuple[str, bool]]] = None,
+        local_files: Optional[List[str]] = None,
+    ) -> None:
+        """Deliver extracted attachments using the shared gateway media contract."""
+        from pathlib import Path
+
+        _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
+        _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
+        _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+
+        for image_url, alt_text in images or []:
+            try:
+                await adapter.send_image(
+                    chat_id=chat_id,
+                    image_url=image_url,
+                    caption=alt_text,
+                    metadata=metadata,
+                )
+            except Exception as e:
+                logger.warning("[%s] Image delivery failed: %s", adapter.name, e)
+
+        for media_path, _is_voice in media_files or []:
+            try:
+                ext = Path(media_path).suffix.lower()
+                if ext in _AUDIO_EXTS:
+                    await adapter.send_voice(
+                        chat_id=chat_id,
+                        audio_path=media_path,
+                        metadata=metadata,
+                    )
+                elif ext in _VIDEO_EXTS:
+                    await adapter.send_video(
+                        chat_id=chat_id,
+                        video_path=media_path,
+                        metadata=metadata,
+                    )
+                elif ext in _IMAGE_EXTS:
+                    await adapter.send_image_file(
+                        chat_id=chat_id,
+                        image_path=media_path,
+                        metadata=metadata,
+                    )
+                else:
+                    await adapter.send_document(
+                        chat_id=chat_id,
+                        file_path=media_path,
+                        metadata=metadata,
+                    )
+            except Exception as e:
+                logger.warning("[%s] Media delivery failed: %s", adapter.name, e)
+
+        for file_path in local_files or []:
+            try:
+                ext = Path(file_path).suffix.lower()
+                if ext in _IMAGE_EXTS:
+                    await adapter.send_image_file(
+                        chat_id=chat_id,
+                        image_path=file_path,
+                        metadata=metadata,
+                    )
+                else:
+                    await adapter.send_document(
+                        chat_id=chat_id,
+                        file_path=file_path,
+                        metadata=metadata,
+                    )
+            except Exception as e:
+                logger.warning("[%s] File delivery failed: %s", adapter.name, e)
 
     async def _handle_rollback_command(self, event: MessageEvent) -> str:
         """Handle /rollback command — list or restore filesystem checkpoints."""
@@ -4620,26 +4648,13 @@ class GatewayRunner:
                         metadata=_thread_metadata,
                     )
 
-                # Send extracted images
-                for image_url, alt_text in (images or []):
-                    try:
-                        await adapter.send_image(
-                            chat_id=source.chat_id,
-                            image_url=image_url,
-                            caption=alt_text,
-                        )
-                    except Exception:
-                        pass
-
-                # Send media files
-                for media_path in (media_files or []):
-                    try:
-                        await adapter.send_document(
-                            chat_id=source.chat_id,
-                            file_path=media_path,
-                        )
-                    except Exception:
-                        pass
+                await self._deliver_extracted_attachments(
+                    adapter=adapter,
+                    chat_id=source.chat_id,
+                    metadata=_thread_metadata,
+                    images=images,
+                    media_files=media_files,
+                )
             else:
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 await adapter.send(
@@ -4796,17 +4811,13 @@ class GatewayRunner:
                     metadata=_thread_meta,
                 )
 
-            for image_url, alt_text in (images or []):
-                try:
-                    await adapter.send_image(chat_id=source.chat_id, image_url=image_url, caption=alt_text)
-                except Exception:
-                    pass
-
-            for media_path in (media_files or []):
-                try:
-                    await adapter.send_file(chat_id=source.chat_id, file_path=media_path)
-                except Exception:
-                    pass
+            await self._deliver_extracted_attachments(
+                adapter=adapter,
+                chat_id=source.chat_id,
+                metadata=_thread_meta,
+                images=images,
+                media_files=media_files,
+            )
 
         except Exception as e:
             logger.exception("/btw task %s failed", task_id)

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -4,8 +4,6 @@ Tests the _handle_background_command handler (run a prompt in a separate
 background session) across gateway messenger platforms.
 """
 
-import asyncio
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -89,7 +87,6 @@ class TestHandleBackgroundCommand:
 
         # Patch asyncio.create_task to capture the coroutine
         created_tasks = []
-        original_create_task = asyncio.create_task
 
         def capture_task(coro, *args, **kwargs):
             # Close the coroutine to avoid warnings
@@ -254,6 +251,119 @@ class TestRunBackgroundTask:
         call_args = mock_adapter.send.call_args
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
         assert "failed" in content.lower()
+
+    @pytest.mark.asyncio
+    async def test_threaded_attachments_keep_metadata_and_unpack_media_paths(self):
+        """Background task attachments should preserve thread metadata and plain file paths."""
+        runner = _make_runner()
+        runner._load_reasoning_config = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={"model": "test-model", "runtime": {"api_key": "test-key"}}
+        )
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock()
+        mock_adapter.send_document = AsyncMock()
+        mock_adapter.extract_media = MagicMock(
+            return_value=(
+                [("/tmp/report.pdf", False)],
+                "Background result\n\n![chart](https://example.com/chart.png)",
+            )
+        )
+        mock_adapter.extract_images = MagicMock(
+            return_value=(
+                [("https://example.com/chart.png", "chart")],
+                "Background result",
+            )
+        )
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+            thread_id="thread-42",
+        )
+        mock_result = {
+            "final_response": (
+                "Background result\n\n"
+                "![chart](https://example.com/chart.png)\n"
+                "MEDIA:/tmp/report.pdf"
+            ),
+            "messages": [],
+        }
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("say hello", source, "bg_test")
+
+        mock_adapter.send_image.assert_called_once_with(
+            chat_id="67890",
+            image_url="https://example.com/chart.png",
+            caption="chart",
+            metadata={"thread_id": "thread-42"},
+        )
+        mock_adapter.send_document.assert_called_once_with(
+            chat_id="67890",
+            file_path="/tmp/report.pdf",
+            metadata={"thread_id": "thread-42"},
+        )
+
+
+class TestRunBtwTask:
+    """Tests for GatewayRunner._run_btw_task (ephemeral side-question execution)."""
+
+    @pytest.mark.asyncio
+    async def test_threaded_media_attachments_use_document_sender_with_metadata(self):
+        """The /btw side-task path should preserve thread metadata and unpack MEDIA tuples."""
+        runner = _make_runner()
+        runner._load_reasoning_config = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={"model": "test-model", "runtime": {"api_key": "test-key"}}
+        )
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_document = AsyncMock()
+        mock_adapter.extract_media = MagicMock(
+            return_value=([("/tmp/report.pdf", False)], "Side answer")
+        )
+        mock_adapter.extract_images = MagicMock(return_value=([], "Side answer"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        runner.session_store.get_or_create_session.return_value = MagicMock(session_id="session-1")
+        runner.session_store.load_transcript.return_value = []
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+            thread_id="thread-42",
+        )
+        mock_result = {
+            "final_response": "Side answer\n\nMEDIA:/tmp/report.pdf",
+            "messages": [],
+        }
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_btw_task("what changed?", source, "session-key", "btw_test")
+
+        mock_adapter.send_document.assert_called_once_with(
+            chat_id="67890",
+            file_path="/tmp/report.pdf",
+            metadata={"thread_id": "thread-42"},
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes attachment delivery in the async gateway side-task paths used by
`/background` and `/btw`.

Those paths had drifted away from the main gateway response flow, which already
has a dedicated attachment-delivery path. That left the async variants with two
bugs:

- follow-up attachments were sent without thread metadata, so threaded chats
  could receive the text reply in the right thread and the attachments in the
  parent chat
- `extract_media()` returns `(path, is_voice)` tuples, but `/background` and
  `/btw` treated those values as plain file paths; `/btw` also called
  `adapter.send_file(...)`, which is not part of the platform adapter contract

This keeps the fix narrow. The side-task paths now reuse a shared attachment
sender instead of maintaining their own partial copy.

## Related Issue

None

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_deliver_extracted_attachments()` in `gateway/run.py`
- Reused that helper from `_deliver_media_from_response()` so streamed and
  side-task delivery share the same media/file sending logic where it matters
- Updated `_run_background_task()` to preserve thread metadata for image and
  `MEDIA:` attachment sends
- Updated `_run_btw_task()` to preserve thread metadata and remove the
  non-existent `adapter.send_file(...)` path
- Added two targeted regression tests in
  `tests/gateway/test_background_command.py`

## How to Test

1. Start from a threaded gateway chat and trigger `/background` with a response
   that includes both a markdown image and a `MEDIA:/tmp/file` attachment.
2. Trigger `/btw` with a response that includes a `MEDIA:/tmp/file` attachment.
3. Verify that the follow-up attachments stay in the same thread as the text
   reply and that `MEDIA:` attachments are delivered using the real file path,
   not the raw tuple returned by `extract_media()`.

Automated regression checks:

```bash
uv run pytest -q -n 0 tests/gateway/test_background_command.py
uvx ruff check tests/gateway/test_background_command.py
uv run python -m py_compile gateway/run.py tests/gateway/test_background_command.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Notes:
- Duplicate PR search via `gh pr list --repo NousResearch/hermes-agent --state all`
  did not find an obvious open or closed PR for this exact async attachment bug.
- Targeted validation passed:
  - `uv run pytest -q -n 0 tests/gateway/test_background_command.py`
  - `uvx ruff check tests/gateway/test_background_command.py`
  - `uv run python -m py_compile gateway/run.py tests/gateway/test_background_command.py`
- `pytest tests/ -q` was not run for this draft.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression checks:

```bash
$ uv run pytest -q -n 0 tests/gateway/test_background_command.py
....................
20 passed in 1.62s

$ uvx ruff check tests/gateway/test_background_command.py
All checks passed!

$ uv run python -m py_compile gateway/run.py tests/gateway/test_background_command.py
```
