### PR TITLE
fix(nix): remove setupSecrets dependency for non-sops-nix users

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -561,7 +561,7 @@
 
       # ── Activation: link config + auth + documents ────────────────────
       {
-        system.activationScripts."hermes-agent-setup" = lib.stringAfter [ "users" "setupSecrets" ] ''
+        system.activationScripts."hermes-agent-setup" = lib.stringAfter [ "users" ] ''
           # Ensure directories exist (activation runs before tmpfiles)
           mkdir -p ${cfg.stateDir}/.hermes
           mkdir -p ${cfg.stateDir}/home


### PR DESCRIPTION
## What broke

NixOS module evaluation fails with `attribute 'setupSecrets' missing` for users not using sops-nix. The `setupSecrets` activation script is only defined when sops-nix is imported, making hermes-agent unusable with other secrets management solutions like agenix.

## Root cause

Line 564 in `nix/nixosModules.nix` declared dependency on `setupSecrets`:
```nix
lib.stringAfter [ "users" "setupSecrets" ]
```

This assumes sops-nix is always present, which is not guaranteed.

## Why this fix is minimal

- Single change: removed `"setupSecrets"` from `stringAfter` list
- Hermes activation script doesn't require secrets to be set up first
- Environment files are read at runtime by `load_hermes_dotenv()`, not during activation
- No behavior change for sops-nix users (secrets still available at runtime)

## What I tested

- Verified no other references to `setupSecrets` in the file
- Confirmed activation script only needs `"users"` dependency

## What I intentionally did not change

- No changes to `environmentFiles` handling
- No changes to secret loading logic
- No opportunistic refactoring

Fixes #6227