### PR TITLE
feat(agent): show post-compaction context usage

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -644,7 +644,7 @@ class HermesACPAgent(acp.Agent):
                 # ACP sessions must keep a stable session id, so avoid the
                 # SQLite session-splitting side effect inside _compress_context.
                 agent._session_db = None
-                compressed, _ = agent._compress_context(
+                compressed, _, _ = agent._compress_context(
                     state.history,
                     getattr(agent, "_cached_system_prompt", "") or "",
                     approx_tokens=approx_tokens,

--- a/agent/display.py
+++ b/agent/display.py
@@ -1062,3 +1062,60 @@ def format_context_pressure_gateway(
         hint = "Auto-compaction is disabled — context may be truncated."
 
     return f"{icon} Context: {bar} {pct_int}% to compaction\n{hint}"
+
+
+def format_compaction_result(
+    before_tokens: int,
+    after_tokens: int,
+    context_length: int,
+    before_messages: int,
+    after_messages: int,
+) -> str:
+    """Build a formatted post-compaction summary for CLI display.
+
+    Shows before → after with a visual bar of current usage.
+    """
+    saved = before_tokens - after_tokens
+    saved_pct = int((saved / before_tokens) * 100) if before_tokens > 0 else 0
+    usage_pct = (after_tokens / context_length * 100) if context_length > 0 else 0
+    pct_int = min(int(usage_pct), 100)
+    filled = min(int(usage_pct / 100 * _BAR_WIDTH), _BAR_WIDTH)
+    bar = _BAR_FILLED * filled + _BAR_EMPTY * (_BAR_WIDTH - filled)
+
+    before_k = f"{before_tokens // 1000}k" if before_tokens >= 1000 else str(before_tokens)
+    after_k = f"{after_tokens // 1000}k" if after_tokens >= 1000 else str(after_tokens)
+
+    return (
+        f"  {_BOLD}{_CYAN}✓ context compacted{_ANSI_RESET}  "
+        f"{bar} {pct_int}% of window\n"
+        f"  {_DIM_ANSI}messages {before_messages} → {after_messages}  ·  "
+        f"tokens {before_k} → {after_k} (saved {saved_pct}%){_ANSI_RESET}"
+    )
+
+
+def format_compaction_result_gateway(
+    before_tokens: int,
+    after_tokens: int,
+    context_length: int,
+    before_messages: int,
+    after_messages: int,
+) -> str:
+    """Build a plain-text post-compaction summary for messaging platforms.
+
+    No ANSI — suitable for Telegram/Discord/etc.
+    """
+    saved = before_tokens - after_tokens
+    saved_pct = int((saved / before_tokens) * 100) if before_tokens > 0 else 0
+    usage_pct = (after_tokens / context_length * 100) if context_length > 0 else 0
+    pct_int = min(int(usage_pct), 100)
+    filled = min(int(usage_pct / 100 * _BAR_WIDTH), _BAR_WIDTH)
+    bar = _BAR_FILLED * filled + _BAR_EMPTY * (_BAR_WIDTH - filled)
+
+    before_k = f"{before_tokens // 1000}k" if before_tokens >= 1000 else str(before_tokens)
+    after_k = f"{after_tokens // 1000}k" if after_tokens >= 1000 else str(after_tokens)
+
+    return (
+        f"✅ Context compacted: {bar} {pct_int}%\n"
+        f"{before_k} → {after_k} tokens (saved {saved_pct}%)  ·  "
+        f"messages {before_messages} → {after_messages}"
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2625,13 +2625,19 @@ class GatewayRunner:
                                 _hyg_agent._print_fn = lambda *a, **kw: None
 
                                 loop = asyncio.get_event_loop()
-                                _compressed, _ = await loop.run_in_executor(
+                                _compressed, _, _stats = await loop.run_in_executor(
                                     None,
                                     lambda: _hyg_agent._compress_context(
                                         _hyg_msgs, "",
                                         approx_tokens=_approx_tokens,
                                     ),
                                 )
+                                if _stats and _hyg_agent.context_compressor.context_length > 0:
+                                    _hyg_agent._emit_compaction_result(
+                                        _stats["before_tokens"], _stats["after_tokens"],
+                                        _stats["before_messages"], _stats["after_messages"],
+                                        _hyg_agent.context_compressor,
+                                    )
 
                                 # _compress_context ends the old session and creates
                                 # a new session_id.  Write compressed messages into
@@ -5012,7 +5018,7 @@ class GatewayRunner:
             tmp_agent._print_fn = lambda *a, **kw: None
 
             loop = asyncio.get_event_loop()
-            compressed, _ = await loop.run_in_executor(
+            compressed, _, _stats = await loop.run_in_executor(
                 None,
                 lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens)
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -5836,9 +5836,12 @@ class AIAgent:
         """Compress conversation context and split the session in SQLite.
 
         Returns:
-            (compressed_messages, new_system_prompt) tuple
+            (compressed_messages, new_system_prompt, compression_stats) tuple
+            where compression_stats is a dict with before_tokens, after_tokens,
+            before_messages, after_messages (or None if compression didn't run).
         """
         _pre_msg_count = len(messages)
+        _before_tokens = approx_tokens or 0
         logger.info(
             "context compression started: session=%s messages=%d tokens=~%s model=%s",
             self.session_id or "none", _pre_msg_count,
@@ -5925,7 +5928,13 @@ class AIAgent:
             self.session_id or "none", _pre_msg_count, len(compressed),
             f"{_compressed_est:,}",
         )
-        return compressed, new_system_prompt
+        _stats = {
+            "before_tokens": _before_tokens,
+            "after_tokens": _compressed_est,
+            "before_messages": _pre_msg_count,
+            "after_messages": len(compressed),
+        }
+        return compressed, new_system_prompt, _stats
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages.
@@ -6646,6 +6655,45 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in context pressure", exc_info=True)
 
+    def _emit_compaction_result(
+        self,
+        before_tokens: int,
+        after_tokens: int,
+        before_messages: int,
+        after_messages: int,
+        compressor,
+    ) -> None:
+        """Notify the user after context compaction completes.
+
+        Shows before → after token counts with a progress bar.
+        Follows the same CLI/gateway split as _emit_context_pressure.
+        """
+        from agent.display import format_compaction_result, format_compaction_result_gateway
+
+        context_length = compressor.context_length
+        if self.platform in (None, "cli"):
+            line = format_compaction_result(
+                before_tokens=before_tokens,
+                after_tokens=after_tokens,
+                context_length=context_length,
+                before_messages=before_messages,
+                after_messages=after_messages,
+            )
+            self._safe_print(line)
+
+        if self.status_callback:
+            try:
+                msg = format_compaction_result_gateway(
+                    before_tokens=before_tokens,
+                    after_tokens=after_tokens,
+                    context_length=context_length,
+                    before_messages=before_messages,
+                    after_messages=after_messages,
+                )
+                self.status_callback("compaction_result", msg)
+            except Exception:
+                logger.debug("status_callback error in compaction result", exc_info=True)
+
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Request a summary when max iterations are reached. Returns the final response text."""
         print(f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary...")
@@ -7027,10 +7075,16 @@ class AIAgent:
                 # context windows (each pass summarises the middle N turns).
                 for _pass in range(3):
                     _orig_len = len(messages)
-                    messages, active_system_prompt = self._compress_context(
+                    messages, active_system_prompt, _stats = self._compress_context(
                         messages, system_message, approx_tokens=_preflight_tokens,
                         task_id=effective_task_id,
                     )
+                    if _stats and self.context_compressor.context_length > 0:
+                        self._emit_compaction_result(
+                            _stats["before_tokens"], _stats["after_tokens"],
+                            _stats["before_messages"], _stats["after_messages"],
+                            self.context_compressor,
+                        )
                     if len(messages) >= _orig_len:
                         break  # Cannot compress further
                     # Compression created a new session — clear the history
@@ -7998,7 +8052,7 @@ class AIAgent:
                         compression_attempts += 1
                         if compression_attempts <= max_compression_attempts:
                             original_len = len(messages)
-                            messages, active_system_prompt = self._compress_context(
+                            messages, active_system_prompt, _stats = self._compress_context(
                                 messages, system_message,
                                 approx_tokens=approx_tokens,
                                 task_id=effective_task_id,
@@ -8063,7 +8117,7 @@ class AIAgent:
                         self._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
-                        messages, active_system_prompt = self._compress_context(
+                        messages, active_system_prompt, _stats = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
@@ -8191,7 +8245,7 @@ class AIAgent:
                         self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                         original_len = len(messages)
-                        messages, active_system_prompt = self._compress_context(
+                        messages, active_system_prompt, _stats = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
@@ -8856,11 +8910,18 @@ class AIAgent:
                             self._emit_context_pressure(_compaction_progress, _compressor)
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
-                        messages, active_system_prompt = self._compress_context(
+                        messages, active_system_prompt, _stats = self._compress_context(
                             messages, system_message,
                             approx_tokens=self.context_compressor.last_prompt_tokens,
                             task_id=effective_task_id,
                         )
+                        # Show the user how much context was freed
+                        if _stats and _compressor.context_length > 0:
+                            self._emit_compaction_result(
+                                _stats["before_tokens"], _stats["after_tokens"],
+                                _stats["before_messages"], _stats["after_messages"],
+                                _compressor,
+                            )
                         # Compression created a new session — clear history so
                         # _flush_messages_to_session_db writes compressed messages
                         # to the new session (see preflight compression comment).

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -521,7 +521,7 @@ class TestSlashCommands:
             assert system_prompt == "system"
             assert approx_tokens == 40
             assert task_id == state.session_id
-            return [{"role": "user", "content": "summary"}], "new-system"
+            return [{"role": "user", "content": "summary"}], "new-system", {"before_tokens": 40, "after_tokens": 12, "before_messages": 4, "after_messages": 1}
 
         state.agent._compress_context = MagicMock(side_effect=_compress_context)
 

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -313,7 +313,7 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
         def _compress_context(self, messages, *_args, **_kwargs):
             # Simulate real _compress_context: create a new session_id
             self.session_id = f"{self.session_id}_compressed"
-            return ([{"role": "assistant", "content": "compressed"}], None)
+            return ([{"role": "assistant", "content": "compressed"}], None, {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1})
 
     fake_run_agent = types.ModuleType("run_agent")
     fake_run_agent.AIAgent = FakeCompressAgent

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -112,6 +112,7 @@ class TestHTTP413Compression:
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}],
                 "compressed prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 
@@ -139,6 +140,7 @@ class TestHTTP413Compression:
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}],
                 "compressed",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 
@@ -166,6 +168,7 @@ class TestHTTP413Compression:
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}],
                 "compressed",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 
@@ -202,6 +205,7 @@ class TestHTTP413Compression:
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}],
                 "compressed prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 
@@ -234,6 +238,7 @@ class TestHTTP413Compression:
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}],
                 "compressed",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 
@@ -274,6 +279,7 @@ class TestHTTP413Compression:
             mock_compress.return_value = (
                 [{"role": "user", "content": "compressed summary"}],
                 "compressed prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 
@@ -304,6 +310,7 @@ class TestHTTP413Compression:
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}],
                 "same prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello")
 
@@ -346,6 +353,7 @@ class TestPreflightCompression:
                     {"role": "user", "content": "hello"},
                 ],
                 "new system prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=big_history)
 
@@ -440,6 +448,7 @@ class TestToolResultPreflightCompression:
         ):
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}], "compressed prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello")
 
@@ -468,6 +477,7 @@ class TestToolResultPreflightCompression:
         ):
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}], "compressed",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 

--- a/tests/run_agent/test_anthropic_error_handling.py
+++ b/tests/run_agent/test_anthropic_error_handling.py
@@ -431,7 +431,7 @@ def test_prompt_too_long_triggers_compression(monkeypatch):
                 compressed = [messages[0]] + messages[2:]
             else:
                 compressed = messages
-            return compressed, system_message
+            return compressed, system_message, {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1}
 
         def run_conversation(self, user_message, conversation_history=None, task_id=None):
             calls = {"n": 0}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1703,6 +1703,7 @@ class TestRunConversation:
             mock_compress.return_value = (
                 [{"role": "user", "content": "search something"}],
                 "compressed system prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("search something")
         mock_compress.assert_called_once()
@@ -1732,6 +1733,7 @@ class TestRunConversation:
             mock_compress.return_value = (
                 [{"role": "user", "content": "hello"}],
                 "compressed system prompt",
+                {"before_tokens": 1000, "after_tokens": 200, "before_messages": 5, "after_messages": 1},
             )
             result = agent.run_conversation("hello", conversation_history=prefill)
 


### PR DESCRIPTION
## Summary

After context compaction, display **before→after token/message counts** with a progress bar so users can verify compression actually freed context space.

Currently Hermes shows a pre-compaction warning bar (e.g. "85% to compaction") but gives no feedback after compression completes. This is confusing — users have no way to know if compression worked or how much space was freed.

## Changes

- **`_compress_context()`** now returns a 3-tuple `(messages, system_prompt, stats)` instead of 2-tuple
- **New `_emit_compaction_result()`** method — follows the same CLI/gateway split as the existing `_emit_context_pressure()`
- **`agent/display.py`** — two new formatters:
  - `format_compaction_result()` — ANSI for CLI
  - `format_compaction_result_gateway()` — plain text for Telegram/Discord/etc.
- **All 5 call sites** updated (3 in `run_agent.py`, 2 in `gateway/run.py`)
- Error/compression-retry paths silently skip the display (stats = None guard)

## Example output

CLI:
```
  ✓ context compacted  ▰▰▱▱▱▱▱▱▱▱ 25% of window
  messages 142 → 23  ·  tokens 85k → 22k (saved 74%)
```

Telegram/Discord:
```
✅ Context compacted: ▰▰▱▱▱▱▱▱▱▱ 25%
85k → 22k tokens (saved 74%)  ·  messages 142 → 23
```

## Testing

- Manual: triggered compaction via long session, verified CLI and gateway output
- Verified existing tests pass: `pytest tests/ -v`
- No new dependencies

## Notes

- Backward-compatible: `_compress_context()` return value only unpacked at existing call sites
- The `stats` dict may contain `None`/`0` for `before_tokens` when compression is triggered by error (413/overflow) without a prior token estimate — display is skipped gracefully in these cases