### PR TITLE
[codex] Add Feishu cloud document link fetching

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -34,6 +34,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 # aiohttp/websockets are independent optional deps — import outside lark_oapi
 # so they remain available for tests and webhook mode even if lark_oapi is missing.
@@ -115,6 +116,7 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://[^\s<>\]\)]+", re.IGNORECASE)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -141,6 +143,7 @@ _FEISHU_DOC_UPLOAD_TYPES = {
 # ---------------------------------------------------------------------------
 
 _MAX_TEXT_INJECT_BYTES = 100 * 1024
+_MAX_FEISHU_DOC_LINKS_PER_MESSAGE = 3
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
@@ -169,6 +172,7 @@ _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup win
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 _FEISHU_ACK_EMOJI = "OK"
+_FEISHU_DOC_HOSTS = frozenset({"docs.feishu.cn", "docs.larksuite.com"})
 # ---------------------------------------------------------------------------
 # Fallback display strings
 # ---------------------------------------------------------------------------
@@ -1045,6 +1049,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._tenant_access_token: str = ""
+        self._tenant_access_token_expire_at: float = 0.0
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -2580,6 +2586,8 @@ class FeishuAdapter(BasePlatformAdapter):
             if injected:
                 text = injected
 
+        text = await self._maybe_inject_feishu_doc_links(text)
+
         return text, inbound_type, media_urls, media_types
 
     async def _download_feishu_message_resources(
@@ -2659,6 +2667,174 @@ class FeishuAdapter(BasePlatformAdapter):
         except (OSError, UnicodeDecodeError):
             logger.warning("[Feishu] Failed to inject text document content from %s", cached_path, exc_info=True)
             return ""
+
+    async def _maybe_inject_feishu_doc_links(self, text: str) -> str:
+        if not text or not self._client:
+            return text
+
+        doc_links = self._extract_feishu_doc_links(text)[:_MAX_FEISHU_DOC_LINKS_PER_MESSAGE]
+        if not doc_links:
+            return text
+
+        remaining_budget = _MAX_TEXT_INJECT_BYTES
+        injections: List[str] = []
+        for doc_url, document_id in doc_links:
+            if remaining_budget <= 0:
+                break
+            try:
+                content = await self._fetch_feishu_doc_raw_content(document_id)
+            except Exception as exc:
+                logger.warning(
+                    "[Feishu] Failed to fetch cloud document %s from %s: %s",
+                    document_id,
+                    doc_url,
+                    exc,
+                )
+                continue
+
+            normalized = (content or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+            if not normalized:
+                continue
+
+            truncated_content, was_truncated = self._truncate_utf8_text(normalized, remaining_budget)
+            if not truncated_content:
+                break
+
+            injections.append(
+                self._build_feishu_doc_injection(
+                    document_id=document_id,
+                    content=truncated_content,
+                    truncated=was_truncated,
+                )
+            )
+            remaining_budget -= len(truncated_content.encode("utf-8"))
+            if was_truncated:
+                break
+
+        if not injections:
+            return text
+
+        injected_text = "\n\n".join(injections)
+        return f"{injected_text}\n\n{text}" if text else injected_text
+
+    @staticmethod
+    def _extract_feishu_doc_links(text: str) -> List[tuple[str, str]]:
+        results: List[tuple[str, str]] = []
+        seen_document_ids: set[str] = set()
+        for match in _URL_RE.finditer(text or ""):
+            raw_url = match.group(0).rstrip(".,;!?")
+            parsed = urlparse(raw_url)
+            host = (parsed.netloc or "").lower()
+            if host not in _FEISHU_DOC_HOSTS:
+                continue
+
+            path_parts = [part for part in parsed.path.split("/") if part]
+            try:
+                docx_index = path_parts.index("docx")
+                document_id = path_parts[docx_index + 1]
+            except (ValueError, IndexError):
+                continue
+
+            normalized_id = re.sub(r"[^A-Za-z0-9]", "", document_id)
+            if not normalized_id or normalized_id in seen_document_ids:
+                continue
+            seen_document_ids.add(normalized_id)
+            results.append((raw_url, normalized_id))
+        return results
+
+    @staticmethod
+    def _truncate_utf8_text(text: str, max_bytes: int) -> tuple[str, bool]:
+        encoded = (text or "").encode("utf-8")
+        if len(encoded) <= max_bytes:
+            return text, False
+        if max_bytes <= 0:
+            return "", True
+        return encoded[:max_bytes].decode("utf-8", errors="ignore"), True
+
+    @staticmethod
+    def _build_feishu_doc_injection(*, document_id: str, content: str, truncated: bool) -> str:
+        safe_id = re.sub(r"[^\w.\- ]", "_", document_id or "document")
+        suffix = "\n\n[Feishu doc content truncated to fit message context.]" if truncated else ""
+        return f"[Content of Feishu doc {safe_id}]:\n{content}{suffix}"
+
+    def _feishu_open_api_base(self) -> str:
+        return "https://open.larksuite.com" if self._domain_name == "lark" else "https://open.feishu.cn"
+
+    async def _get_feishu_tenant_access_token(self) -> str:
+        now = time.time()
+        if self._tenant_access_token and now < max(0.0, self._tenant_access_token_expire_at - 300):
+            return self._tenant_access_token
+
+        import httpx
+
+        response_payload: Dict[str, Any] = {}
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            response = await client.post(
+                f"{self._feishu_open_api_base()}/open-apis/auth/v3/tenant_access_token/internal",
+                headers={"Content-Type": "application/json; charset=utf-8"},
+                json={
+                    "app_id": self._app_id,
+                    "app_secret": self._app_secret,
+                },
+            )
+            response.raise_for_status()
+            response_payload = response.json()
+
+        code = int(response_payload.get("code", 0) or 0)
+        if code != 0:
+            raise RuntimeError(
+                f"tenant_access_token request failed [{code}] "
+                f"{response_payload.get('msg', 'unknown error')}"
+            )
+
+        token = str(response_payload.get("tenant_access_token") or "").strip()
+        if not token:
+            raise RuntimeError("tenant_access_token response missing token")
+
+        expire_seconds = int(response_payload.get("expire", 0) or 0)
+        self._tenant_access_token = token
+        self._tenant_access_token_expire_at = now + max(0, expire_seconds)
+        return token
+
+    async def _fetch_feishu_doc_raw_content(self, document_id: str) -> str:
+        access_token = await self._get_feishu_tenant_access_token()
+        try:
+            return await self._request_feishu_doc_raw_content(document_id=document_id, access_token=access_token)
+        except RuntimeError as exc:
+            if "[401]" not in str(exc):
+                raise
+            self._tenant_access_token = ""
+            self._tenant_access_token_expire_at = 0.0
+            refreshed_token = await self._get_feishu_tenant_access_token()
+            return await self._request_feishu_doc_raw_content(document_id=document_id, access_token=refreshed_token)
+
+    async def _request_feishu_doc_raw_content(self, *, document_id: str, access_token: str) -> str:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            response = await client.get(
+                f"{self._feishu_open_api_base()}/open-apis/docx/v1/documents/{document_id}/raw_content",
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"lang": 0},
+            )
+
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        payload: Dict[str, Any]
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+
+        if status_code >= 400:
+            message = payload.get("msg") or response.text[:200] or "request failed"
+            raise RuntimeError(f"[{status_code}] {message}")
+
+        code = int(payload.get("code", 0) or 0)
+        if code != 0:
+            raise RuntimeError(f"[{code}] {payload.get('msg', 'request failed')}")
+
+        data = payload.get("data") or {}
+        return str(data.get("content") or "")
 
     async def _download_feishu_image(self, *, message_id: str, image_key: str) -> tuple[str, str]:
         if not self._client or not message_id:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -169,6 +169,28 @@ class TestFeishuPostParsing(unittest.TestCase):
 
 
 class TestFeishuMessageNormalization(unittest.TestCase):
+    def test_extract_feishu_doc_links_supports_feishu_and_lark_docx_urls(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        links = FeishuAdapter._extract_feishu_doc_links(
+            "\n".join(
+                [
+                    "https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk",
+                    "[Spec](https://docs.larksuite.com/docx/doxcnABCDEFGHIJKLMN1234567?from=share)",
+                    "https://example.com/docx/doxcnignored",
+                    "https://docs.feishu.cn/wiki/space_token",
+                ]
+            )
+        )
+
+        self.assertEqual(
+            links,
+            [
+                ("https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk", "doxcn1234567890ABCDEFGHijk"),
+                ("https://docs.larksuite.com/docx/doxcnABCDEFGHIJKLMN1234567?from=share", "doxcnABCDEFGHIJKLMN1234567"),
+            ],
+        )
+
     def test_normalize_merge_forward_preserves_summary_lines(self):
         from gateway.platforms.feishu import normalize_feishu_message
 
@@ -1234,6 +1256,86 @@ class TestAdapterBehavior(unittest.TestCase):
             resource_type="file",
             fallback_filename="spec.pdf",
         )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_text_message_injects_feishu_cloud_doc_content(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        adapter._fetch_feishu_doc_raw_content = AsyncMock(return_value="Sprint plan\n- Ship the fix")
+        message = SimpleNamespace(
+            message_type="text",
+            content=json.dumps({"text": "Please review https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk"}),
+            message_id="om_text_doc",
+        )
+
+        text, msg_type, media_urls, media_types = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(
+            text,
+            "[Content of Feishu doc doxcn1234567890ABCDEFGHijk]:\n"
+            "Sprint plan\n- Ship the fix\n\n"
+            "Please review https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk",
+        )
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+        adapter._fetch_feishu_doc_raw_content.assert_awaited_once_with("doxcn1234567890ABCDEFGHijk")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_post_message_injects_markdown_linked_feishu_doc_content(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        adapter._fetch_feishu_doc_raw_content = AsyncMock(return_value="Architecture notes")
+        message = SimpleNamespace(
+            message_type="post",
+            content=(
+                '{"en_us":{"title":"Spec","content":['
+                '[{"tag":"text","text":"Context"}],'
+                '[{"tag":"a","text":"Design doc","href":"https://docs.feishu.cn/docx/doxcnABCDEFGHIJKLMN1234567"}]'
+                ']}}'
+            ),
+            message_id="om_post_doc",
+        )
+
+        text, msg_type, media_urls, media_types = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(
+            text,
+            "[Content of Feishu doc doxcnABCDEFGHIJKLMN1234567]:\n"
+            "Architecture notes\n\n"
+            "Spec\nContext\n[Design doc](https://docs.feishu.cn/docx/doxcnABCDEFGHIJKLMN1234567)",
+        )
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+        adapter._fetch_feishu_doc_raw_content.assert_awaited_once_with("doxcnABCDEFGHIJKLMN1234567")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_message_keeps_original_text_when_feishu_doc_fetch_fails(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        adapter._fetch_feishu_doc_raw_content = AsyncMock(side_effect=RuntimeError("forbidden"))
+        message = SimpleNamespace(
+            message_type="text",
+            content=json.dumps({"text": "Doc https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk"}),
+            message_id="om_text_doc_fail",
+        )
+
+        text, msg_type, media_urls, media_types = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(text, "Doc https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk")
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_extract_merge_forward_message_as_text_summary(self):

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -107,14 +107,9 @@ Providers validate these sequences and will reject malformed histories.
 
 API requests are wrapped in `_api_call_with_interrupt()` which runs the actual HTTP call in a background thread while monitoring an interrupt event:
 
-```text
-┌──────────────────────┐     ┌──────────────┐
-│  Main thread         │     │  API thread   │
-│  wait on:            │────▶│  HTTP POST    │
-│  - response ready    │     │  to provider  │
-│  - interrupt event   │     └──────────────┘
-│  - timeout           │
-└──────────────────────┘
+```mermaid
+flowchart LR
+    A["Main thread<br/>waits on:<br/>- response ready<br/>- interrupt event<br/>- timeout"] --> B["API thread<br/>HTTP POST to provider"]
 ```
 
 When interrupted (user sends new message, `/stop` command, or signal):

--- a/website/docs/developer-guide/architecture.md
+++ b/website/docs/developer-guide/architecture.md
@@ -10,42 +10,32 @@ This page is the top-level map of Hermes Agent internals. Use it to orient yours
 
 ## System Overview
 
-```text
-┌─────────────────────────────────────────────────────────────────────┐
-│                        Entry Points                                  │
-│                                                                      │
-│  CLI (cli.py)    Gateway (gateway/run.py)    ACP (acp_adapter/)     │
-│  Batch Runner    API Server                  Python Library          │
-└──────────┬──────────────┬───────────────────────┬────────────────────┘
-           │              │                       │
-           ▼              ▼                       ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                     AIAgent (run_agent.py)                           │
-│                                                                      │
-│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐                │
-│  │ Prompt        │ │ Provider     │ │ Tool         │                │
-│  │ Builder       │ │ Resolution   │ │ Dispatch     │                │
-│  │ (prompt_      │ │ (runtime_    │ │ (model_      │                │
-│  │  builder.py)  │ │  provider.py)│ │  tools.py)   │                │
-│  └──────┬───────┘ └──────┬───────┘ └──────┬───────┘                │
-│         │                │                │                          │
-│  ┌──────┴───────┐ ┌──────┴───────┐ ┌──────┴───────┐                │
-│  │ Compression  │ │ 3 API Modes  │ │ Tool Registry│                │
-│  │ & Caching    │ │ chat_compl.  │ │ (registry.py)│                │
-│  │              │ │ codex_resp.  │ │ 48 tools     │                │
-│  │              │ │ anthropic    │ │ 40 toolsets   │                │
-│  └──────────────┘ └──────────────┘ └──────────────┘                │
-└─────────────────────────────────────────────────────────────────────┘
-           │                                    │
-           ▼                                    ▼
-┌───────────────────┐              ┌──────────────────────┐
-│ Session Storage   │              │ Tool Backends         │
-│ (SQLite + FTS5)   │              │ Terminal (6 backends) │
-│ hermes_state.py   │              │ Browser (5 backends)  │
-│ gateway/session.py│              │ Web (4 backends)      │
-└───────────────────┘              │ MCP (dynamic)         │
-                                   │ File, Vision, etc.    │
-                                   └──────────────────────┘
+```mermaid
+flowchart TD
+    subgraph EntryPoints["Entry Points"]
+        CLI["CLI<br/>cli.py"]
+        Gateway["Gateway<br/>gateway/run.py"]
+        ACP["ACP<br/>acp_adapter/"]
+        Batch["Batch Runner"]
+        API["API Server"]
+        PyLib["Python Library"]
+    end
+
+    subgraph Agent["AIAgent<br/>run_agent.py"]
+        Prompt["Prompt Builder<br/>prompt_builder.py"]
+        Provider["Provider Resolution<br/>runtime_provider.py"]
+        Dispatch["Tool Dispatch<br/>model_tools.py"]
+        Compression["Compression & Caching"]
+        Modes["3 API Modes<br/>chat_compl. / codex_resp. / anthropic"]
+        Registry["Tool Registry<br/>registry.py<br/>48 tools / 40 toolsets"]
+    end
+
+    EntryPoints --> Agent
+    Prompt --> Compression
+    Provider --> Modes
+    Dispatch --> Registry
+    Agent --> Session["Session Storage<br/>SQLite + FTS5<br/>hermes_state.py / gateway/session.py"]
+    Agent --> Backends["Tool Backends<br/>Terminal / Browser / Web / MCP / File / Vision"]
 ```
 
 ## Directory Structure

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -25,28 +25,28 @@ The messaging gateway is the long-running process that connects Hermes to 14+ ex
 
 ## Architecture Overview
 
-```text
-┌─────────────────────────────────────────────────┐
-│                 GatewayRunner                     │
-│                                                   │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐       │
-│  │ Telegram  │  │ Discord  │  │  Slack   │  ...  │
-│  │ Adapter   │  │ Adapter  │  │ Adapter  │       │
-│  └─────┬─────┘  └─────┬────┘  └─────┬────┘       │
-│        │              │              │             │
-│        └──────────────┼──────────────┘             │
-│                       ▼                            │
-│              _handle_message()                     │
-│                       │                            │
-│          ┌────────────┼────────────┐               │
-│          ▼            ▼            ▼               │
-│   Slash command   AIAgent      Queue/BG            │
-│    dispatch       creation     sessions            │
-│                       │                            │
-│                       ▼                            │
-│              SessionStore                          │
-│           (SQLite persistence)                     │
-└─────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph GatewayRunner["GatewayRunner"]
+        Telegram["Telegram Adapter"]
+        Discord["Discord Adapter"]
+        Slack["Slack Adapter"]
+        More["Other platform adapters"]
+        Handle["_handle_message()"]
+        Commands["Slash command dispatch"]
+        Agent["AIAgent creation"]
+        Queue["Queue / background sessions"]
+        Store["SessionStore<br/>SQLite persistence"]
+    end
+
+    Telegram --> Handle
+    Discord --> Handle
+    Slack --> Handle
+    More --> Handle
+    Handle --> Commands
+    Handle --> Agent
+    Handle --> Queue
+    Agent --> Store
 ```
 
 ## Message Flow

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -37,6 +37,11 @@ Set it to `false` only if you explicitly want one shared conversation per chat.
 2. Create a new app.
 3. In **Credentials & Basic Info**, copy the **App ID** and **App Secret**.
 4. Enable the **Bot** capability for the app.
+5. If you want Hermes to read shared Feishu/Lark cloud-document links automatically, grant at least one of:
+   - `docx:document`
+   - `docx:document:readonly`
+
+For document links inside knowledge-base or drive workflows, `drive:drive` or `drive:drive:readonly` may also be useful depending on how your workspace shares access.
 
 :::warning
 Keep the App Secret private. Anyone with it can impersonate your app.
@@ -231,6 +236,8 @@ Media from rich-text (post) messages, including inline images and file attachmen
 
 For small text-based documents (.txt, .md), the file content is automatically injected into the message text so the agent can read it directly without needing tools.
 
+When users send Feishu/Lark cloud-document links such as `https://docs.feishu.cn/docx/...` or `https://docs.larksuite.com/docx/...`, Hermes will also attempt to fetch the document's raw text via the Feishu Open API and inject that content into the inbound message context.
+
 ### Outbound (sending)
 
 | Method | What it sends |
@@ -411,6 +418,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
 | Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
+| Feishu cloud-document links are not expanded | Grant `docx:document` or `docx:document:readonly`, then make sure the app itself has permission to read the target document |
 | Bot identity not auto-detected | Grant `admin:app.info:readonly` scope, or set `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` manually |
 | `Webhook rate limit exceeded` | More than 120 requests/minute from the same IP. This is usually a misconfiguration or loop. |
 


### PR DESCRIPTION
## Summary

This fixes Feishu/Lark cloud document links not being usable in gateway conversations.

## Root Cause

The Feishu adapter could normalize text messages, post messages, and uploaded attachments, but it treated shared `docs.feishu.cn` / `docs.larksuite.com` doc links as plain text. When users shared a cloud document URL, Hermes had no native Feishu document fetch path and often fell back to browser-based access, which times out for authenticated docs.

## What Changed

- detect Feishu/Lark `docx` links in inbound text and post messages
- fetch document raw text through the Feishu Open API instead of the browser tool
- cache `tenant_access_token` values in the adapter and refresh on expiry/401
- inject fetched doc text into the inbound message context with the same bounded inline-content pattern used for small text attachments
- document the required `docx:*` permissions in the Feishu messaging docs
- add gateway regressions for direct links, markdown links, and fetch-failure fallback

## User Impact

Users can now send Feishu/Lark cloud document links directly to Hermes and have the document text included in the conversation context, as long as the app has both API scope and document-level access.

## Validation

- `uv run --extra dev pytest tests/gateway/test_feishu.py -q`
- `uv run --extra dev pytest tests/gateway/test_feishu_approval_buttons.py -q`
