### PR TITLE
fix(cron): set last_status to 'delivery_failed' when delivery fails

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -590,7 +590,12 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         if job["id"] == job_id:
             now = _hermes_now().isoformat()
             job["last_run_at"] = now
-            job["last_status"] = "ok" if success else "error"
+            if not success:
+                job["last_status"] = "error"
+            elif delivery_error:
+                job["last_status"] = "delivery_failed"
+            else:
+                job["last_status"] = "ok"
             job["last_error"] = error if not success else None
             # Track delivery failures separately — cleared on successful delivery
             job["last_delivery_error"] = delivery_error

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -100,6 +100,8 @@ def cron_list(show_all: bool = False):
             last_run = job.get("last_run_at", "?")
             if last_status == "ok":
                 status_display = color("ok", Colors.GREEN)
+            elif last_status == "delivery_failed":
+                status_display = color("delivery_failed", Colors.YELLOW)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
             print(f"    Last run:  {last_run}  {status_display}")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -340,23 +340,25 @@ class TestMarkJobRun:
         assert updated["last_error"] == "timeout"
 
     def test_delivery_error_tracked_separately(self, tmp_cron_dir):
-        """Agent succeeds but delivery fails — both tracked independently."""
+        """Agent succeeds but delivery fails — status reflects delivery failure."""
         job = create_job(prompt="Report", schedule="every 1h")
         mark_job_run(job["id"], success=True, delivery_error="platform 'telegram' not configured")
         updated = get_job(job["id"])
-        assert updated["last_status"] == "ok"
+        assert updated["last_status"] == "delivery_failed"
         assert updated["last_error"] is None
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
 
     def test_delivery_error_cleared_on_success(self, tmp_cron_dir):
-        """Successful delivery clears the previous delivery error."""
+        """Successful delivery clears the previous delivery error and restores 'ok' status."""
         job = create_job(prompt="Report", schedule="every 1h")
         mark_job_run(job["id"], success=True, delivery_error="network timeout")
         updated = get_job(job["id"])
+        assert updated["last_status"] == "delivery_failed"
         assert updated["last_delivery_error"] == "network timeout"
         # Next run delivers successfully
         mark_job_run(job["id"], success=True, delivery_error=None)
         updated = get_job(job["id"])
+        assert updated["last_status"] == "ok"
         assert updated["last_delivery_error"] is None
 
     def test_both_agent_and_delivery_error(self, tmp_cron_dir):


### PR DESCRIPTION
## Summary

`mark_job_run()` previously set `last_status` to `"ok"` whenever the agent succeeded, even if delivery to the messaging platform (Telegram, Discord, Slack, etc.) failed. This gave users a false sense that their scheduled reports were being delivered when they were not.

## Changes

- **`cron/jobs.py`**: `mark_job_run()` now sets `last_status` to `"delivery_failed"` when `success=True` but `delivery_error` is set. The three-way priority is: `error` (agent failed) > `delivery_failed` (agent ok, delivery failed) > `ok` (both succeeded).
- **`hermes_cli/cron.py`**: `hermes cron list` displays `delivery_failed` in yellow (warning), distinct from green `ok` and red `error`. The detailed delivery error message is already shown on a separate line via `last_delivery_error`.
- **`tests/cron/test_jobs.py`**: Updated existing delivery-error tests to assert the new `"delivery_failed"` status, plus added status round-trip verification (delivery_failed → ok after successful delivery).

## Notes

- Backwards compatible: no code outside these files compares `last_status` to specific values with branching logic (only pass-through in `cronjob_tools.py`).
- Existing persisted jobs with stale `"ok"` + `last_delivery_error` will self-correct on next run.

Fixes #5861
