### PR TITLE
Add /memstatus slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3226,6 +3226,25 @@ class HermesCLI:
         print("  Example: python cli.py --toolsets web,terminal")
         print()
     
+    def _handle_memstatus(self):
+        """Run hermes-memory-status and print its output."""
+        import subprocess
+        script = Path.home() / "bin" / "hermes-memory-status"
+        try:
+            result = subprocess.run(
+                [str(script)], capture_output=True, text=True, timeout=30
+            )
+            if result.stdout:
+                print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+            if result.stderr:
+                print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
+            if result.returncode != 0:
+                print(f"[memstatus exited {result.returncode}]")
+        except FileNotFoundError:
+            print(f"hermes-memory-status not found at {script}")
+        except Exception as e:
+            print(f"Error running hermes-memory-status: {e}")
+
     def _handle_profile_command(self):
         """Display active profile name and home directory."""
         from hermes_constants import get_hermes_home, display_hermes_home
@@ -4446,6 +4465,8 @@ class HermesCLI:
             return False
         elif canonical == "help":
             self.show_help()
+        elif canonical == "memstatus":
+            self._handle_memstatus()
         elif canonical == "profile":
             self._handle_profile_command()
         elif canonical == "tools":

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1634,6 +1634,10 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_help(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/help")
 
+        @tree.command(name="memstatus", description="Show Hermes memory health report")
+        async def slash_memstatus(interaction: discord.Interaction):
+            await self._run_simple_slash(interaction, "/memstatus", "Done")
+
         @tree.command(name="insights", description="Show usage insights and analytics")
         @discord.app_commands.describe(days="Number of days to analyze (default: 7)")
         async def slash_insights(interaction: discord.Interaction, days: int = 7):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2047,6 +2047,9 @@ class GatewayRunner:
         if canonical == "help":
             return await self._handle_help_command(event)
 
+        if canonical == "memstatus":
+            return await self._handle_memstatus_command(event)
+
         if canonical == "commands":
             return await self._handle_commands_command(event)
         
@@ -3331,6 +3334,41 @@ class GatewayRunner:
             return f"{header}\n\n{session_info}"
         return header
     
+    async def _handle_memstatus_command(self, event: MessageEvent) -> str:
+        """Handle /memstatus — run ~/bin/hermes-memory-status and return output."""
+        import asyncio
+        import re
+        from pathlib import Path
+
+        script = Path.home() / "bin" / "hermes-memory-status"
+        if not script.exists():
+            return f"❌ `hermes-memory-status` not found at `{script}`"
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                str(script),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+            except asyncio.TimeoutError:
+                proc.kill()
+                return "❌ `hermes-memory-status` timed out after 30s"
+            output = (stdout or b"").decode("utf-8", errors="replace")
+        except Exception as e:
+            return f"❌ Error running hermes-memory-status: {e}"
+
+        # Strip ANSI color codes (Discord doesn't render them)
+        output = re.sub(r"\x1b\[[0-9;]*m", "", output).rstrip()
+        if not output:
+            output = "(no output)"
+
+        # Wrap in code block for Discord; truncate if too long
+        MAX = 1900
+        if len(output) > MAX:
+            output = output[:MAX] + "\n... (truncated)"
+        return f"```\n{output}\n```"
+
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""
         from hermes_constants import get_hermes_home, display_hermes_home

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -129,6 +129,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]"),
     CommandDef("help", "Show available commands", "Info"),
+    CommandDef("memstatus", "Show health report across all memory layers", "Info",
+               aliases=("mem",)),
     CommandDef("usage", "Show token usage for the current session", "Info"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),


### PR DESCRIPTION
Adds a new `/memstatus` slash command (alias `/mem`) that runs `~/bin/hermes-memory-status` and returns its output. Works in both the CLI and the Discord gateway.

## Changes
- **hermes_cli/commands.py** — register `CommandDef` in `COMMAND_REGISTRY` (Info category, alias `mem`)
- **cli.py** — add `process_command` branch + `_handle_memstatus()` that shells out via `subprocess.run` and prints stdout/stderr
- **gateway/run.py** — add canonical branch + async `_handle_memstatus_command` using `asyncio.create_subprocess_exec` with a 30s timeout. Strips ANSI color codes via regex (Discord doesn't render them — they'd show as garbage) and wraps output in a triple-backtick code block for Discord formatting. Truncates to 1900 chars to stay under Discord's 2000-char message limit.
- **gateway/platforms/discord.py** — register native Discord slash command in `_register_slash_commands()` so `/memstatus` shows up in the autocomplete menu.

## Testing
`python -m pytest tests/cli/test_cli_init.py tests/gateway/ -q` → **2233 passed**, 4 pre-existing failures (whatsapp bridge + run_progress_topics) unrelated to this change.

## Notes
After merging, the Hermes gateway needs to be restarted for the new Discord slash command to register with Discord's API.