### PR TITLE
feat(send_message): add Feishu image/media sending support

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -457,6 +457,49 @@ class TestSendToPlatformChunking:
         assert all(call == [] for call in sent_calls[:-1])
         assert sent_calls[-1] == media
 
+    def test_feishu_media_attaches_to_last_chunk(self):
+        """Feishu: media files are sent only with the last chunk (like Telegram)."""
+        sent_calls = []
+
+        async def fake_send(pconfig, chat_id, message, media_files=None, thread_id=None):
+            sent_calls.append(media_files or [])
+            return {"success": True, "platform": "feishu", "chat_id": chat_id, "message_id": str(len(sent_calls))}
+
+        long_msg = "word " * 2000  # ~10000 chars, will be chunked
+        media = [("/tmp/photo.png", False)]
+        with patch("tools.send_message_tool._send_feishu", fake_send):
+            asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "oc_xxx", long_msg, media_files=media,
+                )
+            )
+        # Message is chunked, media should only be on last chunk
+        assert len(sent_calls) >= 2
+        assert all(call == [] for call in sent_calls[:-1])
+        assert sent_calls[-1] == media
+
+    def test_feishu_media_only_send(self):
+        """Feishu: sending media-only (no message text) should work."""
+        sent_calls = []
+
+        async def fake_send(pconfig, chat_id, message, media_files=None, thread_id=None):
+            sent_calls.append(media_files or [])
+            return {"success": True, "platform": "feishu", "chat_id": chat_id, "message_id": str(len(sent_calls))}
+
+        media = [("/tmp/photo.png", False)]
+        with patch("tools.send_message_tool._send_feishu", fake_send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "oc_xxx", "", media_files=media,
+                )
+            )
+        assert result["success"] is True
+        assert sent_calls[0] == media
+
 
 # ---------------------------------------------------------------------------
 # HTML auto-detection in Telegram send

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -356,15 +356,19 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-Telegram platforms ---
+    # Platforms that support media: Telegram, Feishu
+    _media_supported_platforms = {Platform.TELEGRAM, Platform.FEISHU}
+
     if media_files and not message.strip():
-        return {
-            "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram; "
-                f"target {platform.value} had only media attachments"
-            )
-        }
+        if platform not in _media_supported_platforms:
+            return {
+                "error": (
+                    f"send_message MEDIA delivery is currently only supported for telegram; "
+                    f"target {platform.value} had only media attachments"
+                )
+            }
     warning = None
-    if media_files:
+    if media_files and platform not in _media_supported_platforms:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
             "native send_message media delivery is currently only supported for telegram"
@@ -393,7 +397,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            # Only send media with the last chunk (matching Telegram behavior)
+            is_last = (chunk == chunks[-1]) if chunks else True
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files if is_last else [], thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         else:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -100,6 +100,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    media_files_from_args = args.get("media_files", [])
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -168,7 +169,21 @@ def _handle_send(args):
 
     from gateway.platforms.base import BasePlatformAdapter
 
-    media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
+    # Extract MEDIA: tags from message AND use media_files from args
+    media_files_from_message, cleaned_message = BasePlatformAdapter.extract_media(message)
+    
+    # Combine media files from both args and message tags
+    # args media_files may be simple strings, convert to (path, is_voice) format
+    args_media_formatted = []
+    for f in media_files_from_args:
+        if isinstance(f, str):
+            args_media_formatted.append((f, False))
+        elif isinstance(f, tuple):
+            args_media_formatted.append(f)
+    
+    all_media_files = args_media_formatted + media_files_from_message
+    media_files = all_media_files
+    
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -393,7 +393,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         )
 
     last_result = None
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
+        is_last_chunk = (i == len(chunks) - 1)
+        
         if platform == Platform.DISCORD:
             result = await _send_discord(pconfig.token, chat_id, chunk)
         elif platform == Platform.SLACK:
@@ -416,8 +418,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
             # Only send media with the last chunk (matching Telegram behavior)
-            is_last = (chunk == chunks[-1]) if chunks else True
-            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files if is_last else [], thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files if is_last_chunk else [], thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         else:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -374,11 +374,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # Platforms that support media: Telegram, Feishu
     _media_supported_platforms = {Platform.TELEGRAM, Platform.FEISHU}
 
+    # Derive supported platform names from the set for dynamic, accurate error messages
+    _supported_platform_names = ", ".join(p.value.capitalize() for p in sorted(_media_supported_platforms, key=lambda p: p.value))
+
     if media_files and not message.strip():
         if platform not in _media_supported_platforms:
             return {
                 "error": (
-                    f"send_message MEDIA delivery is currently only supported for telegram; "
+                    f"send_message MEDIA delivery is currently only supported for {_supported_platform_names.lower()}; "
                     f"target {platform.value} had only media attachments"
                 )
             }
@@ -386,7 +389,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and platform not in _media_supported_platforms:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram"
+            f"native send_message media delivery is currently only supported for {_supported_platform_names.lower()}"
         )
 
     last_result = None


### PR DESCRIPTION
Pass media_files to _send_feishu() which was previously missing, add Feishu to supported media platforms alongside Telegram, and only send media with the last chunk to avoid duplicate sends.