### PR TITLE
fix(gateway): honor top-level provider/base_url in config.yaml

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -74,18 +74,31 @@ def _get_model_config() -> Dict[str, Any]:
         # Accept "model" as alias for "default" (users intuitively write model.model)
         if not cfg.get("default") and cfg.get("model"):
             cfg["default"] = cfg["model"]
-        default = (cfg.get("default") or "").strip()
-        base_url = (cfg.get("base_url") or "").strip()
-        is_local = "localhost" in base_url or "127.0.0.1" in base_url
-        is_fallback = not default
-        if is_local and is_fallback and base_url:
-            detected = _auto_detect_local_model(base_url)
-            if detected:
-                cfg["default"] = detected
-        return cfg
-    if isinstance(model_cfg, str) and model_cfg.strip():
-        return {"default": model_cfg.strip()}
-    return {}
+    elif isinstance(model_cfg, str) and model_cfg.strip():
+        cfg = {"default": model_cfg.strip()}
+    else:
+        cfg = {}
+
+    # Honour top-level provider/base_url/api_key/api_mode when the user wrote
+    # them flat in config.yaml instead of nested under `model:` (#6295).  Only
+    # fill keys that aren't already present in the nested model section so the
+    # nested form keeps priority when both are set.
+    for top_key in ("provider", "base_url", "api_key", "api_mode"):
+        if cfg.get(top_key):
+            continue
+        top_val = config.get(top_key)
+        if isinstance(top_val, str) and top_val.strip():
+            cfg[top_key] = top_val.strip()
+
+    default = (cfg.get("default") or "").strip()
+    base_url = (cfg.get("base_url") or "").strip()
+    is_local = "localhost" in base_url or "127.0.0.1" in base_url
+    is_fallback = not default
+    if is_local and is_fallback and base_url:
+        detected = _auto_detect_local_model(base_url)
+        if detected:
+            cfg["default"] = detected
+    return cfg
 
 
 def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1204,6 +1204,53 @@ def test_explicit_nous_auth_failure_still_raises(monkeypatch):
         rp.resolve_runtime_provider(requested="nous")
 
 
+def test_get_model_config_honors_top_level_provider(monkeypatch):
+    """Top-level `provider:` in config.yaml must surface into model config (#6295).
+
+    When users write a flat layout:
+
+        model: MiniMax-M2.7
+        provider: minimax
+        base_url: https://api.minimax.io/anthropic
+
+    the provider must win over auto-detection from env vars. Previously the
+    string form of `model:` dropped the sibling provider and the gateway
+    fell back to OpenRouter.
+    """
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": "MiniMax-M2.7",
+            "provider": "minimax",
+            "base_url": "https://api.minimax.io/anthropic",
+        },
+    )
+    cfg = rp._get_model_config()
+    assert cfg["default"] == "MiniMax-M2.7"
+    assert cfg["provider"] == "minimax"
+    assert cfg["base_url"] == "https://api.minimax.io/anthropic"
+
+    # And `resolve_requested_provider` must now return the configured provider
+    # instead of falling through to env/auto.
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    assert rp.resolve_requested_provider() == "minimax"
+
+
+def test_get_model_config_nested_model_keeps_priority_over_top_level(monkeypatch):
+    """Nested `model.provider` still wins when both forms are present."""
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {"default": "MiniMax-M2.7", "provider": "minimax"},
+            "provider": "openrouter",
+        },
+    )
+    cfg = rp._get_model_config()
+    assert cfg["provider"] == "minimax"
+
+
 def test_openrouter_provider_not_affected_by_custom_fix(monkeypatch):
     """Fixing custom must not change openrouter behavior."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
Fixes #6295.

## Problem

When users write `config.yaml` in a flat layout — e.g.

```yaml
model: MiniMax-M2.7
provider: minimax
base_url: https://api.minimax.io/anthropic
```

the gateway silently ignores the configured provider and routes requests to OpenRouter instead, producing `HTTP 404: No endpoints found for meta-llama/llama-4-maverick:free` on every message.

## Root cause

`hermes_cli/runtime_provider._get_model_config()` collapses a string-valued `model:` to `{"default": "MiniMax-M2.7"}` and throws away the sibling top-level `provider` / `base_url` keys. `resolve_requested_provider()` then sees no provider in the model config, falls through to env-var auto-detection, and picks OpenRouter whenever `OPENROUTER_API_KEY` / `OPENAI_API_KEY` is set — which is the common case.

## Fix

After building the per-`model` cfg dict, merge top-level `provider`, `base_url`, `api_key`, and `api_mode` into it when those keys are not already set under `model:`. Nested `model.*` values keep priority so existing configs are unaffected.

## Tests

- `test_get_model_config_honors_top_level_provider` — flat layout now surfaces provider, base_url, and default model, and `resolve_requested_provider()` returns the configured provider instead of `auto`.
- `test_get_model_config_nested_model_keeps_priority_over_top_level` — nested `model.provider` still wins when both forms are present.