### PR TITLE
fix: relaunch chat in a fresh process when setup leaves stdin dirty

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2842,13 +2842,35 @@ def _offer_launch_chat():
     if prompt_yes_no("Launch hermes chat now?", True):
         from hermes_cli.main import cmd_chat
         from types import SimpleNamespace
-        cmd_chat(SimpleNamespace(
-            query=None, resume=None, continue_last=None, model=None,
-            provider=None, effort=None, skin=None, oneshot=False,
-            quiet=False, verbose=False, toolsets=None, skills=None,
-            yolo=False, source=None, worktree=False, checkpoints=False,
-            pass_session_id=False, max_turns=None,
-        ))
+
+        try:
+            cmd_chat(SimpleNamespace(
+                query=None, resume=None, continue_last=None, model=None,
+                provider=None, effort=None, skin=None, oneshot=False,
+                quiet=False, verbose=False, toolsets=None, skills=None,
+                yolo=False, source=None, worktree=False, checkpoints=False,
+                pass_session_id=False, max_turns=None,
+            ))
+        except OSError as exc:
+            if exc.errno != 22:
+                raise
+            # Interactive setup may leave stdin in a state that prompt_toolkit
+            # cannot re-register with the event loop. Restart chat in a fresh
+            # process so it gets clean stdio and selector state.
+            print()
+            print("Starting chat in a fresh session...")
+            hermes_bin = os.path.join(os.path.dirname(sys.executable), "hermes")
+            if os.path.exists(hermes_bin):
+                try:
+                    os.execvp(hermes_bin, [hermes_bin, "chat"])
+                except OSError:
+                    pass
+            try:
+                os.execvp(sys.executable, [sys.executable, "-m", "hermes_cli", "chat"])
+            except OSError as launch_exc:
+                print_error(f"Could not launch chat automatically: {launch_exc}")
+                print_info("Start it manually with: hermes chat")
+                raise SystemExit(1) from launch_exc
 
 
 def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -4,6 +4,9 @@ import json
 import sys
 import types
 
+import pytest
+
+import hermes_cli.setup as setup_mod
 from hermes_cli.auth import get_active_provider
 from hermes_cli.config import load_config, save_config
 from hermes_cli.setup import setup_model_provider
@@ -305,3 +308,93 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
 
     assert config["terminal"]["backend"] == "modal"
     assert config["terminal"]["modal_mode"] == "direct"
