### PR TITLE
fix(gateway): keep /model and /queue non-interrupting and execute queued /model post-turn

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1165,7 +1165,13 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset"):
+            # Commands that must bypass the running-agent interrupt path:
+            # - approve/deny: agent is blocked on Event.wait() in approval.py
+            # - status: informational, no need to interrupt
+            # - stop/new/reset: session control, handled in run.py with explicit interrupt
+            # - model: post-turn config change, must not kill the running agent
+            # - queue/q: queues for next turn, must not interrupt current one
+            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "model", "queue", "q"):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -339,14 +339,33 @@ def _dequeue_pending_text(adapter, session_key: str) -> str | None:
 
     Preserves media context for captionless photo/document events by
     building a placeholder so the message isn't silently dropped.
+
+    Important: If the pending event is a slash command, re-queue the full
+    event and return None. Command events must be dispatched via the normal
+    gateway message pipeline (process_message), not recursed into _run_agent
+    as plain user text.
     """
     event = adapter.get_pending_message(session_key)
     if not event:
         return None
-    text = event.text
+
+    # Keep command events for post-turn message-pipeline dispatch.
+    text = (event.text or "").strip()
+    if text.startswith("/"):
+        parts = text.split(None, 1)
+        cmd_word = parts[0][1:].lower() if parts else ""
+        if cmd_word:
+            try:
+                from hermes_cli.commands import resolve_command as _resolve_pending_cmd
+                if _resolve_pending_cmd(cmd_word):
+                    adapter._pending_messages[session_key] = event
+                    return None
+            except Exception:
+                pass
+
     if not text and getattr(event, "media_urls", None):
         text = _build_media_placeholder(event)
-    return text
+    return text or None
 
 
 def _check_unavailable_skill(command_name: str) -> str | None:
@@ -7298,8 +7317,11 @@ class GatewayRunner:
                     first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
-                            await adapter.send(source.chat_id, first_response,
-                                               metadata=getattr(event, "metadata", None))
+                            await adapter.send(
+                                source.chat_id,
+                                first_response,
+                                metadata=_progress_metadata,
+                            )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                 # else: interrupted — discard the interrupted response ("Operation

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1968,9 +1968,14 @@ class GatewayRunner:
                     adapter._pending_messages[_quick_key] = queued_event
                 return "Queued for the next turn."
 
-            # /model must not be used while the agent is running.
+            # /model — queue for post-turn execution instead of blocking or erroring.
+            # The pending event is picked up by _process_message_background after the
+            # current turn completes, dispatching it through the normal command pipeline.
             if _cmd_def_inner and _cmd_def_inner.name == "model":
-                return "Agent is running — wait or /stop first, then switch models."
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    adapter._pending_messages[_quick_key] = event
+                return "⏳ Model switch queued — will open after this turn."
 
             # /approve and /deny must bypass the running-agent interrupt path.
             # The agent thread is blocked on a threading.Event inside

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -160,6 +160,30 @@ class TestCommandBypassActiveSession:
         assert sk not in adapter._pending_messages
         assert any("handled:status" in r for r in adapter.sent_responses)
 
+    @pytest.mark.asyncio
+    async def test_model_bypasses_guard(self):
+        """/model must bypass active-session guard (queued command flow)."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/model"))
+
+        assert sk not in adapter._pending_messages
+        assert any("handled:model" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
+    async def test_queue_bypasses_guard(self):
+        """/queue must bypass active-session guard (handled in runner)."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/queue do this next"))
+
+        assert sk not in adapter._pending_messages
+        assert any("handled:queue" in r for r in adapter.sent_responses)
+
 
 # ---------------------------------------------------------------------------
 # Tests: non-bypass messages still get queued
@@ -276,6 +300,31 @@ class TestPendingCommandSafetyNet:
         # The safety net splits on whitespace and takes the first word
         # after stripping '/'.  For '/path/to/file', that's 'path/to/file'.
         assert resolve_command("path/to/file") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: queued slash commands stay as events for post-turn dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestPendingCommandEventPreservation:
+    """Queued slash commands must remain MessageEvents for pipeline dispatch."""
+
+    def test_dequeue_pending_text_requeues_known_slash_command_event(self):
+        from gateway.run import _dequeue_pending_text
+
+        adapter = _make_adapter()
+        sk = _session_key()
+        event = _make_event("/model")
+        adapter._pending_messages[sk] = event
+
+        pending_text = _dequeue_pending_text(adapter, sk)
+
+        # Command should not be converted to plain text recursion input.
+        assert pending_text is None
+        # Event must remain queued for process_message() post-turn dispatch.
+        assert sk in adapter._pending_messages
+        assert adapter._pending_messages[sk] is event
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes gateway behavior for slash commands sent during an active session:

- `/model` and `/queue` no longer trigger active-turn interrupts.
- queued `/model` now executes after the current turn (via normal command pipeline) instead of being dropped.
- fixes a related `NameError` in the first-response-before-queued-message send path.

## Related Issue

Fixes #5057

Additional investigation/comment:
https://github.com/NousResearch/hermes-agent/issues/5057#issuecomment-4208440614

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/base.py`
  - extended active-session bypass allowlist with `model`, `queue`, `q`
- `gateway/run.py`
  - queue `/model` during active run (instead of hard reject)
  - in `_dequeue_pending_text()`, keep queued slash commands as `MessageEvent`s by re-queueing recognized commands and returning `None`
  - fixed undefined `event` reference in post-turn send path
- `tests/gateway/test_command_bypass_active_session.py`
  - added regression tests for `/model` and `/queue` bypass
  - added test ensuring queued slash command events are preserved for post-turn dispatch

## How to Test

1. Start gateway and trigger a long-running turn in Telegram.
2. While running, send `/model` and `/queue <prompt>`.
3. Verify no interrupt occurs.
4. Verify queued `/model` executes after turn completion.
5. Run tests:
   - `./venv/bin/pytest tests/gateway/test_command_bypass_active_session.py tests/gateway/test_queue_consumption.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've tested manually on my platform: Debian 13 / Telegram gateway
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] N/A (no config keys, no docs/API schema changes)

## Screenshots / Logs

Manual live test result in Telegram: `/model` and `/queue` no longer interrupt active turn; queued `/model` executes post-turn.
