### PR TITLE
feat(providers): add Claude CLI subprocess transport

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -102,6 +102,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "minimax": "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7",
     "anthropic": "claude-haiku-4-5-20251001",
+    "claude-cli": "claude-sonnet-4-6",
     "ai-gateway": "google/gemini-3-flash",
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
@@ -955,6 +956,19 @@ def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     return AnthropicAuxiliaryClient(real_client, model, token, base_url, is_oauth=is_oauth), model
 
 
+def _try_claude_cli() -> Tuple[Optional[Any], Optional[str]]:
+    """Return a ClaudeCliAdapter if the ``claude`` CLI is installed."""
+    try:
+        from agent.claude_cli_adapter import ClaudeCliAdapter, is_claude_cli_available
+    except ImportError:
+        return None, None
+    if not is_claude_cli_available():
+        return None, None
+    model = _API_KEY_PROVIDER_AUX_MODELS.get("claude-cli", "claude-sonnet-4-6")
+    logger.debug("Auxiliary client: claude-cli subprocess (model=%s)", model)
+    return ClaudeCliAdapter(model=model), model
+
+
 def _resolve_forced_provider(forced: str) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Resolve a specific forced provider.  Returns (None, None) if creds missing."""
     if forced == "openrouter":
@@ -1012,6 +1026,8 @@ def _get_provider_chain() -> List[tuple]:
         ("local/custom", _try_custom_endpoint),
         ("openai-codex", _try_codex),
         ("api-key", _resolve_api_key_provider),
+        # claude-cli is last: zero-config but subprocess overhead is higher
+        ("claude-cli", _try_claude_cli),
     ]
 
 
@@ -1144,6 +1160,12 @@ def _to_async_client(sync_client, model: str):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
         return AsyncAnthropicAuxiliaryClient(sync_client), model
+    try:
+        from agent.claude_cli_adapter import ClaudeCliAdapter, AsyncClaudeCliAdapter
+        if isinstance(sync_client, ClaudeCliAdapter):
+            return AsyncClaudeCliAdapter(sync_client), model
+    except ImportError:
+        pass
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -1291,6 +1313,22 @@ def resolve_provider_client(
         logger.warning("resolve_provider_client: custom/main requested "
                        "but no endpoint credentials found")
         return None, None
+
+    # ── Claude CLI (subprocess) ───────────────────────────────────────
+    if provider in ("claude-cli", "claude_cli"):
+        client, default = _try_claude_cli()
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: claude-cli requested but the "
+                "'claude' CLI is not installed — "
+                "run: npm install -g @anthropic-ai/claude-code"
+            )
+            return None, None
+        final_model = model or default
+        if async_mode:
+            from agent.claude_cli_adapter import AsyncClaudeCliAdapter
+            return AsyncClaudeCliAdapter(client), final_model
+        return client, final_model
 
     # ── Named custom providers (config.yaml custom_providers list) ───
     try:

--- a/agent/claude_cli_adapter.py
+++ b/agent/claude_cli_adapter.py
@@ -1,0 +1,443 @@
+"""Claude Code CLI subprocess adapter for Hermes Agent.
+
+Enables inference via the locally-installed ``claude`` CLI tool, letting
+users with a Claude Pro/Max subscription run Hermes without a separate API
+key.  The CLI manages its own auth (OAuth via claude.ai); Hermes just drives
+it as a subprocess.
+
+Why this exists vs the native ``anthropic`` provider
+-----------------------------------------------------
+The native ``anthropic`` provider calls ``api.anthropic.com`` directly and
+requires API credits.  Claude Pro/Max subscriptions don't grant API access —
+they grant CLI access.  This adapter bridges the two by shelling out to the
+``claude`` binary for each completion request, which honours the subscription
+billing path.
+
+Limitations
+-----------
+- Tool calls use JSON-in-prompt encoding (no native streaming tool events).
+- Streaming is not implemented; each call blocks until the CLI exits.
+- Multi-turn history is flattened into a single prompt via ``<conversation>``
+  XML tags — token usage numbers may differ from the native API.
+
+Usage::
+
+    from agent.claude_cli_adapter import ClaudeCliAdapter, is_claude_cli_available
+
+    if is_claude_cli_available():
+        adapter = ClaudeCliAdapter()
+        resp = adapter.chat.completions.create(
+            messages=[{"role": "user", "content": "Hello!"}],
+            model="claude-sonnet-4-6",
+        )
+        print(resp.choices[0].message.content)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+CLAUDE_CLI_NAME = "claude"
+DEFAULT_CLAUDE_CLI_MODEL = "claude-sonnet-4-6"
+DEFAULT_TIMEOUT_SECONDS = 120
+
+# ── Tool-call injection ───────────────────────────────────────────────────────
+# When tools are present Hermes needs structured tool-call objects back.
+# We ask Claude to emit a sentinel JSON block that we can reliably parse.
+
+_TOOL_CALL_SYSTEM_INJECT = """
+When you need to call a tool, respond ONLY with this exact JSON structure — no surrounding prose, no markdown fences:
+
+{"tool_call": {"name": "<tool_name>", "arguments": {<argument_object>}}}
+
+After you receive the tool result continue responding normally.
+The available tools are listed below.
+""".strip()
+
+_TOOL_CALL_RE = re.compile(r'\{\s*"tool_call"\s*:\s*\{.*?\}\s*\}', re.DOTALL)
+
+
+# ── Availability helpers ──────────────────────────────────────────────────────
+
+def is_claude_cli_available() -> bool:
+    """Return True if the ``claude`` CLI is installed and on PATH."""
+    return shutil.which(CLAUDE_CLI_NAME) is not None
+
+
+def get_claude_cli_path() -> Optional[str]:
+    """Return the full path to the ``claude`` binary, or None if not found."""
+    return shutil.which(CLAUDE_CLI_NAME)
+
+
+# ── Message formatting ────────────────────────────────────────────────────────
+
+def _extract_text(content: Any) -> str:
+    """Flatten an OpenAI content field (str or list of blocks) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "text":
+                parts.append(block.get("text", ""))
+            elif btype == "tool_result":
+                inner = block.get("content", "")
+                if isinstance(inner, list):
+                    inner = " ".join(
+                        b.get("text", "") for b in inner
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    )
+                parts.append(f"[Tool result: {inner}]")
+        return "\n".join(parts)
+    return str(content) if content else ""
+
+
+def _format_tool_definitions(tools: List[Dict]) -> str:
+    """Produce a compact JSON summary of tool definitions for the system prompt."""
+    simplified = [
+        {
+            "name": t.get("function", {}).get("name", ""),
+            "description": t.get("function", {}).get("description", ""),
+            "parameters": t.get("function", {}).get("parameters", {}),
+        }
+        for t in tools
+        if isinstance(t, dict)
+    ]
+    return json.dumps(simplified, indent=2)
+
+
+def build_prompt_and_system(
+    messages: List[Dict],
+    tools: Optional[List[Dict]] = None,
+) -> Tuple[Optional[str], str]:
+    """Convert OpenAI-style messages to ``(system_prompt, user_prompt)``.
+
+    Multi-turn history is embedded in the user prompt inside
+    ``<conversation_history>`` XML tags so Claude can follow prior context.
+    Tool definitions, when provided, are appended to the system prompt with
+    instructions on how to emit a parseable tool-call block.
+
+    Args:
+        messages: OpenAI-style message list.
+        tools:    OpenAI tool definitions (optional).
+
+    Returns:
+        Tuple of ``(system_prompt_or_None, user_prompt_string)``.
+    """
+    system_parts: List[str] = []
+    turns: List[Dict] = []
+
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = _extract_text(msg.get("content", ""))
+
+        if role == "system":
+            system_parts.append(content)
+            continue
+
+        if role == "assistant":
+            # Embed any tool_calls the assistant made as text so the next turn
+            # has context about what was requested.
+            tc_list = msg.get("tool_calls") or []
+            if tc_list:
+                tc_summary = json.dumps([
+                    {
+                        "name": tc.get("function", {}).get("name"),
+                        "arguments": tc.get("function", {}).get("arguments"),
+                    }
+                    for tc in tc_list
+                ], indent=2)
+                content = (content + f"\n[Tool calls: {tc_summary}]").strip()
+
+        if role == "tool":
+            tool_name = msg.get("name", "tool")
+            turns.append({"role": "tool_result", "name": tool_name, "content": content})
+            continue
+
+        turns.append({"role": role, "content": content})
+
+    # Build system prompt string
+    system_prompt: Optional[str] = "\n\n".join(p for p in system_parts if p) or None
+
+    if tools:
+        tool_defs = _format_tool_definitions(tools)
+        tool_block = f"{_TOOL_CALL_SYSTEM_INJECT}\n\n<tools>\n{tool_defs}\n</tools>"
+        system_prompt = (system_prompt + "\n\n" + tool_block) if system_prompt else tool_block
+
+    if not turns:
+        return system_prompt, ""
+
+    if len(turns) == 1:
+        return system_prompt, turns[0]["content"]
+
+    # Multi-turn: embed history, append last turn as the new prompt
+    _role_label = {"user": "Human", "assistant": "Assistant", "tool_result": "Tool"}
+    history_lines: List[str] = []
+    for turn in turns[:-1]:
+        label = _role_label.get(turn["role"], turn["role"].capitalize())
+        name = turn.get("name", "")
+        prefix = f"{label} ({name})" if name else label
+        history_lines.append(f"{prefix}: {turn['content']}")
+
+    last = turns[-1]
+    last_label = _role_label.get(last["role"], last["role"].capitalize())
+    history = "\n".join(history_lines)
+    prompt = (
+        f"<conversation_history>\n{history}\n</conversation_history>\n\n"
+        f"{last_label}: {last['content']}"
+    )
+    return system_prompt, prompt
+
+
+# ── Response parsing ──────────────────────────────────────────────────────────
+
+def _parse_tool_call(text: str) -> Optional[Dict]:
+    """Extract the first ``{"tool_call": {...}}`` block from the model output."""
+    match = _TOOL_CALL_RE.search(text)
+    if not match:
+        return None
+    try:
+        obj = json.loads(match.group())
+        return obj.get("tool_call")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+def _make_completion_response(
+    text: str,
+    model: str,
+    tools_present: bool = False,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+) -> Any:
+    """Wrap a CLI text response in an OpenAI-compatible ChatCompletion object."""
+    tool_calls = None
+    finish_reason = "stop"
+
+    if tools_present:
+        tc = _parse_tool_call(text)
+        if tc:
+            call_id = f"call_{int(time.time() * 1000)}"
+            tool_calls = [SimpleNamespace(
+                id=call_id,
+                type="function",
+                function=SimpleNamespace(
+                    name=str(tc.get("name", "")),
+                    arguments=(
+                        tc["arguments"]
+                        if isinstance(tc.get("arguments"), str)
+                        else json.dumps(tc.get("arguments", {}))
+                    ),
+                ),
+            )]
+            text = ""
+            finish_reason = "tool_calls"
+
+    message = SimpleNamespace(
+        role="assistant",
+        content=text,
+        tool_calls=tool_calls,
+        refusal=None,
+    )
+    choice = SimpleNamespace(
+        index=0,
+        message=message,
+        finish_reason=finish_reason,
+        logprobs=None,
+    )
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return SimpleNamespace(
+        id=f"claude-cli-{int(time.time() * 1000)}",
+        object="chat.completion",
+        created=int(time.time()),
+        model=model,
+        choices=[choice],
+        usage=usage,
+    )
+
+
+# ── Namespace wrappers ────────────────────────────────────────────────────────
+
+class _CompletionsAdapter:
+    def __init__(self, adapter: "ClaudeCliAdapter") -> None:
+        self._adapter = adapter
+
+    def create(
+        self,
+        *,
+        messages: List[Dict],
+        model: Optional[str] = None,
+        tools: Optional[List[Dict]] = None,
+        timeout: Optional[float] = None,
+        **_kwargs: Any,
+    ) -> Any:
+        return self._adapter._invoke(
+            messages=messages,
+            model=model or self._adapter.model,
+            tools=tools,
+            timeout=timeout,
+        )
+
+
+class _ChatNamespace:
+    def __init__(self, adapter: "ClaudeCliAdapter") -> None:
+        self.completions = _CompletionsAdapter(adapter)
+
+
+# ── Public adapter class ──────────────────────────────────────────────────────
+
+class ClaudeCliAdapter:
+    """Subprocess-backed completions adapter using the local ``claude`` CLI.
+
+    Exposes a ``chat.completions.create`` interface compatible with the OpenAI
+    Python SDK so it acts as a drop-in replacement in Hermes's provider chain.
+
+    Tool calls are handled via JSON-in-prompt encoding: tool definitions are
+    injected into the system prompt and Claude's response is scanned for a
+    ``{"tool_call": {...}}`` JSON block.  This is reliable with Claude models
+    but lacks native streaming tool events.
+
+    Args:
+        model:           Default model slug passed to ``--model``.
+        default_timeout: Subprocess wall-clock timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_CLAUDE_CLI_MODEL,
+        default_timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        cli_path = get_claude_cli_path()
+        if not cli_path:
+            raise FileNotFoundError(
+                "The 'claude' CLI is not installed. "
+                "Install it with: npm install -g @anthropic-ai/claude-code"
+            )
+        self._cli_path = cli_path
+        self.model = model
+        self._default_timeout = default_timeout
+        self.chat = _ChatNamespace(self)
+
+    # OpenAI client duck-type attributes used by Hermes's auxiliary framework
+    @property
+    def api_key(self) -> str:
+        return "claude-cli"
+
+    @property
+    def base_url(self) -> str:
+        return "subprocess://claude"
+
+    def _invoke(
+        self,
+        messages: List[Dict],
+        model: str,
+        tools: Optional[List[Dict]] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        system_prompt, user_prompt = build_prompt_and_system(messages, tools)
+
+        if not user_prompt.strip():
+            raise ValueError("claude-cli: no user message found in conversation")
+
+        cmd = [
+            self._cli_path,
+            "-p", user_prompt,
+            "--output-format", "json",
+            "--model", model,
+        ]
+        if system_prompt:
+            cmd += ["--system", system_prompt]
+
+        logger.debug(
+            "claude-cli: invoking %s model=%s tools=%d",
+            self._cli_path, model, len(tools or []),
+        )
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout or self._default_timeout,
+                env={**os.environ},
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"claude CLI timed out after {timeout or self._default_timeout}s"
+            ) from exc
+
+        if proc.returncode != 0:
+            stderr = proc.stderr.strip() or "(no stderr)"
+            raise RuntimeError(
+                f"claude CLI exited {proc.returncode}: {stderr}"
+            )
+
+        raw = proc.stdout.strip()
+        text = raw
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        try:
+            data = json.loads(raw)
+            if data.get("is_error"):
+                raise RuntimeError(
+                    f"claude CLI error: {data.get('result', 'unknown error')}"
+                )
+            text = data.get("result", "")
+            usage = data.get("usage", {})
+            prompt_tokens = int(usage.get("input_tokens", 0))
+            completion_tokens = int(usage.get("output_tokens", 0))
+        except json.JSONDecodeError:
+            # Older CLI builds may not emit JSON — treat stdout as plain text.
+            text = raw
+
+        return _make_completion_response(
+            text,
+            model,
+            tools_present=bool(tools),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        )
+
+
+# ── Async shim (runs sync adapter in a thread pool) ───────────────────────────
+
+class _AsyncCompletionsAdapter:
+    def __init__(self, sync: _CompletionsAdapter) -> None:
+        self._sync = sync
+
+    async def create(self, **kwargs: Any) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncChatNamespace:
+    def __init__(self, sync_chat: _ChatNamespace) -> None:
+        self.completions = _AsyncCompletionsAdapter(sync_chat.completions)
+
+
+class AsyncClaudeCliAdapter:
+    """Async wrapper over :class:`ClaudeCliAdapter` for use in async contexts."""
+
+    def __init__(self, sync_adapter: ClaudeCliAdapter) -> None:
+        self._sync = sync_adapter
+        self.chat = _AsyncChatNamespace(sync_adapter.chat)
+        self.api_key = sync_adapter.api_key
+        self.base_url = sync_adapter.base_url

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -57,6 +57,16 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 ]
 
 _PROVIDER_MODELS: dict[str, list[str]] = {
+    # Models available via the local ``claude`` CLI subprocess.
+    # The CLI accepts any model the user's subscription supports.
+    "claude-cli": [
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-opus-4-5",
+        "claude-sonnet-4-5",
+        "claude-haiku-4-5-20251001",
+        "claude-3-7-sonnet-20250219",
+    ],
     "nous": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -42,6 +42,13 @@ class HermesOverlay:
 
 
 HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
+    "claude-cli": HermesOverlay(
+        # Inference via the local ``claude`` CLI subprocess.
+        # Requires npm install -g @anthropic-ai/claude-code and a Claude Pro/Max login.
+        # No API key needed — the CLI manages its own OAuth credentials.
+        transport="claude_cli",
+        auth_type="external_process",
+    ),
     "openrouter": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
@@ -158,6 +165,11 @@ class ProviderDef:
 # Uses models.dev IDs where possible.
 
 ALIASES: Dict[str, str] = {
+    # claude-cli
+    "claude_cli": "claude-cli",
+    "claude-code-cli": "claude-cli",
+    "claudecli": "claude-cli",
+
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 
@@ -237,6 +249,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-cli": "Claude CLI",
     "local": "Local endpoint",
 }
 
@@ -247,6 +260,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "openai_chat": "chat_completions",
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
+    "claude_cli": "claude_cli",
 }
 
 
