### PR TITLE
fix(gateway): detect /compress no-op and clarify token estimates

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5017,6 +5017,17 @@ class GatewayRunner:
                 lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens)
             )
 
+            new_count = len(compressed)
+            new_tokens = estimate_messages_tokens_rough(compressed)
+
+            # Detect no-op: compressor returned the input unchanged
+            if new_count == original_count and compressed == msgs:
+                return (
+                    f"Nothing to compress yet — only {original_count} compressible messages "
+                    f"(user/assistant with content). The compressor needs more history before "
+                    f"it can summarize older turns."
+                )
+
             # _compress_context already calls end_session() on the old session
             # (preserving its full transcript in SQLite) and creates a new
             # session_id for the continuation.  Write the compressed messages
@@ -5031,13 +5042,16 @@ class GatewayRunner:
             self.session_store.update_session(
                 session_entry.session_key, last_prompt_tokens=0
             )
-            new_count = len(compressed)
-            new_tokens = estimate_messages_tokens_rough(compressed)
 
-            return (
-                f"🗜️ Compressed: {original_count} → {new_count} messages\n"
-                f"~{approx_tokens:,} → ~{new_tokens:,} tokens"
-            )
+            result = f"🗜️ Compressed: {original_count} → {new_count} messages\n"
+            result += f"~{approx_tokens:,} → ~{new_tokens:,} tokens (rough transcript estimate)"
+            if new_tokens > approx_tokens and new_count < original_count:
+                result += (
+                    "\nNote: token estimate increased because the compaction summary "
+                    "is denser than the removed turns. Actual request pressure is lower."
+                )
+
+            return result
         except Exception as e:
             logger.warning("Manual compress failed: %s", e)
             return f"Compression failed: {e}"


### PR DESCRIPTION
## Summary

Two related fixes for the \\/compress\\ command:

### 1. False success on no-op (#6202)

When the compressor returns the input unchanged (too few compressible messages to meet the \\protect_first_n + protect_last_n + 1\\ threshold), the gateway still showed a success banner like:

\\\
Compressed: 19 -> 19 messages
~11,726 -> ~11,726 tokens
\\\

Now detects no-op by comparing output to input and shows an explicit message:

\\\
Nothing to compress yet - only 19 compressible messages (user/assistant with content).
The compressor needs more history before it can summarize older turns.
\\\

### 2. Misleading token count (#6217)

The token estimate after compression can increase even when compression succeeded (e.g. \\27 -> 13 messages\\ but \\~4,462 -> ~4,727 tokens\\). This happens because the compaction summary is denser than the short turns it replaced, but the banner used a rough transcript-only heuristic that doesn't reflect actual request pressure.

Changes:
- Labels the token count as a \\ough transcript estimate\\ so users know it's approximate
- When the estimate increases despite message count decreasing, adds an explanatory note

## Changes

**gateway/run.py** - \\_handle_compress_command()\\
- Moved \\
ew_count\\/\\
ew_tokens\\ computation before transcript rewrite
- Added no-op detection: if \\compressed == msgs\\, return explicit message
- Added \\(rough transcript estimate)\\ label to token counts
- Added explanatory note when estimate increases despite fewer messages

Closes #6202
Closes #6217