### PR TITLE
fix(skills): block mutations in external skill dirs

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -268,6 +268,22 @@ class TestEditSkill:
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "A test skill" in content
 
+    def test_edit_external_skill_rejected(self, tmp_path):
+        local_skills = tmp_path / "local"
+        external_skills = tmp_path / "external"
+        local_skills.mkdir()
+        (external_skills / "shared-skill").mkdir(parents=True)
+        (external_skills / "shared-skill" / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local_skills), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[local_skills, external_skills]):
+            result = _edit_skill("shared-skill", VALID_SKILL_CONTENT_2)
+
+        assert result["success"] is False
+        assert "read-only" in result["error"]
+        assert "external_dirs" in result["error"]
+        assert "Updated description" not in (external_skills / "shared-skill" / "SKILL.md").read_text()
+
 
 class TestPatchSkill:
     def test_patch_unique_match(self, tmp_path):
@@ -330,6 +346,21 @@ word word
             result = _patch_skill("nonexistent", "old", "new")
         assert result["success"] is False
 
+    def test_patch_external_skill_rejected(self, tmp_path):
+        local_skills = tmp_path / "local"
+        external_skills = tmp_path / "external"
+        local_skills.mkdir()
+        (external_skills / "shared-skill").mkdir(parents=True)
+        (external_skills / "shared-skill" / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local_skills), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[local_skills, external_skills]):
+            result = _patch_skill("shared-skill", "Do the thing.", "Do the new thing.")
+
+        assert result["success"] is False
+        assert "read-only" in result["error"]
+        assert "Do the new thing." not in (external_skills / "shared-skill" / "SKILL.md").read_text()
+
 
 class TestDeleteSkill:
     def test_delete_existing(self, tmp_path):
@@ -349,6 +380,21 @@ class TestDeleteSkill:
             _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")
             _delete_skill("my-skill")
         assert not (tmp_path / "devops").exists()
+
+    def test_delete_external_skill_rejected(self, tmp_path):
+        local_skills = tmp_path / "local"
+        external_skills = tmp_path / "external"
+        local_skills.mkdir()
+        (external_skills / "shared-skill").mkdir(parents=True)
+        (external_skills / "shared-skill" / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local_skills), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[local_skills, external_skills]):
+            result = _delete_skill("shared-skill")
+
+        assert result["success"] is False
+        assert "read-only" in result["error"]
+        assert (external_skills / "shared-skill").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -333,6 +333,26 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     return result
 
 
+def _ensure_local_mutable_skill(name: str) -> Dict[str, Any]:
+    """Resolve a skill and refuse mutations outside the active local skills dir."""
+    existing = _find_skill(name)
+    if not existing:
+        return {"success": False, "error": f"Skill '{name}' not found. Use skills_list() to see available skills."}
+
+    try:
+        existing["path"].relative_to(SKILLS_DIR)
+    except ValueError:
+        return {
+            "success": False,
+            "error": (
+                f"Skill '{name}' is installed in external_dirs at {existing['path']} and is read-only. "
+                "Copy it into the active local skills directory before mutating it."
+            ),
+        }
+
+    return {"success": True, "existing": existing}
+
+
 def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     """Replace the SKILL.md of any existing skill (full rewrite)."""
     err = _validate_frontmatter(content)
@@ -343,9 +363,10 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if err:
         return {"success": False, "error": err}
 
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": f"Skill '{name}' not found. Use skills_list() to see available skills."}
+    resolved = _ensure_local_mutable_skill(name)
+    if not resolved["success"]:
+        return resolved
+    existing = resolved["existing"]
 
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
@@ -383,9 +404,10 @@ def _patch_skill(
     if new_string is None:
         return {"success": False, "error": "new_string is required for 'patch'. Use an empty string to delete matched text."}
 
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": f"Skill '{name}' not found."}
+    resolved = _ensure_local_mutable_skill(name)
+    if not resolved["success"]:
+        return resolved
+    existing = resolved["existing"]
 
     skill_dir = existing["path"]
 
@@ -454,9 +476,10 @@ def _patch_skill(
 
 def _delete_skill(name: str) -> Dict[str, Any]:
     """Delete a skill."""
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": f"Skill '{name}' not found."}
+    resolved = _ensure_local_mutable_skill(name)
+    if not resolved["success"]:
+        return resolved
+    existing = resolved["existing"]
 
     skill_dir = existing["path"]
     shutil.rmtree(skill_dir)


### PR DESCRIPTION
## Summary
- block `skill_manage` mutations when a skill resolves from `skills.external_dirs`
- keep `external_dirs` effectively read-only for edit, patch, and delete flows
- add regression tests covering external skill directories

## Testing
- `python -m pytest tests/tools/test_skill_manager_tool.py -q`
- `python -m pytest tests/tools/ -q` *(fails on pre-existing unrelated test: `tests/tools/test_vision_tools.py::TestVisionRequirements::test_check_requirements_accepts_codex_auth`)*

Closes #5947