### PR TITLE
test(tools): fix mocking for faster_whisper, Python 3.14 stat, and sy…

### DIFF
--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -368,6 +368,9 @@ class TestCmdUpdateLaunchdRestart:
         monkeypatch.setattr(
             gateway_cli, "is_macos", lambda: False,
         )
+        monkeypatch.setattr(
+            gateway_cli, "is_linux", lambda: True,
+        )
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -6,11 +6,17 @@ dispatch.  All external dependencies (faster_whisper, openai) are mocked.
 
 import json
 import os
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch, mock_open
 
 import pytest
+
+# Inject a stub faster_whisper module so patch("faster_whisper.WhisperModel")
+# works even when the optional dependency is not installed.
+if "faster_whisper" not in sys.modules:
+    sys.modules["faster_whisper"] = MagicMock()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -8,10 +8,17 @@ end-to-end dispatch.  All external dependencies are mocked.
 import os
 import struct
 import subprocess
+import sys
 import wave
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Inject a stub faster_whisper module so patch("faster_whisper.WhisperModel")
+# works even when the optional dependency is not installed.
+if "faster_whisper" not in sys.modules:
+    _fw_stub = MagicMock()
+    sys.modules["faster_whisper"] = _fw_stub
 
 
 # ============================================================================
@@ -663,18 +670,11 @@ class TestValidateAudioFileEdgeCases:
         f = tmp_path / "test.ogg"
         f.write_bytes(b"data")
         from tools.transcription_tools import _validate_audio_file
-        real_stat = f.stat()
-        call_count = 0
 
-        def stat_side_effect(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            # First calls are from exists() and is_file(), let them pass
-            if call_count <= 2:
-                return real_stat
-            raise OSError("disk error")
-
-        with patch("pathlib.Path.stat", side_effect=stat_side_effect):
+        # In Python 3.14+ exists() and is_file() use C-level os.stat
+        # rather than Path.stat(), so the first Path.stat() call is the
+        # explicit one inside _validate_audio_file for the size check.
+        with patch("pathlib.Path.stat", side_effect=OSError("disk error")):
             result = _validate_audio_file(str(f))
         assert result is not None
         assert "Failed to access" in result["error"]


### PR DESCRIPTION
Problem
- Transcription tests fail on import when faster_whisper is not installed
- test_stat_oserror fails on Python 3.14 because Path.exists()/Path.is_file() no longer delegate to Path.stat()
- test_update_gateway_restart fails on non-Linux platforms because is_linux() isn't mocked

Fix
- Inject a sys.modules stub for faster_whisper in both transcription test files
- Simplify test_stat_oserror to patch Path.stat directly and assert the validation function returns an error (no call_count threshold)
- Mock is_linux → True in the gateway restart test

Testing
- All three test files pass on macOS with Python 3.14