### PR TITLE
fix(matrix): lock Matrix identity per local gateway

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -65,6 +65,9 @@ _KEY_EXPORT_PASSPHRASE = "hermes-matrix-e2ee-keys"
 _MAX_PENDING_EVENTS = 100
 _PENDING_EVENT_TTL = 300  # seconds — stop retrying after 5 min
 
+# Scoped lock scope for preventing duplicate local consumers of the same
+# Matrix identity (same access token or same homeserver+user_id).
+_MATRIX_LOCK_SCOPE = "matrix-user"
 
 _E2EE_INSTALL_HINT = (
     "Install with: pip install 'matrix-nio[e2e]'  "
@@ -172,6 +175,10 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_REACTIONS", "true"
         ).lower() not in ("false", "0", "no")
 
+        # Scoped lock identity for preventing duplicate local consumers of the
+        # same Matrix account.
+        self._lock_identity: Optional[str] = None
+
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
         if not event_id:
@@ -197,6 +204,43 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.error("Matrix: homeserver URL not configured")
             return False
 
+        def _release_matrix_lock() -> None:
+            try:
+                from gateway.status import release_scoped_lock
+                if self._lock_identity:
+                    release_scoped_lock(_MATRIX_LOCK_SCOPE, self._lock_identity)
+                    self._lock_identity = None
+            except Exception as exc:
+                logger.warning("Matrix: failed to release identity lock: %s", exc, exc_info=True)
+
+        try:
+            from gateway.status import acquire_scoped_lock
+
+            self._lock_identity = self._access_token or f"{self._homeserver}|{self._user_id}"
+            acquired, existing = acquire_scoped_lock(
+                _MATRIX_LOCK_SCOPE,
+                self._lock_identity,
+                metadata={
+                    "platform": self.platform.value,
+                    "homeserver": self._homeserver,
+                    "user_id": self._user_id,
+                },
+            )
+            if not acquired:
+                owner_pid = existing.get("pid") if isinstance(existing, dict) else None
+                message = "Matrix identity already in use"
+                if owner_pid:
+                    message += f" (PID {owner_pid})"
+                message += ". Stop the other gateway first."
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error("matrix_identity_lock", message, retryable=False)
+                return False
+        except Exception as exc:
+            message = f"Matrix identity lock setup failed: {exc}"
+            logger.error("[%s] %s", self.name, message, exc_info=True)
+            self._set_fatal_error("matrix_identity_lock_error", message, retryable=True)
+            return False
+
         # Determine store path and ensure it exists.
         store_path = str(_STORE_DIR)
         _STORE_DIR.mkdir(parents=True, exist_ok=True)
@@ -213,6 +257,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Refusing to connect — encrypted rooms would silently fail.",
                     _E2EE_INSTALL_HINT,
                 )
+                _release_matrix_lock()
                 return False
             try:
                 client = nio.AsyncClient(
@@ -231,6 +276,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Matrix: failed to create E2EE client: %s. %s",
                     exc, _E2EE_INSTALL_HINT,
                 )
+                _release_matrix_lock()
                 return False
         else:
             client = nio.AsyncClient(
@@ -292,6 +338,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER"
                 )
                 await client.close()
+                _release_matrix_lock()
                 return False
         elif self._password and self._user_id:
             resp = await client.login(
@@ -303,10 +350,12 @@ class MatrixAdapter(BasePlatformAdapter):
             else:
                 logger.error("Matrix: login failed — %s", getattr(resp, "message", resp))
                 await client.close()
+                _release_matrix_lock()
                 return False
         else:
             logger.error("Matrix: need MATRIX_ACCESS_TOKEN or MATRIX_USER_ID + MATRIX_PASSWORD")
             await client.close()
+            _release_matrix_lock()
             return False
 
         # If E2EE is enabled, load the crypto store.
@@ -336,6 +385,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 _E2EE_INSTALL_HINT,
             )
             await client.close()
+            _release_matrix_lock()
             return False
 
         # Register event callbacks.
@@ -416,6 +466,14 @@ class MatrixAdapter(BasePlatformAdapter):
         if self._client:
             await self._client.close()
             self._client = None
+
+        try:
+            from gateway.status import release_scoped_lock
+            if self._lock_identity:
+                release_scoped_lock(_MATRIX_LOCK_SCOPE, self._lock_identity)
+                self._lock_identity = None
+        except Exception as exc:
+            logger.warning("Matrix: failed to release identity lock on disconnect: %s", exc, exc_info=True)
 
         logger.info("Matrix: disconnected")
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -616,6 +616,90 @@ class TestMatrixAccessTokenAuth:
         await adapter.disconnect()
 
 
