### PR TITLE
feat(tools): Add user-configurable session settings for Browser Use provider

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -245,6 +245,19 @@ browser:
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
 
+  # Browser Use session settings — customise cloud browser sessions created via
+  # the Browser Use provider.  Each key can also be set (or overridden) with
+  # the corresponding BROWSER_USE_* environment variable.
+  #
+  # browser_use:
+  #   profile_id: ""                # Browser Use profile UUID
+  #   proxy_country_code: us        # Two-letter country code for the proxy
+  #   timeout: 5                    # Session timeout in minutes
+  #   screen_width: 1920            # Browser viewport width in pixels
+  #   screen_height: 1080           # Browser viewport height in pixels
+  #   allow_resizing: false         # Allow the browser window to be resized
+  #   enable_recording: false       # Record the browser session
+
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,105 @@
+"""Shared fixtures for tools tests requiring fake package installation."""
+
+import sys
+import threading
+import types
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+
+
+def _load_tool_module(module_name: str, filename: str):
+    """Load a tool module by file path, registering it in sys.modules."""
+    spec = spec_from_file_location(module_name, TOOLS_DIR / filename)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _reset_modules(prefixes: tuple[str, ...]):
+    """Remove all sys.modules entries matching the given prefixes."""
+    for name in list(sys.modules):
+        if name.startswith(prefixes):
+            sys.modules.pop(name, None)
+
+
+def _install_fake_tools_package():
+    """Install minimal fake tools/agent packages for isolated module loading."""
+    _reset_modules(("tools", "agent"))
+
+    tools_package = types.ModuleType("tools")
+    tools_package.__path__ = [str(TOOLS_DIR)]  # type: ignore[attr-defined]
+    sys.modules["tools"] = tools_package
+
+    env_package = types.ModuleType("tools.environments")
+    env_package.__path__ = [str(TOOLS_DIR / "environments")]  # type: ignore[attr-defined]
+    sys.modules["tools.environments"] = env_package
+
+    agent_package = types.ModuleType("agent")
+    agent_package.__path__ = []  # type: ignore[attr-defined]
+    sys.modules["agent"] = agent_package
+    sys.modules["agent.auxiliary_client"] = types.SimpleNamespace(
+        call_llm=lambda *args, **kwargs: "",
+    )
+
+    sys.modules["tools.managed_tool_gateway"] = _load_tool_module(
+        "tools.managed_tool_gateway",
+        "managed_tool_gateway.py",
+    )
+
+    interrupt_event = threading.Event()
+    sys.modules["tools.interrupt"] = types.SimpleNamespace(
+        set_interrupt=lambda value=True: interrupt_event.set() if value else interrupt_event.clear(),
+        is_interrupted=lambda: interrupt_event.is_set(),
+        _interrupt_event=interrupt_event,
+    )
+    sys.modules["tools.approval"] = types.SimpleNamespace(
+        detect_dangerous_command=lambda *args, **kwargs: None,
+        check_dangerous_command=lambda *args, **kwargs: {"approved": True},
+        check_all_command_guards=lambda *args, **kwargs: {"approved": True},
+        load_permanent_allowlist=lambda *args, **kwargs: [],
+        DANGEROUS_PATTERNS=[],
+    )
+
+    class _Registry:
+        def register(self, **kwargs):
+            return None
+
+    sys.modules["tools.registry"] = types.SimpleNamespace(registry=_Registry())
+
+
+@pytest.fixture()
+def restore_tool_and_agent_modules():
+    """Save and restore tools/agent sys.modules entries around each test."""
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "tools"
+        or name.startswith("tools.")
+        or name == "agent"
+        or name.startswith("agent.")
+    }
+    try:
+        yield
+    finally:
+        _reset_modules(("tools", "agent"))
+        sys.modules.update(original_modules)
+
+
+@pytest.fixture()
+def fake_tools_package(restore_tool_and_agent_modules):
+    """Install fake tools/agent packages and return a module loader callable.
+
+    Usage::
+
+        def test_something(fake_tools_package, tmp_path):
+            mod = fake_tools_package("tools.browser_providers.browser_use",
+                                     "browser_providers/browser_use.py")
+    """
+    _install_fake_tools_package()
+    return _load_tool_module

