### PR TITLE
fix(state): isolate session search between multiple agent instances

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,6 +16,7 @@ Key design decisions:
 
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -31,7 +32,24 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
+
+
+def get_current_instance_id() -> Optional[str]:
+    """Return the current Hermes instance id from ``HERMES_INSTANCE_ID``.
+
+    When multiple Hermes Agent processes share a single state database
+    (e.g. finance vs. general-purpose profiles running side-by-side against
+    the same ``HERMES_HOME``), setting ``HERMES_INSTANCE_ID`` on each process
+    isolates session search / recent-session listings so that one instance
+    cannot leak conversations into another.  Returns ``None`` when the env
+    var is unset or empty — in which case behavior is unchanged and all
+    sessions remain visible (backwards compatible).
+
+    See issue #6320.
+    """
+    val = os.getenv("HERMES_INSTANCE_ID", "").strip()
+    return val or None
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -65,6 +83,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    instance_id TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -87,6 +106,8 @@ CREATE TABLE IF NOT EXISTS messages (
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
+-- NOTE: idx_sessions_instance is created after the v7 migration below,
+-- because legacy databases may not yet have the instance_id column.
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 """
 
@@ -329,6 +350,24 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add instance_id column to sessions — isolates session
+                # search / recent-session listings between multiple Hermes
+                # Agent instances that share a single state database
+                # (e.g. different profiles like hermes-finance and hermes).
+                # See #6320.
+                try:
+                    cursor.execute("ALTER TABLE sessions ADD COLUMN instance_id TEXT")
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                try:
+                    cursor.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_sessions_instance "
+                        "ON sessions(instance_id)"
+                    )
+                except sqlite3.OperationalError:
+                    pass
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -339,6 +378,17 @@ class SessionDB:
             )
         except sqlite3.OperationalError:
             pass  # Index already exists
+
+        # Instance id index — safe to create post-migration because v7 is
+        # guaranteed to have added the column by now, either via ALTER TABLE
+        # above or via the initial CREATE TABLE on a fresh database.
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_instance "
+                "ON sessions(instance_id)"
+            )
+        except sqlite3.OperationalError:
+            pass
 
         # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
         try:
@@ -361,13 +411,31 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        instance_id: Optional[str] = None,
     ) -> str:
-        """Create a new session record. Returns the session_id."""
+        """Create a new session record. Returns the session_id.
+
+        When *instance_id* is ``None`` the current process-level instance id
+        (``HERMES_INSTANCE_ID``) is captured automatically so every session
+        gets tagged with the profile that created it.  Child sessions inherit
+        their parent's ``instance_id`` when the caller omits it, keeping
+        delegation chains in the same isolation bucket.
+        """
+        if instance_id is None:
+            instance_id = get_current_instance_id()
+            if instance_id is None and parent_session_id:
+                # Inherit from parent so compression / delegation sessions
+                # stay in the same isolation bucket even if HERMES_INSTANCE_ID
+                # is set differently for a subprocess.
+                parent = self.get_session(parent_session_id)
+                if parent and parent.get("instance_id"):
+                    instance_id = parent["instance_id"]
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, instance_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -377,6 +445,7 @@ class SessionDB:
                     system_prompt,
                     parent_session_id,
                     time.time(),
+                    instance_id,
                 ),
             )
         self._execute_write(_do)
@@ -511,12 +580,14 @@ class SessionDB:
         create_session() call (e.g. transient SQLite lock at agent startup).
         INSERT OR IGNORE is safe to call even when the row already exists.
         """
+        instance_id = get_current_instance_id()
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions
-                   (id, source, model, started_at)
-                   VALUES (?, ?, ?, ?)""",
-                (session_id, source, model, time.time()),
+                   (id, source, model, started_at, instance_id)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (session_id, source, model, time.time(), instance_id),
             )
         self._execute_write(_do)
 
@@ -787,6 +858,7 @@ class SessionDB:
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
+        instance_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -812,6 +884,12 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+
+        # Instance isolation (#6320): when HERMES_INSTANCE_ID is set,
+        # hide sessions created by other instances sharing this state.db.
+        if instance_id is not None:
+            where_clauses.append("s.instance_id IS ?")
+            params.append(instance_id)
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         query = f"""
@@ -1057,6 +1135,7 @@ class SessionDB:
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
+        instance_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1095,6 +1174,14 @@ class SessionDB:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+
+        # Instance isolation (#6320): when HERMES_INSTANCE_ID is set,
+        # hide messages from sessions owned by other instances sharing
+        # this state.db.  ``IS ?`` binds correctly against NULL too,
+        # but instance_id will always be a non-NULL string here.
+        if instance_id is not None:
+            where_clauses.append("s.instance_id IS ?")
+            params.append(instance_id)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -857,7 +857,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -913,12 +913,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to current schema version
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1286,7 +1286,92 @@ class TestConcurrentWriteSafety:
         assert len(msgs) == 1
         assert msgs[0]["content"] == "hello after lock"
 
-    def test_sqlite_timeout_is_at_least_30s(self, db):
+
+# =========================================================================
+# Instance isolation (#6320)
+# =========================================================================
+
+class TestInstanceIsolation:
+    """Multiple Hermes profiles sharing one state.db must not leak sessions.
+
+    See issue #6320 — running hermes-finance and hermes side-by-side against
+    the same HERMES_HOME caused session_search to return cross-profile hits.
+    """
+
+    def test_create_session_captures_env_instance_id(self, db, monkeypatch):
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "finance")
+        db.create_session(session_id="f1", source="cli")
+        row = db.get_session("f1")
+        assert row["instance_id"] == "finance"
+
+    def test_create_session_without_env_leaves_null(self, db, monkeypatch):
+        monkeypatch.delenv("HERMES_INSTANCE_ID", raising=False)
+        db.create_session(session_id="s1", source="cli")
+        assert db.get_session("s1")["instance_id"] is None
+
+    def test_explicit_instance_id_overrides_env(self, db, monkeypatch):
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "general")
+        db.create_session(session_id="s1", source="cli", instance_id="explicit")
+        assert db.get_session("s1")["instance_id"] == "explicit"
+
+    def test_child_session_inherits_parent_instance_id(self, db, monkeypatch):
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "finance")
+        db.create_session(session_id="parent", source="cli")
+        monkeypatch.delenv("HERMES_INSTANCE_ID", raising=False)
+        db.create_session(
+            session_id="child", source="cli", parent_session_id="parent"
+        )
+        assert db.get_session("child")["instance_id"] == "finance"
+
+    def test_search_messages_scoped_by_instance(self, db, monkeypatch):
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "finance")
+        db.create_session(session_id="fin1", source="cli")
+        db.append_message("fin1", role="user", content="quarterly earnings report")
+
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "general")
+        db.create_session(session_id="gen1", source="cli")
+        db.append_message("gen1", role="user", content="quarterly earnings report")
+
+        # Finance instance should only see its own session
+        fin_hits = db.search_messages(query="quarterly", instance_id="finance")
+        assert [h["session_id"] for h in fin_hits] == ["fin1"]
+
+        gen_hits = db.search_messages(query="quarterly", instance_id="general")
+        assert [h["session_id"] for h in gen_hits] == ["gen1"]
+
+        # No filter — legacy behavior, both are visible.
+        all_hits = db.search_messages(query="quarterly")
+        assert {h["session_id"] for h in all_hits} == {"fin1", "gen1"}
+
+    def test_list_sessions_rich_scoped_by_instance(self, db, monkeypatch):
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "finance")
+        db.create_session(session_id="fin1", source="cli")
+        db.append_message("fin1", role="user", content="b3 validation")
+
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "general")
+        db.create_session(session_id="gen1", source="cli")
+        db.append_message("gen1", role="user", content="general notes")
+
+        fin_rows = db.list_sessions_rich(instance_id="finance")
+        assert [r["id"] for r in fin_rows] == ["fin1"]
+
+        gen_rows = db.list_sessions_rich(instance_id="general")
+        assert [r["id"] for r in gen_rows] == ["gen1"]
+
+        unfiltered = db.list_sessions_rich()
+        assert {r["id"] for r in unfiltered} == {"fin1", "gen1"}
+
+    def test_get_current_instance_id_helper(self, monkeypatch):
+        from hermes_state import get_current_instance_id
+        monkeypatch.delenv("HERMES_INSTANCE_ID", raising=False)
+        assert get_current_instance_id() is None
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "  ")
+        assert get_current_instance_id() is None
+        monkeypatch.setenv("HERMES_INSTANCE_ID", "finance")
+        assert get_current_instance_id() == "finance"
+
+
+    def test_sqlite_timeout_is_at_least_30s_isolated(self, db):
         """Connection timeout should be >= 30s to survive CLI/gateway contention."""
         # Access the underlying connection timeout via sqlite3 introspection.
         # There is no public API, so we check the kwarg via the module default.

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -195,7 +195,20 @@ _HIDDEN_SESSION_SOURCES = ("tool",)
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
-        sessions = db.list_sessions_rich(limit=limit + 5, exclude_sources=list(_HIDDEN_SESSION_SOURCES))  # fetch extra to skip current
+        # Per-instance isolation (#6320): when HERMES_INSTANCE_ID is set,
+        # multiple Hermes profiles sharing one state.db must not see each
+        # other's sessions.  When unset, behavior is unchanged.
+        try:
+            from hermes_state import get_current_instance_id
+            instance_id = get_current_instance_id()
+        except ImportError:
+            instance_id = None
+
+        sessions = db.list_sessions_rich(
+            limit=limit + 5,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            instance_id=instance_id,
+        )  # fetch extra to skip current
 
         # Resolve current session lineage to exclude it
         current_root = None
