### PR TITLE
feat: add interactive youtube automation agent skill

### DIFF
--- a/optional-skills/media/youtube-automation-agent/SKILL.md
+++ b/optional-skills/media/youtube-automation-agent/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: youtube-automation-agent
+description: Run a Hermes-native YouTube automation workflow that mirrors the darkzOGx/youtube-automation-agent stages: strategy, script, thumbnail, SEO, production, publishing, and analytics. Also supports inspecting and probing the upstream repo locally.
+version: 1.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube, automation, media, nodejs, express, seo, thumbnails, publishing, analytics]
+    related_skills: [youtube-content, google-workspace]
+    category: media
+    homepage: https://github.com/darkzOGx/youtube-automation-agent
+---
+
+# YouTube Automation Agent
+
+This optional skill now does two related jobs:
+
+1. It helps Hermes inspect, configure, and troubleshoot the external repo `darkzOGx/youtube-automation-agent`.
+2. It gives Hermes a native interactive workflow that mirrors the repo's claimed pipeline:
+   - strategy
+   - script
+   - thumbnail
+   - SEO
+   - production
+   - publishing
+   - analytics
+
+The goal is to capture the essence of the upstream project as a reusable Hermes workflow without pretending Hermes has magically replaced YouTube OAuth, video rendering, or upload APIs.
+
+## What this skill is good for
+
+Use this skill when the user wants Hermes to:
+- turn a channel concept into a structured YouTube production workflow
+- manage a stage-by-stage content pipeline inside Hermes
+- generate a strategy brief, script brief, thumbnail brief, SEO package, publishing checklist, and analytics review plan
+- inspect whether the upstream repo is actually runnable
+- validate the local server and its main endpoints
+
+## The Hermes-native workflow
+
+This skill mirrors the upstream repo's main agent flow:
+
+1. Content Strategy Agent
+2. Script Writer Agent
+3. Thumbnail Designer Agent
+4. SEO Optimizer Agent
+5. Production Management Agent
+6. Publishing & Scheduling Agent
+7. Analytics & Optimization Agent
+
+In Hermes, those stages are represented as an interactive run workspace that can persist across sessions.
+
+## Locate the helper script
+
+```bash
+SCRIPT="$(find ~/.hermes/skills -path '*/youtube-automation-agent/scripts/youtube_automation_helper.py' -print -quit)"
+```
+
+## Start a new Hermes workflow run
+
+```bash
+python3 "$SCRIPT" init-run \
+  --channel "Ladera Labs" \
+  --niche "AI productivity" \
+  --audience "founders and operators" \
+  --style "educational" \
+  --frequency daily \
+  --topic "AI workflow automations"
+```
+
+This creates a run workspace JSON file under the skill data directory and sets the current stage to `strategy`.
+
+## Check workflow status
+
+```bash
+python3 "$SCRIPT" status --workspace /path/to/run.json
+```
+
+## Get the next stage brief
+
+```bash
+python3 "$SCRIPT" brief --workspace /path/to/run.json
+```
+
+Or a specific stage:
+
+```bash
+python3 "$SCRIPT" brief --workspace /path/to/run.json --stage seo
+```
+
+Each brief includes:
+- the goal for that stage
+- the contextual channel inputs
+- a Hermes-ready prompt
+- expected artifacts to produce
+
+## Complete a stage
+
+After Hermes or the user finishes a stage, save the outcome:
+
+```bash
+python3 "$SCRIPT" complete-stage \
+  --workspace /path/to/run.json \
+  --stage strategy \
+  --notes "Selected a founder-focused AI automation angle" \
+  --artifacts-json '{
+    "selected_topic": "AI workflow automations for founders",
+    "angle": "replace repetitive ops work with reusable agents",
+    "content_type": "Explainer",
+    "keywords": ["ai automation", "workflow automation", "founder productivity"]
+  }'
+```
+
+The helper automatically advances the current stage to the next incomplete stage.
+
+## Export a finished run
+
+```bash
+python3 "$SCRIPT" export --workspace /path/to/run.json
+```
+
+This gives Hermes a portable summary of all completed deliverables.
+
+## How to use this as an interactive Hermes skill
+
+Recommended operator loop:
+
+1. create a run with `init-run`
+2. ask for the current stage brief with `brief`
+3. use Hermes to generate the requested deliverables for that stage
+4. save the result with `complete-stage`
+5. repeat until analytics is complete
+
+This turns the repo's abstract pipeline into a real session-by-session Hermes workflow.
+
+## Upstream repo inspection mode
+
+The skill still supports repo validation.
+
+### Inspect a local clone
+
+```bash
+python3 "$SCRIPT" inspect --repo /path/to/youtube-automation-agent
+```
+
+Checks include:
+- required files
+- missing package script targets
+- config file presence
+- `node_modules/` presence
+- `node --check` syntax checks for key entry files
+
+### Probe a running local server
+
+```bash
+python3 "$SCRIPT" probe --base-url http://localhost:3456
+```
+
+This probes:
+- `/health`
+- `/schedule`
+- `/analytics`
+
+## Known upstream caveats
+
+Before claiming the upstream repo is turnkey, remember:
+
+1. `package.json` references missing script targets in the inspected repo:
+   - `workflows/daily-content-pipeline.js`
+   - `workflows/weekly-strategy-review.js`
+   - `database/init.js`
+2. The README mentions a `workflows/` directory, but it is absent in the inspected repo.
+3. The docs market Gemini as an option, but `utils/credential-manager.js` currently validates `youtube` and `openai`, so Gemini-only setup is not turnkey without upstream changes.
+4. A dashboard alone is not enough; confirm `/health`.
+
+See also:
+- `references/repo-caveats.md`
+- `references/setup-notes.md`
+- `references/manual-ops.md`
+- `references/hermes-native-flow.md`
+
+## Practical boundaries
+
+This skill can help Hermes achieve the same claimed flow structure as the upstream project:
+- strategy
+- scripting
+- thumbnail planning
+- SEO packaging
+- production planning
+- publishing prep
+- analytics feedback loop
+
+But it does not claim that Hermes alone can, without credentials or infrastructure:
+- upload to YouTube automatically
+- render final videos out of thin air
+- authenticate external APIs without setup
+- replace all manual production steps
+
+Instead, it gives a strong, reusable workflow layer that Hermes can run interactively.
+
+## Verification checklist
+
+Before telling the user a workflow is ready:
+
+1. the run workspace exists
+2. the current stage brief is clear
+3. each completed stage has notes and artifacts saved
+4. the export summary contains the expected deliverables
+5. if using the upstream repo, `inspect` and `probe` have been run successfully

--- a/optional-skills/media/youtube-automation-agent/SKILL.md
+++ b/optional-skills/media/youtube-automation-agent/SKILL.md
@@ -1,66 +1,64 @@
 ---
 name: youtube-automation-agent
-description: Run a Hermes-native YouTube automation workflow that mirrors the darkzOGx/youtube-automation-agent stages: strategy, script, thumbnail, SEO, production, publishing, and analytics. Also supports inspecting and probing the upstream repo locally.
-version: 1.1.0
-author: Hermes Agent
+description: Orchestrate staged YouTube production workflows.
+version: 1.2.0
+author: Haithum Abdelfattah (@darkzOGx)
 license: MIT
+platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [youtube, automation, media, nodejs, express, seo, thumbnails, publishing, analytics]
+    tags: [youtube, automation, media, seo, publishing, analytics]
     related_skills: [youtube-content, google-workspace]
     category: media
     homepage: https://github.com/darkzOGx/youtube-automation-agent
 ---
 
-# YouTube Automation Agent
+# YouTube Automation Agent Skill
 
-This optional skill now does two related jobs:
+Run a persistent, interactive workflow from channel strategy through
+post-publish analytics, or inspect the related Node.js project. This skill
+organizes deliverables; it does not replace YouTube credentials, rendering,
+or upload infrastructure.
 
-1. It helps Hermes inspect, configure, and troubleshoot the external repo `darkzOGx/youtube-automation-agent`.
-2. It gives Hermes a native interactive workflow that mirrors the repo's claimed pipeline:
-   - strategy
-   - script
-   - thumbnail
-   - SEO
-   - production
-   - publishing
-   - analytics
+## When to Use
 
