### PR TITLE
refactor: extract turn assembly; fix gateway BOOT.md startup guard

### DIFF
--- a/agent/tool_runtime.py
+++ b/agent/tool_runtime.py
@@ -1,0 +1,159 @@
+"""Tool runtime helpers for normalizing tool execution results while preserving legacy tool message compatibility."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ToolFailure:
+    category: str
+    message: str
+    retriable: bool
+    suggested_next_step: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ToolExecutionEnvelope:
+    tool_name: str
+    ok: bool
+    content: str
+    structured_content: dict[str, Any] = field(default_factory=dict)
+    failure: ToolFailure | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _coerce_content(raw_result: Any) -> str:
+    if raw_result is None:
+        return ""
+    if isinstance(raw_result, str):
+        return raw_result
+    if isinstance(raw_result, (dict, list)):
+        try:
+            return json.dumps(raw_result, ensure_ascii=False)
+        except TypeError:
+            return str(raw_result)
+    return str(raw_result)
+
+
+def _looks_like_error_payload(parsed: Any) -> tuple[bool, str | None, dict[str, Any]]:
+    if not isinstance(parsed, dict):
+        return False, None, {}
+
+    error_value = parsed.get("error")
+    success_value = parsed.get("success")
+    status_value = parsed.get("status")
+
+    message = None
+    if isinstance(error_value, str) and error_value.strip():
+        message = error_value.strip()
+    elif isinstance(parsed.get("message"), str) and parsed.get("message", "").strip():
+        message = parsed.get("message", "").strip()
+
+    is_error = False
+    if message and success_value is False:
+        is_error = True
+    elif message and isinstance(status_value, str) and status_value.lower() in {"error", "failed", "failure"}:
+        is_error = True
+    elif message and "error" in parsed:
+        is_error = True
+
+    details = {}
+    for key in ("error", "success", "status", "code", "type"):
+        if key in parsed:
+            details[key] = parsed[key]
+
+    return is_error, message, details
+
+
+def normalize_tool_result(
+    tool_name: str,
+    raw_result: Any,
+    *,
+    duration_seconds: float | None = None,
+    source: str | None = None,
+) -> ToolExecutionEnvelope:
+    content = _coerce_content(raw_result)
+    metadata: dict[str, Any] = {}
+    if duration_seconds is not None:
+        metadata["duration_seconds"] = round(float(duration_seconds), 6)
+    if source:
+        metadata["source"] = source
+
+    structured_content: dict[str, Any] = {}
+    failure: ToolFailure | None = None
+    ok = True
+
+    try:
+        parsed = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        parsed = None
+
+    if isinstance(parsed, dict):
+        structured_content = parsed
+        is_error, message, details = _looks_like_error_payload(parsed)
+        if is_error:
+            ok = False
+            failure = ToolFailure(
+                category="tool_error",
+                message=message or f"Tool '{tool_name}' reported an error.",
+                retriable=False,
+                details=details,
+            )
+
+    if not ok and failure is None:
+        failure = ToolFailure(
+            category="tool_error",
+            message=f"Tool '{tool_name}' reported an error.",
+            retriable=False,
+        )
+
+    return ToolExecutionEnvelope(
+        tool_name=tool_name,
+        ok=ok,
+        content=content,
+        structured_content=structured_content,
+        failure=failure,
+        metadata=metadata,
+    )
+
+
+def normalize_tool_failure(
+    tool_name: str,
+    error: Exception | str,
+    *,
+    category: str = "execution_error",
+    retriable: bool = False,
+    suggested_next_step: str | None = None,
+    details: dict[str, Any] | None = None,
+    duration_seconds: float | None = None,
+    source: str | None = None,
+) -> ToolExecutionEnvelope:
+    message = str(error)
+    failure = ToolFailure(
+        category=category,
+        message=message,
+        retriable=retriable,
+        suggested_next_step=suggested_next_step,
+        details=details or {},
+    )
+    metadata: dict[str, Any] = {}
+    if duration_seconds is not None:
+        metadata["duration_seconds"] = round(float(duration_seconds), 6)
+    if source:
+        metadata["source"] = source
+    content = f"Error executing tool '{tool_name}': {message}"
+    return ToolExecutionEnvelope(
+        tool_name=tool_name,
+        ok=False,
+        content=content,
+        failure=failure,
+        metadata=metadata,
+    )
+
+
+def envelope_to_legacy_content(envelope: ToolExecutionEnvelope) -> str:
+    return envelope.content

--- a/agent/turn_assembly.py
+++ b/agent/turn_assembly.py
@@ -1,0 +1,180 @@
+"""Turn assembly scaffolds for API-call-time turn preparation only.
+
+Rules:
+- no session persistence
+- no tool execution
+- no policy decisions beyond recording hints/warnings
+- compatibility-first extraction from run_agent.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from collections import Counter
+
+from agent.memory_manager import build_memory_context_block
+
+
+@dataclass
+class SideChannelContext:
+    memory_blocks: list[str] = field(default_factory=list)
+    skill_blocks: list[str] = field(default_factory=list)
+    reference_blocks: list[str] = field(default_factory=list)
+    recall_blocks: list[str] = field(default_factory=list)
+    delegation_blocks: list[str] = field(default_factory=list)
+    platform_blocks: list[str] = field(default_factory=list)
+    extra_blocks: list[str] = field(default_factory=list)
+
+    def flatten(self) -> list[str]:
+        return [
+            *self.memory_blocks,
+            *self.skill_blocks,
+            *self.reference_blocks,
+            *self.recall_blocks,
+            *self.delegation_blocks,
+            *self.platform_blocks,
+            *self.extra_blocks,
+        ]
+
+
+@dataclass
+class TurnAssembly:
+    original_user_message: str
+    assembled_user_message: str
+    system_blocks: list[str] = field(default_factory=list)
+    side_channel: SideChannelContext = field(default_factory=SideChannelContext)
+    warnings: list[str] = field(default_factory=list)
+    references_expanded: bool = False
+    references_blocked: bool = False
+    injected_token_estimate: int = 0
+    tool_visibility_hints: dict[str, Any] = field(default_factory=dict)
+    lineage: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def build_side_channel_context(
+    memory_context: str = "",
+    plugin_user_context: str = "",
+    *,
+    platform: str | None = None,
+) -> SideChannelContext:
+    side_channel = SideChannelContext()
+
+    memory_block = build_memory_context_block(memory_context)
+    if memory_block:
+        side_channel.memory_blocks.append(memory_block)
+
+    if plugin_user_context and plugin_user_context.strip():
+        side_channel.extra_blocks.append(plugin_user_context)
+
+    if platform:
+        side_channel.platform_blocks = list(side_channel.platform_blocks)
+
+    return side_channel
+
+
+def assemble_turn_context(
+    user_message: str,
+    memory_context: str = "",
+    plugin_user_context: str = "",
+    *,
+    reference_result: Any | None = None,
+    platform: str | None = None,
+) -> TurnAssembly:
+    side_channel = build_side_channel_context(
+        memory_context,
+        plugin_user_context,
+        platform=platform,
+    )
+
+    base_message = user_message
+    references_expanded = False
+    references_blocked = False
+    warnings: list[str] = []
+    metadata: dict[str, Any] = {}
+
+    if reference_result is not None:
+        ref_message = getattr(reference_result, "message", None)
+        if isinstance(ref_message, str):
+            base_message = ref_message
+        references_expanded = bool(getattr(reference_result, "expanded", False))
+        references_blocked = bool(getattr(reference_result, "blocked", False))
+        ref_warnings = getattr(reference_result, "warnings", None)
+        if isinstance(ref_warnings, list):
+            warnings.extend(str(w) for w in ref_warnings)
+        injected_tokens = getattr(reference_result, "injected_tokens", None)
+        if injected_tokens is not None:
+            metadata["reference_injected_tokens"] = injected_tokens
+        references = getattr(reference_result, "references", None)
+        if isinstance(references, list):
+            kind_counts = Counter(
+                str(getattr(reference, "kind", "unknown") or "unknown")
+                for reference in references
+            )
+            metadata["reference_summary"] = {
+                "count": len(references),
+                "kinds": dict(sorted(kind_counts.items())),
+            }
+
+    injections = side_channel.flatten()
+    assembled_user_message = base_message
+    if injections:
+        assembled_user_message = base_message + "\n\n" + "\n\n".join(injections)
+
+    lineage: dict[str, Any] = {"platform": platform} if platform else {}
+    if reference_result is not None:
+        lineage["reference_preprocessed"] = True
+        if references_expanded:
+            lineage["references_expanded"] = True
+        if references_blocked:
+            lineage["references_blocked"] = True
+
+    return TurnAssembly(
+        original_user_message=user_message,
+        assembled_user_message=assembled_user_message,
+        side_channel=side_channel,
+        warnings=warnings,
+        references_expanded=references_expanded,
+        references_blocked=references_blocked,
+        metadata=metadata,
+        lineage=lineage,
+    )
+
+
+def apply_turn_assembly_to_user_message(message: dict, assembly: TurnAssembly) -> dict:
+    api_message = message.copy()
+    if api_message.get("role") == "user" and isinstance(api_message.get("content"), str):
+        api_message["content"] = assembly.assembled_user_message
+    return api_message
+
+
+def compose_effective_system_prompt(base_system: str, ephemeral_system_prompt: str | None) -> str:
+    effective_system = base_system or ""
+    if ephemeral_system_prompt:
+        effective_system = (effective_system + "\n\n" + ephemeral_system_prompt).strip()
+    return effective_system
+
+
+def inject_prefill_messages(
+    api_messages: list[dict],
+    prefill_messages: list[dict],
+    effective_system: str,
+) -> list[dict]:
+    injected_messages = list(api_messages)
+    sys_offset = 1 if effective_system else 0
+    for idx, prefill_message in enumerate(prefill_messages or []):
+        injected_messages.insert(sys_offset + idx, prefill_message.copy())
+    return injected_messages
+
+
+__all__ = [
+    "SideChannelContext",
+    "TurnAssembly",
+    "apply_turn_assembly_to_user_message",
+    "assemble_turn_context",
+    "build_side_channel_context",
+    "compose_effective_system_prompt",
+    "inject_prefill_messages",
+]

