### PR TITLE
fix(memory): restore flush memory persistence

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -667,7 +667,7 @@ class GatewayRunner:
                 model=model,
                 max_iterations=8,
                 quiet_mode=True,
-                skip_memory=True,  # Flush agent — no memory provider
+                skip_memory=False,  # Flush agent needs built-in memory writes available
                 enabled_toolsets=["memory", "skills"],
                 session_id=old_session_id,
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -5744,7 +5744,8 @@ class AIAgent:
 
             # Use auxiliary client for the flush call when available --
             # it's cheaper and avoids Codex Responses API incompatibility.
-            from agent.auxiliary_client import call_llm as _call_llm
+            from agent.auxiliary_client import call_llm as _call_llm, _get_task_timeout as _get_aux_timeout
+            flush_timeout = _get_aux_timeout("flush_memories")
             _aux_available = True
             try:
                 response = _call_llm(
@@ -5753,7 +5754,7 @@ class AIAgent:
                     tools=[memory_tool_def],
                     temperature=0.3,
                     max_tokens=5120,
-                    timeout=30.0,
+                    timeout=flush_timeout,
                 )
             except RuntimeError:
                 _aux_available = False
@@ -5785,7 +5786,9 @@ class AIAgent:
                     "temperature": 0.3,
                     **self._max_tokens_param(5120),
                 }
-                response = self._ensure_primary_openai_client(reason="flush_memories").chat.completions.create(**api_kwargs, timeout=30.0)
+                response = self._ensure_primary_openai_client(
+                    reason="flush_memories"
+                ).chat.completions.create(**api_kwargs, timeout=flush_timeout)
 
             # Extract tool calls from the response, handling all API formats
             tool_calls = []

--- a/tests/gateway/test_flush_memory_stale_guard.py
+++ b/tests/gateway/test_flush_memory_stale_guard.py
@@ -152,6 +152,31 @@ class TestMemoryInjection:
 class TestFlushAgentSilenced:
     """The flush agent must not produce any terminal output."""
 
+    def test_flush_agent_enables_builtin_memory(self, tmp_path, monkeypatch):
+        """Gateway flush agent should initialize built-in memory so memory tool writes can persist."""
+        runner = _make_runner()
+        runner.session_store.load_transcript.return_value = _TRANSCRIPT_4_MSGS
+
+        captured_kwargs = {}
+
+        def _fake_ai_agent(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            agent = MagicMock()
+            return agent
+
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _fake_ai_agent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        with (
+            patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "k"}),
+            patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+            patch.dict("sys.modules", {"tools.memory_tool": MagicMock(get_memory_dir=lambda: tmp_path)}),
+        ):
+            runner._flush_memories_for_session("session_memory_enabled")
+
+        assert captured_kwargs["skip_memory"] is False
+
     def test_print_fn_set_to_noop(self, tmp_path, monkeypatch):
         """_print_fn on the flush agent must be a no-op so tool output never leaks."""
         runner = _make_runner()

--- a/tests/run_agent/test_flush_memories_codex.py
+++ b/tests/run_agent/test_flush_memories_codex.py
@@ -113,6 +113,22 @@ class TestFlushMemoriesUsesAuxiliaryClient:
         call_kwargs = mock_call.call_args
         assert call_kwargs.kwargs.get("task") == "flush_memories"
 
+    def test_flush_uses_configured_timeout_for_auxiliary(self, monkeypatch):
+        agent = _make_agent(monkeypatch, api_mode="chat_completions", provider="openrouter")
+        mock_response = _chat_response_with_memory_call()
+
+        with patch("agent.auxiliary_client._get_task_timeout", return_value=123.0), \
+             patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_call, \
+             patch("tools.memory_tool.memory_tool", return_value="Saved."):
+            messages = [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+                {"role": "user", "content": "Remember this"},
+            ]
+            agent.flush_memories(messages)
+
+        assert mock_call.call_args.kwargs["timeout"] == 123.0
+
     def test_flush_uses_main_client_when_no_auxiliary(self, monkeypatch):
         """Non-Codex mode with no auxiliary falls back to self.client."""
         agent = _make_agent(monkeypatch, api_mode="chat_completions", provider="openrouter")
@@ -129,6 +145,25 @@ class TestFlushMemoriesUsesAuxiliaryClient:
                 agent.flush_memories(messages)
 
         agent.client.chat.completions.create.assert_called_once()
+
+    def test_flush_uses_configured_timeout_for_direct_chat_fallback(self, monkeypatch):
+        """Direct chat-completions fallback should use the same configured timeout."""
+        agent = _make_agent(monkeypatch, api_mode="chat_completions", provider="openrouter")
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _chat_response_with_memory_call()
+
+        with patch("agent.auxiliary_client._get_task_timeout", return_value=77.0), \
+             patch("agent.auxiliary_client.call_llm", side_effect=RuntimeError("no provider")), \
+             patch.object(agent, "_ensure_primary_openai_client", return_value=agent.client), \
+             patch("tools.memory_tool.memory_tool", return_value="Saved."):
+            messages = [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+                {"role": "user", "content": "Save this"},
+            ]
+            agent.flush_memories(messages)
+
+        assert agent.client.chat.completions.create.call_args.kwargs["timeout"] == 77.0
 
     def test_flush_executes_memory_tool_calls(self, monkeypatch):
         """Verify that memory tool calls from the flush response actually get executed."""


### PR DESCRIPTION
## Summary
- enable built-in memory for the gateway pre-reset flush agent so memory tool calls can persist writes
- honor `auxiliary.flush_memories.timeout` in `flush_memories()` for both the auxiliary path and the direct chat-completions fallback
- add focused regressions for gateway flush agent construction and timeout propagation

## Issues Addressed
- #6157
- #6154

## Related PR Overlap
- This PR subsumes the gateway-only `#6157` fix proposed in #6179.
- This PR also subsumes the timeout-only `#6154` fix proposed in #6177.
- The branch intentionally combines both flush-path fixes into one focused change because they affect the same memory flush correctness surface.

## Why
The gateway flush path was constructing a temporary agent with memory disabled, which made memory tool calls fail during pre-reset flushes. Separately, the flush helper hardcoded a 30 second timeout and ignored the configured auxiliary timeout.

## Testing
- `source .venv/bin/activate && python -m pytest tests/run_agent/test_flush_memories_codex.py tests/gateway/test_flush_memory_stale_guard.py -q`

## Notes
- This PR is intentionally scoped to the memory flush correctness path only.
- Separate restart/dedup flush issues are not included here.