-The goal is to capture the essence of the upstream project as a reusable Hermes workflow without pretending Hermes has magically replaced YouTube OAuth, video rendering, or upload APIs.
+Use this skill when the user wants to:
 
-## What this skill is good for
+- develop a channel idea through a stage-by-stage content pipeline;
+- produce strategy, script, thumbnail, SEO, production, publishing, and
+  analytics deliverables across multiple sessions;
+- inspect a local clone of `darkzOGx/youtube-automation-agent`; or
+- probe that project's local health, schedule, and analytics endpoints.
 
-Use this skill when the user wants Hermes to:
-- turn a channel concept into a structured YouTube production workflow
-- manage a stage-by-stage content pipeline inside Hermes
-- generate a strategy brief, script brief, thumbnail brief, SEO package, publishing checklist, and analytics review plan
-- inspect whether the upstream repo is actually runnable
-- validate the local server and its main endpoints
+Do not use it for a one-off transcript or summary when the `youtube-content`
+skill is sufficient.
 
-## The Hermes-native workflow
+## Prerequisites
 
-This skill mirrors the upstream repo's main agent flow:
+- Python 3.9 or newer for the bundled helper.
+- An installed copy of this optional skill.
+- For the external Node.js app only: Node.js, npm dependencies, YouTube OAuth,
+  and the AI-provider credentials expected by that project.
 
-1. Content Strategy Agent
-2. Script Writer Agent
-3. Thumbnail Designer Agent
-4. SEO Optimizer Agent
-5. Production Management Agent
-6. Publishing & Scheduling Agent
-7. Analytics & Optimization Agent
-
-In Hermes, those stages are represented as an interactive run workspace that can persist across sessions.
-
-## Locate the helper script
+Resolve paths from the loaded skill rather than assuming the default profile.
+Use the `skill_dir` returned by `skill_view` as `SKILL_DIR`. When only the
+active Hermes home is available, use this fallback:
 
 ```bash
-SCRIPT="$(find ~/.hermes/skills -path '*/youtube-automation-agent/scripts/youtube_automation_helper.py' -print -quit)"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+SKILL_DIR="${SKILL_DIR:-$HERMES_HOME/skills/media/youtube-automation-agent}"
+SCRIPT="$SKILL_DIR/scripts/youtube_automation_helper.py"
 ```
 
-## Start a new Hermes workflow run
+Named profiles set `HERMES_HOME` to their profile directory, so this resolves
+the category-preserving official install without searching another profile.
+
+## How to Run
+
+Initialize a workflow workspace:
 
 ```bash
-python3 "$SCRIPT" init-run \
+python3 "$SKILL_DIR/scripts/youtube_automation_helper.py" init-run \
   --channel "Ladera Labs" \
   --niche "AI productivity" \
   --audience "founders and operators" \
@@ -69,142 +67,114 @@ python3 "$SCRIPT" init-run \
   --topic "AI workflow automations"
 ```
 
-This creates a run workspace JSON file under the skill data directory and sets the current stage to `strategy`.
+The helper writes a JSON workspace beneath the active profile's installed
+skill directory and starts at `strategy`. Pass `--output /path/to/run.json`
+to choose another location, or `--json` for machine-readable output.
 
-## Check workflow status
+## Quick Reference
 
-```bash
-python3 "$SCRIPT" status --workspace /path/to/run.json
-```
+| Goal | Command |
+|---|---|
+| Create a run | `python3 "$SCRIPT" init-run <channel options>` |
+| Show progress | `python3 "$SCRIPT" status --workspace RUN.json` |
+| Get current brief | `python3 "$SCRIPT" brief --workspace RUN.json` |
+| Get another brief | `python3 "$SCRIPT" brief --workspace RUN.json --stage seo` |
+| Save a stage | `python3 "$SCRIPT" complete-stage --workspace RUN.json --stage STAGE --notes TEXT` |
+| Export deliverables | `python3 "$SCRIPT" export --workspace RUN.json` |
+| Inspect Node repo | `python3 "$SCRIPT" inspect --repo /path/to/repo` |
+| Probe local app | `python3 "$SCRIPT" probe --base-url http://localhost:3456` |
 
-## Get the next stage brief
+Workflow stages, in order:
 
-```bash
-python3 "$SCRIPT" brief --workspace /path/to/run.json
-```
+1. `strategy`
+2. `script`
+3. `thumbnail`
+4. `seo`
+5. `production`
+6. `publishing`
+7. `analytics`
 
-Or a specific stage:
+Use `read_file` on these references only when their branch applies:
 
-```bash
-python3 "$SCRIPT" brief --workspace /path/to/run.json --stage seo
-```
+- `references/hermes-native-flow.md` — stage artifact contracts;
+- `references/repo-caveats.md` — grounded upstream limitations;
+- `references/setup-notes.md` — external Node.js setup; and
+- `references/manual-ops.md` — command examples and local endpoints.
 
-Each brief includes:
-- the goal for that stage
-- the contextual channel inputs
-- a Hermes-ready prompt
-- expected artifacts to produce
+## Procedure
 
-## Complete a stage
+### 1. Initialize the run
 
-After Hermes or the user finishes a stage, save the outcome:
+Collect the channel name, niche, audience, style, frequency, and optional
+topic. Run `init-run`, record the returned workspace path, and verify its
+current stage is `strategy`.
+
+### 2. Produce the current stage
+
+Run `brief` against the workspace. Use its goal, context, prompt, and expected
+artifacts as the contract for the stage; do not silently omit required
+artifacts.
+
+### 3. Persist the result
+
+After the user accepts the deliverable, save it with `complete-stage`:
 
 ```bash
 python3 "$SCRIPT" complete-stage \
   --workspace /path/to/run.json \
   --stage strategy \
-  --notes "Selected a founder-focused AI automation angle" \
+  --notes "Selected a founder-focused automation angle" \
   --artifacts-json '{
     "selected_topic": "AI workflow automations for founders",
-    "angle": "replace repetitive ops work with reusable agents",
+    "angle": "replace repetitive operations with reusable agents",
     "content_type": "Explainer",
-    "keywords": ["ai automation", "workflow automation", "founder productivity"]
+    "keywords": ["ai automation", "workflow automation"]
   }'
 ```
 
-The helper automatically advances the current stage to the next incomplete stage.
+Run `status` and confirm the completed stage is recorded and the next
+incomplete stage is `in_progress`.
 
-## Export a finished run
+### 4. Repeat and export
 
-```bash
-python3 "$SCRIPT" export --workspace /path/to/run.json
-```
+Repeat the brief, production, acceptance, and completion loop through
+`analytics`. Run `export` and verify every completed stage appears under
+`deliverables`.
 
-This gives Hermes a portable summary of all completed deliverables.
+### 5. Inspect the external project when requested
 
-## How to use this as an interactive Hermes skill
+Run `inspect --repo` before claiming a local clone is runnable. A `blocked`
+report can include missing required files, unreadable or malformed
+`package.json`, or package scripts whose targets do not exist. A
+`needs-setup` report indicates missing configuration or dependencies.
 
-Recommended operator loop:
+After the app starts, run `probe`. Success requires 2xx responses from
+`/health`, `/schedule`, and `/analytics`, plus `{"status":"healthy"}` from
+`/health`.
 
-1. create a run with `init-run`
-2. ask for the current stage brief with `brief`
-3. use Hermes to generate the requested deliverables for that stage
-4. save the result with `complete-stage`
-5. repeat until analytics is complete
+## Pitfalls
 
-This turns the repo's abstract pipeline into a real session-by-session Hermes workflow.
+1. **Default-profile paths.** Never hardcode the installed helper beneath the
+   default home. Resolve `SKILL_DIR` from `skill_view` or active `HERMES_HOME`.
+2. **Turnkey claims.** The inspected upstream revision references missing
+   `workflows/daily-content-pipeline.js`,
+   `workflows/weekly-strategy-review.js`, and `database/init.js` targets.
+3. **Gemini-only setup.** Upstream credential validation currently expects
+   `youtube` and `openai`; do not present Gemini-only configuration as tested.
+4. **Planning versus execution.** Thumbnail and production stages create
+   briefs and assembly plans unless an external image, audio, or video tool is
+   actually available and exercised.
+5. **Premature completion.** Do not mark a stage complete before its artifacts
+   are accepted and persisted in the workspace.
 
-## Upstream repo inspection mode
+## Verification
 
