### PR TITLE
fix(terminal): guard invalid command values

### DIFF
--- a/tests/tools/test_terminal_none_command_guard.py
+++ b/tests/tools/test_terminal_none_command_guard.py
@@ -1,0 +1,21 @@
+"""Regression tests for invalid/None terminal command handling."""
+
+import json
+
+from tools.terminal_tool import _transform_sudo_command, terminal_tool
+
+
+def test_transform_sudo_command_none_returns_cleanly():
+    transformed, sudo_stdin = _transform_sudo_command(None)
+
+    assert transformed is None
+    assert sudo_stdin is None
+
+
+def test_terminal_tool_none_command_returns_clean_error():
+    result = json.loads(terminal_tool(None))  # type: ignore[arg-type]
+
+    assert result["exit_code"] == -1
+    assert result["status"] == "error"
+    assert "expected string" in result["error"].lower()
+    assert "nonetype" in result["error"].lower()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -327,7 +327,19 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
             del os.environ["HERMES_SPINNER_PAUSE"]
 
 
-def _transform_sudo_command(command: str) -> tuple[str, str | None]:
+def _safe_command_preview(command: Any, limit: int = 200) -> str:
+    """Return a log-safe preview for possibly-invalid command values."""
+    if command is None:
+        return "<None>"
+    if isinstance(command, str):
+        return command[:limit]
+    try:
+        return repr(command)[:limit]
+    except Exception:
+        return f"<{type(command).__name__}>"
+
+
+def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None]:
     """
     Transform sudo commands to use -S flag if SUDO_PASSWORD is available.
 
@@ -365,6 +377,9 @@ def _transform_sudo_command(command: str) -> tuple[str, str | None]:
     import re
 
     # Check if command even contains sudo
+    if command is None:
+        return None, None
+
     if not re.search(r'\bsudo\b', command):
         return command, None  # No sudo in command, nothing to do
 
@@ -1033,6 +1048,18 @@ def terminal_tool(
         # Note: force parameter is internal only, not exposed to model API
     """
     try:
+        if not isinstance(command, str):
+            logger.warning(
+                "Rejected invalid terminal command value: %s",
+                type(command).__name__,
+            )
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": f"Invalid command: expected string, got {type(command).__name__}",
+                "status": "error",
+            }, ensure_ascii=False)
+
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]
@@ -1190,7 +1217,7 @@ def terminal_tool(
             workdir_error = _validate_workdir(workdir)
             if workdir_error:
                 logger.warning("Blocked dangerous workdir: %s (command: %s)",
-                               workdir[:200], command[:200])
+                               workdir[:200], _safe_command_preview(command))
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
@@ -1330,12 +1357,12 @@ def terminal_tool(
                         retry_count += 1
                         wait_time = 2 ** retry_count
                         logger.warning("Execution error, retrying in %ds (attempt %d/%d) - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                                       wait_time, retry_count, max_retries, command[:200], type(e).__name__, e, effective_task_id, env_type)
+                                       wait_time, retry_count, max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                         time.sleep(wait_time)
                         continue
                     
                     logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                                 max_retries, command[:200], type(e).__name__, e, effective_task_id, env_type)
+                                 max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                     return json.dumps({
                         "output": "",
                         "exit_code": -1,


### PR DESCRIPTION
## What does this PR do?

Prevents the terminal tool from double-faulting when an invalid command value
reaches execution.

Before this change, `command=None` could crash in two places:

- `_transform_sudo_command()` called `re.search(..., command)` with no guard
- the retry/error logging path sliced `command[:200]` with no guard

This patch rejects non-string command values early in `terminal_tool()`, adds a
safe preview helper for logging, and makes `_transform_sudo_command()` tolerate
`None` defensively.

## Related Issue

No GitHub issue yet for this specific support-thread crash report.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Guard non-string command values at the start of `tools/terminal_tool.py`
- Add `_safe_command_preview()` so retry/error logging no longer assumes a
  sliceable string
- Make `_transform_sudo_command()` return cleanly for `None`
- Add regression tests in `tests/tools/test_terminal_none_command_guard.py`

## How to Test

1. Reproduce the reported bad state by calling `terminal_tool(None)` and verify
   it returns a clean JSON error instead of crashing.
2. Run:
   `python -m pytest tests/tools/test_terminal_none_command_guard.py tests/tools/test_terminal_exit_semantics.py -q -x -n 0`
3. Run the full suite sequentially:
   `python -m pytest tests/ -q -n 0`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression checks passed:

- `python -m py_compile tools/terminal_tool.py tests/tools/test_terminal_none_command_guard.py`
- `python -m pytest tests/tools/test_terminal_none_command_guard.py tests/tools/test_terminal_exit_semantics.py -q -x -n 0`
  - `33 passed`

Full sequential suite status on current `main` in this environment:

- `python -m pytest tests/ -q -n 0`
  - `26 failed, 9360 passed, 25 skipped, 50 deselected, 1 xpassed`

The failing tests were in unrelated areas such as Telegram slash commands, API
server defaults, approval flow, provider detection, managed browser config,
Matrix send payloads, Tirith, and agent loop tool-calling.
