### PR TITLE
feat(title): auto-generate session title when /title called without args

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -13,9 +13,9 @@ from agent.auxiliary_client import call_llm
 logger = logging.getLogger(__name__)
 
 _TITLE_PROMPT = (
-    "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
-    "following exchange. The title should capture the main topic or intent. "
-    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
+    "Generate a concise 3-word title for this conversation, with words separated by dashes. "
+    "Examples: setup-docker-compose, fix-login-bug, hermes-title-feature, deploy-staging-server. "
+    "Return ONLY the 3-word-dash-separated title, nothing else. No quotes, no prefixes, lowercase."
 )
 
 
@@ -47,13 +47,73 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
         title = title.strip('"\'')
         if title.lower().startswith("title:"):
             title = title[6:].strip()
+        # Normalize to lowercase-dashed format
+        import re
+        title = re.sub(r'[^a-zA-Z0-9\s-]', '', title)
+        title = re.sub(r'\s+', '-', title.strip()).lower()
+        # Enforce max 3 words (dashed segments)
+        parts = [p for p in title.split('-') if p]
+        if len(parts) > 3:
+            parts = parts[:3]
+        title = '-'.join(parts)
         # Enforce reasonable length
         if len(title) > 80:
             title = title[:77] + "..."
         return title if title else None
     except Exception as e:
-        logger.debug("Title generation failed: %s", e)
+        logger.warning("Title generation failed: %s: %s", type(e).__name__, e)
         return None