-The skill still supports repo validation.
+Before reporting success:
 
-### Inspect a local clone
-
-```bash
-python3 "$SCRIPT" inspect --repo /path/to/youtube-automation-agent
-```
-
-Checks include:
-- required files
-- missing package script targets
-- config file presence
-- `node_modules/` presence
-- `node --check` syntax checks for key entry files
-
-### Probe a running local server
-
-```bash
-python3 "$SCRIPT" probe --base-url http://localhost:3456
-```
-
-This probes:
-- `/health`
-- `/schedule`
-- `/analytics`
-
-## Known upstream caveats
-
-Before claiming the upstream repo is turnkey, remember:
-
-1. `package.json` references missing script targets in the inspected repo:
-   - `workflows/daily-content-pipeline.js`
-   - `workflows/weekly-strategy-review.js`
-   - `database/init.js`
-2. The README mentions a `workflows/` directory, but it is absent in the inspected repo.
-3. The docs market Gemini as an option, but `utils/credential-manager.js` currently validates `youtube` and `openai`, so Gemini-only setup is not turnkey without upstream changes.
-4. A dashboard alone is not enough; confirm `/health`.
-
-See also:
-- `references/repo-caveats.md`
-- `references/setup-notes.md`
-- `references/manual-ops.md`
-- `references/hermes-native-flow.md`
-
-## Practical boundaries
-
-This skill can help Hermes achieve the same claimed flow structure as the upstream project:
-- strategy
-- scripting
-- thumbnail planning
-- SEO packaging
-- production planning
-- publishing prep
-- analytics feedback loop
-
-But it does not claim that Hermes alone can, without credentials or infrastructure:
-- upload to YouTube automatically
-- render final videos out of thin air
-- authenticate external APIs without setup
-- replace all manual production steps
-
-Instead, it gives a strong, reusable workflow layer that Hermes can run interactively.
-
-## Verification checklist
-
-Before telling the user a workflow is ready:
-
-1. the run workspace exists
-2. the current stage brief is clear
-3. each completed stage has notes and artifacts saved
-4. the export summary contains the expected deliverables
-5. if using the upstream repo, `inspect` and `probe` have been run successfully
+- [ ] `status` identifies the expected current and completed stages.
+- [ ] Every completed stage contains notes and accepted artifacts.
+- [ ] `export` contains each completed stage under `deliverables`.
+- [ ] The workspace is beneath the active profile or the requested output path.
+- [ ] External-project claims are backed by a fresh `inspect` report.
+- [ ] Running-server claims are backed by a successful `probe` report.
+- [ ] Credential, rendering, and upload dependencies are stated honestly.

--- a/optional-skills/media/youtube-automation-agent/references/hermes-native-flow.md
+++ b/optional-skills/media/youtube-automation-agent/references/hermes-native-flow.md
@@ -1,0 +1,92 @@
+# Hermes-native flow
+
+This document explains how the skill captures the essence of the upstream YouTube automation repo as a native Hermes workflow.
+
+## Stage mapping
+
+### 1. Strategy
+Mirrors:
+- `ContentStrategyAgent.generateContentStrategy()`
+
+Hermes output should include:
+- topic candidates
+- selected topic
+- angle
+- target audience
+- content type
+- keywords
+- best publish timing
+
+### 2. Script
+Mirrors:
+- `ScriptWriterAgent.generateScript()`
+
+Hermes output should include:
+- title
+- hook
+- intro
+- main sections
+- CTA
+- narration-ready full script
+- duration estimate
+
+### 3. Thumbnail
+Mirrors:
+- `ThumbnailDesignerAgent.generateThumbnail()`
+
+Hermes output should include:
+- primary text
+- secondary text
+- concept
+- composition
+- colors
+- alternate thumbnail ideas
+
+### 4. SEO
+Mirrors:
+- `SEOOptimizerAgent.optimize()`
+
+Hermes output should include:
+- optimized title
+- description
+- tags
+- hashtags
+- chapters
+- category suggestion
+
+### 5. Production
+Mirrors:
+- `ProductionManagementAgent.processContent()`
+
+Hermes output should include:
+- narration plan
+- visual asset list
+- caption plan
+- assembly checklist
+- automation-vs-manual split
+
+### 6. Publishing
+Mirrors:
+- `PublishingSchedulingAgent.scheduleContent()` and `publishContent()`
+
+Hermes output should include:
+- publish time
+- privacy status
+- upload checklist
+- metadata map
+- QA checklist
+
+### 7. Analytics
+Mirrors:
+- `AnalyticsOptimizationAgent.analyzeVideoPerformance()`
+
+Hermes output should include:
+- KPI plan
+- review schedule
+- thresholds
+- title/thumbnail iteration triggers
+- next-video feedback loop
+
+## Why this matters
+
+The upstream repo spreads these stages across multiple Node agents. This skill converts the same operational sequence into a persistent Hermes-run workflow so the user can progress stage by stage and keep context across sessions.

--- a/optional-skills/media/youtube-automation-agent/references/manual-ops.md
+++ b/optional-skills/media/youtube-automation-agent/references/manual-ops.md
@@ -1,0 +1,85 @@
+# Manual operations
+
+Use these commands in two modes:
+
+1. upstream repo operations
+2. Hermes-native workflow operations
+
+## Hermes-native workflow commands
+
+### Start a run
+
+```bash
+python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py init-run \
+  --channel "Ladera Labs" \
+  --niche "AI productivity" \
+  --audience "founders and operators" \
+  --style "educational" \
+  --frequency daily \
+  --topic "AI workflow automations"
+```
+
+### Check run status
+
+```bash
+python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py status \
+  --workspace /path/to/run.json
+```
+
+### Get the current stage brief
+
+```bash
+python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py brief \
+  --workspace /path/to/run.json
+```
+
+### Complete a stage
+
+```bash
+python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py complete-stage \
+  --workspace /path/to/run.json \
+  --stage strategy \
+  --notes "selected founder ops angle" \
+  --artifacts-json '{"selected_topic":"AI ops automations","content_type":"Explainer"}'
+```
+
+### Export final deliverables
+
+```bash
+python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py export \
+  --workspace /path/to/run.json
+```
+
+## Upstream repo operations
+
+### Health
+
+```bash
+curl http://localhost:3456/health
+```
+
+### View schedule
+
+```bash
+curl http://localhost:3456/schedule
+```
+
+### View analytics
+
+```bash
+curl http://localhost:3456/analytics
+```
+
+### Generate content manually
+
+```bash
+curl -X POST http://localhost:3456/generate \
+  -H 'Content-Type: application/json' \
+  -d '{"topic":"Top 10 Life Hacks","style":"listicle","length":"medium"}'
+```
+
+### Publish a queued item manually
+
+```bash
+curl -X POST http://localhost:3456/publish/CONTENT_ID
+```

--- a/optional-skills/media/youtube-automation-agent/references/manual-ops.md
+++ b/optional-skills/media/youtube-automation-agent/references/manual-ops.md
@@ -5,12 +5,22 @@ Use these commands in two modes:
 1. upstream repo operations
 2. Hermes-native workflow operations
 
+Resolve the helper from the loaded skill's `skill_dir`. If only the active
+Hermes home is available, initialize the path without assuming the default
+profile:
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+SKILL_DIR="${SKILL_DIR:-$HERMES_HOME/skills/media/youtube-automation-agent}"
+SCRIPT="$SKILL_DIR/scripts/youtube_automation_helper.py"
+```
+
 ## Hermes-native workflow commands
 
 ### Start a run
 
 ```bash
-python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py init-run \
+python3 "$SCRIPT" init-run \
   --channel "Ladera Labs" \
   --niche "AI productivity" \
   --audience "founders and operators" \
@@ -22,21 +32,21 @@ python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automati
 ### Check run status
 
 ```bash
-python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py status \
+python3 "$SCRIPT" status \
   --workspace /path/to/run.json
 ```
 
 ### Get the current stage brief
 
 ```bash
-python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py brief \
+python3 "$SCRIPT" brief \
   --workspace /path/to/run.json
 ```
 
 ### Complete a stage
 
 ```bash
-python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py complete-stage \
+python3 "$SCRIPT" complete-stage \
   --workspace /path/to/run.json \
   --stage strategy \
   --notes "selected founder ops angle" \
@@ -46,7 +56,7 @@ python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automati
 ### Export final deliverables
 
 ```bash
