### PR TITLE
fix: google-workspace per-operation scope check instead of all-or-nothing

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -30,7 +30,7 @@ from pathlib import Path
 try:
     from hermes_constants import display_hermes_home, get_hermes_home
 except ModuleNotFoundError:
-    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
+    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4] / "hermes-agent"
     if HERMES_AGENT_ROOT.exists():
         sys.path.insert(0, str(HERMES_AGENT_ROOT))
     from hermes_constants import display_hermes_home, get_hermes_home
@@ -49,21 +49,86 @@ SCOPES = [
     "https://www.googleapis.com/auth/documents.readonly",
 ]
 
+# Maps each (service, action) to the scopes it requires.
+# If ANY scope in the list is granted, the operation is allowed (OR logic for
+# alternatives like gmail.readonly vs gmail.modify which both permit reads).
+# Each entry is a list of scope-sets; the operation needs at least one scope
+# from each set (AND of ORs).
+_SCOPE_PREFIX = "https://www.googleapis.com/auth/"
+_OPERATION_SCOPES: dict[tuple[str, str], list[list[str]]] = {
+    # Gmail — read-only actions accept readonly OR modify (modify is a superset)
+    ("gmail", "search"):  [[f"{_SCOPE_PREFIX}gmail.readonly", f"{_SCOPE_PREFIX}gmail.modify"]],
+    ("gmail", "get"):     [[f"{_SCOPE_PREFIX}gmail.readonly", f"{_SCOPE_PREFIX}gmail.modify"]],
+    ("gmail", "labels"):  [[f"{_SCOPE_PREFIX}gmail.readonly", f"{_SCOPE_PREFIX}gmail.modify", f"{_SCOPE_PREFIX}gmail.labels"]],
+    ("gmail", "send"):    [[f"{_SCOPE_PREFIX}gmail.send", f"{_SCOPE_PREFIX}gmail.modify"]],
+    ("gmail", "reply"):   [[f"{_SCOPE_PREFIX}gmail.send", f"{_SCOPE_PREFIX}gmail.modify"]],
+    ("gmail", "modify"):  [[f"{_SCOPE_PREFIX}gmail.modify"]],
+    # Calendar
+    ("calendar", "list"):   [[f"{_SCOPE_PREFIX}calendar", f"{_SCOPE_PREFIX}calendar.readonly"]],
+    ("calendar", "create"): [[f"{_SCOPE_PREFIX}calendar"]],
+    ("calendar", "delete"): [[f"{_SCOPE_PREFIX}calendar"]],
+    # Drive
+    ("drive", "search"):    [[f"{_SCOPE_PREFIX}drive.readonly", f"{_SCOPE_PREFIX}drive"]],
+    # Contacts
+    ("contacts", "list"):   [[f"{_SCOPE_PREFIX}contacts.readonly", f"{_SCOPE_PREFIX}contacts"]],
+    # Sheets
+    ("sheets", "get"):      [[f"{_SCOPE_PREFIX}spreadsheets.readonly", f"{_SCOPE_PREFIX}spreadsheets"]],
+    ("sheets", "update"):   [[f"{_SCOPE_PREFIX}spreadsheets"]],
+    ("sheets", "append"):   [[f"{_SCOPE_PREFIX}spreadsheets"]],
+    # Docs
+    ("docs", "get"):        [[f"{_SCOPE_PREFIX}documents.readonly", f"{_SCOPE_PREFIX}documents"]],
+}
 
-def _missing_scopes() -> list[str]:
+
+def _granted_scopes() -> set[str]:
+    """Return the set of OAuth scopes currently granted in the stored token."""
     try:
         payload = json.loads(TOKEN_PATH.read_text())
     except Exception:
-        return []
+        return set()
     raw = payload.get("scopes") or payload.get("scope")
     if not raw:
