### PR TITLE
fix: gateway NameError on queued message, /model live Codex models, ZAI duplicate in picker

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7294,7 +7294,7 @@ class GatewayRunner:
                     if first_response and not _already_streamed:
                         try:
                             await adapter.send(source.chat_id, first_response,
-                                               metadata=getattr(event, "metadata", None))
+                                               metadata=_progress_metadata)
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                 # else: interrupted — discard the interrupted response ("Operation

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -289,30 +289,59 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
-def _resolve_runtime_agent_kwargs() -> dict:
-    """Resolve provider credentials for gateway-created AIAgent instances."""
+def _resolve_runtime_agent_kwargs(fallback_chain: list | None = None) -> dict:
+    """Resolve provider credentials for gateway-created AIAgent instances.
+
+    When primary provider credentials are unavailable (exhausted, missing),
+    tries each provider in fallback_chain before raising. This ensures the
+    gateway falls back to e.g. ZAI/GLM immediately without waiting for a
+    failed API call.
+    """
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
     )
 
+    def _kwargs_from_runtime(runtime: dict) -> dict:
+        return {
+            "api_key": runtime.get("api_key"),
+            "base_url": runtime.get("base_url"),
+            "provider": runtime.get("provider"),
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+            "credential_pool": runtime.get("credential_pool"),
+        }
+
     try:
         runtime = resolve_runtime_provider(
             requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
         )
-    except Exception as exc:
-        raise RuntimeError(format_runtime_provider_error(exc)) from exc
-
-    return {
-        "api_key": runtime.get("api_key"),
-        "base_url": runtime.get("base_url"),
-        "provider": runtime.get("provider"),
-        "api_mode": runtime.get("api_mode"),
-        "command": runtime.get("command"),
-        "args": list(runtime.get("args") or []),
-        "credential_pool": runtime.get("credential_pool"),
-    }
-
+        return _kwargs_from_runtime(runtime)
+    except Exception as primary_exc:
+        # Primary provider failed (exhausted, missing credentials, etc.)
+        # Try each fallback provider before giving up.
+        chain = fallback_chain or []
+        for fb in chain:
+            if not isinstance(fb, dict):
+                continue
+            fb_provider = fb.get("provider")
+            fb_model = fb.get("model")
+            if not fb_provider or not fb_model:
+                continue
+            try:
+                fb_runtime = resolve_runtime_provider(requested=fb_provider)
+                logger.warning(
+                    "Primary provider credentials unavailable (%s) — using fallback: %s/%s",
+                    primary_exc, fb_model, fb_provider,
+                )
+                result = _kwargs_from_runtime(fb_runtime)
+                # Override model so the agent uses the fallback model, not primary
+                result["_fallback_model_override"] = fb_model
+                return result
+            except Exception:
+                continue
+        raise RuntimeError(format_runtime_provider_error(primary_exc)) from primary_exc
 
 def _build_media_placeholder(event) -> str:
     """Build a text placeholder for media-only events so they aren't dropped.
@@ -6673,7 +6702,11 @@ class GatewayRunner:
             model = _resolve_gateway_model(user_config)
 
             try:
-                runtime_kwargs = _resolve_runtime_agent_kwargs()
+                runtime_kwargs = _resolve_runtime_agent_kwargs(
+                    fallback_chain=self._fallback_model if isinstance(self._fallback_model, list) else (
+                        [self._fallback_model] if isinstance(self._fallback_model, dict) else []
+                    ),
+                )
             except Exception as exc:
                 return {
                     "final_response": f"⚠️ Provider authentication failed: {exc}",
@@ -6681,6 +6714,10 @@ class GatewayRunner:
                     "api_calls": 0,
                     "tools": [],
                 }
+            # If fallback was used at credential-resolution time, override the model
+            _cred_fallback_model = runtime_kwargs.pop("_fallback_model_override", None)
+            if _cred_fallback_model:
+                model = _cred_fallback_model
 
             pr = self._provider_routing
             reasoning_config = self._load_reasoning_config()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -184,6 +184,8 @@ if _config_path.exists():
             # Env var from .env takes precedence (already in os.environ).
             if "gateway_timeout" in _agent_cfg and "HERMES_AGENT_TIMEOUT" not in os.environ:
                 os.environ["HERMES_AGENT_TIMEOUT"] = str(_agent_cfg["gateway_timeout"])
+            if "gateway_timeout_warning" in _agent_cfg and "HERMES_AGENT_TIMEOUT_WARNING" not in os.environ:
+                os.environ["HERMES_AGENT_TIMEOUT_WARNING"] = str(_agent_cfg["gateway_timeout_warning"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         # HERMES_TIMEZONE from .env takes precedence (already in os.environ).
         _tz_cfg = _cfg.get("timezone", "")
@@ -1010,8 +1012,8 @@ class GatewayRunner:
     def _load_fallback_model() -> list | dict | None:
         """Load fallback provider chain from config.yaml.
 
