### PR TITLE
feat: add /restart-gateway command for safe remote gateway restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2129,6 +2129,9 @@ class GatewayRunner:
         if canonical == "update":
             return await self._handle_update_command(event)
 
+        if canonical == "restart-gateway":
+            return await self._handle_restart_gateway_command(event)
+
         if canonical == "title":
             return await self._handle_title_command(event)
 
@@ -5613,6 +5616,69 @@ class GatewayRunner:
 
         self._schedule_update_notification_watch()
         return "⚕ Starting Hermes update… I'll stream progress here."
+
+    async def _handle_restart_gateway_command(self, event: MessageEvent) -> str:
+        """Handle /restart-gateway — safely restart the gateway via launchd.
+
+        Spawns a detached process that sleeps briefly (to allow the response
+        message to flush), then uses ``launchctl kickstart -k`` to ask launchd
+        to kill the current gateway and start a fresh one.  The detached process
+        survives the gateway shutdown because it runs in its own session
+        (``start_new_session=True``).
+        """
+        import subprocess
+        import shutil
+
+        # Verify launchd service is loaded before attempting restart
+        service_label = "ai.hermes.gateway"
+        uid = os.getuid()
+        target = f"gui/{uid}/{service_label}"
+
+        check = subprocess.run(
+            ["launchctl", "print", target],
+            capture_output=True, text=True,
+        )
+        if check.returncode != 0:
+            return (
+                f"✗ launchd service '{service_label}' is not loaded. "
+                f"Cannot restart via launchctl. Use `hermes gateway start` from a terminal."
+            )
+
+        # Pre-flight: verify the gateway module imports cleanly
+        preflight = subprocess.run(
+            [sys.executable, "-c", "from gateway.run import GatewayRunner"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent.resolve()),
+        )
+        if preflight.returncode != 0:
+            return (
+                f"✗ Pre-flight import check failed — aborting restart to avoid crash loop.\n\n"
+                f"{preflight.stderr[:500]}"
+            )
+
+        # Spawn a detached process: sleep 3s (let this response flush), then kickstart
+        restart_cmd = f"sleep 3 && launchctl kickstart -k {shlex.quote(target)}"
+        try:
+            setsid_bin = shutil.which("setsid")
+            if setsid_bin:
+                subprocess.Popen(
+                    [setsid_bin, "bash", "-c", restart_cmd],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+            else:
+                subprocess.Popen(
+                    ["bash", "-c", restart_cmd],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+        except Exception as e:
+            return f"✗ Failed to spawn restart process: {e}"
+
+        logger.info("Gateway restart scheduled via /restart-gateway (3s delay)")
+        return "♻️ Restarting gateway in ~3 seconds. I'll be back shortly."
 
     def _schedule_update_notification_watch(self) -> None:
         """Ensure a background task is watching for update completion."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -138,6 +138,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
+    CommandDef("restart-gateway", "Restart the gateway process via launchd", "Info",
+               gateway_only=True, aliases=("restart_gateway",)),
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",


### PR DESCRIPTION
## Summary

Adds a `/restart-gateway` slash command that allows safely restarting the gateway from within a messaging platform (e.g., Telegram) without the self-destruction paradox where the agent kills its own host process.

## Problem

When a gateway restart is needed (e.g., after code changes, config updates requiring restart), the only option was to run `hermes gateway restart` from a terminal. Attempting to restart from within a gateway session (e.g., running `kill` on the gateway PID) causes the agent's own session to die mid-execution, often leaving the gateway down entirely.

This is a real problem for users who manage their Hermes instance remotely and aren't physically near the machine.

## Solution

The `/restart-gateway` command uses the same detached-process pattern as the existing `/update` command:

1. **Verifies launchd service is loaded** — aborts with a clear message if `ai.hermes.gateway` isn't registered with launchd
2. **Runs a pre-flight import check** — spawns a subprocess to verify `from gateway.run import GatewayRunner` succeeds, aborting if the code would crash on startup (prevents crash loops)
3. **Spawns a detached process** — uses `subprocess.Popen(start_new_session=True)` (same pattern as `/update`) that sleeps 3 seconds, then runs `launchctl kickstart -k gui/<uid>/ai.hermes.gateway`
4. **Returns response to user** — the 3-second delay ensures the confirmation message flushes to the messaging platform before the gateway is killed

The detached process survives the gateway shutdown because it runs in its own session. launchd (PID 1) handles the actual kill + restart atomically via `kickstart -k`.

## Changes

- **`hermes_cli/commands.py`**: Added `restart-gateway` CommandDef (gateway_only, aliases: `restart_gateway`)
- **`gateway/run.py`**: Added `_handle_restart_gateway_command()` method + dispatch entry

## Platform Support

Currently supports **macOS launchd** (the standard deployment for `hermes gateway start`). The launchd service check will gracefully abort on systems without the service loaded. Future work could add systemd support for Linux deployments.

## Testing

- Pre-flight import check verified independently
- Gateway test suite passes (1205 passed, same pre-existing failures)
- Tested end-to-end: sent `/restart-gateway` from Telegram, received confirmation, gateway restarted in ~5 seconds, Telegram reconnected automatically