-python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py export \
+python3 "$SCRIPT" export \
   --workspace /path/to/run.json
 ```
 

--- a/optional-skills/media/youtube-automation-agent/references/repo-caveats.md
+++ b/optional-skills/media/youtube-automation-agent/references/repo-caveats.md
@@ -1,0 +1,46 @@
+# Repo caveats for darkzOGx/youtube-automation-agent
+
+These notes are grounded in inspection of the upstream repository and should be surfaced before telling a user the repo is production-ready.
+
+## Confirmed mismatches
+
+### Missing package script targets
+
+The inspected `package.json` contains scripts that point to files that are not present in the repo:
+
+- `workflows/daily-content-pipeline.js`
+- `workflows/weekly-strategy-review.js`
+- `database/init.js`
+
+This means commands mapped to those script targets should be treated as unavailable until upstream adds the files.
+
+### README tree mismatch
+
+The README mentions a `workflows/` directory in the project structure, but the inspected repo does not contain that directory.
+
+### Gemini vs OpenAI mismatch
+
+The README markets Gemini as a usable AI provider option.
+
+However, `utils/credential-manager.js` currently validates required credentials as:
+
+```js
+const requiredCredentials = ['youtube', 'openai'];
+```
+
+So a Gemini-only configuration should not be presented as working out of the box unless the upstream validation flow is changed.
+
+## Operational caveats
+
+- Real YouTube OAuth credentials are required.
+- Full automation may incur provider usage costs.
+- Local startup depends on Node and installed npm dependencies.
+- A visible dashboard is not sufficient proof of healthy initialization; verify `/health`.
+- The repo contains generated-looking data artifacts under `data/`, so do not assume a pristine sample dataset.
+
+## How Hermes should frame the repo
+
+Preferred framing:
+- promising external Node/Express automation project
+- suitable for local setup help, inspection, manual operation, and troubleshooting
+- not guaranteed turnkey in a fresh clone without credentials and dependency setup

--- a/optional-skills/media/youtube-automation-agent/references/setup-notes.md
+++ b/optional-skills/media/youtube-automation-agent/references/setup-notes.md
@@ -1,0 +1,72 @@
+# Setup notes
+
+Use this sequence when helping a user set up the repo locally.
+
+## 1. Clone
+
+```bash
+git clone https://github.com/darkzOGx/youtube-automation-agent.git
+cd youtube-automation-agent
+```
+
+## 2. Inspect before running
+
+```bash
+python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py inspect --repo .
+```
+
+## 3. Install dependencies
+
+```bash
+npm install
+```
+
+## 4. Prepare local config files
+
+```bash
+cp .env.example .env
+cp config/credentials.example.json config/credentials.json
+```
+
+The repo also expects YouTube OAuth tokens in:
+- `config/tokens.json`
+
+## 5. Run setup
+
+```bash
+npm run setup
+```
+
+## 6. Test
+
+```bash
+npm test
+```
+
+## 7. Start app
+
+```bash
+npm start
+```
+
+Expected local port from the repo docs and setup path:
+- `3456`
+
+## 8. Verify endpoints
+
+```bash
+python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py probe --base-url http://localhost:3456
+```
+
+Check these endpoints explicitly:
+- `/health`
+- `/schedule`
+- `/analytics`
+
+## What success looks like
+
+- required repo files are present
+- npm dependencies installed
+- credentials exist
+- local server starts
+- `/health` returns a healthy payload

--- a/optional-skills/media/youtube-automation-agent/references/setup-notes.md
+++ b/optional-skills/media/youtube-automation-agent/references/setup-notes.md
@@ -2,6 +2,15 @@
 
 Use this sequence when helping a user set up the repo locally.
 
+Resolve the helper from the loaded skill's `skill_dir`. If only the active
+Hermes home is available, initialize the profile-safe path:
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+SKILL_DIR="${SKILL_DIR:-$HERMES_HOME/skills/media/youtube-automation-agent}"
+SCRIPT="$SKILL_DIR/scripts/youtube_automation_helper.py"
+```
+
 ## 1. Clone
 
 ```bash
@@ -12,7 +21,7 @@ cd youtube-automation-agent
 ## 2. Inspect before running
 
 ```bash
-python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py inspect --repo .
+python3 "$SCRIPT" inspect --repo .
 ```
 
 ## 3. Install dependencies
@@ -55,7 +64,7 @@ Expected local port from the repo docs and setup path:
 ## 8. Verify endpoints
 
 ```bash