@@ -371,6 +385,7 @@ LABELS: Dict[str, str] = {
     "opencode-go": "OpenCode Go",
     "kilo": "Kilo Gateway",
     "huggingface": "Hugging Face",
+    "claude-cli": "Claude CLI",
     "local": "Local endpoint",
     "custom": "Custom endpoint",
     # Legacy Hermes IDs (point to same providers)

--- a/run_agent.py
+++ b/run_agent.py
@@ -577,8 +577,10 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "claude_cli"}:
             self.api_mode = api_mode
+        elif self.provider in ("claude-cli", "claude_cli"):
+            self.api_mode = "claude_cli"
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self._base_url_lower:
@@ -733,8 +735,16 @@ class AIAgent:
         # access for Codex Responses API streaming.
         self._anthropic_client = None
         self._is_anthropic_oauth = False
+        self._claude_cli_adapter = None
 
-        if self.api_mode == "anthropic_messages":
+        if self.api_mode == "claude_cli":
+            from agent.claude_cli_adapter import ClaudeCliAdapter
+            self._claude_cli_adapter = ClaudeCliAdapter(model=model)
+            self.client = None
+            self._client_kwargs = {}
+            if not self.quiet_mode:
+                print(f"🤖 AI Agent initialized with model: {self.model} (Claude CLI subprocess)")
+        elif self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
             # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
