### PR TITLE
fix(security): restrict RPC socket permissions to owner-only

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -943,6 +943,7 @@ def execute_code(
         # --- Start UDS server ---
         server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         server_sock.bind(sock_path)
+        os.chmod(sock_path, 0o600)  # Restrict to owner-only (security)
         server_sock.listen(1)
 
         rpc_thread = threading.Thread(


### PR DESCRIPTION
## Summary

Unix domain sockets created by the code execution sandbox (`execute_code` tool) in `/tmp` were world-accessible by default (`0o666` umask). On shared systems, any local user could connect to the socket and execute tool calls with the Hermes process owner's privileges.

## Changes

- `tools/code_execution_tool.py`: Added `os.chmod(sock_path, 0o600)` after `server_sock.bind(sock_path)` to restrict the Unix domain socket to owner-only read/write permissions.

This is a one-line fix that follows the principle of least privilege for IPC sockets.

## Testing

- All 61 existing tests in `tests/tools/test_code_execution.py` pass.
- No behavioral change — only tightens filesystem permissions.

Fixes #6230