### PR TITLE
docs(cron): warn about delegate_task inactivity timeout in cron sessions

### DIFF
--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -22,6 +22,12 @@ Cron jobs can:
 Cron-run sessions cannot recursively create more cron jobs. Hermes disables cron management tools inside cron executions to prevent runaway scheduling loops.
 :::
 
+:::warning
+If your cron prompt triggers `delegate_task` (task delegation to a sub-agent), the parent cron session may be killed while the sub-agent is still working. The sub-agent's tool calls and API activity do not update the parent session's activity tracker, so the parent appears idle and is terminated after the inactivity timeout (default 600 seconds), killing both sessions.
+
+**Workaround:** Avoid `delegate_task` in cron job prompts. Put the full task directly in the cron prompt, or attach skills to provide needed context. If delegation is unavoidable, increase the timeout via the `HERMES_CRON_TIMEOUT` environment variable (e.g. `3600` for one hour, or `0` for unlimited).
+:::
+
 ## Creating scheduled tasks
 
 ### In chat with `/cron`


### PR DESCRIPTION
## Problem

When a cron job prompt triggers `delegate_task`, the parent cron session blocks waiting for the sub-agent to complete. However, the sub-agent's activity (tool calls, API calls, stream deltas) only updates its own activity tracker — it does not propagate back to the parent session. The parent's `seconds_since_activity` keeps climbing until the inactivity timeout (default 600s) kills both sessions.

This is a known gap between `cron/scheduler.py`'s inactivity detection loop (L671-708) and the `delegate_task` tool's activity scoping. Users who write cron prompts that involve delegation (e.g. "research X then summarize Y" patterns that trigger sub-agent dispatch) hit silent session kills with no clear error message pointing to the root cause.

## Fix

Add a :::warning admonition to the cron user guide documenting:
- The specific failure mode (parent appears idle → killed → sub-agent dies too)
- Workarounds: avoid delegate_task in cron, use skills instead, or increase `HERMES_CRON_TIMEOUT`

## Changes

- `website/docs/user-guide/features/cron.md` — added warning block after the existing "no recursive cron" warning (+6 lines)