### PR TITLE
fix(feishu): stream replies via interactive cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1013,11 +1013,13 @@ def check_feishu_requirements() -> bool:
 
 
 class FeishuAdapter(BasePlatformAdapter):
-    STREAMING_CURSOR = ""
-    STREAMING_EDIT_INTERVAL = 0.04
-    STREAMING_BUFFER_THRESHOLD = 1
-
     """Feishu/Lark bot adapter."""
+
+    STREAMING_CURSOR = ""
+    # Feishu interactive card patches are rate limited to ~5 QPS per message,
+    # so keep the default cadence comfortably below that ceiling.
+    STREAMING_EDIT_INTERVAL = 0.25
+    STREAMING_BUFFER_THRESHOLD = 8
 
     MAX_MESSAGE_LENGTH = 8000
 
@@ -1360,7 +1362,12 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("[Feishu] Stream card send failed; falling back to plain send: %s", exc)
 
-        return await self.send(chat_id=chat_id, content=content, metadata=metadata)
+        return await self.send(
+            chat_id=chat_id,
+            content=content,
+            reply_to=(metadata or {}).get("source_message_id"),
+            metadata=metadata,
+        )
 
     async def edit_stream_message(
         self,
@@ -1503,7 +1510,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 }
 
             card = {
-                "config": {"wide_screen_mode": True},
+                "config": {"wide_screen_mode": True, "update_multi": True},
                 "header": {
                     "title": {"content": "⚠️ Command Approval Required", "tag": "plain_text"},
                     "template": "orange",
@@ -1554,7 +1561,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         icon = "❌" if choice == "deny" else "✅"
         card = {
-            "config": {"wide_screen_mode": True},
+            "config": {"wide_screen_mode": True, "update_multi": True},
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -63,6 +63,8 @@ try:
         GetMessageRequest,
         GetMessageResourceRequest,
         P2ImMessageMessageReadV1,
+        PatchMessageRequest,
+        PatchMessageRequestBody,
         ReplyMessageRequest,
         ReplyMessageRequestBody,
         UpdateMessageRequest,
@@ -1011,6 +1013,10 @@ def check_feishu_requirements() -> bool:
 
 
 class FeishuAdapter(BasePlatformAdapter):
+    STREAMING_CURSOR = ""
+    STREAMING_EDIT_INTERVAL = 0.04
+    STREAMING_BUFFER_THRESHOLD = 1
+
     """Feishu/Lark bot adapter."""
 
     MAX_MESSAGE_LENGTH = 8000
@@ -1309,6 +1315,78 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    def _build_streaming_card(self, content: str) -> Dict[str, Any]:
+        formatted = self.format_message(content).strip()
+        return {
+            "config": {"wide_screen_mode": True, "update_multi": True},
+            "header": {
+                "title": {"content": "Hermes", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": formatted or "…",
+                }
+            ],
+        }
+
+    async def send_stream_message(
+        self,
+        chat_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send the first Feishu streaming frame as an interactive card.
+
+        Falls back to the normal text/post send path if card delivery fails.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            payload = json.dumps(self._build_streaming_card(content), ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=(metadata or {}).get("source_message_id"),
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "stream send failed")
+            if result.success:
+                return result
+            logger.warning("[Feishu] Stream card send failed; falling back to plain send: %s", result.error)
+        except Exception as exc:
+            logger.warning("[Feishu] Stream card send failed; falling back to plain send: %s", exc)
+
+        return await self.send(chat_id=chat_id, content=content, metadata=metadata)
+
+    async def edit_stream_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+    ) -> SendResult:
+        """Edit a Feishu streaming card in place, with fallback to normal message edit."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            payload = json.dumps(self._build_streaming_card(content), ensure_ascii=False)
+            body = self._build_patch_message_body(content=payload)
+            request = self._build_patch_message_request(message_id=message_id, request_body=body)
+            response = await asyncio.to_thread(self._client.im.v1.message.patch, request)
+            result = self._finalize_send_result(response, "stream update failed")
+            if result.success:
+                result.message_id = message_id
+                return result
+            logger.warning("[Feishu] Stream card update failed; falling back to normal edit: %s", result.error)
+        except Exception as exc:
+            logger.warning("[Feishu] Stream card update failed; falling back to normal edit: %s", exc)
+
+        return await self.edit_message(chat_id=chat_id, message_id=message_id, content=content)
+
     async def send(
         self,
         chat_id: str,
@@ -1490,9 +1568,9 @@ class FeishuAdapter(BasePlatformAdapter):
         }
         try:
             payload = json.dumps(card, ensure_ascii=False)
-            body = self._build_update_message_body(msg_type="interactive", content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            await asyncio.to_thread(self._client.im.v1.message.update, request)
+            body = self._build_patch_message_body(content=payload)
+            request = self._build_patch_message_request(message_id=message_id, request_body=body)
+            await asyncio.to_thread(self._client.im.v1.message.patch, request)
         except Exception as exc:
             logger.warning("[Feishu] Failed to update approval card %s: %s", message_id, exc)
 
@@ -3487,6 +3565,23 @@ class FeishuAdapter(BasePlatformAdapter):
         if "UpdateMessageRequest" in globals():
             return (
                 UpdateMessageRequest.builder()
+                .message_id(message_id)
+                .request_body(request_body)
+                .build()
+            )
+        return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_patch_message_body(*, content: str) -> Any:
+        if "PatchMessageRequestBody" in globals():
+            return PatchMessageRequestBody.builder().content(content).build()
+        return SimpleNamespace(content=content)
+
+    @staticmethod
+    def _build_patch_message_request(message_id: str, request_body: Any) -> Any:
+        if "PatchMessageRequest" in globals():
+            return (
+                PatchMessageRequest.builder()
                 .message_id(message_id)
                 .request_body(request_body)
                 .build()

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -66,6 +66,9 @@ class GatewayStreamConsumer:
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
+        self.cfg.edit_interval = float(getattr(adapter, "STREAMING_EDIT_INTERVAL", self.cfg.edit_interval))
+        self.cfg.buffer_threshold = int(getattr(adapter, "STREAMING_BUFFER_THRESHOLD", self.cfg.buffer_threshold))
+        self.cfg.cursor = getattr(adapter, "STREAMING_CURSOR", self.cfg.cursor)
         self.metadata = metadata
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
@@ -306,6 +309,18 @@ class GatewayStreamConsumer:
         self._last_sent_text = chunks[-1]
         self._fallback_prefix = ""
 
+    async def _send_stream_message(self, text: str):
+        sender = getattr(self.adapter, "send_stream_message", None)
+        if callable(sender):
+            return await sender(chat_id=self.chat_id, content=text, metadata=self.metadata)
+        return await self.adapter.send(chat_id=self.chat_id, content=text, metadata=self.metadata)
+
+    async def _edit_stream_message(self, text: str):
+        editor = getattr(self.adapter, "edit_stream_message", None)
+        if callable(editor):
+            return await editor(chat_id=self.chat_id, message_id=self._message_id, content=text)
+        return await self.adapter.edit_message(chat_id=self.chat_id, message_id=self._message_id, content=text)
+
     async def _send_or_edit(self, text: str) -> None:
         """Send or edit the streaming message."""
         # Strip MEDIA: directives so they don't appear as visible text.
@@ -321,11 +336,7 @@ class GatewayStreamConsumer:
                     if text == self._last_sent_text:
                         return
                     # Edit existing message
-                    result = await self.adapter.edit_message(
-                        chat_id=self.chat_id,
-                        message_id=self._message_id,
-                        content=text,
-                    )
+                    result = await self._edit_stream_message(text)
                     if result.success:
                         self._already_sent = True
                         self._last_sent_text = text
@@ -344,11 +355,7 @@ class GatewayStreamConsumer:
                     pass
             else:
                 # First message — send new
-                result = await self.adapter.send(
-                    chat_id=self.chat_id,
-                    content=text,
-                    metadata=self.metadata,
-                )
+                result = await self._send_stream_message(text)
                 if result.success and result.message_id:
                     self._message_id = result.message_id
                     self._already_sent = True

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -571,7 +571,66 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertEqual(result.message_id, "om_card")
         self.assertFalse(hasattr(captured["request"].request_body, "msg_type"))
         card = json.loads(captured["request"].request_body.content)
+        self.assertEqual(card["config"]["update_multi"], True)
         self.assertIn("Streaming answer updated", card["elements"][0]["content"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_stream_message_falls_back_to_plain_send_with_reply_to(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = object()
+        adapter._feishu_send_with_retry = AsyncMock(return_value=SimpleNamespace(success=lambda: False, code=230099, msg="card failed"))
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="om_plain"))
+
+        result = asyncio.run(
+            adapter.send_stream_message(
+                chat_id="oc_chat",
+                content="Streaming answer",
+                metadata={"source_message_id": "om_source"},
+            )
+        )
+
+        self.assertTrue(result.success)
+        adapter.send.assert_awaited_once_with(
+            chat_id="oc_chat",
+            content="Streaming answer",
+            reply_to="om_source",
+            metadata={"source_message_id": "om_source"},
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_update_approval_card_patches_interactive_card_content(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def patch(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            asyncio.run(adapter._update_approval_card("om_card", "Approved permanently", "Alice", "always"))
+
+        card = json.loads(captured["request"].request_body.content)
+        self.assertEqual(card["config"]["update_multi"], True)
+        self.assertIn("Approved permanently", card["header"]["title"]["content"])
+        self.assertIn("Alice", card["elements"][0]["content"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -505,6 +505,75 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_stream_message_uses_interactive_card_payload(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        async def _fake_send_with_retry(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_card"))
+
+        adapter._client = object()
+        adapter._feishu_send_with_retry = AsyncMock(side_effect=_fake_send_with_retry)
+
+        result = asyncio.run(
+            adapter.send_stream_message(
+                chat_id="oc_chat",
+                content="Streaming answer",
+                metadata={"source_message_id": "om_source"},
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_card")
+        self.assertEqual(captured["msg_type"], "interactive")
+        card = json.loads(captured["payload"])
+        self.assertEqual(card["header"]["title"]["content"], "Hermes")
+        self.assertIn("Streaming answer", card["elements"][0]["content"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_stream_message_patches_interactive_card_content(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def patch(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_stream_message(
+                    chat_id="oc_chat",
+                    message_id="om_card",
+                    content="Streaming answer updated",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_card")
+        self.assertFalse(hasattr(captured["request"].request_body, "msg_type"))
+        card = json.loads(captured["request"].request_body.content)
+        self.assertIn("Streaming answer updated", card["elements"][0]["content"])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -245,30 +245,6 @@ class TestAdapterStreamingOverrides:
         assert consumer.cfg.buffer_threshold == 12
 
 
-class TestInitialSendThreshold:
-    """Adapters can delay the first visible stream frame to avoid tiny pre-tool fragments."""
-
-    @pytest.mark.asyncio
-    async def test_segment_break_drops_tiny_initial_fragment_below_threshold(self):
-        adapter = MagicMock()
-        adapter.STREAMING_MIN_INITIAL_CHARS = 4
-        adapter.send = AsyncMock(side_effect=[SimpleNamespace(success=True, message_id="msg_1")])
-        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
-        adapter.MAX_MESSAGE_LENGTH = 4096
-
-        consumer = GatewayStreamConsumer(adapter, "chat_123", StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""))
-        consumer.on_delta("阿")
-        consumer.on_delta(None)
-        consumer.on_delta("彪你好")
-        consumer.finish()
-
-        await consumer.run()
-
-        assert adapter.send.call_count == 1
-        sent_text = adapter.send.call_args_list[0][1]["content"]
-        assert sent_text == "彪你好"
-
-
 class TestSegmentBreakOnToolBoundary:
     """Verify that on_delta(None) finalizes the current message and starts a
     new one so the final response appears below tool-progress messages."""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -182,6 +182,93 @@ class TestStreamRunMediaStripping:
 # ── Segment break (tool boundary) tests ──────────────────────────────────
 
 
+class TestFeishuStreamingHooks:
+    """Feishu can override the generic text-edit transport with card streaming hooks."""
+
+    @pytest.mark.asyncio
+    async def test_first_send_uses_adapter_stream_send_hook_when_available(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="plain_msg"))
+        adapter.send_stream_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="card_msg"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        await consumer._send_or_edit("Hello from stream")
+
+        adapter.send_stream_message.assert_called_once_with(
+            chat_id="chat_123",
+            content="Hello from stream",
+            metadata=None,
+        )
+        adapter.send.assert_not_called()
+        assert consumer._message_id == "card_msg"
+
+    @pytest.mark.asyncio
+    async def test_edit_uses_adapter_stream_edit_hook_when_available(self):
+        adapter = MagicMock()
+        adapter.send_stream_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="card_msg"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.edit_stream_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="card_msg"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        await consumer._send_or_edit("Hello")
+        await consumer._send_or_edit("Hello world")
+
+        adapter.edit_stream_message.assert_called_once_with(
+            chat_id="chat_123",
+            message_id="card_msg",
+            content="Hello world",
+        )
+        adapter.edit_message.assert_not_called()
+
+
+class TestAdapterStreamingOverrides:
+    """Adapters can override cursor/timing defaults for platform-native streaming."""
+
+    def test_adapter_can_disable_cursor(self):
+        adapter = MagicMock()
+        adapter.STREAMING_CURSOR = ""
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+
+        assert consumer.cfg.cursor == ""
+
+    def test_adapter_can_tune_streaming_timing(self):
+        adapter = MagicMock()
+        adapter.STREAMING_EDIT_INTERVAL = 0.1
+        adapter.STREAMING_BUFFER_THRESHOLD = 12
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+
+        assert consumer.cfg.edit_interval == 0.1
+        assert consumer.cfg.buffer_threshold == 12
+
+
+class TestInitialSendThreshold:
+    """Adapters can delay the first visible stream frame to avoid tiny pre-tool fragments."""
+
+    @pytest.mark.asyncio
+    async def test_segment_break_drops_tiny_initial_fragment_below_threshold(self):
+        adapter = MagicMock()
+        adapter.STREAMING_MIN_INITIAL_CHARS = 4
+        adapter.send = AsyncMock(side_effect=[SimpleNamespace(success=True, message_id="msg_1")])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123", StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""))
+        consumer.on_delta("阿")
+        consumer.on_delta(None)
+        consumer.on_delta("彪你好")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert adapter.send.call_count == 1
+        sent_text = adapter.send.call_args_list[0][1]["content"]
+        assert sent_text == "彪你好"
+
+
 class TestSegmentBreakOnToolBoundary:
     """Verify that on_delta(None) finalizes the current message and starts a
     new one so the final response appears below tool-progress messages."""


### PR DESCRIPTION
## Summary
- send Feishu streaming replies as interactive cards instead of plain text edits
- switch Feishu card updates and approval card status updates to message.patch
- add adapter-level streaming overrides so Feishu can refresh card updates more aggressively
- add regression tests covering stream send/edit hooks and interactive card patch behavior

## Testing
- source venv/bin/activate && pytest tests/gateway/test_stream_consumer.py tests/gateway/test_feishu.py -k "stream_message or interactive or approval or card" -q

## Notes
- This PR stages only the Feishu streaming/card update changes.
- Unrelated local modifications were intentionally left out of the commit.