--- a/tests/tools/test_browser_use_session_settings.py
+++ b/tests/tools/test_browser_use_session_settings.py
@@ -1,0 +1,237 @@
+"""Tests for Browser Use session settings resolution."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable_managed_nous_tools(monkeypatch):
+    monkeypatch.setenv("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1")
+
+
+class _OkResponse:
+    """Fake HTTP 200 response for requests.post."""
+    status_code = 200
+    ok = True
+    text = ""
+
+    def __init__(self, data, headers=None):
+        self._data = data
+        self.headers = headers or {}
+
+    def json(self):
+        return self._data
+
+
+def _make_env(tmp_path, api_key="test-key", extras=None):
+    """Build an environment dict with HERMES_HOME and optional overrides."""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+    if api_key:
+        env["BROWSER_USE_API_KEY"] = api_key
+    else:
+        env.pop("BROWSER_USE_API_KEY", None)
+    if extras:
+        env.update(extras)
+    return env
+
+
+def _resolve_settings(fake_tools_package, tmp_path, config_yaml=None, env_extras=None):
+    """Write config, load provider, and return resolved session settings."""
+    if config_yaml is not None:
+        (tmp_path / "config.yaml").write_text(config_yaml, encoding="utf-8")
+    env = _make_env(tmp_path, extras=env_extras)
+    with patch.dict(os.environ, env, clear=True):
+        mod = fake_tools_package(
+            "tools.browser_providers.browser_use",
+            "browser_providers/browser_use.py",
+        )
+        return mod.BrowserUseProvider()._resolve_session_settings()
+
+
+class TestResolveSessionSettings:
+    """_resolve_session_settings reads from config.yaml and env vars."""
+
+    def test_from_config_yaml(self, fake_tools_package, tmp_path):
+        """Settings in config.yaml browser.browser_use are returned."""
+        settings = _resolve_settings(fake_tools_package, tmp_path, config_yaml=(
+            "browser:\n"
+            "  cloud_provider: browser-use\n"
+            "  browser_use:\n"
+            '    profile_id: "550e8400-e29b-41d4-a716-446655440000"\n'
+            "    proxy_country_code: de\n"
+            "    timeout: 10\n"
+            "    screen_width: 1920\n"
+            "    screen_height: 1080\n"
+            "    allow_resizing: true\n"
+            "    enable_recording: true\n"
+        ))
+        assert settings["profileId"] == "550e8400-e29b-41d4-a716-446655440000"
+        assert settings["proxyCountryCode"] == "de"
+        assert settings["timeout"] == 10
+        assert settings["browserScreenWidth"] == 1920
+        assert settings["browserScreenHeight"] == 1080
+        assert settings["allowResizing"] is True
+        assert settings["enableRecording"] is True
+
+    def test_empty_config(self, fake_tools_package, tmp_path):
+        """When browser_use section is absent, returns empty dict."""
+        settings = _resolve_settings(
+            fake_tools_package, tmp_path,
+            config_yaml="browser:\n  cloud_provider: browser-use\n",
+        )
+        assert settings == {}
+
+    def test_no_config_file(self, fake_tools_package, tmp_path):
+        """When config.yaml doesn't exist, returns empty dict."""
+        settings = _resolve_settings(fake_tools_package, tmp_path)
+        assert settings == {}
+
+    def test_no_browser_use_key_in_config(self, fake_tools_package, tmp_path):
+        """Works when config.yaml has a browser section but no browser_use key."""
+        settings = _resolve_settings(fake_tools_package, tmp_path, config_yaml=(
+            "browser:\n"
+            "  command_timeout: 30\n"
+            "  record_sessions: false\n"
+        ))
+        assert settings == {}
+
+    def test_from_env_vars(self, fake_tools_package, tmp_path):
+        """Environment variables populate session settings."""
+        settings = _resolve_settings(
+            fake_tools_package, tmp_path,
+            config_yaml="browser:\n  cloud_provider: browser-use\n",
+            env_extras={
+                "BROWSER_USE_PROFILE_ID": "env-profile-uuid",
+                "BROWSER_USE_PROXY_COUNTRY_CODE": "gb",
+                "BROWSER_USE_TIMEOUT": "15",
+                "BROWSER_USE_SCREEN_WIDTH": "1280",
+                "BROWSER_USE_SCREEN_HEIGHT": "720",
+                "BROWSER_USE_ALLOW_RESIZING": "true",
+                "BROWSER_USE_ENABLE_RECORDING": "1",
+            },
+        )
+        assert settings["profileId"] == "env-profile-uuid"
+        assert settings["proxyCountryCode"] == "gb"
+        assert settings["timeout"] == 15
+        assert settings["browserScreenWidth"] == 1280
+        assert settings["browserScreenHeight"] == 720
+        assert settings["allowResizing"] is True
+        assert settings["enableRecording"] is True
+
+    def test_env_overrides_config(self, fake_tools_package, tmp_path):
+        """Environment variables take precedence over config.yaml values."""
+        settings = _resolve_settings(
+            fake_tools_package, tmp_path,
+            config_yaml=(
+                "browser:\n"
+                "  browser_use:\n"
+                "    proxy_country_code: de\n"
+                "    timeout: 10\n"
+            ),
+            env_extras={"BROWSER_USE_PROXY_COUNTRY_CODE": "fr"},
+        )
+        assert settings["proxyCountryCode"] == "fr"
+        assert settings["timeout"] == 10
+
+    def test_boolean_false_values(self, fake_tools_package, tmp_path):
+        """Falsy string values ('false', '0') are parsed to False and retained."""
+        settings = _resolve_settings(
+            fake_tools_package, tmp_path,
+            config_yaml="",
+            env_extras={
+                "BROWSER_USE_ALLOW_RESIZING": "false",
+                "BROWSER_USE_ENABLE_RECORDING": "0",
+            },
+        )
+        assert settings["allowResizing"] is False
+        assert settings["enableRecording"] is False
+
+
+class TestCreateSessionPayload:
+    """Session settings flow through to create_session POST payload."""
+
+    def test_direct_mode_sends_user_settings(self, fake_tools_package, tmp_path):
+        """In direct mode, user session settings are sent in the POST payload."""
+        (tmp_path / "config.yaml").write_text(
+            "browser:\n"
+            "  browser_use:\n"
+            '    profile_id: "direct-profile-uuid"\n'
+            "    proxy_country_code: jp\n"
+            "    timeout: 30\n",
+            encoding="utf-8",
+        )
+        env = _make_env(tmp_path, api_key="direct-api-key")
+        response = _OkResponse({"id": "session-direct-1", "cdpUrl": "wss://cdp.example/session"})
+
+        with patch.dict(os.environ, env, clear=True):
+            mod = fake_tools_package(
+                "tools.browser_providers.browser_use",
+                "browser_providers/browser_use.py",
+            )
+            with patch.object(mod.requests, "post", return_value=response) as post:
+                mod.BrowserUseProvider().create_session("task-direct-settings")
+
+        payload = post.call_args.kwargs["json"]
+        assert payload["profileId"] == "direct-profile-uuid"
+        assert payload["proxyCountryCode"] == "jp"
+        assert payload["timeout"] == 30
+
+    def test_managed_mode_user_settings_override_defaults(self, fake_tools_package, tmp_path):
+        """In managed mode, user settings override the managed defaults."""
+        (tmp_path / "config.yaml").write_text(
+            "browser:\n"
+            "  browser_use:\n"
+            "    proxy_country_code: de\n"
+            "    timeout: 8\n",
+            encoding="utf-8",
+        )
+        env = _make_env(tmp_path, api_key=None, extras={
+            "TOOL_GATEWAY_USER_TOKEN": "nous-token",
+            "BROWSER_USE_GATEWAY_URL": "http://127.0.0.1:3009",
+        })
+        response = _OkResponse(
+            {"id": "session-managed-1", "connectUrl": "wss://connect.example/session"},
+            headers={"x-external-call-id": "call-managed-1"},
+        )
+
+        with patch.dict(os.environ, env, clear=True):
+            mod = fake_tools_package(
+                "tools.browser_providers.browser_use",
+                "browser_providers/browser_use.py",
+            )
+            with patch.object(mod.requests, "post", return_value=response) as post:
+                mod.BrowserUseProvider().create_session("task-managed-override")
+
+        payload = post.call_args.kwargs["json"]
+        assert payload["proxyCountryCode"] == "de"
+        assert payload["timeout"] == 8
+
+    def test_managed_mode_preserves_defaults_when_no_user_settings(self, fake_tools_package, tmp_path):
+        """In managed mode without user settings, managed defaults are preserved."""
+        (tmp_path / "config.yaml").write_text(
+            "browser:\n  cloud_provider: browser-use\n",
+            encoding="utf-8",
+        )
+        env = _make_env(tmp_path, api_key=None, extras={
+            "TOOL_GATEWAY_USER_TOKEN": "nous-token",
+            "BROWSER_USE_GATEWAY_URL": "http://127.0.0.1:3009",
+        })
+        response = _OkResponse(
+            {"id": "session-managed-2", "connectUrl": "wss://connect.example/session"},
+            headers={"x-external-call-id": "call-managed-2"},
+        )
+
+        with patch.dict(os.environ, env, clear=True):
+            mod = fake_tools_package(
+                "tools.browser_providers.browser_use",
+                "browser_providers/browser_use.py",
+            )
+            with patch.object(mod.requests, "post", return_value=response) as post:
+                mod.BrowserUseProvider().create_session("task-managed-defaults")
+
+        payload = post.call_args.kwargs["json"]
+        assert payload["timeout"] == 5
+        assert payload["proxyCountryCode"] == "us"