@@ -1325,7 +1335,12 @@ class AIAgent:
             self.api_key = api_key
 
         # ── Build new client ──
-        if api_mode == "anthropic_messages":
+        if api_mode == "claude_cli":
+            from agent.claude_cli_adapter import ClaudeCliAdapter
+            self._claude_cli_adapter = ClaudeCliAdapter(model=new_model)
+            self.client = None
+            self._client_kwargs = {}
+        elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,
                 resolve_anthropic_token,
@@ -4216,6 +4231,12 @@ class AIAgent:
                     )
                 elif self.api_mode == "anthropic_messages":
                     result["response"] = self._anthropic_messages_create(api_kwargs)
+                elif self.api_mode == "claude_cli":
+                    result["response"] = self._claude_cli_adapter.chat.completions.create(
+                        messages=api_kwargs.get("messages", []),
+                        model=api_kwargs.get("model", self.model),
+                        tools=api_kwargs.get("tools") or None,
+                    )
                 else:
                     request_client_holder["client"] = self._create_request_openai_client(reason="chat_completion_request")
                     result["response"] = request_client_holder["client"].chat.completions.create(**api_kwargs)
@@ -4596,7 +4617,15 @@ class AIAgent:
             try:
                 for _stream_attempt in range(_max_stream_retries + 1):
                     try:
