### PR TITLE
feat(tools): integrate Metaso as web search backend and MCP toolset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,10 @@
 # Get at: https://parallel.ai
 # PARALLEL_API_KEY=
 
+# Metaso API Key - Chinese-optimized web search and content extraction
+# Get at: https://metaso.cn
+# METASO_API_KEY=
+
 # Firecrawl API Key - Web search, extract, and crawl
 # Get at: https://firecrawl.dev/
 # FIRECRAWL_API_KEY=

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -634,6 +634,10 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#   metaso:
+#     command: mcpm
+#     args: ["run", "metaso"]
+#     timeout: 60
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/docs/brainstorms/2026-04-09-metaso-web-search-integration-requirements.md
+++ b/docs/brainstorms/2026-04-09-metaso-web-search-integration-requirements.md
@@ -1,0 +1,82 @@
+---
+date: 2026-04-09
+topic: metaso-web-search-integration
+---
+
+# Metaso 搜索集成到 Hermes
+
+## Problem Frame
+
+Hermes 当前支持 4 个 Web 搜索后端（Exa、Firecrawl、Parallel、Tavily），但都需要海外 API Key。用户已有一个 metaso MCP 服务（通过 `mcpm run metaso` 运行），提供中文优化的搜索能力，但尚未接入 Hermes 的工具系统。
+
+**影响范围：** 所有使用 `web_search` / `web_extract` 工具的 Hermes 平台（CLI、Telegram、Discord 等），以及需要通过 MCP 使用 metaso 全部 6 个工具（含专题检索、AI 问答）的场景。
+
+## Requirements
+
+**Native Backend 集成**
+
+- R1. metaso 作为第 5 个 Web 搜索后端注册到 `web_tools.py`，与 Exa/Firecrawl/Parallel/Tavily 平级
+- R2. 支持通过 `~/.hermes/config.yaml` 的 `web.backend: metaso` 切换，也支持自动回退检测（无其他 API Key 时自动选中 metaso）
+- R3. `web_search` 工具调用 metaso API 时，输出格式与现有后端一致（`{success, data.web[]}` 统一结构），确保模型端无感知
+- R4. `web_extract` 工具走 metaso reader API，将 URL 列表转为 markdown 内容
+
+**MCP 工具集集成**
+
+- R5. Hermes 启动时通过 `mcpm run metaso` 发现并注册 metaso 的全部 6 个 MCP 工具（web_search、web_reader、chat、topic_list、topic_search、topic_file_content）
+- R6. MCP 工具独立 toolset（`mcp-metaso`），不影响现有 `web` toolset
+- R7. `mcp-metaso` toolset 自动注入到 `hermes-cli` 及所有 messaging platform toolsets 中
+
+**能力覆盖**
+
+- R8. metaso 的 6 种搜索 scope（webpage、document、paper、image、video、podcast）均可通过 MCP 工具访问；web_search 默认使用 webpage scope，与现有后端行为一致
+- R9. metaso chat（AI 问答）作为独立工具 `metaso_chat` 暴露，支持 fast/fast_thinking/ds-r1 三种模型
+- R10. metaso topic 功能（专题检索）作为独立工具暴露，用于深度领域研究
+
+## Success Criteria
+
+- [ ] `hermes tools` 设置中能看到 metaso 选项
+- [ ] 配置 `web.backend: metaso` 后 `web_search` 工具能正常返回搜索结果
+- [ ] MCP 模式下 6 个 metaso 工具可在 Hermes 对话中调用
+- [ ] 其他后端 API Key 存在时，metaso 不干扰现有优先级
+- [ ] 无其他 API Key 时，metaso 自动成为默认后端
+
+## Scope Boundaries
+
+- 不修改 metaso MCP server 本身（`mcpm run metaso` 已可用）
+- 不替换/删除现有 Exa/Firecrawl/Parallel/Tavily 后端
+- 不改动 Hermes 的工具注册表核心逻辑，仅扩展
+- API Key 通过环境变量 `METASO_API_KEY` 管理，与现有后端一致
+
+## Key Decisions
+
+**双路径集成**：同时支持 native backend（R1-R4）和 MCP 工具集（R5-R7）两种路径。Native backend 让 `web_search` 走 metaso 保持统一接口；MCP 工具集暴露 metaso 独有的高级功能（专题、AI 问答）。两者互补。用户明确选择此方案。
+
+**输出格式归一化**：metaso API 返回结构与 Hermes 现有后端不同，需要在 `web_tools.py` 中做适配层，转换为 `{success: true, data.web: [...]}` 格式。
+
+**MCP 工具自动发现**：利用 Hermes 已有的 `mcp_tool.py` 中的 `discover_mcp_tools()` 机制，在配置中声明 `mcpm run metaso` 作为 MCP server。
+
+**API Key 管理**：通过环境变量 `METASO_API_KEY` 读取，与 Exa/Firecrawl 等保持一致的配置风格。
+
+**默认 scope**：`web_search` 默认使用 webpage scope，与现有后端行为一致。image/video/podcast 等扩展 scope 通过 MCP 工具集暴露，不塞入 `web_search`。
+
+**REST API 验证**：规划阶段需先确认 metaso REST API（`/api/v1/search`、`/api/v1/reader`）的请求/响应格式，可通过 metaso 脚本反推。
+
+## Dependencies / Assumptions
+
+- `mcpm` CLI 已安装在系统中（当前 Claude Code 已通过 mcpm 使用 metaso）
+- metaso API key 通过环境变量 `METASO_API_KEY` 提供
+- metaso API 的 `/api/v1/search` 和 `/api/v1/reader` 端点稳定可用
+
+## Outstanding Questions
+
+### Resolve Before Planning
+（无 — 所有阻塞问题已解决）
+
+### Deferred to Planning
+- [Affects R5][技术] `mcpm run metaso` 作为 MCP server 的 stdio 通道在 Hermes 进程模型中如何管理？是每个 agent 实例独立启动还是复用？
+- [Affects R4][技术] metaso reader API 返回格式与 Firecrawl/Exa extract 不同，是否需要 LLM 二次摘要（现有 web_extract 用 OpenRouter 做摘要）？
+- [Affects R6][Needs research] Hermes 的 `hermes-cli` 等 toolset 如何注入 `mcp-metaso` toolset？用 `includes` 还是 `tools` 列表追加？
+
+## Next Steps
+
+→ /ce:plan 进行结构化实现规划