--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -1,48 +1,11 @@
 import os
 import sys
 import tempfile
-import threading
 import types
-from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-
-TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
-
-
-def _load_tool_module(module_name: str, filename: str):
-    spec = spec_from_file_location(module_name, TOOLS_DIR / filename)
-    assert spec and spec.loader
-    module = module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-def _reset_modules(prefixes: tuple[str, ...]):
-    for name in list(sys.modules):
-        if name.startswith(prefixes):
-            sys.modules.pop(name, None)
-
-
-@pytest.fixture(autouse=True)
-def _restore_tool_and_agent_modules():
-    original_modules = {
-        name: module
-        for name, module in sys.modules.items()
-        if name == "tools"
-        or name.startswith("tools.")
-        or name == "agent"
-        or name.startswith("agent.")
-    }
-    try:
-        yield
-    finally:
-        _reset_modules(("tools", "agent"))
-        sys.modules.update(original_modules)
 
 
 @pytest.fixture(autouse=True)
@@ -50,49 +13,8 @@ def _enable_managed_nous_tools(monkeypatch):
     monkeypatch.setenv("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1")
 
 
-def _install_fake_tools_package():
-    _reset_modules(("tools", "agent"))
-
-    tools_package = types.ModuleType("tools")
-    tools_package.__path__ = [str(TOOLS_DIR)]  # type: ignore[attr-defined]
-    sys.modules["tools"] = tools_package
-
-    env_package = types.ModuleType("tools.environments")
-    env_package.__path__ = [str(TOOLS_DIR / "environments")]  # type: ignore[attr-defined]
-    sys.modules["tools.environments"] = env_package
-
-    agent_package = types.ModuleType("agent")
-    agent_package.__path__ = []  # type: ignore[attr-defined]
-    sys.modules["agent"] = agent_package
-    sys.modules["agent.auxiliary_client"] = types.SimpleNamespace(
-        call_llm=lambda *args, **kwargs: "",
-    )
-
-    sys.modules["tools.managed_tool_gateway"] = _load_tool_module(
-        "tools.managed_tool_gateway",
-        "managed_tool_gateway.py",
-    )
-
-    interrupt_event = threading.Event()
-    sys.modules["tools.interrupt"] = types.SimpleNamespace(
-        set_interrupt=lambda value=True: interrupt_event.set() if value else interrupt_event.clear(),
-        is_interrupted=lambda: interrupt_event.is_set(),
-        _interrupt_event=interrupt_event,
-    )
-    sys.modules["tools.approval"] = types.SimpleNamespace(
-        detect_dangerous_command=lambda *args, **kwargs: None,
-        check_dangerous_command=lambda *args, **kwargs: {"approved": True},
-        check_all_command_guards=lambda *args, **kwargs: {"approved": True},
-        load_permanent_allowlist=lambda *args, **kwargs: [],
-        DANGEROUS_PATTERNS=[],
-    )
-
-    class _Registry:
-        def register(self, **kwargs):
-            return None
-
-    sys.modules["tools.registry"] = types.SimpleNamespace(registry=_Registry())
-
+def _add_environment_stubs():
+    """Register dummy environment module stubs in sys.modules."""
     class _DummyEnvironment:
         def __init__(self, *args, **kwargs):
             self.args = args
