### PR TITLE
feat(plugins): add on_tool_definitions_filter hook

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -63,6 +63,7 @@ VALID_HOOKS: Set[str] = {
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",
+    "on_tool_definitions_filter",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/model_tools.py
+++ b/model_tools.py
@@ -301,6 +301,25 @@ def get_tool_definitions(
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
 
+    # Plugin hook: allow semantic/discovery/filtering plugins to refine the list
+    # before the execute_code schema rebuild and browser_navigate cross-ref stripping.
+    # Plugins receive the fully-resolved, check_fn-filtered tool list and return
+    # the (possibly mutated) list they want the LLM to see.
+    # Fail-open: if no plugin responds or all raise, keep the original list.
+    try:
+        from hermes_cli.plugins import invoke_hook
+        results = invoke_hook(
+            "on_tool_definitions_filter",
+            tools=filtered_tools,
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            quiet_mode=quiet_mode,
+        )
+        if results:
+            filtered_tools = results[0]
+    except Exception:
+        pass  # fail open — keep original filtered_tools
+
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
     # other tools by name — otherwise the model sees tools mentioned in


### PR DESCRIPTION
## Summary

Adds a new plugin hook `on_tool_definitions_filter` that fires after the tool registry resolves tool definitions but before the `execute_code` schema rebuild and `browser_navigate` cross-ref stripping.

This allows semantic/discovery/filtering plugins to refine the tool list the LLM sees — enabling context-aware tool selection without modifying the core agent logic.

## Changes

- **`hermes_cli/plugins.py`**: `VALID_HOOKS` gains `on_tool_definitions_filter`
- **`model_tools.py`**: After `registry.get_definitions()`, invokes the hook with the resolved tool list. Takes the first plugin response; fails open if no plugin responds.

## Behavior

- No change to hermes-agent behavior when no plugins use this hook
- Plugins receive the fully-resolved, `check_fn`-filtered tool list
- Plugin can return a mutated list that replaces the LLM's tool definitions
- Fail-open: any exception or empty result keeps the original list

## Test Plan

- [ ] Existing plugin tests pass
- [ ] Agent behaves identically with no plugins using the new hook
- [ ] A plugin returning a filtered list correctly restricts LLM tool access