### PR TITLE
fix(feishu): fetch cloud document links via Feishu API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,35 @@ RUN apt-get update && \
 COPY . /opt/hermes
 WORKDIR /opt/hermes
 
-# Install Python and Node dependencies in one layer, no cache
-RUN pip install --no-cache-dir -e ".[all]" --break-system-packages && \
-    npm install --prefer-offline --no-audit && \
-    npx playwright install --with-deps chromium --only-shell && \
-    cd /opt/hermes/scripts/whatsapp-bridge && \
-    npm install --prefer-offline --no-audit && \
+# Install Python and Node dependencies in one layer, no cache.
+# Split optional extras into smaller pip passes to avoid resolver-too-deep
+# failures when buildx tries to solve the entire `.[all]` extra at once.
+RUN set -eux; \
+    pip install --no-cache-dir -e . --break-system-packages; \
+    for extra in \
+        modal \
+        daytona \
+        messaging \
+        cron \
+        cli \
+        dev \
+        tts-premium \
+        pty \
+        honcho \
+        mcp \
+        homeassistant \
+        sms \
+        acp \
+        voice \
+        dingtalk \
+        feishu \
+        mistral; do \
+        pip install --no-cache-dir -e ".[${extra}]" --break-system-packages; \
+    done; \
+    npm install --prefer-offline --no-audit; \
+    npx playwright install --with-deps chromium --only-shell; \
+    cd /opt/hermes/scripts/whatsapp-bridge; \
+    npm install --prefer-offline --no-audit; \
     npm cache clean --force
 
 WORKDIR /opt/hermes

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1425,6 +1425,7 @@ def get_async_text_auxiliary_client(task: str = ""):
 _VISION_AUTO_PROVIDER_ORDER = (
     "openrouter",
     "nous",
+    "openai-codex",
 )
 
 
@@ -1470,9 +1471,9 @@ def _preferred_main_vision_provider() -> Optional[str]:
 def get_available_vision_backends() -> List[str]:
     """Return the currently available vision backends in auto-selection order.
 
-    Order: active provider → OpenRouter → Nous → stop.  This is the single
-    source of truth for setup, tool gating, and runtime auto-routing of
-    vision tasks.
+    Order: active provider → OpenRouter → Nous → Codex → stop.  This is the
+    single source of truth for setup, tool gating, and runtime auto-routing
+    of vision tasks.
     """
     available: List[str] = []
     # 1. Active provider — if the user configured a provider, try it first.
@@ -1485,7 +1486,7 @@ def get_available_vision_backends() -> List[str]:
             client, _ = resolve_provider_client(main_provider, _read_main_model())
             if client is not None:
                 available.append(main_provider)
-    # 2. OpenRouter, 3. Nous — skip if already covered by main provider.
+    # 2. OpenRouter, 3. Nous, 4. Codex — skip if already covered by main provider.
     for p in _VISION_AUTO_PROVIDER_ORDER:
         if p not in available and _strict_vision_backend_available(p):
             available.append(p)