--- a/docs/plans/2026-04-09-001-feat-metaso-integration-plan.md
+++ b/docs/plans/2026-04-09-001-feat-metaso-integration-plan.md
@@ -1,0 +1,348 @@
+---
+title: "feat: Integrate Metaso as web search backend and MCP toolset"
+type: feat
+status: active
+date: 2026-04-09
+origin: docs/brainstorms/2026-04-09-metaso-web-search-integration-requirements.md
+---
+
+# Metaso 双路径集成实现规划
+
+## Overview
+
+将 metaso 以双路径集成到 Hermes：（1）作为第 5 个 native web backend，使 `web_search`/`web_extract` 可通过 `config.yaml` 切换到 metaso；（2）作为 MCP 工具集，暴露 metaso 的全部 6 个工具（search、reader、chat、topic_list、topic_search、topic_file_content）。
+
+## Problem Frame
+
+Hermes 当前 4 个 web 搜索后端（Exa、Firecrawl、Parallel、Tavily）均需要海外 API Key。中国地区用户无法使用 web 搜索功能。metaso（metaso.cn）提供中文优化的搜索、阅读、AI 问答能力，已有可用 MCP server（`mcpm run metaso`）和 REST API（`/api/v1/search`、`/api/v1/reader`、`/api/v1/chat/completions`），但尚未接入 Hermes 的工具系统。
+
+## Requirements Trace
+
+- R1. metaso 作为第 5 个 Web 搜索后端注册到 `web_tools.py` → Unit 1, 2
+- R2. 支持 `config.yaml` 的 `web.backend: metaso` 切换 + 自动回退 → Unit 1
+- R3. 输出格式归一化为 `{success, data.web[]}` → Unit 1
+- R4. `web_extract` 走 metaso reader API → Unit 2
+- R5. MCP 工具发现与注册 → Unit 3
+- R6. 独立 toolset `mcp-metaso` → Unit 3
+- R7. `mcp-metaso` 注入到 hermes-cli 及 messaging toolsets → Unit 4
+- R8. webpage 默认 scope，扩展 scope 走 MCP → Unit 1, 3
+- R9. metaso chat 作为独立 MCP 工具 → Unit 3
+- R10. metaso topic 功能作为独立 MCP 工具 → Unit 3
+
+## Scope Boundaries
+
+- 不修改 metaso MCP server 本身（`mcpm run metaso` 已可用）
+- 不替换/删除现有 Exa/Firecrawl/Parallel/Tavily 后端
+- 不改动 Hermes 工具注册表核心逻辑，仅扩展
+- image/video/podcast scope 通过 MCP 工具集暴露，不塞入 native `web_search`
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`tools/web_tools.py`** — 现有后端实现模板。`_exa_search()` 最接近 metaso（简单的 HTTP POST + JSON 归一化）
+- **`tools/registry.py`** — `registry.register()` 模式，`tool_error()`/`tool_result()` 辅助函数
+- **`tools/mcp_tool.py`** — `discover_mcp_tools()` 从 `~/.hermes/config.yaml` 读取 `mcp_servers` 配置，通过 stdio 连接 MCP server
+- **`toolsets.py`** — `TOOLSETS` dict + `_HERMES_CORE_TOOLS` 列表
+- **`hermes_cli/config.py`** — `load_config()` 读取 YAML，`OPTIONAL_ENV_VARS` 定义 API key 元数据
+- **`model_tools.py`** — `_discover_tools()` 中的 `_modules` 列表自动导入工具模块
+
+### Institutional Learnings
+
+- 需求文档已确认双路径策略、API Key 通过环境变量、默认 webpage scope
+- metaso API 使用 Bearer token 认证（`Authorization: Bearer {KEY}`）
+- metaso search API 的 scope 枚举：`webpage`、`document`、`paper`、`image`、`video`、`podcast`
+
+### External References
+
+- metaso API: `https://metaso.cn/api/v1/` (search, reader, chat/completions)
+- MCP SDK: Hermes 使用 `mcp` Python SDK 的 stdio transport
+
+## Key Technical Decisions
+
+- **Native backend 用 httpx 直接调用 REST API**（不通过 MCP SDK）：metaso REST API 已验证可用，httpx 调用比 MCP stdio 更轻量，且与现有 Exa/Tavily 后端风格一致。（see origin: docs/brainstorms/2026-04-09-metaso-web-search-integration-requirements.md）
+- **MCP 工具集通过 `mcpm run metaso` stdio 连接**：保留 metaso MCP server 的全部功能（topic 检索、AI 问答），复用 `discover_mcp_tools()` 现有机制。（see origin: origin doc）
+- **metaso 在自动回退链中优先级最低**：放在 Firecrawl > Parallel > Tavily > Exa 之后，确保不干扰现有配置
+- **metaso reader 返回 markdown**：`Accept: text/plain` header 直接获取 markdown，跳过 LLM 二次摘要（metaso 本身已做内容清洗）
+
+## Open Questions
+
+### Resolved During Planning
+
+- **metaso REST API 响应格式**：search API 的响应结构与现有后端不同，需要在 `_normalize_metaso_search_results()` 中做映射。从 metaso 脚本反推，搜索返回的结果包含 `url`、`title`、`snippet` 等字段，需归一化为 `{url, title, description, position}`。
+
+### Deferred to Implementation
+
+- **metaso search API 响应精确 schema**：脚本中用 `response.raise_for_status()` 但未记录完整响应体。实现时先用已知 API key 做一次真实请求验证，确认字段名。
+- **MCP stdio 多 session 复用**：`mcp_tool.py` 的 `_ensure_mcp_loop()` 使用单个后台线程管理所有 server 连接，metaso 作为标准 MCP server 配置即可共享连接，无需额外处理。
+- **metaso reader 对大页面的处理**：metaso reader 返回的 markdown 是否有长度限制？与现有 `web_extract` 的 ~5000 char 截断策略如何协调？实现时验证后决定。
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification.*
+
+### Native Backend Path (web_search / web_extract)
+
+```
+user query
+    │
+    ▼
+web_search_tool(query)
+    │ _get_backend() → "metaso"
+    ▼
+_metaso_search(query, limit)
+    │ httpx.post("https://metaso.cn/api/v1/search",
+    │   headers={"Authorization": f"Bearer {METASO_API_KEY}"},
+    │   json={"q": query, "scope": "webpage", "size": str(limit)})
+    ▼
+_normalize_metaso_search_results(response)
+    │ maps {url, title, snippet, ...} → {url, title, description, position}
+    ▼
+{"success": true, "data": {"web": [...]}}
+```
+
+### MCP Toolset Path
+
+```
+Hermes startup
+    │
+    ▼
+discover_mcp_tools()
+    │ reads mcp_servers from config.yaml:
+    │   metaso:
+    │     command: mcpm
+    │     args: ["run", "metaso"]
+    │
+    ▼
+MCP stdio subprocess (mcpm run metaso)
+    │
+    ▼
+6 tools registered:
+  mcp_metaso_web_search
+  mcp_metaso_web_reader
+  mcp_metaso_chat
+  mcp_metaso_topic_list
+  mcp_metaso_topic_search
+  mcp_metaso_topic_file_content
+```
+
+### Configuration Flow
+
+```
+~/.hermes/config.yaml
+    │
+    ├── web.backend: "metaso"     → _get_backend() returns "metaso"
+    │                                (需将 "metaso" 加入 _get_backend() 白名单)
+    ├── mcp_servers.metaso:       → discover_mcp_tools() connects
+    │     command: mcpm
+    │     args: ["run", "metaso"]
+    │
+    └── env: METASO_API_KEY       → _has_env("METASO_API_KEY")
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add metaso as native web_search backend**
+
+**Goal:** metaso 作为第 5 个后端接入 `web_search_tool()`，支持搜索查询归一化。
+
+**Requirements:** R1, R2, R3, R8
+
+**Dependencies:** 无（独立于 MCP 路径）
+
+**Files:**
+- Modify: `tools/web_tools.py`（核心：backend 逻辑 + search/extract + dispatch）
+- Test: `tests/test_web_tools.py`（如存在）或新建 `tests/test_metaso_backend.py`
+
+**Approach:**
+- 添加 `_has_metaso_env()` 检查 `METASO_API_KEY`
+- 添加 `_is_metaso_available()` 验证 API key 存在
+- 在 `_get_backend()` 的显式白名单中添加 `"metaso"`（line 91: `if configured in ("...", "metaso"):`）
+- 在 `_get_backend()` 的 fallback 链末尾添加 `("metaso", _has_metaso_env())`
+- 在 `_is_backend_available()` 中添加 `"metaso"` 分支
+- **修复默认回退**：line 107 的 `return "firecrawl"` 改为动态返回首个可用后端，确保无其他 Key 时 metaso 能被自动选中
+- 添加 `_metaso_search(query, limit)` 函数，调用 `POST https://metaso.cn/api/v1/search`
+- 添加 `_normalize_metaso_search_results(raw_response)` 将响应映射为 `{url, title, description, position}`
+- 在 `web_search_tool()` 的 dispatch 中添加 `if backend == "metaso"` 分支
+- 在 `check_web_api_key()` 中添加 metaso 支持（line ~1922）
+- 在 `_web_requires_env()` 中添加 `"METASO_API_KEY"`
+- **防御性归一化**：`_normalize_metaso_search_results()` 中验证期望字段存在，缺失时用 `tool_error()` 返回清晰错误而非静默返回空结果
+- 注意：`.env.example`、`cli-config.yaml.example`、`OPTIONAL_ENV_VARS` 由 Unit 4 负责
+
+**Patterns to follow:**
+- `_exa_search()` 的 HTTP 请求和归一化模式（最简洁的参考）
+- `_tavily_request()` 的 httpx 调用模式
+
+**Test scenarios:**
+- Happy path: 给定有效 METASO_API_KEY 和查询，返回 `{success: true, data.web: [...]}` 且每项包含 url/title/description
+- Edge case: limit=0 或 limit 超过 API 上限，行为正常
+- Edge case: 中文查询返回非空结果
+- Error path: 无效 API key 返回友好错误（不抛出未捕获异常）
+- Error path: 网络超时/连接失败的错误处理
+- Integration: `check_web_api_key()` 在仅设置 METASO_API_KEY 时返回 True
+
+**Verification:**
+- `python -c "from tools.web_tools import web_search_tool; print(web_search_tool('Python 教程'))"` 返回 JSON 且包含有效搜索结果
+
+- [ ] **Unit 2: Add metaso as native web_extract backend**
+
+**Goal:** `web_extract_tool()` 支持通过 metaso reader API 提取 URL 内容。
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1（共享 metaso 客户端和认证逻辑）
+
+**Files:**
+- Modify: `tools/web_tools.py`
+- Test: `tests/test_metaso_backend.py`
+
+**Approach:**
+- 添加 `_metaso_extract(urls)` 函数，对每个 URL 调用 `POST https://metaso.cn/api/v1/reader`（`Accept: text/plain`）
+- **URL 安全验证**：在传给 metaso reader 前验证每个 URL：仅允许 http/https 协议，拒绝私有 IP 段（10.x、172.16-31.x、192.168.x、127.x、localhost）
+- 返回格式归一化为 `{"results": [{url, title, content, error?}]}`，与现有 extract 一致
+- 在 `web_extract_tool()` 的 dispatch 中添加 metaso 分支
+- metaso reader 返回纯 markdown，跳过 LLM 二次摘要（metaso 已做内容清洗）；如果 metaso 返回内容超过现有 `DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION`（5000 chars），仍会进入辅助 LLM 管道，这是可接受的行为
+- 大页面处理：如果返回内容超过现有限制，保持截断策略与现有后端一致
+
+**Patterns to follow:**
+- `_parallel_extract()` 的 async URL 批处理模式
+- Firecrawl extract 的 markdown 返回格式
+
+**Test scenarios:**
+- Happy path: 给定有效 URL 列表，返回 markdown 内容
+- Edge case: 空 URL 列表，返回空结果
+- Error path: 无效 URL 或 404 页面，在结果中标记 error 字段
+- Error path: 非 HTTP 协议 URL（file://, localhost）的拒绝处理
+- Integration: web_extract 与 web_search 联用（搜索结果中的 URL 传给 extract）
+
+**Verification:**
+- `python -c "from tools.web_tools import web_extract_tool; ..."` 对已知 URL 返回可读 markdown 内容
+
+- [ ] **Unit 3: Configure metaso MCP server and expose tools**
+
+**Goal:** 通过 config.yaml 配置 metaso MCP server，使 6 个 metaso 工具被 `discover_mcp_tools()` 自动发现和注册。
+
+**Requirements:** R5, R6, R9, R10
+
+**Dependencies:** 无（与 native backend 路径并行独立）
+
+**Files:**
+- Modify: `cli-config.yaml.example`（添加 metaso MCP server 配置示例）
+- Modify: `hermes_cli/config.py`（如需要添加 mcpm 命令检测）
+- Test: `tests/test_mcp_tool.py`（如存在）
+
+**Approach:**
+- 在 `cli-config.yaml.example` 中添加 metaso MCP server 配置模板：
+  ```yaml
+  mcp_servers:
+    metaso:
+      command: mcpm
+      args: ["run", "metaso"]
+      timeout: 60
+  ```
+- 确认 `mcp_tool.py` 的 `_load_mcp_config()` 能正确读取此配置
+- 确认 `discover_mcp_tools()` 能自动发现并注册 6 个工具
+- 工具命名约定：`mcp_metaso_web_search`、`mcp_metaso_web_reader`、`mcp_metaso_chat` 等（注意：单下划线分隔，`mcp_tool.py` 使用 `f"mcp_{safe_server_name}_{safe_tool_name}"` 格式）
+- 自动创建 `mcp-metaso` toolset（`mcp_tool.py` 的 `create_custom_toolset()` 已支持）
+- 验证 `_sync_mcp_toolsets()` 自动将 `mcp_metaso_*` 工具注入所有 hermes-* toolset（line 1568-1574）
+
+**Test scenarios:**
+- Happy path: 配置 metaso MCP server 后，`discover_mcp_tools()` 返回 6 个工具名
+- Happy path: `resolve_toolset("hermes-cli")` 返回的结果包含 `mcp_metaso_*` 工具名
+- Edge case: `mcpm` 命令不在 PATH 中的错误处理
+- Edge case: MCP server 启动超时（connect_timeout）的错误传播
+- Integration: 通过 Hermes 对话调用 `mcp_metaso_chat` 并获取 AI 问答结果
+
+**Verification:**
+- Hermes 启动日志中显示 MCP 工具注册成功
+- `python -c "from toolsets import resolve_toolset; print(resolve_toolset('hermes-cli'))"` 包含 `mcp_metaso_` 工具名
+
+**Patterns to follow:**
+- 现有 `cli-config.yaml.example` 中的 MCP server 配置格式
+- `mcp_tool.py` 中其他 MCP server 的注册模式
+
+**Test scenarios:**
+- Happy path: 配置 metaso MCP server 后，`discover_mcp_tools()` 返回 6 个工具名
+- Edge case: `mcpm` 命令不在 PATH 中的错误处理
+- Edge case: MCP server 启动超时（connect_timeout）的错误传播
+- Integration: 通过 Hermes 对话调用 `mcp__metaso__chat` 并获取 AI 问答结果
+
+**Verification:**
+- Hermes 启动日志中显示 "Registered 6 MCP tools from metaso server"
+- 在 Hermes 对话中能调用 `mcp__metaso__web_search` 并获取结果
+
+- [ ] **Unit 4: Update configuration wizard and documentation**
+
+**Goal:** `hermes tools` 设置向导支持 metaso 选项，`.env.example` 和 `cli-config.yaml.example` 更新。
+
+**Requirements:** R2（success criteria: hermes tools 设置中能看到 metaso 选项）
+
+**Dependencies:** Unit 1, 3
+
+**Files:**
+- Modify: `hermes_cli/config.py`（OPTIONAL_ENV_VARS 添加 METASO_API_KEY，注意：此条目也是 Unit 1 的功能依赖，但实际添加工作由 Unit 5 完成）
+- Modify: `.env.example`
+- Modify: `cli-config.yaml.example`
+- Modify: `hermes_cli/` 中 tools 设置相关代码（如 `hermes tools` 命令的 backend 选择菜单）
+
+**Approach:**
+- 在 `OPTIONAL_ENV_VARS` 中添加 metaso 条目：
+  ```python
+  "METASO_API_KEY": {
+      "description": "Metaso API key for Chinese-optimized web search",
+      "prompt": "Metaso API key",
+      "url": "https://metaso.cn",
+      "password": True,
+      "category": "tool",
+  }
+  ```
+- 在 `.env.example` 中添加 `METASO_API_KEY=mk-xxxxxxxxx` 的注释行
+- 在 `cli-config.yaml.example` 的 `web:` 部分添加 `metaso` 作为 backend 选项注释
+- 在 `cli-config.yaml.example` 的 `mcp_servers:` 部分添加 metaso 配置示例
+- 更新 `hermes tools` 交互菜单的 backend 选项列表（搜索 `hermes tools` 相关代码找到具体文件）
+
+**Test scenarios:**
+- Happy path: `hermes tools` 命令显示 metaso 作为可选后端
+- Happy path: 设置 web.backend=metaso 并配置 METASO_API_KEY 后，web_search 工作正常
+
+**Verification:**
+- `hermes tools` 交互菜单中显示 metaso 选项
+- `.env.example` 和 `cli-config.yaml.example` 中包含 metaso 配置示例
+
+## System-Wide Impact
+
+- **Interaction graph:** `web_search` 和 `web_extract` 的行为在 metaso backend 下保持一致接口，模型端无需修改调用方式。MCP 路径新增 6 个工具，模型可选择性使用。
+- **Error propagation:** metaso API 错误通过 `tool_error()` 返回 JSON，与现有模式一致。网络超时通过 httpx 的 `TimeoutException` 捕获并转换为工具错误。
+- **State lifecycle risks:** 无状态变更，纯查询操作。
+- **API surface parity:** `web_search` 和 `web_extract` 的输入输出 schema 不变。MCP 工具是新增表面，不影响现有工具。
+- **Integration coverage:** 关键场景是 native backend 和 MCP 工具集都能独立工作，互不干扰。
+- **Unchanged invariants:** Exa/Firecrawl/Parallel/Tavily 后端的行为和优先级不受影响。`check_web_api_key()` 在 metaso 未配置时仍能正确检测其他后端。
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| metaso REST API 响应格式与预期不符 | Medium | High | Unit 1 先用真实请求验证响应 schema；归一化层做字段验证，缺失时返回清晰错误 |
+| `_get_backend()` 硬编码 firecrawl 默认值，metaso 无法自动回退 | Medium | Medium | Unit 1 已包含修复：将 line 107 改为动态返回首个可用后端 |
+| `mcpm` CLI 不在 PATH 中导致 MCP 工具发现失败 | Medium | Medium | MCP 路径是增强功能，失败不影响 native backend；`discover_mcp_tools()` 已有错误处理；需在文档中注明 `mcpm` 安装前提 |
+| metaso API 速率限制 | Medium | Medium | 通过 httpx timeout 配置控制，与现有后端一致；后续可加请求缓存 |
+| MCP stdio 多 session 并发冲突 | Low | High | `mcp_tool.py` 已有单例连接管理，复用同一 stdio 通道 |
+| 中文内容在 ensure_ascii=False 时编码异常 | Low | Low | 现有 `json.dumps(..., ensure_ascii=False)` 已支持 Unicode，与其他后端一致 |
+
+## Documentation / Operational Notes
+
+- 更新 `.env.example` 和 `cli-config.yaml.example` 中的 metaso 配置示例
+- 在 README 或 docs 中添加 metaso 集成的简短说明（如果 Hermes 有集成文档）
+- 无需数据库迁移或回滚计划
+- 无需监控或告警配置（个人使用场景）
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-09-metaso-web-search-integration-requirements.md](docs/brainstorms/2026-04-09-metaso-web-search-integration-requirements.md)
+- **metaso API 参考:** `/Users/xuxukang/.agents/skills/metaso/references/api-reference.md`
+- **现有后端模式:** `tools/web_tools.py` 中的 `_exa_search()`、`_tavily_request()`
+- **MCP 工具发现:** `tools/mcp_tool.py` 中的 `discover_mcp_tools()`、`register_mcp_servers()`
+- **Toolset 系统:** `toolsets.py` 中的 `TOOLSETS`、`resolve_toolset()`
+- **配置系统:** `hermes_cli/config.py` 中的 `load_config()`、`OPTIONAL_ENV_VARS`
+- **工具注册模式:** `tools/registry.py` 中的 `registry.register()`
+- **工具开发指南:** `AGENTS.md` 中的 "Adding New Tools" 章节

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -834,6 +834,14 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
+    "METASO_API_KEY": {
+        "description": "Metaso API key for Chinese-optimized web search, content extraction, and AI Q&A",
+        "prompt": "Metaso API key",
+        "url": "https://metaso.cn",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
     "FIRECRAWL_GATEWAY_URL": {
         "description": "Exact Firecrawl tool-gateway origin override for Nous Subscribers only (optional)",
         "prompt": "Firecrawl gateway URL (leave empty to derive from domain)",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -229,6 +229,14 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "Metaso",
+                "tag": "Chinese-optimized web search and content extraction",
+                "web_backend": "metaso",
+                "env_vars": [
+                    {"key": "METASO_API_KEY", "prompt": "Metaso API key", "url": "https://metaso.cn"},
+                ],
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "tag": "Free - run your own instance",
                 "web_backend": "firecrawl",

--- a/tests/tools/test_web_tools_metaso.py
+++ b/tests/tools/test_web_tools_metaso.py
@@ -1,0 +1,170 @@
+"""Tests for Metaso web backend integration.
+
+Coverage:
+  _metaso_search() — HTTP request construction, result normalization
+  _metaso_extract() — reader API, error handling
+  _is_backend_available() — metaso branch
+  _get_backend() — metaso config selection and fallback
+  check_web_api_key() — metaso availability
+  web_search_tool() — metaso dispatch
+"""
+
+import json
+import os
+from unittest.mock import patch
+
+
+class TestMetasoBackendSelection:
+    """Test _get_backend() with metaso."""
+
+    def setup_method(self):
+        for key in (
+            "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+            "EXA_API_KEY", "PARALLEL_API_KEY", "TAVILY_API_KEY",
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+            "METASO_API_KEY",
+        ):
+            os.environ.pop(key, None)
+
+    def teardown_method(self):
+        self.setup_method()
+
+    def test_config_metaso(self):
+        """web.backend=metaso → 'metaso' regardless of other keys."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "metaso"}):
+            assert _get_backend() == "metaso"
+
+    def test_config_metaso_case_insensitive(self):
+        """web.backend=Metaso → 'metaso'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "Metaso"}):
+            assert _get_backend() == "metaso"
+
+    def test_fallback_metaso_only_key(self):
+        """Only METASO_API_KEY set → 'metaso'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}):
+            with patch.dict(os.environ, {"METASO_API_KEY": "mk-test"}):
+                assert _get_backend() == "metaso"
+
+    def test_fallback_firecrawl_takes_priority_over_metaso(self):
+        """Both FIRECRAWL_API_KEY and METASO_API_KEY → 'firecrawl' (higher priority)."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}):
+            with patch.dict(os.environ, {
+                "FIRECRAWL_API_KEY": "fc-test",
+                "METASO_API_KEY": "mk-test",
+            }):
+                assert _get_backend() == "firecrawl"
+
+
+class TestMetasoBackendAvailability:
+    """Test _is_backend_available() for metaso."""
+
+    def setup_method(self):
+        os.environ.pop("METASO_API_KEY", None)
+
+    def teardown_method(self):
+        os.environ.pop("METASO_API_KEY", None)
+
+    def test_metaso_available_with_key(self):
+        from tools.web_tools import _is_backend_available
+        with patch.dict(os.environ, {"METASO_API_KEY": "mk-test"}):
+            assert _is_backend_available("metaso") is True
+
+    def test_metaso_unavailable_without_key(self):
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("metaso") is False
+
+
+class TestMetasoNormalizeResults:
+    """Test _normalize_metaso_search_results() defensive mapping."""
+
+    def test_standard_data_shape(self):
+        from tools.web_tools import _normalize_metaso_search_results
+        raw = {
+            "data": [
+                {"url": "https://a.com", "title": "A", "snippet": "Snip A"},
+                {"url": "https://b.com", "title": "B", "description": "Desc B"},
+            ]
+        }
+        result = _normalize_metaso_search_results(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0] == {"title": "A", "url": "https://a.com", "description": "Snip A", "position": 1}
+        assert web[1] == {"title": "B", "url": "https://b.com", "description": "Desc B", "position": 2}
+
+    def test_results_shape(self):
+        """Alternative response shape with 'results' key."""
+        from tools.web_tools import _normalize_metaso_search_results
+        raw = {
+            "results": [
+                {"url": "https://x.com", "title": "X", "summary": "Sum X"},
+            ]
+        }
+        result = _normalize_metaso_search_results(raw)
+        assert result["success"] is True
+        assert result["data"]["web"][0]["description"] == "Sum X"
+
+    def test_empty_results_returns_success(self):
+        """No results → success with empty list (not an error)."""
+        from tools.web_tools import _normalize_metaso_search_results
+        raw = {"data": []}
+        result = _normalize_metaso_search_results(raw)
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_unexpected_format_returns_error(self):
+        """Completely unexpected structure → tool_error."""
+        from tools.web_tools import _normalize_metaso_search_results
+        raw = {"status": "error", "message": "bad request"}
+        result = _normalize_metaso_search_results(raw)
+        # tool_error returns a JSON string, not a dict
+        parsed = json.loads(result) if isinstance(result, str) else result
+        assert parsed.get("success") is not True
+
+    def test_missing_fields_handled_gracefully(self):
+        """Items with missing url/title/description → empty strings."""
+        from tools.web_tools import _normalize_metaso_search_results
+        raw = {"data": [{"foo": "bar"}]}
+        result = _normalize_metaso_search_results(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 1
+        assert web[0]["url"] == ""
+        assert web[0]["title"] == ""
+        assert web[0]["description"] == ""
+
+
+class TestMetasoCheckWebApiKey:
+    """Test check_web_api_key() with metaso."""
+
+    def setup_method(self):
+        for key in (
+            "EXA_API_KEY", "PARALLEL_API_KEY", "TAVILY_API_KEY",
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+            "METASO_API_KEY",
+        ):
+            os.environ.pop(key, None)
+
+    def teardown_method(self):
+        self.setup_method()
+
+    def test_metaso_key_only_returns_true(self):
+        with patch.dict(os.environ, {"METASO_API_KEY": "mk-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_no_keys_still_false(self):
+        from tools.web_tools import check_web_api_key
+        assert check_web_api_key() is False
+
+
+class TestMetasoWebRequiresEnv:
+    """Test _web_requires_env() includes METASO_API_KEY."""
+
+    def test_metaso_key_in_requires_env(self):
+        from tools.web_tools import _web_requires_env
+        assert "METASO_API_KEY" in _web_requires_env()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -17,6 +17,7 @@ Backend compatibility:
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
 - Tavily: https://tavily.com (search, extract, crawl)
+- Metaso: https://metaso.cn (search, extract — Chinese-optimized web search)
 
 LLM Processing:
 - Uses OpenRouter API with Gemini 3 Flash Preview for intelligent content extraction
@@ -88,7 +89,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "metaso"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -99,6 +100,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("metaso", _has_env("METASO_API_KEY")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -117,6 +119,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "metaso":
+        return _has_env("METASO_API_KEY")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -189,6 +193,7 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "METASO_API_KEY",
     ]
     if managed_nous_tools_enabled():
         requires.extend(
@@ -282,6 +287,188 @@ def _get_async_parallel_client():
 # ─── Tavily Client ───────────────────────────────────────────────────────────
 
 _TAVILY_BASE_URL = "https://api.tavily.com"
+_METASO_BASE_URL = "https://metaso.cn/api/v1"
+_METASO_API_KEY = None
+_METASO_HTTPX_CLIENT = None
+
+
+def _get_metaso_api_key() -> str:
+    """Return the Metaso API key, raising if unset."""
+    global _METASO_API_KEY
+    if _METASO_API_KEY is not None:
+        return _METASO_API_KEY
+    key = os.getenv("METASO_API_KEY", "").strip()
+    if not key:
+        raise ValueError(
+            "METASO_API_KEY environment variable not set. "
+            "Get your API key at https://metaso.cn"
+        )
+    _METASO_API_KEY = key
+    return key
+
+
+def _get_metaso_httpx_client() -> httpx.Client:
+    """Get or create a cached httpx client for Metaso API calls."""
+    global _METASO_HTTPX_CLIENT
+    if _METASO_HTTPX_CLIENT is None:
+        _METASO_HTTPX_CLIENT = httpx.Client(timeout=60)
+    return _METASO_HTTPX_CLIENT
+
+
+def _metaso_search(query: str, limit: int = 10) -> dict:
+    """Search using the Metaso REST API and return normalized results."""
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return {"error": "Interrupted", "success": False}
+
+    logger.info("Metaso search: '%s' (limit=%d)", query, limit)
+    api_key = _get_metaso_api_key()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "q": query,
+        "scope": "webpage",
+        "size": str(min(limit, 20)),
+    }
+
+    client = _get_metaso_httpx_client()
+    url = f"{_METASO_BASE_URL}/search"
+    response = client.post(url, headers=headers, json=payload)
+    response.raise_for_status()
+    raw = response.json()
+    return _normalize_metaso_search_results(raw)
+
+
+def _normalize_metaso_search_results(raw: dict) -> dict:
+    """Normalize Metaso search response to the standard web search format.
+
+    Expected Metaso response (inferred from API docs and scripts):
+    {
+        "data": [
+            {
+                "url": "...",
+                "title": "...",
+                "snippet": "...",
+                "description": "...",
+                ...
+            }
+        ],
+        ...
+    }
+    Maps to: {success: true, data: {web: [{title, url, description, position}]}}.
+    Defensively validates expected fields — returns tool_error on missing data.
+    """
+    # Try multiple possible response shapes — check key existence, not just default value
+    results_list: list | None = None
+    if isinstance(raw, dict):
+        if "data" in raw:
+            results_list = raw["data"]
+        elif "results" in raw:
+            results_list = raw["results"]
+        elif "web" in raw:
+            results_list = raw["web"]
+
+        if results_list is not None and not isinstance(results_list, list):
+            return tool_error(f"Metaso returned unexpected response format: {json.dumps(raw, ensure_ascii=False)[:500]}")
+
+    if results_list is None:
+        return tool_error(f"Metaso returned unexpected response format: {json.dumps(raw, ensure_ascii=False)[:500]}")
+
+    web_results = []
+    for i, item in enumerate(results_list):
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url", "")
+        title = item.get("title", "")
+        # Try multiple field names for description/snippet
+        description = (
+            item.get("snippet", "")
+            or item.get("description", "")
+            or item.get("summary", "")
+            or item.get("content", "")
+        )
+        web_results.append({
+            "title": title,
+            "url": url,
+            "description": description,
+            "position": i + 1,
+        })
+
+    if not web_results:
+        # Return success with empty results rather than an error — the query
+        # may simply have no matches.
+        return {"success": True, "data": {"web": []}}
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _metaso_extract(urls: List[str]) -> List[Dict[str, Any]]:
+    """Extract content from URLs using the Metaso reader API.
+
+    Returns a list of result dicts matching the structure expected by the
+    LLM post-processing pipeline (url, title, content, metadata).
+    """
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+    api_key = _get_metaso_api_key()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "text/plain",  # Request markdown output
+    }
+
+    results: List[Dict[str, Any]] = []
+    client = _get_metaso_httpx_client()
+
+    for url in urls:
+        try:
+            logger.info("Metaso reader: %s", url)
+            response = client.post(
+                f"{_METASO_BASE_URL}/reader",
+                headers=headers,
+                json={"url": url},
+            )
+            response.raise_for_status()
+            content = response.text
+
+            # Try to extract title from first line if it looks like a heading
+            title = ""
+            lines = content.split("\n", 3)
+            for line in lines:
+                stripped = line.strip()
+                if stripped.startswith("# "):
+                    title = stripped[2:].strip()
+                    break
+
+            results.append({
+                "url": url,
+                "title": title,
+                "content": content,
+                "raw_content": content,
+                "metadata": {"sourceURL": url, "title": title},
+            })
+        except httpx.HTTPStatusError as e:
+            logger.warning("Metaso reader HTTP error for %s: %s", url, e)
+            results.append({
+                "url": url,
+                "title": "",
+                "content": "",
+                "error": f"Metaso reader error: HTTP {e.response.status_code}",
+            })
+        except Exception as e:
+            logger.warning("Metaso reader error for %s: %s", url, e)
+            results.append({
+                "url": url,
+                "title": "",
+                "content": "",
+                "error": f"Metaso reader error: {str(e)}",
+            })
+
+    return results
 
 
 def _tavily_request(endpoint: str, payload: dict) -> dict:
@@ -1117,6 +1304,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "metaso":
+            response_data = _metaso_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
 
         response = _get_firecrawl_client().search(
@@ -1249,6 +1445,9 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "metaso":
+                logger.info("Metaso extract: %d URL(s)", len(safe_urls))
+                results = _metaso_extract(safe_urls)
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
@@ -1539,6 +1738,13 @@ async def web_crawl_tool(
         effective_model = model or _get_default_summarizer_model()
         auxiliary_available = check_auxiliary_model()
         backend = _get_backend()
+
+        # Metaso does not support crawl — suggest alternative
+        if backend == "metaso":
+            return json.dumps({
+                "error": "web_crawl is not supported by the Metaso backend. Use web_search + web_extract instead, or switch to a backend that supports crawling (Firecrawl or Tavily).",
+                "success": False,
+            }, ensure_ascii=False)
 
         # Tavily supports crawl via its /crawl endpoint
         if backend == "tavily":
@@ -1919,9 +2125,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "metaso"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "metaso"))
 
 
 def check_auxiliary_model() -> bool:
@@ -1959,6 +2165,8 @@ if __name__ == "__main__":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
+        elif backend == "metaso":
+            print("   Using Metaso API (https://metaso.cn)")
         else:
             if firecrawl_url_available:
                 print(f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}")
@@ -1971,7 +2179,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL, or METASO_API_KEY"
             f"{_firecrawl_backend_help_suffix()}"
         )
 


### PR DESCRIPTION
## Summary

Integrate [Metaso](https://metaso.cn) as the 5th native web search backend for Chinese-optimized search, content extraction, and AI Q&A.

## Problem

Chinese users cannot use existing web search backends (Exa, Firecrawl, Parallel, Tavily) without overseas API keys.

## Solution

**Dual-path integration:**
1. **Native backend** — / via Metaso REST API (httpx), consistent with existing backend patterns
2. **MCP toolset** — 6 tools via `mcpm run metaso` (search, reader, chat, topic_list, topic_search, topic_file_content)

## Changes

- `tools/web_tools.py` — Metaso client, search, extract, response normalization
- `hermes_cli/config.py` — OPTIONAL_ENV_VARS for METASO_API_KEY
- `hermes_cli/tools_config.py` — Setup wizard Metaso option
- `.env.example`, `cli-config.yaml.example` — Configuration examples
- `tests/tools/test_web_tools_metaso.py` — Unit tests

## Config

```yaml
# ~/.hermes/config.yaml
web:
  backend: metaso

# .env
METASO_API_KEY=mk-your-key
```
