### PR TITLE
fix(prompt): catch PermissionError in context file discovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -102,8 +102,11 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     for directory in [current, *current.parents]:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
-            if candidate.is_file():
-                return candidate
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError as e:
+                logger.debug("Could not access %s: %s", candidate, e)
         # Stop walking at the git root (or filesystem root).
         if stop_at and directory == stop_at:
             break
@@ -883,15 +886,15 @@ def _load_agents_md(cwd_path: Path) -> str:
     """AGENTS.md — top-level only (no recursive walk)."""
     for name in ["AGENTS.md", "agents.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
+        try:
+            if candidate.exists():
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
                     return _truncate_content(result, "AGENTS.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        except Exception as e:
+            logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 
@@ -899,15 +902,15 @@ def _load_claude_md(cwd_path: Path) -> str:
     """CLAUDE.md / claude.md — cwd only."""
     for name in ["CLAUDE.md", "claude.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
+        try:
+            if candidate.exists():
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
                     return _truncate_content(result, "CLAUDE.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        except Exception as e:
+            logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 
@@ -915,26 +918,29 @@ def _load_cursorrules(cwd_path: Path) -> str:
     """.cursorrules + .cursor/rules/*.mdc — cwd only."""
     cursorrules_content = ""
     cursorrules_file = cwd_path / ".cursorrules"
-    if cursorrules_file.exists():
-        try:
+    try:
+        if cursorrules_file.exists():
             content = cursorrules_file.read_text(encoding="utf-8").strip()
             if content:
                 content = _scan_context_content(content, ".cursorrules")
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
-        except Exception as e:
-            logger.debug("Could not read .cursorrules: %s", e)
+    except Exception as e:
+        logger.debug("Could not read .cursorrules: %s", e)
 
     cursor_rules_dir = cwd_path / ".cursor" / "rules"
-    if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
-        mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
-        for mdc_file in mdc_files:
-            try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
-                    cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
-            except Exception as e:
-                logger.debug("Could not read %s: %s", mdc_file, e)
+    try:
+        if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
+            mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
+            for mdc_file in mdc_files:
+                try:
+                    content = mdc_file.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
+                        cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
+                except Exception as e:
+                    logger.debug("Could not read %s: %s", mdc_file, e)
+    except OSError as e:
+        logger.debug("Could not access .cursor/rules: %s", e)
 
     if not cursorrules_content:
         return ""


### PR DESCRIPTION
## Summary

Moves filesystem existence checks (`.exists()`, `.is_file()`) inside existing `try/except` blocks in four context-file loader functions so that `PermissionError` from inaccessible directories is caught and logged at debug level instead of crashing the agent.

**Affected functions:**
- `_find_hermes_md` — `candidate.is_file()` now wrapped in `try/except OSError`
- `_load_agents_md` — `candidate.exists()` moved inside existing `try/except`
- `_load_claude_md` — `candidate.exists()` moved inside existing `try/except`
- `_load_cursorrules` — both `.exists()` checks moved inside `try/except`

**Root cause:** When `TERMINAL_CWD` points to a directory the host user cannot access (e.g. `/root` on a Daytona sandbox backend), `Path.exists()` / `Path.is_file()` raise `PermissionError` which was not caught by the `try/except` blocks that only wrapped `read_text()`.

Fixes #6214

## Test plan

- [ ] Run agent with `TERMINAL_CWD` pointing to an inaccessible directory — agent should start without crashing
- [ ] Run agent with valid `TERMINAL_CWD` containing context files — files should still be loaded normally
- [ ] Verify debug logs show graceful skip messages for inaccessible paths