### PR TITLE
fix(nix): make addToSystemPackages fully functional for interactive CLI

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -157,7 +157,14 @@ def get_project_root() -> Path:
     return Path(__file__).parent.parent.resolve()
 
 def _secure_dir(path):
-    """Set directory to owner-only access (0700). No-op on Windows."""
+    """Set directory to owner-only access (0700). No-op on Windows.
+
+    Skipped in managed mode — the NixOS module sets group-readable
+    permissions (0750) so interactive users in the hermes group can
+    share state with the gateway service.
+    """
+    if is_managed():
+        return
     try:
         os.chmod(path, 0o700)
     except (OSError, NotImplementedError):
@@ -165,7 +172,13 @@ def _secure_dir(path):
 
 
 def _secure_file(path):
-    """Set file to owner-only read/write (0600). No-op on Windows."""
+    """Set file to owner-only read/write (0600). No-op on Windows.
+
+    Skipped in managed mode — the NixOS activation script sets
+    group-readable permissions (0640) on config files.
+    """
+    if is_managed():
+        return
     try:
         if os.path.exists(str(path)):
             os.chmod(path, 0o600)

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -609,7 +609,7 @@
           # so this is the single source of truth for both native and container mode.
           ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
             ENV_FILE="${cfg.stateDir}/.hermes/.env"
-            install -o ${cfg.user} -g ${cfg.group} -m 0600 /dev/null "$ENV_FILE"
+            install -o ${cfg.user} -g ${cfg.group} -m 0640 /dev/null "$ENV_FILE"
             cat > "$ENV_FILE" <<'HERMES_NIX_ENV_EOF'
 ${envFileContent}
 HERMES_NIX_ENV_EOF

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -464,7 +464,11 @@
       addToSystemPackages = mkOption {
         type = types.bool;
         default = false;
-        description = "Add hermes CLI to environment.systemPackages.";
+        description = ''
+          Add the hermes CLI to environment.systemPackages and export
+          HERMES_HOME system-wide (via environment.variables) so interactive
+          shells share state with the gateway service.
+        '';
       };
 
       # ── OCI Container (opt-in) ──────────────────────────────────────────
@@ -545,8 +549,12 @@
       })
 
       # ── Host CLI ──────────────────────────────────────────────────────
+      # Add the hermes CLI to system PATH and export HERMES_HOME system-wide
+      # so interactive shells share state (sessions, skills, cron) with the
+      # gateway service instead of creating a separate ~/.hermes/.
       (lib.mkIf cfg.addToSystemPackages {
         environment.systemPackages = [ cfg.package ];
+        environment.variables.HERMES_HOME = "${cfg.stateDir}/.hermes";
       })
 
       # ── Directories ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #6044. Supersedes #6145.

`addToSystemPackages = true` was documented as putting `hermes` on PATH **and** setting `HERMES_HOME` system-wide, but only did the first part. Even after exporting `HERMES_HOME` (as #6145 correctly identified), interactive users still hit `PermissionError` because Python-side hardening clobbered NixOS-managed permissions on every startup.

This PR cherry-picks the env var export from #6145 and fixes the deeper permission issue that made the feature unusable end-to-end.

## Changes

**`nix/nixosModules.nix`**
- Export `HERMES_HOME` via `environment.variables` when `addToSystemPackages = true` (cherry-picked from #6145 by @zerone0x)
- Change `.env` file permissions from `0600` to `0640` — consistent with `config.yaml` which was already `0640`; users granted `hermes` group membership should be able to read managed secrets

**`hermes_cli/config.py`**
- `_secure_dir()` / `_secure_file()` now skip `chmod` in managed mode (detected via `.managed` marker). Previously, `ensure_hermes_home()` unconditionally forced `0700` on `HERMES_HOME` at every startup, overwriting the NixOS module's `0750`. This was the root cause of the `PermissionError` on `.env` stat.

## Root cause

Three issues stacked on top of each other:

1. **Missing env var export** (#6145): `addToSystemPackages` only added the package to `environment.systemPackages`, never set `HERMES_HOME` in `environment.variables`
2. **`.env` too restrictive**: activation script wrote `.env` with `0600` (owner-only) while `config.yaml` was already `0640` (group-readable)
3. **Python clobbering permissions**: `_secure_dir()` in `config.py` ran `chmod(path, 0o700)` on `HERMES_HOME` at every startup — overwriting the `0750` set by the NixOS activation script, making the directory untraversable for group members

## Test plan

Verified with a NixOS VM integration test (`pkgs.testers.nixosTest`) — a normal user in the `hermes` group against a module config with `addToSystemPackages = true`:

| Test | Result |
|------|--------|
| `HERMES_HOME` in `/etc/set-environment` | PASS |
| `hermes` binary on PATH | PASS |
| Login shell has `HERMES_HOME=/var/lib/hermes/.hermes` | PASS |
| `.hermes` dir retains `0750` after service start | PASS |
| Service env has `HERMES_HOME` | PASS |
| `HERMES_MANAGED` not leaked to interactive shell | PASS |
| `hermes version` from interactive user | PASS |
| `hermes config` reads managed config | PASS |

All 6 existing `nix flake check` checks also pass.