### PR TITLE
feat(skill_manager): non-blocking quality validation for skills (#416)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -10,6 +10,8 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
+    _validate_skill_quality,
+    _extract_referenced_files,
     _find_skill,
     _resolve_skill_dir,
     _create_skill,
@@ -423,3 +425,376 @@ class TestSkillManageDispatcher:
             raw = skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
         result = json.loads(raw)
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Quality validation (issue #416)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReferencedFiles:
+    """Regex-level tests for the file-reference extractor."""
+
+    def test_empty_content(self):
+        assert _extract_referenced_files("") == []
+        assert _extract_referenced_files(None) == []
+
+    def test_finds_bare_reference(self):
+        content = "See references/api.md for details."
+        assert _extract_referenced_files(content) == ["references/api.md"]
+
+    def test_finds_all_four_subdirs(self):
+        content = (
+            "Use references/api.md, templates/config.yaml, "
+            "scripts/setup.sh, and assets/diagram.png."
+        )
+        refs = _extract_referenced_files(content)
+        assert "references/api.md" in refs
+        assert "templates/config.yaml" in refs
+        assert "scripts/setup.sh" in refs
+        assert "assets/diagram.png" in refs
+
+    def test_markdown_link(self):
+        content = "See the [API guide](references/api.md) here."
+        assert _extract_referenced_files(content) == ["references/api.md"]
+
+    def test_code_span(self):
+        content = "Run `scripts/validate.py` to check."
+        assert _extract_referenced_files(content) == ["scripts/validate.py"]
+
+    def test_fenced_code_block(self):
+        content = "```\npython scripts/run.py\n```"
+        assert _extract_referenced_files(content) == ["scripts/run.py"]
+
+    def test_ignores_partial_match_inside_identifier(self):
+        # "my_references/foo" should not match "references/foo"
+        content = "The variable my_references/foo.md is unused."
+        assert _extract_referenced_files(content) == []
+
+    def test_ignores_path_prefix_match(self):
+        # "a/references/foo.md" should not match "references/foo.md"
+        # because the preceding slash fails the lookbehind.
+        content = "Path is /home/references/foo.md"
+        assert _extract_referenced_files(content) == []
+
+    def test_requires_extension(self):
+        # Bare directory mentions should not match.
+        content = "Put stuff in references/ and templates/."
+        assert _extract_referenced_files(content) == []
+
+    def test_skips_glob_patterns(self):
+        content = "Run scripts/*.py to test."
+        assert _extract_referenced_files(content) == []
+
+    def test_strips_trailing_punctuation(self):
+        content = "See references/api.md, templates/config.yaml."
+        refs = _extract_referenced_files(content)
+        assert "references/api.md" in refs
+        assert "templates/config.yaml" in refs
+
+    def test_deduplicates(self):
+        content = (
+            "First mention: references/api.md\n"
+            "Second mention: references/api.md"
+        )
+        assert _extract_referenced_files(content) == ["references/api.md"]
+
+
+class TestValidateSkillQuality:
+    """Tests for the non-blocking quality validator."""
+
+    def _make_skill(self, tmp_path, name="my-skill", body="Step 1: Do it."):
+        """Create a minimal valid skill dir at tmp_path / name."""
+        skill_dir = tmp_path / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = f"---\nname: {name}\ndescription: Test skill.\n---\n\n# {name}\n\n{body}\n"
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+        return skill_dir, content
+
+    def test_clean_skill_no_warnings(self, tmp_path):
+        skill_dir, content = self._make_skill(tmp_path)
+        assert _validate_skill_quality(skill_dir, content=content, expected_name="my-skill") == []
+
+    def test_missing_skill_dir_returns_empty(self, tmp_path):
+        # Non-existent directory should not crash — just return []
+        assert _validate_skill_quality(tmp_path / "does-not-exist") == []
+
+    def test_detects_python_syntax_error(self, tmp_path):
+        skill_dir, content = self._make_skill(tmp_path)
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir()
+        bad_py = scripts_dir / "broken.py"
+        bad_py.write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert any("Python syntax error" in w for w in warnings)
+        assert any("broken.py" in w for w in warnings)
+
+    def test_valid_python_no_warning(self, tmp_path):
+        skill_dir, content = self._make_skill(tmp_path)
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "ok.py").write_text(
+            "def ok():\n    return 42\n", encoding="utf-8"
+        )
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert not any("syntax error" in w for w in warnings)
+
+    def test_skips_hidden_and_pycache_dirs(self, tmp_path):
+        skill_dir, content = self._make_skill(tmp_path)
+        # Create a broken .py inside a __pycache__ dir — should be skipped
+        pycache = skill_dir / "scripts" / "__pycache__"
+        pycache.mkdir(parents=True)
+        (pycache / "garbage.py").write_text("this is (not python", encoding="utf-8")
+        # And one inside a hidden .venv — also skipped
+        hidden = skill_dir / ".venv"
+        hidden.mkdir()
+        (hidden / "also-garbage.py").write_text("also not python (", encoding="utf-8")
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert not any("syntax error" in w for w in warnings)
+
+    def test_detects_broken_symlink(self, tmp_path):
+        skill_dir, content = self._make_skill(tmp_path)
+        broken = skill_dir / "assets" / "missing.png"
+        broken.parent.mkdir()
+        broken.symlink_to(tmp_path / "nonexistent-target.png")
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert any("Broken symlink" in w for w in warnings)
+        assert any("missing.png" in w for w in warnings)
+
+    def test_valid_symlink_no_warning(self, tmp_path):
+        skill_dir, content = self._make_skill(tmp_path)
+        # Create a real target inside the skill dir, then symlink to it
+        target = skill_dir / "assets" / "real.png"
+        target.parent.mkdir()
+        target.write_bytes(b"fake png data")
+        link = skill_dir / "assets" / "link.png"
+        link.symlink_to(target)
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert not any("Broken symlink" in w for w in warnings)
+
+    def test_detects_missing_single_reference(self, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "See references/api.md for details.\n"
+        )
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert any(
+            "Referenced file missing: references/api.md" in w for w in warnings
+        )
+
+    def test_detects_multiple_missing_references(self, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "See references/api.md and templates/config.yaml.\n"
+        )
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        # Combined multi-ref message
+        combined = [w for w in warnings if "Referenced files missing (2)" in w]
+        assert combined
+        assert "references/api.md" in combined[0]
+        assert "templates/config.yaml" in combined[0]
+
+    def test_existing_reference_no_warning(self, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "api.md").write_text("# API", encoding="utf-8")
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "See references/api.md for details.\n"
+        )
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert not any("Referenced file missing" in w for w in warnings)
+        assert not any("Referenced files missing" in w for w in warnings)
+
+    def test_name_mismatch_warning(self, tmp_path):
+        skill_dir = tmp_path / "wrong-dir"
+        skill_dir.mkdir()
+        content = (
+            "---\nname: actual-name\ndescription: Test.\n---\n\nBody.\n"
+        )
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        warnings = _validate_skill_quality(
+            skill_dir, content=content, expected_name="wrong-dir"
+        )
+        assert any(
+            "Frontmatter name 'actual-name' does not match" in w for w in warnings
+        )
+
+    def test_name_match_no_warning(self, tmp_path):
+        skill_dir, content = self._make_skill(tmp_path, name="my-skill")
+        warnings = _validate_skill_quality(
+            skill_dir, content=content, expected_name="my-skill"
+        )
+        assert not any("does not match" in w for w in warnings)
+
+    def test_multiple_issues_accumulated(self, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "See references/api.md.\n"
+        )
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+        # Add a broken .py
+        scripts = skill_dir / "scripts"
+        scripts.mkdir()
+        (scripts / "broken.py").write_text("def (:\n", encoding="utf-8")
+        # Add a broken symlink
+        link = skill_dir / "assets" / "missing.png"
+        link.parent.mkdir()
+        link.symlink_to(tmp_path / "nope.png")
+
+        warnings = _validate_skill_quality(skill_dir, content=content)
+        assert len(warnings) >= 3
+        assert any("Broken symlink" in w for w in warnings)
+        assert any("syntax error" in w for w in warnings)
+        assert any("Referenced file missing" in w for w in warnings)
+
+    def test_reads_skill_md_when_content_omitted(self, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "See references/api.md.\n"
+        )
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        # No content argument — should read from disk
+        warnings = _validate_skill_quality(skill_dir)
+        assert any("Referenced file missing" in w for w in warnings)
+
+
+class TestQualityWarningsIntegration:
+    """Tests that warnings flow into skill_manage results without blocking."""
+
+    def test_create_clean_skill_no_warnings_key(self, tmp_path):
+        # Use content whose frontmatter name matches the skill name
+        # so the name-mismatch check stays silent.
+        clean_content = (
+            "---\nname: my-skill\ndescription: Clean test skill.\n---\n\n"
+            "# My Skill\n\nStep 1: Do the thing.\n"
+        )
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", clean_content)
+        assert result["success"] is True
+        assert "warnings" not in result
+
+    def test_create_with_missing_reference_warns_but_succeeds(self, tmp_path):
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "# My Skill\n\nSee references/missing.md for details.\n"
+        )
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", content)
+
+        # Still succeeds — warnings are non-blocking
+        assert result["success"] is True
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
+        assert "warnings" in result
+        assert any("references/missing.md" in w for w in result["warnings"])
+
+    def test_edit_surfaces_warnings(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            bad_content = (
+                "---\nname: my-skill\ndescription: Updated.\n---\n\n"
+                "# Updated\n\nSee scripts/missing.py for details.\n"
+            )
+            result = _edit_skill("my-skill", bad_content)
+
+        assert result["success"] is True
+        assert "warnings" in result
+        assert any("scripts/missing.py" in w for w in result["warnings"])
+
+    def test_patch_surfaces_warnings(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill(
+                "my-skill",
+                "Do the thing.",
+                "Do the thing. See templates/nope.yaml.",
+            )
+
+        assert result["success"] is True
+        assert "warnings" in result
+        assert any("templates/nope.yaml" in w for w in result["warnings"])
+
+    def test_write_file_resolves_warning(self, tmp_path):
+        """Adding the missing reference file should clear the warning."""
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "# Skill\n\nSee references/api.md for details.\n"
+        )
+        with _skill_dir(tmp_path):
+            create_result = _create_skill("my-skill", content)
+            assert "warnings" in create_result  # missing reference
+
+            write_result = _write_file(
+                "my-skill", "references/api.md", "# API Reference\n\nContent here.\n"
+            )
+
+        assert write_result["success"] is True
+        # Warning should be resolved now — references/api.md exists
+        assert "warnings" not in write_result or not any(
+            "references/api.md" in w for w in write_result.get("warnings", [])
+        )
+
+    def test_python_syntax_warning_via_write_file(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file(
+                "my-skill",
+                "scripts/broken.py",
+                "def broken(:\n    pass\n",  # syntax error
+            )
+
+        assert result["success"] is True  # non-blocking
+        assert "warnings" in result
+        assert any("syntax error" in w for w in result["warnings"])
+        assert any("broken.py" in w for w in result["warnings"])
+
+    def test_name_mismatch_warning_via_create(self, tmp_path):
+        # Frontmatter name doesn't match the skill name parameter
+        content = (
+            "---\nname: different-name\ndescription: Test.\n---\n\n"
+            "# Test\n\nBody.\n"
+        )
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", content)
+
+        assert result["success"] is True
+        assert "warnings" in result
+        assert any(
+            "does not match" in w and "different-name" in w
+            for w in result["warnings"]
+        )
+
+    def test_warnings_serialize_via_dispatcher(self, tmp_path):
+        """End-to-end: skill_manage JSON output contains warnings array."""
+        content = (
+            "---\nname: my-skill\ndescription: Test.\n---\n\n"
+            "# My Skill\n\nSee references/missing.md for details.\n"
+        )
+        with _skill_dir(tmp_path):
+            raw = skill_manage(action="create", name="my-skill", content=content)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "warnings" in result
+        assert isinstance(result["warnings"], list)
+        assert len(result["warnings"]) >= 1

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -32,6 +32,7 @@ Directory layout for user skills:
             └── SKILL.md
 """
 
+import ast
 import json
 import logging
 import os
@@ -40,7 +41,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +190,155 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
     return None
 
 
+# Pattern for detecting referenced supporting files inside SKILL.md prose.
+# Matches paths like "references/api.md", "scripts/setup.sh", "templates/x.yaml",
+# "assets/diagram.png" — anchored on a non-word/slash boundary so it doesn't match
+# partial paths inside larger identifiers (e.g. "my_references/foo"). The trailing
+# `\.\w{1,10}` requires an extension to avoid flagging bare directory mentions.
+_REFERENCED_FILE_RE = re.compile(
+    r'(?<![\w/])((?:references|templates|scripts|assets)/[\w./\-]+\.\w{1,10})'
+)
+
+
+def _extract_referenced_files(content: str) -> List[str]:
+    """
+    Scan SKILL.md content for paths that look like referenced supporting files.
+
+    Returns a sorted list of unique relative paths. Skips paths containing
+    glob wildcards (*, ?) since those aren't literal references.
+    """
+    if not content:
+        return []
+    found = set()
+    for match in _REFERENCED_FILE_RE.finditer(content):
+        path_str = match.group(1)
+        # Strip common trailing punctuation that may have been captured
+        path_str = path_str.rstrip('.,;:)')
+        # Skip glob patterns — not literal file references
+        if "*" in path_str or "?" in path_str:
+            continue
+        found.add(path_str)
+    return sorted(found)
+
+
+def _validate_skill_quality(
+    skill_dir: Path,
+    content: Optional[str] = None,
+    expected_name: Optional[str] = None,
+) -> List[str]:
+    """
+    Run non-blocking quality checks on a skill directory.
+
+    Implements the lint checks requested in issue #416:
+
+      * Python files (`.py`) parse successfully via ``ast.parse``
+      * Files referenced in SKILL.md (``references/``, ``templates/``,
+        ``scripts/``, ``assets/`` paths with extensions) actually exist
+      * No broken symlinks anywhere in the skill directory
+      * Skill ``name`` in frontmatter matches directory name (optional warning)
+
+    All checks are non-blocking: failures are returned as warning strings
+    so the agent can self-correct on the next turn. The caller decides
+    whether to surface them. An empty list means no issues were found.
+
+    Args:
+        skill_dir: Path to the skill directory (containing SKILL.md).
+        content: Optional SKILL.md content to scan. If omitted, reads from disk.
+        expected_name: Optional skill name to verify against frontmatter.
+
+    Returns:
+        List of warning strings. Empty if the skill passes all quality checks.
+    """
+    warnings: List[str] = []
+
+    if not skill_dir.exists() or not skill_dir.is_dir():
+        return warnings
+
+    # 1. Broken symlinks anywhere in the skill dir.
+    try:
+        for path in skill_dir.rglob("*"):
+            try:
+                if path.is_symlink() and not path.exists():
+                    rel = path.relative_to(skill_dir)
+                    warnings.append(f"Broken symlink: {rel}")
+            except OSError:
+                # Unreadable path — skip silently rather than crash the whole scan.
+                continue
+    except OSError as e:
+        logger.debug("Symlink scan failed for %s: %s", skill_dir, e)
+
+    # 2. Python files parse cleanly.
+    try:
+        for py_file in sorted(skill_dir.rglob("*.py")):
+            if not py_file.is_file():
+                continue
+            # Skip files inside hidden directories (e.g. .venv, __pycache__)
+            if any(part.startswith(".") or part == "__pycache__" for part in py_file.relative_to(skill_dir).parts):
+                continue
+            try:
+                src = py_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as e:
+                rel = py_file.relative_to(skill_dir)
+                warnings.append(f"Could not read Python file {rel}: {e}")
+                continue
+            try:
+                ast.parse(src, filename=str(py_file))
+            except SyntaxError as e:
+                rel = py_file.relative_to(skill_dir)
+                line_info = f" line {e.lineno}" if e.lineno else ""
+                warnings.append(
+                    f"Python syntax error in {rel}{line_info}: {e.msg}"
+                )
+    except OSError as e:
+        logger.debug("Python parse scan failed for %s: %s", skill_dir, e)
+
+    # 3. Referenced supporting files exist.
+    if content is None:
+        skill_md = skill_dir / "SKILL.md"
+        if skill_md.exists():
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                content = None
+
+    if content:
+        missing_refs = []
+        for ref in _extract_referenced_files(content):
+            target = skill_dir / ref
+            if not target.exists():
+                missing_refs.append(ref)
+        if missing_refs:
+            if len(missing_refs) == 1:
+                warnings.append(f"Referenced file missing: {missing_refs[0]}")
+            else:
+                warnings.append(
+                    f"Referenced files missing ({len(missing_refs)}): "
+                    + ", ".join(missing_refs)
+                )
+
+    # 4. Skill name in frontmatter matches directory name (optional warning).
+    if expected_name and content:
+        try:
+            # Parse the frontmatter block to get the declared name.
+            if content.startswith("---"):
+                end_match = re.search(r'\n---\s*\n', content[3:])
+                if end_match:
+                    fm = yaml.safe_load(content[3:end_match.start() + 3])
+                    if isinstance(fm, dict):
+                        declared = fm.get("name")
+                        if isinstance(declared, str) and declared != expected_name:
+                            warnings.append(
+                                f"Frontmatter name '{declared}' does not match "
+                                f"directory name '{expected_name}'."
+                            )
+        except (yaml.YAMLError, OSError):
+            # Frontmatter validation is already handled by _validate_frontmatter;
+            # this is a best-effort cross-check only.
+            pass
+
+    return warnings
+
+
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
     """Build the directory path for a new skill, optionally under a category."""
     if category:
@@ -326,6 +476,14 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     }
     if category:
         result["category"] = category
+
+    # Non-blocking quality checks (issue #416)
+    quality_warnings = _validate_skill_quality(
+        skill_dir, content=content, expected_name=name
+    )
+    if quality_warnings:
+        result["warnings"] = quality_warnings
+
     result["hint"] = (
         "To add reference files, templates, or scripts, use "
         "skill_manage(action='write_file', name='{}', file_path='references/example.md', file_content='...')".format(name)
@@ -359,11 +517,20 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
             _atomic_write_text(skill_md, original_content)
         return {"success": False, "error": scan_error}
 
-    return {
+    result = {
         "success": True,
         "message": f"Skill '{name}' updated.",
         "path": str(existing["path"]),
     }
+
+    # Non-blocking quality checks (issue #416)
+    quality_warnings = _validate_skill_quality(
+        existing["path"], content=content, expected_name=name
+    )
+    if quality_warnings:
+        result["warnings"] = quality_warnings
+
+    return result
 
 
 def _patch_skill(
@@ -446,10 +613,22 @@ def _patch_skill(
         _atomic_write_text(target, original_content)
         return {"success": False, "error": scan_error}
 
-    return {
+    result = {
         "success": True,
         "message": f"Patched {'SKILL.md' if not file_path else file_path} in skill '{name}' ({match_count} replacement{'s' if match_count > 1 else ''}).",
     }
+
+    # Non-blocking quality checks (issue #416). When patching SKILL.md we use
+    # the new content directly; for supporting-file patches we let the quality
+    # check re-read SKILL.md from disk.
+    quality_content = new_content if not file_path else None
+    quality_warnings = _validate_skill_quality(
+        skill_dir, content=quality_content, expected_name=name
+    )
+    if quality_warnings:
+        result["warnings"] = quality_warnings
+
+    return result
 
 
 def _delete_skill(name: str) -> Dict[str, Any]:
@@ -515,11 +694,21 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
             target.unlink(missing_ok=True)
         return {"success": False, "error": scan_error}
 
-    return {
+    result = {
         "success": True,
         "message": f"File '{file_path}' written to skill '{name}'.",
         "path": str(target),
     }
+
+    # Non-blocking quality checks (issue #416). Re-read SKILL.md so the
+    # referenced-file check reflects the new file on disk.
+    quality_warnings = _validate_skill_quality(
+        existing["path"], expected_name=name
+    )
+    if quality_warnings:
+        result["warnings"] = quality_warnings
+
+    return result
 
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:


### PR DESCRIPTION
## What does this PR do?

Adds non-blocking quality validation to `skill_manage` create/edit/patch/write_file operations. A new helper `_validate_skill_quality()` scans each skill directory after a successful mutation and surfaces warnings in the result dict under a `warnings` key — without blocking the write. Clean skills are unaffected (no `warnings` key in the result). Matches Implementation Idea #1 from the issue (inline validation with warnings in the return message).

The validator checks:

- Python files (`*.py`) that fail `ast.parse()` — with file and line number
- Files referenced in SKILL.md (`references/`, `templates/`, `scripts/`, `assets/` paths with extensions) that don't exist on disk
- Broken symlinks anywhere in the skill directory
- Frontmatter `name` not matching the directory name (optional, per the issue)

Non-blocking by design so the agent can self-correct on the next turn without losing the write. Hidden directories (`.venv`, etc.) and `__pycache__` are skipped when scanning `.py` files. Reference detection uses a conservative regex with negative lookbehind to avoid false positives from partial matches like `my_references/foo.md`. Glob patterns are skipped. Individual per-file errors are caught per-check so a validator bug can never block a skill write.

Full design notes and rationale are in the commit message.

## Related Issue

Addresses #416 (implements Idea #1 — inline validation. Ideas #2 and #3 deferred to follow-up PRs. Not using a closing keyword so the issue stays open for the remaining work.)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py` (+197 lines): new `_REFERENCED_FILE_RE`, `_extract_referenced_files()`, `_validate_skill_quality()`. Wired into `_create_skill`, `_edit_skill`, `_patch_skill`, `_write_file`. `_delete_skill` and `_remove_file` are unchanged (no write to validate).
- `tests/tools/test_skill_manager_tool.py` (+375 lines, 28 new tests): `TestExtractReferencedFiles` (12 regex tests), `TestValidateSkillQuality` (14 validator tests), `TestQualityWarningsIntegration` (8 end-to-end tests through all four mutation paths).

## How to Test

1. Run the scoped suite — 85 passed (was 57):
   ```
   python -m pytest tests/tools/test_skill_manager_tool.py -q
   ```

2. Run the wider tools suite — 2631 passed. The 5 failures (`test_vision_tools::test_check_requirements_accepts_codex_auth`, `test_voice_mode::test_clean_environment_is_available`, `test_managed_server_tool_support::test_hermes_base_env_*` ×2, `test_send_message_missing_platforms::test_success`) are pre-existing unrelated flakes that reproduce on vanilla `main` before this PR — same ones noted in #6338.

3. End-to-end smoke test showing warnings flow through the dispatcher without blocking:
   ```python
   from tools.skill_manager_tool import skill_manage
   import json
   content = "---\nname: demo\ndescription: Demo.\n---\n\nSee references/missing.md."
   result = json.loads(skill_manage(action="create", name="demo", content=content))
   assert result["success"] is True          # write still lands
   assert "warnings" in result               # but warning surfaced
   # result["warnings"] == ["Referenced file missing: references/missing.md"]
   ```

Tested on: Arch Linux (WSL2), Python 3.11.15.

## Checklist

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass (the 5 unrelated failures noted above reproduce on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (WSL2), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A — full docstring on `_validate_skill_quality` explaining checks, design, and return format
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A — no new config keys
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A — no architectural change
- [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses `pathlib` throughout, no shell calls, no `termios`/`fcntl`, no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — tool contract unchanged; new `warnings` field is additive and only appears when issues are found

## Scope

This PR implements only Implementation Idea #1 from the issue (inline validation with warnings in the return message). Ideas #2 (standalone `hermes skill validate` / `--all` CLI) and #3 (pre-load warnings when `skill_view` loads a skill) are intentionally deferred to keep this change small and reviewable. Happy to follow up with either in subsequent PRs — issue #416 should stay open until all three paths land (or until the remaining ideas are explicitly ruled out).