### PR TITLE
feat(gateway): optional model/thinking header on gateway replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -480,6 +480,7 @@ class GatewayRunner:
         self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
         self._reasoning_config = self._load_reasoning_config()
         self._show_reasoning = self._load_show_reasoning()
+        self._response_header = self._load_response_header()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
         self._smart_model_routing = self._load_smart_model_routing()
@@ -956,6 +957,44 @@ class GatewayRunner:
         except Exception:
             pass
         return False
+
+    @staticmethod
+    def _load_response_header() -> bool:
+        """Load response_header toggle from config.yaml display section.
+
+        When enabled, the gateway prepends a compact one-line header to
+        each assistant reply showing the resolved model and effective
+        reasoning/thinking level. Off by default. See issue #6232.
+        """
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                return bool(cfg.get("display", {}).get("response_header", False))
+        except Exception:
+            pass
+        return False
+
+    @staticmethod
+    def _format_response_header(model, reasoning_cfg) -> str:
+        """Build the compact one-line model/thinking header string.
+
+        Format: ``Model: <model> | Thinking: <level>``
+        - ``model`` falls back to ``unknown`` when not resolvable.
+        - ``reasoning_cfg`` is the dict returned by ``parse_reasoning_effort``:
+          ``None`` -> ``default``; ``{"enabled": False}`` -> ``none``;
+          ``{"enabled": True, "effort": <level>}`` -> ``<level>``.
+        """
+        model_str = (model or "unknown").strip() or "unknown"
+        if reasoning_cfg is None:
+            thinking = "default"
+        elif not reasoning_cfg.get("enabled", False):
+            thinking = "none"
+        else:
+            thinking = str(reasoning_cfg.get("effort") or "default")
+        return f"Model: {model_str} | Thinking: {thinking}"
 
     @staticmethod
     def _load_background_notifications_mode() -> str:
@@ -2976,6 +3015,17 @@ class GatewayRunner:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
+            # Prepend compact model/thinking header when display.response_header is enabled (#6232)
+            if getattr(self, "_response_header", False) and response:
+                try:
+                    _header_line = self._format_response_header(
+                        agent_result.get("model"),
+                        getattr(self, "_reasoning_config", None),
+                    )
+                    response = f"{_header_line}\n\n{response}"
+                except Exception as _hdr_exc:
+                    logger.debug("response_header formatting failed: %s", _hdr_exc)
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
@@ -4834,6 +4884,7 @@ class GatewayRunner:
         config_path = _hermes_home / "config.yaml"
         self._reasoning_config = self._load_reasoning_config()
         self._show_reasoning = self._load_show_reasoning()
+        self._response_header = self._load_response_header()
 
         def _save_config_key(key_path: str, value):
             """Save a dot-separated key to config.yaml."""

--- a/tests/gateway/test_response_header.py
+++ b/tests/gateway/test_response_header.py
@@ -1,0 +1,43 @@
+"""Tests for the optional gateway response header (issue #6232).
+
+The ``display.response_header`` config flag prepends a compact
+``Model: <model> | Thinking: <level>`` line to assistant replies so that
+messaging users (Telegram, Discord, Slack, etc.) can tell at a glance
+which model / reasoning level produced a given reply.
+"""
+from __future__ import annotations
+
+from gateway.run import GatewayRunner
+
+
+def test_format_response_header_default_reasoning():
+    header = GatewayRunner._format_response_header("gpt-5.4", None)
+    assert header == "Model: gpt-5.4 | Thinking: default"
+
+
+def test_format_response_header_none_reasoning():
+    header = GatewayRunner._format_response_header(
+        "claude-sonnet-4.5", {"enabled": False}
+    )
+    assert header == "Model: claude-sonnet-4.5 | Thinking: none"
+
+
+def test_format_response_header_high_reasoning():
+    header = GatewayRunner._format_response_header(
+        "gpt-5.4", {"enabled": True, "effort": "high"}
+    )
+    assert header == "Model: gpt-5.4 | Thinking: high"
+
+
+def test_format_response_header_missing_model():
+    header = GatewayRunner._format_response_header(
+        None, {"enabled": True, "effort": "medium"}
+    )
+    assert header == "Model: unknown | Thinking: medium"
+
+
+def test_format_response_header_empty_model():
+    header = GatewayRunner._format_response_header(
+        "  ", {"enabled": True, "effort": "low"}
+    )
+    assert header == "Model: unknown | Thinking: low"


### PR DESCRIPTION
## Summary

Adds an optional `display.response_header` config flag (off by default) that prepends a compact one-line header to assistant replies delivered through the gateway:

```
Model: gpt-5.4 | Thinking: high

<actual reply follows>
```

Messaging users (Telegram, Discord, Slack, WhatsApp, etc.) do not have the CLI status bar, so this gives them an at-a-glance view of which model and reasoning effort actually produced the reply. Useful for comparing providers, validating config changes took effect in messaging sessions, and debugging reports like "the thread says it is one model but config says another".

## Behavior

- Controlled by `display.response_header: true|false` in `config.yaml`, mirroring the existing `display.show_reasoning` pattern
- **Off by default** — zero behavior change for existing users
- Uses the **resolved runtime model** from `agent_result["model"]` (not just the configured default)
- Uses the **effective reasoning config** for the turn: `none` for disabled, the effort level (`low`/`medium`/`high`/`xhigh`/`minimal`) when enabled, or `default` when unconfigured
- Plain text format so it renders safely across platforms that don't support rich formatting
- Applied after the existing `show_reasoning` block in the gateway response assembly, wrapped in `try/except` so any formatting hiccup degrades gracefully to the original reply

## Changes

- `gateway/run.py`
  - New `_load_response_header()` static loader (same shape as `_load_show_reasoning`)
  - New `_format_response_header(model, reasoning_cfg)` static formatter
  - `_response_header` attribute initialized in `__init__` and reloaded alongside `_show_reasoning` in the `/reasoning` command handler
  - Prepend logic in the gateway response assembly path
- `tests/gateway/test_response_header.py` — unit tests for the formatter covering default / none / high / missing-model / empty-model cases

Fixes #6232