### PR TITLE
fix(docker): #6197 enable unbuffered stdout for live logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:13.4
 
+# Disable Python stdout buffering to ensure logs are printed immediately
+ENV PYTHONUNBUFFERED=1
+
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## What does this PR do?


This PR adds the `ENV PYTHONUNBUFFERED=1` variable to the Dockerfile. 

Previously, Python buffered stdout when running inside the Docker container, which prevented the live logs from displaying when using `docker logs -f hermes-agent`. By setting this environment variable, Python will print logs directly to stdout, allowing users to monitor the gateway and agent activities in real-time.


Fixes #6197