### PR TITLE
fix: prevent false-success reporting on model switch via config edit

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -282,6 +282,29 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
 # message representation stays consistent ("system" everywhere).
 DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 
+# Guidance to prevent false-success reporting on model-switch requests.
+# When a user asks to switch models via natural language (not /model), the
+# agent may edit config.yaml but the live session remains on the old model.
+# This guidance ensures the agent uses the /model command path and reports
+# accurately.  See: https://github.com/NousResearch/hermes-agent/issues/6213
+MODEL_SWITCH_GUIDANCE = (
+    "# Model switching rules\n"
+    "When the user asks you to switch models, change the default model, or "
+    "use a different AI model:\n"
+    "1. ALWAYS direct them to use the `/model` command (e.g. `/model "
+    "<name>` for session-only, `/model <name> --global` to persist). "
+    "Do NOT attempt to switch models by editing config.yaml directly — "
+    "file edits do not take effect in the current session.\n"
+    "2. If you have already edited config.yaml to change the model, you MUST "
+    "clearly tell the user: 'I updated the default model in config.yaml, but "
+    "this change will only take effect after a session restart. The current "
+    "session is still using [current model]. Use `/model <name>` to switch "
+    "immediately, or `/new` to start a fresh session with the new default.'\n"
+    "3. NEVER say 'all set' or claim the switch is complete unless the current "
+    "live session is actually using the new model. Be precise about what "
+    "changed (future default vs. current session).\n"
+)
+
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "

--- a/run_agent.py
+++ b/run_agent.py
@@ -92,7 +92,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, MODEL_SWITCH_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -2744,6 +2744,12 @@ class AIAgent:
         if self.provider:
             timestamp_line += f"\nProvider: {self.provider}"
         prompt_parts.append(timestamp_line)
+
+        # ── Model-switch honesty guidance ──
+        # Prevent the agent from claiming a model switch is complete after
+        # editing config.yaml — the live session is unaffected by file edits.
+        # Directs users to /model instead.  See #6213.
+        prompt_parts.append(MODEL_SWITCH_GUIDANCE)
 
         # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
         # of the requested model. Inject explicit model identity into the system prompt

--- a/tests/agent/test_model_switch_guidance.py
+++ b/tests/agent/test_model_switch_guidance.py
@@ -1,0 +1,78 @@
+"""Tests for MODEL_SWITCH_GUIDANCE injection into system prompt.
+
+Verifies that the model-switch reporting guidance (Issue #6213) is:
+  1. Defined as a non-empty constant in prompt_builder.
+  2. Injected into the system prompt built by AIAgent._build_system_prompt().
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestModelSwitchGuidanceConstant(unittest.TestCase):
+    """MODEL_SWITCH_GUIDANCE must exist and contain key directives."""
+
+    def test_constant_is_defined(self):
+        from agent.prompt_builder import MODEL_SWITCH_GUIDANCE
+        self.assertIsInstance(MODEL_SWITCH_GUIDANCE, str)
+        self.assertTrue(len(MODEL_SWITCH_GUIDANCE) > 0)
+
+    def test_constant_mentions_model_command(self):
+        from agent.prompt_builder import MODEL_SWITCH_GUIDANCE
+        self.assertIn("/model", MODEL_SWITCH_GUIDANCE)
+
+    def test_constant_warns_against_config_edit(self):
+        from agent.prompt_builder import MODEL_SWITCH_GUIDANCE
+        self.assertIn("config.yaml", MODEL_SWITCH_GUIDANCE)
+
+    def test_constant_warns_against_false_success(self):
+        from agent.prompt_builder import MODEL_SWITCH_GUIDANCE
+        # Must warn against claiming "all set" prematurely
+        self.assertIn("all set", MODEL_SWITCH_GUIDANCE.lower())
+
+    def test_constant_mentions_session_restart(self):
+        from agent.prompt_builder import MODEL_SWITCH_GUIDANCE
+        # Must mention that config edits require a session restart
+        self.assertIn("session", MODEL_SWITCH_GUIDANCE.lower())
+
+
+class TestModelSwitchGuidanceInjection(unittest.TestCase):
+    """MODEL_SWITCH_GUIDANCE must be present in the assembled system prompt."""
+
+    def test_guidance_in_system_prompt(self):
+        """_build_system_prompt() should include MODEL_SWITCH_GUIDANCE."""
+        from agent.prompt_builder import MODEL_SWITCH_GUIDANCE
+
+        # Patch heavy dependencies that _build_system_prompt touches
+        with patch("run_agent.load_soul_md", return_value=None), \
+             patch("run_agent.build_context_files_prompt", return_value=""), \
+             patch("run_agent.build_skills_system_prompt", return_value=""), \
+             patch("run_agent.build_nous_subscription_prompt", return_value=""):
+
+            # Create a minimal AIAgent mock that has the fields
+            # _build_system_prompt reads.
+            from run_agent import AIAgent
+            agent = object.__new__(AIAgent)
+
+            # Minimal required attributes
+            agent.model = "test-model"
+            agent.provider = "openrouter"
+            agent.platform = "cli"
+            agent.valid_tool_names = set()
+            agent.skip_context_files = True
+            agent._memory_store = None
+            agent._memory_manager = None
+            agent._tool_use_enforcement = False
+            agent.pass_session_id = False
+            agent.session_id = "test-session"
+            agent.ephemeral_system_prompt = None
+
+            prompt = agent._build_system_prompt()
+
+            self.assertIn("Model switching rules", prompt)
+            self.assertIn("/model", prompt)
+            self.assertIn("config.yaml", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #6213 - Model-switch requests report "all set" before the live session actually changes models.

## Problem

When a user asks Hermes to switch models via natural language (e.g. "switch to GPT-5.4"), the agent:
1. Edits config.yaml to update model.default
2. 2. Reports "all set!" to the user
However, the live session remains on the old model because file edits don't trigger a runtime model swap. The /model command pathway does this correctly (it calls agent.switch_model() and updates _session_model_overrides), but the natural-language config-edit path bypasses all of this.

## Solution

Adds MODEL_SWITCH_GUIDANCE to the system prompt that instructs the agent to:

* Always direct users to /model for immediate, session-level switches
* * Never claim "all set" after a config-only edit - clearly distinguish between "future default updated" vs. "current session changed"
* * Be honest about what actually changed - if only config.yaml was edited, tell the user the current session still uses the old model and suggest /model <name> or /new
### Changes

| File | Change |
|------|--------|
| agent/prompt_builder.py | Added MODEL_SWITCH_GUIDANCE constant |
| run_agent.py | Import + inject guidance into _build_system_prompt() |
| tests/agent/test_model_switch_guidance.py | Unit tests for the new guidance |

## Why a system-prompt approach?

The /model command already handles model switching correctly at the runtime level. The bug only manifests when the agent bypasses /model and edits config directly. A system-prompt behavioral guard is the minimal, non-invasive fix that:
* Directly addresses the reported false-success UX
* * Requires no architectural changes to the gateway runtime
* * Works across all platforms (CLI, Telegram, Discord, etc.)
* * Zero risk of breaking existing /model functionality