@@ -1538,7 +1539,8 @@ def resolve_vision_provider_client(
         #   1. Active provider + model (user's main chat config)
         #   2. OpenRouter  (known vision-capable default model)
         #   3. Nous Portal (known vision-capable default model)
-        #   4. Stop
+        #   4. Codex OAuth (Responses API)
+        #   5. Stop
         main_provider = _read_main_provider()
         main_model = _read_main_model()
         if main_provider and main_provider not in ("auto", ""):

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -34,6 +34,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 # aiohttp/websockets are independent optional deps — import outside lark_oapi
 # so they remain available for tests and webhook mode even if lark_oapi is missing.
@@ -115,6 +116,7 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://[^\s<>\]\)]+", re.IGNORECASE)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -141,6 +143,7 @@ _FEISHU_DOC_UPLOAD_TYPES = {
 # ---------------------------------------------------------------------------
 
 _MAX_TEXT_INJECT_BYTES = 100 * 1024
+_MAX_FEISHU_DOC_LINKS_PER_MESSAGE = 3
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
@@ -169,6 +172,7 @@ _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup win
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 _FEISHU_ACK_EMOJI = "OK"
+_FEISHU_DOC_HOSTS = frozenset({"docs.feishu.cn", "docs.larksuite.com"})
 # ---------------------------------------------------------------------------
 # Fallback display strings
 # ---------------------------------------------------------------------------
@@ -1045,6 +1049,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._tenant_access_token: str = ""
+        self._tenant_access_token_expire_at: float = 0.0
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -2580,6 +2586,8 @@ class FeishuAdapter(BasePlatformAdapter):
             if injected:
                 text = injected
 
+        text = await self._maybe_inject_feishu_doc_links(text)
+
         return text, inbound_type, media_urls, media_types
 
     async def _download_feishu_message_resources(
@@ -2659,6 +2667,174 @@ class FeishuAdapter(BasePlatformAdapter):
         except (OSError, UnicodeDecodeError):
             logger.warning("[Feishu] Failed to inject text document content from %s", cached_path, exc_info=True)
             return ""
+
+    async def _maybe_inject_feishu_doc_links(self, text: str) -> str:
+        if not text or not self._client:
+            return text
+
+        doc_links = self._extract_feishu_doc_links(text)[:_MAX_FEISHU_DOC_LINKS_PER_MESSAGE]
+        if not doc_links:
+            return text
+
+        remaining_budget = _MAX_TEXT_INJECT_BYTES
+        injections: List[str] = []
+        for doc_url, document_id in doc_links:
+            if remaining_budget <= 0:
+                break
+            try:
+                content = await self._fetch_feishu_doc_raw_content(document_id)
+            except Exception as exc:
+                logger.warning(
+                    "[Feishu] Failed to fetch cloud document %s from %s: %s",
+                    document_id,
+                    doc_url,
+                    exc,
+                )
+                continue
+
+            normalized = (content or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+            if not normalized:
+                continue
+
+            truncated_content, was_truncated = self._truncate_utf8_text(normalized, remaining_budget)
+            if not truncated_content:
+                break
+
+            injections.append(
+                self._build_feishu_doc_injection(
+                    document_id=document_id,
+                    content=truncated_content,
+                    truncated=was_truncated,
+                )
+            )
+            remaining_budget -= len(truncated_content.encode("utf-8"))
+            if was_truncated:
+                break
+
+        if not injections:
+            return text
+
+        injected_text = "\n\n".join(injections)
+        return f"{injected_text}\n\n{text}" if text else injected_text
+
+    @staticmethod
+    def _extract_feishu_doc_links(text: str) -> List[tuple[str, str]]:
+        results: List[tuple[str, str]] = []
+        seen_document_ids: set[str] = set()
+        for match in _URL_RE.finditer(text or ""):
+            raw_url = match.group(0).rstrip(".,;!?")
+            parsed = urlparse(raw_url)
+            host = (parsed.netloc or "").lower()
+            if host not in _FEISHU_DOC_HOSTS:
+                continue
+
+            path_parts = [part for part in parsed.path.split("/") if part]
+            try:
+                docx_index = path_parts.index("docx")
+                document_id = path_parts[docx_index + 1]
+            except (ValueError, IndexError):
+                continue
+
+            normalized_id = re.sub(r"[^A-Za-z0-9]", "", document_id)
+            if not normalized_id or normalized_id in seen_document_ids:
+                continue
+            seen_document_ids.add(normalized_id)
+            results.append((raw_url, normalized_id))
+        return results
+
+    @staticmethod
+    def _truncate_utf8_text(text: str, max_bytes: int) -> tuple[str, bool]:
+        encoded = (text or "").encode("utf-8")
+        if len(encoded) <= max_bytes:
+            return text, False
+        if max_bytes <= 0:
+            return "", True
+        return encoded[:max_bytes].decode("utf-8", errors="ignore"), True
+
+    @staticmethod
+    def _build_feishu_doc_injection(*, document_id: str, content: str, truncated: bool) -> str:
+        safe_id = re.sub(r"[^\w.\- ]", "_", document_id or "document")
+        suffix = "\n\n[Feishu doc content truncated to fit message context.]" if truncated else ""
+        return f"[Content of Feishu doc {safe_id}]:\n{content}{suffix}"
+
+    def _feishu_open_api_base(self) -> str:
+        return "https://open.larksuite.com" if self._domain_name == "lark" else "https://open.feishu.cn"
+
+    async def _get_feishu_tenant_access_token(self) -> str:
+        now = time.time()
+        if self._tenant_access_token and now < max(0.0, self._tenant_access_token_expire_at - 300):
+            return self._tenant_access_token
+
+        import httpx
+
+        response_payload: Dict[str, Any] = {}
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            response = await client.post(
+                f"{self._feishu_open_api_base()}/open-apis/auth/v3/tenant_access_token/internal",
+                headers={"Content-Type": "application/json; charset=utf-8"},
+                json={
+                    "app_id": self._app_id,
+                    "app_secret": self._app_secret,
+                },
+            )
+            response.raise_for_status()
+            response_payload = response.json()
+
+        code = int(response_payload.get("code", 0) or 0)
+        if code != 0:
+            raise RuntimeError(
+                f"tenant_access_token request failed [{code}] "
+                f"{response_payload.get('msg', 'unknown error')}"
+            )
+
+        token = str(response_payload.get("tenant_access_token") or "").strip()
+        if not token:
+            raise RuntimeError("tenant_access_token response missing token")
+
+        expire_seconds = int(response_payload.get("expire", 0) or 0)
+        self._tenant_access_token = token
+        self._tenant_access_token_expire_at = now + max(0, expire_seconds)
+        return token
+
+    async def _fetch_feishu_doc_raw_content(self, document_id: str) -> str:
+        access_token = await self._get_feishu_tenant_access_token()
+        try:
+            return await self._request_feishu_doc_raw_content(document_id=document_id, access_token=access_token)
+        except RuntimeError as exc:
+            if "[401]" not in str(exc):
+                raise
+            self._tenant_access_token = ""
+            self._tenant_access_token_expire_at = 0.0
+            refreshed_token = await self._get_feishu_tenant_access_token()
+            return await self._request_feishu_doc_raw_content(document_id=document_id, access_token=refreshed_token)
+
+    async def _request_feishu_doc_raw_content(self, *, document_id: str, access_token: str) -> str:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            response = await client.get(
+                f"{self._feishu_open_api_base()}/open-apis/docx/v1/documents/{document_id}/raw_content",
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"lang": 0},
+            )
+
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        payload: Dict[str, Any]
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+
+        if status_code >= 400:
+            message = payload.get("msg") or response.text[:200] or "request failed"
+            raise RuntimeError(f"[{status_code}] {message}")
+
+        code = int(payload.get("code", 0) or 0)
+        if code != 0:
+            raise RuntimeError(f"[{code}] {payload.get('msg', 'request failed')}")
+
+        data = payload.get("data") or {}
+        return str(data.get("content") or "")
 
     async def _download_feishu_image(self, *, message_id: str, image_key: str) -> tuple[str, str]:
         if not self._client or not message_id:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,11 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
-messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
+# Keep Slack-related lower bounds tight enough to avoid pip resolver
+# backtracking explosions when installing the full [all] extra in Docker.
+messaging = ["python-telegram-bot[webhooks]>=22.7,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.28.0,<2", "slack-sdk>=3.41.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
-slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
+slack = ["slack-bolt>=1.28.0,<2", "slack-sdk>=3.41.0,<4"]
 matrix = ["matrix-nio[e2e]>=0.24.0,<1", "Markdown>=3.6,<4"]
 cli = ["simple-term-menu>=1.0,<2"]
 tts-premium = ["elevenlabs>=1.0,<2"]
@@ -85,7 +87,6 @@ all = [
   "hermes-agent[cli]",
   "hermes-agent[dev]",
   "hermes-agent[tts-premium]",
-  "hermes-agent[slack]",
   "hermes-agent[pty]",
   "hermes-agent[honcho]",
   "hermes-agent[mcp]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,13 @@ pty = [
   "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
 ]
-honcho = ["honcho-ai>=2.0.1,<3"]
+honcho = ["honcho-ai>=2.1.0,<3"]
 mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
 acp = ["agent-client-protocol>=0.9.0,<1.0"]
 mistral = ["mistralai>=2.3.0,<3"]
-dingtalk = ["dingtalk-stream>=0.1.0,<1"]
+dingtalk = ["dingtalk-stream>=0.24.3,<1"]
 feishu = ["lark-oapi>=1.5.3,<2"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -768,6 +768,24 @@ class TestAuxiliaryPoolAwareness:
         assert client is not None
         assert provider == "custom:local"
 
+    def test_vision_auto_falls_back_to_codex(self, monkeypatch):
+        """When OpenRouter/Nous are unavailable, vision auto should use Codex auth."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value=""),
+            patch("agent.auxiliary_client._read_main_model", return_value=""),
+            patch("agent.auxiliary_client._read_nous_auth", return_value=None),
+            patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-token"),
+            patch("agent.auxiliary_client.OpenAI", return_value=MagicMock()),
+        ):
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "openai-codex"
+        assert client is not None
+        assert model == "gpt-5.2-codex"
+
     def test_vision_direct_endpoint_override(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         monkeypatch.setenv("AUXILIARY_VISION_BASE_URL", "http://localhost:4567/v1")

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -169,6 +169,28 @@ class TestFeishuPostParsing(unittest.TestCase):
 
 
 class TestFeishuMessageNormalization(unittest.TestCase):
+    def test_extract_feishu_doc_links_supports_feishu_and_lark_docx_urls(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        links = FeishuAdapter._extract_feishu_doc_links(
+            "\n".join(
+                [
+                    "https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk",
+                    "[Spec](https://docs.larksuite.com/docx/doxcnABCDEFGHIJKLMN1234567?from=share)",
+                    "https://example.com/docx/doxcnignored",
+                    "https://docs.feishu.cn/wiki/space_token",
+                ]
+            )
+        )
+
+        self.assertEqual(
+            links,
+            [
+                ("https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk", "doxcn1234567890ABCDEFGHijk"),
+                ("https://docs.larksuite.com/docx/doxcnABCDEFGHIJKLMN1234567?from=share", "doxcnABCDEFGHIJKLMN1234567"),
+            ],
+        )
+
     def test_normalize_merge_forward_preserves_summary_lines(self):
         from gateway.platforms.feishu import normalize_feishu_message
 
@@ -1234,6 +1256,86 @@ class TestAdapterBehavior(unittest.TestCase):
             resource_type="file",
             fallback_filename="spec.pdf",
         )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_text_message_injects_feishu_cloud_doc_content(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        adapter._fetch_feishu_doc_raw_content = AsyncMock(return_value="Sprint plan\n- Ship the fix")
+        message = SimpleNamespace(
+            message_type="text",
+            content=json.dumps({"text": "Please review https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk"}),
+            message_id="om_text_doc",
+        )
+
+        text, msg_type, media_urls, media_types = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(
+            text,
+            "[Content of Feishu doc doxcn1234567890ABCDEFGHijk]:\n"
+            "Sprint plan\n- Ship the fix\n\n"
+            "Please review https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk",
+        )
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+        adapter._fetch_feishu_doc_raw_content.assert_awaited_once_with("doxcn1234567890ABCDEFGHijk")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_post_message_injects_markdown_linked_feishu_doc_content(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        adapter._fetch_feishu_doc_raw_content = AsyncMock(return_value="Architecture notes")
+        message = SimpleNamespace(
+            message_type="post",
+            content=(
+                '{"en_us":{"title":"Spec","content":['
+                '[{"tag":"text","text":"Context"}],'
+                '[{"tag":"a","text":"Design doc","href":"https://docs.feishu.cn/docx/doxcnABCDEFGHIJKLMN1234567"}]'
+                ']}}'
+            ),
+            message_id="om_post_doc",
+        )
+
+        text, msg_type, media_urls, media_types = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(
+            text,
+            "[Content of Feishu doc doxcnABCDEFGHIJKLMN1234567]:\n"
+            "Architecture notes\n\n"
+            "Spec\nContext\n[Design doc](https://docs.feishu.cn/docx/doxcnABCDEFGHIJKLMN1234567)",
+        )
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+        adapter._fetch_feishu_doc_raw_content.assert_awaited_once_with("doxcnABCDEFGHIJKLMN1234567")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_message_keeps_original_text_when_feishu_doc_fetch_fails(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        adapter._fetch_feishu_doc_raw_content = AsyncMock(side_effect=RuntimeError("forbidden"))
+        message = SimpleNamespace(
+            message_type="text",
+            content=json.dumps({"text": "Doc https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk"}),
+            message_id="om_text_doc_fail",
+        )
+
+        text, msg_type, media_urls, media_types = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(text, "Doc https://docs.feishu.cn/docx/doxcn1234567890ABCDEFGHijk")
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_extract_merge_forward_message_as_text_summary(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1819,7 +1819,6 @@ requires-dist = [
     { name = "hermes-agent", extras = ["mistral"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["modal"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'all'" },
-    { name = "hermes-agent", extras = ["slack"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["tts-premium"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["voice"], marker = "extra == 'all'" },
@@ -1844,16 +1843,16 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2" },
-    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
+    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.7,<23" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "rich", specifier = ">=14.3.3,<15" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
-    { name = "slack-bolt", marker = "extra == 'messaging'", specifier = ">=1.18.0,<2" },
-    { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18.0,<2" },
-    { name = "slack-sdk", marker = "extra == 'messaging'", specifier = ">=3.27.0,<4" },
-    { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0,<4" },
+    { name = "slack-bolt", marker = "extra == 'messaging'", specifier = ">=1.28.0,<2" },
+    { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.28.0,<2" },
+    { name = "slack-sdk", marker = "extra == 'messaging'", specifier = ">=3.41.0,<4" },
+    { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.41.0,<4" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6,<1" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
     { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
@@ -3998,15 +3997,15 @@ wheels = [
 
 [[package]]
 name = "python-telegram-bot"
-version = "22.6"
+version = "22.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpcore", marker = "python_full_version >= '3.14'" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/9b/8df90c85404166a6631e857027866263adb27440d8af1dbeffbdc4f0166c/python_telegram_bot-22.6.tar.gz", hash = "sha256:50ae8cc10f8dff01445628687951020721f37956966b92a91df4c1bf2d113742", size = 1503761, upload-time = "2026-01-24T13:57:00.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/25/2258161b1069e66d6c39c0a602dbe57461d4767dc0012539970ea40bc9d6/python_telegram_bot-22.7.tar.gz", hash = "sha256:784b59ea3852fe4616ad63b4a0264c755637f5d725e87755ecdee28300febf61", size = 1516454, upload-time = "2026-03-16T09:36:03.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/97/7298f0e1afe3a1ae52ff4c5af5087ed4de319ea73eb3b5c8c4dd4e76e708/python_telegram_bot-22.6-py3-none-any.whl", hash = "sha256:e598fe171c3dde2dfd0f001619ee9110eece66761a677b34719fb18934935ce0", size = 737267, upload-time = "2026-01-24T13:56:58.06Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f7/0e2f89dd62f45d46d4ea0d8aec5893ce5b37389638db010c117f46f11450/python_telegram_bot-22.7-py3-none-any.whl", hash = "sha256:d72eed532cf763758cd9331b57a6d790aff0bb4d37d8f4e92149436fe21c6475", size = 745365, upload-time = "2026-03-16T09:36:01.498Z" },
 ]
 
 [package.optional-dependencies]
@@ -4448,23 +4447,23 @@ wheels = [
 
 [[package]]
 name = "slack-bolt"
-version = "1.27.0"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "slack-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/28/50ed0b86e48b48e6ddcc71de93b91c8ac14a55d1249e4bff0586494a2f90/slack_bolt-1.27.0.tar.gz", hash = "sha256:3db91d64e277e176a565c574ae82748aa8554f19e41a4fceadca4d65374ce1e0", size = 129101, upload-time = "2025-11-13T20:17:46.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/97/a62dde97e84027b252807f2044bed2edcda2d063a5cb0c535fb2be8d9b5d/slack_bolt-1.28.0.tar.gz", hash = "sha256:bfe367d867e8fb157a057248ebd4ac2d7f43acac6d0700fa31381db1e10f3b0f", size = 130768, upload-time = "2026-04-06T23:24:59.936Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/a8/1acb355759747ba4da5f45c1a33d641994b9e04b914908c9434f18bd97e8/slack_bolt-1.27.0-py2.py3-none-any.whl", hash = "sha256:c43c94bf34740f2adeb9b55566c83f1e73fed6ba2878bd346cdfd6fd8ad22360", size = 230428, upload-time = "2025-11-13T20:17:45.465Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a9/697b6a92c728f09d5ef6b8e83dc6c8a87bc6d59499b2933ed067f11b7e30/slack_bolt-1.28.0-py2.py3-none-any.whl", hash = "sha256:738d1ca5e7c7039b6e18103d29267ced6e18c2517053eff18991fdd593acce5c", size = 234819, upload-time = "2026-04-06T23:24:58.278Z" },
 ]
 
 [[package]]
 name = "slack-sdk"
-version = "3.40.1"
+version = "3.41.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/18/784859b33a3f9c8cdaa1eda4115eb9fe72a0a37304718887d12991eeb2fd/slack_sdk-3.40.1.tar.gz", hash = "sha256:a215333bc251bc90abf5f5110899497bf61a3b5184b6d9ee35d73ebf09ec3fd0", size = 250379, upload-time = "2026-02-18T22:11:01.819Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/35/fc009118a13187dd9731657c60138e5a7c2dea88681a7f04dc406af5da7d/slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca", size = 250568, upload-time = "2026-03-12T16:10:11.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/e1/bb81f93c9f403e3b573c429dd4838ec9b44e4ef35f3b0759eb49557ab6e3/slack_sdk-3.40.1-py2.py3-none-any.whl", hash = "sha256:cd8902252979aa248092b0d77f3a9ea3cc605bc5d53663ad728e892e26e14a65", size = 313687, upload-time = "2026-02-18T22:11:00.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/df/2e4be347ff98281b505cc0ccf141408cdd25eb5ca9f3830deb361b2472d3/slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89", size = 313885, upload-time = "2026-03-12T16:10:09.811Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1795,7 +1795,7 @@ requires-dist = [
     { name = "croniter", marker = "extra == 'cron'", specifier = ">=6.0.0,<7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
-    { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = ">=0.1.0,<1" },
+    { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = ">=0.24.3,<1" },
     { name = "discord-py", extras = ["voice"], marker = "extra == 'messaging'", specifier = ">=2.7.1,<3" },
     { name = "edge-tts", specifier = ">=7.2.7,<8" },
     { name = "elevenlabs", marker = "extra == 'tts-premium'", specifier = ">=1.0,<2" },
@@ -1822,7 +1822,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["tts-premium"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["voice"], marker = "extra == 'all'" },
-    { name = "honcho-ai", marker = "extra == 'honcho'", specifier = ">=2.0.1,<3" },
+    { name = "honcho-ai", marker = "extra == 'honcho'", specifier = ">=2.1.0,<3" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.5.3,<2" },
@@ -1928,16 +1928,16 @@ wheels = [
 
 [[package]]
 name = "honcho-ai"
-version = "2.0.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/30/d30ba159404050d53b4b1b1c4477f9591f43af18758be1fb7dab6afbfe7d/honcho_ai-2.0.1.tar.gz", hash = "sha256:6fdeebf9454e62bc523d57888e50359e67baafdb21f68621f9c14e08dc00623a", size = 46732, upload-time = "2026-02-09T21:03:26.99Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/07/fb2a6654a9f44ff1070d88feb269113a865923e0aa91acf7864459179a1b/honcho_ai-2.1.0.tar.gz", hash = "sha256:c1988bbbf61492c2db168c2f0aa4317c489e18ea9867f74cb318a5f1b83289c8", size = 48050, upload-time = "2026-03-30T14:59:56.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/83fda0c057cfa11d6b5ed532623184591aa7dcff4a067934ba6811026229/honcho_ai-2.0.1-py3-none-any.whl", hash = "sha256:94887e61d59f353e1e1e20b395858040780f5d67ca1e9d450538646544e4e42f", size = 56780, upload-time = "2026-02-09T21:03:25.992Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/34/b814ea3bed1d96807377814461d58294f0d6c5c66e29f06625c0ac6069b6/honcho_ai-2.1.0-py3-none-any.whl", hash = "sha256:c07389036ef839ff31dc66e4757fa451da25ce976830bce108372e0756daf500", size = 58295, upload-time = "2026-03-30T14:59:55.774Z" },
 ]
 
 [[package]]

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -107,14 +107,9 @@ Providers validate these sequences and will reject malformed histories.
 
 API requests are wrapped in `_api_call_with_interrupt()` which runs the actual HTTP call in a background thread while monitoring an interrupt event:
 
-```text
-┌──────────────────────┐     ┌──────────────┐
-│  Main thread         │     │  API thread   │
-│  wait on:            │────▶│  HTTP POST    │
-│  - response ready    │     │  to provider  │
-│  - interrupt event   │     └──────────────┘
-│  - timeout           │
-└──────────────────────┘
+```mermaid
+flowchart LR
+    A["Main thread<br/>waits on:<br/>- response ready<br/>- interrupt event<br/>- timeout"] --> B["API thread<br/>HTTP POST to provider"]
 ```
 
 When interrupted (user sends new message, `/stop` command, or signal):

--- a/website/docs/developer-guide/architecture.md
+++ b/website/docs/developer-guide/architecture.md
@@ -10,42 +10,32 @@ This page is the top-level map of Hermes Agent internals. Use it to orient yours
 
 ## System Overview
 
-```text
-┌─────────────────────────────────────────────────────────────────────┐
-│                        Entry Points                                  │
-│                                                                      │
-│  CLI (cli.py)    Gateway (gateway/run.py)    ACP (acp_adapter/)     │
-│  Batch Runner    API Server                  Python Library          │
-└──────────┬──────────────┬───────────────────────┬────────────────────┘
-           │              │                       │
-           ▼              ▼                       ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                     AIAgent (run_agent.py)                           │
-│                                                                      │
-│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐                │
-│  │ Prompt        │ │ Provider     │ │ Tool         │                │
-│  │ Builder       │ │ Resolution   │ │ Dispatch     │                │
-│  │ (prompt_      │ │ (runtime_    │ │ (model_      │                │
-│  │  builder.py)  │ │  provider.py)│ │  tools.py)   │                │
-│  └──────┬───────┘ └──────┬───────┘ └──────┬───────┘                │
-│         │                │                │                          │
-│  ┌──────┴───────┐ ┌──────┴───────┐ ┌──────┴───────┐                │
-│  │ Compression  │ │ 3 API Modes  │ │ Tool Registry│                │
-│  │ & Caching    │ │ chat_compl.  │ │ (registry.py)│                │
-│  │              │ │ codex_resp.  │ │ 48 tools     │                │
-│  │              │ │ anthropic    │ │ 40 toolsets   │                │
-│  └──────────────┘ └──────────────┘ └──────────────┘                │
-└─────────────────────────────────────────────────────────────────────┘
-           │                                    │
-           ▼                                    ▼
-┌───────────────────┐              ┌──────────────────────┐
-│ Session Storage   │              │ Tool Backends         │
-│ (SQLite + FTS5)   │              │ Terminal (6 backends) │
-│ hermes_state.py   │              │ Browser (5 backends)  │
-│ gateway/session.py│              │ Web (4 backends)      │
-└───────────────────┘              │ MCP (dynamic)         │
-                                   │ File, Vision, etc.    │
-                                   └──────────────────────┘
+```mermaid
+flowchart TD
+    subgraph EntryPoints["Entry Points"]
+        CLI["CLI<br/>cli.py"]
+        Gateway["Gateway<br/>gateway/run.py"]
+        ACP["ACP<br/>acp_adapter/"]
+        Batch["Batch Runner"]
+        API["API Server"]
+        PyLib["Python Library"]
+    end
+
+    subgraph Agent["AIAgent<br/>run_agent.py"]
+        Prompt["Prompt Builder<br/>prompt_builder.py"]
+        Provider["Provider Resolution<br/>runtime_provider.py"]
+        Dispatch["Tool Dispatch<br/>model_tools.py"]
+        Compression["Compression & Caching"]
+        Modes["3 API Modes<br/>chat_compl. / codex_resp. / anthropic"]
+        Registry["Tool Registry<br/>registry.py<br/>48 tools / 40 toolsets"]
+    end
+
+    EntryPoints --> Agent
+    Prompt --> Compression
+    Provider --> Modes
+    Dispatch --> Registry
+    Agent --> Session["Session Storage<br/>SQLite + FTS5<br/>hermes_state.py / gateway/session.py"]
+    Agent --> Backends["Tool Backends<br/>Terminal / Browser / Web / MCP / File / Vision"]
 ```
 
 ## Directory Structure

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -25,28 +25,28 @@ The messaging gateway is the long-running process that connects Hermes to 14+ ex
 
 ## Architecture Overview
 
-```text
-┌─────────────────────────────────────────────────┐
-│                 GatewayRunner                     │
-│                                                   │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐       │
-│  │ Telegram  │  │ Discord  │  │  Slack   │  ...  │
-│  │ Adapter   │  │ Adapter  │  │ Adapter  │       │
-│  └─────┬─────┘  └─────┬────┘  └─────┬────┘       │
-│        │              │              │             │
-│        └──────────────┼──────────────┘             │
-│                       ▼                            │
-│              _handle_message()                     │
-│                       │                            │
-│          ┌────────────┼────────────┐               │
-│          ▼            ▼            ▼               │
-│   Slash command   AIAgent      Queue/BG            │
-│    dispatch       creation     sessions            │
-│                       │                            │
-│                       ▼                            │
-│              SessionStore                          │
-│           (SQLite persistence)                     │
-└─────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph GatewayRunner["GatewayRunner"]
+        Telegram["Telegram Adapter"]
+        Discord["Discord Adapter"]
+        Slack["Slack Adapter"]
+        More["Other platform adapters"]
+        Handle["_handle_message()"]
+        Commands["Slash command dispatch"]
+        Agent["AIAgent creation"]
+        Queue["Queue / background sessions"]
+        Store["SessionStore<br/>SQLite persistence"]
+    end
+
+    Telegram --> Handle
+    Discord --> Handle
+    Slack --> Handle
+    More --> Handle
+    Handle --> Commands
+    Handle --> Agent
+    Handle --> Queue
+    Agent --> Store
 ```
 
 ## Message Flow

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -37,6 +37,11 @@ Set it to `false` only if you explicitly want one shared conversation per chat.
 2. Create a new app.
 3. In **Credentials & Basic Info**, copy the **App ID** and **App Secret**.
 4. Enable the **Bot** capability for the app.
+5. If you want Hermes to read shared Feishu/Lark cloud-document links automatically, grant at least one of:
+   - `docx:document`
+   - `docx:document:readonly`
+
+For document links inside knowledge-base or drive workflows, `drive:drive` or `drive:drive:readonly` may also be useful depending on how your workspace shares access.
 
 :::warning
 Keep the App Secret private. Anyone with it can impersonate your app.
@@ -231,6 +236,8 @@ Media from rich-text (post) messages, including inline images and file attachmen
 
 For small text-based documents (.txt, .md), the file content is automatically injected into the message text so the agent can read it directly without needing tools.
 
+When users send Feishu/Lark cloud-document links such as `https://docs.feishu.cn/docx/...` or `https://docs.larksuite.com/docx/...`, Hermes will also attempt to fetch the document's raw text via the Feishu Open API and inject that content into the inbound message context.
+
 ### Outbound (sending)
 
 | Method | What it sends |
@@ -411,6 +418,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
 | Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
+| Feishu cloud-document links are not expanded | Grant `docx:document` or `docx:document:readonly`, then make sure the app itself has permission to read the target document |
 | Bot identity not auto-detected | Grant `admin:app.info:readonly` scope, or set `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` manually |
 | `Webhook rate limit exceeded` | More than 120 requests/minute from the same IP. This is usually a misconfiguration or loop. |
 


### PR DESCRIPTION
## Summary

This fixes Feishu/Lark cloud document links not being usable in gateway conversations.

## Root Cause

The Feishu adapter could normalize text messages, post messages, and uploaded attachments, but it treated shared `docs.feishu.cn` / `docs.larksuite.com` doc links as plain text. When users shared a cloud document URL, Hermes had no native Feishu document fetch path and often fell back to browser-based access, which times out for authenticated docs.

## What Changed

- detect Feishu/Lark `docx` links in inbound text and post messages
- fetch document raw text through the Feishu Open API instead of the browser tool
- cache `tenant_access_token` values in the adapter and refresh on expiry/401
- inject fetched doc text into the inbound message context with the same bounded inline-content pattern used for small text attachments
- document the required `docx:*` permissions in the Feishu messaging docs
- add gateway regressions for direct links, markdown links, and fetch-failure fallback
- replace the failing ASCII docs diagrams with Mermaid so docs-site lint passes

## User Impact

Users can now send Feishu/Lark cloud document links directly to Hermes and have the document text included in the conversation context, as long as the app has both API scope and document-level access.

## Validation

- `uv run --extra dev pytest tests/gateway/test_feishu.py -q`
- `uv run --extra dev pytest tests/gateway/test_feishu_approval_buttons.py -q`
- `uv run --with ascii-guard ascii-guard lint website/docs`

Fixes #6378 
