### PR TITLE
fix(run_agent): use safe attribute extraction instead of vars() on response objects (#6133)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9002,7 +9002,16 @@ class AIAgent:
                         # Check for x-openrouter-provider or similar metadata
                         if provider_name == "Unknown" and response:
                             # Log all response attributes for debugging
-                            resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                            try:
+                                if hasattr(response, "__dict__"):
+                                    _resp_dict = response.__dict__
+                                elif hasattr(response, "model_dump"):
+                                    _resp_dict = response.model_dump()
+                                else:
+                                    _resp_dict = {}
+                                resp_attrs = {k: str(v)[:100] for k, v in _resp_dict.items() if not k.startswith('_')}
+                            except (TypeError, AttributeError):
+                                resp_attrs = {}
                             if self.verbose_logging:
                                 logging.debug(f"Response attributes for invalid response: {resp_attrs}")
                         

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1240,6 +1240,7 @@ def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch
     assert "enc_second" in encrypted_contents
 
 
+
 def test_chat_messages_to_responses_input_deduplicates_reasoning_ids(monkeypatch):
     """Duplicate reasoning item IDs across multi-turn incomplete responses
     must be deduplicated so the Responses API doesn't reject with HTTP 400."""
@@ -1301,3 +1302,41 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     # IDs must be stripped — with store=False the API 404s on id lookups.
     for it in reasoning_items:
         assert "id" not in it
+
+
+# ---------------------------------------------------------------------------
+# Issue #6133 — vars() on response objects that lack __dict__ raises TypeError.
+# The fix must use a safe fallback (hasattr __dict__ / model_dump) instead.
+# ---------------------------------------------------------------------------
+
+
+def test_run_conversation_slots_response_does_not_raise(monkeypatch):
+    """Response objects that define __slots__ (and therefore have no __dict__)
+    must not crash the invalid-response debug logging path."""
+
+    class _SlotsResponse:
+        """Minimal Responses-API response with __slots__ — no __dict__ attribute."""
+        __slots__ = ("output", "output_text", "status")
+
+        def __init__(self):
+            self.output = []
+            self.output_text = None
+            self.status = "completed"
+
+    agent = _build_agent(monkeypatch)
+    calls = {"n": 0}
+
+    def _fake_api(api_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _SlotsResponse()
+        return _codex_message_response("Recovered")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api)
+
+    # Should not raise TypeError — the safe extraction handles __slots__ objects.
+    result = agent.run_conversation("ping")
+
+    assert calls["n"] >= 2
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered"


### PR DESCRIPTION
## Problem

When provider detection falls back to scanning response attributes for debugging (run_agent.py line 7479), `vars(response)` is called, which raises `TypeError` on any response object that doesn't expose `__dict__`. This includes pydantic v2 models and certain OpenAI SDK response types, causing a crash in the error-handling path.

## Root Cause

`vars(obj)` is equivalent to `obj.__dict__` — it raises `TypeError` when the object defines `__slots__` or is a C extension type with no instance dictionary. The crash only surfaces when hitting specific providers that return these response types.

## Fix

Replace `vars(response)` with a three-way safe fallback:
1. Use `response.__dict__` if available
2. Fall back to `response.model_dump()` for pydantic v2 models
3. Fall back to an empty dict otherwise

The block is wrapped in `try/except (TypeError, AttributeError)` to guard any remaining edge cases. This matches the pattern already used elsewhere in the file (see `_build_assistant_message_from_response`).

## Testing

A regression test (`test_run_conversation_slots_response_does_not_raise`) is added in `tests/run_agent/test_run_agent_codex_responses.py`. It constructs a `__slots__`-based response object with no `__dict__` and confirms the conversation loop recovers cleanly without raising.

Fixes #6133
