### PR TITLE
fix(agent): correct vision provider resolution, context length key, a…

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -90,7 +90,9 @@ def _normalize_aux_provider(provider: Optional[str], *, for_vision: bool = False
         # and non-aggregator providers (DeepSeek, Alibaba, etc.) work correctly.
         main_prov = _read_main_provider()
         if main_prov and main_prov not in ("auto", "main", ""):
-            return main_prov
+            if for_vision:
+                return main_prov
+            return _normalize_aux_provider(main_prov)
         return "custom"
     return _PROVIDER_ALIASES.get(normalized, normalized)
 
@@ -825,7 +827,8 @@ def _read_main_provider() -> str:
     """Read the user's configured main provider from config.yaml.
 
     Returns the lowercase provider id (e.g. "alibaba", "openrouter") or ""
-    if not configured.
+    if not configured.  Named custom providers are returned with the
+    ``custom:`` prefix intact so callers can distinguish them.
     """
     try:
         from hermes_cli.config import load_config
@@ -834,7 +837,12 @@ def _read_main_provider() -> str:
         if isinstance(model_cfg, dict):
             provider = model_cfg.get("provider", "")
             if isinstance(provider, str) and provider.strip():
-                return _normalize_aux_provider(provider)
+                prov = provider.strip().lower()
+                if prov.startswith("custom:"):
+                    return prov
+                if prov == "codex":
+                    return "openai-codex"
+                return _PROVIDER_ALIASES.get(prov, prov)
     except Exception:
         pass
     return ""
@@ -1425,6 +1433,7 @@ def get_async_text_auxiliary_client(task: str = ""):
 _VISION_AUTO_PROVIDER_ORDER = (
     "openrouter",
     "nous",
+    "openai-codex",
 )
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -136,7 +136,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek-ai/DeepSeek-V3.2": 65536,
     "moonshotai/Kimi-K2.5": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
-    "minimaxai/minimax-m2.5": 1048576,
+    "MiniMaxAI/MiniMax-M2.5": 1048576,
     "XiaomiMiMo/MiMo-V2-Flash": 32768,
     "mimo-v2-pro": 1048576,
     "mimo-v2-omni": 1048576,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -204,10 +204,11 @@ def _has_any_provider_configured() -> bool:
     # often don't require an API key.
     from hermes_cli.auth import PROVIDER_REGISTRY
 
-    # Collect all provider env vars
+    # Collect all provider env vars (skip copilot — its GITHUB_TOKEN is
+    # ambient on many CI/dev machines and causes false positives).
     provider_env_vars = {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"}
-    for pconfig in PROVIDER_REGISTRY.values():
-        if pconfig.auth_type == "api_key":
+    for pid, pconfig in PROVIDER_REGISTRY.items():
+        if pconfig.auth_type == "api_key" and pid != "copilot":
             provider_env_vars.update(pconfig.api_key_env_vars)
     if any(os.getenv(v) for v in provider_env_vars):
         return True
@@ -227,13 +228,26 @@ def _has_any_provider_configured() -> bool:
         except Exception:
             pass
 
-    # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
+    # Check provider-specific auth fallbacks (skip copilot — handled below).
     try:
         for provider_id, pconfig in PROVIDER_REGISTRY.items():
             if pconfig.auth_type != "api_key":
                 continue
+            if provider_id == "copilot":
+                continue
             status = get_auth_status(provider_id)
             if status.get("logged_in"):
+                return True
+    except Exception:
+        pass
+
+    # Copilot: only detect via the gh CLI to avoid ambient GITHUB_TOKEN false positives.
+    try:
+        from hermes_cli.copilot_auth import _try_gh_cli_token, validate_copilot_token
+        token = _try_gh_cli_token()
+        if token:
+            valid, _ = validate_copilot_token(token)
+            if valid:
                 return True
     except Exception:
         pass

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -645,6 +645,7 @@ class TestHasAnyProviderConfigured:
             "agent.anthropic_adapter.is_claude_code_token_valid",
             lambda creds: True,
         )
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is False
 
@@ -722,6 +723,7 @@ class TestHasAnyProviderConfigured:
         for var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
                      "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"):
             monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is False
 


### PR DESCRIPTION
## Problem
- Named custom providers (custom:beans) lose their custom: prefix during vision provider resolution
- MiniMaxAI/MiniMax-M2.5 context length key uses wrong casing and never matches
- Ambient GITHUB_TOKEN (e.g. from Copilot) causes false positive in fresh-install provider detection

## Fix
- _read_main_provider: preserve custom: prefix instead of stripping it
- _normalize_aux_provider: pass custom providers through for vision without re-normalizing
- Add openai-codex to _VISION_AUTO_PROVIDER_ORDER
- Fix DEFAULT_CONTEXT_LENGTHS key: minimaxai/minimax-m2.5 → MiniMaxAI/MiniMax-M2.5
- Skip copilot in env-var/auth loops; detect via _try_gh_cli_token only
- Mock _try_gh_cli_token in two no-provider-configured tests

## Testing
- test_custom_provider_name_preserved
- test_custom_provider_vision_passthrough
- test_config_dict_no_provider_no_creds_still_false
- test_claude_code_creds_ignored_on_fresh_install
- test_gh_cli_token_counts all pass