-                        if self.api_mode == "anthropic_messages":
+                        if self.api_mode == "claude_cli":
+                            # Claude CLI does not support streaming — run
+                            # non-interruptibly and return the full response.
+                            result["response"] = self._claude_cli_adapter.chat.completions.create(
+                                messages=api_kwargs.get("messages", []),
+                                model=api_kwargs.get("model", self.model),
+                                tools=api_kwargs.get("tools") or None,
+                            )
+                        elif self.api_mode == "anthropic_messages":
                             self._try_refresh_anthropic_client_credentials()
                             result["response"] = _call_anthropic()
                         else:


### PR DESCRIPTION
## Summary

- Adds a new `claude_cli` transport that routes inference through the locally installed `claude` CLI binary, letting users with a **Claude Pro/Max subscription** use Hermes without a separate API key
- The CLI manages its own OAuth credentials — no `ANTHROPIC_API_KEY` needed
- Works for all auxiliary tasks (context compression, title generation, etc.) and the main agent loop

## Motivation

Users who have `claude` CLI installed and a Claude Pro/Max subscription have no way to use Hermes without also obtaining a separate Anthropic API key. The native `anthropic` provider calls `api.anthropic.com` directly and requires API credits. This transport bridges the gap by shelling out to the `claude` binary, which honours the subscription billing path — the same approach OpenClaw uses with `--auth-choice claude-cli`.

