### PR TITLE
fix(gateway): stop echoing local file paths in media fallbacks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -797,12 +797,15 @@ class BasePlatformAdapter(ABC):
         Send a video natively via the platform API.
 
         Override in subclasses to send videos as inline playable media.
-        Default falls back to sending the file path as text.
+        Default reports failure without leaking the local filesystem path
+        as message text (fixes #6249).
         """
-        text = f"🎬 Video: {video_path}"
         if caption:
-            text = f"{caption}\n{text}"
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+            await self.send(chat_id=chat_id, content=caption, reply_to=reply_to)
+        return SendResult(
+            success=False,
+            error=f"send_video not implemented for {self.name}; cannot deliver local file",
+        )
 
     async def send_document(
         self,
@@ -817,12 +820,15 @@ class BasePlatformAdapter(ABC):
         Send a document/file natively via the platform API.
 
         Override in subclasses to send files as downloadable attachments.
-        Default falls back to sending the file path as text.
+        Default reports failure without leaking the local filesystem path
+        as message text (fixes #6249).
         """
-        text = f"📎 File: {file_path}"
         if caption:
-            text = f"{caption}\n{text}"
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+            await self.send(chat_id=chat_id, content=caption, reply_to=reply_to)
+        return SendResult(
+            success=False,
+            error=f"send_document not implemented for {self.name}; cannot deliver local file",
+        )
 
     async def send_image_file(
         self,
@@ -837,12 +843,16 @@ class BasePlatformAdapter(ABC):
 
         Unlike send_image() which takes a URL, this takes a local file path.
         Override in subclasses for native photo attachments.
-        Default falls back to sending the file path as text.
+        Default reports failure without leaking the local filesystem path
+        as message text (fixes #6249) — echoing the absolute on-disk path
+        is both confusing for users and a minor information disclosure.
         """
-        text = f"🖼️ Image: {image_path}"
         if caption:
-            text = f"{caption}\n{text}"
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+            await self.send(chat_id=chat_id, content=caption, reply_to=reply_to)
+        return SendResult(
+            success=False,
+            error=f"send_image_file not implemented for {self.name}; cannot deliver local file",
+        )
 
     @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:


### PR DESCRIPTION
Fixes #6249

## Problem
When the gateway delivered a `MEDIA:/path/to/img.png` directive on Telegram, users sometimes saw a plain text message like:

```
🖼️ Image: /data/repo/home/cache/screenshots/browser_screenshot_*.png
```

instead of a native photo upload. This happened whenever the dispatch fell through the base `PlatformAdapter.send_image_file` fallback — either because a subclass did not override it, or because an override raised and called `super().send_image_file(...)` (e.g. Telegram's adapter does this on `send_photo` errors). The base implementation built a text message containing the absolute on-disk path and sent it as a normal chat message, which:

- contradicts the documented MEDIA: behaviour (native attachment),
- confuses users with an unintelligible internal path, and
- minor info disclosure of internal paths.

`send_document` and `send_video` had the same fallback shape.

## Fix
Make the base `send_image_file` / `send_document` / `send_video` fallbacks return a `SendResult(success=False, ...)` instead of echoing the local filesystem path. Captions, if provided, are still forwarded as a normal text message. Callers in `gateway/platforms/base.py` and `gateway/run.py` already log delivery failures, so the user simply does not see a bogus path masquerading as an image.

## Test plan
- [ ] Manual: trigger a `browser_vision` screenshot reply on Telegram and verify the screenshot arrives as a native photo (or, on failure, no path is leaked into the chat).
- [ ] Existing gateway tests still pass (no tests asserted the old `🖼️ Image: …` fallback string).