+
+
+def generate_title_from_history(conversation_history: list, timeout: float = 30.0) -> Optional[str]:
+    """Generate a session title from conversation history (any point in the session).
+
+    Extracts the most recent user and assistant messages to build context,
+    then asks the auxiliary LLM for a short title.  Used by ``/title`` when
+    called without arguments mid-conversation.
+
+    Falls back to a truncated first user message if the LLM call fails.
+    """
+    if not conversation_history:
+        return None
+
+    # Collect recent user and assistant messages (last 3 of each, for context)
+    user_msgs = [m["content"] for m in conversation_history
+                 if m.get("role") == "user" and m.get("content")]
+    assistant_msgs = [m["content"] for m in conversation_history
+                      if m.get("role") == "assistant" and m.get("content")]
+
+    if not user_msgs:
+        return None
+
+    # Use last few messages to capture the session's topic
+    user_snippet = "\n".join(msg[:200] for msg in user_msgs[-3:])[:500]
+    assistant_snippet = "\n".join(msg[:200] for msg in assistant_msgs[-3:])[:500] if assistant_msgs else ""
+
+    title = generate_title(user_snippet, assistant_snippet, timeout=timeout)
+
+    # Fallback: truncate first user message if LLM title generation failed
+    if not title and user_msgs:
+        first_msg = user_msgs[0].strip()
+        # Remove system prefixes like "[SYSTEM: ...]"
+        if first_msg.startswith("[SYSTEM:"):
+            # Try next user message
+            for msg in user_msgs[1:]:
+                if not msg.strip().startswith("[SYSTEM:"):
+                    first_msg = msg.strip()
+                    break
+            else:
+                first_msg = ""
+        if first_msg:
+            import re
+            # Extract first 3 meaningful words, dashed
+            words = re.sub(r'[^a-zA-Z0-9\s]', '', first_msg).split()
+            words = [w.lower() for w in words[:3] if w]
+            title = '-'.join(words) if words else None
+            if title:
+                logger.info("Title generation fell back to truncated user message")
+
+    return title
 
 
 def auto_title_session(

--- a/cli.py
+++ b/cli.py
@@ -4371,7 +4371,35 @@ class HermesCLI:
             parts = cmd_original.split(maxsplit=1)
             if len(parts) > 1:
                 raw_title = parts[1].strip()
-                if raw_title:
+                if raw_title and raw_title.lower() == "!new":
+                    # Force re-generate title from conversation history
+                    if self._session_db and self.conversation_history:
+                        _cprint("  Generating new title...")
+                        try:
+                            from agent.title_generator import generate_title_from_history
+                            title = generate_title_from_history(self.conversation_history)
+                            if title:
+                                from hermes_state import SessionDB
+                                sanitized = SessionDB.sanitize_title(title)
+                                if sanitized:
+                                    if self._session_db.get_session(self.session_id):
+                                        self._session_db.set_session_title(self.session_id, sanitized)
+                                        _cprint(f"  ✏️ Title regenerated: {sanitized}")
+                                    else:
+                                        self._pending_title = sanitized
+                                        _cprint(f"  ✏️ Title regenerated (pending): {sanitized}")
+                                else:
+                                    _cprint("  Could not generate a title.")
+                            else:
+                                _cprint("  Could not generate a title.")
+                        except Exception as e:
+                            logger.debug("Title regeneration failed: %s", e)
+                            _cprint(f"  Could not generate a title ({type(e).__name__}: {e})")
+                    elif not self.conversation_history:
+                        _cprint("  No conversation yet to generate a title from.")
+                    else:
+                        _cprint("  Session database not available.")
+                elif raw_title:
                     if self._session_db:
                         # Sanitize the title early so feedback matches what gets stored
                         try:
@@ -4405,16 +4433,42 @@ class HermesCLI:
                 else:
                     _cprint("  Usage: /title <your session title>")
             else:
-                # Show current title and session ID if no argument given
+                # Show current title and session ID if no argument given.
+                # If no title exists, auto-generate one from conversation history.
                 if self._session_db:
                     _cprint(f"  Session ID: {self.session_id}")
                     session = self._session_db.get_session(self.session_id)
-                    if session and session.get("title"):
-                        _cprint(f"  Title: {session['title']}")
+                    existing_title = (session.get("title") or "").strip() if session else ""
+                    if existing_title:
+                        _cprint(f"  Title: {existing_title}")
+                        _cprint("  To regenerate: /title !new")
                     elif self._pending_title:
                         _cprint(f"  Title (pending): {self._pending_title}")
+                    elif self.conversation_history:
+                        # Auto-generate a title from conversation history
+                        _cprint("  Generating title...")
+                        try:
+                            from agent.title_generator import generate_title_from_history
+                            title = generate_title_from_history(self.conversation_history)
+                            if title:
+                                from hermes_state import SessionDB
+                                sanitized = SessionDB.sanitize_title(title)
+                                if sanitized:
+                                    if self._session_db.get_session(self.session_id):
+                                        self._session_db.set_session_title(self.session_id, sanitized)
+                                        _cprint(f"  ✏️ Title auto-generated: {sanitized}")
+                                    else:
+                                        self._pending_title = sanitized
+                                        _cprint(f"  ✏️ Title auto-generated (pending): {sanitized}")
+                                else:
+                                    _cprint("  Could not generate a title. Usage: /title <your session title>")
+                            else:
+                                _cprint("  Could not generate a title. Usage: /title <your session title>")
+                        except Exception as e:
+                            logger.debug("Auto-title generation failed: %s", e)
+                            _cprint(f"  Could not generate a title ({type(e).__name__}: {e}). Usage: /title <your session title>")
                     else:
-                        _cprint("  No title set. Usage: /title <your session title>")
+                        _cprint("  No conversation yet. Usage: /title <your session title>")
                 else:
                     _cprint("  Session database not available.")
         elif canonical == "new":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5027,7 +5027,21 @@ class GatewayRunner:
                 pass  # Session might already exist, ignore errors
 
         title_arg = event.get_command_args().strip()
-        if title_arg:
+        if title_arg and title_arg.lower() == "!new":
+            # Force re-generate title from conversation history
+            try:
+                history = self._session_db.get_messages_as_conversation(session_id)
+                if history:
+                    from agent.title_generator import generate_title_from_history
+                    generated = generate_title_from_history(history)
+                    if generated:
+                        sanitized = self._session_db.sanitize_title(generated)
+                        if sanitized and self._session_db.set_session_title(session_id, sanitized):
+                            return f"✏️ Title regenerated: **{sanitized}**"
+            except Exception:
+                pass
+            return "Could not regenerate title."
+        elif title_arg:
             # Sanitize the title before setting
             try:
                 sanitized = self._session_db.sanitize_title(title_arg)
@@ -5044,11 +5058,27 @@ class GatewayRunner:
             except ValueError as e:
                 return f"⚠️ {e}"
         else:
-            # Show the current title and session ID
+            # Show the current title and session ID.
+            # If no title exists, auto-generate one from conversation history.
             title = self._session_db.get_session_title(session_id)
             if title:
-                return f"📌 Session: `{session_id}`\nTitle: **{title}**"
+                return (
+                    f"📌 Session: `{session_id}`\nTitle: **{title}**\n"
+                    f"_To regenerate: `/title !new`_"
+                )
             else:
+                # Try to auto-generate from conversation history
+                try:
+                    history = self._session_db.get_messages_as_conversation(session_id)
+                    if history:
+                        from agent.title_generator import generate_title_from_history
+                        generated = generate_title_from_history(history)
+                        if generated:
+                            sanitized = self._session_db.sanitize_title(generated)
+                            if sanitized and self._session_db.set_session_title(session_id, sanitized):
+                                return f"✏️ Title auto-generated: **{sanitized}**"
+                except Exception:
+                    pass
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
     async def _handle_resume_command(self, event: MessageEvent) -> str:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -7,6 +7,7 @@ import pytest
 
 from agent.title_generator import (
     generate_title,
+    generate_title_from_history,
     auto_title_session,
     maybe_auto_title,
 )
@@ -81,6 +82,71 @@ class TestGenerateTitle:
         # The user content in the messages should be truncated
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
+
+
+class TestGenerateTitleFromHistory:
+    """Tests for generate_title_from_history() — mid-conversation title generation."""
+
+    def test_returns_title_from_history(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "GitHub PR Workflow"
+
+        history = [
+            {"role": "user", "content": "help me create a PR"},
+            {"role": "assistant", "content": "Sure, let me set up the branch..."},
+            {"role": "user", "content": "push it to origin"},
+            {"role": "assistant", "content": "Done, PR created."},
+        ]
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title_from_history(history)
+            assert title == "GitHub PR Workflow"
+
+    def test_returns_none_for_empty_history(self):
+        assert generate_title_from_history([]) is None
+        assert generate_title_from_history(None) is None
+
+    def test_returns_none_for_no_user_messages(self):
+        history = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        assert generate_title_from_history(history) is None
+
+    def test_uses_last_messages_for_context(self):
+        """Should use last 3 user + last 3 assistant messages, not all."""
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Recent Topic"
+            return resp
+
+        history = [
+            {"role": "user", "content": f"msg-{i}"} if i % 2 == 0
+            else {"role": "assistant", "content": f"reply-{i}"}
+            for i in range(10)
+        ]
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title_from_history(history)
+            assert title == "Recent Topic"
+
+        # The LLM should have been called with truncated content
+        user_content = captured_kwargs["messages"][1]["content"]
+        # Should contain recent messages, not all 5 user messages
+        assert "msg-8" in user_content  # last user msg
+
+    def test_handles_llm_failure_gracefully(self):
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        with patch("agent.title_generator.call_llm", side_effect=RuntimeError("fail")):
+            assert generate_title_from_history(history) is None
 
 
 class TestAutoTitleSession:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -23,7 +23,7 @@ class TestGenerateTitle:
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             title = generate_title("help me fix this import", "Sure, let me check...")
-            assert title == "Debugging Python Import Errors"
+            assert title == "debugging-python-import"
 
     def test_strips_quotes(self):
         mock_response = MagicMock()
@@ -32,7 +32,7 @@ class TestGenerateTitle:
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             title = generate_title("how do I set up docker", "First install...")
-            assert title == "Setting Up Docker Environment"
+            assert title == "setting-up-docker"
 
     def test_strips_title_prefix(self):
         mock_response = MagicMock()
@@ -41,7 +41,7 @@ class TestGenerateTitle:
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             title = generate_title("my pod keeps crashing", "Let me look...")
-            assert title == "Kubernetes Pod Debugging"
+            assert title == "kubernetes-pod-debugging"
 
     def test_truncates_long_titles(self):
         mock_response = MagicMock()
@@ -101,7 +101,7 @@ class TestGenerateTitleFromHistory:
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             title = generate_title_from_history(history)
-            assert title == "GitHub PR Workflow"
+            assert title == "github-pr-workflow"
 
     def test_returns_none_for_empty_history(self):
         assert generate_title_from_history([]) is None
@@ -133,7 +133,7 @@ class TestGenerateTitleFromHistory:
 
         with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
             title = generate_title_from_history(history)
-            assert title == "Recent Topic"
+            assert title == "recent-topic"
 
         # The LLM should have been called with truncated content
         user_content = captured_kwargs["messages"][1]["content"]
@@ -146,7 +146,7 @@ class TestGenerateTitleFromHistory:
             {"role": "assistant", "content": "hi"},
         ]
         with patch("agent.title_generator.call_llm", side_effect=RuntimeError("fail")):
-            assert generate_title_from_history(history) is None
+            assert generate_title_from_history(history) == "hello"
 
 
 class TestAutoTitleSession:


### PR DESCRIPTION
## Summary
- auto-generate a session title when `/title` is called without explicit args
- wire the behavior through CLI and gateway paths
- update title-generator tests to match the final behavior

## Downstream carry
- Carried patch: `patch-upstream-pr-6459`

## Previous PR
- Supersedes accidentally closed PR #5716
- The previous PR was auto-closed after the fork head branch was mistakenly deleted during branch cleanup

## Test Plan
- Updated `tests/agent/test_title_generator.py`
