### PR TITLE
fix(slack): respect require_mention config for channel messages

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -809,12 +809,14 @@ class SlackAdapter(BasePlatformAdapter):
         #   2. The message is a reply in a thread the bot started/participated in, OR
         #   3. The message is in a thread where the bot was previously @mentioned, OR
         #   4. There's an existing session for this thread (survives restarts)
+        #   5. require_mention is set to false in config (respond to all messages)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         is_mentioned = bot_uid and f"<@{bot_uid}>" in text
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        require_mention = self.config.extra.get("require_mention", True)
 
-        if not is_dm and bot_uid and not is_mentioned:
+        if not is_dm and bot_uid and not is_mentioned and require_mention:
             reply_to_bot_thread = (
                 is_thread_reply and event_thread_ts in self._bot_message_ts
             )

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -544,6 +544,33 @@ class TestMessageRouting:
         }
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
+    @pytest.mark.asyncio
+    async def test_channel_message_without_mention_when_require_mention_false(self, adapter):
+        """Channel messages without mention should be processed when require_mention is false."""
+        adapter.config.extra["require_mention"] = False
+        event = {
+            "text": "just talking",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_channel_message_without_mention_when_require_mention_true(self, adapter):
+        """Channel messages without mention should be ignored when require_mention is true (default)."""
+        adapter.config.extra["require_mention"] = True
+        event = {
+            "text": "just talking",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Slack adapter had mention gating hardcoded - it always required @mention in channels regardless of the `require_mention` config setting. The setting was properly stored in `config.extra` by `gateway/config.py` (lines 529-535) but never consulted by the Slack adapter's message routing logic.

## Changes

**gateway/platforms/slack.py**
- Read `self.config.extra.get('require_mention', True)` before the mention gating check
- Skip mention gating when `require_mention` is `false`, allowing the bot to respond to all channel messages

**tests/gateway/test_slack.py**
- Added two tests covering both `require_mention: true` (default) and `require_mention: false` behavior

## Root Cause

In `gateway/platforms/slack.py`, the channel message filter was:

\\\python
if not is_dm and bot_uid and not is_mentioned:
    # check thread/session fallbacks...
    return  # ignore if none match
\\\

This blocked all non-mention channel messages unconditionally. The fix adds:

\\\python
require_mention = self.config.extra.get('require_mention', True)
if not is_dm and bot_uid and not is_mentioned and require_mention:
\\\

## Config Example

\\\yaml
slack:
  require_mention: false  # respond to all channel messages without @mention
\\\

Closes #6218