### PR TITLE
fix(security): restrict RPC socket perms to owner (0o600)

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -941,26 +941,62 @@ def execute_code(
             f.write(code)
 
         # --- Start UDS server ---
-        # Restrict the RPC socket to the owning user (0o600). This channel
-        # accepts JSON-RPC requests that execute the sandbox tool surface
-        # (terminal, file ops, web, etc.) with this process's privileges —
-        # on a shared system, default-permission sockets in /tmp let any
-        # local user connect and drive the tools. We set umask before
-        # bind() so the socket inode is created with the correct mode on
-        # filesystems that honour umask, then os.chmod() as defense in
-        # depth for filesystems (NFS, some network mounts) that ignore it.
-        _old_umask = os.umask(0o077)
-        try:
-            server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            server_sock.bind(sock_path)
-        finally:
-            os.umask(_old_umask)
+        # Restrict the RPC socket to the owning user. This channel accepts
+        # JSON-RPC requests that execute the sandbox tool surface (terminal,
+        # file ops, web, etc.) with this process's privileges — on a shared
+        # system, default-permission sockets in /tmp let any local user
+        # connect and drive the tools.
+        #
+        # Approach:
+        #   1. bind() creates the socket inode with default perms.
+        #   2. Immediately chmod to 0o600 (owner rw only).
+        #   3. Stat-verify the resulting mode and fail-closed if any
+        #      group/other bit is still set — refuses to expose the tool
+        #      surface on a filesystem where chmod was a silent no-op.
+        #
+        # Deliberately avoids `os.umask()` here because umask is process-
+        # global and not thread-safe — any other thread creating files
+        # during the bind window would inherit the temporary umask.
+        server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server_sock.bind(sock_path)
         try:
             os.chmod(sock_path, 0o600)
-        except OSError:
-            # Non-fatal: umask already applied the intended perms. Only
-            # hits exotic filesystems where chmod on a UDS is unsupported.
-            pass
+        except OSError as _chmod_err:
+            logger.warning(
+                "Could not chmod RPC socket %s: %s (will verify mode below)",
+                sock_path,
+                _chmod_err,
+            )
+
+        # Fail-closed: verify the socket is actually owner-only before we
+        # accept any connection. If chmod was a no-op on an exotic
+        # filesystem and the mode still allows group/other access, we
+        # cannot safely expose the tool surface — tear down and raise.
+        try:
+            _sock_mode = os.stat(sock_path).st_mode & 0o777
+        except OSError as _stat_err:
+            # If we can't stat our own socket, something is deeply wrong.
+            server_sock.close()
+            try:
+                os.unlink(sock_path)
+            except OSError:
+                pass
+            raise RuntimeError(
+                f"RPC socket {sock_path} could not be stat'd after bind: "
+                f"{_stat_err}; refusing to expose code-execution tool surface."
+            ) from _stat_err
+        if _sock_mode & 0o077:
+            server_sock.close()
+            try:
+                os.unlink(sock_path)
+            except OSError:
+                pass
+            raise RuntimeError(
+                f"RPC socket {sock_path} has permissive mode "
+                f"0o{_sock_mode:03o} after bind+chmod; refusing to expose "
+                f"code-execution tool surface on a shared socket."
+            )
+
         server_sock.listen(1)
 
         rpc_thread = threading.Thread(

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -941,8 +941,26 @@ def execute_code(
             f.write(code)
 
         # --- Start UDS server ---
-        server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        server_sock.bind(sock_path)
+        # Restrict the RPC socket to the owning user (0o600). This channel
+        # accepts JSON-RPC requests that execute the sandbox tool surface
+        # (terminal, file ops, web, etc.) with this process's privileges —
+        # on a shared system, default-permission sockets in /tmp let any
+        # local user connect and drive the tools. We set umask before
+        # bind() so the socket inode is created with the correct mode on
+        # filesystems that honour umask, then os.chmod() as defense in
+        # depth for filesystems (NFS, some network mounts) that ignore it.
+        _old_umask = os.umask(0o077)
+        try:
+            server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server_sock.bind(sock_path)
+        finally:
+            os.umask(_old_umask)
+        try:
+            os.chmod(sock_path, 0o600)
+        except OSError:
+            # Non-fatal: umask already applied the intended perms. Only
+            # hits exotic filesystems where chmod on a UDS is unsupported.
+            pass
         server_sock.listen(1)
 
         rpc_thread = threading.Thread(


### PR DESCRIPTION
## Summary

Fixes #6230 — local privilege escalation via world-accessible RPC socket.

The sandbox code-execution RPC channel at `tools/code_execution_tool.py:943` binds a Unix domain socket at a predictable path in `/tmp` that accepts JSON-RPC requests driving the full sandbox tool surface (terminal, file ops, web fetch, code execution) with the Hermes process's privileges. Without explicit permission hardening the socket inode is created with default permissions — 0o755 on macOS, umask-dependent on Linux (typically 0o755/0o775 with a default 0o022 umask).

On a shared system any local user can:
1. `ls /tmp/hermes_rpc_*.sock` (the filename uses a predictable prefix and a `uuid4().hex` suffix)
2. `connect()` to it
3. Frame and send a JSON-RPC request to execute arbitrary tool calls

This elevates from \"local user with shell\" to \"full Hermes tool execution as the Hermes process owner.\"

## Fix

Belt-and-suspenders: set a restrictive umask *before* `bind()` so the socket is created with 0o600 directly on filesystems that honour umask, then explicitly `os.chmod(0o600)` for defense in depth. The chmod is wrapped in a narrow `try/except OSError` because a small set of exotic filesystems (e.g. some NFS mounts) reject chmod on socket nodes — in those cases the umask-applied perms are still in effect, so the chmod failure is non-fatal.

\`\`\`python
# Before:
server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
server_sock.bind(sock_path)

# After:
_old_umask = os.umask(0o077)
try:
    server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
    server_sock.bind(sock_path)
finally:
    os.umask(_old_umask)
try:
    os.chmod(sock_path, 0o600)
except OSError:
    # Non-fatal: umask already applied the intended perms.
    pass
\`\`\`

The umask save/restore is scoped to the bind call only, so it doesn't leak into any other file creation in this process.

## Test plan

Reproduced both states locally on macOS with a minimal harness:

\`\`\`python
# Baseline (current main)
s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
s.bind(sock_path)
# → 0o755 (world-readable)

# Patched
_old = os.umask(0o077)
s.bind(sock_path)
os.umask(_old)
os.chmod(sock_path, 0o600)
# → 0o600 (owner-only)
\`\`\`

- [x] Baseline confirmed: unpatched socket perms are 0o755 on macOS `/tmp`
- [x] Patched: socket perms are 0o600
- [x] Python AST parse passes (no syntax regressions)
- [x] Imports already present (`os`, `socket` both imported at the top of the file)
- [ ] CI suite (please run on merge)

## Severity

**Local privilege escalation / unauthorized tool execution** on any multi-user host running `hermes`. Single-user systems (most developer machines) are unaffected in practice, but CI runners, shared dev boxes, and container hosts with multiple UIDs are exposed.

## Scope

Intentionally minimal — only the UDS bind site is touched. No changes to the RPC protocol, socket path naming, sandbox tool surface, or the env-stripping already in place below this call site.