--- a/docs/architecture/2026-04-09-hermes-runtime-organs-rfc.md
+++ b/docs/architecture/2026-04-09-hermes-runtime-organs-rfc.md
@@ -1,0 +1,649 @@
+# Hermes Runtime Organs RFC
+
+> For Hermes: this RFC defines the runtime architecture upgrades needed to close the highest-value gaps identified in `Claude Code 模式映射到 Hermes：差距报告`.
+
+Status: Proposed
+Author: Hermes Agent
+Date: 2026-04-09
+Scope: `run_agent.py`, `model_tools.py`, `agent/context_compressor.py`, `agent/context_references.py`, selected tool runtime surfaces
+
+---
+
+## 1. Goal
+
+Strengthen Hermes as a runtime system without diluting its existing advantages.
+
+Do not turn Hermes into Claude Code.
+Do not weaken approval, gateway, or delegation primitives.
+Do not start with feature sprawl.
+
+This RFC proposes five runtime organs:
+
+1. Input World Assembly
+2. Dynamic Tool Exposure
+3. Unified Side-Channel Context Bus
+4. Post-Compaction Reconstruction + Lineage
+5. Tool Result / Failure Envelope + Hook Chain
+
+The objective is simple:
+make Hermes feel less like a powerful bag of subsystems and more like a coherent nervous system.
+
+---
+
+## 2. Current State
+
+Hermes already has strong parts:
+
+- `run_agent.py` provides the main conversation loop, iteration budgets, tool execution flow, prompt assembly, and context compression integration.
+- `model_tools.py` provides registry-backed discovery, dispatch, toolset resolution, plugin/MCP discovery, and async bridging.
+- `agent/context_compressor.py` already does structured compaction with pruning, protected head/tail, and iterative updates.
+- `agent/context_references.py` already gives explicit `@file/@folder/@diff/@url` expansion with root restriction and token guardrails.
+- `tools/approval.py` is a mature policy gate for dangerous terminal commands.
+- `tools/delegate_tool.py` provides strong child isolation and controlled tool inheritance.
+
+The problem is not missing power.
+The problem is that several core runtime decisions are still expressed as scattered implementation details instead of first-class architecture.
+
+---
+
+## 3. Non-Goals
+
+This RFC does not propose:
+
+- replacing the current tool registry
+- replacing toolsets with fully autonomous tool search
+- changing gateway platform behavior
+- rewriting compaction from scratch
+- changing memory semantics
+- changing approval UX first
+
+This is a runtime-structure RFC.
+Not a product redesign.
+
+---
+
+## 4. Design Principles
+
+### 4.1 Preserve Hermes strengths
+
+Do not damage:
+- approval enforcement
+- session persistence
+- multi-platform gateway behavior
+- explicit toolsets
+- delegation isolation
+
+### 4.2 Add explicit architecture before changing behavior
+
+First introduce named runtime boundaries.
+Then migrate existing logic into them.
+Only after that add smarter behavior.
+
+### 4.3 Prefer additive refactors
+
+Most phase-1 work should be wrappers and extraction layers.
+Existing behavior should remain stable.
+
+### 4.4 Keep policy and capability separate
+
+Approval says whether an action is allowed.
+Exposure says whether the model should even see the action.
+They are connected but not the same.
+
+---
+
+## 5. Proposed Runtime Organs
+
+## 5.1 Input World Assembly
+
+### Problem
+
+Today the material that defines “what exists for this turn” is spread across:
+- prompt builder logic
+- context reference expansion
+- memory injection
+- skill injection
+- platform hints
+- session/tooling side context
+- ad hoc preflight branches in CLI and agent loop
+
+The work happens.
+But there is no single named assembly stage.
+
+### Proposal
+
+Introduce a dedicated turn-preparation function and data structure.
+
+New module:
+- `agent/turn_assembly.py`
+
+Primary API:
+- `assemble_turn_context(...) -> TurnAssembly`
+
+Suggested object:
+
+```python
+@dataclass
+class TurnAssembly:
+    original_user_message: str
+    assembled_user_message: str
+    system_blocks: list[str]
+    side_channel_blocks: list[str]
+    warnings: list[str]
+    references_expanded: bool
+    references_blocked: bool
+    injected_token_estimate: int
+    tool_visibility_hints: dict[str, object]
+    lineage: dict[str, object]
+```
+
+### Responsibilities
+
+`assemble_turn_context()` should:
+- normalize incoming user text
+- expand context references through `agent/context_references.py`
+- inject memory/user profile blocks
+- inject skill blocks
+- include platform or environment hints
+- record warnings and token-impact metadata
+- prepare later phases for tool exposure and lineage
+
+### Why it matters
+
+This creates a single preflight organ.
+It becomes the source of truth for what the model sees at turn start.
+
+---
+
+## 5.2 Unified Side-Channel Context Bus
+
+### Problem
+
+Hermes already has side channels, but they are implicit and fragmented:
+- memory/profile context
+- skill content
+- context refs
+- session_search recall
+- delegated summaries
+- future MCP or plugin-derived context
+
+These are currently “extra prompt text”.
+That is too weak as an architecture concept.
+
+### Proposal
+
+Introduce a named side-channel layer.
+
+New object:
+
+```python
+@dataclass
+class SideChannelContext:
+    memory_blocks: list[str] = field(default_factory=list)
+    skill_blocks: list[str] = field(default_factory=list)
+    reference_blocks: list[str] = field(default_factory=list)
+    recall_blocks: list[str] = field(default_factory=list)
+    delegation_blocks: list[str] = field(default_factory=list)
+    platform_blocks: list[str] = field(default_factory=list)
+    extra_blocks: list[str] = field(default_factory=list)
+
+    def flatten(self) -> list[str]:
+        ...
+```
+
+### Integration
+
+`TurnAssembly` owns one `SideChannelContext` instance.
+Prompt construction consumes it in a stable order.
+
+Recommended order:
+1. policy / system constraints
+2. memory and user profile
+3. skills
+4. session recall
+5. context references
+6. delegation outputs
+7. platform hints
+8. final assembled user message
+
+### Benefits
+
+- clear provenance of injected context
+- easier debugging
+- easier token accounting
+- easier future ranking/truncation of side-channel content
+
+---
+
+## 5.3 Dynamic Tool Exposure
+
+### Problem
+
+Hermes has strong static tool governance via toolsets.
+But the model often receives a broad visible tool surface from the start.
+That increases prompt size and weakens capability steering.
+
+### Proposal
+
+Keep static allowlists.
+Add a dynamic visibility layer on top.
+
+New module:
+- `agent/tool_visibility.py`
+
+Primary API:
+- `resolve_visible_tools(all_allowed_tools, assembly, runtime_state) -> list[dict]`
+
+New state object:
+
+```python
+@dataclass
+class ToolVisibilityState:
+    visible_tool_names: list[str]
+    hidden_tool_names: list[str]
+    reason_by_tool: dict[str, str]
+    exposure_phase: str
+```
+
+### Inputs
+
+The resolver may use:
+- platform
+- current task text
+- detected context refs
+- token pressure
+- prior failed tool attempts
+- explicit user requests
+- safe defaults
+
+### Example policies
+
+- If no browser/web cues exist, hide browser tools.
+- If no file/reference cues exist, hide file-heavy tools except a minimal file set.
+- If the turn is already near context threshold, expose a compact tool subset.
+- If the user explicitly asks for background process inspection, expose process tools.
+- If a prior attempt failed due to missing capability, widen exposure in the next round.
+
+### Guardrails
+
+- Never expose tools outside static permissions.
+- Never bypass approval.
+- Prefer deterministic heuristics in phase 1.
+- Add learned/LLM-mediated exposure only later, if ever.
+
+---
+
+## 5.4 Post-Compaction Reconstruction + Lineage
+
+### Problem
+
+Hermes compression is already solid.
+But the continuation model is still mostly “summary plus surviving tail”.
+What is missing is explicit lineage and recovery semantics.
+
+### Proposal
+
+Introduce compaction lineage metadata and a reconstruction block.
+
+New module:
+- `agent/lineage.py`
+
+Suggested objects:
+
+```python
+@dataclass
+class CompactionLineage:
+    chain_id: str
+    generation: int
+    parent_summary_id: str | None
+    source_message_range: tuple[int, int] | None
+    created_at: str
+
+@dataclass
+class RecoveryContext:
+    lineage: CompactionLineage | None
+    summary_block: str | None
+    unresolved_threads: list[str]
+    recent_tool_failures: list[str]
+    pending_next_steps: list[str]
+```
+
+### Behavior
+
+When compaction runs:
+- generate/update lineage metadata
+- produce a compact reconstruction block, not just a summary blob
+- preserve unresolved threads and recent failed attempts in structured form
+
+### Reconstruction block shape
+
+Recommended sections:
+- Goal
+- Confirmed progress
+- Files / state already changed
+- Failed attempts to avoid repeating
+- Outstanding threads
+- Most recent safe next move
+
+### Benefits
+
+- stronger continuation after long runs
+- better resilience after compression or provider retries
+- future compatibility with session replay and postmortem tooling
+
+---
+
+## 5.5 Tool Result / Failure Envelope + Hook Chain
+
+### Problem
+
+Hermes handles tool execution centrally, but result semantics remain too string-oriented.
+Errors often enter the model as plain text blobs.
+That works. It does not scale gracefully.
+
+### Proposal
+
+Introduce a standard envelope around tool outcomes plus pre/post hooks.
+
+New module:
+- `agent/tool_runtime.py`
+
+Suggested dataclasses:
+
+```python
+@dataclass
+class ToolFailure:
+    category: str
+    message: str
+    retriable: bool
+    suggested_next_step: str | None = None
+    details: dict[str, object] = field(default_factory=dict)
+
+@dataclass
+class ToolExecutionEnvelope:
+    tool_name: str
+    ok: bool
+    content: str
+    structured_content: dict[str, object] = field(default_factory=dict)
+    failure: ToolFailure | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+```
+
+### Hook points
+
+```python
+def run_tool_with_hooks(...):
+    pre_tool_hooks(...)
+    execute_tool(...)
+    normalize_result(...)
+    post_tool_hooks(...)
+    return envelope
+```
+
+### Hook use cases
+
+- standard logging
+- approval/policy instrumentation
+- normalization of tool errors
+- truncation metadata
+- persistent storage metadata
+- future auditing or observability
+
+### Initial failure taxonomy
+
+Use a conservative enum-like string set:
+- `invalid_input`
+- `permission_denied`
+- `approval_denied`
+- `not_found`
+- `timeout`
+- `environment_error`
+- `transient_external_error`
+- `internal_tool_error`
+
+---
+
+## 6. Module-Level Changes
+
+## 6.1 `run_agent.py`
+
+### Add
+- turn assembly invocation before API calls
+- dynamic tool visibility resolution before schema emission
+- lineage/recovery state carried on agent instance
+- tool runtime hook/envelope consumption
+
+### Reduce
+- scattered prompt injection branches
+- direct ad hoc preflight logic that belongs in assembly
+- string-only tool error shaping inside the main loop
+
+### Target shape
+
+```python
+assembly = assemble_turn_context(...)
+visible_tools = resolve_visible_tools(..., assembly=assembly, runtime_state=...)
+messages = build_messages_from_assembly(...)
+response = call_model(messages=messages, tools=visible_tools)
+for tool_call in response.tool_calls:
+    envelope = run_tool_with_hooks(...)
+    messages.append(tool_message_from_envelope(envelope))
+```
+
+---
+
+## 6.2 `model_tools.py`
+
+### Keep
+- discovery
+- registry-backed dispatch
+- async bridging
+- toolset resolution
+
+### Add
+- an execution path that returns structured envelopes, not only plain strings
+- hook registration or callback slots
+
+### Avoid
+Do not duplicate policy or prompt logic here.
+This remains the tool platform boundary.
+
+---
+
+## 6.3 `agent/context_compressor.py`
+
+### Keep
+- compaction mechanics
+- iterative summary updates
+- pruning
+- token budgeting
+
+### Add
+- structured reconstruction output option
+- lineage metadata creation/update
+- summary IDs or generation counters exposed to runtime state
+
+---
+
+## 6.4 `agent/context_references.py`
+
+### Keep
+- parsing and expansion behavior
+- allowed-root restrictions
+- token hard/soft limits
+
+### Add
+- richer metadata return fields that integrate cleanly into `TurnAssembly`
+- optional categorization of reference types for tool visibility hints
+
+Potential additions to `ContextReferenceResult`:
+- `reference_kinds: list[str]`
+- `paths_touched: list[str]`
+- `git_context_present: bool`
+
+---
+
+## 6.5 New modules
+
+Create:
+- `agent/turn_assembly.py`
+- `agent/tool_visibility.py`
+- `agent/lineage.py`
+- `agent/tool_runtime.py`
+
+These should be thin and explicit.
+No giant god module.
+
+---
+
+## 7. Runtime Flow After RFC
+
+Desired turn lifecycle:
+
+1. Receive user input
+2. Assemble turn world (`TurnAssembly`)
+3. Resolve visible tools (`ToolVisibilityState`)
+4. Build prompt/messages from assembly + side-channel context
+5. Call model
+6. If tool calls returned, execute via runtime hook chain and structured envelopes
+7. Update lineage / recovery state
+8. If near threshold, compact and emit reconstruction metadata
+9. Continue or finalize
+
+This creates a real phase model without tearing down the existing system.
+
+---
+
+## 8. Migration Plan
+
+## Phase 1: Structural extraction
+
+Goal: introduce new modules with no intentional behavior change.
+
+Work:
+- create `agent/turn_assembly.py`
+- create `agent/tool_runtime.py`
+- wrap existing string tool results in envelopes
+- move context-ref preflight into assembly
+- keep old code paths available behind compatibility wrappers
+
+Success criteria:
+- existing tests still pass
+- no user-visible regressions in CLI/gateway
+- turn assembly is the single preflight entry point
+
+## Phase 2: Controlled intelligence
+
+Goal: make runtime decisions smarter without changing trust boundaries.
+
+Work:
+- create `agent/tool_visibility.py`
+- add heuristic dynamic exposure on top of static toolsets
+- add reference-derived visibility hints
+- add failure taxonomy normalization
+
+Success criteria:
+- tool schema count drops on average turns
+- no capability escalation
+- failed-tool recovery improves on repeated-turn workflows
+
+## Phase 3: Continuity hardening
+
+Goal: improve long-run continuation and post-compaction behavior.
+
+Work:
+- create `agent/lineage.py`
+- add compaction lineage IDs/generations
+- upgrade summary output into reconstruction blocks
+- surface lineage in session metadata and diagnostics
+
+Success criteria:
+- fewer repeated actions after compaction
+- clearer continuation state in long sessions
+- better debugging of “why did the agent repeat itself?”
+
+---
+
+## 9. Testing Strategy
+
+### Unit tests
+
+Add tests for:
+- turn assembly output stability
+- side-channel ordering
+- reference expansion metadata
+- dynamic visibility heuristics
+- failure envelope normalization
+- lineage generation and increment behavior
+
+### Integration tests
+
+Cover:
+- standard CLI turn without refs
+- turn with `@file` / `@diff`
+- turn with compaction
+- turn with dangerous terminal request needing approval
+- delegated subagent run with summarized return
+
+### Regression tests
+
+Protect:
+- approval behavior
+- toolset restriction behavior
+- session persistence
+- gateway compatibility
+- existing compaction thresholds
+
+---
+
+## 10. Risks
+
+### Risk 1: Over-abstraction
+
+Mitigation:
+phase rollout, thin dataclasses, compatibility wrappers.
+
+### Risk 2: Prompt regressions
+
+Mitigation:
+snapshot tests for assembled prompt blocks and visible tool lists.
+
+### Risk 3: Hidden capability bugs
+
+Mitigation:
+dynamic exposure must only narrow from static permissions, never widen beyond them.
+
+### Risk 4: Compaction churn
+
+Mitigation:
+make lineage additive first; do not replace current compactor output immediately.
+
+---
+
+## 11. Open Questions
+
+1. Should dynamic tool exposure be fully heuristic, or partly model-informed later?
+2. Should tool envelopes be persisted in session storage as structured JSON alongside text?
+3. Should lineage metadata surface in `/status` or diagnostics commands?
+4. Should side-channel blocks be token-ranked when context pressure is high?
+5. Should subagent summaries carry a formal type so they enter the bus as `delegation_blocks` automatically?
+
+---
+
+## 12. Bottom Line
+
+Hermes already has the weapons.
+
+What it lacks is explicit runtime anatomy.
+
+This RFC does not ask Hermes to imitate Claude Code.
+It asks Hermes to keep its own strengths and add five missing organs:
+- turn assembly
+- side-channel bus
+- dynamic tool visibility
+- lineage-aware reconstruction
+- structured tool runtime semantics
+
+That is the right direction.
+Not more tools.
+Better nerves.