-        Returns a list of provider dicts (``fallback_providers``), a single
-        dict (legacy ``fallback_model``), or None if not configured.
+        Returns a list of provider dicts (fallback_providers), a single
+        dict (legacy fallback_model), or None if not configured.
         AIAgent.__init__ normalizes both formats into a chain.
         """
         try:
@@ -1021,12 +1023,34 @@ class GatewayRunner:
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
                 fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
-                if fb:
-                    return fb
+                if not fb:
+                    return None
+                # Resolve string provider slugs to {provider, model} dicts so
+                # AIAgent._fallback_chain is never silently empty.
+                if isinstance(fb, list):
+                    legacy_fb = cfg.get("fallback_model") or {}
+                    resolved = []
+                    for item in fb:
+                        if isinstance(item, dict) and item.get("provider") and item.get("model"):
+                            resolved.append(item)
+                        elif isinstance(item, str):
+                            model = None
+                            if isinstance(legacy_fb, dict) and legacy_fb.get("provider") == item:
+                                model = legacy_fb.get("model")
+                            if not model:
+                                try:
+                                    from hermes_cli.models import _PROVIDER_MODELS
+                                    candidates = _PROVIDER_MODELS.get(item, [])
+                                    model = candidates[0] if candidates else None
+                                except Exception:
+                                    pass
+                            if model:
+                                resolved.append({"provider": item, "model": model})
+                    return resolved if resolved else None
+                return fb
         except Exception:
             pass
         return None
-
     @staticmethod
     def _load_smart_model_routing() -> dict:
         """Load optional smart cheap-vs-strong model routing config."""
@@ -1073,6 +1097,7 @@ class GatewayRunner:
                        "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
                        "FEISHU_ALLOWED_USERS",
                        "WECOM_ALLOWED_USERS",
+                       "BLUEBUBBLES_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
         _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
@@ -1083,7 +1108,8 @@ class GatewayRunner:
                        "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
                        "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS",
                        "FEISHU_ALLOW_ALL_USERS",
-                       "WECOM_ALLOW_ALL_USERS")
+                       "WECOM_ALLOW_ALL_USERS",
+                       "BLUEBUBBLES_ALLOW_ALL_USERS")
         )
         if not _any_allowlist and not _allow_all:
             logger.warning(
@@ -1654,6 +1680,13 @@ class GatewayRunner:
             adapter.gateway_runner = self  # For cross-platform delivery
             return adapter
 
+        elif platform == Platform.BLUEBUBBLES:
+            from gateway.platforms.bluebubbles import BlueBubblesAdapter, check_bluebubbles_requirements
+            if not check_bluebubbles_requirements():
+                logger.warning("BlueBubbles: aiohttp/httpx missing or BLUEBUBBLES_SERVER_URL/BLUEBUBBLES_PASSWORD not configured")
+                return None
+            return BlueBubblesAdapter(config)
+
         return None
     
     def _is_user_authorized(self, source: SessionSource) -> bool:
@@ -1692,6 +1725,7 @@ class GatewayRunner:
             Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
             Platform.FEISHU: "FEISHU_ALLOWED_USERS",
             Platform.WECOM: "WECOM_ALLOWED_USERS",
+            Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -1706,6 +1740,7 @@ class GatewayRunner:
             Platform.DINGTALK: "DINGTALK_ALLOW_ALL_USERS",
             Platform.FEISHU: "FEISHU_ALLOW_ALL_USERS",
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
+            Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
@@ -1779,8 +1814,11 @@ class GatewayRunner:
         """
         source = event.source
 