+
+
+def test_offer_launch_chat_reexecs_after_oserror(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
+    monkeypatch.setattr(setup_mod.sys, "executable", "/tmp/venv/bin/python")
+    monkeypatch.setattr(setup_mod.os.path, "exists", lambda path: path == "/tmp/venv/bin/hermes")
+
+    def fake_cmd_chat(args):
+        assert args.query is None
+        raise OSError(22, "Invalid argument")
+
+    exec_calls = []
+
+    def fake_execvp(path, argv):
+        exec_calls.append((path, argv))
+        raise SystemExit(0)
+
+    monkeypatch.setattr("hermes_cli.main.cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(setup_mod.os, "execvp", fake_execvp)
+
+    with pytest.raises(SystemExit):
+        setup_mod._offer_launch_chat()
+
+    assert exec_calls == [("/tmp/venv/bin/hermes", ["/tmp/venv/bin/hermes", "chat"])]
+    assert "Starting chat in a fresh session..." in capsys.readouterr().out
+
+
+def test_offer_launch_chat_reraises_unrelated_oserror(monkeypatch):
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
+
+    def fake_cmd_chat(args):
+        raise OSError(2, "No such file or directory")
+
+    monkeypatch.setattr("hermes_cli.main.cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(setup_mod.os, "execvp", lambda *args, **kwargs: pytest.fail("unexpected execvp"))
+
+    with pytest.raises(OSError, match="No such file or directory"):
+        setup_mod._offer_launch_chat()
+
+
+def test_offer_launch_chat_falls_back_to_module_when_binary_missing(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
+    monkeypatch.setattr(setup_mod.sys, "executable", "/tmp/venv/bin/python")
+    monkeypatch.setattr(setup_mod.os.path, "exists", lambda path: False)
+
+    def fake_cmd_chat(args):
+        raise OSError(22, "Invalid argument")
+
+    exec_calls = []
+
+    def fake_execvp(path, argv):
+        exec_calls.append((path, argv))
+        raise SystemExit(0)
+
+    monkeypatch.setattr("hermes_cli.main.cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(setup_mod.os, "execvp", fake_execvp)
+
+    with pytest.raises(SystemExit):
+        setup_mod._offer_launch_chat()
+
+    assert exec_calls == [("/tmp/venv/bin/python", ["/tmp/venv/bin/python", "-m", "hermes_cli", "chat"])]
+    assert "Starting chat in a fresh session..." in capsys.readouterr().out
+
+
+def test_offer_launch_chat_falls_back_to_module_when_binary_exec_fails(monkeypatch):
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
+    monkeypatch.setattr(setup_mod.sys, "executable", "/tmp/venv/bin/python")
+    monkeypatch.setattr(setup_mod.os.path, "exists", lambda path: path == "/tmp/venv/bin/hermes")
+
+    def fake_cmd_chat(args):
+        raise OSError(22, "Invalid argument")
+
+    exec_calls = []
+
+    def fake_execvp(path, argv):
+        exec_calls.append((path, argv))
+        if path == "/tmp/venv/bin/hermes":
+            raise OSError(8, "Exec format error")
+        raise SystemExit(0)
+
+    monkeypatch.setattr("hermes_cli.main.cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(setup_mod.os, "execvp", fake_execvp)
+
+    with pytest.raises(SystemExit):
+        setup_mod._offer_launch_chat()
+
+    assert exec_calls == [
+        ("/tmp/venv/bin/hermes", ["/tmp/venv/bin/hermes", "chat"]),
+        ("/tmp/venv/bin/python", ["/tmp/venv/bin/python", "-m", "hermes_cli", "chat"]),
+    ]


### PR DESCRIPTION
## Summary

- Fixes #5884
- catch `OSError` with `errno == 22` in `hermes_cli/setup.py::_offer_launch_chat()`
- fall back to `os.execvp(...)` so `hermes chat` starts in a fresh process with clean stdio state
- add regression tests for the fallback path and for re-raising unrelated `OSError`s

## What did NOT change

- the normal in-process `cmd_chat(...)` path still runs when chat starts cleanly
- no chat flags, provider selection behavior, or setup flow prompts were changed

## User-visible changes

- after setup finishes, choosing `Launch hermes chat now?` no longer crashes on the known stdin-selector failure path
- when the selector registration bug is hit, Hermes prints `Starting chat in a fresh session...` and relaunches chat

## Compatibility / Security impact

- no API, config schema, or database changes
- no new permissions or network behavior
- behavior change is limited to the setup-to-chat handoff when the known `OSError(22, ...)` path is hit

## Test plan

- [x] `pytest tests/hermes_cli/test_setup.py -k offer_launch_chat_reexecs_after_oserror -q`
- [x] `pytest tests/hermes_cli/test_setup.py -k offer_launch_chat_reraises_unrelated_oserror -q`
- [x] `pytest tests/hermes_cli/test_setup.py -k 'binary_missing or binary_exec_fails' -q`
- [x] `pytest tests/hermes_cli/test_setup.py -q`
- [x] `pytest tests/ -v`

## Evidence / Actual results

- targeted setup suite: `14 passed in 2.02s`
- focused fallback tests: `4 passed in 1.35s`
- full suite on this branch: `28 failed, 9355 passed, 31 skipped, 1 xpassed`
- full suite on clean `origin/main` baseline: `28 failed, 9351 passed, 31 skipped, 1 xpassed`
- real TTY smoke test in isolated temp profile: setup wizard reached `Launch hermes chat now?`, accepted `y`, and launched chat TUI without the selector crash
- verification profile path: `/tmp/hermes-pr1-hv.XOBmql`

## Human verification

Completed in a real TTY against an isolated temp profile:

- `HERMES_HOME=/tmp/hermes-pr1-hv.XOBmql`
- ran `hermes setup` in the temp venv
- skipped the OpenClaw import prompt to avoid using existing user state
- reached `Launch hermes chat now?`
- answered `y`
- Hermes launched the chat TUI and showed `Welcome to Hermes Agent! Type your message or /help for commands.`

What was verified:

- the setup-to-chat handoff completes in a fresh session
- the selector/stdin crash does not occur on the launch path

What was not verified:

- sending a chat message through a live provider in this temp profile
- provider-auth setup was not completed in the isolated run

## Risks / rollback

- risk is limited to the setup handoff path; unrelated `OSError`s are re-raised instead of triggering a relaunch
- rollback is a simple revert of `hermes_cli/setup.py` and `tests/hermes_cli/test_setup.py`
