### PR TITLE
fix(prompt_builder): handle PermissionError during context file discovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -95,15 +95,28 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     Search order: *cwd* first, then each parent directory up to (and
     including) the git repository root.  Returns the first match, or
     ``None`` if nothing is found.
+
+    All filesystem operations are wrapped in OSError handlers because
+    the caller may pass a *cwd* that points into a sandbox filesystem
+    (e.g. ``TERMINAL_CWD=/root`` on a Daytona backend) which the host
+    user cannot read — see #6214.
     """
-    stop_at = _find_git_root(cwd)
-    current = cwd.resolve()
+    try:
+        stop_at = _find_git_root(cwd)
+        current = cwd.resolve()
+    except OSError as e:
+        logger.debug("Could not resolve cwd %s for .hermes.md search: %s", cwd, e)
+        return None
 
     for directory in [current, *current.parents]:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
-            if candidate.is_file():
-                return candidate
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError as e:
+                logger.debug("Could not stat %s: %s", candidate, e)
+                continue
         # Stop walking at the git root (or filesystem root).
         if stop_at and directory == stop_at:
             break
@@ -883,15 +896,18 @@ def _load_agents_md(cwd_path: Path) -> str:
     """AGENTS.md — top-level only (no recursive walk)."""
     for name in ["AGENTS.md", "agents.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        try:
+            if not candidate.exists():
+                continue
+            content = candidate.read_text(encoding="utf-8").strip()
+            if content:
+                content = _scan_context_content(content, name)
+                result = f"## {name}\n\n{content}"
+                return _truncate_content(result, "AGENTS.md")
+        except OSError as e:
+            # Includes PermissionError — cwd may point into a sandbox
+            # filesystem the host user cannot read. See #6214.
+            logger.debug("Could not access %s: %s", candidate, e)
     return ""
 
 
@@ -899,15 +915,18 @@ def _load_claude_md(cwd_path: Path) -> str:
     """CLAUDE.md / claude.md — cwd only."""
     for name in ["CLAUDE.md", "claude.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "CLAUDE.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        try:
+            if not candidate.exists():
+                continue
+            content = candidate.read_text(encoding="utf-8").strip()
+            if content:
+                content = _scan_context_content(content, name)
+                result = f"## {name}\n\n{content}"
+                return _truncate_content(result, "CLAUDE.md")
+        except OSError as e:
+            # Includes PermissionError — cwd may point into a sandbox
+            # filesystem the host user cannot read. See #6214.
+            logger.debug("Could not access %s: %s", candidate, e)
     return ""
 
 
@@ -915,26 +934,31 @@ def _load_cursorrules(cwd_path: Path) -> str:
     """.cursorrules + .cursor/rules/*.mdc — cwd only."""
     cursorrules_content = ""
     cursorrules_file = cwd_path / ".cursorrules"
-    if cursorrules_file.exists():
-        try:
+    try:
+        if cursorrules_file.exists():
             content = cursorrules_file.read_text(encoding="utf-8").strip()
             if content:
                 content = _scan_context_content(content, ".cursorrules")
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
-        except Exception as e:
-            logger.debug("Could not read .cursorrules: %s", e)
+    except OSError as e:
+        # Includes PermissionError — cwd may point into a sandbox
+        # filesystem the host user cannot read. See #6214.
+        logger.debug("Could not access .cursorrules: %s", e)
 
     cursor_rules_dir = cwd_path / ".cursor" / "rules"
-    if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
-        mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
-        for mdc_file in mdc_files:
-            try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
-                    cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
-            except Exception as e:
-                logger.debug("Could not read %s: %s", mdc_file, e)
+    try:
+        if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
+            mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
+            for mdc_file in mdc_files:
+                try:
+                    content = mdc_file.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
+                        cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
+                except OSError as e:
+                    logger.debug("Could not read %s: %s", mdc_file, e)
+    except OSError as e:
+        logger.debug("Could not access .cursor/rules: %s", e)
 
     if not cursorrules_content:
         return ""
@@ -959,18 +983,27 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     if cwd is None:
         cwd = os.getcwd()
 
-    cwd_path = Path(cwd).resolve()
+    try:
+        cwd_path = Path(cwd).resolve()
+    except OSError as e:
+        # ``cwd`` may point into a sandbox path the host user cannot
+        # read — skip project context discovery entirely in that case.
+        # See #6214.
+        logger.debug("Could not resolve context cwd %s: %s", cwd, e)
+        cwd_path = None
+
     sections = []
 
     # Priority-based project context: first match wins
-    project_context = (
-        _load_hermes_md(cwd_path)
-        or _load_agents_md(cwd_path)
-        or _load_claude_md(cwd_path)
-        or _load_cursorrules(cwd_path)
-    )
-    if project_context:
-        sections.append(project_context)
+    if cwd_path is not None:
+        project_context = (
+            _load_hermes_md(cwd_path)
+            or _load_agents_md(cwd_path)
+            or _load_claude_md(cwd_path)
+            or _load_cursorrules(cwd_path)
+        )
+        if project_context:
+            sections.append(project_context)
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -904,10 +904,13 @@ def _load_agents_md(cwd_path: Path) -> str:
                 content = _scan_context_content(content, name)
                 result = f"## {name}\n\n{content}"
                 return _truncate_content(result, "AGENTS.md")
-        except OSError as e:
-            # Includes PermissionError — cwd may point into a sandbox
-            # filesystem the host user cannot read. See #6214.
-            logger.debug("Could not access %s: %s", candidate, e)
+        except (OSError, UnicodeError) as e:
+            # OSError (incl. PermissionError) — cwd may point into a
+            # sandbox filesystem the host user cannot read.
+            # UnicodeError (incl. UnicodeDecodeError) — the file exists
+            # and is readable but isn't valid UTF-8. Fail gracefully so
+            # prompt construction continues either way. See #6214.
+            logger.debug("Could not load %s: %s", candidate, e)
     return ""
 
 
@@ -923,10 +926,13 @@ def _load_claude_md(cwd_path: Path) -> str:
                 content = _scan_context_content(content, name)
                 result = f"## {name}\n\n{content}"
                 return _truncate_content(result, "CLAUDE.md")
-        except OSError as e:
-            # Includes PermissionError — cwd may point into a sandbox
-            # filesystem the host user cannot read. See #6214.
-            logger.debug("Could not access %s: %s", candidate, e)
+        except (OSError, UnicodeError) as e:
+            # OSError (incl. PermissionError) — cwd may point into a
+            # sandbox filesystem the host user cannot read.
+            # UnicodeError (incl. UnicodeDecodeError) — the file exists
+            # and is readable but isn't valid UTF-8. Fail gracefully so
+            # prompt construction continues either way. See #6214.
+            logger.debug("Could not load %s: %s", candidate, e)
     return ""
 
 
@@ -940,10 +946,11 @@ def _load_cursorrules(cwd_path: Path) -> str:
             if content:
                 content = _scan_context_content(content, ".cursorrules")
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
-    except OSError as e:
-        # Includes PermissionError — cwd may point into a sandbox
-        # filesystem the host user cannot read. See #6214.
-        logger.debug("Could not access .cursorrules: %s", e)
+    except (OSError, UnicodeError) as e:
+        # OSError (incl. PermissionError) — cwd may point into a
+        # sandbox filesystem the host user cannot read.
+        # UnicodeError — the file isn't valid UTF-8. See #6214.
+        logger.debug("Could not load .cursorrules: %s", e)
 
     cursor_rules_dir = cwd_path / ".cursor" / "rules"
     try:
@@ -955,8 +962,10 @@ def _load_cursorrules(cwd_path: Path) -> str:
                     if content:
                         content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
                         cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
-                except OSError as e:
-                    logger.debug("Could not read %s: %s", mdc_file, e)
+                except (OSError, UnicodeError) as e:
+                    # Skip the offending file (OSError for unreadable,
+                    # UnicodeError for non-UTF-8) and continue with the rest.
+                    logger.debug("Could not load %s: %s", mdc_file, e)
     except OSError as e:
         logger.debug("Could not access .cursor/rules: %s", e)
 


### PR DESCRIPTION
## Summary

Fixes #6214 — agent crashes during system prompt construction with \`PermissionError\` when \`TERMINAL_CWD\` points to a sandbox path the host user cannot read (e.g. Daytona backend with \`TERMINAL_CWD=/root\` and hermes running as \`hermesadmin\`).

## Root cause

\`Path.exists()\` and \`Path.is_file()\` only swallow \`ENOENT\` / \`ENOTDIR\` — they propagate every other \`OSError\` including \`EACCES\`. Four context-file loaders in \`agent/prompt_builder.py\` had their existing \`try/except\` blocks wrapped around \`read_text()\` only, leaving the \`.exists()\` / \`.is_file()\` calls unprotected:

\`\`\`python
# Current (broken) pattern in _load_agents_md:
for name in ["AGENTS.md", "agents.md"]:
    candidate = cwd_path / name
    if candidate.exists():            # ← raises PermissionError, uncaught
        try:
            content = candidate.read_text(...)
            ...
        except Exception as e:         # ← too late
            logger.debug(...)
\`\`\`

The issue reporter's trace:
\`\`\`
Error during OpenAI-compatible API call #3: [Errno 13] Permission denied: '/root/AGENTS.md'
\`\`\`

## Fix

Move the existence checks inside the error handlers, widen handlers to cover filesystem walking in \`_find_hermes_md\`, and narrow the exception type from \`Exception\` to \`OSError\` (more principled — we only want to swallow filesystem access errors, not mask logic bugs).

Five call sites patched:

| Function | Fix |
|---|---|
| \`_find_hermes_md\` | Wrap \`_find_git_root\` + \`cwd.resolve()\` + per-candidate \`is_file()\` in \`OSError\` handlers |
| \`_load_agents_md\` | Move \`candidate.exists()\` inside \`try\` block |
| \`_load_claude_md\` | Move \`candidate.exists()\` inside \`try\` block |
| \`_load_cursorrules\` | Wrap both \`.cursorrules\` and \`.cursor/rules/\` existence + enumeration in \`OSError\` handlers |
| \`build_context_files_prompt\` | Wrap \`Path(cwd).resolve()\` in an \`OSError\` handler and skip project context discovery when it fails (SOUL.md loading still proceeds) |

All errors are logged at \`logger.debug\` level consistent with the existing pattern — no new log noise.

## Test plan

Reproduced both states with a minimal harness:

\`\`\`python
# Create an unreadable dir containing AGENTS.md
unreadable = "/tmp/hermes_permtest/unreadable"
open(f"{unreadable}/AGENTS.md", "w").write("secret")
os.chmod(unreadable, 0o000)

p = Path(unreadable) / "AGENTS.md"
# Baseline: Path.exists() raises
p.exists()
# → PermissionError: [Errno 13] Permission denied

# Patched helper: OSError caught at exists() call, returns gracefully
\`\`\`

- [x] Baseline: \`Path.exists()\` raises \`PermissionError\` on the reported scenario
- [x] Patched: all five functions gracefully return empty / \`None\` / skip and log at debug
- [x] Python AST parse (no syntax regressions)
- [x] Existing \`read_text()\` error paths preserved — no behavior change on the happy path
- [ ] CI suite (please run on merge)

## Behavior change

**None on the happy path.** Existing agents that can read their cwd see identical output. The only new behavior is \"graceful skip instead of crash\" when cwd is inaccessible — which is exactly what the issue reporter asked for:

> *Expected: Context file discovery should fail gracefully when \`TERMINAL_CWD\` points to a directory the host user cannot access. The agent should continue initialization and skip context files it cannot read.*

## Scope

Only \`agent/prompt_builder.py\`. No changes to the RPC protocol, system prompt contents, skill loading, or the SOUL.md path.