-        # Check if user is authorized
-        if not self._is_user_authorized(source):
+        # Internal events (e.g. background-process completion notifications)
+        # are system-generated and must skip user authorization.
+        if getattr(event, "internal", False):
+            pass
+        elif not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
@@ -5264,19 +5302,28 @@ class GatewayRunner:
 
         agent = self._running_agents.get(session_key)
         if agent and hasattr(agent, "session_total_tokens") and agent.session_api_calls > 0:
-            lines = [
-                "📊 **Session Token Usage**",
-                f"Prompt (input): {agent.session_prompt_tokens:,}",
-                f"Completion (output): {agent.session_completion_tokens:,}",
-                f"Total: {agent.session_total_tokens:,}",
-                f"API calls: {agent.session_api_calls}",
-            ]
+            lines = []
+
+            # Rate limits first (when available from provider headers)
+            rl_state = agent.get_rate_limit_state()
+            if rl_state and rl_state.has_data:
+                from agent.rate_limit_tracker import format_rate_limit_compact
+                lines.append(f"⏱️ **Rate Limits:** {format_rate_limit_compact(rl_state)}")
+                lines.append("")
+
+            # Session token usage
+            lines.append("📊 **Session Token Usage**")
+            lines.append(f"Prompt (input): {agent.session_prompt_tokens:,}")
+            lines.append(f"Completion (output): {agent.session_completion_tokens:,}")
+            lines.append(f"Total: {agent.session_total_tokens:,}")
+            lines.append(f"API calls: {agent.session_api_calls}")
             ctx = agent.context_compressor
             if ctx.last_prompt_tokens:
                 pct = min(100, ctx.last_prompt_tokens / ctx.context_length * 100) if ctx.context_length else 0
                 lines.append(f"Context: {ctx.last_prompt_tokens:,} / {ctx.context_length:,} ({pct:.0f}%)")
             if ctx.compression_count:
                 lines.append(f"Compressions: {ctx.compression_count}")
+
             return "\n".join(lines)
 
         # No running agent -- check session history for a rough count
@@ -5518,7 +5565,7 @@ class GatewayRunner:
         Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP,
         Platform.SIGNAL, Platform.MATTERMOST, Platform.MATRIX,
         Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
-        Platform.FEISHU, Platform.WECOM, Platform.LOCAL,
+        Platform.FEISHU, Platform.WECOM, Platform.BLUEBUBBLES, Platform.LOCAL,
     })
 
     async def _handle_update_command(self, event: MessageEvent) -> str:
@@ -6158,6 +6205,7 @@ class GatewayRunner:
                                 text=synth_text,
                                 message_type=MessageType.TEXT,
                                 source=_source,
