### PR TITLE
fix(webhook): require explicit opt-in for INSECURE_NO_AUTH to prevent unintended RCE

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -113,6 +113,21 @@ class WebhookAdapter(BasePlatformAdapter):
                     f"Set 'secret' on the route or globally. "
                     f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
                 )
+            if secret == _INSECURE_NO_AUTH:
+                import os as _os
+                if not _os.getenv("HERMES_ALLOW_INSECURE_WEBHOOKS"):
+                    raise ValueError(
+                        f"[webhook] Route '{name}' uses {_INSECURE_NO_AUTH} which disables "
+                        "all authentication and enables unauthenticated RCE. "
+                        "Set HERMES_ALLOW_INSECURE_WEBHOOKS=1 to allow this in testing only. "
+                        "NEVER use this in production."
+                    )
+                logger.warning(
+                    "[webhook] SECURITY WARNING: Route '%s' has %s — "
+                    "ALL requests accepted without HMAC verification! "
+                    "This is for local testing only.",
+                    name, _INSECURE_NO_AUTH,
+                )
 
         app = web.Application()
         app.router.add_get("/health", self._handle_health)


### PR DESCRIPTION
Fixes #6440

INSECURE_NO_AUTH now requires HERMES_ALLOW_INSECURE_WEBHOOKS=1 env var at startup, otherwise raises ValueError. Emits a loud WARNING when enabled. Prevents unauthenticated RCE in production deployments.