### PR TITLE
fix(prompt): ignore inaccessible context files

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -102,8 +102,11 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     for directory in [current, *current.parents]:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
-            if candidate.is_file():
-                return candidate
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError as e:
+                logger.debug("Could not inspect %s: %s", candidate, e)
         # Stop walking at the git root (or filesystem root).
         if stop_at and directory == stop_at:
             break
@@ -883,15 +886,15 @@ def _load_agents_md(cwd_path: Path) -> str:
     """AGENTS.md — top-level only (no recursive walk)."""
     for name in ["AGENTS.md", "agents.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
+        try:
+            if candidate.exists():
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
                     return _truncate_content(result, "AGENTS.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        except OSError as e:
+            logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 
@@ -899,15 +902,15 @@ def _load_claude_md(cwd_path: Path) -> str:
     """CLAUDE.md / claude.md — cwd only."""
     for name in ["CLAUDE.md", "claude.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
+        try:
+            if candidate.exists():
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
                     return _truncate_content(result, "CLAUDE.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        except OSError as e:
+            logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 
@@ -915,26 +918,29 @@ def _load_cursorrules(cwd_path: Path) -> str:
     """.cursorrules + .cursor/rules/*.mdc — cwd only."""
     cursorrules_content = ""
     cursorrules_file = cwd_path / ".cursorrules"
-    if cursorrules_file.exists():
-        try:
+    try:
+        if cursorrules_file.exists():
             content = cursorrules_file.read_text(encoding="utf-8").strip()
             if content:
                 content = _scan_context_content(content, ".cursorrules")
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
-        except Exception as e:
-            logger.debug("Could not read .cursorrules: %s", e)
+    except OSError as e:
+        logger.debug("Could not read .cursorrules: %s", e)
 
     cursor_rules_dir = cwd_path / ".cursor" / "rules"
-    if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
-        mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
-        for mdc_file in mdc_files:
-            try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
-                    cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
-            except Exception as e:
-                logger.debug("Could not read %s: %s", mdc_file, e)
+    try:
+        if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
+            mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
+            for mdc_file in mdc_files:
+                try:
+                    content = mdc_file.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
+                        cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
+                except OSError as e:
+                    logger.debug("Could not read %s: %s", mdc_file, e)
+    except OSError as e:
+        logger.debug("Could not inspect %s: %s", cursor_rules_dir, e)
 
     if not cursorrules_content:
         return ""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -670,6 +671,70 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "ESLint" in result
 
+    def test_skips_inaccessible_agents_md(self, tmp_path, monkeypatch):
+        target = tmp_path / "AGENTS.md"
+        target.write_text("blocked")
+
+        original_exists = Path.exists
+
+        def fake_exists(path):
+            if path == target:
+                raise PermissionError("denied")
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+
+        result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+        assert "## AGENTS.md" not in result
+
+    def test_skips_inaccessible_claude_md(self, tmp_path, monkeypatch):
+        target = tmp_path / "CLAUDE.md"
+        target.write_text("blocked")
+
+        original_exists = Path.exists
+
+        def fake_exists(path):
+            if path == target:
+                raise PermissionError("denied")
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+
+        result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+        assert "## CLAUDE.md" not in result
+
+    def test_skips_inaccessible_cursorrules(self, tmp_path, monkeypatch):
+        target = tmp_path / ".cursorrules"
+        target.write_text("blocked")
+
+        original_exists = Path.exists
+
+        def fake_exists(path):
+            if path == target:
+                raise PermissionError("denied")
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+
+        result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+        assert "## .cursorrules" not in result
+
+    def test_skips_inaccessible_cursor_rules_dir(self, tmp_path, monkeypatch):
+        rules_dir = tmp_path / ".cursor" / "rules"
+        rules_dir.mkdir(parents=True)
+
+        original_exists = Path.exists
+
+        def fake_exists(path):
+            if path == rules_dir:
+                raise PermissionError("denied")
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+
+        result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+        assert "## .cursor/rules/" not in result
+
 
 # =========================================================================
 # .hermes.md helper functions
@@ -680,6 +745,20 @@ class TestFindHermesMd:
     def test_finds_in_cwd(self, tmp_path):
         (tmp_path / ".hermes.md").write_text("rules")
         assert _find_hermes_md(tmp_path) == tmp_path / ".hermes.md"
+
+    def test_skips_inaccessible_candidate(self, tmp_path, monkeypatch):
+        target = tmp_path / ".hermes.md"
+
+        original_is_file = Path.is_file
+
+        def fake_is_file(path):
+            if path == target:
+                raise PermissionError("denied")
+            return original_is_file(path)
+
+        monkeypatch.setattr(Path, "is_file", fake_is_file)
+
+        assert _find_hermes_md(tmp_path) is None
 
     def test_finds_uppercase(self, tmp_path):
         (tmp_path / "HERMES.md").write_text("rules")


### PR DESCRIPTION
## Summary
- catch inaccessible-path filesystem probes while discovering `.hermes.md`, `AGENTS.md`, `CLAUDE.md`, and Cursor rules context files
- keep context-file loading best-effort when `TERMINAL_CWD` points to a host-inaccessible path such as `/root` from a sandbox backend
- add regression tests covering `PermissionError` from `Path.exists()` and `Path.is_file()` during context discovery

## Testing
- `source venv/bin/activate && python -m pytest tests/agent/test_prompt_builder.py -q`
- `source venv/bin/activate && python -m pytest tests/agent/ -q` *(fails on pre-existing unrelated test: `tests/agent/test_auxiliary_named_custom_providers.py::TestNormalizeVisionProvider::test_main_resolves_to_named_custom`)*

Closes #6214