@@ -113,8 +35,14 @@ def _install_fake_tools_package():
     sys.modules["tools.environments.managed_modal"] = types.SimpleNamespace(ManagedModalEnvironment=_DummyEnvironment)
 
 
-def test_browser_use_explicit_local_mode_stays_local_even_when_managed_gateway_is_ready(tmp_path):
-    _install_fake_tools_package()
+@pytest.fixture()
+def load_module(fake_tools_package):
+    """Install fake tools package with dummy environment modules. Returns module loader."""
+    _add_environment_stubs()
+    return fake_tools_package
+
+
+def test_browser_use_explicit_local_mode_stays_local_even_when_managed_gateway_is_ready(load_module, tmp_path):
     (tmp_path / "config.yaml").write_text("browser:\n  cloud_provider: local\n", encoding="utf-8")
     env = os.environ.copy()
     env.pop("BROWSER_USE_API_KEY", None)
@@ -125,7 +53,7 @@ def test_browser_use_explicit_local_mode_stays_local_even_when_managed_gateway_i
     })
 
     with patch.dict(os.environ, env, clear=True):
-        browser_tool = _load_tool_module("tools.browser_tool", "browser_tool.py")
+        browser_tool = load_module("tools.browser_tool", "browser_tool.py")
 
         local_mode = browser_tool._is_local_mode()
         provider = browser_tool._get_cloud_provider()
@@ -134,8 +62,7 @@ def test_browser_use_explicit_local_mode_stays_local_even_when_managed_gateway_i
     assert provider is None
 
 
-def test_browserbase_does_not_use_gateway_only_configuration():
-    _install_fake_tools_package()
+def test_browserbase_does_not_use_gateway_only_configuration(load_module):
     env = os.environ.copy()
     env.pop("BROWSERBASE_API_KEY", None)
     env.pop("BROWSERBASE_PROJECT_ID", None)
@@ -145,7 +72,7 @@ def test_browserbase_does_not_use_gateway_only_configuration():
     })
 
     with patch.dict(os.environ, env, clear=True):
