### PR TITLE
fix(agent): disable stale stream timeout for local providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4728,18 +4728,25 @@ class AIAgent:
                     self._close_request_openai_client(request_client, reason="stream_request_complete")
 
         _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
-        # Scale the stale timeout for large contexts: slow models (like Opus)
-        # can legitimately think for minutes before producing the first token
-        # when the context is large.  Without this, the stale detector kills
-        # healthy connections during the model's thinking phase, producing
-        # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
+        # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
+        # for prefill on large contexts.  Disable the stale detector unless
+        # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
+        if _stream_stale_timeout_base == 180.0 and self.base_url and is_local_endpoint(self.base_url):
+            _stream_stale_timeout = float("inf")
+            logger.debug("Local provider detected (%s) — stale stream timeout disabled", self.base_url)
         else:
-            _stream_stale_timeout = _stream_stale_timeout_base
+            # Scale the stale timeout for large contexts: slow models (like Opus)
+            # can legitimately think for minutes before producing the first token
+            # when the context is large.  Without this, the stale detector kills
+            # healthy connections during the model's thinking phase, producing
+            # spurious RemoteProtocolError ("peer closed connection").
+            _est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
+            if _est_tokens > 100_000:
+                _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
+            elif _est_tokens > 50_000:
+                _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
+            else:
+                _stream_stale_timeout = _stream_stale_timeout_base
 
         t = threading.Thread(target=_call, daemon=True)
         t.start()


### PR DESCRIPTION
## Summary

Local inference providers (Ollama, oMLX, llama-cpp) can take 300+ seconds for prefill on large contexts. The 180s stale stream detector was killing these connections while the provider was still actively processing, causing spurious reconnects and abandoned requests.

Inspired by PR #6123 by @Archerouyang (who identified the issue in #5889). This implementation uses the existing `is_local_endpoint()` from `agent/model_metadata.py` instead of creating a new detection method — it does proper URL parsing with localhost, RFC-1918, IPv6, and WSL support without the false positives from substring matching.

## Changes

**run_agent.py** — 1 file, +18/-11 lines

Before the existing token-scaled stale timeout logic, check if:
1. The timeout is at the default 180s (user hasn't explicitly set `HERMES_STREAM_STALE_TIMEOUT`)
2. A base_url is set (not the SDK default)
3. `is_local_endpoint()` identifies it as local

If all three, disable the stale detector (`float('inf')`). Otherwise, fall through to the existing token-scaled logic unchanged.

## Behavior matrix

| Scenario | Stale timeout |
|----------|--------------|
| Ollama on localhost, default config | Disabled (inf) |
| Ollama on localhost, explicit `HERMES_STREAM_STALE_TIMEOUT=300` | 300s (user setting honored) |
| LAN server (192.168.x.x) | Disabled (inf) |
| OpenRouter / cloud provider | 180s (with token scaling) |
| Cloud Ollama proxy (api.ollama.com) | 180s (correctly NOT detected as local) |
| Empty/None URL (SDK default) | 180s (correctly NOT detected as local) |

## Test plan

- 671 run_agent tests pass, 5 skipped
- E2E verified: `is_local_endpoint()` correctly identifies all local patterns and rejects cloud URLs
- `py_compile` clean

Fixes #5889