### PR TITLE
fix(auth): add kimi-for-coding alias to _PROVIDER_ALIASES

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -809,7 +809,7 @@ def resolve_provider(
     _PROVIDER_ALIASES = {
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
-        "kimi": "kimi-coding", "moonshot": "kimi-coding",
+        "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
         "claude": "anthropic", "claude-code": "anthropic",
         "github": "copilot", "github-copilot": "copilot",

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -170,6 +170,13 @@ class TestResolveProvider:
     def test_alias_moonshot(self):
         assert resolve_provider("moonshot") == "kimi-coding"
 
+    def test_alias_kimi_for_coding(self):
+        # HERMES_OVERLAYS keys Kimi as "kimi-for-coding" while
+        # PROVIDER_REGISTRY keys it as "kimi-coding". The Telegram
+        # /model picker passes the overlay slug through resolve_provider(),
+        # so this alias is required to bridge the two registries.
+        assert resolve_provider("kimi-for-coding") == "kimi-coding"
+
     def test_alias_minimax_underscore(self):
         assert resolve_provider("minimax_cn") == "minimax-cn"
 


### PR DESCRIPTION
## Summary

- Add `"kimi-for-coding": "kimi-coding"` to `_PROVIDER_ALIASES` in `hermes_cli/auth.py`, alongside the existing `"kimi"` and `"moonshot"` entries
- Fixes "Unknown provider 'kimi-for-coding'" error when switching to Kimi via the Telegram interactive `/model` picker
- Adds a unit test next to the other alias tests in `TestResolveProvider`

## Details

### Dual-registry mismatch

Kimi Code is keyed differently in the two provider registries:

| Registry | File | Key |
|---|---|---|
| `HERMES_OVERLAYS` | `hermes_cli/providers.py` | `kimi-for-coding` |
| `PROVIDER_REGISTRY` | `hermes_cli/auth.py` | `kimi-coding` |

`_PROVIDER_ALIASES` in `resolve_provider()` bridges several such gaps (`glm → zai`, `google → gemini`, `claude → anthropic`, etc.) but has no entry for `kimi-for-coding → kimi-coding`. Only `kimi → kimi-coding` and `moonshot → kimi-coding` are present.

### User-visible symptom

The Telegram interactive `/model` picker enumerates providers via `list_authenticated_providers()`, which returns the **overlay** slug (`kimi-for-coding`) for Kimi. When the user selects Kimi from the picker, the handler passes that slug straight into `resolve_provider()`, which fails:

\`\`\`
Error: Could not resolve credentials for provider 'Kimi For Coding':
Unknown provider 'kimi-for-coding'. Check 'hermes model' for available
providers, or run 'hermes doctor' to diagnose config issues.
\`\`\`

The error is confusing because \`hermes model\` does list Kimi, and \`KIMI_API_KEY\` is correctly set — the mismatch happens purely because the overlay slug never gets normalized to the canonical provider ID.

### Diff

\`\`\`diff
-        "kimi": "kimi-coding", "moonshot": "kimi-coding",
+        "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
\`\`\`

## Test plan

- [x] New test \`test_alias_kimi_for_coding\` added to \`tests/hermes_cli/test_api_key_providers.py::TestResolveProvider\`, placed alongside \`test_alias_kimi\` and \`test_alias_moonshot\`
- [x] \`pytest tests/hermes_cli/test_api_key_providers.py::TestResolveProvider -v\` → **38/38 passed** (local run on Raspberry Pi 4B, Python 3.11, Hermes Agent v0.8.0 venv)
- [x] \`pytest tests/hermes_cli/test_api_key_providers.py::TestResolveProvider::test_alias_kimi_for_coding -v\` → **PASSED**
- [x] Verified end-to-end on gateway: \`list_authenticated_providers()\` in a KIMI_API_KEY-loaded env now returns all three providers (Nous Portal, Kimi For Coding, OpenAI Codex) without error

## Related

This is the follow-up to the alias gap I reported as a comment on #5910 after PR #5911 was filed. The \`model_switch.py\` half of #5910 shipped upstream as part of #5983 / Hermes v0.8.0 (thanks @teknium1 for the salvage), but the \`auth.py\` alias was left behind because it was only described in a comment, not a separate PR.

This PR does **not** close #5910 — another contributor (@vmlinuzx) recently added more Codex-related \`/model\` bugs to that issue which are out of scope here.

## Environment

- Hermes Agent v0.8.0 (\`ff6a86cb\` + later commits on \`main\`)
- Raspberry Pi 4B, aarch64, Python 3.11.15
- Gateway mode (Telegram + Discord), \`KIMI_API_KEY\` env var authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)