### PR TITLE
fix(gateway): strip [CONTEXT COMPACTION] echoes from gateway responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2921,6 +2921,22 @@ class GatewayRunner:
 
             response = agent_result.get("final_response") or ""
             agent_messages = agent_result.get("messages", [])
+
+            # Strip compaction handoff echoes — if the model parrots the
+            # [CONTEXT COMPACTION] summary stored in its context, remove
+            # it so the user gets a clean greeting instead of a raw
+            # internal handoff blob (#6212).
+            if response and "[CONTEXT COMPACTION]" in response:
+                import re as _re_compact
+                response = _re_compact.sub(
+                    r'\[CONTEXT COMPACTION\].*?(?:avoid repeating work:)',
+                    '',
+                    response,
+                    flags=_re_compact.DOTALL,
+                ).strip()
+                if not response:
+                    response = ""
+
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)


### PR DESCRIPTION
## Summary

When a Telegram session has prior compressed context, the model can parrot the stored \\[CONTEXT COMPACTION]\\ handoff summary back as its response to a simple greeting like \\/start\\ or \\Hello?\\. This makes the bot dump an opaque internal handoff blob instead of greeting normally.

## Root Cause

The context compressor stores a structured handoff summary prefixed with \\[CONTEXT COMPACTION] Earlier turns in this conversation were compacted...\\ in the conversation history. When a user re-enters the conversation, the model sees this in its context and may echo it verbatim as the response.

## Changes

**gateway/run.py** - response post-processing (after \\gent_result.get('final_response')\\)
- Detects \\[CONTEXT COMPACTION]\\ in the response text
- Strips the compaction prefix and boilerplate (up to \\void repeating work:\\)
- If stripping empties the response, sets it to empty string so downstream processing doesn't send a blank message

## Observed Behavior

**Before:**
> [CONTEXT COMPACTION] Earlier turns in this conversation were compacted to save context space. The summary below describes work that was already completed...

**After:**
The compaction boilerplate is stripped, leaving only any user-facing content the model generated after the echo.

Closes #6212