-        return []
-    granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
-    return sorted(scope for scope in SCOPES if scope not in granted)
+        return set()
+    return {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
 
 
-def get_credentials():
-    """Load and refresh credentials from token file."""
+def _check_operation_scopes(service: str, action: str) -> None:
+    """Check that the token has sufficient scopes for the requested operation.
+
+    Exits with a helpful message if scopes are missing, suggesting the user
+    re-run setup to grant the needed scopes.  Does nothing if the operation
+    is not in the map (fail-open for unknown operations, letting the API
+    itself reject if needed).
+    """
+    key = (service, action)
+    required = _OPERATION_SCOPES.get(key)
+    if required is None:
+        return  # unknown operation — let the API decide
+    granted = _granted_scopes()
+    for alternatives in required:
+        if not any(scope in granted for scope in alternatives):
+            print(
+                f"This operation ({service} {action}) requires one of the following scopes:",
+                file=sys.stderr,
+            )
+            for scope in alternatives:
+                print(f"  - {scope}", file=sys.stderr)
+            print(
+                f"\nYour token does not include any of them. "
+                f"Re-run setup.py from the active Hermes profile ({display_hermes_home()}) "
+                f"to grant the additional scope.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+def get_credentials(*, required_scopes: list[str] | None = None):
+    """Load and refresh credentials from token file.
+
+    If *required_scopes* is provided, only those scopes are checked.
+    Otherwise the token is loaded with whatever scopes it already has
+    (no blanket all-scopes gate).
+    """
     if not TOKEN_PATH.exists():
         print("Not authenticated. Run the setup script first:", file=sys.stderr)
         print(f"  python {Path(__file__).parent / 'setup.py'}", file=sys.stderr)
@@ -72,26 +137,16 @@ def get_credentials():
     from google.oauth2.credentials import Credentials
     from google.auth.transport.requests import Request
 
-    creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+    # Load with the granted scopes (not the full SCOPES list) so the
+    # credentials object doesn't think it's under-scoped and refuse to work.
+    granted = _granted_scopes()
+    load_scopes = list(granted) if granted else None
+    creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), load_scopes)
     if creds.expired and creds.refresh_token:
         creds.refresh(Request())
         TOKEN_PATH.write_text(creds.to_json())
     if not creds.valid:
         print("Token is invalid. Re-run setup.", file=sys.stderr)
-        sys.exit(1)
-
-    missing_scopes = _missing_scopes()
-    if missing_scopes:
-        print(
-            "Token is valid but missing Google Workspace scopes required by this skill.",
-            file=sys.stderr,
-        )
-        for scope in missing_scopes:
-            print(f"  - {scope}", file=sys.stderr)
-        print(
-            f"Re-run setup.py from the active Hermes profile ({display_hermes_home()}) to restore full access.",
-            file=sys.stderr,
-        )
         sys.exit(1)
     return creds
 
@@ -512,6 +567,8 @@ def main():
     p.set_defaults(func=docs_get)
 
     args = parser.parse_args()
+    # Per-operation scope check: only require scopes needed for THIS action.
+    _check_operation_scopes(args.service, args.action)
     args.func(args)
 
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,4 +1,4 @@
-"""Regression tests for Google Workspace API credential validation."""
+"""Regression tests for Google Workspace API credential and scope validation."""
 
 import importlib.util
 import json
