### PR TITLE
fix(tools): restrict RPC socket permissions to owner-only

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -943,6 +943,7 @@ def execute_code(
         # --- Start UDS server ---
         server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         server_sock.bind(sock_path)
+        os.chmod(sock_path, 0o600)
         server_sock.listen(1)
 
         rpc_thread = threading.Thread(


### PR DESCRIPTION
## What & Why

The code execution sandbox creates a Unix domain socket at `/tmp/hermes_rpc_<uuid>.sock` with default permissions after `socket.bind()`. On shared systems (university servers, CI runners, multi-tenant VMs), any local user can enumerate and connect to these sockets to execute tool calls with the Hermes process owner's privileges.

Added `os.chmod(sock_path, 0o600)` after bind to restrict access to the owning user only.

## How to test

1. Run `hermes chat` and trigger code execution with sandbox tools
2. Check socket permissions: `ls -la /tmp/hermes_rpc_*.sock`
3. Verify permissions show `srw-------` (owner-only)

## Platform tested

- macOS 15 (Apple Silicon)

Closes #6230