### PR TITLE
feat(web): add native local OSS web stack

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,8 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``local_oss`` → ``searxng`` → ``crawl4ai`` →
+   ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,7 +125,9 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "local_oss",
     "searxng",
+    "crawl4ai",
     "brave-free",
     "ddgs",
 )
@@ -148,7 +151,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → local_oss → searxng → crawl4ai → brave-free → ddgs) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1024,6 +1024,7 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "crawl_backend": "",     # per-capability override for web_crawl (e.g. "crawl4ai")
     },
 
     "browser": {

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -371,6 +371,7 @@ def get_nous_subscription_features(
     # search/extract independently of web.backend.
     web_search_backend = str(web_cfg.get("search_backend") or "").strip().lower()
     web_extract_backend = str(web_cfg.get("extract_backend") or "").strip().lower()
+    web_crawl_backend = str(web_cfg.get("crawl_backend") or "").strip().lower()
     tts_provider = str(tts_cfg.get("provider") or "edge").strip().lower()
     # STT default is "local" (faster-whisper) per DEFAULT_CONFIG, which
     # requires `pip install faster-whisper`. For Nous subscribers we'd
@@ -404,7 +405,9 @@ def get_nous_subscription_features(
     direct_firecrawl = bool(get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL"))
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
-    direct_searxng = bool(get_env_value("SEARXNG_URL"))
+    direct_searxng = bool(get_env_value("SEARXNG_API_URL") or get_env_value("SEARXNG_URL"))
+    direct_crawl4ai = bool(get_env_value("CRAWL4AI_API_URL"))
+    direct_local_oss = direct_searxng and direct_crawl4ai
     direct_fal = fal_key_is_configured()
     direct_fal_video = direct_fal  # same FAL_KEY; separate var so use_gateway is independent
     direct_openai_tts = bool(resolve_openai_audio_api_key())
@@ -512,17 +515,32 @@ def get_nous_subscription_features(
             or (web_backend == "parallel" and direct_parallel)
             or (web_backend == "tavily" and direct_tavily)
             or (web_backend == "searxng" and direct_searxng)
-            # Per-capability overrides: search_backend or extract_backend may be set
+            or (web_backend == "crawl4ai" and direct_crawl4ai)
+            or (web_backend == "local_oss" and direct_local_oss)
+            # Per-capability overrides may be set
             # without web.backend (using the new split config from #20061)
             or (web_search_backend == "searxng" and direct_searxng)
+            or (web_search_backend == "local_oss" and direct_local_oss)
             or (web_search_backend == "exa" and direct_exa)
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
             or (web_search_backend == "tavily" and direct_tavily)
+            or (web_extract_backend == "crawl4ai" and direct_crawl4ai)
+            or (web_extract_backend == "local_oss" and direct_local_oss)
+            or (web_crawl_backend == "crawl4ai" and direct_crawl4ai)
+            or (web_crawl_backend == "local_oss" and direct_local_oss)
+            or (web_crawl_backend == "firecrawl" and direct_firecrawl)
+            or (web_crawl_backend == "tavily" and direct_tavily)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available
+        or direct_exa
+        or direct_firecrawl
+        or direct_parallel
+        or direct_tavily
+        or direct_searxng
+        or direct_crawl4ai
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal
@@ -639,8 +657,8 @@ def get_nous_subscription_features(
             managed_by_nous=web_managed,
             direct_override=web_active and not web_managed,
             toolset_enabled=web_tool_enabled,
-            current_provider=web_backend or web_search_backend or "",
-            explicit_configured=bool(web_backend or web_search_backend),
+            current_provider=web_backend or web_search_backend or web_extract_backend or web_crawl_backend or "",
+            explicit_configured=bool(web_backend or web_search_backend or web_extract_backend or web_crawl_backend),
         ),
         "image_gen": NousFeatureState(
             key="image_gen",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -221,6 +221,25 @@ def _checklist_toolset_keys(platform: str) -> Set[str]:
         if _toolset_allowed_for_platform(ts_key, platform)
     }
 
+
+def _toolset_tools_present_in_composite(
+    ts_key: str,
+    ts_tools: Set[str],
+    composite_tools: Set[str],
+) -> bool:
+    """Return True when ``composite_tools`` should imply ``ts_key``.
+
+    Most configurable toolsets must be fully present in the platform
+    composite. ``web`` has a backward-compatible carve-out: older/custom
+    composites that predate ``web_crawl`` still represent the web toolset when
+    they include the established ``web_search`` + ``web_extract`` pair.
+    """
+    if ts_tools and ts_tools.issubset(composite_tools):
+        return True
+    if ts_key == "web":
+        return {"web_search", "web_extract"}.issubset(composite_tools)
+    return False
+
 # Platform display config — derived from the canonical registry so every
 # module shares the same data.  Kept as dict-of-dicts for backward
 # compatibility with existing ``PLATFORMS[key]["label"]`` access patterns.
@@ -1347,7 +1366,7 @@ def _get_platform_tools(
                 if not _toolset_allowed_for_platform(ts_key, platform):
                     continue
                 ts_tools = set(resolve_toolset(ts_key))
-                if ts_tools and ts_tools.issubset(composite_tools):
+                if _toolset_tools_present_in_composite(ts_key, ts_tools, composite_tools):
                     expanded.add(ts_key)
 
             default_off = set(_DEFAULT_OFF_TOOLSETS)
@@ -1370,7 +1389,7 @@ def _get_platform_tools(
             if not _toolset_allowed_for_platform(ts_key, platform):
                 continue
             ts_tools = set(resolve_toolset(ts_key))
-            if ts_tools and ts_tools.issubset(all_tool_names):
+            if _toolset_tools_present_in_composite(ts_key, ts_tools, all_tool_names):
                 enabled_toolsets.add(ts_key)
 
         # Auto-enable ``x_search`` when xAI credentials are configured.
@@ -1857,8 +1876,8 @@ def _plugin_video_gen_providers() -> list[dict]:
 
 # Mirror of _plugin_image_gen_providers for web search backends. Surfaces
 # every plugin-registered web provider so it appears in the
-# "Web Search & Extract" picker. All seven providers (brave-free, ddgs,
-# searxng, exa, parallel, tavily, firecrawl) live as plugins after
+# "Web Search & Extract" picker. Bundled providers (brave-free, crawl4ai,
+# ddgs, searxng, exa, local_oss, parallel, tavily, firecrawl, xai) live as plugins after
 # PR #25182 — this helper is the sole source of truth for the category's
 # provider rows. The hardcoded entries that used to drive the category
 # were deleted in the same PR; only the two non-provider UX rows
@@ -1874,8 +1893,7 @@ def _plugin_web_search_providers() -> list[dict]:
     marker) so the picker behaves identically whether a provider is
     hardcoded or plugin-registered.
 
-    After PR #25182, all seven web providers (brave-free, ddgs, searxng,
-    exa, parallel, tavily, firecrawl) are plugins; this helper is the sole
+    After PR #25182, bundled web providers are plugins; this helper is the sole
     source of provider rows for the Web Search & Extract category.
     """
     try:

--- a/model_tools.py
+++ b/model_tools.py
@@ -218,7 +218,7 @@ _last_resolved_tool_names: List[str] = []
 # =============================================================================
 
 _LEGACY_TOOLSET_MAP = {
-    "web_tools": ["web_search", "web_extract"],
+    "web_tools": ["web_search", "web_extract", "web_crawl"],
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
     "moa_tools": ["mixture_of_agents"],

--- a/plugins/web/local_oss/__init__.py
+++ b/plugins/web/local_oss/__init__.py
@@ -1,0 +1,20 @@
+"""Local OSS web backend plugin.
+
+Registers:
+
+- ``local_oss``: SearXNG search + Crawl4AI extract.
+- ``crawl4ai``: Crawl4AI extract-only backend for per-capability config.
+"""
+
+from __future__ import annotations
+
+from plugins.web.local_oss.provider import (
+    Crawl4AIWebSearchProvider,
+    LocalOSSWebSearchProvider,
+)
+
+
+def register(ctx) -> None:
+    """Register the local OSS web providers with the plugin context."""
+    ctx.register_web_search_provider(LocalOSSWebSearchProvider())
+    ctx.register_web_search_provider(Crawl4AIWebSearchProvider())

--- a/plugins/web/local_oss/plugin.yaml
+++ b/plugins/web/local_oss/plugin.yaml
@@ -1,0 +1,8 @@
+name: web-local-oss
+version: 1.0.0
+description: "Self-hosted SearXNG search and Crawl4AI extraction."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - local_oss
+  - crawl4ai

--- a/plugins/web/local_oss/provider.py
+++ b/plugins/web/local_oss/provider.py
@@ -1,0 +1,475 @@
+"""Local OSS web providers backed by SearXNG and Crawl4AI.
+
+``local_oss`` is the composite provider: search goes to SearXNG and
+extract goes to Crawl4AI. ``crawl4ai`` is registered separately so users
+can set ``web.extract_backend: crawl4ai`` alongside any search backend.
+
+Env vars:
+
+    SEARXNG_API_URL=http://localhost:8080  # or legacy SEARXNG_URL
+    CRAWL4AI_API_URL=http://localhost:11235
+    CRAWL4AI_API_TOKEN=...                 # optional bearer token
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _has_env(name: str) -> bool:
+    value = os.getenv(name)
+    return bool(value and value.strip())
+
+
+def _get_searxng_api_url() -> str:
+    """Return the configured SearXNG base URL."""
+    url = (
+        os.getenv("SEARXNG_API_URL", "").strip()
+        or os.getenv("SEARXNG_URL", "").strip()
+    ).rstrip("/")
+    if not url:
+        raise ValueError("SEARXNG_API_URL or SEARXNG_URL environment variable not set.")
+    return url
+
+
+def _get_crawl4ai_api_url() -> str:
+    """Return the configured Crawl4AI base URL."""
+    url = os.getenv("CRAWL4AI_API_URL", "").strip().rstrip("/")
+    if not url:
+        raise ValueError("CRAWL4AI_API_URL environment variable not set.")
+    return url
+
+
+def _get_crawl4ai_headers() -> Dict[str, str]:
+    """Return headers for Crawl4AI API requests."""
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    token = os.getenv("CRAWL4AI_API_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _normalize_searxng_search_results(
+    response: Dict[str, Any],
+    limit: int,
+) -> Dict[str, Any]:
+    """Normalize SearXNG ``/search`` JSON responses to Hermes' schema."""
+    raw_results = (response or {}).get("results", [])
+    if not isinstance(raw_results, list):
+        raw_results = []
+
+    web_results = []
+    for idx, result in enumerate(raw_results[:limit]):
+        if not isinstance(result, dict):
+            continue
+        web_results.append(
+            {
+                "title": result.get("title") or result.get("url", ""),
+                "url": result.get("url", ""),
+                "description": (
+                    result.get("content")
+                    or result.get("snippet")
+                    or result.get("description")
+                    or ""
+                ),
+                "position": idx + 1,
+            }
+        )
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _to_plain_object(value: Any) -> Any:
+    """Convert SDK/Pydantic-ish objects to plain Python structures."""
+    if value is None:
+        return None
+    if isinstance(value, (dict, list, str, int, float, bool)):
+        return value
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump()
+        except Exception:
+            pass
+    if hasattr(value, "__dict__"):
+        try:
+            return {k: v for k, v in value.__dict__.items() if not k.startswith("_")}
+        except Exception:
+            pass
+    return value
+
+
+def _normalize_crawl4ai_document(
+    item: Any,
+    fallback_url: str = "",
+) -> Dict[str, Any]:
+    """Normalize one Crawl4AI result entry into Hermes' document schema."""
+    plain = _to_plain_object(item)
+    if not isinstance(plain, dict):
+        return {}
+
+    metadata = _to_plain_object(plain.get("metadata"))
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    markdown_payload = _to_plain_object(plain.get("markdown"))
+    markdown_content = (
+        (
+            markdown_payload.get("fit_markdown")
+            or markdown_payload.get("raw_markdown")
+            or markdown_payload.get("markdown_with_citations")
+            or markdown_payload.get("references_markdown")
+            or ""
+        )
+        if isinstance(markdown_payload, dict)
+        else (markdown_payload if isinstance(markdown_payload, str) else "")
+    )
+    content = (
+        markdown_content
+        or plain.get("fit_markdown")
+        or plain.get("raw_markdown")
+        or plain.get("extracted_content")
+        or plain.get("content")
+        or plain.get("cleaned_html")
+        or plain.get("html")
+        or ""
+    )
+    url = (
+        plain.get("url")
+        or plain.get("redirected_url")
+        or metadata.get("sourceURL")
+        or metadata.get("url")
+        or fallback_url
+    )
+    title = plain.get("title") or metadata.get("title") or ""
+    error = None
+
+    if plain.get("success") is False:
+        error = (
+            plain.get("error")
+            or plain.get("error_message")
+            or plain.get("message")
+            or "crawl failed"
+        )
+        content = ""
+    elif plain.get("error") and not content:
+        error = str(plain.get("error"))
+
+    result = {
+        "url": url,
+        "title": title,
+        "content": content,
+        "raw_content": content,
+        "metadata": metadata,
+    }
+    if error:
+        result["error"] = error
+    return result
+
+
+def _normalize_crawl4ai_documents(
+    response: Any,
+    fallback_url: str = "",
+) -> List[Dict[str, Any]]:
+    """Normalize Crawl4AI API response payloads to Hermes' document schema."""
+    plain = _to_plain_object(response)
+    if not isinstance(plain, dict):
+        return []
+
+    raw_results = plain.get("results")
+    if not isinstance(raw_results, list) and isinstance(plain.get("result"), list):
+        raw_results = plain.get("result")
+    if not isinstance(raw_results, list):
+        raw_results = []
+
+    documents: List[Dict[str, Any]] = []
+    for item in raw_results:
+        normalized = _normalize_crawl4ai_document(item, fallback_url=fallback_url)
+        if normalized:
+            documents.append(normalized)
+
+    if not documents and plain.get("markdown"):
+        normalized = _normalize_crawl4ai_document(plain, fallback_url=fallback_url)
+        if normalized:
+            documents.append(normalized)
+
+    return documents
+
+
+async def _crawl4ai_post(
+    path: str,
+    payload: Dict[str, Any],
+    timeout: int = 120,
+) -> Dict[str, Any]:
+    """POST JSON to Crawl4AI and return the parsed payload."""
+    url = f"{_get_crawl4ai_api_url()}{path}"
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(url, json=payload, headers=_get_crawl4ai_headers())
+        response.raise_for_status()
+        return response.json()
+
+
+async def _crawl4ai_fetch_rendered_document(
+    url: str,
+    format: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fetch one rendered Crawl4AI document in the requested format."""
+    if format == "html":
+        raw = await _crawl4ai_post("/html", {"url": url}, timeout=60)
+        return _normalize_crawl4ai_document(raw, fallback_url=url)
+
+    raw = await _crawl4ai_post("/md", {"url": url, "f": "fit"}, timeout=60)
+    document = _normalize_crawl4ai_document(raw, fallback_url=url)
+    if document.get("content"):
+        return document
+
+    raw = await _crawl4ai_post("/md", {"url": url, "f": "raw"}, timeout=60)
+    return _normalize_crawl4ai_document(raw, fallback_url=url)
+
+
+def _crawl4ai_extract_timeout(num_urls: int) -> int:
+    return max(60, min(180, 30 * max(num_urls, 1)))
+
+
+async def _crawl4ai_extract(
+    urls: List[str],
+    *,
+    format: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Extract page content with Crawl4AI and normalize to Hermes' shape."""
+    raw = await _crawl4ai_post(
+        "/crawl",
+        {
+            "urls": urls,
+            "browser_config": {"headless": True},
+            "crawler_config": {"cache_mode": "bypass"},
+        },
+        timeout=_crawl4ai_extract_timeout(len(urls)),
+    )
+    results = _normalize_crawl4ai_documents(
+        raw,
+        fallback_url=urls[0] if urls else "",
+    )
+    rendered_results = await asyncio.gather(
+        *[_crawl4ai_fetch_rendered_document(url, format=format) for url in urls]
+    )
+    if not results:
+        results = [item for item in rendered_results if item]
+    rendered_by_url = {
+        item.get("url", ""): item
+        for item in rendered_results
+        if item
+    }
+    for result in results:
+        rendered = rendered_by_url.get(result.get("url", ""))
+        if rendered and rendered.get("content"):
+            result["content"] = rendered["content"]
+            result["raw_content"] = rendered["raw_content"]
+        elif rendered and rendered.get("error") and not result.get("error"):
+            result["error"] = rendered["error"]
+    return results
+
+
+async def crawl4ai_crawl(
+    url: str,
+    *,
+    depth: str = "basic",
+) -> List[Dict[str, Any]]:
+    """Crawl a site with Crawl4AI and return normalized documents."""
+    max_depth = 2 if depth == "advanced" else 1
+    raw = await _crawl4ai_post(
+        "/crawl",
+        {
+            "urls": [url],
+            "browser_config": {"headless": True},
+            "crawler_config": {
+                "cache_mode": "bypass",
+                "deep_crawl_strategy": {
+                    "type": "BFSDeepCrawlStrategy",
+                    "params": {
+                        "max_depth": max_depth,
+                        "max_pages": 20,
+                    },
+                },
+            },
+        },
+        timeout=180,
+    )
+    results = _normalize_crawl4ai_documents(raw, fallback_url=url)
+    rendered_results = await asyncio.gather(
+        *[
+            _crawl4ai_fetch_rendered_document(result.get("url", ""))
+            for result in results
+            if result.get("url")
+        ]
+    )
+    if not results:
+        results = [item for item in rendered_results if item]
+    rendered_by_url = {
+        item.get("url", ""): item
+        for item in rendered_results
+        if item
+    }
+    for result in results:
+        rendered = rendered_by_url.get(result.get("url", ""))
+        if rendered and rendered.get("content"):
+            result["content"] = rendered["content"]
+            result["raw_content"] = rendered["raw_content"]
+        elif rendered and rendered.get("error") and not result.get("error"):
+            result["error"] = rendered["error"]
+    return results
+
+
+class LocalOSSWebSearchProvider(WebSearchProvider):
+    """Composite SearXNG search + Crawl4AI extract provider."""
+
+    @property
+    def name(self) -> str:
+        return "local_oss"
+
+    @property
+    def display_name(self) -> str:
+        return "Local OSS (SearXNG + Crawl4AI)"
+
+    def is_available(self) -> bool:
+        return (
+            (_has_env("SEARXNG_API_URL") or _has_env("SEARXNG_URL"))
+            and _has_env("CRAWL4AI_API_URL")
+        )
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            logger.info("SearXNG search via local_oss: '%s' (limit=%d)", query, limit)
+            response = httpx.get(
+                f"{_get_searxng_api_url()}/search",
+                params={"q": query, "format": "json"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            return _normalize_searxng_search_results(response.json(), limit)
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:
+            logger.warning("local_oss search error: %s", exc)
+            return {"success": False, "error": f"SearXNG search failed: {exc}"}
+
+    async def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+            logger.info("Crawl4AI extract via local_oss: %d URL(s)", len(urls))
+            return await _crawl4ai_extract(urls, format=kwargs.get("format"))
+        except ValueError as exc:
+            return [{"url": u, "title": "", "content": "", "error": str(exc)} for u in urls]
+        except Exception as exc:
+            logger.warning("local_oss extract error: %s", exc)
+            return [
+                {
+                    "url": u,
+                    "title": "",
+                    "content": "",
+                    "error": f"Crawl4AI extract failed: {exc}",
+                }
+                for u in urls
+            ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Local OSS",
+            "badge": "free · self-hosted",
+            "tag": "SearXNG search plus Crawl4AI page extraction.",
+            "env_vars": [
+                {
+                    "key": "SEARXNG_API_URL",
+                    "prompt": "SearXNG instance URL",
+                    "url": "https://docs.searxng.org/",
+                },
+                {
+                    "key": "CRAWL4AI_API_URL",
+                    "prompt": "Crawl4AI API URL",
+                    "url": "https://docs.crawl4ai.com/core/self-hosting/",
+                },
+            ],
+        }
+
+
+class Crawl4AIWebSearchProvider(WebSearchProvider):
+    """Crawl4AI extract-only provider."""
+
+    @property
+    def name(self) -> str:
+        return "crawl4ai"
+
+    @property
+    def display_name(self) -> str:
+        return "Crawl4AI"
+
+    def is_available(self) -> bool:
+        return _has_env("CRAWL4AI_API_URL")
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    async def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+            logger.info("Crawl4AI extract: %d URL(s)", len(urls))
+            return await _crawl4ai_extract(urls, format=kwargs.get("format"))
+        except ValueError as exc:
+            return [{"url": u, "title": "", "content": "", "error": str(exc)} for u in urls]
+        except Exception as exc:
+            logger.warning("Crawl4AI extract error: %s", exc)
+            return [
+                {
+                    "url": u,
+                    "title": "",
+                    "content": "",
+                    "error": f"Crawl4AI extract failed: {exc}",
+                }
+                for u in urls
+            ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Crawl4AI",
+            "badge": "free · self-hosted",
+            "tag": "Extract-only backend for pairing with any search provider.",
+            "env_vars": [
+                {
+                    "key": "CRAWL4AI_API_URL",
+                    "prompt": "Crawl4AI API URL",
+                    "url": "https://docs.crawl4ai.com/core/self-hosting/",
+                },
+            ],
+        }

--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -15,9 +15,10 @@ Config keys this provider responds to::
       search_backend: "searxng"     # explicit per-capability
       backend: "searxng"            # shared fallback
 
-Env var::
+Env vars::
 
-    SEARXNG_URL=http://localhost:8080
+    SEARXNG_API_URL=http://localhost:8080  # preferred
+    SEARXNG_URL=http://localhost:8080      # legacy alias
 """
 
 from __future__ import annotations
@@ -32,16 +33,20 @@ logger = logging.getLogger(__name__)
 
 
 def _searxng_url() -> str:
-    """Return SEARXNG_URL from Hermes config-aware env, falling back to process env."""
-    try:
-        from hermes_cli.config import get_env_value
+    """Return the configured SearXNG URL, preferring ``SEARXNG_API_URL``."""
+    for key in ("SEARXNG_API_URL", "SEARXNG_URL"):
+        try:
+            from hermes_cli.config import get_env_value
 
-        val = get_env_value("SEARXNG_URL")
-    except Exception:
-        val = None
-    if val is None:
-        val = os.getenv("SEARXNG_URL", "")
-    return (val or "").strip()
+            val = get_env_value(key)
+        except Exception:
+            val = None
+        if val is None:
+            val = os.getenv(key, "")
+        val = (val or "").strip()
+        if val:
+            return val
+    return ""
 
 
 class SearXNGWebSearchProvider(WebSearchProvider):
@@ -56,7 +61,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
         return "SearXNG"
 
     def is_available(self) -> bool:
-        """Return True when ``SEARXNG_URL`` is set."""
+        """Return True when a SearXNG URL is configured."""
         return bool(_searxng_url())
 
     def supports_search(self) -> bool:
@@ -71,7 +76,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
 
         base_url = _searxng_url().rstrip("/")
         if not base_url:
-            return {"success": False, "error": "SEARXNG_URL is not set"}
+            return {"success": False, "error": "SEARXNG_API_URL or SEARXNG_URL is not set"}
 
         params: Dict[str, Any] = {
             "q": query,
@@ -145,7 +150,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
             "tag": "Free, privacy-respecting metasearch. Point SEARXNG_URL at your instance.",
             "env_vars": [
                 {
-                    "key": "SEARXNG_URL",
+                    "key": "SEARXNG_API_URL",
                     "prompt": "SearXNG instance URL (e.g. http://localhost:8080)",
                     "url": "https://searx.space/",
                 },

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All ten bundled providers (brave-free, crawl4ai, ddgs, exa, firecrawl,
+  local_oss, parallel, searxng, tavily, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -33,7 +33,10 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip every web-provider env var so is_available() returns False."""
     for k in (
         "BRAVE_SEARCH_API_KEY",
+        "SEARXNG_API_URL",
         "SEARXNG_URL",
+        "CRAWL4AI_API_URL",
+        "CRAWL4AI_API_TOKEN",
         "TAVILY_API_KEY",
         "TAVILY_BASE_URL",
         "EXA_API_KEY",
@@ -68,18 +71,20 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All bundled web providers discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
         names = sorted(p.name for p in list_providers())
         assert names == [
             "brave-free",
+            "crawl4ai",
             "ddgs",
             "exa",
             "firecrawl",
+            "local_oss",
             "parallel",
             "searxng",
             "tavily",
@@ -90,10 +95,12 @@ class TestBundledPluginsRegister:
         "plugin_name,expected_search,expected_extract",
         [
             ("brave-free", True, False),
+            ("crawl4ai", False, True),
             ("ddgs", True, False),
             ("searxng", True, False),
             ("exa", True, True),
             ("parallel", True, True),
+            ("local_oss", True, True),
             ("tavily", True, True),
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
@@ -116,7 +123,18 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        [
+            "brave-free",
+            "crawl4ai",
+            "ddgs",
+            "searxng",
+            "exa",
+            "local_oss",
+            "parallel",
+            "tavily",
+            "firecrawl",
+            "xai",
+        ],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +147,18 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        [
+            "brave-free",
+            "crawl4ai",
+            "ddgs",
+            "searxng",
+            "exa",
+            "local_oss",
+            "parallel",
+            "tavily",
+            "firecrawl",
+            "xai",
+        ],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -169,7 +198,32 @@ class TestIsAvailable:
         p = get_provider("searxng")
         assert p is not None
         assert p.is_available() is False
-        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        monkeypatch.setenv("SEARXNG_API_URL", "http://localhost:8080")
+        assert p.is_available() is True
+
+    def test_crawl4ai_requires_api_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("crawl4ai")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("CRAWL4AI_API_URL", "http://localhost:11235")
+        assert p.is_available() is True
+
+    def test_local_oss_requires_searxng_and_crawl4ai(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("local_oss")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("SEARXNG_API_URL", "http://localhost:8080")
+        assert p.is_available() is False
+        monkeypatch.setenv("CRAWL4AI_API_URL", "http://localhost:11235")
         assert p.is_available() is True
 
     def test_tavily_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -328,6 +382,37 @@ class TestRegistryResolution:
             # means an env var leaked in.
             assert result.is_available() is True
 
+    def test_local_oss_wins_when_both_local_urls_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import _resolve
+
+        monkeypatch.setenv("SEARXNG_API_URL", "http://localhost:8080")
+        monkeypatch.setenv("CRAWL4AI_API_URL", "http://localhost:11235")
+
+        search = _resolve(None, capability="search")
+        extract = _resolve(None, capability="extract")
+
+        assert search is not None
+        assert extract is not None
+        assert search.name == "local_oss"
+        assert extract.name == "local_oss"
+
+    def test_crawl4ai_extract_resolves_when_only_crawl4ai_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import _resolve
+
+        monkeypatch.setenv("CRAWL4AI_API_URL", "http://localhost:11235")
+        result = _resolve(None, capability="extract")
+
+        assert result is not None
+        assert result.name == "crawl4ai"
+
 
 # ---------------------------------------------------------------------------
 # Sync-vs-async extract detection
@@ -350,6 +435,22 @@ class TestAsyncExtractDispatch:
         from agent.web_search_registry import get_provider
 
         p = get_provider("firecrawl")
+        assert p is not None
+        assert inspect.iscoroutinefunction(p.extract) is True
+
+    def test_crawl4ai_extract_is_async(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("crawl4ai")
+        assert p is not None
+        assert inspect.iscoroutinefunction(p.extract) is True
+
+    def test_local_oss_extract_is_async(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("local_oss")
         assert p is not None
         assert inspect.iscoroutinefunction(p.extract) is True
 
@@ -448,6 +549,28 @@ class TestErrorResponseShapes:
         assert isinstance(result, list)
         if result:  # if anything came back, it should be an error entry
             assert "error" in result[0]
+
+    def test_crawl4ai_extract_returns_per_url_errors_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("crawl4ai")
+        assert p is not None
+        result = asyncio.run(p.extract(["https://example.com"]))
+        assert isinstance(result, list)
+        assert result[0]["url"] == "https://example.com"
+        assert "error" in result[0]
+
+    def test_local_oss_returns_error_dict_when_search_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("local_oss")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
 
     def test_firecrawl_config_error_points_paid_users_to_nous_subscription(self, monkeypatch):
         from plugins.web.firecrawl import provider as firecrawl_provider

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -44,7 +44,7 @@ class TestGetToolset:
 
         ts = get_toolset("web")
         assert ts is not None
-        assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
+        assert set(ts["tools"]) == {"web_search", "web_extract", "web_crawl", "web_search_plus"}
 
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None
@@ -53,13 +53,14 @@ class TestGetToolset:
 class TestResolveToolset:
     def test_leaf_toolset(self):
         tools = resolve_toolset("web")
-        assert set(tools) == {"web_search", "web_extract"}
+        assert set(tools) == {"web_search", "web_extract", "web_crawl"}
 
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
         assert "terminal" in tools
         assert "web_search" in tools
         assert "web_extract" in tools
+        assert "web_crawl" in tools
 
     def test_cycle_detection(self):
         # Create a cycle: A includes B, B includes A
@@ -110,6 +111,7 @@ class TestResolveMultipleToolsets:
         tools = resolve_multiple_toolsets(["web", "terminal"])
         assert "web_search" in tools
         assert "web_extract" in tools
+        assert "web_crawl" in tools
         assert "terminal" in tools
         # No duplicates
         assert len(tools) == len(set(tools))
@@ -152,7 +154,7 @@ class TestGetToolsetInfo:
         info = get_toolset_info("web")
         assert info["name"] == "web"
         assert info["is_composite"] is False
-        assert info["tool_count"] == 2
+        assert info["tool_count"] == 3
 
     def test_composite(self):
         info = get_toolset_info("debugging")

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -24,6 +24,10 @@ def register_all_web_providers():
     from plugins.web.ddgs.provider import DDGSWebSearchProvider
     from plugins.web.exa.provider import ExaWebSearchProvider
     from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+    from plugins.web.local_oss.provider import (
+        Crawl4AIWebSearchProvider,
+        LocalOSSWebSearchProvider,
+    )
     from plugins.web.parallel.provider import ParallelWebSearchProvider
     from plugins.web.searxng.provider import SearXNGWebSearchProvider
     from plugins.web.tavily.provider import TavilyWebSearchProvider
@@ -35,6 +39,8 @@ def register_all_web_providers():
         DDGSWebSearchProvider,
         ExaWebSearchProvider,
         FirecrawlWebSearchProvider,
+        LocalOSSWebSearchProvider,
+        Crawl4AIWebSearchProvider,
         ParallelWebSearchProvider,
         SearXNGWebSearchProvider,
         TavilyWebSearchProvider,

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -24,7 +24,7 @@ from tests.tools.conftest import register_all_web_providers
 class TestWebProviderABCs:
     """The unified WebSearchProvider ABC enforces the interface contract.
 
-    After PR #25182, all seven providers are subclasses of
+    After PR #25182, bundled providers are subclasses of
     :class:`agent.web_search_provider.WebSearchProvider`. The legacy
     in-tree ABCs at ``tools.web_providers.base`` (separate
     ``WebSearchProvider`` + ``WebExtractProvider``) were deleted in the
@@ -217,10 +217,12 @@ class TestDefaultConfig:
         assert "backend" in web
         assert "search_backend" in web
         assert "extract_backend" in web
+        assert "crawl_backend" in web
         # All empty string by default (no override)
         assert web["backend"] == ""
         assert web["search_backend"] == ""
         assert web["extract_backend"] == ""
+        assert web["crawl_backend"] == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -31,11 +31,13 @@ class TestSearXNGSearchProviderIsConfigured:
         assert SearXNGWebSearchProvider().is_available() is True
 
     def test_not_configured_when_url_missing(self, monkeypatch):
+        monkeypatch.delenv("SEARXNG_API_URL", raising=False)
         monkeypatch.delenv("SEARXNG_URL", raising=False)
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
         assert SearXNGWebSearchProvider().is_available() is False
 
     def test_not_configured_when_url_empty_string(self, monkeypatch):
+        monkeypatch.delenv("SEARXNG_API_URL", raising=False)
         monkeypatch.setenv("SEARXNG_URL", "   ")
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
         assert SearXNGWebSearchProvider().is_available() is False
@@ -184,6 +186,7 @@ class TestSearXNGSearchProviderSearch:
         assert "localhost:8080" in result["error"] or "connection" in result["error"].lower()
 
     def test_missing_url_returns_failure(self, monkeypatch):
+        monkeypatch.delenv("SEARXNG_API_URL", raising=False)
         monkeypatch.delenv("SEARXNG_URL", raising=False)
         from plugins.web.searxng.provider import SearXNGWebSearchProvider
 
@@ -220,6 +223,7 @@ class TestIsBackendAvailable:
         assert _is_backend_available("searxng") is True
 
     def test_searxng_unavailable_when_url_missing(self, monkeypatch):
+        monkeypatch.delenv("SEARXNG_API_URL", raising=False)
         monkeypatch.delenv("SEARXNG_URL", raising=False)
         from tools.web_tools import _is_backend_available
         assert _is_backend_available("searxng") is False
@@ -250,6 +254,8 @@ class TestGetBackendSearXNG:
         monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
         monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_API_URL", raising=False)
+        monkeypatch.delenv("CRAWL4AI_API_URL", raising=False)
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         # Suppress tool gateway
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
@@ -321,7 +327,9 @@ class TestCheckWebApiKey:
         monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
         monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_API_URL", raising=False)
         monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.delenv("CRAWL4AI_API_URL", raising=False)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -259,6 +259,10 @@ class TestBackendSelection:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SEARXNG_URL",
+        "SEARXNG_API_URL",
+        "CRAWL4AI_API_URL",
+        "CRAWL4AI_API_TOKEN",
     )
 
     def setup_method(self):
@@ -324,6 +328,20 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={"backend": "Tavily"}):
             assert _get_backend() == "tavily"
 
+    def test_config_local_oss(self):
+        """web.backend=local_oss in config → composite local backend."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "local_oss"}):
+            assert _get_backend() == "local_oss"
+
+    def test_local_oss_resolves_for_each_capability(self):
+        """Composite backend remains the effective provider for each capability."""
+        from tools.web_tools import _get_backend_for_capability
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "local_oss"}):
+            assert _get_backend_for_capability("search") == "local_oss"
+            assert _get_backend_for_capability("extract") == "local_oss"
+            assert _get_backend_for_capability("crawl") == "local_oss"
+
     # ── Fallback (no web.backend in config) ───────────────────────────
 
     def test_fallback_parallel_only_key(self):
@@ -367,6 +385,34 @@ class TestBackendSelection:
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "PARALLEL_API_KEY": "par-test"}):
+            assert _get_backend() == "tavily"
+
+    def test_fallback_local_oss_when_both_local_urls_set(self):
+        """SearXNG + Crawl4AI URLs, no config -> local_oss."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {
+                 "SEARXNG_API_URL": "https://search.example.test",
+                 "CRAWL4AI_API_URL": "https://crawl.example.test",
+             }):
+            assert _get_backend() == "local_oss"
+
+    def test_fallback_crawl4ai_only_url(self):
+        """Only CRAWL4AI_API_URL set -> crawl4ai."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"CRAWL4AI_API_URL": "https://crawl.example.test"}):
+            assert _get_backend() == "crawl4ai"
+
+    def test_explicit_paid_backends_beat_local_oss_auto_detect(self):
+        """Local OSS auto-detect does not override explicit paid API keys."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {
+                 "TAVILY_API_KEY": "tvly-test",
+                 "SEARXNG_API_URL": "https://search.example.test",
+                 "CRAWL4AI_API_URL": "https://crawl.example.test",
+             }):
             assert _get_backend() == "tavily"
 
     def test_fallback_parallel_beats_firecrawl_direct(self):
@@ -581,6 +627,10 @@ class TestCheckWebApiKey:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SEARXNG_URL",
+        "SEARXNG_API_URL",
+        "CRAWL4AI_API_URL",
+        "CRAWL4AI_API_TOKEN",
     )
 
     def setup_method(self):
@@ -622,6 +672,22 @@ class TestCheckWebApiKey:
     def test_tavily_key_only(self):
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
             from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_local_oss_urls_return_true(self):
+        with patch.dict(os.environ, {
+            "SEARXNG_API_URL": "https://search.example.test",
+            "CRAWL4AI_API_URL": "https://crawl.example.test",
+        }):
+            from tools.web_tools import (
+                check_web_api_key,
+                check_web_search_available,
+                check_web_extract_available,
+                check_web_crawl_available,
+            )
+            assert check_web_search_available() is True
+            assert check_web_extract_available() is True
+            assert check_web_crawl_available() is True
             assert check_web_api_key() is True
 
     def test_no_keys_returns_false(self):
@@ -709,3 +775,5 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+    assert "SEARXNG_API_URL" in _web_requires_env()
+    assert "CRAWL4AI_API_URL" in _web_requires_env()

--- a/tests/tools/test_web_tools_local_oss.py
+++ b/tests/tools/test_web_tools_local_oss.py
@@ -1,0 +1,156 @@
+"""Tests for native SearXNG + Crawl4AI backend dispatch."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.usefixtures("web_registry_populated")
+
+
+def test_web_search_dispatches_to_searxng():
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "results": [
+            {
+                "title": "Hermes Agent",
+                "url": "https://example.com/hermes",
+                "content": "Local OSS backend docs",
+            }
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("tools.web_tools._load_web_config", return_value={"backend": "local_oss"}), \
+         patch("tools.web_tools._ensure_web_plugins_loaded", return_value=None), \
+         patch("plugins.web.local_oss.provider.httpx.get", return_value=mock_response) as mock_get, \
+         patch("plugins.web.local_oss.provider._get_searxng_api_url", return_value="https://search.example.test"), \
+         patch("tools.interrupt.is_interrupted", return_value=False):
+        from tools.web_tools import web_search_tool
+
+        result = json.loads(web_search_tool("hermes", limit=3))
+
+    assert result["success"] is True
+    assert result["data"]["web"][0]["title"] == "Hermes Agent"
+    assert result["data"]["web"][0]["url"] == "https://example.com/hermes"
+    mock_get.assert_called_once()
+
+
+def test_normalize_crawl4ai_document_uses_nested_markdown_content():
+    from tools.web_tools import _normalize_crawl4ai_document
+
+    result = _normalize_crawl4ai_document(
+        {
+            "url": "https://example.com/page",
+            "metadata": {"title": "Page"},
+            "markdown": {
+                "fit_markdown": "Fit markdown",
+                "raw_markdown": "Raw markdown",
+            },
+            "success": True,
+        }
+    )
+
+    assert result["title"] == "Page"
+    assert result["content"] == "Fit markdown"
+
+
+def test_web_extract_dispatches_to_crawl4ai():
+    raw_response = {
+        "results": [
+            {
+                "url": "https://example.com/page",
+                "title": "Page",
+                "markdown": {
+                    "raw_markdown": "Raw markdown",
+                },
+                "success": True,
+            }
+        ]
+    }
+    md_response = {
+        "url": "https://example.com/page",
+        "markdown": "Extracted markdown",
+        "success": True,
+    }
+
+    with patch("tools.web_tools._load_web_config", return_value={"extract_backend": "crawl4ai"}), \
+         patch("tools.web_tools._ensure_web_plugins_loaded", return_value=None), \
+         patch.dict("os.environ", {"CRAWL4AI_API_URL": "https://crawl.example.test"}), \
+         patch(
+             "plugins.web.local_oss.provider._crawl4ai_post",
+             new=AsyncMock(side_effect=[raw_response, md_response]),
+         ) as mock_post:
+        from tools.web_tools import web_extract_tool
+
+        result = json.loads(
+            asyncio.run(
+                web_extract_tool(
+                    ["https://example.com/page"],
+                    use_llm_processing=False,
+                )
+            )
+        )
+
+    assert result["results"][0]["url"] == "https://example.com/page"
+    assert result["results"][0]["title"] == "Page"
+    assert result["results"][0]["content"] == "Extracted markdown"
+    crawl_payload = mock_post.await_args_list[0].args[1]
+    md_payload = mock_post.await_args_list[1].args[1]
+    assert mock_post.await_args_list[0].args[0] == "/crawl"
+    assert crawl_payload["urls"] == ["https://example.com/page"]
+    assert crawl_payload["crawler_config"]["cache_mode"] == "bypass"
+    assert mock_post.await_args_list[1].args[0] == "/md"
+    assert md_payload == {"url": "https://example.com/page", "f": "fit"}
+
+
+def test_web_crawl_dispatches_to_crawl4ai():
+    raw_response = {
+        "results": [
+            {
+                "url": "https://example.com/docs/start",
+                "title": "Start",
+                "markdown": {
+                    "raw_markdown": "Raw doc page",
+                },
+                "success": True,
+            }
+        ]
+    }
+    md_response = {
+        "url": "https://example.com/docs/start",
+        "markdown": "Doc page",
+        "success": True,
+    }
+
+    with patch("tools.web_tools._load_web_config", return_value={"crawl_backend": "crawl4ai"}), \
+         patch.dict("os.environ", {"CRAWL4AI_API_URL": "https://crawl.example.test"}), \
+         patch(
+             "plugins.web.local_oss.provider._crawl4ai_post",
+             new=AsyncMock(side_effect=[raw_response, md_response]),
+         ) as mock_post, \
+         patch("tools.web_tools.check_website_access", return_value=None), \
+         patch("tools.interrupt.is_interrupted", return_value=False):
+        from tools.web_tools import web_crawl_tool
+
+        result = json.loads(
+            asyncio.run(
+                web_crawl_tool(
+                    "https://example.com/docs",
+                    depth="advanced",
+                    use_llm_processing=False,
+                )
+            )
+        )
+
+    assert result["results"][0]["url"] == "https://example.com/docs/start"
+    assert result["results"][0]["title"] == "Start"
+    assert result["results"][0]["content"] == "Doc page"
+    payload = mock_post.await_args_list[0].args[1]
+    strategy = payload["crawler_config"]["deep_crawl_strategy"]
+    assert strategy["type"] == "BFSDeepCrawlStrategy"
+    assert strategy["params"]["max_depth"] == 2
+    assert strategy["params"]["max_pages"] == 20
+    assert mock_post.await_args_list[1].args[0] == "/md"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -10,12 +10,15 @@ for Nous Subscribers only.
 Available tools:
 - web_search_tool: Search the web for information
 - web_extract_tool: Extract content from specific web pages
+- web_crawl_tool: Crawl a website and return page content
 
 Backend compatibility:
 - Exa: https://exa.ai (search, extract)
-- Firecrawl: https://docs.firecrawl.dev/introduction (search, extract; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
+- Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
-- Tavily: https://tavily.com (search, extract)
+- SearXNG: https://docs.searxng.org/ (search)
+- Crawl4AI: https://docs.crawl4ai.com/core/self-hosting/ (extract, crawl)
+- Tavily: https://tavily.com (search, extract, crawl)
 
 LLM Processing:
 - Uses OpenRouter API with Gemini 3 Flash Preview for intelligent content extraction
@@ -56,6 +59,7 @@ from plugins.web.firecrawl.provider import (
     _get_firecrawl_client,  # noqa: F401  # re-exported for tests that `from tools.web_tools import _get_firecrawl_client`
     _get_firecrawl_gateway_url,
     _is_tool_gateway_ready,
+    _to_plain_object as _firecrawl_to_plain_object,
     check_firecrawl_api_key,
 )
 # Tavily helpers re-exported for backward-compat with existing unit tests
@@ -73,6 +77,18 @@ from plugins.web.parallel.provider import (  # noqa: F401 — backward-compat na
     _get_parallel_client,
 )
 from plugins.web.exa.provider import _get_exa_client  # noqa: F401
+from plugins.web.local_oss.provider import (  # noqa: F401 — backward-compat/test helpers
+    _crawl4ai_extract_timeout,
+    _crawl4ai_fetch_rendered_document,
+    _crawl4ai_post,
+    _get_crawl4ai_api_url,
+    _get_crawl4ai_headers,
+    _get_searxng_api_url,
+    _normalize_crawl4ai_document,
+    _normalize_crawl4ai_documents,
+    _normalize_searxng_search_results,
+    crawl4ai_crawl as _crawl4ai_crawl,
+)
 
 # Module-level cache slots for the per-vendor clients. The plugins read/write
 # these via tools.web_tools so unit tests that reset
@@ -103,9 +119,49 @@ from tools.tool_backend_helpers import (  # noqa: F401
     prefers_gateway,
 )
 from tools.url_safety import async_is_safe_url, normalize_url_for_request
+from tools.website_policy import check_website_access
 import sys
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_OSS_BACKEND = "local_oss"
+_KNOWN_WEB_BACKENDS = {
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "exa",
+    "searxng",
+    "brave-free",
+    "ddgs",
+    "xai",
+    "crawl4ai",
+    _LOCAL_OSS_BACKEND,
+}
+_SEARCH_CAPABLE_BACKENDS = {
+    "exa",
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "searxng",
+    "brave-free",
+    "ddgs",
+    "xai",
+    _LOCAL_OSS_BACKEND,
+}
+_EXTRACT_CAPABLE_BACKENDS = {
+    "exa",
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "crawl4ai",
+    _LOCAL_OSS_BACKEND,
+}
+_CRAWL_CAPABLE_BACKENDS = {
+    "firecrawl",
+    "tavily",
+    "crawl4ai",
+    _LOCAL_OSS_BACKEND,
+}
 
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
@@ -133,6 +189,20 @@ def _env_value(name: str) -> str:
 def _has_env(name: str) -> bool:
     return bool(_env_value(name))
 
+
+def _normalize_backend_name(value: object | None) -> str:
+    return str(value or "").strip().lower()
+
+
+def _backend_supports_capability(backend: str, capability: str) -> bool:
+    if capability == "search":
+        return backend in _SEARCH_CAPABLE_BACKENDS
+    if capability == "extract":
+        return backend in _EXTRACT_CAPABLE_BACKENDS
+    if capability == "crawl":
+        return backend in _CRAWL_CAPABLE_BACKENDS
+    return False
+
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
@@ -148,8 +218,8 @@ def _get_backend() -> str:
     Falls back to whichever API key is present for users who configured
     keys manually without running setup.
     """
-    configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    configured = _normalize_backend_name(_load_web_config().get("backend"))
+    if configured in _KNOWN_WEB_BACKENDS:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -158,14 +228,18 @@ def _get_backend() -> str:
     # pre-empted by a Nous OAuth token whose subscription tier may not
     # actually grant web-search access (the gateway then fails at runtime
     # with "no subscription" and the tool returns an error to the agent
-    # without falling back). Free-tier backends trail the paid ones.
+    # without falling back). Self-hosted local URLs are also explicit user
+    # configuration, so they beat the managed gateway probe. Free-tier
+    # package-only backends trail the configured services.
     backend_candidates = (
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
+        (_LOCAL_OSS_BACKEND, (_has_env("SEARXNG_API_URL") or _has_env("SEARXNG_URL")) and _has_env("CRAWL4AI_API_URL")),
+        ("searxng", _has_env("SEARXNG_API_URL") or _has_env("SEARXNG_URL")),
+        ("crawl4ai", _has_env("CRAWL4AI_API_URL")),
         ("firecrawl", _is_tool_gateway_ready()),
-        ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
     )
@@ -201,6 +275,11 @@ def _get_extract_backend() -> str:
     return _get_capability_backend("extract")
 
 
+def _get_crawl_backend() -> str:
+    """Determine which backend to use for web_crawl specifically."""
+    return _get_capability_backend("crawl")
+
+
 def _get_capability_backend(capability: str) -> str:
     """Shared helper for per-capability backend selection.
 
@@ -208,10 +287,15 @@ def _get_capability_backend(capability: str) -> str:
     uses it. Otherwise falls through to the shared ``_get_backend()``.
     """
     cfg = _load_web_config()
-    specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
+    specific = _normalize_backend_name(cfg.get(f"{capability}_backend"))
     if specific and _is_backend_available(specific):
         return specific
     return _get_backend()
+
+
+def _get_backend_for_capability(capability: str) -> str:
+    """Resolve the effective backend for a specific web capability."""
+    return _get_capability_backend(capability)
 
 
 def _is_backend_available(backend: str) -> bool:
@@ -225,11 +309,18 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
     if backend == "searxng":
-        return _has_env("SEARXNG_URL")
+        return _has_env("SEARXNG_API_URL") or _has_env("SEARXNG_URL")
     if backend == "brave-free":
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "crawl4ai":
+        return _has_env("CRAWL4AI_API_URL")
+    if backend == _LOCAL_OSS_BACKEND:
+        return (
+            (_has_env("SEARXNG_API_URL") or _has_env("SEARXNG_URL"))
+            and _has_env("CRAWL4AI_API_URL")
+        )
     if backend == "xai":
         # Cheap probe — env var OR auth.json has OAuth tokens. Must not
         # call resolve_xai_http_credentials() here because the OAuth path
@@ -285,6 +376,11 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "SEARXNG_URL",
+        "SEARXNG_API_URL",
+        "CRAWL4AI_API_URL",
+        "CRAWL4AI_API_TOKEN",
+        "BRAVE_SEARCH_API_KEY",
         "FIRECRAWL_GATEWAY_URL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
@@ -758,8 +854,7 @@ def clean_base64_images(text: str) -> str:
 def _ensure_web_plugins_loaded() -> None:
     """Idempotently trigger plugin discovery so the web registry is populated.
 
-    Every bundled web provider (brave-free, ddgs, searxng, exa, parallel,
-    tavily, firecrawl) registers itself via ``plugins/web/<vendor>/__init__.py``
+    Every bundled web provider registers itself via ``plugins/web/<vendor>/__init__.py``
     during plugin discovery. Tool dispatch can be reached from contexts that
     haven't already triggered discovery — subprocess agent runs, delegate
     children, standalone scripts, certain test paths — and without it the
@@ -840,10 +935,9 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
+        # Dispatch through the web search registry. Bundled providers now
+        # live as plugins; the dispatcher is just a registry lookup +
+        # delegation. Sync only — every search provider's search() is sync.
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_search_provider,
@@ -978,10 +1072,10 @@ async def web_extract_tool(
         else:
             backend = _get_extract_backend()
 
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
+            # Bundled providers now live as plugins. The dispatcher is a
             # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
+            # async (parallel, firecrawl, crawl4ai, local_oss), others sync
+            # (exa, tavily) — we
             # detect coroutine functions and await; sync functions run
             # inline (the policy gate, SSRF re-check, etc. live inside the
             # provider itself for the firecrawl per-URL loop).
@@ -1006,8 +1100,8 @@ async def web_extract_tool(
                             "error": (
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "Set web.extract_backend to crawl4ai, local_oss, "
+                                "firecrawl, tavily, exa, or parallel."
                             ),
                         },
                         ensure_ascii=False,
@@ -1019,8 +1113,8 @@ async def web_extract_tool(
                             "success": False,
                             "error": (
                                 "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "Set web.extract_backend to crawl4ai, local_oss, "
+                                "firecrawl, tavily, exa, or parallel."
                             ),
                         },
                         ensure_ascii=False,
@@ -1053,8 +1147,8 @@ async def web_extract_tool(
         
         debug_call_data["pages_extracted"] = pages_extracted
         debug_call_data["original_response_size"] = len(json.dumps(response))
-        effective_model = model or _get_default_summarizer_model()
-        auxiliary_available = check_auxiliary_model()
+        effective_model = model or (_get_default_summarizer_model() if use_llm_processing else None)
+        auxiliary_available = check_auxiliary_model() if use_llm_processing else False
         
         # Process each result with LLM if enabled
         if use_llm_processing and auxiliary_available:
@@ -1181,15 +1275,409 @@ async def web_extract_tool(
         return tool_error(error_msg)
 
 
-# Convenience function to check Firecrawl credentials
+def _normalize_firecrawl_crawl_results(crawl_result: Any) -> List[Dict[str, Any]]:
+    """Normalize Firecrawl crawl() results to Hermes' document schema."""
+    plain = _firecrawl_to_plain_object(crawl_result)
+    if isinstance(plain, dict):
+        data_list = plain.get("data") or plain.get("results") or []
+    elif isinstance(plain, list):
+        data_list = plain
+    else:
+        data_list = []
+
+    pages: List[Dict[str, Any]] = []
+    for item in data_list:
+        doc = _firecrawl_to_plain_object(item)
+        if not isinstance(doc, dict):
+            continue
+
+        metadata = _firecrawl_to_plain_object(doc.get("metadata"))
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        markdown = _firecrawl_to_plain_object(doc.get("markdown"))
+        if isinstance(markdown, dict):
+            content = (
+                markdown.get("fit_markdown")
+                or markdown.get("raw_markdown")
+                or markdown.get("markdown")
+                or ""
+            )
+        else:
+            content = markdown if isinstance(markdown, str) else ""
+        content = content or doc.get("content") or doc.get("html") or ""
+
+        page_url = (
+            doc.get("url")
+            or doc.get("sourceURL")
+            or metadata.get("sourceURL")
+            or metadata.get("url")
+            or ""
+        )
+        title = doc.get("title") or metadata.get("title") or ""
+
+        page_blocked = check_website_access(page_url) if page_url else None
+        if page_blocked:
+            logger.info(
+                "Blocked crawled page %s by rule %s",
+                page_blocked["host"],
+                page_blocked["rule"],
+            )
+            pages.append(
+                {
+                    "url": page_url,
+                    "title": title,
+                    "content": "",
+                    "raw_content": "",
+                    "error": page_blocked["message"],
+                    "blocked_by_policy": {
+                        "host": page_blocked["host"],
+                        "rule": page_blocked["rule"],
+                        "source": page_blocked["source"],
+                    },
+                }
+            )
+            continue
+
+        pages.append(
+            {
+                "url": page_url,
+                "title": title,
+                "content": content,
+                "raw_content": content,
+                "metadata": metadata,
+            }
+        )
+
+    return pages
+
+
+async def _finalize_web_crawl_results(
+    results: List[Dict[str, Any]],
+    *,
+    debug_call_data: Dict[str, Any],
+    use_llm_processing: bool,
+    auxiliary_available: bool,
+    effective_model: Optional[str],
+    min_length: int,
+) -> str:
+    """Apply optional LLM processing, trim fields, and log crawl debug data."""
+    response = {"results": results}
+    pages_crawled = len(response.get("results", []))
+    logger.info("Crawled %d pages", pages_crawled)
+
+    debug_call_data["pages_crawled"] = pages_crawled
+    debug_call_data["original_response_size"] = len(json.dumps(response))
+
+    if use_llm_processing and auxiliary_available:
+        logger.info("Processing crawled content with LLM (parallel)...")
+        debug_call_data["processing_applied"].append("llm_processing")
+
+        async def process_single_crawl_result(result: Dict[str, Any]):
+            page_url = result.get("url", "Unknown URL")
+            title = result.get("title", "")
+            content = result.get("content", "")
+            if not content:
+                return result, None, "no_content"
+
+            original_size = len(content)
+            processed = await process_content_with_llm(
+                content,
+                page_url,
+                title,
+                effective_model,
+                min_length,
+            )
+            if processed:
+                result["raw_content"] = content
+                result["content"] = processed
+                metrics = {
+                    "url": page_url,
+                    "original_size": original_size,
+                    "processed_size": len(processed),
+                    "compression_ratio": len(processed) / original_size if original_size else 1.0,
+                    "model_used": effective_model,
+                }
+                return result, metrics, "processed"
+
+            metrics = {
+                "url": page_url,
+                "original_size": original_size,
+                "processed_size": original_size,
+                "compression_ratio": 1.0,
+                "model_used": None,
+                "reason": "content_too_short",
+            }
+            return result, metrics, "too_short"
+
+        tasks = [process_single_crawl_result(result) for result in response.get("results", [])]
+        processed_results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result_item in processed_results:
+            if isinstance(result_item, BaseException):
+                logger.warning("Web crawl result processing task failed: %s", result_item)
+                continue
+            result, metrics, status = result_item
+            page_url = result.get("url", "Unknown URL")
+            if status == "processed":
+                debug_call_data["compression_metrics"].append(metrics)
+                debug_call_data["pages_processed_with_llm"] += 1
+                logger.info("%s (processed)", page_url)
+            elif status == "too_short":
+                debug_call_data["compression_metrics"].append(metrics)
+                logger.info("%s (no processing - content too short)", page_url)
+            else:
+                logger.warning("%s (no content to process)", page_url)
+    elif use_llm_processing and not auxiliary_available:
+        logger.warning("LLM processing requested but no auxiliary model available, returning raw content")
+        debug_call_data["processing_applied"].append("llm_processing_unavailable")
+
+    trimmed_results = [
+        {
+            "url": r.get("url", ""),
+            "title": r.get("title", ""),
+            "content": r.get("content", ""),
+            "error": r.get("error"),
+            **({"blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
+        }
+        for r in response.get("results", [])
+    ]
+    result_json = json.dumps({"results": trimmed_results}, indent=2, ensure_ascii=False)
+    cleaned_result = clean_base64_images(result_json)
+
+    debug_call_data["final_response_size"] = len(cleaned_result)
+    debug_call_data["processing_applied"].append("base64_image_removal")
+    _debug.log_call("web_crawl_tool", debug_call_data)
+    _debug.save()
+    return cleaned_result
+
+
+async def web_crawl_tool(
+    url: str,
+    instructions: str = None,
+    depth: str = "basic",
+    use_llm_processing: bool = True,
+    model: Optional[str] = None,
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+) -> str:
+    """Crawl a website using the configured crawl-capable web backend."""
+    debug_call_data = {
+        "parameters": {
+            "url": url,
+            "instructions": instructions,
+            "depth": depth,
+            "use_llm_processing": use_llm_processing,
+            "model": model,
+            "min_length": min_length,
+        },
+        "error": None,
+        "pages_crawled": 0,
+        "pages_processed_with_llm": 0,
+        "original_response_size": 0,
+        "final_response_size": 0,
+        "compression_metrics": [],
+        "processing_applied": [],
+    }
+
+    try:
+        effective_model = model or (_get_default_summarizer_model() if use_llm_processing else None)
+        auxiliary_available = check_auxiliary_model() if use_llm_processing else False
+        backend = _get_crawl_backend()
+
+        if not url.startswith(("http://", "https://")):
+            url = f"https://{url}"
+            logger.info("Added https:// prefix to URL: %s", url)
+
+        normalized_url = normalize_url_for_request(url)
+        if normalized_url != url:
+            url = normalized_url
+            debug_call_data["parameters"]["url"] = url
+
+        if not await async_is_safe_url(url):
+            return json.dumps(
+                {
+                    "results": [
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "error": "Blocked: URL targets a private or internal network address",
+                        }
+                    ]
+                },
+                ensure_ascii=False,
+            )
+
+        blocked = check_website_access(url)
+        if blocked:
+            logger.info("Blocked web_crawl for %s by rule %s", blocked["host"], blocked["rule"])
+            return json.dumps(
+                {
+                    "results": [
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "error": blocked["message"],
+                            "blocked_by_policy": {
+                                "host": blocked["host"],
+                                "rule": blocked["rule"],
+                                "source": blocked["source"],
+                            },
+                        }
+                    ]
+                },
+                ensure_ascii=False,
+            )
+
+        from tools.interrupt import is_interrupted as _is_int
+        if _is_int():
+            return tool_error("Interrupted", success=False)
+
+        if backend in ("searxng", "brave-free", "ddgs", "xai"):
+            label = {
+                "searxng": "SearXNG",
+                "brave-free": "Brave Search (free tier)",
+                "ddgs": "DuckDuckGo (ddgs)",
+                "xai": "xAI Web Search",
+            }[backend]
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"{label} is a search-only backend and cannot crawl URLs. "
+                        "Set web.crawl_backend to crawl4ai, firecrawl, or tavily."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+
+        if backend in ("crawl4ai", _LOCAL_OSS_BACKEND):
+            if instructions:
+                logger.info(
+                    "Instructions parameter ignored for Crawl4AI crawl API; "
+                    "Hermes applies summarization after crawling"
+                )
+            logger.info("Crawl4AI crawl: %s (depth=%s)", url, depth)
+            results = await _crawl4ai_crawl(url, depth=depth)
+            return await _finalize_web_crawl_results(
+                results,
+                debug_call_data=debug_call_data,
+                use_llm_processing=use_llm_processing,
+                auxiliary_available=auxiliary_available,
+                effective_model=effective_model,
+                min_length=min_length,
+            )
+
+        if backend == "tavily":
+            logger.info("Tavily crawl: %s", url)
+            payload: Dict[str, Any] = {
+                "url": url,
+                "limit": 20,
+                "extract_depth": depth,
+            }
+            if instructions:
+                payload["instructions"] = instructions
+            raw = await asyncio.to_thread(_tavily_request, "crawl", payload)
+            results = _normalize_tavily_documents(raw, fallback_url=url)
+            return await _finalize_web_crawl_results(
+                results,
+                debug_call_data=debug_call_data,
+                use_llm_processing=use_llm_processing,
+                auxiliary_available=auxiliary_available,
+                effective_model=effective_model,
+                min_length=min_length,
+            )
+
+        if backend == "firecrawl":
+            if not check_firecrawl_api_key():
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            "web_crawl requires Firecrawl. Set FIRECRAWL_API_KEY, "
+                            "FIRECRAWL_API_URL"
+                            f"{_firecrawl_backend_help_suffix()}, or use web_search + web_extract instead."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+
+            if instructions:
+                logger.info("Instructions parameter ignored (not supported in Firecrawl crawl API)")
+            crawl_params = {
+                "limit": 20,
+                "scrape_options": {"formats": ["markdown"]},
+            }
+            logger.info("Firecrawl crawl: %s", url)
+            crawl_result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    _get_firecrawl_client().crawl,
+                    url=url,
+                    **crawl_params,
+                ),
+                timeout=180,
+            )
+            results = _normalize_firecrawl_crawl_results(crawl_result)
+            return await _finalize_web_crawl_results(
+                results,
+                debug_call_data=debug_call_data,
+                use_llm_processing=use_llm_processing,
+                auxiliary_available=auxiliary_available,
+                effective_model=effective_model,
+                min_length=min_length,
+            )
+
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"web_crawl is not supported by the configured backend '{backend}'. "
+                    "Use Crawl4AI, Firecrawl, Tavily, or configure web.backend=local_oss."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    except Exception as e:
+        error_msg = f"Error crawling website: {str(e)}"
+        logger.debug("%s", error_msg)
+
+        debug_call_data["error"] = error_msg
+        _debug.log_call("web_crawl_tool", debug_call_data)
+        _debug.save()
+
+        return tool_error(error_msg)
+
+
+def check_web_search_available() -> bool:
+    """Check whether the configured search backend is available."""
+    backend = _get_backend_for_capability("search")
+    return _backend_supports_capability(backend, "search") and _is_backend_available(backend)
+
+
+def check_web_extract_available() -> bool:
+    """Check whether the configured extraction backend is available."""
+    backend = _get_backend_for_capability("extract")
+    return _backend_supports_capability(backend, "extract") and _is_backend_available(backend)
+
+
+def check_web_crawl_available() -> bool:
+    """Check whether the configured crawl backend is available."""
+    backend = _get_backend_for_capability("crawl")
+    return _backend_supports_capability(backend, "crawl") and _is_backend_available(backend)
+
+
 def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+    """Check whether any configured web capability is available."""
+    configured = _normalize_backend_name(_load_web_config().get("backend"))
+    if configured in _KNOWN_WEB_BACKENDS:
         return _is_backend_available(configured)
     return any(
-        _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+        (
+            check_web_search_available(),
+            check_web_extract_available(),
+            check_web_crawl_available(),
+        )
     )
 
 
@@ -1226,11 +1714,15 @@ if __name__ == "__main__":
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
         elif backend == "searxng":
-            print(f"   Using SearXNG (search only): {_env_value('SEARXNG_URL')}")
+            print(f"   Using SearXNG (search only): {_env_value('SEARXNG_API_URL') or _env_value('SEARXNG_URL')}")
         elif backend == "brave-free":
             print("   Using Brave Search free tier (search only)")
         elif backend == "ddgs":
             print("   Using DuckDuckGo via ddgs package (search only)")
+        elif backend == "crawl4ai":
+            print("   Using Crawl4AI (extract/crawl only)")
+        elif backend == _LOCAL_OSS_BACKEND:
+            print("   Using local OSS backend (SearXNG + Crawl4AI)")
         elif firecrawl_url_available:
             print(f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}")
         elif firecrawl_key_available:
@@ -1242,7 +1734,8 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, "
+            "FIRECRAWL_API_URL, SEARXNG_API_URL, or CRAWL4AI_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 
@@ -1353,6 +1846,31 @@ WEB_EXTRACT_SCHEMA = {
     }
 }
 
+WEB_CRAWL_SCHEMA = {
+    "name": "web_crawl",
+    "description": "Crawl a website and return page content in markdown format. Uses a crawl-capable backend such as Firecrawl, Tavily, Crawl4AI, or local_oss. Use this when you need multiple pages from the same site; for a single page, prefer web_extract.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "Base website URL to crawl.",
+            },
+            "instructions": {
+                "type": "string",
+                "description": "Optional crawl/extraction instructions when supported by the backend.",
+            },
+            "depth": {
+                "type": "string",
+                "enum": ["basic", "advanced"],
+                "description": "Crawl depth. basic crawls shallowly; advanced allows one additional link depth.",
+                "default": "basic",
+            },
+        },
+        "required": ["url"],
+    },
+}
+
 registry.register(
     name="web_search",
     toolset="web",
@@ -1373,5 +1891,20 @@ registry.register(
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="web_crawl",
+    toolset="web",
+    schema=WEB_CRAWL_SCHEMA,
+    handler=lambda args, **kw: web_crawl_tool(
+        args.get("url", ""),
+        instructions=args.get("instructions"),
+        depth=args.get("depth", "basic"),
+    ),
+    check_fn=check_web_api_key,
+    requires_env=_web_requires_env(),
+    is_async=True,
+    emoji="🕸️",
     max_result_size_chars=100_000,
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "web_crawl",
     # Terminal + process management
     "terminal", "process",
     # Read the desktop GUI's embedded terminal pane (gated on HERMES_DESKTOP
@@ -92,7 +92,7 @@ TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
+        "tools": ["web_search", "web_extract", "web_crawl"],
         "includes": []  # No other toolsets included
     },
     
@@ -377,7 +377,7 @@ TOOLSETS = {
     "hermes-acp": {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_crawl",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
@@ -397,7 +397,7 @@ TOOLSETS = {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
             # Web
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_crawl",
             # Terminal + process management
             "terminal", "process",
             # File manipulation


### PR DESCRIPTION
## Summary

- add a bundled `local_oss` web provider that routes `web_search` to SearXNG and `web_extract` to Crawl4AI
- register `crawl4ai` as an extract-only backend so `web.extract_backend: crawl4ai` is a real provider name
- expose `web_crawl` in Hermes web toolsets and route crawl-capable backends through Firecrawl, Tavily, Crawl4AI, or `local_oss`
- normalize Crawl4AI v0.8.x response shapes to Hermes' existing document schema and use Crawl4AI's `/md` endpoint for flat markdown output

## Why

Hermes already has a good web tool surface, but the self-hosted story was incomplete:

- SearXNG-only integrations solve search but still need Firecrawl for extract/crawl
- Crawl4AI-only integrations still need a separate search backend
- `web.extract_backend: crawl4ai` had been suggested in related threads but was not a registered backend
- Crawl4AI's native `/crawl` response shape is richer than Hermes' current Firecrawl-shaped `content` path, so a straight endpoint swap returns oversized nested payloads instead of page markdown

This keeps the integration aligned with the current plugin-backed web provider architecture while making the local OSS stack usable end to end for search, fetch, and crawl.

## Implementation Notes

- `plugins/web/local_oss/` registers two providers:
  - `local_oss`: SearXNG search + Crawl4AI extract
  - `crawl4ai`: Crawl4AI extract-only for per-capability config
- `web_crawl` remains in `tools/web_tools.py` because the web provider ABC currently models search/extract, not crawl
- `web.crawl_backend` was added as an additive config key for explicit crawl routing
- SearXNG now accepts both `SEARXNG_API_URL` and legacy `SEARXNG_URL`
- no hosts, ports, or backend endpoints are hardcoded in code

The returned Hermes shape stays aligned with the current web tools contract:

```json
{
  "results": [
    {
      "url": "...",
      "title": "...",
      "content": "...",
      "error": null
    }
  ]
}
```

## Hermes Configuration

Recommended explicit config:

```yaml
web:
  backend: local_oss
browser:
  cloud_provider: local
```

Required environment variables for the local OSS web stack:

```bash
SEARXNG_API_URL=http://<your-searxng-host>:<port>
CRAWL4AI_API_URL=http://<your-crawl4ai-host>:<port>
```

Optional environment variables:

```bash
CRAWL4AI_API_TOKEN=<token-if-your-crawl4ai-instance-enables-auth>
BROWSER_CDP_URL=http://<your-cdp-host>:9222
```

Notes:

- if `web.backend` is not set, Hermes auto-detects `local_oss` when both `SEARXNG_API_URL` and `CRAWL4AI_API_URL` are present
- if only Crawl4AI is available, `web.extract_backend: crawl4ai` and `web.crawl_backend: crawl4ai` are supported
- `BROWSER_CDP_URL` is optional and only needed if you also want Hermes browser tools to use a local CDP-compatible browser

## Self-Hosted Backend Notes

### SearXNG

Hermes expects SearXNG's JSON search API. That means your SearXNG instance must allow `format=json` on `/search`.

In practice, `json` needs to be enabled in SearXNG's `search.formats` settings:

```yaml
search:
  formats:
    - html
    - json
```

If JSON is disabled, SearXNG returns `403` for `format=json` requests.

### Crawl4AI

This adapter targets the Crawl4AI v0.8.x REST shape.

For extract/crawl support, Hermes only needs the Crawl4AI API to be reachable at `CRAWL4AI_API_URL`.

For optional local browser support via the same stack, Hermes can already connect to any local CDP-compatible browser through `BROWSER_CDP_URL`. In local validation, that meant enabling Crawl4AI's built-in browser/CDP path and exposing a debugging port. The relevant Crawl4AI-side settings looked like:

```yaml
crawler:
  browser:
    kwargs:
      browser_mode: builtin
      debugging_port: 9222
    extra_args:
      - --remote-debugging-address=0.0.0.0
```

## Validation

Focused changed-area tests on Windows with the repo dev environment:

```bash
uv run --extra all --extra dev pytest tests/tools/test_web_tools_config.py tests/tools/test_web_tools_local_oss.py tests/tools/test_web_providers.py tests/tools/test_web_providers_searxng.py tests/plugins/web/test_web_search_provider_plugins.py tests/test_toolsets.py -q --timeout-method=thread
```

Result:

- `189 passed`

`--timeout-method=thread` is only needed for this Windows run because the repo pytest config uses `--timeout-method=signal`, which requires `SIGALRM`.

## Scope

Intentionally out of scope for this PR:

- changes to Hermes browser tool implementation
- a broader web provider ABC refactor to model crawl as a plugin capability
- docs updates for every deployment topology

This PR stays focused on making the existing Hermes web tools work cleanly with a self-hosted SearXNG + Crawl4AI stack.