### PR TITLE
feat(model): add Z.AI Coding endpoint selection under Z.AI provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -831,6 +831,9 @@ def resolve_provider(
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
+        # Backward-compat aliases for the old standalone Z.AI Coding provider.
+        "zai-coding": "zai", "z-coding": "zai", "z.ai-coding": "zai",
+        "glm-coding": "zai", "zhipu-coding": "zai",
         # Local server aliases — route through the generic custom provider
         "lmstudio": "custom", "lm-studio": "custom", "lm_studio": "custom",
         "ollama": "custom", "vllm": "custom", "llamacpp": "custom",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2296,20 +2296,76 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         print(f"  {pconfig.name} API key: {existing_key[:8]}... ✓")
         print()
 
-    # Optional base URL override
+    # Base URL selection / override
     current_base = ""
     if base_url_env:
         current_base = get_env_value(base_url_env) or os.getenv(base_url_env, "")
     effective_base = current_base or pconfig.inference_base_url
 
-    try:
-        override = input(f"Base URL [{effective_base}]: ").strip()
-    except (KeyboardInterrupt, EOFError):
+    if provider_id == "zai" and base_url_env:
+        endpoint_choices = [
+            ("Auto-detect endpoint (recommended)", ""),
+            ("Z.AI Global (General) — https://api.z.ai/api/paas/v4", "https://api.z.ai/api/paas/v4"),
+            ("Z.AI Global (Coding) — https://api.z.ai/api/coding/paas/v4", "https://api.z.ai/api/coding/paas/v4"),
+            ("Z.AI China (General) — https://open.bigmodel.cn/api/paas/v4", "https://open.bigmodel.cn/api/paas/v4"),
+            ("Z.AI China (Coding) — https://open.bigmodel.cn/api/coding/paas/v4", "https://open.bigmodel.cn/api/coding/paas/v4"),
+            ("Custom base URL...", None),
+            (f"Keep current ({effective_base})", "__keep__"),
+        ]
+
+        normalized_current_base = current_base.rstrip("/") if current_base else ""
+        default_choice = "1" if not normalized_current_base else "7"
+        if normalized_current_base:
+            for idx, (_label, value) in enumerate(endpoint_choices, start=1):
+                if isinstance(value, str) and value not in {"", "__keep__"}:
+                    if normalized_current_base == value.rstrip("/"):
+                        default_choice = str(idx)
+                        break
+
+        print("  Select Z.AI endpoint:")
+        for idx, (label, _value) in enumerate(endpoint_choices, start=1):
+            print(f"    {idx}. {label}")
         print()
-        override = ""
-    if override and base_url_env:
-        save_env_value(base_url_env, override)
-        effective_base = override
+
+        try:
+            endpoint_choice = input(f"  Choice [1-7] ({default_choice}): ").strip() or default_choice
+        except (KeyboardInterrupt, EOFError):
+            print()
+            endpoint_choice = default_choice
+
+        if endpoint_choice not in {"1", "2", "3", "4", "5", "6", "7"}:
+            endpoint_choice = default_choice
+
+        selected_value = endpoint_choices[int(endpoint_choice) - 1][1]
+
+        if selected_value == "":
+            save_env_value(base_url_env, "")
+            effective_base = pconfig.inference_base_url
+            print("  Using auto-detected Z.AI endpoint.")
+        elif selected_value is None:
+            try:
+                override = input(f"  Custom base URL [{effective_base}]: ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                override = ""
+            if override:
+                save_env_value(base_url_env, override)
+                effective_base = override
+        elif selected_value == "__keep__":
+            pass
+        else:
+            save_env_value(base_url_env, selected_value)
+            effective_base = selected_value
+        print()
+    else:
+        try:
+            override = input(f"Base URL [{effective_base}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            override = ""
+        if override and base_url_env:
+            save_env_value(base_url_env, override)
+            effective_base = override
 
     # Model selection — resolution order:
     #   1. models.dev registry (cached, filtered for agentic/tool-capable models)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -493,6 +493,12 @@ _PROVIDER_ALIASES = {
     "z-ai": "zai",
     "z.ai": "zai",
     "zhipu": "zai",
+    # Backward-compat aliases for the former standalone Z.AI Coding entry.
+    "zai-coding": "zai",
+    "z-coding": "zai",
+    "z.ai-coding": "zai",
+    "glm-coding": "zai",
+    "zhipu-coding": "zai",
     "github": "copilot",
     "github-copilot": "copilot",
     "github-models": "copilot",

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -161,6 +161,15 @@ class TestResolveProvider:
     def test_alias_z_ai(self):
         assert resolve_provider("z-ai") == "zai"
 
+    def test_alias_glm_coding(self):
+        assert resolve_provider("glm-coding") == "zai"
+
+    def test_alias_zai_coding(self):
+        assert resolve_provider("zai-coding") == "zai"
+
+    def test_alias_z_coding(self):
+        assert resolve_provider("z-coding") == "zai"
+
     def test_alias_zhipu(self):
         assert resolve_provider("zhipu") == "zai"
 

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -257,3 +257,52 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("provider") == "opencode-go"
         assert model.get("default") == "minimax-m2.5"
         assert model.get("api_mode") == "anthropic_messages"
+
+    def test_zai_coding_endpoint_selection_persists_base_url(self, config_home, monkeypatch):
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        monkeypatch.setenv("GLM_API_KEY", "glm-test-key")
+
+        with patch("agent.models_dev.list_agentic_models", return_value=[]), \
+             patch("hermes_cli.models.fetch_api_models", return_value=[]), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-4.7"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value="3"):
+            _model_flow_api_key_provider(load_config(), "zai", "glm-5")
+
+        import yaml
+        from hermes_cli.config import get_env_value
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("provider") == "zai"
+        assert model.get("default") == "glm-4.7"
+        assert model.get("base_url") == "https://api.z.ai/api/coding/paas/v4"
+        assert get_env_value("GLM_BASE_URL") == "https://api.z.ai/api/coding/paas/v4"
+
+    def test_zai_auto_detect_choice_clears_base_url_override(self, config_home, monkeypatch):
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        monkeypatch.setenv("GLM_API_KEY", "glm-test-key")
+        monkeypatch.setenv("GLM_BASE_URL", "https://custom.example/v4")
+
+        with patch("agent.models_dev.list_agentic_models", return_value=[]), \
+             patch("hermes_cli.models.fetch_api_models", return_value=[]), \
+             patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
+             patch("hermes_cli.auth.deactivate_provider"), \
+             patch("builtins.input", return_value="1"):
+            _model_flow_api_key_provider(load_config(), "zai", "glm-4.7")
+
+        import yaml
+        from hermes_cli.config import get_env_value
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("provider") == "zai"
+        assert model.get("default") == "glm-5"
+        assert model.get("base_url") == "https://api.z.ai/api/paas/v4"
+        assert get_env_value("GLM_BASE_URL") == ""


### PR DESCRIPTION
## Summary
Add Z.AI Coding endpoint selection as a sub-option under the existing Z.AI provider, so users can choose between General and Coding endpoints (Global + China) during `hermes model` setup.

## Context
Z.AI offers separate API endpoints for General and Coding use cases, across Global and China regions. Previously, users had to manually set `GLM_BASE_URL` to use the Coding endpoint (`https://api.z.ai/api/coding/paas/v4`). This PR surfaces all four endpoint variants as first-class choices in the interactive model selection flow.

## Changes

### Endpoint selection menu (`hermes_cli/main.py`)
When the user selects Z.AI as their provider via `hermes model`, the base URL prompt is replaced with a numbered endpoint picker:
1. Auto-detect endpoint (recommended) — lets the existing probe logic decide
2. Z.AI Global (General) — `https://api.z.ai/api/paas/v4`
3. Z.AI Global (Coding) — `https://api.z.ai/api/coding/paas/v4`
4. Z.AI China (General) — `https://open.bigmodel.cn/api/paas/v4`
5. Z.AI China (Coding) — `https://open.bigmodel.cn/api/coding/paas/v4`
6. Custom base URL...
7. Keep current

The selection is persisted to `GLM_BASE_URL` in `.env` and `model.base_url` in `config.yaml`. Choosing "Auto-detect" clears any previous override.

### Backward-compatible alias resolution (`hermes_cli/auth.py`, `hermes_cli/models.py`)
The aliases `zai-coding`, `z-coding`, `glm-coding`, `zhipu-coding`, and `z.ai-coding` all resolve to the `zai` provider. This ensures that any existing config or CLI usage referencing the old standalone "Z.AI Coding" concept continues to work.

### Tests
- Alias resolution tests: verify all coding aliases map to `zai`
- Endpoint persistence tests: verify that selecting the Coding endpoint correctly persists `GLM_BASE_URL` and `model.base_url`, and that selecting Auto-detect clears the override

## Testing
```bash
# Run targeted tests
python -m pytest tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_model_provider_persistence.py -q

# Manual verification
hermes model
# Select "Z.AI / GLM" provider
# Choose option 3 (Z.AI Global Coding)
# Verify GLM_BASE_URL is set in ~/.hermes/.env
```

## Files Changed
- `hermes_cli/main.py` — Z.AI endpoint selection menu in `_model_flow_api_key_provider()`
- `hermes_cli/auth.py` — backward-compat aliases in `resolve_provider()`
- `hermes_cli/models.py` — matching aliases in `_PROVIDER_ALIASES`
- `tests/hermes_cli/test_api_key_providers.py` — alias resolution tests
- `tests/hermes_cli/test_model_provider_persistence.py` — endpoint selection persistence tests