-python3 ~/.hermes/skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py probe --base-url http://localhost:3456
+python3 "$SCRIPT" probe --base-url http://localhost:3456
 ```
 
 Check these endpoints explicitly:

--- a/optional-skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py
+++ b/optional-skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_FILES = [
+    "package.json",
+    "index.js",
+    "setup.js",
+    "test.js",
+    "schedules/daily-automation.js",
+    "utils/credential-manager.js",
+]
+
+OPTIONAL_CONFIG_FILES = [
+    ".env",
+    "config/credentials.json",
+    "config/tokens.json",
+]
+
+ENDPOINTS = ["/health", "/schedule", "/analytics"]
+STAGES = ["strategy", "script", "thumbnail", "seo", "production", "publishing", "analytics"]
+
+
+@dataclass
+class CheckResult:
+    label: str
+    ok: bool
+    detail: str
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _slugify(text: str) -> str:
+    value = re.sub(r"[^a-zA-Z0-9]+", "-", text.strip().lower()).strip("-")
+    return value or "youtube-run"
+
+
+def _default_runs_dir() -> Path:
+    hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    return hermes_home / "skills" / "media" / "youtube-automation-agent" / "data" / "runs"
+
+
+def _save_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _check(path: Path, label: str) -> CheckResult:
+    return CheckResult(label=label, ok=path.exists(), detail=str(path))
+
+
+def _load_package_json(repo: Path) -> dict[str, Any]:
+    pkg_path = repo / "package.json"
+    return json.loads(pkg_path.read_text(encoding="utf-8"))
+
+
+def inspect_repo(repo: Path) -> dict[str, Any]:
+    results: list[CheckResult] = []
+    for rel in REQUIRED_FILES:
+        results.append(_check(repo / rel, f"required:{rel}"))
+
+    for rel in OPTIONAL_CONFIG_FILES:
+        results.append(_check(repo / rel, f"config:{rel}"))
+
+    node_path = shutil.which("node")
+    results.append(CheckResult("command:node", node_path is not None, node_path or "node not found"))
+    results.append(_check(repo / "node_modules", "deps:node_modules"))
+
+    package_json = _load_package_json(repo)
+    missing_script_targets: list[dict[str, str]] = []
+    for name, command in package_json.get("scripts", {}).items():
+        parts = command.split()
+        if len(parts) >= 2 and parts[0] == "node":
+            target = repo / parts[1]
+            if not target.exists():
+                missing_script_targets.append({"script": name, "target": parts[1]})
+
+    syntax_checks: list[dict[str, Any]] = []
+    if node_path:
+        for rel in ["index.js", "setup.js", "test.js"]:
+            target = repo / rel
+            if not target.exists():
+                continue
+            proc = subprocess.run(
+                [node_path, "--check", str(target)],
+                text=True,
+                capture_output=True,
+                cwd=repo,
+            )
+            syntax_checks.append(
+                {
+                    "file": rel,
+                    "ok": proc.returncode == 0,
+                    "stdout": proc.stdout.strip(),
+                    "stderr": proc.stderr.strip(),
+                }
+            )
+
+    required_missing = [r.label for r in results if r.label.startswith("required:") and not r.ok]
+    config_missing = [r.label for r in results if r.label.startswith("config:") and not r.ok]
+    verdict = "ready"
+    if required_missing or missing_script_targets:
+        verdict = "blocked"
+    elif config_missing or not (repo / "node_modules").exists():
+        verdict = "needs-setup"
+
+    return {
+        "repo": str(repo),
+        "verdict": verdict,
+        "checks": [r.__dict__ for r in results],
+        "missing_script_targets": missing_script_targets,
+        "syntax_checks": syntax_checks,
+    }
+
+
+def _fetch_json(url: str, timeout: int = 5) -> dict[str, Any]:
+    req = urllib.request.Request(url, headers={"User-Agent": "hermes-youtube-automation-helper/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+        return {"status": resp.status, "body": body}
+
+
+def probe_server(base_url: str) -> dict[str, Any]:
+    endpoints: list[dict[str, Any]] = []
+    healthy = True
+    for endpoint in ENDPOINTS:
+        url = f"{base_url.rstrip('/')}{endpoint}"
+        try:
+            result = _fetch_json(url)
+            status = int(result["status"])
+            body = result["body"]
+            endpoint_ok = 200 <= status < 300
+            if endpoint == "/health":
+                try:
+                    payload = json.loads(body)
+                    endpoint_ok = endpoint_ok and payload.get("status") == "healthy"
+                except json.JSONDecodeError:
+                    endpoint_ok = False
+            healthy = healthy and endpoint_ok
+            endpoints.append({
+                "endpoint": endpoint,
+                "ok": endpoint_ok,
+                "status": status,
+                "body_preview": body[:400],
+            })
+        except urllib.error.URLError as exc:
+            healthy = False
+            endpoints.append({
+                "endpoint": endpoint,
+                "ok": False,
+                "status": None,
+                "error": str(exc),
+            })
+    return {"base_url": base_url, "healthy": healthy, "endpoints": endpoints}
+
+
+def init_run(channel: str, niche: str, audience: str, style: str, frequency: str, topic: str | None, repo: str | None, output: str | None) -> dict[str, Any]:
+    title_basis = topic or f"{channel}-{niche}"
+    slug = _slugify(title_basis)
+    output_path = Path(output).expanduser().resolve() if output else _default_runs_dir() / f"{slug}.json"
+    run = {
+        "version": 1,
+        "created_at": _now(),
+        "updated_at": _now(),
+        "current_stage": STAGES[0],
+        "completed_stages": [],
+        "run": {
+            "channel": channel,
+            "niche": niche,
+            "audience": audience,
+            "style": style,
+            "frequency": frequency,
+            "topic": topic,
+            "repo": repo,
+        },
+        "stages": {
+            stage: {
+                "status": "pending",
+                "notes": "",
+                "artifacts": {},
+                "completed_at": None,
+            }
+            for stage in STAGES
+        },
+    }
+    run["stages"][STAGES[0]]["status"] = "in_progress"
+    _save_json(output_path, run)
+    return {"workspace": str(output_path), "run": run}
+
+
+def _ensure_workspace(path: str) -> Path:
+    workspace = Path(path).expanduser().resolve()
+    if not workspace.exists():
+        raise FileNotFoundError(f"Workspace does not exist: {workspace}")
+    return workspace
+
+
+def get_status(workspace: Path) -> dict[str, Any]:
+    payload = _load_json(workspace)
+    summary = {
+        "workspace": str(workspace),
+        "current_stage": payload["current_stage"],
+        "completed_stages": payload["completed_stages"],
+        "pending_stages": [s for s in STAGES if s not in payload["completed_stages"]],
+        "run": payload["run"],
+        "stages": payload["stages"],
+    }
+    return summary
+
+
+def _stage_brief(stage: str, payload: dict[str, Any]) -> dict[str, Any]:
+    run = payload["run"]
+    base_context = {
+        "channel": run["channel"],
+        "niche": run["niche"],
+        "audience": run["audience"],
+        "style": run["style"],
+        "frequency": run["frequency"],
+        "topic": run.get("topic"),
+    }
+    prompts = {
+        "strategy": {
+            "goal": "Find a strong video angle based on the niche, audience, and channel direction.",
+            "prompt": f"Research a YouTube content strategy for channel '{run['channel']}' in niche '{run['niche']}' targeting '{run['audience']}'. Produce topic ideas, one selected topic, angle, content type, target keywords, competitor cues, and best publish timing.",
+            "expected_artifacts": ["topic_candidates", "selected_topic", "angle", "content_type", "keywords", "best_publish_time"],
+        },
+        "script": {
+            "goal": "Turn the selected strategy into a watch-time-focused video script.",
+            "prompt": "Using the completed strategy stage, write a script package with title, hook, introduction, main sections, CTA, estimated duration, and a narration-ready full script.",
+            "expected_artifacts": ["title", "hook", "outline", "full_script", "duration_estimate"],
+        },
+        "thumbnail": {
+            "goal": "Design the thumbnail concept that matches the script and maximizes CTR.",
+            "prompt": "Using the script stage, create a thumbnail brief with primary text, secondary text, emotional angle, composition, color palette, and visual elements. Include 2-3 alternate concepts.",
+            "expected_artifacts": ["primary_text", "secondary_text", "concept", "color_palette", "alternatives"],
+        },
+        "seo": {
+            "goal": "Package the video for YouTube discovery.",
+            "prompt": "Using the script and strategy stages, create an SEO package with optimized title, description, tags, hashtags, chapters, and category recommendation.",
+            "expected_artifacts": ["seo_title", "description", "tags", "hashtags", "chapters", "category"],
+        },
+        "production": {
+            "goal": "Prepare the production assembly plan mirroring the upstream production agent.",
+            "prompt": "Create a production plan for this video: narration asset, visual assets, thumbnail source, caption plan, editing sequence, and final assembly checklist. Call out what can be automated vs what requires manual work.",
+            "expected_artifacts": ["asset_list", "narration_plan", "visual_plan", "caption_plan", "assembly_checklist"],
+        },
+        "publishing": {
+            "goal": "Prepare upload and scheduling details for YouTube publishing.",
+            "prompt": "Create a publishing package with privacy status, publish time, upload checklist, metadata mapping, thumbnail/captions attachments, and final pre-publish QA steps.",
+            "expected_artifacts": ["publish_time", "privacy_status", "upload_checklist", "metadata_map", "qa_steps"],
+        },
+        "analytics": {
+            "goal": "Create the post-publish analytics review loop.",
+            "prompt": "Create a 7-day and 30-day analytics review plan with KPIs, thresholds, thumbnail/title iteration triggers, and next-video feedback loop.",
+            "expected_artifacts": ["kpis", "thresholds", "review_schedule", "iteration_triggers", "next_video_feedback"],
+        },
+    }
+    return {
+        "stage": stage,
+        "context": base_context,
+        "stage_state": payload["stages"][stage],
+        **prompts[stage],
+    }
+
+
+def get_brief(workspace: Path, stage: str | None) -> dict[str, Any]:
+    payload = _load_json(workspace)
+    selected_stage = stage or payload["current_stage"]
+    if selected_stage not in STAGES:
+        raise ValueError(f"Unknown stage: {selected_stage}")
+    return {
+        "workspace": str(workspace),
+        "brief": _stage_brief(selected_stage, payload),
+    }
+
+
+def complete_stage(workspace: Path, stage: str, notes: str, artifacts: dict[str, Any] | None) -> dict[str, Any]:
+    payload = _load_json(workspace)
+    if stage not in STAGES:
+        raise ValueError(f"Unknown stage: {stage}")
+    entry = payload["stages"][stage]
+    entry["status"] = "completed"
+    entry["notes"] = notes
+    entry["artifacts"] = artifacts or {}
+    entry["completed_at"] = _now()
+    if stage not in payload["completed_stages"]:
+        payload["completed_stages"].append(stage)
+
+    next_stage = None
+    for candidate in STAGES:
+        if candidate not in payload["completed_stages"]:
+            next_stage = candidate
+            break
+
+    payload["current_stage"] = next_stage or stage
+    if next_stage:
+        payload["stages"][next_stage]["status"] = "in_progress"
+    payload["updated_at"] = _now()
+    _save_json(workspace, payload)
+    return {
+        "workspace": str(workspace),
+        "completed_stage": stage,
+        "next_stage": next_stage,
+        "status": get_status(workspace),
+    }
+
+
+def export_run(workspace: Path) -> dict[str, Any]:
+    payload = _load_json(workspace)
+    completed = payload["completed_stages"]
+    return {
+        "workspace": str(workspace),
+        "channel": payload["run"]["channel"],
+        "niche": payload["run"]["niche"],
+        "current_stage": payload["current_stage"],
+        "completed_stages": completed,
+        "deliverables": {stage: payload["stages"][stage] for stage in completed},
+    }
+
+
+def _print_inspect(report: dict[str, Any]) -> None:
+    print(f"Repo: {report['repo']}")
+    print(f"Verdict: {report['verdict']}")
+    print()
+    print("Checks:")
+    for item in report["checks"]:
+        status = "PASS" if item["ok"] else "WARN"
+        print(f"- [{status}] {item['label']} :: {item['detail']}")
+    if report["missing_script_targets"]:
+        print()
+        print("Missing package script targets:")
+        for item in report["missing_script_targets"]:
+            print(f"- {item['script']} -> {item['target']}")
+    if report["syntax_checks"]:
+        print()
+        print("Node syntax checks:")
+        for item in report["syntax_checks"]:
+            status = "PASS" if item["ok"] else "FAIL"
+            detail = item["stderr"] or item["stdout"] or "ok"
+            print(f"- [{status}] {item['file']} :: {detail}")
+
+
+def _print_probe(report: dict[str, Any]) -> None:
+    print(f"Base URL: {report['base_url']}")
+    print(f"Healthy: {report['healthy']}")
+    print()
+    for item in report["endpoints"]:
+        status = "PASS" if item["ok"] else "FAIL"
+        line = f"- [{status}] {item['endpoint']}"
+        if item.get("status") is not None:
+            line += f" status={item['status']}"
+        if item.get("error"):
+            line += f" error={item['error']}"
+        print(line)
+        if item.get("body_preview"):
+            print(f"  preview: {item['body_preview']}")
+
+
+def _print_status(report: dict[str, Any]) -> None:
+    print(f"Workspace: {report['workspace']}")
+    print(f"Current stage: {report['current_stage']}")
+    print(f"Completed: {', '.join(report['completed_stages']) or '(none)'}")
+    print()
+    for stage in STAGES:
+        entry = report['stages'][stage]
+        print(f"- {stage}: {entry['status']}")
+
+
+def _print_brief(report: dict[str, Any]) -> None:
+    brief = report['brief']
+    print(f"Workspace: {report['workspace']}")
+    print(f"Stage: {brief['stage']}")
+    print(f"Goal: {brief['goal']}")
+    print()
+    print("Context:")
+    for key, value in brief['context'].items():
+        print(f"- {key}: {value}")
+    print()
+    print("Prompt:")
+    print(brief['prompt'])
+    print()
+    print("Expected artifacts:")
+    for item in brief['expected_artifacts']:
+        print(f"- {item}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Helper for the youtube-automation-agent Hermes skill")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    inspect_parser = sub.add_parser("inspect", help="Inspect a local clone of the repo")
+    inspect_parser.add_argument("--repo", required=True, help="Path to the local repository clone")
+    inspect_parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+
+    probe_parser = sub.add_parser("probe", help="Probe a running local server")
+    probe_parser.add_argument("--base-url", default="http://localhost:3456", help="Base URL to probe")
+    probe_parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+
+    init_parser = sub.add_parser("init-run", help="Create a Hermes-native interactive YouTube workflow run")
+    init_parser.add_argument("--channel", required=True)
+    init_parser.add_argument("--niche", required=True)
+    init_parser.add_argument("--audience", required=True)
+    init_parser.add_argument("--style", required=True)
+    init_parser.add_argument("--frequency", default="daily")
+    init_parser.add_argument("--topic")
+    init_parser.add_argument("--repo")
+    init_parser.add_argument("--output")
+    init_parser.add_argument("--json", action="store_true")
+
+    status_parser = sub.add_parser("status", help="Show workflow status")
+    status_parser.add_argument("--workspace", required=True)
+    status_parser.add_argument("--json", action="store_true")
+
+    brief_parser = sub.add_parser("brief", help="Show the current or requested stage brief")
+    brief_parser.add_argument("--workspace", required=True)
+    brief_parser.add_argument("--stage", choices=STAGES)
+    brief_parser.add_argument("--json", action="store_true")
+
+    complete_parser = sub.add_parser("complete-stage", help="Mark a stage complete and save artifacts")
+    complete_parser.add_argument("--workspace", required=True)
+    complete_parser.add_argument("--stage", required=True, choices=STAGES)
+    complete_parser.add_argument("--notes", required=True)
+    complete_parser.add_argument("--artifacts-json")
+    complete_parser.add_argument("--json", action="store_true")
+
+    export_parser = sub.add_parser("export", help="Export all completed deliverables")
+    export_parser.add_argument("--workspace", required=True)
+    export_parser.add_argument("--json", action="store_true")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "inspect":
+        repo = Path(args.repo).expanduser().resolve()
+        if not repo.exists():
+            print(f"Repo path does not exist: {repo}", file=sys.stderr)
+            return 2
+        report = inspect_repo(repo)
+        if args.json:
+            print(json.dumps(report, indent=2))
+        else:
+            _print_inspect(report)
+        return 0 if report["verdict"] != "blocked" else 1
+
+    if args.command == "probe":
+        report = probe_server(args.base_url)
+        if args.json:
+            print(json.dumps(report, indent=2))
+        else:
+            _print_probe(report)
+        return 0 if report["healthy"] else 1
+
+    if args.command == "init-run":
+        result = init_run(args.channel, args.niche, args.audience, args.style, args.frequency, args.topic, args.repo, args.output)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Workspace: {result['workspace']}")
+            print(f"Current stage: {result['run']['current_stage']}")
+        return 0
+
+    if args.command == "status":
+        workspace = _ensure_workspace(args.workspace)
+        result = get_status(workspace)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            _print_status(result)
+        return 0
+
+    if args.command == "brief":
+        workspace = _ensure_workspace(args.workspace)
+        result = get_brief(workspace, args.stage)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            _print_brief(result)
+        return 0
+
+    if args.command == "complete-stage":
+        workspace = _ensure_workspace(args.workspace)
+        artifacts = json.loads(args.artifacts_json) if args.artifacts_json else None
+        result = complete_stage(workspace, args.stage, args.notes, artifacts)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Completed stage: {result['completed_stage']}")
+            print(f"Next stage: {result['next_stage']}")
+        return 0
+
+    if args.command == "export":
+        workspace = _ensure_workspace(args.workspace)
+        result = export_run(workspace)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(json.dumps(result, indent=2))
+        return 0
+
+    parser.error("unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py
+++ b/optional-skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py
@@ -69,9 +69,39 @@ def _check(path: Path, label: str) -> CheckResult:
     return CheckResult(label=label, ok=path.exists(), detail=str(path))
 
 
-def _load_package_json(repo: Path) -> dict[str, Any]:
+def _load_package_json(repo: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     pkg_path = repo / "package.json"
-    return json.loads(pkg_path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(pkg_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, {"ok": False, "error": "package.json is missing"}
+    except UnicodeDecodeError as exc:
+        error = f"package.json is malformed: invalid UTF-8 at byte {exc.start}"
+        return {}, {"ok": False, "error": error}
+    except json.JSONDecodeError as exc:
+        error = f"package.json is malformed: line {exc.lineno} column {exc.colno}"
+        return {}, {"ok": False, "error": error}
+    except OSError as exc:
+        return {}, {"ok": False, "error": f"package.json could not be read: {exc}"}
+
+    if not isinstance(payload, dict):
+        return {}, {
+            "ok": False,
+            "error": "package.json is malformed: expected a JSON object",
+        }
+
+    scripts = payload.get("scripts", {})
+    if not isinstance(scripts, dict):
+        return {}, {
+            "ok": False,
+            "error": "package.json is malformed: scripts must be a JSON object",
+        }
+    if any(not isinstance(command, str) for command in scripts.values()):
+        return {}, {
+            "ok": False,
+            "error": "package.json is malformed: script commands must be strings",
+        }
+    return payload, {"ok": True, "error": None}
 
 
 def inspect_repo(repo: Path) -> dict[str, Any]:
@@ -86,7 +116,9 @@ def inspect_repo(repo: Path) -> dict[str, Any]:
     results.append(CheckResult("command:node", node_path is not None, node_path or "node not found"))
     results.append(_check(repo / "node_modules", "deps:node_modules"))
 
-    package_json = _load_package_json(repo)
+    package_json, package_metadata = _load_package_json(repo)
+    metadata_detail = package_metadata["error"] or str(repo / "package.json")
+    results.append(CheckResult("metadata:package.json", package_metadata["ok"], metadata_detail))
     missing_script_targets: list[dict[str, str]] = []
     for name, command in package_json.get("scripts", {}).items():
         parts = command.split()
@@ -118,16 +150,18 @@ def inspect_repo(repo: Path) -> dict[str, Any]:
 
     required_missing = [r.label for r in results if r.label.startswith("required:") and not r.ok]
     config_missing = [r.label for r in results if r.label.startswith("config:") and not r.ok]
+    syntax_failed = any(not item["ok"] for item in syntax_checks)
     verdict = "ready"
-    if required_missing or missing_script_targets:
+    if required_missing or missing_script_targets or not package_metadata["ok"] or syntax_failed:
         verdict = "blocked"
-    elif config_missing or not (repo / "node_modules").exists():
+    elif config_missing or not (repo / "node_modules").exists() or not node_path:
         verdict = "needs-setup"
 
     return {
         "repo": str(repo),
         "verdict": verdict,
         "checks": [r.__dict__ for r in results],
+        "package_metadata": package_metadata,
         "missing_script_targets": missing_script_targets,
         "syntax_checks": syntax_checks,
     }
@@ -153,7 +187,11 @@ def probe_server(base_url: str) -> dict[str, Any]:
             if endpoint == "/health":
                 try:
                     payload = json.loads(body)
-                    endpoint_ok = endpoint_ok and payload.get("status") == "healthy"
+                    endpoint_ok = (
+                        endpoint_ok
+                        and isinstance(payload, dict)
+                        and payload.get("status") == "healthy"
+                    )
                 except json.JSONDecodeError:
                     endpoint_ok = False
             healthy = healthy and endpoint_ok

--- a/tests/skills/test_youtube_automation_agent_skill.py
+++ b/tests/skills/test_youtube_automation_agent_skill.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import socketserver
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "media"
+    / "youtube-automation-agent"
+    / "scripts"
+    / "youtube_automation_helper.py"
+)
+
+
+def run_helper(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(SCRIPT_PATH), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_inspect_reports_missing_script_targets(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "schedules").mkdir(parents=True)
+    (repo / "utils").mkdir(parents=True)
+    (repo / "config").mkdir(parents=True)
+
+    (repo / "index.js").write_text("console.log('ok')\n", encoding="utf-8")
+    (repo / "setup.js").write_text("console.log('setup')\n", encoding="utf-8")
+    (repo / "test.js").write_text("console.log('test')\n", encoding="utf-8")
+    (repo / "schedules" / "daily-automation.js").write_text("module.exports = {}\n", encoding="utf-8")
+    (repo / "utils" / "credential-manager.js").write_text("module.exports = {}\n", encoding="utf-8")
+    (repo / "package.json").write_text(
+        json.dumps(
+            {
+                "scripts": {
+                    "start": "node index.js",
+                    "workflow:daily": "node workflows/daily-content-pipeline.js",
+                    "db:init": "node database/init.js",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    proc = run_helper("inspect", "--repo", str(repo), "--json")
+    assert proc.returncode == 1
+
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "blocked"
+    assert {item["target"] for item in payload["missing_script_targets"]} == {
+        "workflows/daily-content-pipeline.js",
+        "database/init.js",
+    }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path == "/health":
+            body = json.dumps({"status": "healthy", "initialized": True}).encode()
+            self.send_response(200)
+        elif self.path == "/schedule":
+            body = b"[]"
+            self.send_response(200)
+        elif self.path == "/analytics":
+            body = b"{}"
+            self.send_response(200)
+        else:
+            body = b"not found"
+            self.send_response(404)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+def test_probe_reports_healthy_server():
+    with socketserver.TCPServer(("127.0.0.1", 0), _Handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base_url = f"http://127.0.0.1:{server.server_address[1]}"
+
+        proc = run_helper("probe", "--base-url", base_url, "--json")
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["healthy"] is True
+    assert [item["endpoint"] for item in payload["endpoints"]] == ["/health", "/schedule", "/analytics"]
+    assert all(item["ok"] for item in payload["endpoints"])
+
+
+def test_init_run_and_stage_brief(tmp_path: Path):
+    workspace = tmp_path / "run.json"
+    proc = run_helper(
+        "init-run",
+        "--channel",
+        "Ladera Labs",
+        "--niche",
+        "AI productivity",
+        "--audience",
+        "founders",
+        "--style",
+        "educational",
+        "--frequency",
+        "daily",
+        "--topic",
+        "agent workflows",
+        "--output",
+        str(workspace),
+        "--json",
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["workspace"] == str(workspace)
+    assert payload["run"]["current_stage"] == "strategy"
+
+    brief_proc = run_helper("brief", "--workspace", str(workspace), "--json")
+    assert brief_proc.returncode == 0
+    brief_payload = json.loads(brief_proc.stdout)
+    assert brief_payload["brief"]["stage"] == "strategy"
+    assert "selected topic" in brief_payload["brief"]["prompt"].lower()
+
+
+def test_complete_stage_advances_to_next_stage(tmp_path: Path):
+    workspace = tmp_path / "run.json"
+    init_proc = run_helper(
+        "init-run",
+        "--channel",
+        "Ladera Labs",
+        "--niche",
+        "AI productivity",
+        "--audience",
+        "founders",
+        "--style",
+        "educational",
+        "--frequency",
+        "daily",
+        "--output",
+        str(workspace),
+        "--json",
+    )
+    assert init_proc.returncode == 0
+
+    complete_proc = run_helper(
+        "complete-stage",
+        "--workspace",
+        str(workspace),
+        "--stage",
+        "strategy",
+        "--notes",
+        "Selected workflow automation angle",
+        "--artifacts-json",
+        '{"selected_topic":"AI workflow automation","content_type":"Explainer"}',
+        "--json",
+    )
+    assert complete_proc.returncode == 0
+    payload = json.loads(complete_proc.stdout)
+    assert payload["completed_stage"] == "strategy"
+    assert payload["next_stage"] == "script"
+
+    status_proc = run_helper("status", "--workspace", str(workspace), "--json")
+    status_payload = json.loads(status_proc.stdout)
+    assert status_payload["current_stage"] == "script"
+    assert status_payload["stages"]["strategy"]["artifacts"]["selected_topic"] == "AI workflow automation"
+
+    export_proc = run_helper("export", "--workspace", str(workspace), "--json")
+    export_payload = json.loads(export_proc.stdout)
+    assert export_payload["completed_stages"] == ["strategy"]
+    assert "strategy" in export_payload["deliverables"]

--- a/tests/skills/test_youtube_automation_agent_skill.py
+++ b/tests/skills/test_youtube_automation_agent_skill.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import json
+import importlib.util
+import os
+import shutil
 import socketserver
 import subprocess
+import sys
 import threading
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
+
+import pytest
 
 
 SCRIPT_PATH = (
@@ -16,11 +22,47 @@ SCRIPT_PATH = (
     / "scripts"
     / "youtube_automation_helper.py"
 )
+SKILL_DIR = SCRIPT_PATH.parents[1]
+SKILL_PATH = SKILL_DIR / "SKILL.md"
+
+
+def load_helper_module():
+    spec = importlib.util.spec_from_file_location(
+        "youtube_automation_helper_under_test", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_ready_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    for rel in [
+        "schedules/daily-automation.js",
+        "utils/credential-manager.js",
+        "config/credentials.json",
+        "config/tokens.json",
+    ]:
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+    for rel in ["index.js", "setup.js", "test.js"]:
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("console.log('ok')\n", encoding="utf-8")
+    (repo / ".env").write_text("# test\n", encoding="utf-8")
+    (repo / "node_modules").mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"scripts": {"start": "node index.js"}}), encoding="utf-8"
+    )
+    return repo
 
 
 def run_helper(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["python3", str(SCRIPT_PATH), *args],
+        [sys.executable, str(SCRIPT_PATH), *args],
         text=True,
         capture_output=True,
         check=False,
@@ -62,6 +104,178 @@ def test_inspect_reports_missing_script_targets(tmp_path: Path):
     }
 
 
+def test_inspect_reports_missing_package_metadata_without_traceback(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    proc = run_helper("inspect", "--repo", str(repo), "--json")
+
+    assert proc.returncode == 1
+    assert proc.stderr == ""
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "blocked"
+    assert payload["package_metadata"] == {
+        "ok": False,
+        "error": "package.json is missing",
+    }
+
+
+def test_inspect_reports_malformed_package_metadata_without_traceback(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text("{not valid json", encoding="utf-8")
+
+    proc = run_helper("inspect", "--repo", str(repo), "--json")
+
+    assert proc.returncode == 1
+    assert proc.stderr == ""
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "blocked"
+    assert payload["package_metadata"]["ok"] is False
+    assert payload["package_metadata"]["error"].startswith("package.json is malformed:")
+
+
+def test_inspect_reports_non_utf8_package_metadata_without_traceback(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_bytes(b"\xff")
+
+    proc = run_helper("inspect", "--repo", str(repo), "--json")
+
+    assert proc.returncode == 1
+    assert proc.stderr == ""
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "blocked"
+    assert payload["package_metadata"] == {
+        "ok": False,
+        "error": "package.json is malformed: invalid UTF-8 at byte 0",
+    }
+
+
+@pytest.mark.parametrize("scripts", [[], {"start": 42}])
+def test_inspect_reports_invalid_scripts_metadata_without_traceback(
+    tmp_path: Path, scripts: object
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"scripts": scripts}), encoding="utf-8"
+    )
+
+    proc = run_helper("inspect", "--repo", str(repo), "--json")
+
+    assert proc.returncode == 1
+    assert proc.stderr == ""
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "blocked"
+    assert payload["package_metadata"]["ok"] is False
+    assert payload["package_metadata"]["error"].startswith(
+        "package.json is malformed:"
+    )
+
+
+def test_inspect_reports_missing_node_as_needs_setup(tmp_path: Path, monkeypatch):
+    repo = make_ready_repo(tmp_path)
+    helper = load_helper_module()
+    monkeypatch.setattr(helper.shutil, "which", lambda command: None)
+
+    report = helper.inspect_repo(repo)
+
+    assert report["verdict"] == "needs-setup"
+    node_check = next(item for item in report["checks"] if item["label"] == "command:node")
+    assert node_check == {"label": "command:node", "ok": False, "detail": "node not found"}
+
+
+def test_inspect_reports_failed_node_syntax_as_blocked(tmp_path: Path, monkeypatch):
+    repo = make_ready_repo(tmp_path)
+    helper = load_helper_module()
+    monkeypatch.setattr(helper.shutil, "which", lambda command: "node")
+    monkeypatch.setattr(
+        helper.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args[0], returncode=1, stdout="", stderr="SyntaxError"
+        ),
+    )
+
+    report = helper.inspect_repo(repo)
+
+    assert report["verdict"] == "blocked"
+    assert report["syntax_checks"]
+    assert all(item["ok"] is False for item in report["syntax_checks"])
+
+
+def test_skill_frontmatter_and_sections_follow_external_skill_contract():
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    frontmatter = content.split("---", 2)[1]
+    fields = {
+        key.strip(): value.strip()
+        for line in frontmatter.splitlines()
+        if ":" in line and not line.startswith(" ")
+        for key, value in [line.split(":", 1)]
+    }
+
+    description = fields["description"]
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert fields["author"].startswith("Haithum Abdelfattah (@darkzOGx)")
+    assert "platforms" in fields
+
+    expected_sections = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [content.index(section) for section in expected_sections]
+    assert positions == sorted(positions)
+
+
+def test_named_profile_install_uses_active_hermes_home(tmp_path: Path):
+    named_home = tmp_path / ".hermes" / "profiles" / "creator"
+    installed_skill = named_home / "skills" / "media" / "youtube-automation-agent"
+    shutil.copytree(SKILL_DIR, installed_skill)
+
+    documented_files = [SKILL_PATH, *sorted((SKILL_DIR / "references").glob("*.md"))]
+    documentation = "\n".join(path.read_text(encoding="utf-8") for path in documented_files)
+    assert "~/.hermes/skills" not in documentation
+    assert "$HERMES_HOME" in documentation
+    assert "$SKILL_DIR/scripts/youtube_automation_helper.py" in documentation
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(named_home)
+    installed_script = installed_skill / "scripts" / "youtube_automation_helper.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(installed_script),
+            "init-run",
+            "--channel",
+            "Profile Channel",
+            "--niche",
+            "testing",
+            "--audience",
+            "creators",
+            "--style",
+            "educational",
+            "--topic",
+            "profile workflow",
+            "--json",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    workspace = Path(json.loads(proc.stdout)["workspace"])
+    assert workspace.parent == installed_skill / "data" / "runs"
+
+
 class _Handler(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802
         if self.path == "/health":
@@ -85,6 +299,18 @@ class _Handler(BaseHTTPRequestHandler):
         return
 
 
+class _NonObjectHealthHandler(_Handler):
+    def do_GET(self):  # noqa: N802
+        if self.path != "/health":
+            return super().do_GET()
+        body = b"[]"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
 def test_probe_reports_healthy_server():
     with socketserver.TCPServer(("127.0.0.1", 0), _Handler) as server:
         thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -100,6 +326,24 @@ def test_probe_reports_healthy_server():
     assert payload["healthy"] is True
     assert [item["endpoint"] for item in payload["endpoints"]] == ["/health", "/schedule", "/analytics"]
     assert all(item["ok"] for item in payload["endpoints"])
+
+
+def test_probe_reports_non_object_health_json_as_unhealthy():
+    with socketserver.TCPServer(("127.0.0.1", 0), _NonObjectHealthHandler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base_url = f"http://127.0.0.1:{server.server_address[1]}"
+
+        proc = run_helper("probe", "--base-url", base_url, "--json")
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert proc.returncode == 1
+    assert proc.stderr == ""
+    payload = json.loads(proc.stdout)
+    assert payload["healthy"] is False
+    health = next(item for item in payload["endpoints"] if item["endpoint"] == "/health")
+    assert health["ok"] is False
 
 
 def test_init_run_and_stage_brief(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add an optional Hermes skill for a YouTube automation workflow modeled on `darkzOGx/youtube-automation-agent`
- turn the upstream repo’s agent pipeline into a Hermes-native interactive stage flow: strategy, script, thumbnail, SEO, production, publishing, and analytics
- keep repo inspection/probing support so Hermes can still validate the external Node app when users want to run the original project locally
- add tests covering repo inspection, endpoint probing, workflow initialization, stage briefs, stage completion, and export behavior

## Why
The upstream repo has a compelling workflow concept, but it is more useful inside Hermes if the flow itself becomes reusable across sessions instead of existing only as a separate Node app.

This PR captures the essence of that repo as a Hermes skill:
- users can run the content pipeline interactively inside Hermes
- Hermes can persist progress across stages
- Hermes can still inspect and troubleshoot the original repo honestly

## What’s included
- `optional-skills/media/youtube-automation-agent/SKILL.md`
- `optional-skills/media/youtube-automation-agent/scripts/youtube_automation_helper.py`
- `optional-skills/media/youtube-automation-agent/references/hermes-native-flow.md`
- `optional-skills/media/youtube-automation-agent/references/repo-caveats.md`
- `optional-skills/media/youtube-automation-agent/references/setup-notes.md`
- `optional-skills/media/youtube-automation-agent/references/manual-ops.md`
- `tests/skills/test_youtube_automation_agent_skill.py`

## Hermes-native workflow design
The skill mirrors the upstream repo’s main agent stages:
- strategy
- script
- thumbnail
- SEO
- production
- publishing
- analytics

The helper script supports:
- `init-run` — create a persistent workflow workspace
- `status` — inspect current stage and completed stages
- `brief` — get a stage-specific goal/prompt/artifact contract
- `complete-stage` — save results and advance to the next stage
- `export` — export completed deliverables
- `inspect` — validate a local clone of the upstream repo
- `probe` — verify the running upstream app’s main endpoints

## Grounded upstream caveats documented by the skill
- upstream `package.json` points to missing files:
  - `workflows/daily-content-pipeline.js`
  - `workflows/weekly-strategy-review.js`
  - `database/init.js`
- the README references a `workflows/` directory that is absent in the inspected repo
- upstream credential validation currently expects `youtube` and `openai`, so Gemini-only setup is not presented as turnkey
- the skill explicitly avoids claiming Hermes alone replaces external credentials, rendering, or YouTube upload infrastructure

## Validation
- `python -m pytest tests/skills/test_youtube_automation_agent_skill.py -q`
- manual helper verification for:
  - workflow init
  - stage brief generation
  - stage completion/advancement
  - repo inspection against a live clone
  - endpoint probing behavior

## Suggested PR title
feat: add interactive youtube automation agent skill
