### PR TITLE
fix(gateway): write home channel to .env instead of config.yaml

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4027,16 +4027,12 @@ class GatewayRunner:
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
         
-        # Save to config.yaml
+        # Save to .env (the canonical location for platform credentials/IDs).
+        # Previously this wrote to config.yaml, which is wrong — env-style
+        # variables belong in .env so they are loaded by dotenv on startup.
         try:
-            import yaml
-            config_path = _hermes_home / 'config.yaml'
-            user_config = {}
-            if config_path.exists():
-                with open(config_path, encoding="utf-8") as f:
-                    user_config = yaml.safe_load(f) or {}
-            user_config[env_key] = chat_id
-            atomic_yaml_write(config_path, user_config)
+            from hermes_cli.config import save_env_value
+            save_env_value(env_key, str(chat_id))
             # Also set in the current environment so it takes effect immediately
             os.environ[env_key] = str(chat_id)
         except Exception as e:

--- a/tests/gateway/test_sethome_command.py
+++ b/tests/gateway/test_sethome_command.py
@@ -1,0 +1,60 @@
+"""Test /sethome writes to .env, not config.yaml."""
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with minimal config."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: test\n")
+    (home / ".env").write_text("# env\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+class TestSethomeWritesToEnv:
+    """Regression: /sethome must write HOME_CHANNEL to .env, not config.yaml."""
+
+    @pytest.mark.asyncio
+    async def test_sethome_writes_env_not_yaml(self, hermes_home, monkeypatch):
+        """Verify save_env_value is called with the right key/value."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+
+        source = MagicMock()
+        source.platform.value = "discord"
+        source.chat_id = "123456789"
+        source.chat_name = "general"
+
+        event = MagicMock()
+        event.source = source
+
+        with patch("gateway.run.save_env_value", create=True) as mock_save, \
+             patch.dict(os.environ, {}, clear=False):
+            # Inline the import so the patched version is used
+            import gateway.run as gw_mod
+            original = gw_mod.GatewayRunner._handle_sethome_command
+
+            # Call with the mock
+            with patch("hermes_cli.config.save_env_value") as mock_save_env:
+                result = await original(runner, event)
+
+            assert "✅" in result
+            mock_save_env.assert_called_once_with("DISCORD_HOME_CHANNEL", "123456789")
+
+    def test_sethome_does_not_write_config_yaml(self, hermes_home):
+        """After /sethome, config.yaml must not contain HOME_CHANNEL keys."""
+        import yaml
+
+        config_path = hermes_home / "config.yaml"
+        config = yaml.safe_load(config_path.read_text()) or {}
+        # Before the fix, /sethome would inject DISCORD_HOME_CHANNEL here
+        assert "DISCORD_HOME_CHANNEL" not in config
+        assert "TELEGRAM_HOME_CHANNEL" not in config

--- a/tests/gateway/test_sethome_command.py
+++ b/tests/gateway/test_sethome_command.py
@@ -40,7 +40,7 @@ class TestSethomeWritesToEnv:
              patch.dict(os.environ, {}, clear=False):
             # Inline the import so the patched version is used
             import gateway.run as gw_mod
-            original = gw_mod.GatewayRunner._handle_sethome_command
+            original = gw_mod.GatewayRunner._handle_set_home_command
 
             # Call with the mock
             with patch("hermes_cli.config.save_env_value") as mock_save_env:


### PR DESCRIPTION
## Summary

The `/sethome` command wrote `*_HOME_CHANNEL` as a top-level key in `config.yaml` instead of persisting it to `.env` where env-style variables belong.

This caused:
- `.env` value unchanged after `/sethome` (stale on next restart)
- `config.yaml` polluted with an env-var-style key (`DISCORD_HOME_CHANNEL: 123456789`)

## Fix

Replace the manual YAML read/write with `save_env_value()` from `hermes_cli.config`, which handles:
- Atomic file writes
- Key dedup/update in existing `.env`
- File permission hardening (0600 on POSIX)
- Windows encoding edge cases

## Testing

- Added `tests/gateway/test_sethome_command.py` with regression test
- `python -m py_compile gateway/run.py` — syntax OK

Fixes #6447
