### PR TITLE
fix(gateway): handle windows pid probe failures

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -23,6 +23,16 @@ from typing import Any, Optional
 _GATEWAY_KIND = "hermes-gateway"
 _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
+_PID_LIVENESS_ERRORS = (ProcessLookupError, PermissionError, OSError, SystemError)
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Best-effort cross-platform liveness probe for a PID."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except _PID_LIVENESS_ERRORS:
+        return False
 
 
 def _get_pid_path() -> Path:
@@ -263,9 +273,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
 
         stale = existing_pid is None
         if not stale:
-            try:
-                os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            if not _pid_is_alive(existing_pid):
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -366,9 +374,7 @@ def get_running_pid() -> Optional[int]:
         remove_pid_file()
         return None
 
-    try:
-        os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    if not _pid_is_alive(pid):
         remove_pid_file()
         return None
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional
 
+from gateway.status import _pid_is_alive
+
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 # Directories bootstrapped inside every new profile
@@ -294,10 +296,8 @@ def _check_gateway_running(profile_dir: Path) -> bool:
             return False
         data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
         pid = int(data["pid"])
-        os.kill(pid, 0)  # existence check
-        return True
-    except (json.JSONDecodeError, KeyError, ValueError, TypeError,
-            ProcessLookupError, PermissionError, OSError):
+        return _pid_is_alive(pid)
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
         return False
 
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -62,6 +62,27 @@ class TestGatewayPidState:
 
         assert status.get_running_pid() == os.getpid()
 
+    def test_pid_is_alive_handles_windows_systemerror(self, monkeypatch):
+        def fake_kill(pid, sig):
+            raise SystemError("<built-in function kill> returned a result with an exception set")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status._pid_is_alive(12345) is False
+
+    def test_get_running_pid_removes_pid_file_on_windows_systemerror(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({"pid": 12345}))
+
+        def fake_kill(pid, sig):
+            raise SystemError("windows kill wrapper failure")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
 
 class TestGatewayRuntimeStatus:
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -758,6 +758,17 @@ class TestEdgeCases:
         with patch("os.kill", return_value=None):
             assert _check_gateway_running(default_home) is True
 
+    def test_gateway_running_check_windows_systemerror(self, profile_env):
+        """Windows-style SystemError from os.kill should be treated as not running."""
+        from hermes_cli.profiles import _check_gateway_running
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        pid_file = default_home / "gateway.pid"
+        pid_file.write_text(json.dumps({"pid": 12345}))
+
+        with patch("os.kill", side_effect=SystemError("windows kill wrapper failure")):
+            assert _check_gateway_running(default_home) is False
+
     def test_profile_name_boundary_single_char(self):
         """Single alphanumeric character is valid."""
         validate_profile_name("a")


### PR DESCRIPTION
## Summary
- centralise gateway PID liveness probing in a cross-platform helper
- treat Windows `SystemError` / `OSError` failures from `os.kill(pid, 0)` as stale PID records
- reuse the same helper for profile gateway status checks

## Testing
- `python -m pytest tests/gateway/test_status.py tests/hermes_cli/test_profiles.py -q`
- `python -m pytest tests/gateway/ -q` *(fails on pre-existing unrelated test: `tests/gateway/test_run_progress_topics.py::test_run_agent_progress_stays_in_originating_topic` expecting `💻 terminal: "pwd"` but current output is `⚙️ terminal: "pwd"`)*

Closes #5760
