### PR TITLE
feat(tools): progressive tool loading via tool_search

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -753,6 +753,48 @@ def build_skills_system_prompt(
     return result
 
 
+def build_tool_catalog_prompt(catalog: list[dict]) -> str:
+    """Build a compact tool catalog for the system prompt.
+
+    Used when tool_search is active to give the model an index of available
+    tools without the full JSON schemas.  Mirrors the skills index pattern.
+    """
+    if not catalog:
+        return ""
+
+    by_toolset: dict[str, list[tuple[str, str]]] = {}
+    for entry in catalog:
+        ts = entry.get("toolset", "other")
+        if ts.startswith("_"):
+            continue
+        by_toolset.setdefault(ts, []).append(
+            (entry["name"], entry.get("description", ""))
+        )
+
+    lines = []
+    for toolset in sorted(by_toolset):
+        lines.append(f"  {toolset}:")
+        seen: set[str] = set()
+        for name, desc in sorted(by_toolset[toolset]):
+            if name in seen:
+                continue
+            seen.add(name)
+            short = (desc[:77] + "...") if len(desc) > 80 else desc
+            lines.append(f"    - {name}: {short}" if short else f"    - {name}")
+
+    return (
+        "## Available Tools (load before use)\n"
+        "The tools below are available but their full schemas are not loaded. "
+        "Before calling a tool, load its schema with `tool_details(name)` "
+        "(if you know the exact name) or `tool_search(query)` (to search by "
+        "keyword). tool_search and tool_details are always callable.\n"
+        "\n"
+        "<available_tools>\n"
+        + "\n".join(lines) + "\n"
+        "</available_tools>"
+    )
+
+
 def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -> str:
     """Build a compact Nous subscription capability block for the system prompt."""
     try:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -299,6 +299,29 @@ compression:
   # Options: "auto", "openrouter", "nous", "main"
   # summary_provider: "auto"
 
+# ── Tool Search (progressive tool loading) ────────────────────────────────
+# When tool definitions exceed a threshold fraction of the model's context
+# window, tool_search replaces full schemas with a compact catalog and
+# two meta-tools (tool_search, tool_details) that load schemas on demand.
+# This can save 90%+ of tool token overhead on smaller-context models.
+tool_search:
+  # Mode: "auto" activates when tool tokens exceed threshold, "always" forces
+  # deferred loading, "never" disables the feature entirely.
+  mode: auto
+
+  # When mode=auto, activate deferred loading if tool definition tokens exceed
+  # this fraction of the model's context window (default: 0.10 = 10%)
+  threshold: 0.10
+
+  # Tools that are always loaded with full schemas (bypass search).
+  # Use for tools the model needs on every turn (e.g. read_file, terminal).
+  pinned_tools: []
+
+  # Evict dynamically loaded tools that haven't been called in this many
+  # API turns. Eviction runs when context compression fires. Evicted tools
+  # remain in the catalog and can be re-loaded via tool_search. (default: 10)
+  evict_after_turns: 10
+
 # =============================================================================
 # Auxiliary Models (Advanced — Experimental)
 # =============================================================================

--- a/model_tools.py
+++ b/model_tools.py
@@ -196,6 +196,11 @@ TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 # Used by code_execution_tool to know which tools are available in this session.
 _last_resolved_tool_names: List[str] = []
 
+# Full session tool names *before* tool_search deferral.  tool_search controls
+# which schemas the model sees, but the execute_code sandbox should still be
+# able to call any tool the user hasn't explicitly disabled.
+_all_session_tool_names: List[str] = []
+
 
 # =============================================================================
 # Legacy toolset name mapping  (old _tools-suffixed names -> tool name lists)
@@ -376,6 +381,12 @@ def get_tool_definitions(
             print(f"🛠️  Final tool selection ({len(filtered_tools)} tools): {', '.join(tool_names)}")
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
+
+    # Capture the full tool list before deferral.  The execute_code sandbox
+    # needs this so it can generate stubs for all registered tools, not just
+    # the subset that tool_search exposes to the model.
+    global _all_session_tool_names
+    _all_session_tool_names = [t["function"]["name"] for t in filtered_tools]
 
     # ── Deferred tool loading ────────────────────────────────────────
     # When deferred=True, replace full schemas with tool_search/tool_details
@@ -574,9 +585,14 @@ def handle_function_call(
             pass
 
         if function_name == "execute_code":
-            # Prefer the caller-provided list so subagents can't overwrite
-            # the parent's tool set via the process-global.
-            sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+            # Use the full session tools (pre-deferral) so the sandbox can
+            # call tools that tool_search deferred from the model's view.
+            # Falls back to caller-provided list, then the process-global.
+            sandbox_enabled = (
+                _all_session_tool_names
+                or enabled_tools
+                or _last_resolved_tool_names
+            )
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,

--- a/model_tools.py
+++ b/model_tools.py
@@ -228,6 +228,34 @@ _LEGACY_TOOLSET_MAP = {
 
 
 # =============================================================================
+# Deferred tool loading (tool search)
+# =============================================================================
+
+_deferred_catalog: list[dict] | None = None
+
+
+def _estimate_tool_tokens(definitions: list[dict]) -> int:
+    """Rough token estimate for tool definitions (~4 chars/token)."""
+    return sum(len(json.dumps(d)) // 4 for d in definitions)
+
+
+def should_defer_tools(
+    tool_token_estimate: int,
+    context_length: int,
+    mode: str = "auto",
+    threshold: float = 0.10,
+) -> bool:
+    """Decide whether to use deferred tool loading."""
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    if context_length <= 0:
+        return False
+    return tool_token_estimate / context_length > threshold
+
+
+# =============================================================================
 # get_tool_definitions  (the main schema provider)
 # =============================================================================
 
@@ -235,6 +263,8 @@ def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    deferred: bool = False,
+    pinned_tools: list[str] | None = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -346,6 +376,39 @@ def get_tool_definitions(
             print(f"🛠️  Final tool selection ({len(filtered_tools)} tools): {', '.join(tool_names)}")
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
+
+    # ── Deferred tool loading ────────────────────────────────────────
+    # When deferred=True, replace full schemas with tool_search/tool_details
+    # meta-tools + any pinned tools.  Store the compact catalog globally so
+    # prompt_builder can inject it into the system prompt.
+    if deferred:
+        global _deferred_catalog
+        from tools.tool_search import register_tool_search
+        register_tool_search()
+
+        _deferred_catalog = registry.get_catalog(tools_to_include)
+
+        pinned = set(pinned_tools or [])
+        pinned_defs = [d for d in filtered_tools if d["function"]["name"] in pinned]
+        meta_defs = registry.get_definitions({"tool_search", "tool_details"}, quiet=True)
+        filtered_tools = meta_defs + pinned_defs
+
+        if not quiet_mode:
+            n_deferred = len(_deferred_catalog) - len(pinned_defs)
+            tool_names = [t["function"]["name"] for t in filtered_tools]
+            print(
+                f"🔍 Tool search active: {n_deferred} tools deferred, "
+                f"{len(pinned_defs)} pinned, {len(meta_defs)} meta-tools"
+            )
+            print(f"🛠️  Loaded tools: {', '.join(tool_names)}")
+
+    else:
+        if not quiet_mode:
+            if filtered_tools:
+                tool_names = [t["function"]["name"] for t in filtered_tools]
+                print(f"🛠️  Final tool selection ({len(filtered_tools)} tools): {', '.join(tool_names)}")
+            else:
+                print("🛠️  No tools selected (all filtered out or unavailable)")
 
     global _last_resolved_tool_names
     _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]

--- a/run_agent.py
+++ b/run_agent.py
@@ -6809,6 +6809,9 @@ class AIAgent:
                 except Exception as cb_err:
                     logging.debug(f"Tool complete callback error: {cb_err}")
 
+            # Capture raw result before post-processing for tool_search parsing
+            _raw_result = function_result
+
             function_result = maybe_persist_tool_result(
                 content=function_result,
                 tool_name=function_name,
@@ -6832,7 +6835,7 @@ class AIAgent:
             if self._tool_search_active:
                 if function_name in ("tool_search", "tool_details"):
                     try:
-                        data = json.loads(function_result)
+                        data = json.loads(_raw_result)
                         for schema in data.get("tools", []):
                             tn = schema.get("function", {}).get("name")
                             if tn and tn not in self.valid_tool_names:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1200,6 +1200,12 @@ class AIAgent:
                     pinned_tools=pinned,
                 )
                 self._tool_search_active = True
+                # Re-inject memory provider tools — they were appended to
+                # self.tools earlier but get_tool_definitions() replaced the
+                # list from the registry which doesn't include them.
+                if self._memory_manager:
+                    for _schema in self._memory_manager.get_all_tool_schemas():
+                        self.tools.append({"type": "function", "function": _schema})
                 self.valid_tool_names = {t["function"]["name"] for t in self.tools}
 
         # Track dynamically loaded tools for eviction.

--- a/run_agent.py
+++ b/run_agent.py
@@ -894,7 +894,8 @@ class AIAgent:
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
-        
+        self._tool_search_active = False
+
         # Show tool configuration and store valid tool names for validation
         self.valid_tool_names = set()
         if self.tools:
@@ -1179,6 +1180,38 @@ class AIAgent:
             provider=self.provider,
         )
         self.compression_enabled = compression_enabled
+
+        # ── Deferred tool loading (tool search) ──────────────────────
+        # Must run after compressor init so we have the real context_length.
+        ts_config = _agent_cfg.get("tool_search", {})
+        defer_mode = ts_config.get("mode", "auto")
+        if defer_mode != "never" and self.tools:
+            from model_tools import should_defer_tools, _estimate_tool_tokens
+            tool_tokens = _estimate_tool_tokens(self.tools)
+            ctx_len = self.context_compressor.context_length
+            defer_threshold = float(ts_config.get("threshold", 0.10))
+            if should_defer_tools(tool_tokens, ctx_len, defer_mode, defer_threshold):
+                pinned = ts_config.get("pinned_tools", [])
+                self.tools = get_tool_definitions(
+                    enabled_toolsets=enabled_toolsets,
+                    disabled_toolsets=disabled_toolsets,
+                    quiet_mode=self.quiet_mode,
+                    deferred=True,
+                    pinned_tools=pinned,
+                )
+                self._tool_search_active = True
+                self.valid_tool_names = {t["function"]["name"] for t in self.tools}
+
+        # Track dynamically loaded tools for eviction.
+        # _loaded_tools maps tool_name -> last api_call_count when it was called.
+        # _pinned_tool_names are never evicted.
+        self._loaded_tools: dict[str, int] = {}
+        self._pinned_tool_names: set[str] = set()
+        if self._tool_search_active:
+            self._pinned_tool_names = set(ts_config.get("pinned_tools", []))
+            self._pinned_tool_names |= {"tool_search", "tool_details"}
+            self._tool_evict_after: int = int(ts_config.get("evict_after_turns", 10))
+
         self._subdirectory_hints = SubdirectoryHintTracker(
             working_dir=os.getenv("TERMINAL_CWD") or None,
         )
@@ -2774,6 +2807,14 @@ class AIAgent:
             skills_prompt = ""
         if skills_prompt:
             prompt_parts.append(skills_prompt)
+
+        if self._tool_search_active:
+            from model_tools import _deferred_catalog
+            from agent.prompt_builder import build_tool_catalog_prompt
+            if _deferred_catalog:
+                tool_catalog_prompt = build_tool_catalog_prompt(_deferred_catalog)
+                if tool_catalog_prompt:
+                    prompt_parts.append(tool_catalog_prompt)
 
         if not self.skip_context_files:
             # Use TERMINAL_CWD for context file discovery when set (gateway
@@ -6010,6 +6051,38 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
+    def _evict_stale_tools(self) -> list[str]:
+        """Remove dynamically loaded tools that haven't been used recently.
+
+        Evicts tools from self.tools and self.valid_tool_names that were
+        loaded via tool_search but not called in the last evict_after_turns
+        API calls.  Pinned tools and the meta-tools are never evicted.
+
+        Returns the list of evicted tool names.
+        """
+        if not self._tool_search_active or not self._loaded_tools:
+            return []
+
+        cutoff = self._api_call_count - getattr(self, "_tool_evict_after", 10)
+        stale = [
+            name for name, last_used in self._loaded_tools.items()
+            if last_used < cutoff and name not in self._pinned_tool_names
+        ]
+        if not stale:
+            return []
+
+        stale_set = set(stale)
+        self.tools = [t for t in self.tools if t.get("function", {}).get("name") not in stale_set]
+        self.valid_tool_names -= stale_set
+        for name in stale:
+            del self._loaded_tools[name]
+
+        logger.info(
+            "Tool eviction: removed %d stale tool(s): %s",
+            len(stale), ", ".join(sorted(stale)),
+        )
+        return stale
+
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default") -> tuple:
         """Compress conversation context and split the session in SQLite.
 
@@ -6022,6 +6095,16 @@ class AIAgent:
             self.session_id or "none", _pre_msg_count,
             f"{approx_tokens:,}" if approx_tokens else "unknown", self.model,
         )
+
+        # Evict unused dynamically loaded tools before compression
+        evicted = self._evict_stale_tools()
+        if evicted and not self.quiet_mode:
+            from model_tools import _estimate_tool_tokens
+            saved = _estimate_tool_tokens(
+                [{"type": "function", "function": {"name": n, "parameters": {}}} for n in evicted]
+            )
+            logger.info("Evicted %d tool(s) on compression, freeing ~%d schema tokens", len(evicted), saved)
+
         # Pre-compression memory flush: let the model save memories before they're lost
         self.flush_memories(messages, min_turns=0)
 
@@ -6421,6 +6504,27 @@ class AIAgent:
             turn_tool_msgs = messages[-num_tools:]
             enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id))
 
+        # ── Dynamic tool loading + usage tracking ──────────────────────
+        if self._tool_search_active:
+            for r in results:
+                if r is None:
+                    continue
+                fname = r[0]
+                if fname in ("tool_search", "tool_details"):
+                    try:
+                        data = json.loads(r[2])
+                        for schema in data.get("tools", []):
+                            tool_name = schema.get("function", {}).get("name")
+                            if tool_name and tool_name not in self.valid_tool_names:
+                                self.tools.append(schema)
+                                self.valid_tool_names.add(tool_name)
+                                self._loaded_tools[tool_name] = self._api_call_count
+                                logger.info("Dynamically loaded tool: %s", tool_name)
+                    except (json.JSONDecodeError, KeyError, TypeError):
+                        pass
+                elif fname in self._loaded_tools:
+                    self._loaded_tools[fname] = self._api_call_count
+
         # ── Budget pressure injection ────────────────────────────────────
         budget_warning = self._get_budget_warning(api_call_count)
         if budget_warning and messages and messages[-1].get("role") == "tool":
@@ -6723,6 +6827,23 @@ class AIAgent:
                 "tool_call_id": tool_call.id
             }
             messages.append(tool_msg)
+
+            # ── Dynamic tool loading + usage tracking ──────────────────
+            if self._tool_search_active:
+                if function_name in ("tool_search", "tool_details"):
+                    try:
+                        data = json.loads(function_result)
+                        for schema in data.get("tools", []):
+                            tn = schema.get("function", {}).get("name")
+                            if tn and tn not in self.valid_tool_names:
+                                self.tools.append(schema)
+                                self.valid_tool_names.add(tn)
+                                self._loaded_tools[tn] = self._api_call_count
+                                logger.info("Dynamically loaded tool: %s", tn)
+                    except (json.JSONDecodeError, KeyError, TypeError):
+                        pass
+                elif function_name in self._loaded_tools:
+                    self._loaded_tools[function_name] = self._api_call_count
 
             if not self.quiet_mode:
                 if self.verbose_logging:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8906,6 +8906,24 @@ class AIAgent:
                             if repaired:
                                 print(f"{self.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
                                 tc.function.name = repaired
+
+                    # Auto-load deferred tools the model tried to call directly.
+                    # Weaker models skip tool_details/tool_search and just call
+                    # tools they see in the catalog.  If the tool is registered
+                    # (just not in the active set), load it on the fly.
+                    if self._tool_search_active:
+                        from tools.registry import registry as _tool_registry
+                        for tc in assistant_message.tool_calls:
+                            fname = tc.function.name
+                            if fname not in self.valid_tool_names:
+                                _schema = _tool_registry.get_single_definition(fname)
+                                if _schema:
+                                    self.tools.append(_schema)
+                                    self.valid_tool_names.add(fname)
+                                    self._loaded_tools[fname] = self._api_call_count
+                                    logger.info("Auto-loaded deferred tool on direct call: %s", fname)
+                                    self._vprint(f"{self.log_prefix}🔍 Auto-loaded deferred tool '{fname}'")
+
                     invalid_tool_calls = [
                         tc.function.name for tc in assistant_message.tool_calls
                         if tc.function.name not in self.valid_tool_names

--- a/tests/test_tool_eviction.py
+++ b/tests/test_tool_eviction.py
@@ -1,0 +1,201 @@
+"""Tests for tool search eviction logic.
+
+Tests _evict_stale_tools behavior without instantiating a full AIAgent
+by constructing a minimal object with the required attributes.
+"""
+
+import json
+import types
+
+
+def _make_schema(name, desc=""):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": desc or f"A {name} tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _make_agent_stub(
+    tools: list[dict],
+    loaded_tools: dict[str, int],
+    pinned: set[str] | None = None,
+    api_call_count: int = 20,
+    evict_after: int = 10,
+    active: bool = True,
+):
+    """Build a minimal object with the attributes _evict_stale_tools needs."""
+    # Import the real method from run_agent so we test the actual code
+    import ast
+    import textwrap
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parent.parent / "run_agent.py"
+    tree = ast.parse(source.read_text())
+
+    stub = types.SimpleNamespace(
+        _tool_search_active=active,
+        _loaded_tools=dict(loaded_tools),
+        _pinned_tool_names=pinned or {"tool_search", "tool_details"},
+        _api_call_count=api_call_count,
+        _tool_evict_after=evict_after,
+        tools=list(tools),
+        valid_tool_names={t["function"]["name"] for t in tools},
+        quiet_mode=True,
+    )
+
+    # Bind the real _evict_stale_tools method to our stub
+    exec_ns: dict = {}
+    # Extract just the method source and make it a standalone function
+    func_source = textwrap.dedent("""\
+    def _evict_stale_tools(self):
+        import logging
+        logger = logging.getLogger(__name__)
+        if not self._tool_search_active or not self._loaded_tools:
+            return []
+
+        cutoff = self._api_call_count - getattr(self, "_tool_evict_after", 10)
+        stale = [
+            name for name, last_used in self._loaded_tools.items()
+            if last_used < cutoff and name not in self._pinned_tool_names
+        ]
+        if not stale:
+            return []
+
+        stale_set = set(stale)
+        self.tools = [t for t in self.tools if t.get("function", {}).get("name") not in stale_set]
+        self.valid_tool_names -= stale_set
+        for name in stale:
+            del self._loaded_tools[name]
+
+        logger.info(
+            "Tool eviction: removed %d stale tool(s): %s",
+            len(stale), ", ".join(sorted(stale)),
+        )
+        return stale
+    """)
+    exec(func_source, exec_ns)
+    stub._evict_stale_tools = types.MethodType(exec_ns["_evict_stale_tools"], stub)
+    return stub
+
+
+class TestEvictStaleTools:
+    def test_no_op_when_inactive(self):
+        agent = _make_agent_stub([], {}, active=False)
+        assert agent._evict_stale_tools() == []
+
+    def test_no_op_when_no_loaded_tools(self):
+        meta = [_make_schema("tool_search"), _make_schema("tool_details")]
+        agent = _make_agent_stub(meta, {})
+        assert agent._evict_stale_tools() == []
+
+    def test_evicts_stale_tools(self):
+        tools = [
+            _make_schema("tool_search"),
+            _make_schema("tool_details"),
+            _make_schema("read_file"),
+            _make_schema("web_search"),
+        ]
+        loaded = {"read_file": 5, "web_search": 5}
+        agent = _make_agent_stub(tools, loaded, api_call_count=20, evict_after=10)
+
+        evicted = agent._evict_stale_tools()
+        assert set(evicted) == {"read_file", "web_search"}
+        assert len(agent.tools) == 2
+        assert agent.valid_tool_names == {"tool_search", "tool_details"}
+        assert agent._loaded_tools == {}
+
+    def test_keeps_recently_used(self):
+        tools = [
+            _make_schema("tool_search"),
+            _make_schema("tool_details"),
+            _make_schema("read_file"),
+            _make_schema("web_search"),
+        ]
+        # read_file used at turn 15 (within window), web_search at turn 5 (stale)
+        loaded = {"read_file": 15, "web_search": 5}
+        agent = _make_agent_stub(tools, loaded, api_call_count=20, evict_after=10)
+
+        evicted = agent._evict_stale_tools()
+        assert evicted == ["web_search"]
+        assert "read_file" in agent.valid_tool_names
+        assert "read_file" in agent._loaded_tools
+        remaining_names = {t["function"]["name"] for t in agent.tools}
+        assert "read_file" in remaining_names
+        assert "web_search" not in remaining_names
+
+    def test_never_evicts_pinned(self):
+        tools = [
+            _make_schema("tool_search"),
+            _make_schema("tool_details"),
+            _make_schema("terminal"),
+        ]
+        loaded = {"terminal": 1}
+        agent = _make_agent_stub(
+            tools, loaded,
+            pinned={"tool_search", "tool_details", "terminal"},
+            api_call_count=100, evict_after=10,
+        )
+
+        evicted = agent._evict_stale_tools()
+        assert evicted == []
+        assert "terminal" in agent.valid_tool_names
+
+    def test_never_evicts_meta_tools(self):
+        tools = [_make_schema("tool_search"), _make_schema("tool_details")]
+        # Even if someone manually added meta-tools to _loaded_tools
+        loaded = {"tool_search": 1, "tool_details": 1}
+        agent = _make_agent_stub(tools, loaded, api_call_count=100)
+
+        evicted = agent._evict_stale_tools()
+        assert evicted == []
+
+    def test_eviction_boundary_exact(self):
+        tools = [_make_schema("tool_search"), _make_schema("tool_details"), _make_schema("t")]
+        # Turn 10, evict_after=10, cutoff = 10 - 10 = 0
+        # Tool used at turn 0: 0 < 0 is False, so NOT evicted
+        loaded = {"t": 0}
+        agent = _make_agent_stub(tools, loaded, api_call_count=10, evict_after=10)
+        assert agent._evict_stale_tools() == []
+
+    def test_eviction_boundary_one_past(self):
+        tools = [_make_schema("tool_search"), _make_schema("tool_details"), _make_schema("t")]
+        # Turn 11, evict_after=10, cutoff = 11 - 10 = 1
+        # Tool used at turn 0: 0 < 1 is True, so evicted
+        loaded = {"t": 0}
+        agent = _make_agent_stub(tools, loaded, api_call_count=11, evict_after=10)
+        assert agent._evict_stale_tools() == ["t"]
+
+    def test_mixed_stale_and_fresh(self):
+        tools = [
+            _make_schema("tool_search"),
+            _make_schema("tool_details"),
+            _make_schema("a"),
+            _make_schema("b"),
+            _make_schema("c"),
+            _make_schema("d"),
+        ]
+        loaded = {"a": 2, "b": 18, "c": 5, "d": 19}
+        agent = _make_agent_stub(tools, loaded, api_call_count=20, evict_after=10)
+
+        evicted = agent._evict_stale_tools()
+        assert set(evicted) == {"a", "c"}
+        assert {"b", "d"} <= agent.valid_tool_names
+        assert "a" not in agent._loaded_tools
+        assert "b" in agent._loaded_tools
+
+    def test_custom_evict_window(self):
+        tools = [_make_schema("tool_search"), _make_schema("tool_details"), _make_schema("t")]
+        loaded = {"t": 15}
+        # evict_after=3, api_call_count=20, cutoff=17 -> 15 < 17, evicted
+        agent = _make_agent_stub(tools, loaded, api_call_count=20, evict_after=3)
+        assert agent._evict_stale_tools() == ["t"]
+
+        # Same but evict_after=6, cutoff=14 -> 15 < 14 is False, kept
+        tools2 = [_make_schema("tool_search"), _make_schema("tool_details"), _make_schema("t")]
+        loaded2 = {"t": 15}
+        agent2 = _make_agent_stub(tools2, loaded2, api_call_count=20, evict_after=6)
+        assert agent2._evict_stale_tools() == []

--- a/tests/test_tool_eviction.py
+++ b/tests/test_tool_eviction.py
@@ -4,8 +4,11 @@ Tests _evict_stale_tools behavior without instantiating a full AIAgent
 by constructing a minimal object with the required attributes.
 """
 
-import json
+import logging
 import types
+
+
+logger = logging.getLogger(__name__)
 
 
 def _make_schema(name, desc=""):
@@ -19,6 +22,32 @@ def _make_schema(name, desc=""):
     }
 
 
+def _evict_stale_tools(self):
+    """Mirrors the real _evict_stale_tools logic from run_agent.AIAgent."""
+    if not self._tool_search_active or not self._loaded_tools:
+        return []
+
+    cutoff = self._api_call_count - getattr(self, "_tool_evict_after", 10)
+    stale = [
+        name for name, last_used in self._loaded_tools.items()
+        if last_used < cutoff and name not in self._pinned_tool_names
+    ]
+    if not stale:
+        return []
+
+    stale_set = set(stale)
+    self.tools = [t for t in self.tools if t.get("function", {}).get("name") not in stale_set]
+    self.valid_tool_names -= stale_set
+    for name in stale:
+        del self._loaded_tools[name]
+
+    logger.info(
+        "Tool eviction: removed %d stale tool(s): %s",
+        len(stale), ", ".join(sorted(stale)),
+    )
+    return stale
+
+
 def _make_agent_stub(
     tools: list[dict],
     loaded_tools: dict[str, int],
@@ -28,14 +57,6 @@ def _make_agent_stub(
     active: bool = True,
 ):
     """Build a minimal object with the attributes _evict_stale_tools needs."""
-    # Import the real method from run_agent so we test the actual code
-    import ast
-    import textwrap
-    from pathlib import Path
-
-    source = Path(__file__).resolve().parent.parent / "run_agent.py"
-    tree = ast.parse(source.read_text())
-
     stub = types.SimpleNamespace(
         _tool_search_active=active,
         _loaded_tools=dict(loaded_tools),
@@ -46,39 +67,7 @@ def _make_agent_stub(
         valid_tool_names={t["function"]["name"] for t in tools},
         quiet_mode=True,
     )
-
-    # Bind the real _evict_stale_tools method to our stub
-    exec_ns: dict = {}
-    # Extract just the method source and make it a standalone function
-    func_source = textwrap.dedent("""\
-    def _evict_stale_tools(self):
-        import logging
-        logger = logging.getLogger(__name__)
-        if not self._tool_search_active or not self._loaded_tools:
-            return []
-
-        cutoff = self._api_call_count - getattr(self, "_tool_evict_after", 10)
-        stale = [
-            name for name, last_used in self._loaded_tools.items()
-            if last_used < cutoff and name not in self._pinned_tool_names
-        ]
-        if not stale:
-            return []
-
-        stale_set = set(stale)
-        self.tools = [t for t in self.tools if t.get("function", {}).get("name") not in stale_set]
-        self.valid_tool_names -= stale_set
-        for name in stale:
-            del self._loaded_tools[name]
-
-        logger.info(
-            "Tool eviction: removed %d stale tool(s): %s",
-            len(stale), ", ".join(sorted(stale)),
-        )
-        return stale
-    """)
-    exec(func_source, exec_ns)
-    stub._evict_stale_tools = types.MethodType(exec_ns["_evict_stale_tools"], stub)
+    stub._evict_stale_tools = types.MethodType(_evict_stale_tools, stub)
     return stub
 
 

--- a/tests/test_tool_search_integration.py
+++ b/tests/test_tool_search_integration.py
@@ -1,0 +1,97 @@
+"""Integration tests for tool search deferred loading pipeline.
+
+Covers should_defer_tools(), _estimate_tool_tokens(), and
+build_tool_catalog_prompt() working together.
+"""
+
+import json
+
+from model_tools import should_defer_tools, _estimate_tool_tokens
+from agent.prompt_builder import build_tool_catalog_prompt
+
+
+class TestShouldDeferTools:
+    def test_auto_defers_when_over_threshold(self):
+        assert should_defer_tools(5000, 32768, "auto", 0.10) is True
+
+    def test_auto_does_not_defer_under_threshold(self):
+        assert should_defer_tools(1000, 200000, "auto", 0.10) is False
+
+    def test_always_mode(self):
+        assert should_defer_tools(1, 999999, "always", 0.10) is True
+
+    def test_never_mode(self):
+        assert should_defer_tools(999999, 1, "never", 0.10) is False
+
+    def test_zero_context_length(self):
+        assert should_defer_tools(5000, 0, "auto", 0.10) is False
+
+    def test_boundary_exactly_at_threshold(self):
+        # 3277 / 32768 ≈ 0.1000 — right at threshold, should not defer
+        assert should_defer_tools(3276, 32768, "auto", 0.10) is False
+
+    def test_boundary_just_over(self):
+        assert should_defer_tools(3277, 32768, "auto", 0.10) is True
+
+
+class TestEstimateToolTokens:
+    def test_empty_list(self):
+        assert _estimate_tool_tokens([]) == 0
+
+    def test_rough_estimate(self):
+        defs = [
+            {"type": "function", "function": {"name": "test", "description": "x" * 400}},
+        ]
+        tokens = _estimate_tool_tokens(defs)
+        assert tokens > 0
+        # ~400 chars desc + overhead, /4 ≈ ~120 tokens
+        assert 80 < tokens < 300
+
+
+class TestBuildToolCatalogPrompt:
+    def test_empty_catalog(self):
+        assert build_tool_catalog_prompt([]) == ""
+
+    def test_groups_by_toolset(self):
+        catalog = [
+            {"name": "read_file", "description": "Read a file", "toolset": "file"},
+            {"name": "write_file", "description": "Write a file", "toolset": "file"},
+            {"name": "web_search", "description": "Search the web", "toolset": "web"},
+        ]
+        prompt = build_tool_catalog_prompt(catalog)
+        assert "file:" in prompt
+        assert "web:" in prompt
+        assert "read_file" in prompt
+        assert "web_search" in prompt
+
+    def test_excludes_internal_toolsets(self):
+        catalog = [
+            {"name": "tool_search", "description": "Search tools", "toolset": "_tool_search"},
+            {"name": "real_tool", "description": "Real", "toolset": "core"},
+        ]
+        prompt = build_tool_catalog_prompt(catalog)
+        assert "_tool_search" not in prompt
+        assert "real_tool" in prompt
+
+    def test_truncates_long_descriptions(self):
+        catalog = [
+            {"name": "verbose_tool", "description": "A" * 200, "toolset": "misc"},
+        ]
+        prompt = build_tool_catalog_prompt(catalog)
+        assert "..." in prompt
+
+    def test_contains_usage_instructions(self):
+        catalog = [
+            {"name": "t", "description": "test", "toolset": "s"},
+        ]
+        prompt = build_tool_catalog_prompt(catalog)
+        assert "tool_details" in prompt
+        assert "tool_search" in prompt
+
+    def test_available_tools_header(self):
+        catalog = [
+            {"name": "t", "description": "test", "toolset": "s"},
+        ]
+        prompt = build_tool_catalog_prompt(catalog)
+        assert "## Available Tools" in prompt
+        assert "<available_tools>" in prompt

--- a/tests/tools/test_registry_catalog.py
+++ b/tests/tools/test_registry_catalog.py
@@ -1,0 +1,123 @@
+"""Tests for ToolRegistry.get_catalog() and get_single_definition()."""
+
+import json
+
+from tools.registry import ToolRegistry
+
+
+def _make_schema(name, desc=""):
+    return {
+        "name": name,
+        "description": desc or f"A {name} tool",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _dummy_handler(args, **kw):
+    return json.dumps({"ok": True})
+
+
+class TestGetCatalog:
+    def test_returns_compact_entries(self):
+        reg = ToolRegistry()
+        reg.register(name="alpha", toolset="core", schema=_make_schema("alpha", "Do alpha"),
+                     handler=_dummy_handler, description="Do alpha")
+        reg.register(name="beta", toolset="core", schema=_make_schema("beta", "Do beta"),
+                     handler=_dummy_handler, description="Do beta")
+
+        catalog = reg.get_catalog()
+        assert len(catalog) == 2
+        for entry in catalog:
+            assert set(entry.keys()) == {"name", "description", "toolset"}
+
+    def test_sorted_by_name(self):
+        reg = ToolRegistry()
+        reg.register(name="zeta", toolset="z", schema=_make_schema("zeta"),
+                     handler=_dummy_handler, description="Zeta tool")
+        reg.register(name="alpha", toolset="a", schema=_make_schema("alpha"),
+                     handler=_dummy_handler, description="Alpha tool")
+        catalog = reg.get_catalog()
+        assert catalog[0]["name"] == "alpha"
+        assert catalog[1]["name"] == "zeta"
+
+    def test_filters_by_tool_names(self):
+        reg = ToolRegistry()
+        reg.register(name="a", toolset="s", schema=_make_schema("a"),
+                     handler=_dummy_handler, description="A")
+        reg.register(name="b", toolset="s", schema=_make_schema("b"),
+                     handler=_dummy_handler, description="B")
+        reg.register(name="c", toolset="s", schema=_make_schema("c"),
+                     handler=_dummy_handler, description="C")
+
+        catalog = reg.get_catalog(tool_names={"a", "c"})
+        names = [e["name"] for e in catalog]
+        assert names == ["a", "c"]
+
+    def test_respects_check_fn(self):
+        reg = ToolRegistry()
+        reg.register(name="ok", toolset="s", schema=_make_schema("ok"),
+                     handler=_dummy_handler, check_fn=lambda: True, description="OK")
+        reg.register(name="no", toolset="s", schema=_make_schema("no"),
+                     handler=_dummy_handler, check_fn=lambda: False, description="NO")
+
+        catalog = reg.get_catalog()
+        names = [e["name"] for e in catalog]
+        assert "ok" in names
+        assert "no" not in names
+
+    def test_check_fn_exception_treated_as_unavailable(self):
+        reg = ToolRegistry()
+
+        def bad_check():
+            raise RuntimeError("boom")
+
+        reg.register(name="broken", toolset="s", schema=_make_schema("broken"),
+                     handler=_dummy_handler, check_fn=bad_check, description="Broken")
+
+        catalog = reg.get_catalog()
+        assert len(catalog) == 0
+
+    def test_description_from_schema_fallback(self):
+        reg = ToolRegistry()
+        reg.register(name="t", toolset="s",
+                     schema={"name": "t", "description": "From schema", "parameters": {}},
+                     handler=_dummy_handler)
+
+        catalog = reg.get_catalog()
+        assert catalog[0]["description"] == "From schema"
+
+    def test_empty_registry(self):
+        reg = ToolRegistry()
+        assert reg.get_catalog() == []
+
+
+class TestGetSingleDefinition:
+    def test_returns_openai_format(self):
+        reg = ToolRegistry()
+        reg.register(name="tool1", toolset="s", schema=_make_schema("tool1", "Desc"),
+                     handler=_dummy_handler)
+
+        defn = reg.get_single_definition("tool1")
+        assert defn is not None
+        assert defn["type"] == "function"
+        assert defn["function"]["name"] == "tool1"
+
+    def test_returns_none_for_missing(self):
+        reg = ToolRegistry()
+        assert reg.get_single_definition("ghost") is None
+
+    def test_respects_check_fn(self):
+        reg = ToolRegistry()
+        reg.register(name="hidden", toolset="s", schema=_make_schema("hidden"),
+                     handler=_dummy_handler, check_fn=lambda: False)
+
+        assert reg.get_single_definition("hidden") is None
+
+    def test_returns_for_passing_check(self):
+        reg = ToolRegistry()
+        reg.register(name="visible", toolset="s", schema=_make_schema("visible"),
+                     handler=_dummy_handler, check_fn=lambda: True)
+
+        defn = reg.get_single_definition("visible")
+        assert defn is not None
+        assert defn["function"]["name"] == "visible"

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -1,0 +1,182 @@
+"""Tests for tool_search meta-tool and keyword matching."""
+
+import json
+import pytest
+
+from tools.registry import ToolRegistry
+from tools.tool_search import (
+    _match_score,
+    search_tools,
+    get_tool_details,
+    register_tool_search,
+    _TOOLSET_NAME,
+)
+
+
+def _make_schema(name, desc=""):
+    return {
+        "name": name,
+        "description": desc or f"A {name} tool",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _dummy_handler(args, **kw):
+    return json.dumps({"ok": True})
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry(monkeypatch):
+    """Replace the module-level singleton with a fresh registry per test."""
+    fresh = ToolRegistry()
+    import tools.tool_search as ts_mod
+    monkeypatch.setattr(ts_mod, "registry", fresh)
+    return fresh
+
+
+# ── _match_score ─────────────────────────────────────────────────────
+
+class TestMatchScore:
+    def test_exact_name_match(self):
+        assert _match_score("read_file", "read_file", "Read a file") == 1.0
+
+    def test_query_substring_of_name(self):
+        score = _match_score("read", "read_file", "Read a file from disk")
+        assert score >= 0.7
+
+    def test_name_substring_of_query(self):
+        score = _match_score("read_file contents", "read_file", "")
+        assert score >= 0.7
+
+    def test_word_overlap_in_name(self):
+        score = _match_score("search files", "search_files", "Search for files")
+        assert score >= 0.8
+
+    def test_word_overlap_in_description_only(self):
+        score = _match_score("shell", "terminal", "Run a shell command")
+        assert 0.3 < score < 0.8
+
+    def test_no_match_returns_zero(self):
+        assert _match_score("database", "web_search", "Search the web") == 0.0
+
+    def test_case_insensitive(self):
+        score = _match_score("READ_FILE", "read_file", "Read a file")
+        assert score == 1.0
+
+    def test_hyphen_splitting(self):
+        score = _match_score("web search", "web-search", "Search the web")
+        assert score >= 0.8
+
+
+# ── search_tools ─────────────────────────────────────────────────────
+
+class TestSearchTools:
+    def test_empty_query_returns_error(self, _fresh_registry):
+        result = json.loads(search_tools({"query": ""}))
+        assert "error" in result
+        assert result["matched_count"] == 0
+
+    def test_finds_matching_tools(self, _fresh_registry):
+        _fresh_registry.register(
+            name="read_file", toolset="file", schema=_make_schema("read_file", "Read a file from disk"),
+            handler=_dummy_handler, description="Read a file from disk",
+        )
+        _fresh_registry.register(
+            name="write_file", toolset="file", schema=_make_schema("write_file", "Write to a file"),
+            handler=_dummy_handler, description="Write to a file",
+        )
+        _fresh_registry.register(
+            name="web_search", toolset="web", schema=_make_schema("web_search", "Search the internet"),
+            handler=_dummy_handler, description="Search the internet",
+        )
+
+        result = json.loads(search_tools({"query": "file"}))
+        assert result["matched_count"] >= 1
+        names = {t["function"]["name"] for t in result["tools"]}
+        assert "read_file" in names or "write_file" in names
+
+    def test_returns_full_openai_schemas(self, _fresh_registry):
+        _fresh_registry.register(
+            name="terminal", toolset="core", schema=_make_schema("terminal", "Run shell commands"),
+            handler=_dummy_handler, description="Run shell commands",
+        )
+        result = json.loads(search_tools({"query": "terminal"}))
+        assert result["matched_count"] == 1
+        schema = result["tools"][0]
+        assert schema["type"] == "function"
+        assert "name" in schema["function"]
+        assert "parameters" in schema["function"]
+
+    def test_excludes_meta_tools(self, _fresh_registry):
+        register_tool_search()
+        _fresh_registry.register(
+            name="read_file", toolset="file", schema=_make_schema("read_file"),
+            handler=_dummy_handler, description="Read a file",
+        )
+        result = json.loads(search_tools({"query": "tool search"}))
+        names = {t["function"]["name"] for t in result["tools"]}
+        assert "tool_search" not in names
+        assert "tool_details" not in names
+
+    def test_max_results_cap(self, _fresh_registry):
+        for i in range(20):
+            name = f"file_tool_{i}"
+            _fresh_registry.register(
+                name=name, toolset="file", schema=_make_schema(name, f"File operation {i}"),
+                handler=_dummy_handler, description=f"File operation {i}",
+            )
+        result = json.loads(search_tools({"query": "file"}))
+        assert result["matched_count"] <= 5
+
+    def test_hint_present(self, _fresh_registry):
+        _fresh_registry.register(
+            name="test_tool", toolset="t", schema=_make_schema("test_tool"),
+            handler=_dummy_handler, description="A test tool",
+        )
+        result = json.loads(search_tools({"query": "test"}))
+        assert "hint" in result
+
+
+# ── get_tool_details ─────────────────────────────────────────────────
+
+class TestGetToolDetails:
+    def test_empty_name_returns_error(self):
+        result = json.loads(get_tool_details({"name": ""}))
+        assert "error" in result
+
+    def test_returns_schema_for_existing_tool(self, _fresh_registry):
+        _fresh_registry.register(
+            name="patch", toolset="file", schema=_make_schema("patch", "Apply a patch"),
+            handler=_dummy_handler, description="Apply a patch",
+        )
+        result = json.loads(get_tool_details({"name": "patch"}))
+        assert result["matched_count"] == 1
+        assert result["tools"][0]["function"]["name"] == "patch"
+
+    def test_returns_error_for_missing_tool(self):
+        result = json.loads(get_tool_details({"name": "nonexistent_tool"}))
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_suggests_tool_search_on_miss(self):
+        result = json.loads(get_tool_details({"name": "nope"}))
+        assert "tool_search" in result["error"]
+
+
+# ── register_tool_search ─────────────────────────────────────────────
+
+class TestRegisterToolSearch:
+    def test_registers_both_meta_tools(self, _fresh_registry):
+        register_tool_search()
+        assert _fresh_registry._tools.get("tool_search") is not None
+        assert _fresh_registry._tools.get("tool_details") is not None
+
+    def test_idempotent(self, _fresh_registry):
+        register_tool_search()
+        register_tool_search()
+        assert _fresh_registry._tools.get("tool_search") is not None
+
+    def test_meta_tools_in_correct_toolset(self, _fresh_registry):
+        register_tool_search()
+        assert _fresh_registry._tools["tool_search"].toolset == _TOOLSET_NAME
+        assert _fresh_registry._tools["tool_details"].toolset == _TOOLSET_NAME

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -142,6 +142,45 @@ class ToolRegistry:
             result.append({"type": "function", "function": schema_with_name})
         return result
 
+    def get_catalog(
+        self, tool_names: set[str] | None = None, quiet: bool = True,
+    ) -> list[dict]:
+        """Return compact catalog entries (name, description, toolset) only.
+
+        Used by tool_search to provide a token-efficient tool index in the
+        system prompt.  Applies check_fn filtering like get_definitions().
+        """
+        entries = []
+        check_results: dict[Callable, bool] = {}
+        for name in sorted(self._tools):
+            entry = self._tools[name]
+            if tool_names and name not in tool_names:
+                continue
+            if entry.check_fn:
+                if entry.check_fn not in check_results:
+                    try:
+                        check_results[entry.check_fn] = bool(entry.check_fn())
+                    except Exception:
+                        check_results[entry.check_fn] = False
+                if not check_results[entry.check_fn]:
+                    continue
+            desc = entry.description or entry.schema.get("description", "")
+            entries.append({
+                "name": name,
+                "description": desc,
+                "toolset": entry.toolset,
+            })
+        return entries
+
+    def get_single_definition(self, tool_name: str) -> dict | None:
+        """Return the full OpenAI-format schema for one tool, or None.
+
+        Applies check_fn filtering.  Convenience wrapper around
+        get_definitions() for tool_search / tool_details lookups.
+        """
+        results = self.get_definitions({tool_name}, quiet=True)
+        return results[0] if results else None
+
     # ------------------------------------------------------------------
     # Dispatch
     # ------------------------------------------------------------------

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1,0 +1,175 @@
+"""Tool search meta-tool for progressive disclosure of tool definitions.
+
+Mirrors the skills progressive disclosure pattern: the model sees a compact
+catalog of tool names + descriptions in the system prompt, then uses
+tool_search() to load full schemas on demand before calling them.
+
+Activated automatically when tool definition tokens exceed a configurable
+threshold of the model's context window.
+"""
+
+import json
+import logging
+from typing import Any
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+TOOL_SEARCH_SCHEMA = {
+    "name": "tool_search",
+    "description": (
+        "Search for tools by keyword. Returns full tool schemas that you can "
+        "then call directly. Use this when you need a tool that isn't already "
+        "loaded — check the tool catalog in your system prompt for available tools."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": (
+                    "Search keywords — tool name, action verb, or what you're "
+                    "trying to do (e.g., 'read file', 'search web', 'git')"
+                ),
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+TOOL_DETAILS_SCHEMA = {
+    "name": "tool_details",
+    "description": (
+        "Load the full schema for a specific tool by exact name. "
+        "Use when you know which tool you need from the catalog."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Exact tool name from the catalog",
+            },
+        },
+        "required": ["name"],
+    },
+}
+
+_DEFAULT_MAX_RESULTS = 5
+_TOOLSET_NAME = "_tool_search"
+
+
+def _match_score(query: str, tool_name: str, tool_description: str) -> float:
+    """Score how well a query matches a tool (0.0 to 1.0).
+
+    Simple keyword matching — no embeddings required.  Sufficient for
+    catalogs under ~200 tools.  Weights name matches higher than
+    description matches since tool names are concise and intentional.
+    """
+    query_lower = query.lower()
+    name_lower = tool_name.lower()
+    desc_lower = tool_description.lower()
+
+    if query_lower == name_lower:
+        return 1.0
+
+    score = 0.0
+
+    if query_lower in name_lower:
+        score = max(score, 0.8)
+    elif name_lower in query_lower:
+        score = max(score, 0.7)
+
+    query_words = set(query_lower.replace("_", " ").replace("-", " ").split())
+    name_words = set(name_lower.replace("_", " ").replace("-", " ").split())
+    desc_words = set(desc_lower.replace("_", " ").replace("-", " ").split())
+
+    if query_words:
+        name_overlap = len(query_words & name_words) / len(query_words)
+        desc_overlap = len(query_words & desc_words) / len(query_words)
+        score = max(score, name_overlap * 0.9, desc_overlap * 0.5)
+
+    return score
+
+
+def search_tools(args: dict[str, Any], **kwargs) -> str:
+    """Search the tool catalog and return full schemas for matching tools."""
+    query = args.get("query", "").strip()
+    if not query:
+        return json.dumps({"error": "query is required", "matched_count": 0, "tools": []})
+
+    catalog = registry.get_catalog()
+    scored = []
+    for entry in catalog:
+        if entry["name"] in ("tool_search", "tool_details"):
+            continue
+        s = _match_score(query, entry["name"], entry["description"])
+        if s > 0.1:
+            scored.append((s, entry["name"]))
+
+    scored.sort(key=lambda x: -x[0])
+    top_names = [name for _, name in scored[:_DEFAULT_MAX_RESULTS]]
+
+    schemas = []
+    for name in top_names:
+        schema = registry.get_single_definition(name)
+        if schema:
+            schemas.append(schema)
+
+    logger.info(
+        "tool_search(%r): %d matches from %d catalog entries, returning %d schemas",
+        query, len(scored), len(catalog), len(schemas),
+    )
+
+    return json.dumps({
+        "matched_count": len(schemas),
+        "tools": schemas,
+        "hint": (
+            "These tool schemas are now loaded. You can call them directly "
+            "on your next action. If you don't see what you need, try a "
+            "different search query."
+        ),
+    })
+
+
+def get_tool_details(args: dict[str, Any], **kwargs) -> str:
+    """Load full schema for a single tool by exact name."""
+    name = args.get("name", "").strip()
+    if not name:
+        return json.dumps({"error": "name is required"})
+
+    schema = registry.get_single_definition(name)
+    if not schema:
+        return json.dumps({
+            "error": f"Tool '{name}' not found or unavailable. "
+                     "Use tool_search(query) to find available tools.",
+        })
+
+    return json.dumps({"matched_count": 1, "tools": [schema]})
+
+
+def register_tool_search():
+    """Register the tool_search and tool_details meta-tools.
+
+    Safe to call multiple times — skips if already registered.
+    """
+    if registry._tools.get("tool_search"):
+        return
+
+    registry.register(
+        name="tool_search",
+        toolset=_TOOLSET_NAME,
+        schema=TOOL_SEARCH_SCHEMA,
+        handler=search_tools,
+        description="Search for and load tool schemas by keyword",
+        emoji="🔍",
+    )
+    registry.register(
+        name="tool_details",
+        toolset=_TOOLSET_NAME,
+        schema=TOOL_DETAILS_SCHEMA,
+        handler=get_tool_details,
+        description="Load full schema for a specific tool by name",
+        emoji="🔍",
+    )

--- a/website/docs/developer-guide/tool-search.md
+++ b/website/docs/developer-guide/tool-search.md
@@ -1,0 +1,66 @@
+# Tool Search: Progressive Disclosure for Tool Definitions
+
+Tool definitions consume significant context tokens — often 10-15% of a 32K-token model's context window before the user says a word. Tool search replaces the full JSON schemas with a compact text catalog and two meta-tools that load schemas on demand.
+
+## How it Works
+
+1. **Startup**: Hermes estimates the token cost of tool definitions vs. the model's context window. If tool tokens exceed the threshold (default 10%), deferred mode activates.
+
+2. **System prompt**: Instead of full schemas, the model sees a compact catalog listing each tool's name, toolset, and one-line description — roughly 5-8 tokens per tool vs. 200-400 tokens per full schema.
+
+3. **Meta-tools**: Two tools are always loaded:
+   - `tool_search(query)` — keyword search across the catalog; returns full schemas for matching tools
+   - `tool_details(name)` — loads one tool's full schema by exact name
+
+4. **Dynamic loading**: When the model calls `tool_search` or `tool_details`, the returned schemas are injected into the API's `tools` parameter for subsequent turns.
+
+5. **Eviction**: When context compression fires, tools that haven't been called in the last N turns (default 10) are evicted from `self.tools`. They remain in the catalog and can be re-loaded via `tool_search` if needed later. Pinned tools and the meta-tools are never evicted.
+
+## Configuration
+
+```yaml
+tool_search:
+  mode: auto              # auto | always | never
+  threshold: 0.10         # activate when tool tokens > 10% of context
+  pinned_tools: []        # tools always loaded with full schemas
+  evict_after_turns: 10   # evict unused tools after this many API turns
+```
+
+### Pinned tools
+
+Tools listed in `pinned_tools` always have their full schemas loaded, bypassing tool search. Use this for tools the model needs on nearly every turn:
+
+```yaml
+tool_search:
+  mode: auto
+  pinned_tools:
+    - read_file
+    - terminal
+    - write_file
+```
+
+## Auto-activation
+
+With `mode: auto`, Hermes estimates tool tokens as `sum(len(json.dumps(schema)) / 4)` across all enabled tools. If this estimate exceeds `threshold × context_length`, deferred mode activates.
+
+On large-context models (128K+), tool definitions are a negligible fraction and tool search stays off. On 32K models with ~60 tools, it typically activates and saves ~12K tokens.
+
+## Interaction with Context Compression
+
+Dynamically loaded tool schemas live on the agent's `self.tools` list, not in the message history. Context compression only touches messages, so loaded tools survive compression by default.
+
+However, to prevent token creep from accumulated tool schemas, **eviction** runs as part of the compression cycle. When compression fires, any dynamically loaded tool that hasn't been *called* (not just searched for) in the last `evict_after_turns` API turns is removed from `self.tools`. The tool remains in the catalog, so the model can re-discover and re-load it with one extra turn of latency if needed.
+
+This mirrors how both Anthropic and OpenAI approach the problem: loaded tools persist until explicitly removed. The difference is that on large-context models (200K+) neither platform needs automatic eviction, while on 32K models every token counts, so we evict proactively.
+
+Pinned tools and the `tool_search`/`tool_details` meta-tools are never evicted.
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `tools/tool_search.py` | Meta-tool handlers and keyword matching |
+| `tools/registry.py` | `get_catalog()` and `get_single_definition()` |
+| `agent/prompt_builder.py` | `build_tool_catalog_prompt()` |
+| `model_tools.py` | `should_defer_tools()`, deferred mode in `get_tool_definitions()` |
+| `run_agent.py` | Activation logic and dynamic schema injection |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -182,6 +182,7 @@ const sidebars: SidebarsConfig = {
           label: 'Internals',
           items: [
             'developer-guide/tools-runtime',
+            'developer-guide/tool-search',
             'developer-guide/acp-internals',
             'developer-guide/cron-internals',
             'developer-guide/environments',


### PR DESCRIPTION
## What does this PR do?

Adds progressive tool loading to reduce tool definition token overhead on smaller-context models. When tool schemas consume more than a configurable threshold of the model's context window (default 10%), full JSON schemas are replaced with a compact text catalog and two meta-tools (`tool_search`, `tool_details`) that load schemas on demand.

On a 32K-context model with 72 registered tools, this reduces tool definition overhead from **~19,210 tokens (58.6% of context) to ~2,198 tokens (6.7%)** — an **89% reduction**. The model discovers and loads tools transparently; no user-facing workflow changes required.

Dynamically loaded tools are tracked and automatically evicted during context compression if they haven't been called within a configurable window (default 10 API turns). Evicted tools remain in the catalog for re-discovery, so the worst case is one extra turn of latency.

## Related Issue

Addresses #4379

This directly tackles the tool definition overhead identified in that analysis (~8,759 tokens / 46.1% of each API call for 31 tools). With the progressive loading approach, those 31 tools would cost ~750 tokens as a catalog + ~216 tokens for the two meta-tools.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### New files
- `tools/tool_search.py` — Meta-tool module with keyword matching, `tool_search()` and `tool_details()` handlers. Mirrors the skills progressive disclosure pattern.
- `tests/tools/test_tool_search.py` — 21 tests for meta-tool handlers and keyword matching
- `tests/tools/test_registry_catalog.py` — 11 tests for new registry methods
- `tests/test_tool_search_integration.py` — 15 tests for deferred loading pipeline
- `tests/test_tool_eviction.py` — 10 tests for eviction logic
- `website/docs/developer-guide/tool-search.md` — Developer documentation

### Modified files
- `tools/registry.py` — Added `get_catalog()` (compact tool index with check_fn filtering) and `get_single_definition()` (single-tool OpenAI-format lookup)
- `agent/prompt_builder.py` — Added `build_tool_catalog_prompt()` for injecting the compact catalog into the system prompt, grouped by toolset
- `model_tools.py` — Added `should_defer_tools()`, `_estimate_tool_tokens()`, and deferred mode support in `get_tool_definitions()` with pinned tool passthrough
- `run_agent.py` — Auto-activation after compressor init (uses real context_length), dynamic schema injection in both concurrent and sequential tool dispatch paths, `_evict_stale_tools()` called during `_compress_context()`
- `cli-config.yaml.example` — Added `tool_search` config block with `mode`, `threshold`, `pinned_tools`, and `evict_after_turns`

## How to Test

### Automatic (unit tests)

```bash
pytest tests/tools/test_tool_search.py tests/tools/test_registry_catalog.py \
       tests/test_tool_search_integration.py tests/test_tool_eviction.py -v
```

All 57 new tests pass. All 21 existing registry tests pass (zero regressions).

### Manual (with a small-context model)

1. Configure a model with ≤32K context (e.g., local llama.cpp with Gemma 4)
2. Start `hermes` normally — look for:
   ```
   🔍 Tool search active: ~70 tools deferred, 0 pinned, 2 meta-tools
   ```
3. Ask the model to do something requiring tools (e.g., "read a file"). It should call `tool_search` or `tool_details` first, then use the loaded tool.
4. Context usage should start at ~8K instead of ~19K+ for tool definitions alone.

### Manual (verify auto-deactivation on large context)

1. Configure a model with 128K+ context
2. Start `hermes` — tool search should NOT activate (tool tokens < 10% threshold)
3. All tools loaded normally as before

### Manual (eviction)

1. Use a 32K model with tool_search active
2. Have a long conversation that triggers context compression
3. Check logs — stale tools should be evicted, recently-used ones kept

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools):`, `test(tools):`, `docs(tools):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (57 new tests across 4 test files)
- [x] I've tested on my platform: Ubuntu (kernel 6.17.0-19-generic), Python 3.13.7, RTX 5090 w/ Gemma 4 31B Q4_K_M via llama.cpp (32K context)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/developer-guide/tool-search.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — added `tool_search` block
- [x] I've considered cross-platform impact — pure Python, no OS-specific code, no new dependencies
- [x] N/A — no changes to tool descriptions/schemas for existing tools

## Design Notes

### How it compares to industry approaches

- **OpenAI** has first-class `tool_search` with `defer_loading: true` in their Agents SDK (gpt-5.4+). Our design mirrors this: compact catalog → search → load → call. They don't have automatic eviction.
- **Anthropic** has `clear_tool_uses` for clearing tool *results* from message history, which is orthogonal — it addresses result bloat, not schema bloat. They don't have schema deferral.
- **This PR** adds automatic eviction (tied to compression) because at 32K context, accumulated schemas matter. On 200K+ models neither platform needs this.

### Self-regulating behavior

The feature is designed to be invisible:
- `mode: auto` only activates when tool tokens exceed the threshold — large-context models never see it
- Eviction only fires during compression — if context is fine, nothing gets evicted
- Pinned tools bypass search entirely for tools needed every turn
- The whole system degrades gracefully: worst case is one extra API turn to re-load an evicted tool