### PR TITLE
fix(terminal): require approval for host-bound Docker commands

### DIFF
--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -9,6 +9,7 @@ Covers the bugs discovered while setting up TBLite evaluation:
 6. /home/ added to host prefix check
 """
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -153,6 +154,30 @@ class TestCwdHandling:
         assert captured["cwd"] == "/workspace"
         assert captured["host_cwd"] == "/home/user/project"
         assert captured["auto_mount_cwd"] is True
+
+    def test_terminal_tool_passes_docker_host_access_to_approval_guard(self, monkeypatch):
+        """Dangerous Docker commands should not bypass approval when host binds are exposed."""
+        class _FakeEnv:
+            def execute(self, *args, **kwargs):
+                raise AssertionError("terminal_tool should stop before executing the command")
+
+        monkeypatch.setattr(_tt_mod, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(_tt_mod, "_create_environment", lambda **kwargs: _FakeEnv())
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", '["/tmp:/hosttmp"]')
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        _tt_mod._active_environments.pop("docker-host-access", None)
+        _tt_mod._last_activity.pop("docker-host-access", None)
+
+        result = json.loads(_tt_mod.terminal_tool("rm -rf /workspace", task_id="docker-host-access"))
+
+        assert result["status"] == "approval_required"
+        assert result["command"] == "rm -rf /workspace"
+        assert "delete" in result["description"].lower()
 
     def test_ssh_preserves_home_paths(self, monkeypatch):
         """SSH backend should NOT replace /home/ paths (they're valid remotely)."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -536,8 +536,16 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
         return "escalate"
 
 
+def _should_skip_container_guards(env_type: str, has_host_access: bool = False) -> bool:
+    """Return True when the backend is isolated enough to skip dangerous-command prompts."""
+    if env_type == "docker":
+        return not has_host_access
+    return env_type in ("singularity", "modal", "daytona")
+
+
 def check_dangerous_command(command: str, env_type: str,
-                            approval_callback=None) -> dict:
+                            approval_callback=None,
+                            has_host_access: bool = False) -> dict:
     """Check if a command is dangerous and handle approval.
 
     This is the main entry point called by terminal_tool before executing
@@ -551,7 +559,7 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
-    if env_type in ("docker", "singularity", "modal", "daytona"):
+    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
         return {"approved": True, "message": None}
 
     # --yolo: bypass all approval prompts
@@ -643,7 +651,8 @@ def _format_tirith_description(tirith_result: dict) -> str:
 
 
 def check_all_command_guards(command: str, env_type: str,
-                             approval_callback=None) -> dict:
+                             approval_callback=None,
+                             has_host_access: bool = False) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -651,8 +660,9 @@ def check_all_command_guards(command: str, env_type: str,
     a gateway force=True replay from bypassing one check when only the
     other was shown to the user.
     """
-    # Skip containers for both checks
-    if env_type in ("docker", "singularity", "modal", "daytona"):
+    # Skip isolated container backends. Docker stops skipping once host paths
+    # are bind-mounted into the sandbox.
+    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
         return {"approved": True, "message": None}
 
     # --yolo or approvals.mode=off: bypass all approval prompts

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -137,15 +137,29 @@ def set_approval_callback(cb):
 
 # Dangerous command detection + approval now consolidated in tools/approval.py
 from tools.approval import (
-    check_dangerous_command as _check_dangerous_command_impl,
     check_all_command_guards as _check_all_guards_impl,
 )
 
 
-def _check_all_guards(command: str, env_type: str) -> dict:
-    """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
-    return _check_all_guards_impl(command, env_type,
-                                  approval_callback=_approval_callback)
+def _docker_volume_uses_host_path(volume_spec: str) -> bool:
+    """Return True when a docker volume spec bind-mounts a host path."""
+    if not isinstance(volume_spec, str):
+        return False
+
+    vol = volume_spec.strip()
+    return bool(vol) and (
+        vol.startswith(("/", "~", "./", "../")) or
+        (len(vol) >= 3 and vol[1] == ":" and vol[2] in ("/", "\\"))
+    )
+
+
+def _docker_has_host_access(config: Dict[str, Any]) -> bool:
+    """Return True when a Docker sandbox exposes host paths through bind mounts."""
+    if config.get("env_type") != "docker":
+        return False
+    if config.get("host_cwd") and config.get("docker_mount_cwd_to_workspace"):
+        return True
+    return any(_docker_volume_uses_host_path(vol) for vol in config.get("docker_volumes", []))
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -655,7 +669,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             sandbox_kwargs["memory"] = memory
         if disk > 0:
             try:
-                import inspect, modal
+                import inspect
+                import modal
                 if "ephemeral_disk" in inspect.signature(modal.Sandbox.create).parameters:
                     sandbox_kwargs["ephemeral_disk"] = disk
             except Exception:
@@ -1196,7 +1211,12 @@ def terminal_tool(
         # Skip check if force=True (user has confirmed they want to run it)
         approval_note = None
         if not force:
-            approval = _check_all_guards(command, env_type)
+            approval = _check_all_guards_impl(
+                command,
+                env_type,
+                approval_callback=_approval_callback,
+                has_host_access=_docker_has_host_access(config),
+            )
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
                 if approval.get("status") == "approval_required":


### PR DESCRIPTION
## What does this PR do?

Fixes an approval bypass in the Docker terminal backend.

Hermes currently treats every Docker session as safe enough to skip dangerous-command approvals. That assumption only holds when the container is actually isolated. Once Docker is allowed to bind host paths into the container, the command is no longer confined to the sandbox. A command like `rm -rf /workspace` can hit real host files, but Hermes still auto-approves it today.

This patch fixes that mismatch. Isolated Docker sandboxes keep the current fast path. Docker sessions with host bind mounts go through the normal approval flow again.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/terminal_tool.py`
  Detect when the Docker backend exposes host paths through `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` or host bind mounts in `TERMINAL_DOCKER_VOLUMES`, then pass that state into the approval guard.
- `tools/approval.py`
  Keep skipping dangerous-command approvals for isolated container backends, but stop skipping Docker when it has host filesystem access.
- `tests/tools/test_modal_sandbox_fixes.py`
  Add one regression test through the real `terminal_tool()` path to verify host-bound Docker commands return `approval_required` instead of running.

## How to Test

1. Configure Hermes to use the Docker terminal backend in gateway mode, and expose a host path with either `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true` or `TERMINAL_DOCKER_VOLUMES='["/tmp:/hosttmp"]'`.
2. Run a dangerous command against the mounted path, for example `rm -rf /workspace`.
3. Before this patch, Hermes approves the command immediately because Docker is blanket-skipped even though the command can reach host files.
4. With this patch, the same command returns `approval_required` instead.
5. Run:
   `./.venv/bin/pytest tests/tools/test_command_guards.py tests/tools/test_yolo_mode.py tests/tools/test_modal_sandbox_fixes.py`
6. Optional lint check for the touched files:
   `ruff check tools/approval.py tools/terminal_tool.py tests/tools/test_modal_sandbox_fixes.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ ruff check tools/approval.py tools/terminal_tool.py tests/tools/test_modal_sandbox_fixes.py
tools/terminal_tool.py still reports pre-existing E402 import-order violations in that file.

$ ./.venv/bin/pytest tests/tools/test_command_guards.py tests/tools/test_yolo_mode.py tests/tools/test_modal_sandbox_fixes.py
49 passed
```
