### PR TITLE
feat(plugins): add on_tool_definitions_filter hook

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -10,8 +10,6 @@ lifecycle instead of read-only search endpoints.
 Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account (default: root)
-  OPENVIKING_USER      — Tenant user (default: default)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -23,44 +21,19 @@ Capabilities:
 
 from __future__ import annotations
 
-import atexit
 import json
 import logging
 import os
 import threading
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
 
 from agent.memory_provider import MemoryProvider
-from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
-
-
-# ---------------------------------------------------------------------------
-# Process-level atexit safety net — ensures pending sessions are committed
-# even if shutdown_memory_provider is never called (e.g. gateway crash,
-# SIGKILL, or exception in _async_flush_memories preventing shutdown).
-# ---------------------------------------------------------------------------
-_last_active_provider: Optional["OpenVikingMemoryProvider"] = None
-
-
-def _atexit_commit_sessions():
-    """Fire on_session_end for the last active provider on process exit."""
-    global _last_active_provider
-    provider = _last_active_provider
-    if provider is None:
-        return
-    _last_active_provider = None
-    try:
-        provider.on_session_end([])
-    except Exception:
-        pass  # best-effort at shutdown time
-
-
-atexit.register(_atexit_commit_sessions)
 
 
 # ---------------------------------------------------------------------------
@@ -79,22 +52,15 @@ def _get_httpx():
 class _VikingClient:
     """Thin HTTP client for the OpenViking REST API."""
 
-    def __init__(self, endpoint: str, api_key: str = "",
-                 account: str = "", user: str = ""):
+    def __init__(self, endpoint: str, api_key: str = ""):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
-        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "root")
-        self._user = user or os.environ.get("OPENVIKING_USER", "default")
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
 
     def _headers(self) -> dict:
-        h = {
-            "Content-Type": "application/json",
-            "X-OpenViking-Account": self._account,
-            "X-OpenViking-User": self._user,
-        }
+        h = {"Content-Type": "application/json"}
         if self._api_key:
             h["X-API-Key"] = self._api_key
         return h
@@ -303,19 +269,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
             logger.warning("httpx not installed — OpenViking plugin disabled")
             self._client = None
 
-        # Register as the last active provider for atexit safety net
-        global _last_active_provider
-        _last_active_provider = self
-
     def system_prompt_block(self) -> str:
         if not self._client:
             return ""
         # Provide brief info about the knowledge base
         try:
             # Check what's in the knowledge base via a root listing