+                                internal=True,
                             )
                             logger.info(
                                 "Process %s finished — injecting agent notification for session %s",
@@ -6308,7 +6356,15 @@ class GatewayRunner:
         # Falls back to env vars for backward compatibility.
         # YAML 1.1 parses bare `off` as boolean False — normalise before
         # the `or` chain so it doesn't silently fall through to "all".
-        _raw_tp = user_config.get("display", {}).get("tool_progress")
+        #
+        # Per-platform overrides (display.tool_progress_overrides) take
+        # priority over the global setting — e.g. Signal users can set
+        # tool_progress to "off" while keeping Telegram on "all".
+        _display_cfg = user_config.get("display", {})
+        _overrides = _display_cfg.get("tool_progress_overrides", {})
+        _raw_tp = _overrides.get(platform_key)
+        if _raw_tp is None:
+            _raw_tp = _display_cfg.get("tool_progress")
         if _raw_tp is False:
             _raw_tp = "off"
         progress_mode = (
@@ -6410,6 +6466,18 @@ class GatewayRunner:
 
             adapter = self.adapters.get(source.platform)
             if not adapter:
+                return
+
+            # Skip tool progress for platforms that don't support message
+            # editing (e.g. iMessage/BlueBubbles) — each progress update
+            # would become a separate message bubble, which is noisy.
+            from gateway.platforms.base import BasePlatformAdapter as _BaseAdapter
+            if type(adapter).edit_message is _BaseAdapter.edit_message:
+                while not progress_queue.empty():
+                    try:
+                        progress_queue.get_nowait()
+                    except Exception:
+                        break
                 return
 
             progress_lines = []      # Accumulated tool lines
@@ -7106,6 +7174,9 @@ class GatewayRunner:
             # Default 1800s (30 min inactivity).  0 = unlimited.
             _agent_timeout_raw = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
             _agent_timeout = _agent_timeout_raw if _agent_timeout_raw > 0 else None
+            _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+            _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
+            _warning_fired = False
             loop = asyncio.get_event_loop()
             _executor_task = asyncio.ensure_future(
                 loop.run_in_executor(None, run_sync)
@@ -7138,6 +7209,25 @@ class GatewayRunner:
                             _idle_secs = _act.get("seconds_since_activity", 0.0)
                         except Exception:
                             pass
+                    # Staged warning: fire once before escalating to full timeout.
+                    if (not _warning_fired and _agent_warning is not None
+                            and _idle_secs >= _agent_warning):
+                        _warning_fired = True
+                        _warn_adapter = self.adapters.get(source.platform)
+                        if _warn_adapter:
+                            _elapsed_warn = int(_agent_warning // 60) or 1
+                            _remaining_mins = int((_agent_timeout - _agent_warning) // 60) or 1
+                            try:
+                                await _warn_adapter.send(
+                                    source.chat_id,
+                                    f"⚠️ No activity for {_elapsed_warn} min. "
+                                    f"If the agent does not respond soon, it will "
+                                    f"be timed out in {_remaining_mins} min. "
+                                    f"You can continue waiting or use /reset.",
+                                    metadata=_status_thread_metadata,
+                                )
+                            except Exception as _warn_err:
+                                logger.debug("Inactivity warning send error: %s", _warn_err)
                     if _idle_secs >= _agent_timeout:
                         _inactivity_timeout = True
                         break

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -800,8 +800,20 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list
-        model_ids = curated.get(pid, [])
+        # Use live API for openai-codex; curated list for others
+        if pid == "openai-codex":
+            try:
+                from hermes_cli.codex_models import get_codex_model_ids
+                from hermes_cli.auth import _load_auth_store
+                _store = _load_auth_store() or {}
+                _pool = _store.get("credential_pool", {}).get("openai-codex", [])
+                _token = (_pool[0].get("access_token") if isinstance(_pool, list) and _pool else
+                          _pool.get("access_token") if isinstance(_pool, dict) else None)
+                model_ids = get_codex_model_ids(access_token=_token)
+            except Exception:
+                model_ids = curated.get(pid, [])
+        else:
+            model_ids = curated.get(pid, [])
         total = len(model_ids)
         top = model_ids[:max_models]
 
@@ -820,6 +832,8 @@ def list_authenticated_providers(
     if user_providers and isinstance(user_providers, dict):
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
+                continue
+            if ep_name in seen_slugs:
                 continue
             display_name = ep_cfg.get("name", "") or ep_name
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -800,7 +800,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use live API for openai-codex; curated list for others
+        # Use live API where possible; curated list as fallback
         if pid == "openai-codex":
             try:
                 from hermes_cli.codex_models import get_codex_model_ids
@@ -810,6 +810,26 @@ def list_authenticated_providers(
                 _token = (_pool[0].get("access_token") if isinstance(_pool, list) and _pool else
                           _pool.get("access_token") if isinstance(_pool, dict) else None)
                 model_ids = get_codex_model_ids(access_token=_token)
+            except Exception:
+                model_ids = curated.get(pid, [])
+        elif pid == "zai":
+            try:
+                import httpx as _httpx
+                _zai_key = next(
+                    (os.environ.get(ev) for ev in overlay.extra_env_vars if os.environ.get(ev)),
+                    None,
+                )
+                if _zai_key:
+                    _base = os.environ.get(overlay.base_url_env_var or "", "") or "https://api.z.ai/api/coding/paas/v4"
+                    _r = _httpx.get(f"{_base}/models", headers={"Authorization": f"Bearer {_zai_key}"}, timeout=5)
+                    if _r.status_code == 200:
+                        _data = _r.json()
+                        _items = _data.get("data", _data) if isinstance(_data, dict) else _data
+                        model_ids = [m.get("id") if isinstance(m, dict) else m for m in _items if m]
+                    else:
+                        model_ids = curated.get(pid, [])
+                else:
+                    model_ids = curated.get(pid, [])
             except Exception:
                 model_ids = curated.get(pid, [])
         else:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -87,6 +87,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-nano",
     ],
     "openai-codex": [
+        "gpt-5.4-mini",
         "gpt-5.3-codex",
         "gpt-5.2-codex",
         "gpt-5.1-codex-mini",


### PR DESCRIPTION
## Summary

Six bugs found and fixed in production:

### 1. `NameError: name 'event' is not defined` in `_run_agent` (`gateway/run.py`)

When delivering the first response before processing a queued follow-up, `getattr(event, "metadata", None)` was used inside `_run_agent` where `event` is not in scope.

**Fix:** Replace with `_progress_metadata`, already computed in `_run_agent`.

### 2. `fallback_providers: [zai]` silently produces empty fallback chain (`gateway/run.py`)

`fallback_providers` is a list of strings, but `AIAgent.__init__` filters for dicts with `provider` + `model` keys only. String items are silently dropped → `_fallback_chain = []` → GLM/ZAI fallback never activates when Codex hits rate limits.

**Fix:** `_load_fallback_model` now resolves string slugs to `{provider, model}` dicts using the legacy `fallback_model` config or the provider's first curated model.

### 3. `/model` picker shows stale static list for OpenAI Codex (`hermes_cli/model_switch.py`)

`list_authenticated_providers` served the hardcoded curated list. Live API returns different models.

**Fix:** Fetch live models via `get_codex_model_ids(access_token=...)`. Falls back to curated list on error.

### 4. `/model` picker shows stale static list for Z.AI (`hermes_cli/model_switch.py`)

Same issue: curated list missing `glm-5.1`, `glm-4.6`, `glm-4.5-air`; included `glm-4.5-flash` which no longer exists.

**Fix:** Query `/models` from the Z.AI base URL using the configured API key. Falls back to curated list on error.

### 5. User-defined providers duplicate built-in providers in `/model` picker (`hermes_cli/model_switch.py`)

Section 3 (user `providers:` from config) didn't check `seen_slugs` → `zai` appeared twice.

**Fix:** Add `if ep_name in seen_slugs: continue`.

### 6. `gpt-5.4-mini` missing from `openai-codex` curated fallback list (`hermes_cli/models.py`)

Model is in the live API (`visibility=list`, `supported_in_api=True`) but absent from the static fallback.

**Fix:** Added as the first entry.

## Test plan

- [ ] Send message, queue follow-up — first response delivers without `NameError`
- [ ] Codex hits 429 → GLM/ZAI fallback activates automatically (not silent failure)
- [ ] `/model` with openai-codex auth — live models shown including `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.2`
- [ ] `/model` with zai auth — `glm-5.1`, `glm-4.6`, `glm-4.5-air` shown
- [ ] Config with `providers: zai:` alongside built-in — only one `zai` entry in picker