## Changes

| File | Description |
|------|-------------|
| `agent/claude_cli_adapter.py` (**new**) | `ClaudeCliAdapter` with a `chat.completions`-compatible interface. Tool calls via JSON-in-prompt encoding. Async shim via `asyncio.to_thread`. |
| `hermes_cli/providers.py` | Register `claude-cli` in `HERMES_OVERLAYS` (`transport="claude_cli"`, `auth_type="external_process"`), aliases, label, and `TRANSPORT_TO_API_MODE` entry. |
| `hermes_cli/models.py` | Add `claude-cli` model list (opus-4-6, sonnet-4-6, haiku-4-5, etc.). |
| `agent/auxiliary_client.py` | `_try_claude_cli()`, appended to `_get_provider_chain()` as last-resort fallback, `resolve_provider_client()` branch, `_to_async_client()` support. |
| `run_agent.py` | Recognise `claude_cli` api_mode; initialise in `__init__` and `switch_model`; dispatch in `_interruptible_api_call` and streaming path. |

## How tool calls work

The `claude` CLI's `-p` mode returns a final text response. To get structured tool-call decisions, tool definitions are injected into the system prompt as JSON and Claude is instructed to respond with:

```json
{"tool_call": {"name": "tool_name", "arguments": {...}}}
```

The adapter parses this sentinel block and returns an OpenAI-compatible `tool_calls` array. This is reliable with Claude models but lacks native streaming tool events.

## Usage

```bash
# Install the Claude CLI if not already present
npm install -g @anthropic-ai/claude-code

# Log in (one-time)
claude login

# Switch Hermes to use it
hermes model claude-cli
# or: hermes --provider claude-cli --model claude-sonnet-4-6 chat "Hello!"
```

## Test plan

- [ ] `is_claude_cli_available()` returns `True` when `claude` is on PATH
- [ ] `hermes model claude-cli` lists available models without error
- [ ] Single-turn text response works: `hermes --provider claude-cli chat "2+2?"`
- [ ] Multi-turn context is preserved across turns
- [ ] Tool call sentinel is correctly parsed (`tool_calls` populated in response)
- [ ] Auto-detect chain falls through to `claude-cli` when no other provider is configured
- [ ] `hermes --provider claude-cli` in async auxiliary context (context compression) works
- [ ] Graceful error when `claude` CLI is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)