### PR TITLE
feat: make api retry count configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -219,6 +219,9 @@ DEFAULT_CONFIG = {
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
+        # Main API call retry count for transient/invalid provider responses.
+        # Must be a positive integer; invalid values fall back to 3.
+        "api_max_retries": 3,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/run_agent.py
+++ b/run_agent.py
@@ -167,6 +167,8 @@ def _install_safe_stdio() -> None:
 
 def _coerce_positive_int(value: Any, default: int) -> int:
     """Return a positive integer config value, or default for invalid input."""
+    if isinstance(value, bool):
+        return default
     try:
         parsed = int(value)
     except (TypeError, ValueError):

--- a/run_agent.py
+++ b/run_agent.py
@@ -165,6 +165,15 @@ def _install_safe_stdio() -> None:
             setattr(sys, stream_name, _SafeWriter(stream))
 
 
+def _coerce_positive_int(value: Any, default: int) -> int:
+    """Return a positive integer config value, or default for invalid input."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
 class IterationBudget:
     """Thread-safe iteration counter for an agent.
 
@@ -1106,6 +1115,10 @@ class AIAgent:
         if not isinstance(_agent_section, dict):
             _agent_section = {}
         self._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
+        self._api_max_retries = _coerce_positive_int(
+            _agent_section.get("api_max_retries", 3),
+            default=3,
+        )
 
         # Initialize context compressor for automatic context management
         # Compresses conversation when approaching model's context limit
@@ -7412,7 +7425,7 @@ class AIAgent:
             
             api_start_time = time.time()
             retry_count = 0
-            max_retries = 3
+            max_retries = self._api_max_retries
             primary_recovery_attempted = False
             max_compression_attempts = 3
             codex_auth_retry_attempted=False

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -122,7 +122,7 @@ def test_api_max_retries_reads_positive_integer_from_config():
     assert agent._api_max_retries == 20
 
 
-@pytest.mark.parametrize("invalid_value", [0, -1, "abc", None])
+@pytest.mark.parametrize("invalid_value", [0, -1, "abc", None, False, True])
 def test_api_max_retries_invalid_values_fall_back_to_3(invalid_value):
     with (
         patch(
@@ -141,46 +141,6 @@ def test_api_max_retries_invalid_values_fall_back_to_3(invalid_value):
         )
 
     assert agent._api_max_retries == 3
-
-
-def test_api_max_retries_false_falls_back_to_3():
-    with (
-        patch(
-            "run_agent.get_tool_definitions",
-            return_value=_make_tool_defs("web_search"),
-        ),
-        patch("run_agent.check_toolset_requirements", return_value={}),
-        patch("run_agent.OpenAI"),
-        patch("hermes_cli.config.load_config", return_value={"agent": {"api_max_retries": False}}),
-    ):
-        agent = AIAgent(
-            api_key="test-key-1234567890",
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-        )
-
-    assert agent._api_max_retries == 3
-
-
-def test_api_max_retries_true_is_parsed_as_1():
-    with (
-        patch(
-            "run_agent.get_tool_definitions",
-            return_value=_make_tool_defs("web_search"),
-        ),
-        patch("run_agent.check_toolset_requirements", return_value={}),
-        patch("run_agent.OpenAI"),
-        patch("hermes_cli.config.load_config", return_value={"agent": {"api_max_retries": True}}),
-    ):
-        agent = AIAgent(
-            api_key="test-key-1234567890",
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-        )
-
-    assert agent._api_max_retries == 1
 
 
 def test_aiagent_reuses_existing_errors_log_handler():

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -143,6 +143,46 @@ def test_api_max_retries_invalid_values_fall_back_to_3(invalid_value):
     assert agent._api_max_retries == 3
 
 
+def test_api_max_retries_false_falls_back_to_3():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value={"agent": {"api_max_retries": False}}),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._api_max_retries == 3
+
+
+def test_api_max_retries_true_is_parsed_as_1():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value={"agent": {"api_max_retries": True}}),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._api_max_retries == 1
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -82,6 +82,67 @@ def agent_with_memory_tool():
         return a
 
 
+def test_api_max_retries_defaults_to_3():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._api_max_retries == 3
+
+
+def test_api_max_retries_reads_positive_integer_from_config():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value={"agent": {"api_max_retries": 20}}),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._api_max_retries == 20
+
+
+@pytest.mark.parametrize("invalid_value", [0, -1, "abc", None])
+def test_api_max_retries_invalid_values_fall_back_to_3(invalid_value):
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value={"agent": {"api_max_retries": invalid_value}}),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._api_max_retries == 3
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -496,6 +496,7 @@ Warnings are injected into the last tool result's JSON (as a `_budget_warning` f
 ```yaml
 agent:
   max_turns: 90                # Max iterations per conversation turn (default: 90)
+  api_max_retries: 3           # Main API retries per call (default: 3; invalid values fall back to 3)
 ```
 
 Budget pressure is enabled by default. The agent sees warnings naturally as part of tool results, encouraging it to consolidate its work and deliver a response before running out of iterations.


### PR DESCRIPTION
Summary

- Partially addresses #5570
- add agent.api_max_retries so the main model API retry count is configurable
- keep the default at 3 for backward compatibility
- reject invalid values, including booleans, by falling back to 3
- cover invalid and boolean config inputs in targeted tests

What did NOT change
- no change to other retry constants outside the main agent request loop
- no change to fallback-provider behavior or compression behavior

User-visible changes
- users can set agent.api_max_retries in config.yaml, for example to 20

Compatibility / Security impact
- default behavior stays at 3 retries when the setting is absent
- invalid values fall back to 3

Test plan
- [x] python -m pytest -o addopts='' tests/run_agent/test_run_agent.py -k api_max_retries
- [x] manual validation for default=3, configured=20, invalid values -> 3

Evidence / Actual results
- pytest: 8 passed, 232 deselected in 3.04s
- manual validation output before bool hardening: default 3; configured_20 20; invalid_string 3; invalid_zero 3
- bool hardening verification: True/False now both fall back to 3 via targeted tests

Human verification
- inspected config wiring in run_agent.py and default config in hermes_cli/config.py

Risks / rollback
- higher retry counts can prolong failures for persistent provider errors
- rollback: remove the config or set it back to 3
