### PR TITLE
fix: catch terminfo errors from simple_term_menu on unsupported terminals (Ghostty)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2581,7 +2581,7 @@ def _prompt_model_selection(
             custom = input("Enter model name: ").strip()
             return custom if custom else None
         return None
-    except (ImportError, NotImplementedError):
+    except Exception:
         pass
 
     # Fallback: numbered list

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1654,7 +1654,7 @@ def _remove_custom_provider(config):
         )
         idx = menu.show()
         print()
-    except (ImportError, NotImplementedError):
+    except Exception:
         for i, c in enumerate(choices, 1):
             print(f"  {i}. {c}")
         print()
@@ -1735,7 +1735,7 @@ def _model_flow_named_custom(config, provider_info):
                 print("Cancelled.")
                 return
             model_name = models[idx]
-        except (ImportError, NotImplementedError):
+        except Exception:
             for i, m in enumerate(models, 1):
                 print(f"  {i}. {m}")
             print(f"  {len(models) + 1}. Cancel")
@@ -1853,7 +1853,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
         if idx == len(ordered):
             return "none"
         return None
-    except (ImportError, NotImplementedError):
+    except Exception:
         pass
 
     print("Select reasoning effort:")


### PR DESCRIPTION
## Summary
- Broadened `except` clauses around all `TerminalMenu` usages from `(ImportError, NotImplementedError)` to `Exception`
- This fixes a crash when running under Ghostty (and other terminals with missing terminfo entries), where `tput lines` fails with `CalledProcessError` inside `simple_term_menu`

## Problem
Ghostty sets `TERM=xterm-ghostty`, which has no terminfo database entry. When `simple_term_menu` tries to query terminal dimensions via `tput`, it raises `subprocess.CalledProcessError`. The existing exception handlers only caught `ImportError` and `NotImplementedError`, so this error propagated as an unhandled crash instead of falling through to the numbered-list fallback.

## Test plan
- [ ] Run `hermes model` under Ghostty terminal — should fall back to numbered list instead of crashing
- [ ] Run `hermes model` under a standard terminal (xterm-256color, etc.) — interactive menu should still work normally
- [ ] Run `hermes model remove-provider` under Ghostty — should fall back gracefully
- [ ] Run reasoning effort selection under Ghostty — should fall back gracefully