-        browserbase_module = _load_tool_module(
+        browserbase_module = load_module(
             "tools.browser_providers.browserbase",
             "browser_providers/browserbase.py",
         )
@@ -154,8 +81,7 @@ def test_browserbase_does_not_use_gateway_only_configuration():
     assert provider.is_configured() is False
 
 
-def test_browser_use_managed_gateway_adds_idempotency_key_and_persists_external_call_id():
-    _install_fake_tools_package()
+def test_browser_use_managed_gateway_adds_idempotency_key_and_persists_external_call_id(load_module):
     env = os.environ.copy()
     env.pop("BROWSER_USE_API_KEY", None)
     env.update({
@@ -176,7 +102,7 @@ def test_browser_use_managed_gateway_adds_idempotency_key_and_persists_external_
             }
 
     with patch.dict(os.environ, env, clear=True):
-        browser_use_module = _load_tool_module(
+        browser_use_module = load_module(
             "tools.browser_providers.browser_use",
             "browser_providers/browser_use.py",
         )
@@ -194,8 +120,7 @@ def test_browser_use_managed_gateway_adds_idempotency_key_and_persists_external_
     assert session["external_call_id"] == "call-browser-use-1"
 
 
-def test_browser_use_managed_gateway_reuses_pending_idempotency_key_after_timeout():
-    _install_fake_tools_package()
+def test_browser_use_managed_gateway_reuses_pending_idempotency_key_after_timeout(load_module):
     env = os.environ.copy()
     env.pop("BROWSER_USE_API_KEY", None)
     env.update({
@@ -216,7 +141,7 @@ def test_browser_use_managed_gateway_reuses_pending_idempotency_key_after_timeou
             }
 
     with patch.dict(os.environ, env, clear=True):
-        browser_use_module = _load_tool_module(
+        browser_use_module = load_module(
             "tools.browser_providers.browser_use",
             "browser_providers/browser_use.py",
         )
@@ -242,8 +167,7 @@ def test_browser_use_managed_gateway_reuses_pending_idempotency_key_after_timeou
     assert first_headers["X-Idempotency-Key"] == second_headers["X-Idempotency-Key"]
 
 
-def test_browser_use_managed_gateway_preserves_pending_idempotency_key_for_in_progress_conflicts():
-    _install_fake_tools_package()
+def test_browser_use_managed_gateway_preserves_pending_idempotency_key_for_in_progress_conflicts(load_module):
     env = os.environ.copy()
     env.pop("BROWSER_USE_API_KEY", None)
     env.update({
@@ -278,7 +202,7 @@ def test_browser_use_managed_gateway_preserves_pending_idempotency_key_for_in_pr
             }
 
     with patch.dict(os.environ, env, clear=True):
-        browser_use_module = _load_tool_module(
+        browser_use_module = load_module(
             "tools.browser_providers.browser_use",
             "browser_providers/browser_use.py",
         )
@@ -303,8 +227,7 @@ def test_browser_use_managed_gateway_preserves_pending_idempotency_key_for_in_pr
     assert first_headers["X-Idempotency-Key"] == second_headers["X-Idempotency-Key"]
 
 
-def test_browser_use_managed_gateway_uses_new_idempotency_key_for_a_new_session_after_success():
-    _install_fake_tools_package()
+def test_browser_use_managed_gateway_uses_new_idempotency_key_for_a_new_session_after_success(load_module):
     env = os.environ.copy()
     env.pop("BROWSER_USE_API_KEY", None)
     env.update({
@@ -325,7 +248,7 @@ def test_browser_use_managed_gateway_uses_new_idempotency_key_for_a_new_session_
             }
 
     with patch.dict(os.environ, env, clear=True):
-        browser_use_module = _load_tool_module(
+        browser_use_module = load_module(
             "tools.browser_providers.browser_use",
             "browser_providers/browser_use.py",
         )
@@ -340,14 +263,13 @@ def test_browser_use_managed_gateway_uses_new_idempotency_key_for_a_new_session_
     assert first_headers["X-Idempotency-Key"] != second_headers["X-Idempotency-Key"]
 
 
-def test_terminal_tool_prefers_managed_modal_when_gateway_ready_and_no_direct_creds():
-    _install_fake_tools_package()
+def test_terminal_tool_prefers_managed_modal_when_gateway_ready_and_no_direct_creds(load_module):
     env = os.environ.copy()
     env.pop("MODAL_TOKEN_ID", None)
     env.pop("MODAL_TOKEN_SECRET", None)
 
     with patch.dict(os.environ, env, clear=True):
-        terminal_tool = _load_tool_module("tools.terminal_tool", "terminal_tool.py")
+        terminal_tool = load_module("tools.terminal_tool", "terminal_tool.py")
 
         with (
             patch.object(terminal_tool, "is_managed_tool_gateway_ready", return_value=True),
@@ -375,8 +297,7 @@ def test_terminal_tool_prefers_managed_modal_when_gateway_ready_and_no_direct_cr
     assert not direct_ctor.called
 
 
-def test_terminal_tool_auto_mode_prefers_managed_modal_when_available():
-    _install_fake_tools_package()
+def test_terminal_tool_auto_mode_prefers_managed_modal_when_available(load_module):
     env = os.environ.copy()
     env.update({
         "MODAL_TOKEN_ID": "tok-id",
@@ -384,7 +305,7 @@ def test_terminal_tool_auto_mode_prefers_managed_modal_when_available():
     })
 
     with patch.dict(os.environ, env, clear=True):
-        terminal_tool = _load_tool_module("tools.terminal_tool", "terminal_tool.py")
+        terminal_tool = load_module("tools.terminal_tool", "terminal_tool.py")
 
         with (
             patch.object(terminal_tool, "is_managed_tool_gateway_ready", return_value=True),
@@ -411,8 +332,7 @@ def test_terminal_tool_auto_mode_prefers_managed_modal_when_available():
     assert not direct_ctor.called
 
 
-def test_terminal_tool_auto_mode_falls_back_to_direct_modal_when_managed_unavailable():
-    _install_fake_tools_package()
+def test_terminal_tool_auto_mode_falls_back_to_direct_modal_when_managed_unavailable(load_module):
     env = os.environ.copy()
     env.update({
         "MODAL_TOKEN_ID": "tok-id",
@@ -420,7 +340,7 @@ def test_terminal_tool_auto_mode_falls_back_to_direct_modal_when_managed_unavail
     })
 
     with patch.dict(os.environ, env, clear=True):
-        terminal_tool = _load_tool_module("tools.terminal_tool", "terminal_tool.py")
+        terminal_tool = load_module("tools.terminal_tool", "terminal_tool.py")
 
         with (
             patch.object(terminal_tool, "is_managed_tool_gateway_ready", return_value=False),
@@ -447,14 +367,13 @@ def test_terminal_tool_auto_mode_falls_back_to_direct_modal_when_managed_unavail
     assert not managed_ctor.called
 
 
-def test_terminal_tool_respects_direct_modal_mode_without_falling_back_to_managed():
-    _install_fake_tools_package()
+def test_terminal_tool_respects_direct_modal_mode_without_falling_back_to_managed(load_module):
     env = os.environ.copy()
     env.pop("MODAL_TOKEN_ID", None)
     env.pop("MODAL_TOKEN_SECRET", None)
 
     with patch.dict(os.environ, env, clear=True):
-        terminal_tool = _load_tool_module("tools.terminal_tool", "terminal_tool.py")
+        terminal_tool = load_module("tools.terminal_tool", "terminal_tool.py")
 
         with (
             patch.object(terminal_tool, "is_managed_tool_gateway_ready", return_value=True),

--- a/tools/browser_providers/browser_use.py
+++ b/tools/browser_providers/browser_use.py
@@ -4,21 +4,34 @@ import logging
 import os
 import threading
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any
 
 import requests
+import yaml
 
+from hermes_constants import get_hermes_home
 from tools.browser_providers.base import CloudBrowserProvider
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
 logger = logging.getLogger(__name__)
-_pending_create_keys: Dict[str, str] = {}
+_pending_create_keys: dict[str, str] = {}
 _pending_create_keys_lock = threading.Lock()
 
 _BASE_URL = "https://api.browser-use.com/api/v3"
 _DEFAULT_MANAGED_TIMEOUT_MINUTES = 5
 _DEFAULT_MANAGED_PROXY_COUNTRY_CODE = "us"
+
+# Maps snake_case config keys to camelCase API parameter names.
+_CONFIG_KEY_TO_API_PARAM: dict[str, str] = {
+    "profile_id": "profileId",
+    "proxy_country_code": "proxyCountryCode",
+    "timeout": "timeout",
+    "screen_width": "browserScreenWidth",
+    "screen_height": "browserScreenHeight",
+    "allow_resizing": "allowResizing",
+    "enable_recording": "enableRecording",
+}
 
 
 def _get_or_create_pending_create_key(task_id: str) -> str:
@@ -35,6 +48,15 @@ def _get_or_create_pending_create_key(task_id: str) -> str:
 def _clear_pending_create_key(task_id: str) -> None:
     with _pending_create_keys_lock:
         _pending_create_keys.pop(task_id, None)
+
+
+def _parse_env_value(value: str, api_key: str) -> Any:
+    """Parse an environment variable string into the appropriate type."""
+    if api_key in ("allowResizing", "enableRecording"):
+        return value.lower() in ("1", "true", "yes")
+    if api_key in ("timeout", "browserScreenWidth", "browserScreenHeight"):
+        return int(value)
+    return value
 
 
 def _should_preserve_pending_create_key(response: requests.Response) -> bool:
@@ -69,11 +91,7 @@ class BrowserUseProvider(CloudBrowserProvider):
     def is_configured(self) -> bool:
         return self._get_config_or_none() is not None
 
-    # ------------------------------------------------------------------
-    # Config resolution (direct API key OR managed Nous gateway)
-    # ------------------------------------------------------------------
-
-    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+    def _get_config_or_none(self) -> dict[str, Any] | None:
         api_key = os.environ.get("BROWSER_USE_API_KEY")
         if api_key:
             return {
@@ -92,7 +110,7 @@ class BrowserUseProvider(CloudBrowserProvider):
             "managed_mode": True,
         }
 
-    def _get_config(self) -> Dict[str, Any]:
+    def _get_config(self) -> dict[str, Any]:
         config = self._get_config_or_none()
         if config is None:
             message = (
@@ -106,18 +124,48 @@ class BrowserUseProvider(CloudBrowserProvider):
             raise ValueError(message)
         return config
 
-    # ------------------------------------------------------------------
-    # Session lifecycle
-    # ------------------------------------------------------------------
+    def _resolve_session_settings(self) -> dict[str, Any]:
+        """Resolve Browser Use session settings from config YAML and env vars.
 
-    def _headers(self, config: Dict[str, Any]) -> Dict[str, str]:
+        Reads ``browser.browser_use`` from ``~/.hermes/config.yaml``, then
+        applies environment variable overrides (``BROWSER_USE_<UPPER_KEY>``).
+        Returns a dict with camelCase keys matching the Browser Use API.
+        """
+        settings: dict[str, Any] = {}
+
+        config_path = get_hermes_home() / "config.yaml"
+        if config_path.exists():
+            try:
+                with open(config_path) as f:
+                    cfg = yaml.safe_load(f) or {}
+                bu_cfg = cfg.get("browser", {}).get("browser_use", {})
+                if isinstance(bu_cfg, dict):
+                    for config_key, api_key in _CONFIG_KEY_TO_API_PARAM.items():
+                        if config_key in bu_cfg:
+                            settings[api_key] = bu_cfg[config_key]
+            except Exception:
+                logger.debug("Could not read browser_use settings from config.yaml", exc_info=True)
+
+        for config_key, api_key in _CONFIG_KEY_TO_API_PARAM.items():
+            env_var = f"BROWSER_USE_{config_key.upper()}"
+            value = os.environ.get(env_var)
+            if value is not None:
+                try:
+                    settings[api_key] = _parse_env_value(value, api_key)
+                except (ValueError, TypeError):
+                    logger.warning("Invalid value for %s: %r, skipping", env_var, value)
+
+        # Remove None values (explicit null in YAML means "don't send")
+        return {k: v for k, v in settings.items() if v is not None}
+
+    def _headers(self, config: dict[str, Any]) -> dict[str, str]:
         headers = {
             "Content-Type": "application/json",
             "X-Browser-Use-API-Key": config["api_key"],
         }
         return headers
 
-    def create_session(self, task_id: str) -> Dict[str, object]:
+    def create_session(self, task_id: str) -> dict[str, object]:
         config = self._get_config()
         managed_mode = bool(config.get("managed_mode"))
 
@@ -128,14 +176,14 @@ class BrowserUseProvider(CloudBrowserProvider):
         # Keep gateway-backed sessions short so billing authorization does not
         # default to a long Browser-Use timeout when Hermes only needs a task-
         # scoped ephemeral browser.
-        payload = (
-            {
-                "timeout": _DEFAULT_MANAGED_TIMEOUT_MINUTES,
-                "proxyCountryCode": _DEFAULT_MANAGED_PROXY_COUNTRY_CODE,
-            }
-            if managed_mode
-            else {}
-        )
+        # Start with managed defaults if applicable, then overlay user settings.
+        payload: dict[str, Any] = {}
+        if managed_mode:
+            payload["timeout"] = _DEFAULT_MANAGED_TIMEOUT_MINUTES
+            payload["proxyCountryCode"] = _DEFAULT_MANAGED_PROXY_COUNTRY_CODE
+
+        user_settings = self._resolve_session_settings()
+        payload.update(user_settings)
 
         response = requests.post(
             f"{config['base_url']}/browsers",

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -84,6 +84,13 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |
+| `BROWSER_USE_PROFILE_ID` | Browser Use profile UUID (overrides `browser.browser_use.profile_id` in config) |
+| `BROWSER_USE_PROXY_COUNTRY_CODE` | Two-letter proxy country code (overrides `browser.browser_use.proxy_country_code`) |
+| `BROWSER_USE_TIMEOUT` | Session timeout in minutes (overrides `browser.browser_use.timeout`) |
+| `BROWSER_USE_SCREEN_WIDTH` | Browser viewport width in pixels (overrides `browser.browser_use.screen_width`) |
+| `BROWSER_USE_SCREEN_HEIGHT` | Browser viewport height in pixels (overrides `browser.browser_use.screen_height`) |
+| `BROWSER_USE_ALLOW_RESIZING` | Allow browser window resizing: `true`/`false` (overrides `browser.browser_use.allow_resizing`) |
+| `BROWSER_USE_ENABLE_RECORDING` | Record browser session: `true`/`false` (overrides `browser.browser_use.enable_recording`) |
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds (default: 300) |
 | `BROWSER_CDP_URL` | Chrome DevTools Protocol URL for local browser (set via `/browser connect`, e.g. `ws://localhost:9222`) |
 | `CAMOFOX_URL` | Camofox local anti-detection browser URL (default: `http://localhost:9377`) |

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -56,6 +56,33 @@ BROWSER_USE_API_KEY=***
 
 Get your API key at [browser-use.com](https://browser-use.com). Browser Use provides a cloud browser via its REST API. If both Browserbase and Browser Use credentials are set, Browserbase takes priority.
 
+#### Session settings
+
+You can customise Browser Use sessions via `config.yaml` and/or environment variables. Environment variables override config values.
+
+```yaml
+# In ~/.hermes/config.yaml
+browser:
+  browser_use:
+    profile_id: "550e8400-e29b-41d4-a716-446655440000"
+    proxy_country_code: de
+    timeout: 10
+    screen_width: 1920
+    screen_height: 1080
+    allow_resizing: true
+    enable_recording: true
+```
+
+| Config key | Env var | Description |
+|---|---|---|
+| `profile_id` | `BROWSER_USE_PROFILE_ID` | Browser Use profile UUID |
+| `proxy_country_code` | `BROWSER_USE_PROXY_COUNTRY_CODE` | Two-letter country code for the proxy |
+| `timeout` | `BROWSER_USE_TIMEOUT` | Session timeout in minutes |
+| `screen_width` | `BROWSER_USE_SCREEN_WIDTH` | Browser viewport width in pixels |
+| `screen_height` | `BROWSER_USE_SCREEN_HEIGHT` | Browser viewport height in pixels |
+| `allow_resizing` | `BROWSER_USE_ALLOW_RESIZING` | Allow the browser window to be resized |
+| `enable_recording` | `BROWSER_USE_ENABLE_RECORDING` | Record the browser session |
+
 ### Firecrawl cloud mode
 
 To use Firecrawl as your cloud browser provider, add:


### PR DESCRIPTION
## What does this PR do?

Adds support for user-configurable Browser Use session settings via `config.yaml` and environment variables. Users can now customize profile, proxy, timeout, screen dimensions, resizing, and recording options for Browser Use cloud browser sessions. Settings from config are applied first, then environment variables override them, and in managed mode user settings override the managed defaults.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_providers/browser_use.py`: Add `_resolve_session_settings()` method that reads `browser.browser_use` from `config.yaml` and applies `BROWSER_USE_*` env var overrides. Add `_CONFIG_KEY_TO_API_PARAM` mapping and `_parse_env_value()` helper. Wire resolved settings into `create_session()` payload so user settings overlay managed defaults. Modernize type hints (`dict[str, Any]` instead of `Dict[str, Any]`). Catch `ValueError` for invalid env var values.
- `tests/tools/conftest.py` (new): Extract shared test boilerplate (`_load_tool_module`, `_reset_modules`, `_install_fake_tools_package`) and fixtures (`restore_tool_and_agent_modules`, `fake_tools_package`) used by both browser-use and managed-tool test files.
- `tests/tools/test_browser_use_session_settings.py` (new): 10 tests covering config resolution, env var resolution, env-overrides-config precedence, boolean parsing, and create_session payload integration for both direct and managed modes. Organized into `TestResolveSessionSettings` and `TestCreateSessionPayload` classes.
- `tests/tools/test_managed_browserbase_and_modal.py`: Remove ~100 lines of duplicated boilerplate in favor of shared `fake_tools_package` fixture from conftest.
- `cli-config.yaml.example`: Add commented `browser.browser_use` section documenting all 7 session settings.
- `website/docs/user-guide/features/browser.md`: Add session settings subsection under Browser Use cloud mode with config example and settings table.
- `website/docs/reference/environment-variables.md`: Add 7 `BROWSER_USE_*` environment variables to the Tool APIs table.

## How to Test

1. `uv run python -m pytest tests/tools/test_browser_use_session_settings.py tests/tools/test_managed_browserbase_and_modal.py -v`
2. All 20 tests should pass.
3. To test manually, add a `browser.browser_use` section to `~/.hermes/config.yaml`:
   ```yaml
   browser:
     cloud_provider: browser-use
     browser_use:
       proxy_country_code: de
       timeout: 10
       screen_width: 1920
       screen_height: 1080
   ```
   Or set env vars like `BROWSER_USE_PROXY_COUNTRY_CODE=fr` to override config values.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Supported Settings

| Config key (`browser.browser_use.*`) | Env var | API parameter | Type |
|---|---|---|---|
| `profile_id` | `BROWSER_USE_PROFILE_ID` | `profileId` | string |
| `proxy_country_code` | `BROWSER_USE_PROXY_COUNTRY_CODE` | `proxyCountryCode` | string |
| `timeout` | `BROWSER_USE_TIMEOUT` | `timeout` | int |
| `screen_width` | `BROWSER_USE_SCREEN_WIDTH` | `browserScreenWidth` | int |
| `screen_height` | `BROWSER_USE_SCREEN_HEIGHT` | `browserScreenHeight` | int |
| `allow_resizing` | `BROWSER_USE_ALLOW_RESIZING` | `allowResizing` | bool |
| `enable_recording` | `BROWSER_USE_ENABLE_RECORDING` | `enableRecording` | bool |