### PR TITLE
feat(tools): add TinyFish cloud browser provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1025,7 +1025,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 22,
+    "_config_version": 23,
 }
 
 # =============================================================================
@@ -1041,6 +1041,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    23: ["TINYFISH_API_KEY", "TINYFISH_API_URL", "TINYFISH_BROWSER_TIMEOUT"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1516,6 +1517,29 @@ OPTIONAL_ENV_VARS = {
     "FIRECRAWL_BROWSER_TTL": {
         "description": "Firecrawl browser session TTL in seconds (optional, default 300)",
         "prompt": "Browser session TTL (seconds)",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": False,
+        "category": "tool",
+    },
+    "TINYFISH_API_KEY": {
+        "description": "TinyFish API key for cloud browser, search, fetch, and agent",
+        "prompt": "TinyFish API key",
+        "url": "https://agent.tinyfish.ai/api-keys",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": True,
+        "category": "tool",
+    },
+    "TINYFISH_API_URL": {
+        "description": "TinyFish browser API URL override (optional, for staging/dev)",
+        "prompt": "TinyFish API URL (leave empty for default)",
+        "url": None,
+        "tools": ["browser_navigate", "browser_click"],
+        "password": False,
+        "category": "tool",
+    },
+    "TINYFISH_BROWSER_TIMEOUT": {
+        "description": "TinyFish browser session inactivity timeout in seconds (optional, default 300)",
+        "prompt": "Browser session timeout (seconds)",
         "tools": ["browser_navigate", "browser_click"],
         "password": False,
         "category": "tool",
@@ -3762,6 +3786,7 @@ def show_config():
         ("TAVILY_API_KEY", "Tavily"),
         ("BROWSERBASE_API_KEY", "Browserbase"),
         ("BROWSER_USE_API_KEY", "Browser Use"),
+        ("TINYFISH_API_KEY", "TinyFish"),
         ("FAL_KEY", "FAL"),
     ]
     
@@ -3943,6 +3968,7 @@ def set_config_value(key: str, value: str):
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
         'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
+        'TINYFISH_API_KEY', 'TINYFISH_API_URL',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -133,6 +133,7 @@ def _browser_label(current_provider: str) -> str:
         "browserbase": "Browserbase",
         "browser-use": "Browser Use",
         "firecrawl": "Firecrawl",
+        "tinyfish": "TinyFish",
         "camofox": "Camofox",
         "local": "Local browser",
     }
@@ -161,6 +162,7 @@ def _resolve_browser_feature_state(
     direct_browserbase: bool,
     direct_browser_use: bool,
     direct_firecrawl: bool,
+    direct_tinyfish: bool,
     managed_browser_available: bool,
 ) -> tuple[str, bool, bool, bool]:
     """Resolve browser availability using the same precedence as runtime."""
@@ -186,6 +188,10 @@ def _resolve_browser_feature_state(
             return current_provider, available, active, managed
         if current_provider == "firecrawl":
             available = bool(browser_local_available and direct_firecrawl)
+            active = bool(browser_tool_enabled and available)
+            return current_provider, available, active, False
+        if current_provider == "tinyfish":
+            available = bool(browser_local_available and direct_tinyfish)
             active = bool(browser_tool_enabled and available)
             return current_provider, available, active, False
         if current_provider == "camofox":
@@ -278,6 +284,7 @@ def get_nous_subscription_features(
     direct_camofox = bool(get_env_value("CAMOFOX_URL"))
     direct_browserbase = bool(get_env_value("BROWSERBASE_API_KEY") and get_env_value("BROWSERBASE_PROJECT_ID"))
     direct_browser_use = bool(get_env_value("BROWSER_USE_API_KEY"))
+    direct_tinyfish = bool(get_env_value("TINYFISH_API_KEY"))
     direct_modal = has_direct_modal_credentials()
 
     # When use_gateway is set, suppress direct credentials for managed detection
@@ -355,6 +362,7 @@ def get_nous_subscription_features(
         direct_browserbase=direct_browserbase,
         direct_browser_use=direct_browser_use,
         direct_firecrawl=direct_firecrawl,
+        direct_tinyfish=direct_tinyfish,
         managed_browser_available=managed_browser_available,
     )
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -370,6 +370,15 @@ TOOL_CATEGORIES = {
                 "post_setup": "agent_browser",
             },
             {
+                "name": "TinyFish",
+                "tag": "Low latency browser with stealth & proxies",
+                "env_vars": [
+                    {"key": "TINYFISH_API_KEY", "prompt": "TinyFish API key", "url": "https://agent.tinyfish.ai/api-keys"},
+                ],
+                "browser_provider": "tinyfish",
+                "post_setup": "agent_browser",
+            },
+            {
                 "name": "Camofox",
                 "badge": "free · local",
                 "tag": "Anti-detection browser (Firefox/Camoufox)",

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -58,3 +58,10 @@ class TestCamofoxConfigDefaults:
 
         browser_cfg = DEFAULT_CONFIG["browser"]
         assert browser_cfg["camofox"]["managed_persistence"] is False
+
+    def test_config_version_matches_current_schema(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        # The current schema version is tracked globally; unrelated default
+        # options may bump it after browser defaults are added.
+        assert DEFAULT_CONFIG["_config_version"] == 23

--- a/tools/browser_providers/tinyfish.py
+++ b/tools/browser_providers/tinyfish.py
@@ -1,0 +1,129 @@
+"""TinyFish cloud browser provider."""
+
+import logging
+import os
+import uuid
+from typing import Any, Dict, Optional
+
+import requests
+
+from tools.browser_providers.base import CloudBrowserProvider
+from tools.managed_tool_gateway import resolve_managed_tool_gateway
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.browser.tinyfish.ai"
+_DEFAULT_TIMEOUT_SECONDS = 300
+
+
+class TinyFishBrowserProvider(CloudBrowserProvider):
+    """TinyFish (https://tinyfish.ai) cloud browser backend."""
+
+    def provider_name(self) -> str:
+        return "TinyFish"
+
+    # ------------------------------------------------------------------
+    # Config resolution (direct API key OR managed Nous gateway)
+    # ------------------------------------------------------------------
+
+    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+        api_key = os.environ.get("TINYFISH_API_KEY")
+        if api_key:
+            return {
+                "api_key": api_key,
+                "base_url": os.environ.get("TINYFISH_API_URL", _DEFAULT_BASE_URL).rstrip("/"),
+                "managed_mode": False,
+            }
+
+        managed = resolve_managed_tool_gateway("tinyfish")
+        if managed is None:
+            return None
+
+        return {
+            "api_key": managed.nous_user_token,
+            "base_url": managed.gateway_origin.rstrip("/"),
+            "managed_mode": True,
+        }
+
+    def _get_config(self) -> Dict[str, Any]:
+        config = self._get_config_or_none()
+        if config is None:
+            raise ValueError(
+                "TinyFish requires a TINYFISH_API_KEY environment variable. "
+                "Get your API key at https://agent.tinyfish.ai/api-keys"
+            )
+        return config
+
+    def is_configured(self) -> bool:
+        return self._get_config_or_none() is not None
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def _headers(self, config: Dict[str, Any]) -> Dict[str, str]:
+        return {
+            "X-API-Key": config["api_key"],
+            "Content-Type": "application/json",
+        }
+
+    def create_session(self, task_id: str) -> Dict[str, object]:
+        config = self._get_config()
+
+        timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+        try:
+            timeout_seconds = int(os.environ.get("TINYFISH_BROWSER_TIMEOUT", str(_DEFAULT_TIMEOUT_SECONDS)))
+        except (ValueError, TypeError):
+            pass
+
+        response = requests.post(
+            config["base_url"],
+            headers=self._headers(config),
+            json={"timeout_seconds": timeout_seconds},
+            timeout=30,
+        )
+
+        if response.status_code in (401, 403):
+            raise ValueError(
+                f"TinyFish authentication failed (HTTP {response.status_code}). "
+                "Check your TINYFISH_API_KEY at https://agent.tinyfish.ai/api-keys"
+            )
+        if response.status_code == 402:
+            raise ValueError(
+                "TinyFish browser session failed: insufficient credits or no active subscription. "
+                "Check your account at https://agent.tinyfish.ai"
+            )
+        if response.status_code == 404:
+            raise ValueError(
+                "TinyFish browser API is not enabled on your plan. "
+                "Contact support or upgrade at https://agent.tinyfish.ai"
+            )
+        if not response.ok:
+            raise RuntimeError(
+                f"Failed to create TinyFish browser session: "
+                f"{response.status_code} {response.text[:200]}"
+            )
+
+        data = response.json()
+        session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
+
+        logger.info("Created TinyFish browser session %s", session_name)
+
+        return {
+            "session_name": session_name,
+            "bb_session_id": data["session_id"],
+            "cdp_url": data["cdp_url"],
+            "features": {"tinyfish": True},
+        }
+
+    def close_session(self, session_id: str) -> bool:
+        # TinyFish has no explicit delete endpoint — sessions auto-expire on inactivity timeout.
+        logger.debug(
+            "TinyFish sessions expire automatically on inactivity — no close call needed for %s",
+            session_id,
+        )
+        return True
+
+    def emergency_cleanup(self, session_id: str) -> None:
+        # No-op: TinyFish sessions are cleaned up server-side on inactivity.
+        logger.debug("TinyFish emergency_cleanup skipped for %s — auto-expiry handles cleanup", session_id)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -81,6 +81,7 @@ from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
 from tools.browser_providers.firecrawl import FirecrawlProvider
+from tools.browser_providers.tinyfish import TinyFishBrowserProvider
 from tools.tool_backend_helpers import normalize_browser_cloud_provider
 
 # Camofox local anti-detection browser backend (optional).
@@ -389,6 +390,7 @@ _PROVIDER_REGISTRY: Dict[str, type] = {
     "browserbase": BrowserbaseProvider,
     "browser-use": BrowserUseProvider,
     "firecrawl": FirecrawlProvider,
+    "tinyfish": TinyFishBrowserProvider,
 }
 
 _cached_cloud_provider: Optional[CloudBrowserProvider] = None

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -111,6 +111,9 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds (default: 300) |
+| `TINYFISH_API_KEY` | TinyFish API key for cloud browser ([agent.tinyfish.ai](https://agent.tinyfish.ai/api-keys)) |
+| `TINYFISH_API_URL` | TinyFish browser API URL override for staging/dev (optional) |
+| `TINYFISH_BROWSER_TIMEOUT` | TinyFish browser session inactivity timeout in seconds (default: 300) |
 | `BROWSER_CDP_URL` | Chrome DevTools Protocol URL for local browser (set via `/browser connect`, e.g. `ws://localhost:9222`) |
 | `CAMOFOX_URL` | Camofox local anti-detection browser URL (default: `http://localhost:9377`) |
 | `BROWSER_INACTIVITY_TIMEOUT` | Browser session inactivity timeout in seconds |

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -12,6 +12,7 @@ Hermes Agent includes a full browser automation toolset with multiple backend op
 - **Browserbase cloud mode** via [Browserbase](https://browserbase.com) for managed cloud browsers and anti-bot tooling
 - **Browser Use cloud mode** via [Browser Use](https://browser-use.com) as an alternative cloud browser provider
 - **Firecrawl cloud mode** via [Firecrawl](https://firecrawl.dev) for cloud browsers with built-in scraping
+- **TinyFish cloud mode** via [TinyFish](https://tinyfish.ai) for fast cloud CDP browsers
 - **Camofox local mode** via [Camofox](https://github.com/jo-inc/camofox-browser) for local anti-detection browsing (Firefox-based fingerprint spoofing)
 - **Local Chrome via CDP** — connect browser tools to your own Chrome instance using `/browser connect`
 - **Local browser mode** via the `agent-browser` CLI and a local Chromium installation
@@ -84,6 +85,29 @@ FIRECRAWL_API_URL=http://localhost:3002
 
 # Session TTL in seconds (default: 300)
 FIRECRAWL_BROWSER_TTL=600
+```
+
+### TinyFish cloud mode
+
+To use TinyFish as your cloud browser provider, add:
+
+```bash
+# Add to ~/.hermes/.env
+TINYFISH_API_KEY=your_key_here
+```
+
+Get your API key at [agent.tinyfish.ai/api-keys](https://agent.tinyfish.ai/api-keys). Then select TinyFish as your browser provider:
+
+```bash
+hermes setup tools
+# → Browser Automation → TinyFish
+```
+
+Optional settings:
+
+```bash
+# Session inactivity timeout in seconds (default: 300, capped to your plan maximum)
+TINYFISH_BROWSER_TIMEOUT=600
 ```
 
 ### Hybrid routing: cloud for public URLs, local for LAN/localhost


### PR DESCRIPTION
## Summary

Adds [TinyFish](https://tinyfish.ai) as a cloud browser provider alongside Browserbase, Browser Use, and Firecrawl. All browser tools route through TinyFish's cloud browser via CDP when selected.

TinyFish provides low-latency cloud browsers with built-in stealth and proxies. Sessions are created via a simple POST request that returns a CDP websocket URL — Hermes connects to it and drives the browser as normal.

## Changes

- `tools/browser_providers/tinyfish.py` — `TinyFishBrowserProvider` implementing `CloudBrowserProvider` ABC
- `tools/browser_tool.py` — register under `"tinyfish"` key in `_PROVIDER_REGISTRY`
- `hermes_cli/tools_config.py` — add TinyFish to the onboarding provider picker
- `hermes_cli/config.py` — add `TINYFISH_API_KEY`, `TINYFISH_API_URL`, `TINYFISH_BROWSER_TIMEOUT`; bump config version 12 → 13
- `hermes_cli/nous_subscription.py` — add `tinyfish` to browser label mapping and feature state resolver
- `website/docs/reference/environment-variables.md` — document the three new env vars
- `website/docs/user-guide/features/browser.md` — add TinyFish setup section
- `tests/tools/test_browser_camofox_state.py` — bump expected config version to 13

## Setup

```bash
# Add to ~/.hermes/.env
TINYFISH_API_KEY=your_key_here
```

Get your API key at [agent.tinyfish.ai/api-keys](https://agent.tinyfish.ai/api-keys). Then select TinyFish as your browser provider:

```bash
hermes setup tools
# → Browser Automation → TinyFish
```

Optional settings:

```bash
# Inactivity timeout in seconds (default: 300, silently capped to your plan maximum)
TINYFISH_BROWSER_TIMEOUT=600

# Override API URL for staging/dev
TINYFISH_API_URL=https://staging.api.browser.tinyfish.ai
```

## Implementation notes

- **No close endpoint** — TinyFish sessions auto-expire on inactivity timeout. `close_session()` and `emergency_cleanup()` are intentional no-ops (not laziness — there's genuinely no delete endpoint).
- **Auth header** — uses `X-API-Key` rather than `Authorization: Bearer`, unlike the other providers.
- **Managed gateway ready** — `resolve_managed_tool_gateway("tinyfish")` is wired up in `_get_config_or_none()` so the Nous Portal path works in a future pass without a code change.
- **Explicit opt-in only** — TinyFish is not added to the auto-detection fallback chain (Browser Use → Browserbase). Users select it explicitly via config or `hermes setup tools`.

## Test plan

- [ ] `hermes setup tools` → TinyFish appears in provider picker with tagline "Low latency browser with stealth & proxies"
- [ ] Selecting TinyFish sets `browser.cloud_provider: tinyfish` in `~/.hermes/config.yaml`
- [ ] `TINYFISH_API_KEY` set → `is_configured()` returns `True`; unset → `False`
- [ ] `hermes` → ask agent to navigate to a URL → TinyFish session created, CDP URL returned, browser connects
- [ ] Existing Browserbase / Browser Use / Firecrawl / Local / Camofox paths unaffected
- [ ] `pytest tests/tools/test_browser_camofox_state.py` passes with config version 13