@@ -275,6 +288,17 @@ def session_search(
         if role_filter and role_filter.strip():
             role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
+        # Per-instance isolation (#6320): when HERMES_INSTANCE_ID is set,
+        # scope the search to sessions owned by the current instance so
+        # multiple profiles sharing one state.db cannot leak into each
+        # other.  When the env var is unset, instance_id stays None and
+        # the query is unchanged.
+        try:
+            from hermes_state import get_current_instance_id
+            instance_id = get_current_instance_id()
+        except ImportError:
+            instance_id = None
+
         # FTS5 search -- get matches ranked by relevance
         raw_results = db.search_messages(
             query=query,
@@ -282,6 +306,7 @@ def session_search(
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             limit=50,  # Get more matches to find unique sessions
             offset=0,
+            instance_id=instance_id,
         )
 
         if not raw_results:


### PR DESCRIPTION
## Summary

- Fixes #6320 — running multiple Hermes profiles (e.g. `hermes-finance` and `hermes`) against a shared `state.db` leaked sessions across profiles because `session_search` and recent-session listings had no notion of a "current instance."
- Introduces an optional `HERMES_INSTANCE_ID` env var that tags every session at creation and scopes session search / recent listings to the active profile. When the env var is unset behavior is unchanged and all existing (NULL-tagged) sessions remain visible.
- Schema bumped to v7 with a nullable `sessions.instance_id` column plus `idx_sessions_instance`. Child sessions inherit their parent's `instance_id` so compression / delegation chains stay in the same isolation bucket.

## Root cause

`tools/session_search_tool.py` calls `db.search_messages()` and `db.list_sessions_rich()` with only `exclude_sources=("tool",)`. Both queries span *all* rows in `state.db`, so when two Hermes processes share a `HERMES_HOME` (the default `~/.hermes`) each instance sees the other's sessions. Memory files are already profile-scoped via `HERMES_HOME`, so the leak is specifically the SQLite session store.

## Fix

1. `hermes_state.py`
   - New `get_current_instance_id()` reads `HERMES_INSTANCE_ID` (stripped, empty -> None).
   - `create_session` / `ensure_session` auto-capture the current instance id. `create_session` also inherits from `parent_session_id` when the env var is unset so compression/delegation chains stay in the same bucket.
   - `search_messages` and `list_sessions_rich` gain an optional `instance_id` filter. Passing `None` preserves the legacy unfiltered query.
   - Schema v7 migration: `ALTER TABLE sessions ADD COLUMN instance_id TEXT` + `idx_sessions_instance`. Pre-v7 rows keep `instance_id = NULL`.
2. `tools/session_search_tool.py` — threads `get_current_instance_id()` into both DB calls used by the tool.
3. `tests/test_hermes_state.py` — new `TestInstanceIsolation` class covering env-var capture, explicit override, parent inheritance, `search_messages`/`list_sessions_rich` scoping, and the env-var helper. Updated schema-version tests to v7.

## Test plan

- [x] `pytest tests/test_hermes_state.py` — 141 passed (8 new isolation tests + migrated v2->v7 migration test).
- [x] `pytest tests/tools/test_session_search.py` — 25 passed.
- [ ] Manual: run two processes with `HERMES_INSTANCE_ID=finance` and `HERMES_INSTANCE_ID=general` sharing one `HERMES_HOME`, confirm each sees only its own sessions in `session_search`.
- [ ] Verify upgrade: existing `~/.hermes/state.db` migrates cleanly to v7 and legacy sessions (NULL `instance_id`) remain visible when `HERMES_INSTANCE_ID` is unset.

Fixes #6320