### PR TITLE
docs(setup): replace hardcoded ~/.hermes/hermes-agent with generic paths

### DIFF
--- a/datagen-config-examples/run_browser_tasks.sh
+++ b/datagen-config-examples/run_browser_tasks.sh
@@ -15,7 +15,7 @@
 #   - A dataset JSONL file with one {"prompt": "..."} per line
 #
 # Usage:
-#   cd ~/.hermes/hermes-agent
+#   cd /path/to/hermes-agent
 #   bash datagen-config-examples/run_browser_tasks.sh
 #
 # Output: data/browser_tasks_example/trajectories.jsonl

--- a/docs/acp-setup.md
+++ b/docs/acp-setup.md
@@ -53,7 +53,7 @@ Open your VS Code settings (`Ctrl+,` → click the `{}` icon for JSON) and add:
 ```
 
 Replace `/path/to/hermes-agent` with the actual path to your Hermes Agent
-installation (e.g. `~/.hermes/hermes-agent`).
+installation (e.g. `/root/hermes-agent`, `~/src/hermes-agent`, or wherever you cloned the repo).
 
 Alternatively, if `hermes` is on your PATH, the ACP Client can discover it
 automatically via the registry directory.

--- a/optional-skills/mlops/hermes-atropos-environments/references/usage-patterns.md
+++ b/optional-skills/mlops/hermes-atropos-environments/references/usage-patterns.md
@@ -11,7 +11,7 @@ training server.
 ### Step 1: Run 1 trajectory
 
 ```bash
