### PR TITLE
fix(setup): reject malformed inherited custom endpoint URLs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1413,6 +1413,26 @@ def _model_flow_qwen_oauth(_config, current_model=""):
 
 
 
+def _is_valid_http_endpoint_url(url: str) -> bool:
+    """Return True when *url* is a syntactically valid http/https endpoint URL."""
+    from urllib.parse import urlparse
+
+    candidate = (url or "").strip()
+    if not candidate:
+        return False
+    try:
+        parsed = urlparse(candidate)
+        if parsed.scheme not in {"http", "https"}:
+            return False
+        if not parsed.hostname:
+            return False
+        _ = parsed.port  # triggers ValueError for malformed ports like '6153export'
+        return True
+    except ValueError:
+        return False
+
+
+
 def _model_flow_custom(config):
     """Custom endpoint: collect URL, API key, and model name.
 
@@ -1446,8 +1466,17 @@ def _model_flow_custom(config):
 
     # Validate URL format
     effective_url = base_url or current_url
-    if not effective_url.startswith(("http://", "https://")):
-        print(f"Invalid URL: {effective_url} (must start with http:// or https://)")
+    if not _is_valid_http_endpoint_url(effective_url):
+        if not base_url and current_url:
+            print(
+                "Invalid current custom endpoint URL saved in environment/config: "
+                f"{current_url!r}. Enter a valid http(s) base URL instead."
+            )
+        else:
+            print(
+                f"Invalid URL: {effective_url!r} "
+                "(must be a valid http:// or https:// endpoint URL)"
+            )
         return
 
     effective_key = api_key or current_key

--- a/run_agent.py
+++ b/run_agent.py
@@ -3568,7 +3568,26 @@ class AIAgent:
             return bool(getattr(http_client, "is_closed", False))
         return False
 
+    @staticmethod
+    def _validate_openai_base_url(base_url: Any) -> None:
+        """Validate custom OpenAI-compatible base URLs before client creation."""
+        from urllib.parse import urlparse
+
+        candidate = str(base_url or "").strip()
+        if not candidate or candidate.startswith("acp://"):
+            return
+        try:
+            parsed = urlparse(candidate)
+            if parsed.scheme in {"http", "https"}:
+                _ = parsed.port  # raises ValueError for malformed ports like '6153export'
+        except ValueError as exc:
+            raise RuntimeError(
+                "Malformed custom endpoint URL: "
+                f"{candidate!r}. Run `hermes setup` or `hermes model` and enter a valid http(s) base URL."
+            ) from exc
+
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
+        self._validate_openai_base_url(client_kwargs.get("base_url"))
         if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
             from agent.copilot_acp_client import CopilotACPClient
 

--- a/tests/hermes_cli/test_custom_endpoint_setup.py
+++ b/tests/hermes_cli/test_custom_endpoint_setup.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from hermes_cli.main import _is_valid_http_endpoint_url, _model_flow_custom
+
+
+def test_valid_http_endpoint_url_rejects_malformed_port_suffix():
+    assert _is_valid_http_endpoint_url("https://api.example.com/v1") is True
+    assert _is_valid_http_endpoint_url("http://127.0.0.1:6153/v1") is True
+    assert _is_valid_http_endpoint_url("http://127.0.0.1:6153export") is False
+    assert _is_valid_http_endpoint_url("https://") is False
+
+
+def test_model_flow_custom_refuses_invalid_saved_current_url(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:6153export")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text("model: gpt-5\n_config_version: 12\n", encoding="utf-8")
+
+    config = {"model": "gpt-5", "_config_version": 12}
+
+    with patch("builtins.input", side_effect=[""]), patch("getpass.getpass", return_value="test-key"):
+        _model_flow_custom(config)
+
+    out = capsys.readouterr().out
+    assert "Invalid current custom endpoint URL" in out
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"] == "gpt-5"
+    assert not saved.get("custom_providers")
+
+
+def test_model_flow_custom_accepts_valid_user_entered_url(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text("model: gpt-5\n_config_version: 12\n", encoding="utf-8")
+
+    config = {"model": "gpt-5", "_config_version": 12}
+
+    with patch("builtins.input", side_effect=["http://127.0.0.1:6153/v1", "gpt-5.4", ""]), \
+         patch("getpass.getpass", return_value="test-key"), \
+         patch("hermes_cli.models.probe_api_models", return_value={"models": None, "probed_url": "http://127.0.0.1:6153/v1", "suggested_base_url": None}):
+        _model_flow_custom(config)
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"]["provider"] == "custom"
+    assert saved["model"]["base_url"] == "http://127.0.0.1:6153/v1"
+    assert saved["model"]["api_key"] == "test-key"
+    assert saved["model"]["default"] == "gpt-5.4"

--- a/tests/run_agent/test_custom_base_url_validation.py
+++ b/tests/run_agent/test_custom_base_url_validation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def test_validate_openai_base_url_accepts_normal_http_urls():
+    AIAgent._validate_openai_base_url("https://api.example.com/v1")
+    AIAgent._validate_openai_base_url("http://127.0.0.1:6153/v1")
+    AIAgent._validate_openai_base_url("acp://copilot")
+    AIAgent._validate_openai_base_url("")
+
+
+def test_validate_openai_base_url_rejects_malformed_port_suffix():
+    with pytest.raises(RuntimeError, match="Malformed custom endpoint URL"):
+        AIAgent._validate_openai_base_url("http://127.0.0.1:6153export")


### PR DESCRIPTION
## Summary
- validate custom OpenAI-compatible endpoint URLs with real URL parsing during setup
- reject malformed inherited endpoint values before saving them into the active custom model config
- validate custom endpoint URLs again at runtime before creating the OpenAI client
- add regression tests for malformed inherited URLs, valid setup flows, and runtime validation

## Root cause
The custom endpoint flow only checked whether the URL started with `http://` or `https://`.
That allowed malformed inherited values like `http://127.0.0.1:6153export` to pass setup validation and get saved as the active custom endpoint.
Later, Hermes failed during OpenAI client initialization with:

`Invalid port: '6153export'`

The latest issue comment also suggests the `6153` fragment likely came from a local proxy / SOCKS port, which fits the hypothesis that a locally corrupted endpoint string was being persisted and reused.

I reproduced this locally in an isolated `HERMES_HOME` by:
- setting `OPENAI_BASE_URL=http://127.0.0.1:6153export`
- entering custom endpoint setup
- pressing Enter to reuse the inherited current URL
- observing the malformed URL get saved into `model.base_url`
- confirming OpenAI client initialization then throws the same invalid-port error

## Fix
### Setup-side
- add `_is_valid_http_endpoint_url()` to parse and validate http/https endpoint URLs
- reject malformed inherited current URLs instead of silently reusing them
- show a clearer message telling the user to enter a valid base URL

### Runtime-side
- validate the resolved custom base URL again before creating the OpenAI client
- convert malformed saved values into a clearer Hermes error telling the user to rerun `hermes setup` / `hermes model`

This means the fix now covers both:
- preventing new bad values from being saved
- handling already-persisted bad values more gracefully

## How to test
Automated checks run locally:
- `pytest tests/hermes_cli/test_custom_endpoint_setup.py tests/run_agent/test_custom_base_url_validation.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_runtime_provider_resolution.py -q -o addopts=`
- `python -m py_compile run_agent.py hermes_cli/main.py tests/run_agent/test_custom_base_url_validation.py tests/hermes_cli/test_custom_endpoint_setup.py`

Manual reproduction:
1. Set `OPENAI_BASE_URL=http://127.0.0.1:6153export`
2. Run `hermes setup` → quick setup → custom endpoint
3. Press Enter at the base URL prompt to reuse the inherited value
4. Before this PR, Hermes could save the malformed URL and later fail with the raw OpenAI invalid-port exception
5. After this PR, setup rejects it immediately, and runtime also fails with a clearer Hermes-side configuration error if a broken value is already persisted

## Platform coverage
- Tested locally on Linux
- Change is setup/runtime config validation logic only

Fixes #6360
