### PR TITLE
fix(prune): handle recursive child sessions in prune_sessions

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1284,21 +1284,36 @@ class SessionDB:
                 )
             session_ids = set(row["id"] for row in cursor.fetchall())
 
-            # Delete children first whose parents are in the prune set
-            # (avoids FK constraint errors)
-            for sid in list(session_ids):
-                child_ids = [r[0] for r in conn.execute(
+            # Collect ALL descendant session IDs (not just direct children)
+            # to handle chains like A -> B -> C -> D
+            all_to_delete = set()
+            queue = list(session_ids)
+            while queue:
+                sid = queue.pop()
+                if sid in all_to_delete:
+                    continue
+                all_to_delete.add(sid)
+                children = [r[0] for r in conn.execute(
                     "SELECT id FROM sessions WHERE parent_session_id = ?",
                     (sid,),
                 ).fetchall()]
-                for cid in child_ids:
-                    conn.execute("DELETE FROM messages WHERE session_id = ?", (cid,))
-                    conn.execute("DELETE FROM sessions WHERE id = ?", (cid,))
-                    session_ids.discard(cid)  # don't double-delete
+                queue.extend(children)
 
-            for sid in session_ids:
+            # Null out parent references for sessions NOT being deleted
+            # that reference sessions being deleted as their parent
+            # (avoids FK constraint: sessions.parent_session_id -> sessions.id)
+            for sid in all_to_delete:
+                conn.execute(
+                    "UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id = ? AND id NOT IN ({})".format(
+                        ",".join("?" * len(all_to_delete))
+                    ),
+                    (sid, *all_to_delete),
+                )
+
+            for sid in all_to_delete:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
+            for sid in all_to_delete:
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
-            return len(session_ids)
+            return len(all_to_delete)
 
         return self._execute_write(_do)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1299,12 +1299,13 @@ class SessionDB:
                     continue
                 visited.add(sid)
 
-                children = [r[0] for r in conn.execute(
+                child_rows = conn.execute(
                     "SELECT id, ended_at FROM sessions WHERE parent_session_id = ?",
                     (sid,),
-                ).fetchall()]
+                ).fetchall()
 
-                for child_id, child_ended in children:
+                for row in child_rows:
+                    child_id, child_ended = row[0], row[1]
                     if child_ended is not None:
                         # Ended child — delete it too
                         depth[child_id] = depth[sid] + 1

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1284,36 +1284,58 @@ class SessionDB:
                 )
             session_ids = set(row["id"] for row in cursor.fetchall())
 
-            # Collect ALL descendant session IDs (not just direct children)
-            # to handle chains like A -> B -> C -> D
-            all_to_delete = set()
+            # BFS to collect all descendant IDs (ended sessions only).
+            # Active sessions are never deleted — their parent references
+            # are nulled out to satisfy the FK without removing them.
+            to_delete = []
+            to_null = []  # sessions NOT being deleted that reference deleted sessions
+            visited = set()
             queue = list(session_ids)
+            depth = {sid: 0 for sid in session_ids}
+
             while queue:
-                sid = queue.pop()
-                if sid in all_to_delete:
+                sid = queue.pop(0)
+                if sid in visited:
                     continue
-                all_to_delete.add(sid)
+                visited.add(sid)
+
                 children = [r[0] for r in conn.execute(
-                    "SELECT id FROM sessions WHERE parent_session_id = ?",
+                    "SELECT id, ended_at FROM sessions WHERE parent_session_id = ?",
                     (sid,),
                 ).fetchall()]
-                queue.extend(children)
 
-            # Null out parent references for sessions NOT being deleted
-            # that reference sessions being deleted as their parent
-            # (avoids FK constraint: sessions.parent_session_id -> sessions.id)
-            for sid in all_to_delete:
+                for child_id, child_ended in children:
+                    if child_ended is not None:
+                        # Ended child — delete it too
+                        depth[child_id] = depth[sid] + 1
+                        queue.append(child_id)
+                    else:
+                        # Active child — don't delete, just orphan it
+                        to_null.append(child_id)
+
+            # Only ended sessions get deleted
+            to_delete = [sid for sid in visited if sid in session_ids or conn.execute(
+                "SELECT ended_at FROM sessions WHERE id = ?", (sid,)
+            ).fetchone()[0] is not None]
+
+            # Sort children before parents (deeper first)
+            to_delete.sort(key=lambda s: depth.get(s, 0), reverse=True)
+
+            # Null out parent_session_id for ALL sessions referencing deleted sessions
+            # (both deleted sessions referencing each other, and active sessions
+            # referencing deleted parents)
+            if to_delete:
+                placeholders = ",".join("?" * len(to_delete))
                 conn.execute(
-                    "UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id = ? AND id NOT IN ({})".format(
-                        ",".join("?" * len(all_to_delete))
-                    ),
-                    (sid, *all_to_delete),
+                    f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({placeholders})",
+                    to_delete,
                 )
 
-            for sid in all_to_delete:
+            # Delete messages first, then sessions in child-before-parent order
+            for sid in to_delete:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
-            for sid in all_to_delete:
+            for sid in to_delete:
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
-            return len(all_to_delete)
+            return len(to_delete)
 
         return self._execute_write(_do)


### PR DESCRIPTION
## Problem

The `prune_sessions` function in `hermes_state.py` only deletes direct children of sessions being pruned. When session chains form (e.g., resuming a session multiple times creates `A -> B -> C -> D`), pruning fails with:

```
sqlite3.IntegrityError: FOREIGN KEY constraint failed
```

This happens because:
1. Session `A` is in the prune set
2. The code finds `B` as a child of `A` and tries to delete it
3. But `C` still has `parent_session_id = B`
4. The FK constraint on `sessions.parent_session_id -> sessions.id` blocks the deletion

## Reproduction

1. Resume a session multiple times, creating a parent-child chain (5+ levels)
2. Let those sessions end
3. Run `hermes sessions prune --older-than 15`
4. FK constraint error

## Fix

Two changes:

1. **BFS traversal** to collect ALL descendants of sessions being pruned, not just direct children
2. **Null out orphaned parent references** for any session NOT being deleted that references a session being deleted as its parent

This ensures:
- Multi-level chains are fully deleted (not just direct children)
- Non-deleted sessions don't reference deleted sessions (avoids FK constraint)
- Messages are deleted before sessions (consistent ordering)