### PR TITLE
fix: improve context compression quality — higher limits, tool tracking, degradation warning

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -199,30 +199,39 @@ class ContextCompressor:
         budget = int(content_tokens * _SUMMARY_RATIO)
         return max(_MIN_SUMMARY_TOKENS, min(budget, self.max_summary_tokens))
 
+    # Truncation limits for the summarizer input.  These bound how much of
+    # each message the summary model sees — the budget is the *summary*
+    # model's context window, not the main model's.
+    _CONTENT_MAX = 6000       # total chars per message body
+    _CONTENT_HEAD = 4000      # chars kept from the start
+    _CONTENT_TAIL = 1500      # chars kept from the end
+    _TOOL_ARGS_MAX = 1500     # tool call argument chars
+    _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
+
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
 
-        Includes tool call arguments and result content (up to 3000 chars
-        per message) so the summarizer can preserve specific details like
-        file paths, commands, and outputs.
+        Includes tool call arguments and result content (up to
+        ``_CONTENT_MAX`` chars per message) so the summarizer can preserve
+        specific details like file paths, commands, and outputs.
         """
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
             content = msg.get("content") or ""
 
-            # Tool results: keep more content than before (3000 chars)
+            # Tool results: keep enough content for the summarizer
             if role == "tool":
                 tool_id = msg.get("tool_call_id", "")
-                if len(content) > 3000:
-                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+                if len(content) > self._CONTENT_MAX:
+                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
                 parts.append(f"[TOOL RESULT {tool_id}]: {content}")
                 continue
 
             # Assistant messages: include tool call names AND arguments
             if role == "assistant":
-                if len(content) > 3000:
-                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+                if len(content) > self._CONTENT_MAX:
+                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
                 tool_calls = msg.get("tool_calls", [])
                 if tool_calls:
                     tc_parts = []
@@ -232,8 +241,8 @@ class ContextCompressor:
                             name = fn.get("name", "?")
                             args = fn.get("arguments", "")
                             # Truncate long arguments but keep enough for context
-                            if len(args) > 500:
-                                args = args[:400] + "..."
+                            if len(args) > self._TOOL_ARGS_MAX:
+                                args = args[:self._TOOL_ARGS_HEAD] + "..."
                             tc_parts.append(f"  {name}({args})")
                         else:
                             fn = getattr(tc, "function", None)
@@ -244,8 +253,8 @@ class ContextCompressor:
                 continue
 
             # User and other roles
-            if len(content) > 3000:
-                content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+            if len(content) > self._CONTENT_MAX:
+                content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
             parts.append(f"[{role.upper()}]: {content}")
 
         return "\n\n".join(parts)
@@ -310,6 +319,9 @@ Update the summary using this exact structure. PRESERVE all existing information
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
 
+## Tools & Patterns
+[Which tools were used, how they were used effectively, and any tool-specific discoveries. Accumulate across compactions.]
+
 Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions.
 
 Write only the summary body. Do not include any preamble or prefix."""
@@ -347,6 +359,9 @@ Use this exact structure:
 
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
+
+## Tools & Patterns
+[Which tools were used, how they were used effectively, and any tool-specific discoveries (e.g., preferred flags, working invocations, successful command patterns)]
 
 Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions. The goal is to prevent the next assistant from repeating work or losing important details.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6013,6 +6013,15 @@ class AIAgent:
             except Exception as e:
                 logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
+        # Warn on repeated compressions (quality degrades with each pass)
+        _cc = self.context_compressor.compression_count
+        if _cc >= 2:
+            self._vprint(
+                f"{self.log_prefix}⚠️  Session compressed {_cc} times — "
+                f"accuracy may degrade. Consider /new to start fresh.",
+                force=True,
+            )
+
         # Update token estimate after compaction so pressure calculations
         # use the post-compression count, not the stale pre-compression one.
         _compressed_est = (

--- a/tests/run_agent/test_context_pressure.py
+++ b/tests/run_agent/test_context_pressure.py
@@ -219,6 +219,7 @@ class TestContextPressureFlags:
         ]
         agent.context_compressor.context_length = 200_000
         agent.context_compressor.threshold_tokens = 100_000
+        agent.context_compressor.compression_count = 1
 
         agent._todo_store = MagicMock()
         agent._todo_store.format_for_injection.return_value = None


### PR DESCRIPTION
## Summary

Salvage of PR #4156 by @SHL0MS (cherry-picked onto current main) with one test fix.

Three targeted improvements to context compression quality, addressing the most impactful issues from #499.

### 1. Higher serializer truncation limits (3K → 6K)

The summarizer model was working from heavily truncated data. Magic numbers replaced with named class constants:

| Content type | Before | After |
|---|---|---|
| Message body | 3,000 chars (2000+800) | 6,000 chars (4000+1500) |
| Tool call arguments | 500 chars (400 head) | 1,500 chars (1200 head) |

These only affect input to the *auxiliary summarizer model* — no impact on the main model's context or prompt cache.

### 2. "Tools & Patterns" section in compression prompts

Both prompt templates (first-pass and iterative-update) now include:
```
## Tools & Patterns
[Which tools were used, how they were used effectively, and any
tool-specific discoveries. Accumulate across compactions.]
```

Preserves HOW tools were used effectively across compaction boundaries — the agent often re-discovers effective flag combos after compression.

### 3. Degradation warning after repeated compressions

After 2+ compressions:
```
⚠️  Session compressed 3 times — accuracy may degrade. Consider /new to start fresh.
```

`compression_count` was tracked internally but never surfaced to the user. Uses `_vprint(force=True)` — purely user-facing, does NOT inject into the message stream or affect prompt caching.

## Follow-up fix

Set `compression_count = 1` on the MagicMock in `test_flag_reset_on_compression` — the new degradation warning reads this attribute as an int, but the existing mock returned a MagicMock object.

## Test plan

- 36 compressor tests pass
- 23 context pressure tests pass (including the fixed one)
- `py_compile` clean on both files

Ref #499