-cd ~/.hermes/hermes-agent
+cd /path/to/hermes-agent
 source venv/bin/activate
 
 python environments/your_env.py process \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1056,7 +1056,7 @@ print_success() {
     echo -e "   ${YELLOW}Config:${NC}    ~/.hermes/config.yaml"
     echo -e "   ${YELLOW}API Keys:${NC}  ~/.hermes/.env"
     echo -e "   ${YELLOW}Data:${NC}      ~/.hermes/cron/, sessions/, logs/"
-    echo -e "   ${YELLOW}Code:${NC}      ~/.hermes/hermes-agent/"
+    echo -e "   ${YELLOW}Code:${NC}      $INSTALL_DIR/"
     echo ""
 
     echo -e "${CYAN}─────────────────────────────────────────────────────────${NC}"

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -296,7 +296,7 @@ Type these during an interactive chat session.
 ~/.hermes/sessions/         Session transcripts
 ~/.hermes/logs/             Gateway and error logs
 ~/.hermes/auth.json         OAuth tokens and credential pools
-~/.hermes/hermes-agent/     Source code (if git-installed)
+/path/to/hermes-agent/        Source code (wherever you cloned it)
 ```
 
 Profiles use `~/.hermes/profiles/<name>/` with the same layout.
@@ -541,7 +541,7 @@ grep -i "failed to send\|error" ~/.hermes/logs/gateway.log | tail -20
 | CLI commands | `hermes --help` or [CLI reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) |
 | Gateway logs | `~/.hermes/logs/gateway.log` |
 | Session files | `~/.hermes/sessions/` or `hermes sessions browse` |
-| Source code | `~/.hermes/hermes-agent/` |
+| Source code | `/path/to/hermes-agent/` (wherever you cloned it) |
 
 ---
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -589,7 +589,7 @@ class TestGatewayProtection:
     """Prevent agents from starting the gateway outside systemd management."""
 
     def test_gateway_run_with_disown_detected(self):
-        cmd = "kill 1605 && cd ~/.hermes/hermes-agent && source venv/bin/activate && python -m hermes_cli.main gateway run --replace &disown; echo done"
+        cmd = "kill 1605 && cd /path/to/hermes-agent && source venv/bin/activate && python -m hermes_cli.main gateway run --replace &disown; echo done"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is True
         assert "systemctl" in desc

--- a/website/docs/developer-guide/extending-the-cli.md
+++ b/website/docs/developer-guide/extending-the-cli.md
@@ -76,7 +76,7 @@ if __name__ == "__main__":
 Run it:
 
 ```bash
-cd ~/.hermes/hermes-agent
+cd /path/to/hermes-agent
 source .venv/bin/activate
 python my_cli.py
 ```

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -42,7 +42,7 @@ If you installed Hermes with the standard install script, MCP support is already
 If you installed without extras and need to add MCP separately:
 
 ```bash
-cd ~/.hermes/hermes-agent
+cd /path/to/hermes-agent
 uv pip install -e ".[mcp]"
 ```
 

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -432,7 +432,7 @@ hermes chat --continue
 **Solution:**
 ```bash
 # Ensure MCP dependencies are installed (already included in standard install)
-cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"
+cd /path/to/hermes-agent && uv pip install -e ".[mcp]"
 
 # For npm-based servers, ensure Node.js is available
 node --version
@@ -659,7 +659,7 @@ Skills with very long descriptions are truncated to 40 characters in the Telegra
 
 3. On the new machine, run `hermes setup` to verify API keys and provider config are working. Re-authenticate any messaging platforms (especially WhatsApp, which uses QR pairing).
 
-The `~/.hermes/` directory contains everything: `config.yaml`, `.env`, `SOUL.md`, `memories/`, `skills/`, `state.db` (sessions), `cron/`, and any custom plugins. The code itself lives in `~/.hermes/hermes-agent/` and is installed fresh.
+The `~/.hermes/` directory contains everything: `config.yaml`, `.env`, `SOUL.md`, `memories/`, `skills/`, `state.db` (sessions), `cron/`, and any custom plugins. The code itself lives in your checkout directory and is installed wherever you cloned it.
 
 ### Permission denied when reloading shell after install
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -963,7 +963,7 @@ quick_commands:
     command: df -h /
   update:
     type: exec
-    command: cd ~/.hermes/hermes-agent && git pull && pip install -e .
+    command: cd /path/to/hermes-agent && git pull && pip install -e .
   gpu:
     type: exec
     command: nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total --format=csv,noheader

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -23,8 +23,8 @@ If you have ever wanted Hermes to use a tool that already exists somewhere else,
 1. Install MCP support (already included if you used the standard install script):
 
 ```bash
-cd ~/.hermes/hermes-agent
-uv pip install -e ".[mcp]"
+cd /path/to/hermes-agent
+source venv/bin/activate && uv pip install -e ".[mcp]"
 ```
 
 2. Add an MCP server to `~/.hermes/config.yaml`:
@@ -382,7 +382,7 @@ Check:
 
 ```bash
 # Verify MCP deps are installed (already included in standard install)
-cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"
+cd /path/to/hermes-agent && uv pip install -e ".[mcp]"
 
 node --version
 npx --version


### PR DESCRIPTION
## Summary

The source checkout path `~/.hermes/hermes-agent` was hardcoded across docs, scripts, skills, and tests. This is misleading for users who install Hermes in a custom location (e.g. `/root/src/hermes-agent`, `/opt/hermes-agent`, or any non-default path).

## Changes

Replaced hardcoded `~/.hermes/hermes-agent` with generic alternatives across 11 files:

- **docs/**: Generic install examples instead of assuming default path
- **scripts/install.sh**: Display `$INSTALL_DIR` variable instead of hardcoded path
- **skills/**: Generic source code path reference
- **optional-skills/**: Generic `cd` path
- **datagen-config-examples/**: Generic `cd` path
- **tests/**: Generic path in test fixture (path is irrelevant to the test assertion)
- **website/docs/**: Generic `cd` paths and command examples

Intentionally kept:
- `scripts/install.sh:78` — `--help` text showing the actual default install directory

## Testing

- All 100 tests in `tests/tools/test_approval.py` pass.
- All documentation links and code examples remain syntactically valid.

Fixes #6237