@@ -29,7 +29,7 @@ class FakeAuthorizedCredentials:
 
     def to_json(self):
         return json.dumps({
-            "token": "refreshed-token",
+            "token": "***",
             "refresh_token": self.refresh_token,
             "token_uri": "https://oauth2.googleapis.com/token",
             "client_id": "client-id",
@@ -84,8 +84,8 @@ def google_api_module(monkeypatch, tmp_path):
 
 def _write_token(path: Path, scopes):
     path.write_text(json.dumps({
-        "token": "access-token",
-        "refresh_token": "refresh-token",
+        "token": "***",
+        "refresh_token": "***",
         "token_uri": "https://oauth2.googleapis.com/token",
         "client_id": "client-id",
         "client_secret": "client-secret",
@@ -93,25 +93,225 @@ def _write_token(path: Path, scopes):
     }))
 
 
-def test_get_credentials_rejects_missing_scopes(google_api_module, capsys):
-    FakeCredentialsFactory.creds = FakeAuthorizedCredentials(valid=True)
-    _write_token(google_api_module.TOKEN_PATH, [
-        "https://www.googleapis.com/auth/drive.readonly",
-        "https://www.googleapis.com/auth/spreadsheets",
-    ])
-
-    with pytest.raises(SystemExit):
-        google_api_module.get_credentials()
-
-    err = capsys.readouterr().err
-    assert "missing google workspace scopes" in err.lower()
-    assert "gmail.send" in err
-
+# =========================================================================
+# get_credentials — no longer gates on ALL scopes, just loads the token
+# =========================================================================
 
 def test_get_credentials_accepts_full_scope_token(google_api_module):
+    """Token with all scopes should load fine."""
     FakeCredentialsFactory.creds = FakeAuthorizedCredentials(valid=True)
     _write_token(google_api_module.TOKEN_PATH, list(google_api_module.SCOPES))
 
     creds = google_api_module.get_credentials()
 
     assert creds is FakeCredentialsFactory.creds
+
+
+def test_get_credentials_accepts_partial_scope_token(google_api_module):
+    """Token with only some scopes should still load (no blanket gate)."""
+    FakeCredentialsFactory.creds = FakeAuthorizedCredentials(valid=True)
+    _write_token(google_api_module.TOKEN_PATH, [
+        "https://www.googleapis.com/auth/gmail.readonly",
+    ])
+
+    creds = google_api_module.get_credentials()
+
+    assert creds is FakeCredentialsFactory.creds
+
+
+def test_get_credentials_rejects_missing_token(google_api_module, capsys):
+    """No token file at all should exit."""
+    with pytest.raises(SystemExit):
+        google_api_module.get_credentials()
+
+    err = capsys.readouterr().err
+    assert "not authenticated" in err.lower()
+
+
+# =========================================================================
+# _check_operation_scopes — per-operation scope validation
+# =========================================================================
+
+class TestCheckOperationScopes:
+    """Tests for the per-operation scope gate."""
+
+    def test_gmail_search_allowed_with_readonly(self, google_api_module):
+        """gmail.readonly is sufficient for gmail search."""
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.readonly",
+        ])
+        # Should not raise
+        google_api_module._check_operation_scopes("gmail", "search")
+
+    def test_gmail_search_allowed_with_modify(self, google_api_module):
+        """gmail.modify is a superset that also permits gmail search."""
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.modify",
+        ])
+        google_api_module._check_operation_scopes("gmail", "search")
+
+    def test_gmail_get_allowed_with_readonly(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.readonly",
+        ])
+        google_api_module._check_operation_scopes("gmail", "get")
+
+    def test_gmail_send_blocked_without_send_or_modify(self, google_api_module, capsys):
+        """gmail send requires gmail.send or gmail.modify."""
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.readonly",
+        ])
+        with pytest.raises(SystemExit):
+            google_api_module._check_operation_scopes("gmail", "send")
+
+        err = capsys.readouterr().err
+        assert "gmail.send" in err
+        assert "gmail.modify" in err
+
+    def test_gmail_send_allowed_with_send_scope(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.send",
+        ])
+        google_api_module._check_operation_scopes("gmail", "send")
+
+    def test_gmail_send_allowed_with_modify_scope(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.modify",
+        ])
+        google_api_module._check_operation_scopes("gmail", "send")
+
+    def test_gmail_reply_blocked_without_send_or_modify(self, google_api_module, capsys):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.readonly",
+        ])
+        with pytest.raises(SystemExit):
+            google_api_module._check_operation_scopes("gmail", "reply")
+
+    def test_gmail_modify_blocked_without_modify(self, google_api_module, capsys):
+        """gmail modify (labels) requires specifically gmail.modify."""
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.send",
+        ])
+        with pytest.raises(SystemExit):
+            google_api_module._check_operation_scopes("gmail", "modify")
+
+    def test_gmail_labels_allowed_with_labels_scope(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.labels",
+        ])
+        google_api_module._check_operation_scopes("gmail", "labels")
+
+    def test_calendar_list_allowed_with_readonly(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/calendar.readonly",
+        ])
+        google_api_module._check_operation_scopes("calendar", "list")
+
+    def test_calendar_create_blocked_with_readonly(self, google_api_module, capsys):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/calendar.readonly",
+        ])
+        with pytest.raises(SystemExit):
+            google_api_module._check_operation_scopes("calendar", "create")
+
+    def test_calendar_create_allowed_with_full_scope(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/calendar",
+        ])
+        google_api_module._check_operation_scopes("calendar", "create")
+
+    def test_drive_search_allowed_with_readonly(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/drive.readonly",
+        ])
+        google_api_module._check_operation_scopes("drive", "search")
+
+    def test_sheets_get_allowed_with_readonly(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/spreadsheets.readonly",
+        ])
+        google_api_module._check_operation_scopes("sheets", "get")
+
+    def test_sheets_update_blocked_with_readonly(self, google_api_module, capsys):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/spreadsheets.readonly",
+        ])
+        with pytest.raises(SystemExit):
+            google_api_module._check_operation_scopes("sheets", "update")
+
+    def test_sheets_update_allowed_with_full_scope(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/spreadsheets",
+        ])
+        google_api_module._check_operation_scopes("sheets", "update")
+
+    def test_docs_get_allowed_with_readonly(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/documents.readonly",
+        ])
+        google_api_module._check_operation_scopes("docs", "get")
+
+    def test_contacts_list_allowed_with_readonly(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/contacts.readonly",
+        ])
+        google_api_module._check_operation_scopes("contacts", "list")
+
+    def test_unknown_operation_passes(self, google_api_module):
+        """Operations not in the map should pass (fail-open, let API decide)."""
+        _write_token(google_api_module.TOKEN_PATH, [])
+        # Should not raise — unknown operations are not gated
+        google_api_module._check_operation_scopes("unknown_service", "unknown_action")
+
+    def test_error_message_is_actionable(self, google_api_module, capsys):
+        """Error should tell user which scope to grant and how to fix it."""
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.readonly",
+        ])
+        with pytest.raises(SystemExit):
+            google_api_module._check_operation_scopes("gmail", "send")
+
+        err = capsys.readouterr().err
+        assert "gmail send" in err.lower() or "gmail send" in err
+        assert "Re-run setup.py" in err
+
+
+# =========================================================================
+# _granted_scopes — helper function
+# =========================================================================
+
+class TestGrantedScopes:
+    def test_returns_scopes_from_list(self, google_api_module):
+        _write_token(google_api_module.TOKEN_PATH, [
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/calendar",
+        ])
+        result = google_api_module._granted_scopes()
+        assert result == {
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/calendar",
+        }
+
+    def test_returns_empty_set_for_missing_file(self, google_api_module):
+        # TOKEN_PATH doesn't exist
+        result = google_api_module._granted_scopes()
+        assert result == set()
+
+    def test_returns_empty_set_for_no_scopes_key(self, google_api_module):
+        google_api_module.TOKEN_PATH.write_text(json.dumps({
+            "token": "***",
+            "refresh_token": "***",
+        }))
+        result = google_api_module._granted_scopes()
+        assert result == set()
+
+    def test_handles_space_separated_scope_string(self, google_api_module):
+        """Some token formats store scopes as a space-separated string."""
+        google_api_module.TOKEN_PATH.write_text(json.dumps({
+            "token": "***",
+            "scope": "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/calendar",
+        }))
+        result = google_api_module._granted_scopes()
+        assert "https://www.googleapis.com/auth/gmail.readonly" in result
+        assert "https://www.googleapis.com/auth/calendar" in result


### PR DESCRIPTION
## Summary
- change google-workspace scope checks to be per-operation instead of all-or-nothing
- allow narrower valid operations to run without requiring unrelated scopes
- update skill script tests to cover the new behavior

## Downstream carry
- Carried patch: `patch-upstream-pr-6457`

## Previous PR
- Supersedes accidentally closed PR #5690
- The previous PR was auto-closed after the fork head branch was mistakenly deleted during branch cleanup

## Test Plan
- Updated `tests/skills/test_google_workspace_api.py`
