### PR TITLE
fix(tests): stop forcing xdist auto locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,9 @@ hermes chat -q "Hello"
 pytest tests/ -v
 ```
 
+If you want parallelism locally, opt into it explicitly with a small worker count, for example
+`pytest tests/ -v -n 2`. Do not rely on automatic worker selection in WSL or on smaller machines.
+
 ---
 
 ## Project Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,4 +112,4 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
-addopts = "-m 'not integration' -n auto"
+addopts = "-m 'not integration'"


### PR DESCRIPTION
## What does this PR do?

Stops local pytest runs from forcing `xdist` auto-parallelism through the repo default `addopts`.
This keeps `pytest` single-process unless a contributor explicitly opts into a worker count, which is
safer for WSL and smaller machines while leaving CI free to request parallelism explicitly.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- remove `-n auto` from the global pytest `addopts` in `pyproject.toml`
- keep the default `not integration` filter in place
- add a short note to `CONTRIBUTING.md` telling contributors to opt into a small worker count explicitly when they want local parallelism

## How to Test

1. Run `python -m pytest tests/gateway/test_slack.py -q -x` locally without adding `-n`.
2. Confirm the test run completes normally without automatically spawning xdist workers.
3. If desired, opt into bounded local parallelism explicitly with something like `pytest tests/ -v -n 2`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local verification completed:

- `/home/gille/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_slack.py -q -x` → `69 passed, 13 warnings`
