### PR TITLE
fix(gateway): suppress memory tool progress in messaging output

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6336,6 +6336,14 @@ class GatewayRunner:
             if event_type not in ("tool.started",):
                 return
 
+            # Suppress internal memory tool lifecycle from user-facing gateway
+            # progress output. The memory tool's args (content/old_text) were
+            # leaking into Telegram messages with raw +/-/~ operation markers
+            # (see issue #6316). Memory writes should be silent on messaging
+            # platforms; CLI progress is unaffected.
+            if tool_name == "memory":
+                return
+
             # "new" mode: only report when tool changes
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return


### PR DESCRIPTION
Fixes #6316

## Problem
The memory tool's internal lifecycle events were being forwarded to platform progress messages, causing raw operation markers (`+`/`-`/`~`) and `old_text`/`content` arguments to appear directly in Telegram chats:

```
🧠 memory: "+memory: \"BUG: memory tool response...\""
🧠 memory: "~memory: \"Matrix homeserver UR\""
🧠 memory: "-memory: \"OpenClaw models via\""
```

## Fix
Skip `memory` tool events in the gateway `progress_callback` (`gateway/run.py`). Memory writes are now silent on messaging platforms. CLI progress display is unaffected since it has its own callback.

Minimal 8-line change, no behavioral impact outside the gateway progress stream.