### PR TITLE
feat(discord): inherit forum channel topic in thread sessions

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1767,8 +1767,9 @@ class DiscordAdapter(BasePlatformAdapter):
             if hasattr(interaction.channel, "guild") and interaction.channel.guild:
                 chat_name = f"{interaction.channel.guild.name} / #{chat_name}"
 
-        # Get channel topic (if available)
-        chat_topic = getattr(interaction.channel, "topic", None)
+        # Get channel topic (if available).
+        # For forum threads, inherit the parent forum's topic.
+        chat_topic = self._get_effective_topic(interaction.channel, is_thread=is_thread)
 
         source = self.build_source(
             chat_id=str(interaction.channel_id),
@@ -1842,6 +1843,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
         chat_name = f"{guild_name} / {thread_name}" if guild_name else thread_name
 
+        # Inherit forum topic when the thread was created inside a forum channel.
+        _chan = getattr(interaction, "channel", None)
+        chat_topic = self._get_effective_topic(_chan, is_thread=True) if _chan else None
+
         source = self.build_source(
             chat_id=thread_id,
             chat_name=chat_name,
@@ -1849,6 +1854,7 @@ class DiscordAdapter(BasePlatformAdapter):
             user_id=str(interaction.user.id),
             user_name=interaction.user.display_name,
             thread_id=thread_id,
+            chat_topic=chat_topic,
         )
 
         event = MessageEvent(
@@ -2134,6 +2140,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 return True
         return False
 
+    def _get_effective_topic(self, channel: Any, is_thread: bool = False) -> Optional[str]:
+        """Return the channel topic, falling back to the parent forum's topic for forum threads."""
+        topic = getattr(channel, "topic", None)
+        if not topic and is_thread:
+            parent = getattr(channel, "parent", None)
+            if parent and self._is_forum_parent(parent):
+                topic = getattr(parent, "topic", None)
+        return topic
+
     def _format_thread_chat_name(self, thread: Any) -> str:
         """Build a readable chat name for thread-like Discord channels, including forum context when available."""
         thread_name = getattr(thread, "name", None) or str(getattr(thread, "id", "thread"))
@@ -2301,8 +2316,10 @@ class DiscordAdapter(BasePlatformAdapter):
             if hasattr(message.channel, "guild") and message.channel.guild:
                 chat_name = f"{message.channel.guild.name} / #{chat_name}"
 
-        # Get channel topic (if available - TextChannels have topics, DMs/threads don't)
-        chat_topic = getattr(message.channel, "topic", None)
+        # Get channel topic (if available - TextChannels have topics, DMs/threads don't).
+        # For threads whose parent is a forum channel, inherit the parent's topic
+        # so forum descriptions (e.g. project instructions) appear in the session context.
+        chat_topic = self._get_effective_topic(message.channel, is_thread=is_thread)
 
         # Build source
         source = self.build_source(


### PR DESCRIPTION
## Problem

Discord forum threads don't carry their own `topic` — only the parent `ForumChannel` does. The existing code reads `chat_topic` via `getattr(channel, "topic", None)`, which always returns `None` for `Thread` objects. This means any description set on a forum channel is silently dropped, and the `**Channel Topic:**` line never appears in the session context for forum thread sessions.

The infrastructure to handle this is already in place — `_is_forum_parent()` already detects forum channels, `_format_thread_chat_name()` already traverses up to the parent to build the chat name, and `build_session_context_prompt()` already renders `**Channel Topic:**` when `chat_topic` is present. The forum parent is being identified and used for other purposes; the topic just isn't being pulled from it.

This is inconsistent with regular text channels, where the topic is already picked up and injected correctly.

## Fix

Adds a `_get_effective_topic(channel, is_thread)` helper that reads `channel.topic` first, then falls back to the parent forum's topic when the channel is a thread inside a forum (gated by the existing `_is_forum_parent()` helper).

All three Discord session entry points now use this helper:
- `_handle_message` — regular messages
- `_build_slash_event` — slash commands in threads
- `_dispatch_thread_session` — `/thread` command creating new forum threads

## Use case

Users can write agent instructions in a Discord forum's description field. Every new thread in that forum automatically receives those instructions in its session context via `**Channel Topic:**`, with no config changes or new features required.

One powerful example: you can create a Discord forum dedicated to a project repo and set the forum description to context-loading instructions (e.g. "Project: /path/to/repo — read AGENTS.md first, then PROJECT_STATE.md, then check live service state before making changes"). Every new thread in that forum inherits those instructions automatically, so each conversation starts with the agent already grounded in the right codebase — no need to paste a boilerplate prompt at the top of every thread.

## Changes

- `gateway/platforms/discord.py` — 21 insertions, 4 deletions
- No new dependencies, config keys, or migrations
- Existing tests pass; the `_dispatch_thread_session` test mock was compatible without changes (the helper uses defensive `getattr` chains)