### PR TITLE
fix(cli): improve ChatConsole usage and fix associated tests

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1609,6 +1609,7 @@ class HermesCLI:
         """
         # Initialize Rich console
         self.console = Console()
+        self.chat_console = ChatConsole()
         self.config = CLI_CONFIG
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
@@ -2676,7 +2677,7 @@ class HermesCLI:
             )
         except Exception as exc:
             message = format_runtime_provider_error(exc)
-            ChatConsole().print(f"[bold red]{message}[/]")
+            self.chat_console.print(f"[bold red]{message}[/]")
             return False
 
         api_key = runtime.get("api_key")
@@ -2834,14 +2835,14 @@ class HermesCLI:
                 title_part = ""
                 if session_meta.get("title"):
                     title_part = f" \"{session_meta['title']}\""
-                ChatConsole().print(
+                self.chat_console.print(
                     f"[bold {_accent_hex()}]↻ Resumed session[/] "
                     f"[bold]{_escape(self.session_id)}[/]"
                     f"[bold {_accent_hex()}]{_escape(title_part)}[/] "
                     f"({msg_count} user message{'s' if msg_count != 1 else ''}, {len(restored)} total messages)"
                 )
             else:
-                ChatConsole().print(
+                self.chat_console.print(
                     f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
                 )
             # Re-open the session (clear ended_at so it's active again)
@@ -2931,7 +2932,7 @@ class HermesCLI:
                     self._pending_title = None
             return True
         except Exception as e:
-            ChatConsole().print(f"[bold red]Failed to initialize agent: {e}[/]")
+            self.chat_console.print(f"[bold red]Failed to initialize agent: {e}[/]")
             return False
     
     def show_banner(self):
@@ -3750,12 +3751,12 @@ class HermesCLI:
             for cmd, desc in commands.items():
                 if not self._command_available(cmd):
                     continue
-                ChatConsole().print(f"    [bold {_accent_hex()}]{cmd:<15}[/] [dim]-[/] {_escape(desc)}")
+                self.chat_console.print(f"    [bold {_accent_hex()}]{cmd:<15}[/] [dim]-[/] {_escape(desc)}")
 
         if _skill_commands:
             _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed):")
             for cmd, info in sorted(_skill_commands.items()):
-                ChatConsole().print(
+                self.chat_console.print(
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"
                 )
 
@@ -5241,7 +5242,7 @@ class HermesCLI:
     def _handle_skills_command(self, cmd: str):
         """Handle /skills slash command — delegates to hermes_cli.skills_hub."""
         from hermes_cli.skills_hub import handle_skills_slash
-        handle_skills_slash(cmd, ChatConsole())
+        handle_skills_slash(cmd, self.chat_console)
 
     def _show_gateway_status(self):
         """Show status of the gateway and connected messaging platforms."""
@@ -5350,10 +5351,9 @@ class HermesCLI:
             # renderer) instead of self.console (which writes raw to stdout
             # and gets mangled by patch_stdout).
             if self._app:
-                cc = ChatConsole()
                 term_w = shutil.get_terminal_size().columns
                 if self.compact or term_w < 80:
-                    cc.print(_build_compact_banner())
+                    self.chat_console.print(_build_compact_banner())
                 else:
                     tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
@@ -5361,7 +5361,7 @@ class HermesCLI:
                     if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
                         ctx_len = self.agent.context_compressor.context_length
                     build_welcome_banner(
-                        console=cc,
+                        console=self.chat_console,
                         model=self.model,
                         cwd=cwd,
                         tools=tools,
@@ -5379,7 +5379,7 @@ class HermesCLI:
                         _tip_color = get_active_skin().get_color("banner_dim", "#B8860B")
                     except Exception:
                         _tip_color = "#B8860B"
-                    cc.print(f"[dim {_tip_color}]✦ Tip: {_tip}[/]")
+                    self.chat_console.print(f"[dim {_tip_color}]✦ Tip: {_tip}[/]")
                 except Exception:
                     pass
             else:
@@ -5486,7 +5486,7 @@ class HermesCLI:
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"
-            self.console.print(f"  Status bar {state}")
+            self.chat_console.print(f"  Status bar {state}")
         elif canonical == "verbose":
             self._toggle_verbose()
         elif canonical == "yolo":
@@ -5580,15 +5580,15 @@ class HermesCLI:
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:
-                                self.console.print(_rich_text_from_ansi(output))
+                                self.chat_console.print(_rich_text_from_ansi(output))
                             else:
-                                self.console.print("[dim]Command returned no output[/]")
+                                self.chat_console.print("[dim]Command returned no output[/]")
                         except subprocess.TimeoutExpired:
-                            self.console.print("[bold red]Quick command timed out (30s)[/]")
+                            self.chat_console.print("[bold red]Quick command timed out (30s)[/]")
                         except Exception as e:
-                            self.console.print(f"[bold red]Quick command error: {e}[/]")
+                            self.chat_console.print(f"[bold red]Quick command error: {e}[/]")
                     else:
-                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
+                        self.chat_console.print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
                 elif qcmd.get("type") == "alias":
                     target = qcmd.get("target", "").strip()
                     if target:
@@ -5597,9 +5597,9 @@ class HermesCLI:
                         aliased_command = f"{target} {user_args}".strip()
                         return self.process_command(aliased_command)
                     else:
-                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
+                        self.chat_console.print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
                 else:
-                    self.console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
+                    self.chat_console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import get_plugin_command_handler
@@ -5624,7 +5624,7 @@ class HermesCLI:
                     if hasattr(self, '_pending_input'):
                         self._pending_input.put(msg)
                 else:
-                    ChatConsole().print(f"[bold red]Failed to load skill for {base_cmd}[/]")
+                    self.chat_console.print(f"[bold red]Failed to load skill for {base_cmd}[/]")
             else:
                 # Prefix matching: if input uniquely identifies one command, execute it.
                 # Matches against both built-in COMMANDS and installed skill commands so
@@ -5685,14 +5685,14 @@ class HermesCLI:
         )
 
         if not msg:
-            ChatConsole().print("[bold red]Failed to load the bundled /plan skill[/]")
+            self.chat_console.print("[bold red]Failed to load the bundled /plan skill[/]")
             return
 
         _cprint(f"  📝 Plan mode queued via skill. Markdown plan target: {plan_path}")
         if hasattr(self, '_pending_input'):
             self._pending_input.put(msg)
         else:
-            ChatConsole().print("[bold red]Plan mode unavailable: input queue not initialized[/]")
+            self.chat_console.print("[bold red]Plan mode unavailable: input queue not initialized[/]")
     
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.
@@ -5781,10 +5781,10 @@ class HermesCLI:
                     import time as _tmod
                     _tmod.sleep(0.05)  # brief pause for refresh
                 print()
-                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                self.chat_console.print(f"[{_accent_hex()}]{'─' * 40}[/]")
                 _cprint(f"  ✅ Background task #{task_num} complete")
                 _cprint(f"  Prompt: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
-                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                self.chat_console.print(f"[{_accent_hex()}]{'─' * 40}[/]")
                 if response:
                     try:
                         from hermes_cli.skin_engine import get_active_skin
@@ -5797,8 +5797,7 @@ class HermesCLI:
                         _resp_color = "#CD7F32"
                         _resp_text = "#FFF8DC"
 
-                    _chat_console = ChatConsole()
-                    _chat_console.print(Panel(
+                    self.chat_console.print(Panel(
                         _rich_text_from_ansi(response),
                         title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
                         title_align="left",
@@ -5923,7 +5922,7 @@ class HermesCLI:
                     except Exception:
                         _resp_color = "#4F6D4A"
 
-                    ChatConsole().print(Panel(
+                    self.chat_console.print(Panel(
                         _rich_text_from_ansi(response),
                         title=f"[{_resp_color} bold]⚕ /btw[/]",
                         title_align="left",
@@ -6245,10 +6244,10 @@ class HermesCLI:
         current = bool(os.environ.get("HERMES_YOLO_MODE"))
         if current:
             os.environ.pop("HERMES_YOLO_MODE", None)
-            self.console.print("  ⚠ YOLO mode [bold red]OFF[/] — dangerous commands will require approval.")
+            self.chat_console.print("  ⚠ YOLO mode [bold red]OFF[/] — dangerous commands will require approval.")
         else:
             os.environ["HERMES_YOLO_MODE"] = "1"
-            self.console.print("  ⚡ YOLO mode [bold green]ON[/] — all commands auto-approved. Use with caution.")
+            self.chat_console.print("  ⚡ YOLO mode [bold green]ON[/] — all commands auto-approved. Use with caution.")
 
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.
@@ -7633,7 +7632,7 @@ class HermesCLI:
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
 
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+        self.chat_console.print(f"[{_accent_hex()}]{'─' * 40}[/]")
         print(flush=True)
         
         try:
@@ -7914,8 +7913,7 @@ class HermesCLI:
                     # _flush_stream() already closed the box. Skip Rich Panel.
                     pass
                 else:
-                    _chat_console = ChatConsole()
-                    _chat_console.print(Panel(
+                    self.chat_console.print(Panel(
                         _rich_text_from_ansi(response),
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
@@ -9602,19 +9600,19 @@ class HermesCLI:
                         n_pastes = len(paste_refs)
                         _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
                         print()
-                        ChatConsole().print(_user_bar)
+                        self.chat_console.print(_user_bar)
                         # Show any surrounding user text alongside the paste summary
                         split_parts = _paste_ref_re.split(user_input)
                         visible_user_text = " ".join(
                             split_parts[i].strip() for i in range(0, len(split_parts), 2) if split_parts[i].strip()
                         )
                         if visible_user_text:
-                            ChatConsole().print(
+                            self.chat_console.print(
                                 f"[bold {_accent_hex()}]\u25cf[/] [bold]{_escape(visible_user_text)}[/] "
                                 f"[dim]({n_pastes} pasted block{'s' if n_pastes > 1 else ''}, {total_lines} lines total)[/]"
                             )
                         else:
-                            ChatConsole().print(
+                            self.chat_console.print(
                                 f"[bold {_accent_hex()}]\u25cf[/] [bold]{_escape(f'[Pasted text: {total_lines} lines]')}[/]"
                             )
                         user_input = expanded
@@ -9624,15 +9622,15 @@ class HermesCLI:
                             first_line = user_input.split('\n')[0]
                             line_count = user_input.count('\n') + 1
                             print()
-                            ChatConsole().print(_user_bar)
-                            ChatConsole().print(
+                            self.chat_console.print(_user_bar)
+                            self.chat_console.print(
                                 f"[bold {_accent_hex()}]●[/] [bold]{_escape(first_line)}[/] "
                                 f"[dim](+{line_count - 1} lines)[/]"
                             )
                         else:
                             print()
-                            ChatConsole().print(_user_bar)
-                            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
+                            self.chat_console.print(_user_bar)
+                            self.chat_console.print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
                     
                     # Show image attachment count
                     if submit_images:

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -7,6 +7,7 @@ def _make_cli():
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.config = {}
     cli_obj.console = MagicMock()
+    cli_obj.chat_console = MagicMock()
     cli_obj.agent = None
     cli_obj.conversation_history = []
     cli_obj.session_id = None

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -11,6 +11,7 @@ def _make_cli():
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.config = {}
     cli_obj.console = MagicMock()
+    cli_obj.chat_console = MagicMock()
     cli_obj.agent = None
     cli_obj.conversation_history = []
     cli_obj.session_id = "session-123"

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -1,6 +1,6 @@
 """Tests for user-defined quick commands that bypass the agent loop."""
 import subprocess
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, patch
 from rich.text import Text
 import pytest
 
@@ -20,7 +20,7 @@ class TestCLIQuickCommands:
         from cli import HermesCLI
         cli = HermesCLI.__new__(HermesCLI)
         cli.config = {"quick_commands": quick_commands}
-        cli.console = MagicMock()
+        cli.chat_console = MagicMock()
         cli.agent = None
         cli.conversation_history = []
         return cli
@@ -29,8 +29,8 @@ class TestCLIQuickCommands:
         cli = self._make_cli({"dn": {"type": "exec", "command": "echo daily-note"}})
         result = cli.process_command("/dn")
         assert result is True
-        cli.console.print.assert_called_once()
-        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        cli.chat_console.print.assert_called_once()
+        printed = self._printed_plain(cli.chat_console.print.call_args[0][0])
         assert printed == "daily-note"
 
     def test_exec_command_stderr_shown_on_no_stdout(self):
@@ -38,13 +38,13 @@ class TestCLIQuickCommands:
         result = cli.process_command("/err")
         assert result is True
         # stderr fallback — should print something
-        cli.console.print.assert_called_once()
+        cli.chat_console.print.assert_called_once()
 
     def test_exec_command_no_output_shows_fallback(self):
         cli = self._make_cli({"empty": {"type": "exec", "command": "true"}})
         cli.process_command("/empty")
-        cli.console.print.assert_called_once()
-        args = cli.console.print.call_args[0][0]
+        cli.chat_console.print.assert_called_once()
+        args = cli.chat_console.print.call_args[0][0]
         assert "no output" in args.lower()
 
     def test_alias_command_routes_to_target(self):
@@ -65,22 +65,22 @@ class TestCLIQuickCommands:
     def test_alias_no_target_shows_error(self):
         cli = self._make_cli({"broken": {"type": "alias", "target": ""}})
         cli.process_command("/broken")
-        cli.console.print.assert_called_once()
-        args = cli.console.print.call_args[0][0]
+        cli.chat_console.print.assert_called_once()
+        args = cli.chat_console.print.call_args[0][0]
         assert "no target defined" in args.lower()
 
     def test_unsupported_type_shows_error(self):
         cli = self._make_cli({"bad": {"type": "prompt", "command": "echo hi"}})
         cli.process_command("/bad")
-        cli.console.print.assert_called_once()
-        args = cli.console.print.call_args[0][0]
+        cli.chat_console.print.assert_called_once()
+        args = cli.chat_console.print.call_args[0][0]
         assert "unsupported type" in args.lower()
 
     def test_missing_command_field_shows_error(self):
         cli = self._make_cli({"oops": {"type": "exec"}})
         cli.process_command("/oops")
-        cli.console.print.assert_called_once()
-        args = cli.console.print.call_args[0][0]
+        cli.chat_console.print.assert_called_once()
+        args = cli.chat_console.print.call_args[0][0]
         assert "no command defined" in args.lower()
 
     def test_quick_command_takes_priority_over_skill_commands(self):
@@ -88,8 +88,8 @@ class TestCLIQuickCommands:
         cli = self._make_cli({"mygif": {"type": "exec", "command": "echo overridden"}})
         with patch("cli._skill_commands", {"/mygif": {"name": "gif-search"}}):
             cli.process_command("/mygif")
-        cli.console.print.assert_called_once()
-        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        cli.chat_console.print.assert_called_once()
+        printed = self._printed_plain(cli.chat_console.print.call_args[0][0])
         assert printed == "overridden"
 
     def test_unknown_command_still_shows_error(self):
@@ -104,8 +104,8 @@ class TestCLIQuickCommands:
         cli = self._make_cli({"slow": {"type": "exec", "command": "sleep 100"}})
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("sleep", 30)):
             cli.process_command("/slow")
-        cli.console.print.assert_called_once()
-        args = cli.console.print.call_args[0][0]
+        cli.chat_console.print.assert_called_once()
+        args = cli.chat_console.print.call_args[0][0]
         assert "timed out" in args.lower()
 
 


### PR DESCRIPTION
## What does this PR do?

`ChatConsole` was being instantiated fresh on every call throughout `HermesCLI`, allocating a `StringIO` buffer and a Rich `Console` object that were immediately discarded after each `print()`. This PR initialises a  single `self.chat_console` instance in `__init__` and reuses it everywhere.                                                                                                                                                                     
                                                                                                                                                                                                                                              
Additionally, four call sites inside TUI command handlers (`/statusbar`, `/yolo`, and quick command exec output) were incorrectly using `self.console` — the plain Rich console that writes directly to stdout and gets mangled by prompt_toolkit's `patch_stdout` into garbled escape sequences (e.g. `YOLO mode ?[1;32mON?[0m`). These are corrected to use `self.chat_console`.

I noticed these issues due to some of the `tests/cli/test_quick_commands.py` tests failing since they were still checking for the use of `self.console.print` as it was prior to the changes in https://github.com/NousResearch/hermes-agent/pull/5974 where it started using `ChatConsole()`. These tests are now fixed.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `cli.py`: Add `self.chat_console = ChatConsole()` in `HermesCLI.__init__` after `self.console`                                                                                                                                                
- `cli.py`: Replace all `ChatConsole()` instantiations with `self.chat_console`
- `cli.py`: Fix `/statusbar` handler (line ~4588), `/yolo` handler (lines ~5302, 5305), and quick command exec output (line ~4670) to use `self.chat_console` instead of `self.console `                                                     
- `tests/cli/test_quick_commands.py`: Update mock setup and assertions from `cli.console` to `cli.chat_console`  

## How to Test

1. Start hermes and type `/yolo` to toggle on/off — feedback message should render with correct colors, not garbled escape sequences
2. Type `/help` — command list should render correctly (was already working, regression check since this is one of the places `ChatConsole()` is replaced with `self.chat_console`) 
3. Run `pytest tests/cli/test_quick_commands.py` — all tests should pass

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (NOTE: there are failing tests, but they also fail on main, so are not associated with my changes)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
