### PR TITLE
fix(update): clear __pycache__ after code update to prevent stale .pyc errors

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3567,8 +3567,22 @@ def cmd_update(args):
         print()
         print("✓ Code updated!")
         
-        # After git pull, source files on disk are newer than cached Python
-        # modules in this process.  Reload hermes_constants so that any lazy
+        # After git pull, source files on disk are newer than cached .pyc
+        # bytecode files.  Stale .pyc can cause TypeError / ImportError
+        # when new signatures don't match the cached compiled modules.
+        # Clear all __pycache__ dirs under the project root.
+        try:
+            import shutil as _shutil_pyc
+            _pyc_count = 0
+            for _cache_dir in PROJECT_ROOT.rglob("__pycache__"):
+                _shutil_pyc.rmtree(_cache_dir, ignore_errors=True)
+                _pyc_count += 1
+            if _pyc_count:
+                print(f"  ✓ Cleared {_pyc_count} __pycache__ directories")
+        except Exception:
+            pass  # non-fatal — worst case a stale .pyc causes a restart
+
+        # Reload hermes_constants so that any lazy
         # import executed below (skills sync, gateway restart) sees new
         # attributes like display_hermes_home() added since the last release.
         try:


### PR DESCRIPTION
## Summary

After \\hermes update\\ (git pull), Python can still load stale \\.pyc\\ bytecode from \\__pycache__\\ directories. When new code adds or changes function signatures (e.g. \\max_result_size_chars\\ parameter added to \\ToolRegistry.register()\\), the cached compiled modules reject the new arguments, causing \\TypeError\\ or \\ImportError\\ on gateway restart.

## Changes

**hermes_cli/main.py** - \\cmd_update()\\
- Added \\__pycache__\\ cleanup step after successful code update (git pull)
- Runs before module reloads and skill syncs
- Uses \\shutil.rmtree\\ with \\ignore_errors=True\\ for safety
- Reports count of cleared directories

## Reproduction

1. Run hermes-agent gateway (generates .pyc cache)
2. Update code (git pull) that changes a function signature
3. Restart gateway without clearing cache
4. Gateway crashes on tool import with \\TypeError: got an unexpected keyword argument\\

## Fix

The cleanup runs at the right point in cmd_update - after the git pull succeeds but before any module reloads or skill syncs. This is non-fatal; if cleanup fails, the worst case is the existing stale-cache behavior.

Closes #6207