+class TestMatrixIdentityLock:
+    @pytest.mark.asyncio
+    async def test_connect_fails_when_identity_lock_is_held(self):
+        from gateway.platforms.matrix import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_nio = MagicMock()
+
+        with patch.dict("sys.modules", {"nio": fake_nio}):
+            with patch("gateway.status.acquire_scoped_lock", return_value=(False, {"pid": 424242})):
+                result = await adapter.connect()
+
+        assert result is False
+        assert adapter._fatal_error_code == "matrix_identity_lock"
+        assert "PID 424242" in (adapter._fatal_error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_disconnect_releases_identity_lock_after_successful_connect(self):
+        from gateway.platforms.matrix import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        class FakeWhoamiResponse:
+            def __init__(self, user_id, device_id):
+                self.user_id = user_id
+                self.device_id = device_id
+
+        class FakeSyncResponse:
+            def __init__(self):
+                self.rooms = MagicMock(join={})
+
+        fake_client = MagicMock()
+        fake_client.whoami = AsyncMock(return_value=FakeWhoamiResponse("@bot:example.org", "DEV123"))
+        fake_client.sync = AsyncMock(return_value=FakeSyncResponse())
+        fake_client.close = AsyncMock()
+        fake_client.add_event_callback = MagicMock()
+        fake_client.rooms = {}
+        fake_client.account_data = {}
+        fake_client.olm = None
+
+        fake_nio = MagicMock()
+        fake_nio.AsyncClient = MagicMock(return_value=fake_client)
+        fake_nio.WhoamiResponse = FakeWhoamiResponse
+        fake_nio.SyncResponse = FakeSyncResponse
+        fake_nio.LoginResponse = type("LoginResponse", (), {})
+        fake_nio.RoomMessageText = type("RoomMessageText", (), {})
+        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
+        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
+        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
+        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
+        fake_nio.InviteMemberEvent = type("InviteMemberEvent", (), {})
+        fake_nio.MegolmEvent = type("MegolmEvent", (), {})
+
+        with patch.dict("sys.modules", {"nio": fake_nio}):
+            with patch("gateway.status.acquire_scoped_lock", return_value=(True, None)) as acquire_lock:
+                with patch("gateway.status.release_scoped_lock") as release_lock:
+                    with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                        with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                            assert await adapter.connect() is True
+                            acquire_lock.assert_called_once()
+                            assert adapter._lock_identity == "syt_test_access_token"
+
+                    await adapter.disconnect()
+                    release_lock.assert_called_with("matrix-user", "syt_test_access_token")
+                    assert adapter._lock_identity is None
+
+
 class TestMatrixE2EEHardFail:
     """connect() must refuse to start when E2EE is requested but deps are missing."""
 


### PR DESCRIPTION
## What does this PR do?

Adds a machine-local scoped identity lock to the Matrix gateway adapter so only one local gateway process can consume a given Matrix identity at a time. This prevents duplicate reactions, duplicate thinking panes, and duplicate replies when the same Matrix account is accidentally started from multiple local gateways or `HERMES_HOME` contexts.

## Why this is needed

We already have a core pidfile/startup race fix in #6193, and that PR should still stand. But the Matrix adapter also needs the same defense-in-depth used by other gateways (Slack/Discord/Telegram/etc.): an external-identity lock at adapter connect time.

Without that adapter-level lock, multiple local processes can still log in as the same Matrix user and independently process the same inbound event stream.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `matrix-user` scoped lock in `gateway/platforms/matrix.py`
- Lock identity is derived from the Matrix access token, or `homeserver|user_id` when token is unavailable
- Refuse adapter startup with a fatal non-retryable error when the identity is already owned by another local process
- Release the scoped lock on disconnect and on connect-time failure paths
- Add regression tests for:
  - lock acquisition failure
  - successful release on disconnect

## How to Test

1. Run:
   `python -m pytest tests/gateway/test_matrix.py -q -o 'addopts='`
2. Start one Matrix-backed gateway normally
3. Start a second local gateway with a different `HERMES_HOME` but the same Matrix credentials
4. Confirm the second process logs `Matrix identity already in use` and does NOT connect

## Notes

- This is intentionally scoped to Matrix only
- #6193 (pidfile/startup ownership) remains useful and should NOT be replaced by this PR; the two fixes address different layers

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run targeted pytest coverage for the affected Matrix path
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu Linux