-            resp = self._client.get("/api/v1/fs/ls", params={"uri": "viking://"})
-            result = resp.get("result", [])
-            children = len(result) if isinstance(result, list) else 0
+            resp = self._client.get("/api/v1/fs/stat?uri=" + urlencode({"uri": "viking://"}))
+            result = resp.get("result", {})
+            children = result.get("children", 0)
             if children == 0:
                 return ""
             return (
@@ -417,17 +379,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         OpenViking automatically extracts 6 categories of memories:
         profile, preferences, entities, events, cases, and patterns.
         """
-        if not self._client:
+        if not self._client or self._turn_count == 0:
             return
 
-        # Wait for any pending sync to finish first — do this before the
-        # turn_count check so the last turn's messages are flushed even if
-        # the count hasn't been incremented yet.
+        # Wait for any pending sync to finish first
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=10.0)
-
-        if self._turn_count == 0:
-            return
 
         try:
             self._client.post(f"/api/v1/sessions/{self._session_id}/commit")
@@ -462,7 +419,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if not self._client:
-            return tool_error("OpenViking server not connected")
+            return json.dumps({"error": "OpenViking server not connected"})
 
         try:
             if tool_name == "viking_search":
@@ -475,26 +432,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 return self._tool_remember(args)
             elif tool_name == "viking_add_resource":
                 return self._tool_add_resource(args)
-            return tool_error(f"Unknown tool: {tool_name}")
+            return json.dumps({"error": f"Unknown tool: {tool_name}"})
         except Exception as e:
-            return tool_error(str(e))
+            return json.dumps({"error": str(e)})
 
     def shutdown(self) -> None:
         # Wait for background threads to finish
         for t in (self._sync_thread, self._prefetch_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Clear atexit reference so it doesn't double-commit
-        global _last_active_provider
-        if _last_active_provider is self:
-            _last_active_provider = None
 
     # -- Tool implementations ------------------------------------------------
 
     def _tool_search(self, args: dict) -> str:
         query = args.get("query", "")
         if not query:
-            return tool_error("query is required")
+            return json.dumps({"error": "query is required"})
 
         payload: Dict[str, Any] = {"query": query}
         mode = args.get("mode", "auto")
@@ -531,20 +484,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _tool_read(self, args: dict) -> str:
         uri = args.get("uri", "")
         if not uri:
-            return tool_error("uri is required")
+            return json.dumps({"error": "uri is required"})
 
         level = args.get("level", "overview")
-        # Map our level names to OpenViking GET endpoints
+        # Map our level names to OpenViking GET endpoints with query params
         if level == "abstract":
-            resp = self._client.get("/api/v1/content/abstract", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/abstract?uri=" + urlencode({"uri": uri}))
         elif level == "full":
-            resp = self._client.get("/api/v1/content/read", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/read?uri=" + urlencode({"uri": uri}))
         else:  # overview
-            resp = self._client.get("/api/v1/content/overview", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/read?" + urlencode({"uri": uri, "level": "overview"}))
 
-        result = resp.get("result", "")
-        # result is a plain string from the content endpoints
-        content = result if isinstance(result, str) else result.get("content", "")
+        result = resp.get("result", {})
+        content = result.get("content", "")
 
         # Truncate very long content to avoid flooding the context
         if len(content) > 8000:
@@ -560,21 +512,27 @@ class OpenVikingMemoryProvider(MemoryProvider):
         action = args.get("action", "list")
         path = args.get("path", "viking://")
 
-        # Map action to the correct fs endpoint (all GET with uri= param)
-        endpoint_map = {"tree": "/api/v1/fs/tree", "list": "/api/v1/fs/ls", "stat": "/api/v1/fs/stat"}
-        endpoint = endpoint_map.get(action, "/api/v1/fs/ls")
-        resp = self._client.get(endpoint, params={"uri": path})
+        # Map to OpenViking GET /api/v1/fs/* endpoints
+        if action == "list":
+            endpoint = "/api/v1/fs/ls?uri=" + urlencode({"uri": path})
+        elif action == "tree":
+            endpoint = "/api/v1/fs/tree?uri=" + urlencode({"uri": path})
+        elif action == "stat":
+            endpoint = "/api/v1/fs/stat?uri=" + urlencode({"uri": path})
+        else:
+            return json.dumps({"error": f"Unknown action: {action}"})
+
+        resp = self._client.get(endpoint)
         result = resp.get("result", {})
 
-        # Format list/tree results for readability
-        if action in ("list", "tree") and isinstance(result, list):
+        # Format for readability
+        if action == "list" and "entries" in result:
             entries = []
-            for e in result[:50]:  # cap at 50 entries
+            for e in result["entries"][:50]:  # cap at 50 entries
                 entries.append({
-                    "name": e.get("rel_path", e.get("name", "")),
+                    "name": e.get("name", ""),
                     "uri": e.get("uri", ""),
-                    "type": "dir" if e.get("isDir") else "file",
-                    "abstract": e.get("abstract", ""),
+                    "type": "dir" if e.get("is_dir") else "file",
                 })
             return json.dumps({"path": path, "entries": entries}, ensure_ascii=False)
 
@@ -583,7 +541,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _tool_remember(self, args: dict) -> str:
         content = args.get("content", "")
         if not content:
-            return tool_error("content is required")
+            return json.dumps({"error": "content is required"})
 
         # Store as a session message that will be extracted during commit.
         # The category hint helps OpenViking's extraction classify correctly.
@@ -607,7 +565,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _tool_add_resource(self, args: dict) -> str:
         url = args.get("url", "")
         if not url:
-            return tool_error("url is required")
+            return json.dumps({"error": "url is required"})
 
         payload: Dict[str, Any] = {"path": url}
         if args.get("reason"):


### PR DESCRIPTION
## Summary

Adds a new plugin hook `on_tool_definitions_filter` that fires after the tool registry resolves tool definitions but before the `execute_code` schema rebuild and `browser_navigate` cross-ref stripping.

This allows semantic/discovery/filtering plugins to refine the tool list the LLM sees — enabling context-aware tool selection without modifying the core agent logic.

## Changes

- **`hermes_cli/plugins.py`**: `VALID_HOOKS` gains `on_tool_definitions_filter`
- **`model_tools.py`**: After `registry.get_definitions()`, invokes the hook with the resolved tool list. Takes the first plugin response; fails open if no plugin responds.

## Behavior

- No change to hermes-agent behavior when no plugins use this hook
- Plugins receive the fully-resolved, `check_fn`-filtered tool list
- Plugin can return a mutated list that replaces the LLM's tool definitions
- Fail-open: any exception or empty result keeps the original list

## Test Plan

- [ ] Existing plugin tests pass
- [ ] Agent behaves identically with no plugins using the new hook
- [ ] A plugin returning a filtered list correctly restricts LLM tool access