--- a/docs/architecture/2026-04-09-phase1-runtime-organs-implementation-plan.md
+++ b/docs/architecture/2026-04-09-phase1-runtime-organs-implementation-plan.md
@@ -1,0 +1,655 @@
+# Phase 1 Runtime Organs Implementation Plan
+
+> For Hermes: use subagent-driven-development only after this plan is approved. Execute task-by-task. Preserve behavior. Prefer extraction wrappers over rewrites.
+
+Goal: introduce Phase 1 runtime structure for Hermes by extracting turn assembly and tool runtime normalization into explicit modules, while keeping user-visible behavior stable.
+
+Architecture: create thin orchestration modules around existing behavior in `run_agent.py`, `model_tools.py`, `agent/memory_manager.py`, and `agent/context_references.py`. Phase 1 does not change policy, approval, or toolset boundaries. It creates named runtime seams and compatibility wrappers so later phases can add dynamic exposure and lineage without reopening the whole loop.
+
+Tech Stack: Python, dataclasses, existing Hermes agent loop, registry-backed tools, current plugin hook system, current context-reference and memory subsystems.
+
+---
+
+## Preconditions
+
+Before touching code, keep these truths fixed:
+
+- `run_agent.py` currently injects memory prefetch and plugin user context directly into the current user message around lines `7291-7303`.
+- `run_agent.py` currently appends `ephemeral_system_prompt` and `prefill_messages` during API-call assembly around lines `7331-7350`.
+- `_build_system_prompt()` around line `2605` already assembles the stable system prompt and must remain the source of cached system content.
+- `model_tools.handle_function_call()` currently returns plain strings and fires plugin hooks at lines `500-540`.
+- `_invoke_tool()` in `run_agent.py` handles agent-loop tools separately at lines `6075-6139`.
+- `_execute_tool_calls_concurrent()` currently persists tool results and appends tool messages around lines `6323-6339`.
+- `agent/context_references.py` already returns `ContextReferenceResult` with `warnings`, `injected_tokens`, `expanded`, and `blocked`.
+
+Success means these behaviors still work after extraction.
+
+---
+
+## Task 1: Create the Phase 1 design scaffold document inside code comments and module headers
+
+Objective: make the new modules self-explanatory so later work does not collapse back into `run_agent.py` sprawl.
+
+Files:
+- Create: `agent/turn_assembly.py`
+- Create: `agent/tool_runtime.py`
+
+Step 1: Create `agent/turn_assembly.py` with a module docstring that says this module owns API-call-time turn preparation only.
+
+Add these rules in the docstring:
+- no session persistence
+- no tool execution
+- no policy decisions beyond recording hints/warnings
+- compatibility-first extraction from `run_agent.py`
+
+Step 2: Create `agent/tool_runtime.py` with a module docstring that says this module normalizes tool execution results but does not replace approval or registry dispatch.
+
+Step 3: Add stub dataclasses only. No behavior yet.
+
+`agent/turn_assembly.py`
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SideChannelContext:
+    memory_blocks: list[str] = field(default_factory=list)
+    skill_blocks: list[str] = field(default_factory=list)
+    reference_blocks: list[str] = field(default_factory=list)
+    recall_blocks: list[str] = field(default_factory=list)
+    delegation_blocks: list[str] = field(default_factory=list)
+    platform_blocks: list[str] = field(default_factory=list)
+    extra_blocks: list[str] = field(default_factory=list)
+
+    def flatten(self) -> list[str]:
+        return [
+            *self.memory_blocks,
+            *self.skill_blocks,
+            *self.recall_blocks,
+            *self.reference_blocks,
+            *self.delegation_blocks,
+            *self.platform_blocks,
+            *self.extra_blocks,
+        ]
+
+
+@dataclass
+class TurnAssembly:
+    original_user_message: str
+    assembled_user_message: str
+    system_blocks: list[str] = field(default_factory=list)
+    side_channel: SideChannelContext = field(default_factory=SideChannelContext)
+    warnings: list[str] = field(default_factory=list)
+    references_expanded: bool = False
+    references_blocked: bool = False
+    injected_token_estimate: int = 0
+    tool_visibility_hints: dict[str, Any] = field(default_factory=dict)
+    lineage: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+`agent/tool_runtime.py`
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ToolFailure:
+    category: str
+    message: str
+    retriable: bool
+    suggested_next_step: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ToolExecutionEnvelope:
+    tool_name: str
+    ok: bool
+    content: str
+    structured_content: dict[str, Any] = field(default_factory=dict)
+    failure: ToolFailure | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+Step 4: Run import smoke test.
+
+Run:
+`python - <<'PY'
+from agent.turn_assembly import TurnAssembly, SideChannelContext
+from agent.tool_runtime import ToolExecutionEnvelope, ToolFailure
+print('ok')
+PY`
+
+Expected: `ok`
+
+Step 5: Commit.
+
+```bash
+git add agent/turn_assembly.py agent/tool_runtime.py
+git commit -m "refactor: add runtime assembly and tool envelope scaffolds"
+```
+
+---
+
+## Task 2: Implement turn assembly helpers that preserve current injection order
+
+Objective: move API-call-time user-message injection logic out of `run_agent.py` without changing visible behavior.
+
+Files:
+- Modify: `agent/turn_assembly.py`
+- Test: new test file under `tests/` for assembly behavior
+
+Step 1: Add helper functions in `agent/turn_assembly.py`.
+
+Required functions:
+- `build_side_channel_context(...) -> SideChannelContext`
+- `assemble_turn_context(...) -> TurnAssembly`
+- `apply_turn_assembly_to_user_message(message: dict, assembly: TurnAssembly) -> dict`
+- `compose_effective_system_prompt(base_system: str, ephemeral_system_prompt: str | None) -> str`
+- `inject_prefill_messages(api_messages: list[dict], prefill_messages: list[dict], effective_system: str) -> list[dict]`
+
+Step 2: Preserve current semantics exactly.
+
+Rules:
+- Memory prefetch is fenced using `build_memory_context_block()` from `agent.memory_manager`.
+- Plugin user context is appended after memory context.
+- These injections affect only the current API call, never persisted session messages.
+- `ephemeral_system_prompt` is appended to the cached system prompt only at API-call time.
+- `prefill_messages` are inserted immediately after the system message when one exists, otherwise at the start.
+
+Step 3: Put the existing order into code explicitly.
+
+Recommended implementation shape:
+```python
+def build_side_channel_context(*, memory_context: str = '', plugin_user_context: str = '') -> SideChannelContext:
+    side = SideChannelContext()
+    if memory_context:
+        side.memory_blocks.append(memory_context)
+    if plugin_user_context:
+        side.extra_blocks.append(plugin_user_context)
+    return side
+
+
+def assemble_turn_context(
+    user_message: str,
+    *,
+    memory_context: str = '',
+    plugin_user_context: str = '',
+    reference_result=None,
+    platform: str | None = None,
+) -> TurnAssembly:
+    assembled = reference_result.message if reference_result else user_message
+    warnings = list(getattr(reference_result, 'warnings', []) or [])
+    side = build_side_channel_context(
+        memory_context=memory_context,
+        plugin_user_context=plugin_user_context,
+    )
+    return TurnAssembly(
+        original_user_message=user_message,
+        assembled_user_message=assembled,
+        side_channel=side,
+        warnings=warnings,
+        references_expanded=bool(getattr(reference_result, 'expanded', False)),
+        references_blocked=bool(getattr(reference_result, 'blocked', False)),
+        injected_token_estimate=int(getattr(reference_result, 'injected_tokens', 0) or 0),
+        tool_visibility_hints={
+            'platform': platform,
+            'has_references': bool(getattr(reference_result, 'references', [])),
+        },
+    )
+```
+
+Step 4: Add tests.
+
+Create tests that assert:
+- no injection returns original user content
+- memory block is appended before plugin user context
+- reference-result message replaces original user text for API-call-time assembly
+- effective system prompt joins base + ephemeral with one blank line
+- prefill insertion order matches current `run_agent.py` behavior
+
+Step 5: Run focused tests.
+
+Run:
+`pytest -q tests/test_turn_assembly.py`
+
+Expected: pass
+
+Step 6: Commit.
+
+```bash
+git add agent/turn_assembly.py tests/test_turn_assembly.py
+git commit -m "refactor: extract turn assembly helpers from api message prep"
+```
+
+---
+
+## Task 3: Wire `run_agent.py` to use turn assembly helpers without changing persistence behavior
+
+Objective: replace duplicated assembly logic in the main loop with calls into `agent/turn_assembly.py`.
+
+Files:
+- Modify: `run_agent.py`
+- Test: existing or new integration-focused tests for API message assembly
+
+Step 1: Add imports near other agent imports.
+
+```python
+from agent.turn_assembly import (
+    assemble_turn_context,
+    apply_turn_assembly_to_user_message,
+    compose_effective_system_prompt,
+    inject_prefill_messages,
+)
+```
+
+Step 2: Identify the current user-turn assembly site.
+
+Relevant region:
+- current user message appended around `7047-7050`
+- API-call-time injection loop around `7282-7303`
+- system/prefill assembly around `7331-7350`
+
+Step 3: Build a `TurnAssembly` once per API request cycle using the already available ephemeral data.
+
+Inputs should include:
+- current user message content
+- fenced memory context built from `_ext_prefetch_cache`
+- `_plugin_user_context`
+- any context-reference result if already available in the turn path
+- `self.platform`
+
+Step 4: Replace inline injection block with helper call.
+
+Instead of open-coded `_injections`, do this:
+```python
+if idx == current_turn_user_idx and msg.get('role') == 'user':
+    api_msg = apply_turn_assembly_to_user_message(api_msg, turn_assembly)
+```
+
+Step 5: Replace open-coded effective-system assembly.
+
+```python
+effective_system = compose_effective_system_prompt(
+    active_system_prompt or '',
+    self.ephemeral_system_prompt,
+)
+```
+
+Step 6: Replace open-coded prefill insertion.
+
+```python
+api_messages = inject_prefill_messages(api_messages, self.prefill_messages, effective_system)
+```
+
+Step 7: Preserve storage boundaries.
+
+Verify:
+- `messages` list is still not mutated with ephemeral memory/plugin injections
+- system prompt cache behavior is unchanged
+- session persistence still records the original user message, not the assembled one
+
+Step 8: Run targeted tests.
+
+Run:
+`pytest -q tests/test_turn_assembly.py`
+
+Then run a narrower existing suite if available:
+`pytest -q -k "prompt or api_messages or context_references"`
+
+Expected: pass or known unrelated skips only
+
+Step 9: Commit.
+
+```bash
+git add run_agent.py tests/
+git commit -m "refactor: route api-call message prep through turn assembly"
+```
+
+---
+
+## Task 4: Extend context-reference metadata for Phase 1 hints, not behavior changes
+
+Objective: enrich `ContextReferenceResult` so later tool visibility work has clean metadata, without changing expansion semantics.
+
+Files:
+- Modify: `agent/context_references.py`
+- Test: context-reference tests
+
+Step 1: Extend `ContextReferenceResult` fields.
+
+Add:
+```python
+reference_kinds: list[str] = field(default_factory=list)
+paths_touched: list[str] = field(default_factory=list)
+git_context_present: bool = False
+```
+
+Step 2: Populate fields conservatively.
+
+Rules:
+- `reference_kinds` = ordered unique list of kinds seen in parsed refs
+- `git_context_present` = `True` if any ref kind is `diff`, `staged`, or `git`
+- `paths_touched` = resolved file/folder targets when safe and meaningful; omit URLs and unresolved/blocked entries
+
+Step 3: Do not change these semantics:
+- root restriction
+- sensitive path blocking
+- soft/hard token limits
+- final message text format
+
+Step 4: Add tests for the new metadata only.
+
+Assertions:
+- `@file:x` yields `reference_kinds == ['file']`
+- git-style refs set `git_context_present`
+- blocked refs still populate kinds but not unsafe paths
+
+Step 5: Run tests.
+
+Run:
+`pytest -q -k "context_references"`
+
+Expected: pass
+
+Step 6: Commit.
+
+```bash
+git add agent/context_references.py tests/
+git commit -m "refactor: add structured metadata to context reference results"
+```
+
+---
+
+## Task 5: Add tool runtime normalization helpers that wrap string results in envelopes
+
+Objective: standardize tool result shape without replacing the current dispatcher.
+
+Files:
+- Modify: `agent/tool_runtime.py`
+- Test: new tool-runtime unit tests
+
+Step 1: Add helper functions.
+
+Required functions:
+- `categorize_tool_failure(tool_name: str, content: str) -> ToolFailure | None`
+- `build_tool_envelope(tool_name: str, content: str, *, metadata: dict | None = None) -> ToolExecutionEnvelope`
+- `tool_message_from_envelope(envelope: ToolExecutionEnvelope, tool_call_id: str) -> dict`
+
+Step 2: Start with deterministic string heuristics only.
+
+Recommended categories:
+- `approval_denied`
+- `permission_denied`
+- `timeout`
+- `not_found`
+- `invalid_input`
+- `environment_error`
+- `internal_tool_error`
+
+Step 3: Use the existing `_detect_tool_failure(...)` semantics as a compatibility anchor where possible. Do not invent speculative failures.
+
+Step 4: Keep `content` untouched.
+
+The envelope adds metadata. It does not rewrite the tool output text in Phase 1.
+
+Step 5: Add tests.
+
+Test cases:
+- success string returns `ok=True`, `failure=None`
+- timeout-like string maps to `timeout`
+- permission/approval-denied strings map correctly
+- `tool_message_from_envelope()` returns the same message shape `run_agent.py` already expects
+
+Step 6: Run tests.
+
+Run:
+`pytest -q tests/test_tool_runtime.py`
+
+Expected: pass
+
+Step 7: Commit.
+
+```bash
+git add agent/tool_runtime.py tests/test_tool_runtime.py
+git commit -m "refactor: add tool execution envelope normalization"
+```
+
+---
+
+## Task 6: Route concurrent and sequential tool result handling through envelopes
+
+Objective: use the new runtime helper in `run_agent.py` while preserving tool callbacks, persistence, and tool message content.
+
+Files:
+- Modify: `run_agent.py`
+- Test: tool execution path tests if present
+
+Step 1: Import the new helpers.
+
+```python
+from agent.tool_runtime import build_tool_envelope, tool_message_from_envelope
+```
+
+Step 2: In `_execute_tool_calls_concurrent()` keep `_invoke_tool()` exactly as the execution mechanism.
+
+Do not replace:
+- callbacks
+- checkpoint logic
+- `maybe_persist_tool_result(...)`
+- `enforce_turn_budget(...)`
+
+Step 3: After persistence and subdirectory hint augmentation, build an envelope.
+
+Recommended shape:
+```python
+persisted_result = maybe_persist_tool_result(...)
+if subdir_hints:
+    persisted_result += subdir_hints
+envelope = build_tool_envelope(
+    name,
+    persisted_result,
+    metadata={
+        'tool_call_id': tc.id,
+        'duration_seconds': tool_duration,
+        'is_error': is_error,
+    },
+)
+tool_msg = tool_message_from_envelope(envelope, tc.id)
+messages.append(tool_msg)
+```
+
+Step 4: Mirror the same wrapping in the sequential execution path.
+
+Phase 1 is incomplete if only concurrent calls use the envelope.
+
+Step 5: Preserve last-mile message shape.
+
+Tool messages in `messages` must still look like:
+```python
+{
+  'role': 'tool',
+  'content': <string>,
+  'tool_call_id': tc.id,
+}
+```
+
+Step 6: Add at least one regression test proving the envelope path does not alter stored tool content.
+
+Step 7: Run targeted tests.
+
+Run:
+`pytest -q -k "tool_runtime or tool_call or concurrent"`
+
+Expected: pass
+
+Step 8: Commit.
+
+```bash
+git add run_agent.py tests/
+git commit -m "refactor: normalize tool results through runtime envelopes"
+```
+
+---
+
+## Task 7: Add compatibility diagnostics for assembly and envelopes
+
+Objective: make the extraction debuggable before later phases build on it.
+
+Files:
+- Modify: `agent/turn_assembly.py`
+- Modify: `agent/tool_runtime.py`
+- Optionally modify: `run_agent.py`
+
+Step 1: Add `to_debug_dict()` methods or equivalent serialization helpers on both dataclass families.
+
+Example:
+```python
+def to_debug_dict(self) -> dict:
+    return {
+        'original_user_message': self.original_user_message,
+        'assembled_user_message': self.assembled_user_message,
+        'warnings': self.warnings,
+        'references_expanded': self.references_expanded,
+        'references_blocked': self.references_blocked,
+        'injected_token_estimate': self.injected_token_estimate,
+        'tool_visibility_hints': self.tool_visibility_hints,
+    }
+```
+
+Step 2: Under verbose logging only, emit one debug line for turn assembly creation and one for tool envelope creation.
+
+Do not print these in normal quiet-mode UX.
+
+Step 3: Verify logs do not include secret material beyond what is already present in current debug paths.
+
+Step 4: Run tests or smoke command.
+
+Run:
+`python - <<'PY'
+from agent.turn_assembly import TurnAssembly
+from agent.tool_runtime import build_tool_envelope
+print(build_tool_envelope('x', 'ok').metadata == {})
+PY`
+
+Expected: `True`
+
+Step 5: Commit.
+
+```bash
+git add agent/turn_assembly.py agent/tool_runtime.py run_agent.py
+git commit -m "chore: add runtime assembly and envelope diagnostics"
+```
+
+---
+
+## Task 8: Run Phase 1 verification sweep
+
+Objective: prove the extraction did not break core runtime behavior.
+
+Files:
+- No new files required unless test fixes are needed
+
+Step 1: Run focused unit and integration tests.
+
+Run exactly:
+```bash
+pytest -q tests/test_turn_assembly.py tests/test_tool_runtime.py
+pytest -q -k "context_references or prompt or tool_call"
+```
+
+Step 2: Run lightweight import smoke.
+
+```bash
+python - <<'PY'
+from agent.turn_assembly import assemble_turn_context
+from agent.tool_runtime import build_tool_envelope
+print('phase1-smoke-ok')
+PY`
+```
+
+Expected: `phase1-smoke-ok`
+
+Step 3: If Hermes has an existing self-test or CLI smoke command, run one representative command in a safe workspace.
+
+Example shape:
+```bash
+python run_agent.py --help >/dev/null
+```
+
+Step 4: Review git diff for scope control.
+
+Run:
+```bash
+git diff --stat HEAD~8..HEAD
+```
+
+Expected:
+- mostly additive changes
+- no approval-path rewrites
+- no unrelated module churn
+
+Step 5: Final commit if verification required follow-up edits.
+
+```bash
+git add -A
+git commit -m "test: verify phase 1 runtime organs extraction"
+```
+
+---
+
+## Acceptance Criteria
+
+Phase 1 is complete only if all are true:
+
+- `agent/turn_assembly.py` exists and owns API-call-time turn preparation helpers.
+- `agent/tool_runtime.py` exists and owns result-envelope helpers.
+- `run_agent.py` no longer open-codes memory/plugin user-message assembly or system/prefill composition in the main API request path.
+- `ContextReferenceResult` exposes structured metadata for future visibility logic.
+- Tool execution still runs through current mechanisms, but result handling is normalized with envelopes before tool messages are appended.
+- Persisted conversation history remains behaviorally unchanged.
+- Approval, toolsets, memory writes, delegate isolation, and gateway behavior remain intact.
+- Focused tests pass.
+
+---
+
+## Known Pitfalls
+
+- Do not mutate stored `messages` with ephemeral injections. That would pollute session persistence.
+- Do not move `_build_system_prompt()` responsibilities into turn assembly. Stable system prompt caching must stay separate.
+- Do not let envelope helpers rewrite tool text. Phase 1 is normalization, not reinterpretation.
+- Do not change tool-message wire format yet. Later phases can add richer metadata elsewhere.
+- Do not widen context-reference permissions while collecting `paths_touched`.
+- Do not duplicate plugin hook firing in both `model_tools.py` and `agent/tool_runtime.py`.
+
+---
+
+## Recommended Execution Order
+
+1. Task 1 scaffold
+2. Task 2 turn assembly helpers
+3. Task 3 `run_agent.py` integration
+4. Task 4 context-reference metadata
+5. Task 5 tool envelope helpers
+6. Task 6 `run_agent.py` envelope integration
+7. Task 7 diagnostics
+8. Task 8 verification sweep
+
+---
+
+## Definition of Done
+
+The codebase gains explicit runtime seams for turn assembly and tool result normalization.
+
+Nothing flashy.
+Nothing reckless.
+Just cleaner nerves.
+
+Date: 2026-04-09

--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -50,7 +50,11 @@ def _run_boot_agent(content: str) -> None:
         from run_agent import AIAgent
 
         prompt = _build_boot_prompt(content)
+        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model
+
         agent = AIAgent(
+            model=_resolve_gateway_model(),
+            **_resolve_runtime_agent_kwargs(),
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -67,7 +71,7 @@ def _run_boot_agent(content: str) -> None:
 
 
 async def handle(event_type: str, context: dict) -> None:
-    """Gateway startup handler — run BOOT.md if it exists."""
+    """Gateway startup handler — run BOOT.md if it exists and model is configured."""
     if not BOOT_FILE.exists():
         return
 
@@ -75,7 +79,18 @@ async def handle(event_type: str, context: dict) -> None:
     if not content:
         return
 
-    logger.info("Running BOOT.md (%d chars)", len(content))
+    try:
+        from gateway.run import _resolve_gateway_model
+        boot_model = (_resolve_gateway_model() or "").strip()
+    except Exception as e:
+        logger.warning("Skipping BOOT.md: could not resolve model: %s", e)
+        return
+
+    if not boot_model:
+        logger.warning("Skipping BOOT.md: gateway model is empty")
+        return
+
+    logger.info("Running BOOT.md (%d chars) with model %s", len(content), boot_model)
 
     # Run in a background thread so we don't block gateway startup.
     thread = threading.Thread(

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -55,14 +55,16 @@ class HookRegistry:
         """Register built-in hooks that are always active."""
         try:
             from gateway.builtin_hooks.boot_md import handle as boot_md_handle
+            import os
 
-            self._handlers.setdefault("gateway:startup", []).append(boot_md_handle)
-            self._loaded_hooks.append({
-                "name": "boot-md",
-                "description": "Run ~/.hermes/BOOT.md on gateway startup",
-                "events": ["gateway:startup"],
-                "path": "(builtin)",
-            })
+            if str(os.getenv("HERMES_DISABLE_BOOT_MD", "")).strip().lower() not in {"1", "true", "yes", "on"}:
+                self._handlers.setdefault("gateway:startup", []).append(boot_md_handle)
+                self._loaded_hooks.append({
+                    "name": "boot-md",
+                    "description": "Run ~/.hermes/BOOT.md on gateway startup",
+                    "events": ["gateway:startup"],
+                    "path": "(builtin)",
+                })
         except Exception as e:
             print(f"[hooks] Could not load built-in boot-md hook: {e}", flush=True)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -69,14 +69,25 @@ from model_tools import (
 from tools.terminal_tool import cleanup_vm, get_active_env, is_persistent_env
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
 from tools.interrupt import set_interrupt as _set_interrupt
+from agent.tool_runtime import (
+    envelope_to_legacy_content,
+    normalize_tool_failure,
+    normalize_tool_result,
+)
 from tools.browser_tool import cleanup_browser
 
 
 from hermes_constants import OPENROUTER_BASE_URL
 
 # Agent internals extracted to agent/ package for modularity
-from agent.memory_manager import build_memory_context_block
 from agent.retry_utils import jittered_backoff
+from agent.turn_assembly import (
+    apply_turn_assembly_to_user_message,
+    assemble_turn_context,
+    compose_effective_system_prompt,
+    inject_prefill_messages,
+)
+from agent.context_references import preprocess_context_references
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
@@ -6280,17 +6291,28 @@ class AIAgent:
             """Worker function executed in a thread."""
             start = time.time()
             try:
-                result = self._invoke_tool(function_name, function_args, effective_task_id, tool_call.id)
+                raw_result = self._invoke_tool(function_name, function_args, effective_task_id, tool_call.id)
+                duration = time.time() - start
+                envelope = normalize_tool_result(
+                    function_name,
+                    raw_result,
+                    duration_seconds=duration,
+                )
             except Exception as tool_error:
-                result = f"Error executing tool '{function_name}': {tool_error}"
+                duration = time.time() - start
+                envelope = normalize_tool_failure(
+                    function_name,
+                    tool_error,
+                    duration_seconds=duration,
+                )
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
-            duration = time.time() - start
-            is_error, _ = _detect_tool_failure(function_name, result)
+            result = envelope_to_legacy_content(envelope)
+            is_error = not envelope.ok
             if is_error:
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
             else:
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
-            results[index] = (function_name, function_args, result, duration, is_error)
+            results[index] = (function_name, function_args, envelope, duration, is_error)
 
         # Start spinner for CLI mode (skip when TUI handles tool progress)
         spinner = None
@@ -6324,7 +6346,8 @@ class AIAgent:
                 function_result = f"Error executing tool '{name}': thread did not return a result"
                 tool_duration = 0.0
             else:
-                function_name, function_args, function_result, tool_duration, is_error = r
+                function_name, function_args, envelope, tool_duration, is_error = r
+                function_result = envelope_to_legacy_content(envelope)
 
                 if is_error:
                     result_preview = function_result[:200] if len(function_result) > 200 else function_result
@@ -6638,13 +6661,19 @@ class AIAgent:
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
                 tool_duration = time.time() - tool_start_time
 
+            envelope = normalize_tool_result(
+                function_name,
+                function_result,
+                duration_seconds=tool_duration,
+            )
+            function_result = envelope_to_legacy_content(envelope)
             result_preview = function_result if self.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
             )
 
             # Log tool errors to the persistent error log so [error] tags
             # in the UI always have a corresponding detailed entry on disk.
-            _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+            _is_error_result = not envelope.ok
             if _is_error_result:
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
             else:
@@ -7266,6 +7295,34 @@ class AIAgent:
             except Exception:
                 pass
 
+        _reference_result = None
+        if isinstance(user_message, str) and "@" in user_message:
+            try:
+                from agent.model_metadata import get_model_context_length
+
+                _ctx_len = get_model_context_length(
+                    self.model,
+                    base_url=self.base_url or "",
+                    api_key=self.api_key or "",
+                    provider=self.provider,
+                )
+                _reference_result = preprocess_context_references(
+                    user_message,
+                    cwd=os.getcwd(),
+                    context_length=_ctx_len,
+                )
+            except Exception as exc:
+                logger.warning("context reference preprocessing failed: %s", exc)
+                _reference_result = None
+
+        _turn_assembly = assemble_turn_context(
+            user_message,
+            _ext_prefetch_cache,
+            _plugin_user_context,
+            reference_result=_reference_result,
+            platform=self.platform,
+        )
+
         while api_call_count < self.max_iterations and self.iteration_budget.remaining > 0:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
@@ -7333,17 +7390,7 @@ class AIAgent:
                 # API-call-time only — the original message in `messages` is
                 # never mutated, so nothing leaks into session persistence.
                 if idx == current_turn_user_idx and msg.get("role") == "user":
-                    _injections = []
-                    if _ext_prefetch_cache:
-                        _fenced = build_memory_context_block(_ext_prefetch_cache)
-                        if _fenced:
-                            _injections.append(_fenced)
-                    if _plugin_user_context:
-                        _injections.append(_plugin_user_context)
-                    if _injections:
-                        _base = api_msg.get("content", "")
-                        if isinstance(_base, str):
-                            api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                    api_msg = apply_turn_assembly_to_user_message(api_msg, _turn_assembly)
 
                 # For ALL assistant messages, pass reasoning back to the API
                 # This ensures multi-turn reasoning context is preserved
@@ -7376,9 +7423,10 @@ class AIAgent:
             # Ephemeral additions are API-call-time only (not persisted to session DB).
             # External recall context is injected into the user message, not the system
             # prompt, so the stable cache prefix remains unchanged.
-            effective_system = active_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            effective_system = compose_effective_system_prompt(
+                active_system_prompt or "",
+                self.ephemeral_system_prompt,
+            )
             # NOTE: Plugin context from pre_llm_call hooks is injected into the
             # user message (see injection block above), NOT the system prompt.
             # This is intentional — system prompt modifications break the prompt
@@ -7389,9 +7437,11 @@ class AIAgent:
             # Inject ephemeral prefill messages right after the system prompt
             # but before conversation history. Same API-call-time-only pattern.
             if self.prefill_messages:
-                sys_offset = 1 if effective_system else 0
-                for idx, pfm in enumerate(self.prefill_messages):
-                    api_messages.insert(sys_offset + idx, pfm.copy())
+                api_messages = inject_prefill_messages(
+                    api_messages,
+                    self.prefill_messages,
+                    effective_system,
+                )
 
             # Apply Anthropic prompt caching for Claude models via OpenRouter.
             # Auto-detected: if model name contains "claude" and base_url is OpenRouter,

--- a/tests/agent/test_run_agent_context_references.py
+++ b/tests/agent/test_run_agent_context_references.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import run_agent
+from agent.turn_assembly import apply_turn_assembly_to_user_message
+from run_agent import AIAgent
+
+
+def test_run_conversation_preprocesses_context_references_for_api_messages_only(monkeypatch):
+    captured = {}
+
+    def fake_get_model_context_length(*args, **kwargs):
+        captured["ctx_lookup"] = (args, kwargs)
+        return 8192
+
+    def fake_preprocess_context_references(message, *, cwd, context_length, **kwargs):
+        captured["preprocess"] = {
+            "message": message,
+            "cwd": cwd,
+            "context_length": context_length,
+        }
+        return SimpleNamespace(
+            message="expanded message",
+            original_message=message,
+            references=[SimpleNamespace(kind="file")],
+            warnings=[],
+            injected_tokens=9,
+            expanded=True,
+            blocked=False,
+        )
+
+    original_assemble = run_agent.assemble_turn_context
+
+    def wrapped_assemble(*args, **kwargs):
+        captured["assemble_args"] = args
+        assembly = original_assemble(*args, **kwargs)
+        captured["turn_assembly"] = assembly
+        raise RuntimeError("stop after assembly")
+
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", fake_get_model_context_length)
+    monkeypatch.setattr("run_agent.preprocess_context_references", fake_preprocess_context_references)
+    monkeypatch.setattr("run_agent.assemble_turn_context", wrapped_assemble)
+
+    agent = AIAgent(model="test-model", quiet_mode=True, max_iterations=1)
+    try:
+        agent.run_conversation("Check @file:README.md")
+    except RuntimeError as exc:
+        assert str(exc) == "stop after assembly"
+
+    assert captured["assemble_args"][0] == "Check @file:README.md"
+    assert captured["preprocess"]["message"] == "Check @file:README.md"
+    assert captured["preprocess"]["context_length"] == 8192
+
+    assembly = captured["turn_assembly"]
+    api_user_message = apply_turn_assembly_to_user_message(
+        {"role": "user", "content": "Check @file:README.md"},
+        assembly,
+    )
+    assert api_user_message["content"] == "expanded message"
+    assert assembly.original_user_message == "Check @file:README.md"
+
+

--- a/tests/agent/test_tool_runtime.py
+++ b/tests/agent/test_tool_runtime.py
@@ -1,0 +1,49 @@
+import json
+
+from agent.tool_runtime import (
+    envelope_to_legacy_content,
+    normalize_tool_failure,
+    normalize_tool_result,
+)
+
+
+def test_normalize_tool_result_keeps_string_content_backward_compatible():
+    envelope = normalize_tool_result("web_search", "plain text result", duration_seconds=1.25)
+
+    assert envelope.ok is True
+    assert envelope.content == "plain text result"
+    assert envelope.structured_content == {}
+    assert envelope.failure is None
+    assert envelope.metadata["duration_seconds"] == 1.25
+    assert envelope_to_legacy_content(envelope) == "plain text result"
+
+
+
+def test_normalize_tool_result_extracts_json_and_detects_failure_payload():
+    envelope = normalize_tool_result(
+        "memory",
+        {"success": False, "error": "backend unavailable", "status": "error"},
+    )
+
+    assert envelope.ok is False
+    assert envelope.structured_content == {
+        "success": False,
+        "error": "backend unavailable",
+        "status": "error",
+    }
+    assert envelope.failure is not None
+    assert envelope.failure.category == "tool_error"
+    assert envelope.failure.message == "backend unavailable"
+    assert envelope_to_legacy_content(envelope) == json.dumps(envelope.structured_content, ensure_ascii=False)
+
+
+
+def test_normalize_tool_failure_builds_legacy_error_string():
+    envelope = normalize_tool_failure("terminal", RuntimeError("boom"), duration_seconds=0.5)
+
+    assert envelope.ok is False
+    assert envelope.failure is not None
+    assert envelope.failure.category == "execution_error"
+    assert envelope.failure.message == "boom"
+    assert envelope.content == "Error executing tool 'terminal': boom"
+    assert envelope.metadata["duration_seconds"] == 0.5

--- a/tests/agent/test_turn_assembly.py
+++ b/tests/agent/test_turn_assembly.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+
+from agent.memory_manager import build_memory_context_block
+from agent.turn_assembly import (
+    apply_turn_assembly_to_user_message,
+    assemble_turn_context,
+    compose_effective_system_prompt,
+    inject_prefill_messages,
+)
+
+
+def test_assemble_turn_context_without_injection_returns_original_user_content():
+    assembly = assemble_turn_context("hello")
+
+    assert assembly.assembled_user_message == "hello"
+    assert apply_turn_assembly_to_user_message(
+        {"role": "user", "content": "hello"},
+        assembly,
+    ) == {"role": "user", "content": "hello"}
+
+
+def test_memory_block_appended_before_plugin_user_context():
+    assembly = assemble_turn_context(
+        "hello",
+        memory_context="remember this",
+        plugin_user_context="plugin context",
+    )
+
+    assert assembly.assembled_user_message == (
+        "hello\n\n"
+        f"{build_memory_context_block('remember this')}\n\n"
+        "plugin context"
+    )
+
+
+def test_reference_result_message_replaces_original_user_text_for_api_call_time_assembly():
+    reference_result = SimpleNamespace(
+        message="expanded message",
+        expanded=True,
+        blocked=False,
+        warnings=["warn"],
+        injected_tokens=12,
+        references=[
+            SimpleNamespace(kind="file"),
+            SimpleNamespace(kind="file"),
+            SimpleNamespace(kind="git"),
+        ],
+    )
+
+    assembly = assemble_turn_context(
+        "original message",
+        plugin_user_context="plugin context",
+        reference_result=reference_result,
+    )
+
+    assert assembly.assembled_user_message == "expanded message\n\nplugin context"
+    assert assembly.original_user_message == "original message"
+    assert assembly.references_expanded is True
+    assert assembly.references_blocked is False
+    assert assembly.warnings == ["warn"]
+    assert assembly.metadata["reference_injected_tokens"] == 12
+    assert assembly.metadata["reference_summary"] == {
+        "count": 3,
+        "kinds": {"file": 2, "git": 1},
+    }
+    assert assembly.lineage["reference_preprocessed"] is True
+    assert assembly.lineage["references_expanded"] is True
+
+
+def test_apply_turn_assembly_preserves_non_string_user_content():
+    assembly = assemble_turn_context("expanded text", plugin_user_context="plugin context")
+    message = {
+        "role": "user",
+        "content": [{"type": "text", "text": "hello"}],
+    }
+
+    result = apply_turn_assembly_to_user_message(message, assembly)
+
+    assert result == message
+    assert result is not message
+
+
+
+def test_build_side_channel_context_skips_blank_contexts():
+    assembly = assemble_turn_context(
+        "hello",
+        memory_context="   ",
+        plugin_user_context="  \n\t  ",
+    )
+
+    assert assembly.side_channel.flatten() == []
+    assert assembly.assembled_user_message == "hello"
+
+
+def test_compose_effective_system_prompt_joins_base_and_ephemeral_with_one_blank_line():
+    assert compose_effective_system_prompt("base", "ephemeral") == "base\n\nephemeral"
+
+
+def test_inject_prefill_messages_inserts_after_system_message_when_present():
+    api_messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u"},
+    ]
+    prefill_messages = [
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u1"},
+    ]
+
+    result = inject_prefill_messages(api_messages, prefill_messages, "sys")
+
+    assert result == [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u1"},
+        {"role": "user", "content": "u"},
+    ]
+    assert api_messages == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u"},
+    ]
+
+
+def test_inject_prefill_messages_inserts_at_start_when_no_system_message():
+    api_messages = [{"role": "user", "content": "u"}]
+    prefill_messages = [{"role": "assistant", "content": "a1"}]
+
+    result = inject_prefill_messages(api_messages, prefill_messages, "")
+
+    assert result == [
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u"},
+    ]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -19,6 +19,7 @@ import pytest
 import run_agent
 from run_agent import AIAgent
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from tools.tool_result_storage import PERSISTED_OUTPUT_TAG
 
 
 # ---------------------------------------------------------------------------
@@ -1259,9 +1260,29 @@ class TestConcurrentToolExecution:
 
         assert len(messages) == 2
         # First tool should have error
-        assert "Error" in messages[0]["content"] or "boom" in messages[0]["content"]
+        assert messages[0]["content"] == "Error executing tool 'web_search': boom"
         # Second tool should succeed
         assert "success" in messages[1]["content"]
+
+    def test_concurrent_normalizes_json_failure_but_keeps_legacy_content(self, agent):
+        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc2 = _mock_tool_call(name="read_file", arguments='{"path":"x.py"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+
+        with patch(
+            "run_agent.handle_function_call",
+            side_effect=['{"success": false, "error": "backend unavailable"}', '{"ok": true}'],
+        ):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert messages[0] == {
+            "role": "tool",
+            "content": '{"success": false, "error": "backend unavailable"}',
+            "tool_call_id": "c1",
+        }
+        assert messages[1]["tool_call_id"] == "c2"
+        assert messages[1]["content"] == '{"ok": true}'
 
     def test_concurrent_interrupt_before_start(self, agent):
         """If interrupt is requested before concurrent execution, all tools are skipped."""
@@ -1323,6 +1344,35 @@ class TestConcurrentToolExecution:
 
         assert starts == [("c1", "web_search", {"query": "hello"})]
         assert completes == [("c1", "web_search", {"query": "hello"}, '{"success": true}')]
+
+    def test_sequential_normalizes_failure_and_persists_legacy_string(self, agent):
+        tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        with patch("run_agent.handle_function_call", return_value='{"success": false, "error": "denied"}'):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert messages == [{
+            "role": "tool",
+            "content": '{"success": false, "error": "denied"}',
+            "tool_call_id": "c1",
+        }]
+
+    def test_sequential_success_still_persists_large_results(self, agent, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+        tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+        big_result = "x" * 150_000
+
+        with patch("run_agent.handle_function_call", return_value=big_result):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert len(messages) == 1
+        assert len(messages[0]["content"]) < len(big_result)
+        assert ("Truncated" in messages[0]["content"] or PERSISTED_OUTPUT_TAG in messages[0]["content"])
 
     def test_concurrent_tool_callbacks_fire_for_each_tool(self, agent):
         tc1 = _mock_tool_call(name="web_search", arguments='{"query":"one"}', call_id="c1")


### PR DESCRIPTION
## What does this PR do?

This PR extracts two explicit Phase 1 runtime seams from `run_agent.py` while preserving existing external behavior:

- API-call-time turn assembly now lives in `agent/turn_assembly.py`
- tool execution result normalization now lives in `agent/tool_runtime.py`

It also hardens the built-in gateway `BOOT.md` startup hook so it only runs when a gateway model can be resolved, and adds `HERMES_DISABLE_BOOT_MD` as an explicit disable switch.

The intent is to make turn preparation and tool-result handling easier to reason about without changing approval, registry dispatch, or legacy tool-message compatibility.

## Related Issue

Fixes #5239

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent/turn_assembly.py` with `TurnAssembly` / `SideChannelContext` helpers for API-call-time prompt assembly
- Added `agent/tool_runtime.py` with `ToolExecutionEnvelope` / `ToolFailure` normalization helpers
- Integrated turn assembly and tool-result normalization into `run_agent.py`
- Preserved legacy string-based tool-message behavior after normalization
- Added focused tests for:
  - `tests/agent/test_turn_assembly.py`
  - `tests/agent/test_run_agent_context_references.py`
  - `tests/agent/test_tool_runtime.py`
  - `tests/run_agent/test_run_agent.py`
