### PR TITLE
fix(gateway): read require_mention from config.extra for Slack adapter

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -814,7 +814,8 @@ class SlackAdapter(BasePlatformAdapter):
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
 
-        if not is_dm and bot_uid and not is_mentioned:
+        require_mention = self.config.extra.get("require_mention", True)
+        if not is_dm and bot_uid and not is_mentioned and require_mention:
             reply_to_bot_thread = (
                 is_thread_reply and event_thread_ts in self._bot_message_ts
             )


### PR DESCRIPTION
## Summary

The Slack adapter hardcoded mention-gating behavior, ignoring the `require_mention` config key that all other platforms (Telegram, Discord, WhatsApp, Matrix) already support via the gateway config bridge in `gateway/config.py` (lines 529+).

Users who set `slack.require_mention: false` in their gateway config expected the bot to respond to all channel messages, but it was silently ignored because `slack.py` never read the bridged value from `config.extra`.

## Changes

- `gateway/platforms/slack.py`: Added `self.config.extra.get("require_mention", True)` check before the mention-gating block. Default is `True` to preserve existing behavior for users who don't set the key.

This follows the exact same pattern used by other platform adapters.

## Testing

- All 69 existing tests in `tests/gateway/test_slack.py` pass.
- No behavioral change for existing users (default remains `require_mention: true`).

Fixes #6218