### PR TITLE
fix(gateway): prevent gateway flood with "Restore stash?" message every 2s

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5796,6 +5796,10 @@ class GatewayRunner:
                                 f"or type your answer directly."
                             )
                         self._update_prompt_pending[session_key] = True
+                        # Delete the prompt file so the watcher doesn't
+                        # re-send it every poll interval (causes Telegram
+                        # flood control when left in place).
+                        prompt_path.unlink(missing_ok=True)
                         logger.info("Forwarded update prompt to %s: %s", session_key, prompt_text[:80])
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug("Failed to read update prompt: %s", e)

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -322,6 +322,60 @@ class TestWatchUpdateProgress:
         # (may be cleared by the time we check since update finished)
 
     @pytest.mark.asyncio
+    async def test_prompt_sent_only_once_and_file_deleted(self, tmp_path):
+        """After forwarding the prompt, the watcher must delete .update_prompt.json
+        so it is not re-sent on the next poll interval.  Re-sending every 2s
+        causes Telegram flood control."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {"platform": "telegram", "chat_id": "111", "user_id": "222",
+                   "session_key": "agent:main:telegram:dm:111"}
+        (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
+        (hermes_home / ".update_output.txt").write_text("output\n")
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        # Write a prompt — the watcher should forward it then delete the file.
+        # We do NOT delete it ourselves; we verify the watcher does.
+        async def simulate_prompt_and_finish():
+            await asyncio.sleep(0.3)
+            prompt = {"prompt": "Restore? [Y/n]", "default": "y", "id": "test2"}
+            (hermes_home / ".update_prompt.json").write_text(json.dumps(prompt))
+            # Wait long enough for several poll cycles
+            await asyncio.sleep(1.0)
+            # Finish the update
+            (hermes_home / ".update_exit_code").write_text("0")
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            task = asyncio.create_task(simulate_prompt_and_finish())
+            await runner._watch_update_progress(
+                poll_interval=0.1,
+                stream_interval=0.2,
+                timeout=10.0,
+            )
+            await task
+
+        # Count how many times the prompt text was sent via adapter.send
+        send_calls = [str(c) for c in mock_adapter.send.call_args_list]
+        prompt_sends = [s for s in send_calls if "Restore" in s]
+        assert len(prompt_sends) == 1, (
+            f"Prompt should be sent exactly once, but was sent {len(prompt_sends)} times. "
+            f"Indicates .update_prompt.json was not deleted after forwarding."
+        )
+
+        # The prompt file should have been deleted by the watcher
+        assert not (hermes_home / ".update_prompt.json").exists(), (
+            "Watcher should delete .update_prompt.json after forwarding"
+        )
+
+        # send_update_prompt (button path) should also be called at most once
+        if mock_adapter.send_update_prompt.called:
+            assert mock_adapter.send_update_prompt.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_cleans_up_on_completion(self, tmp_path):
         """All marker files are cleaned up when update finishes."""
         runner = _make_runner()


### PR DESCRIPTION
## What does this PR do?

The update watcher (`_watch_update_progress`) polls `.update_prompt.json` every 2 seconds to forward interactive prompts to the user (e.g. "Restore stash? [Y/n]"). After forwarding, the file was never deleted, so the watcher re-sent the same prompt on every poll interval. Telegram's flood control blocked subsequent sends, generating repeated errors and eventually causing the watcher to time out after 1800s.

This PR deletes `.update_prompt.json` after successfully forwarding the prompt, preventing the re-send loop.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py:5802` — Added `prompt_path.unlink(missing_ok=True)` after forwarding the update prompt, so the watcher doesn't re-send it every poll interval
- `tests/gateway/test_update_streaming.py` — Added `test_prompt_sent_only_once_and_file_deleted` that verifies the prompt is sent exactly once and the file is deleted by the watcher

## How to Test

1. Run `hermes update --gateway` and observe that the update prompt (if any) is sent once without flood control errors in `logs/errors.log`
2. Run `pytest tests/gateway/test_update_streaming.py -v` — all 17 tests pass
3. To confirm the bug exists without the fix: revert the `prompt_path.unlink` line and run `test_prompt_sent_only_once_and_file_deleted` — it fails with "Prompt should be sent exactly once, but was sent 10 times"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Raspberry Pi 4, Debian 13 (trixie), Python 3.11

### Documentation & Housekeeping

- [x] N/A — internal bug fix, no docs or config changes needed

## Screenshots / Logs

Before the fix, `logs/errors.log` shows repeated flood control errors during `hermes update`:

```
2026-04-08 14:15:37,226 WARNING gateway.platforms.telegram: [Telegram] send_update_prompt failed: Flood control exceeded. Retry in 18 seconds
2026-04-08 14:15:39,403 WARNING gateway.platforms.telegram: [Telegram] send_update_prompt failed: Flood control exceeded. Retry in 16 seconds
2026-04-08 14:15:41,552 WARNING gateway.platforms.telegram: [Telegram] send_update_prompt failed: Flood control exceeded. Retry in 14 seconds
...
2026-04-08 14:47:36,521 WARNING gateway.run: Update watcher timed out after 1800s
```

After the fix: no flood control errors, update completes normally.

Telegram chat screenshot: 
<img width="324" height="671" alt="image" src="https://github.com/user-attachments/assets/b3078076-3392-436e-9f46-778fd1495242" />