- Added architecture/docs artifacts:
  - `docs/architecture/2026-04-09-hermes-runtime-organs-rfc.md`
  - `docs/architecture/2026-04-09-phase1-runtime-organs-implementation-plan.md`
- Updated gateway startup handling:
  - `gateway/builtin_hooks/boot_md.py` now resolves the configured gateway model before running `BOOT.md`
  - startup skips cleanly when the model is missing or resolution fails
  - `gateway/hooks.py` now supports disabling the built-in boot hook via `HERMES_DISABLE_BOOT_MD`

## How to Test

1. Run the focused runtime and agent-loop regression coverage:
   `pytest -q tests/agent/test_turn_assembly.py tests/agent/test_run_agent_context_references.py tests/agent/test_tool_runtime.py tests/run_agent/test_run_agent.py tests/agent/test_context_references.py tests/run_agent/test_agent_loop_tool_calling.py tests/run_agent/test_dict_tool_call_args.py tests/run_agent/test_tool_arg_coercion.py tests/run_agent/test_agent_loop.py`
2. Confirm the targeted validation passes:
   - `323 passed`
   - `1 skipped`
   - `0 failed`
3. For gateway behavior:
   - start the gateway with a valid configured model and confirm `BOOT.md` runs normally
   - start the gateway with no resolvable model and confirm the boot hook is skipped with a warning
   - set `HERMES_DISABLE_BOOT_MD=1` and confirm the built-in startup hook is not registered

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused validation result:
- `323 passed`
- `1 skipped`
- `0 failed`
