### PR TITLE
fix(cli): render full multiline user messages in chat transcript

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8349,14 +8349,9 @@ class HermesCLI:
                     else:
                         _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
                         if '\n' in user_input:
-                            first_line = user_input.split('\n')[0]
-                            line_count = user_input.count('\n') + 1
                             print()
                             ChatConsole().print(_user_bar)
-                            ChatConsole().print(
-                                f"[bold {_accent_hex()}]●[/] [bold]{_escape(first_line)}[/] "
-                                f"[dim](+{line_count - 1} lines)[/]"
-                            )
+                            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
                         else:
                             print()
                             ChatConsole().print(_user_bar)


### PR DESCRIPTION
Problem:
When a user submits a multiline message in the CLI, the transcript only shows the first line plus a summary like "(+N lines)". This hides the full submitted content from the visible conversation log.

Expected:
The CLI transcript should render the full multiline user message after submission.

Fix:
Update the user-message echo path in cli.py to print the full escaped multiline content instead of truncating to the first line.

Validation:
- Verified cli.py compiles with: python -m py_compile cli.py
- Confirmed the change is isolated to the CLI user-message rendering path

Notes:
This does not add multiline input support itself; multiline input is already enabled upstream. This change improves how submitted multiline input is displayed in the CLI transcript.