### PR TITLE
fix(cli): update TUI status bar model name on provider fallback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1602,7 +1602,12 @@ class HermesCLI:
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
-        model_name = self.model or "unknown"
+        # Prefer the agent's model name — it updates on fallback.
+        # self.model reflects the originally configured model and never
+        # changes mid-session, so the TUI would show a stale name after
+        # _try_activate_fallback() switches provider/model.
+        agent = getattr(self, "agent", None)
+        model_name = (getattr(agent, "model", None) or self.model or "unknown")
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
@@ -1628,7 +1633,6 @@ class HermesCLI:
             "compressions": 0,
         }
 
-        agent = getattr(self, "agent", None)
         if not agent:
             return snapshot
 


### PR DESCRIPTION
## Summary

- Read model name from `agent.model` (live, updated by `_try_activate_fallback()`) instead of `self.model` (stale CLI attribute set once at init)
- Remove redundant `getattr(self, "agent")` call already done earlier in the method

Fixes #6398

## Problem

When provider fallback activates, the TUI status bar shows the original model name while `context_length_max` correctly updates to the fallback model's limit — a confusing mismatch.

`self.model` on the CLI class is set once during `__init__` and never updated mid-session. `_try_activate_fallback()` in `run_agent.py` swaps `agent.model` but the CLI never sees it.