### PR TITLE
fix(feishu): use open_message_id for card action replies

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1913,6 +1913,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         context = getattr(event, "context", None)
         chat_id = str(getattr(context, "open_chat_id", "") or "")
+        card_message_id = str(getattr(context, "open_message_id", "") or "")
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
         if not chat_id or not open_id:
@@ -1968,7 +1969,7 @@ class FeishuAdapter(BasePlatformAdapter):
             await self._update_approval_card(state.get("message_id", ""), label, user_name, choice)
             return
 
-        synthetic_text = f"/card {action_tag}"
+        synthetic_text = f"[card:{action_tag}]"
         if action_value:
             try:
                 synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
@@ -1989,10 +1990,10 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         synthetic_event = MessageEvent(
             text=synthetic_text,
-            message_type=MessageType.COMMAND,
+            message_type=MessageType.TEXT,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            message_id=card_message_id or token or str(uuid.uuid4()),
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)


### PR DESCRIPTION
Three bugs in `_handle_card_action_event()`:

1. **Invalid message_id for ACK/reply**: Card token (e.g. `c-668433...`) was used as `message_id`, causing Feishu API error 99992354 (invalid open_message_id). Now extracts `open_message_id` from `CallBackContext`.

2. **Unrecognized slash command**: Synthetic text used `/card {action_tag}` which was routed as an unknown slash command. Changed to `[card:{action_tag}]`.

3. **Wrong message type**: `MessageType.COMMAND` triggered slash-command routing instead of normal agent processing. Changed to `MessageType.TEXT`.

Tested with interactive card button clicks via WebSocket mode — card callbacks are now received, processed by the agent, and replies are sent successfully.