### PR TITLE
Fix Cloudflare 403s for openai-codex provider on server IPs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -779,6 +779,23 @@ class AIAgent:
                     }
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
+                elif "chatgpt.com" in effective_base.lower():
+                    # Match official Codex CLI headers to avoid Cloudflare challenges.
+                    # The ChatGPT-Account-Id header is critical — without it,
+                    # server-hosted agents get 403 Cloudflare JS challenges.
+                    _codex_headers = {
+                        "User-Agent": "hermes-agent/1.0",
+                        "originator": "hermes-agent",
+                    }
+                    try:
+                        import base64 as _b64
+                        _jwt_payload = json.loads(_b64.b64decode(api_key.split(".")[1] + "=="))
+                        _acct_id = _jwt_payload.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+                        if _acct_id:
+                            _codex_headers["ChatGPT-Account-Id"] = _acct_id
+                    except Exception:
+                        pass
+                    client_kwargs["default_headers"] = _codex_headers
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -4105,6 +4122,21 @@ class AIAgent:
             self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
         elif "portal.qwen.ai" in normalized:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
+        elif "chatgpt.com" in normalized:
+            _codex_headers = {
+                "User-Agent": "hermes-agent/1.0",
+                "originator": "hermes-agent",
+            }
+            try:
+                import base64 as _b64
+                _ak = self._client_kwargs.get("api_key", "")
+                _jwt_payload = json.loads(_b64.b64decode(_ak.split(".")[1] + "=="))
+                _acct_id = _jwt_payload.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+                if _acct_id:
+                    _codex_headers["ChatGPT-Account-Id"] = _acct_id
+            except Exception:
+                pass
+            self._client_kwargs["default_headers"] = _codex_headers
         else:
             self._client_kwargs.pop("default_headers", None)
 


### PR DESCRIPTION
Running Hermes with the `openai-codex` provider against `chatgpt.com/backend-api/codex` from any non-residential IP (VPS, Mac Mini, etc.) hits Cloudflare 403 JavaScript challenges. Laptops on home networks work fine, which makes this annoying to diagnose.

The issue is missing headers. The official codex-rs CLI sends `ChatGPT-Account-Id` (extracted from the JWT) and `originator: codex_cli_rs`, which Cloudflare uses to verify the request is from an authorized client. Without them, the OpenAI SDK's default `User-Agent: OpenAI/Python ...` looks like bot traffic and gets blocked.

The fix adds three headers when `base_url` contains `chatgpt.com`: `ChatGPT-Account-Id` (decoded from the access token), `originator: hermes-agent`, and a clean `User-Agent`. Applied in both `AIAgent.__init__` and `_update_base_url_headers` to cover credential rotation. JWT decode is wrapped in try/except — if the token format changes, it skips the header rather than crashing.

~30 lines across two locations in `run_agent.py`. No new dependencies. Tested on a Hetzner VPS and a Mac Mini, both previously getting consistent 403s.