### PR TITLE
fix(tools): write to correct memory file if target is a symlink

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -412,19 +412,23 @@ class MemoryStore:
         file *before* the lock is acquired, creating a race window where
         concurrent readers see an empty file. Atomic rename avoids this:
         readers always see either the old complete file or the new one.
+
+        Resolves any symlinks in the path so os.replace writes to the
+        real file rather than clobbering the symlink entry itself.
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
+        real_path = Path(os.path.realpath(str(path)))
         try:
             # Write to temp file in same directory (same filesystem for atomic rename)
             fd, tmp_path = tempfile.mkstemp(
-                dir=str(path.parent), suffix=".tmp", prefix=".mem_"
+                dir=str(real_path.parent), suffix=".tmp", prefix=".mem_"
             )
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(content)
                     f.flush()
                     os.fsync(f.fileno())
-                os.replace(tmp_path, str(path))  # Atomic on same filesystem
+                os.replace(tmp_path, str(real_path))  # Atomic on same filesystem
             except BaseException:
                 # Clean up temp file on any failure
                 try:
@@ -554,7 +558,3 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
-
-
-


### PR DESCRIPTION
## What does this PR do?

## What does this PR do?

`_write_file` uses an atomic temp-file + `os.replace` (rename) pattern. When the memory file path is a symlink, `os.replace` replaces the symlink entry itself rather than writing to the real target and silently breaking any external storage setup.

Fix: resolve the real path with `os.path.realpath` before creating the temp file and calling `os.replace`. The temp file is created in `real_path.parent` (same filesystem as the target) so the atomic rename guarantee is preserved. Non-symlink paths are unaffected as `realpath` returns the same path when no symlink is involved.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py` — `MemoryStore._write_file`: resolve `path` via `os.path.realpath`
  before `mkstemp` and `os.replace`; update docstring

## How to Test

1. Symlink one of the memory files to a path outside the memories dir:
   `ln -s ~/external/MEMORY.md ~/.hermes/memories/MEMORY.md`
2. Run hermes and trigger a memory write (add an entry)
3. Confirm the real file (`~/external/MEMORY.md`) is updated and the symlink is intact
4. Confirm the normal (non-symlink) path still works unchanged

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

