### PR TITLE
fix(discord): strip all mentions from auto-thread names

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1957,6 +1957,14 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         # Build a short thread name from the message
         content = (message.content or "").strip()
+        # Strip Discord mention syntax so thread names don't show raw IDs:
+        # - <@123> (user mention), <@!123> (user mention with nickname)
+        # - <@&456> (role mention)
+        # - <#789> (channel mention)
+        content = re.sub(r'<@!?\d+>', '', content)   # user mentions
+        content = re.sub(r'<@&\d+>', '', content)    # role mentions
+        content = re.sub(r'<#\d+>', '', content)    # channel mentions
+        content = content.strip()
         thread_name = content[:80] if content else "Hermes"
         if len(content) > 80:
             thread_name = thread_name[:77] + "..."


### PR DESCRIPTION
## Summary

Strips Discord mention syntax from auto-thread names to prevent raw IDs from appearing in thread titles.

**Before:** Thread named `Hello <@&1490963422786093149>`
**After:** Thread named `Hello`

## Changes

- Added regex stripping for role mentions (`<@&...>`)
- Added regex stripping for channel mentions (`<#...>`)  
- Added regex stripping for user mentions (`<@...>` and `<@!...>`)

Fixes #6336