### PR TITLE
feat(lcm): Lossless Context Management as ContextEngine plugin

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -93,11 +93,9 @@ class ContextEngine(ABC):
         DAG, or do anything else — as long as the returned list is a valid
         OpenAI-format message sequence.
 
-        Args:
-            focus_topic: Optional topic string from manual ``/compress <focus>``.
-                Engines that support guided compression should prioritise
-                preserving information related to this topic.  Engines that
-                don't support it may simply ignore this argument.
+        ``focus_topic`` is advisory: callers may pass a topic hint to guide
+        compression. Implementations that do not use it should accept and
+        ignore it.
         """
 
     # -- Optional: pre-flight check ----------------------------------------

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -560,6 +560,24 @@ def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _MAX_COMPLETION_KEYS)
 
 
+def _extract_lmstudio_context_length(model: Dict[str, Any]) -> Optional[int]:
+    """Prefer loaded LM Studio runtime context, then advertised model max."""
+    for inst in model.get("loaded_instances", []) or []:
+        if not isinstance(inst, dict):
+            continue
+        cfg = inst.get("config", {})
+        ctx = cfg.get("context_length") if isinstance(cfg, dict) else None
+        coerced = _coerce_reasonable_int(ctx)
+        if coerced is not None:
+            return coerced
+
+    for key in _CONTEXT_LENGTH_KEYS:
+        coerced = _coerce_reasonable_int(model.get(key))
+        if coerced is not None:
+            return coerced
+    return None
+
+
 def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     novita_input = payload.get("input_token_price_per_m")
     novita_output = payload.get("output_token_price_per_m")
@@ -688,15 +706,7 @@ def fetch_endpoint_model_metadata(
                         continue
                     entry: Dict[str, Any] = {"name": model.get("name", model_id)}
 
-                    context_length = None
-                    for inst in model.get("loaded_instances", []) or []:
-                        if not isinstance(inst, dict):
-                            continue
-                        cfg = inst.get("config", {})
-                        ctx = cfg.get("context_length") if isinstance(cfg, dict) else None
-                        if isinstance(ctx, int) and ctx > 0:
-                            context_length = ctx
-                            break
+                    context_length = _extract_lmstudio_context_length(model)
                     if context_length is not None:
                         entry["context_length"] = context_length
 
@@ -1153,12 +1163,9 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
                     data = resp.json()
                     for m in data.get("models", []):
                         if _model_id_matches(m.get("key", ""), model) or _model_id_matches(m.get("id", ""), model):
-                            # Prefer loaded instance context (actual runtime value)
-                            for inst in m.get("loaded_instances", []):
-                                cfg = inst.get("config", {})
-                                ctx = cfg.get("context_length")
-                                if ctx and isinstance(ctx, (int, float)):
-                                    return int(ctx)
+                            context_length = _extract_lmstudio_context_length(m)
+                            if context_length is not None:
+                                return context_length
                             break
 
             # LM Studio / vLLM / llama.cpp: try /v1/models/{model}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1567,6 +1567,18 @@ DEFAULT_CONFIG = {
         "servers": {},
     },
 
+    # LCM (Lossless Context Management) engine settings.
+    # Only used when context.engine is set to "lcm".
+    # Three-layer memory: L1 Hot (LLM summarization), L2 Warm (DAM), L3 Cold (HRR).
+    "lcm": {
+        "enabled": True,
+        "tau_soft": 0.50,           # Soft threshold — trigger async compaction
+        "tau_hard": 0.85,           # Hard threshold — trigger blocking compaction
+        "deterministic_target": 512,
+        "protect_last_n": 4,
+        "summary_model": "",        # Empty = use main configured model
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 23,
 }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1080,14 +1080,21 @@ DEFAULT_CONFIG = {
         "max_ms": 2500,
     },
     
-    # Context engine -- controls how the context window is managed when
+       # Context engine -- controls how the context window is managed when
     # approaching the model's token limit.
     # "compressor" = built-in lossy summarization (default).
-    # Set to a plugin name to activate an alternative engine (e.g. "lcm"
-    # for Lossless Context Management).  The engine must be installed as
-    # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
+    # "lcm" = Lossless Context Management (reversible compression via DAG).
+    # "rlm" = Recursive Language Model (REPL-based context interaction).
+    # For LCM+RLM mode: set engine: lcm and rlm: true
+    # The engine must be installed as a plugin in plugins/context_engine/<name>/
+    # or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+        "rlm": False,          # Enable RLM companion mode when engine is "lcm"
+        "rlm_config": {        # RLM-specific settings (ignored when rlm is False)
+            "max_iterations": 20,    # Max REPL iterations before auto-terminate
+            "output_limit": 8192,    # Max output chars per REPL execution
+        },
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -12,6 +12,7 @@ import os
 import urllib.request
 import urllib.error
 import time
+import hashlib
 from difflib import get_close_matches
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
@@ -1802,10 +1803,6 @@ def detect_static_provider_for_model(
     name_lower = name.lower()
     current_keys = _provider_keys(current_provider)
 
-    alias_match = _resolve_static_model_alias(name_lower, current_keys)
-    if alias_match:
-        return alias_match
-
     # --- Step 0: bare provider name typed as model ---
     # If someone types `/model nous` or `/model anthropic`, treat it as a
     # provider switch and pick the first model from that provider's catalog.
@@ -1820,6 +1817,10 @@ def detect_static_provider_for_model(
             and resolved_provider not in current_keys
         ):
             return (resolved_provider, default_models[0])
+
+    alias_match = _resolve_static_model_alias(name_lower, current_keys)
+    if alias_match:
+        return alias_match
 
     # Aggregators list other providers' models — never auto-switch TO them
     # If the model belongs to the current provider's catalog, don't suggest switching
@@ -2459,10 +2460,17 @@ def fetch_github_model_catalog(
 
 # ─── Copilot catalog context-window helpers ─────────────────────────────────
 
-# Module-level cache: {model_id: max_prompt_tokens}
-_copilot_context_cache: dict[str, int] = {}
-_copilot_context_cache_time: float = 0.0
+# Module-level cache: {credential_scope: {model_id: max_prompt_tokens}}
+_copilot_context_cache: dict[str, dict[str, int]] = {}
+_copilot_context_cache_time: dict[str, float] = {}
 _COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
+
+
+def _copilot_context_cache_scope(api_key: Optional[str]) -> str:
+    token = (api_key or "").strip()
+    if not token:
+        return "default"
+    return "token:" + hashlib.sha256(token.encode()).hexdigest()[:16]
 
 
 def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> Optional[int]:
@@ -2473,10 +2481,15 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
     """
     global _copilot_context_cache, _copilot_context_cache_time
 
+    scope = _copilot_context_cache_scope(api_key)
+    now = time.time()
+
     # Serve from cache if fresh
-    if _copilot_context_cache and (time.time() - _copilot_context_cache_time < _COPILOT_CONTEXT_CACHE_TTL):
-        if model_id in _copilot_context_cache:
-            return _copilot_context_cache[model_id]
+    cached = _copilot_context_cache.get(scope)
+    cached_at = _copilot_context_cache_time.get(scope, 0.0)
+    if cached is not None and (now - cached_at < _COPILOT_CONTEXT_CACHE_TTL):
+        if model_id in cached:
+            return cached[model_id]
         # Cache is fresh but model not in it — don't re-fetch
         return None
 
@@ -2496,8 +2509,8 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
         if isinstance(max_prompt, int) and max_prompt > 0:
             cache[mid] = max_prompt
 
-    _copilot_context_cache = cache
-    _copilot_context_cache_time = time.time()
+    _copilot_context_cache[scope] = cache
+    _copilot_context_cache_time[scope] = now
 
     return cache.get(model_id)
 

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -228,7 +228,7 @@ def _load_engine_from_dir(
     if hasattr(mod, "register"):
         collector = _EngineCollector()
         try:
-            mod.register(collector)
+            mod.register(collector, **kwargs)
             if collector.engine:
                 return collector.engine
         except Exception as e:

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import inspect
 import logging
 import sys
 from pathlib import Path
@@ -228,7 +229,9 @@ def _load_engine_from_dir(
     if hasattr(mod, "register"):
         collector = _EngineCollector()
         try:
-            mod.register(collector, **kwargs)
+            reg_sig = inspect.signature(mod.register)
+            filtered = _filter_kwargs(kwargs, reg_sig)
+            mod.register(collector, **filtered)
             if collector.engine:
                 return collector.engine
         except Exception as e:
@@ -241,11 +244,31 @@ def _load_engine_from_dir(
         if (isinstance(attr, type) and issubclass(attr, ContextEngine)
                 and attr is not ContextEngine):
             try:
-                return attr(**kwargs)
+                init_sig = inspect.signature(attr.__init__)
+                filtered = _filter_kwargs(kwargs, init_sig)
+                return attr(**filtered)
             except Exception:
                 pass
 
     return None
+
+
+def _filter_kwargs(kwargs: Dict[str, Any], sig: "inspect.Signature") -> Dict[str, Any]:
+    """Return a filtered copy of kwargs accepted by the given signature.
+
+    If the callable declares a **kwargs parameter (VAR_KEYWORD), all kwargs are
+    passed through unchanged — the callee accepts arbitrary keyword arguments.
+    Otherwise only the kwargs whose names appear as explicit parameters are kept.
+    This prevents TypeError when a custom engine's register() does not declare
+    parameters like ``rlm_config`` or ``lcm_config``.
+    """
+    params = sig.parameters
+    # If there's a **kwargs catch-all, pass everything
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return dict(kwargs)
+    # Otherwise filter to only declared parameter names (excluding 'self'/'ctx')
+    accepted = set(params.keys()) - {"self", "ctx"}
+    return {k: v for k, v in kwargs.items() if k in accepted}
 
 
 class _EngineCollector:

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -5,15 +5,14 @@ plugins.  Each subdirectory must contain ``__init__.py`` with a class
 implementing the ContextEngine ABC.
 
 Context engines are separate from the general plugin system — they live
-in the repo and are always available without user installation.  Only ONE
-can be active at a time, selected via ``context.engine`` in config.yaml.
+in the repo and are always available without user installation.
+
+Supported configurations:
+- context.engine: lcm      — LCM for compression only
+- context.engine: rlm      — RLM as standalone engine
+- context.engine: lcm + context.rlm: true — LCM + RLM companion mode
+
 The default engine is ``"compressor"`` (the built-in ContextCompressor).
-
-Usage:
-    from plugins.context_engine import discover_context_engines, load_context_engine
-
-    available = discover_context_engines()   # [(name, desc, available), ...]
-    engine = load_context_engine("lcm")      # ContextEngine instance
 """
 
 from __future__ import annotations
@@ -23,7 +22,7 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -76,18 +75,26 @@ def discover_context_engines() -> List[Tuple[str, str, bool]]:
     return results
 
 
-def load_context_engine(name: str) -> Optional["ContextEngine"]:
+def load_context_engine(name: str, **kwargs: Any) -> Optional["ContextEngine"]:
     """Load and return a ContextEngine instance by name.
+
+    Args:
+        name: Engine name (e.g. "lcm", "rlm", "compressor")
+        **kwargs: Configuration passed to the engine constructor
 
     Returns None if the engine is not found or fails to load.
     """
+    if name == "compressor":
+        # Built-in engine — don't auto-load plugins
+        return None
+
     engine_dir = _CONTEXT_ENGINE_PLUGINS_DIR / name
     if not engine_dir.is_dir():
         logger.debug("Context engine '%s' not found in %s", name, _CONTEXT_ENGINE_PLUGINS_DIR)
         return None
 
     try:
-        engine = _load_engine_from_dir(engine_dir)
+        engine = _load_engine_from_dir(engine_dir, **kwargs)
         if engine:
             return engine
         logger.warning("Context engine '%s' loaded but no engine instance found", name)
@@ -97,7 +104,52 @@ def load_context_engine(name: str) -> Optional["ContextEngine"]:
         return None
 
 
-def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
+def load_composite_engine(
+    compression_name: str = "lcm",
+    rlm_enabled: bool = False,
+    **kwargs: Any,
+) -> Optional["ContextEngine"]:
+    """Load a composite context engine combining LCM (compression) and RLM (tools).
+
+    When rlm_enabled=True, creates a CompositeContextEngine that wraps both
+    the compression engine and the RLM engine. When rlm_enabled=False,
+    returns the compression engine directly.
+
+    Args:
+        compression_name: Name of the compression engine (default: "lcm")
+        rlm_enabled: Whether to enable RLM companion mode
+        **kwargs: Configuration passed to both engines
+
+    Returns a ContextEngine instance (compressed engine or composite wrapper).
+    """
+    compression_engine = load_context_engine(compression_name, **kwargs)
+    if compression_engine is None:
+        return None
+
+    if not rlm_enabled:
+        return compression_engine
+
+    # Load RLM companion engine
+    try:
+        from plugins.context_engine.rlm import RlmContextEngine
+        rlm_engine = RlmContextEngine(**kwargs)
+    except Exception as e:
+        logger.debug("Failed to load RLM companion engine: %s", e)
+        return compression_engine
+
+    # Load the CompositeContextEngine
+    try:
+        from plugins.context_engine.rlm import CompositeContextEngine
+        engine = CompositeContextEngine(compression_engine, rlm_engine, **kwargs)
+        return engine
+    except Exception as e:
+        logger.warning("Failed to create composite engine: %s", e)
+        return compression_engine
+
+
+def _load_engine_from_dir(
+    engine_dir: Path, **kwargs: Any
+) -> Optional["ContextEngine"]:
     """Import an engine module and extract the ContextEngine instance.
 
     The module must have either:
@@ -189,7 +241,7 @@ def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
         if (isinstance(attr, type) and issubclass(attr, ContextEngine)
                 and attr is not ContextEngine):
             try:
-                return attr()
+                return attr(**kwargs)
             except Exception:
                 pass
 
@@ -217,3 +269,4 @@ class _EngineCollector:
 
     def register_memory_provider(self, *args, **kwargs):
         pass
+

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -140,6 +140,7 @@ class LcmContextEngine(ContextEngine):
         self,
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
+        focus_topic: str = None,
     ) -> List[Dict[str, Any]]:
         """Ingest any new messages, then compact if needed.
 

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -1,0 +1,313 @@
+"""LCM — Lossless Context Management engine plugin.
+
+Three-layer memory hierarchy for hermes-agent context compression:
+
+  L1 Hot   — LLM summarization (in-turn, soft/hard thresholds)
+  L2 Warm  — Dense Associative Memory (Modern Hopfield network, per-session)
+  L3 Cold  — HRR persistent knowledge store (cross-session)
+
+Activation: set ``context.engine: lcm`` in config.yaml.
+
+All 7 LCM tools (lcm_expand, lcm_pin, lcm_forget, lcm_search, lcm_budget,
+lcm_toc, lcm_focus) are exposed via the ContextEngine ABC's get_tool_schemas()
+and handle_tool_call() — no run_agent.py patches needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from agent.context_engine import ContextEngine
+
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.engine import LcmEngine, CompactionAction, ContextEntry
+from plugins.context_engine.lcm.dag import SummaryDag, SummaryNode, MessageId
+from plugins.context_engine.lcm.store import ImmutableStore
+from plugins.context_engine.lcm.tools import LCM_TOOL_SCHEMAS
+from plugins.context_engine.lcm.summarizer import Summarizer, SummarizerConfig
+from plugins.context_engine.lcm.tokens import TokenEstimator, TokenEstimatorConfig, estimate_messages_tokens_rough
+from plugins.context_engine.lcm.semantic import SemanticIndex, SemanticIndexConfig, NoOpSemanticIndex, create_semantic_index
+
+logger = logging.getLogger(__name__)
+
+
+class LcmContextEngine(ContextEngine):
+    """LCM adapter that implements the ContextEngine ABC.
+
+    Delegates all real work to an internal LcmEngine instance.
+    The ABC's compress() method is the main entry point — it handles
+    both ingestion of new messages and compaction.
+    """
+    def __init__(self, **kwargs: Any) -> None:
+        # Extract config from kwargs (passed by plugin loader or agent init)
+        lcm_cfg = kwargs.get("lcm_config", {})
+        model = kwargs.get("model", "")
+        provider = kwargs.get("provider", "")
+        context_length = kwargs.get("context_length", 128_000)
+
+        if isinstance(lcm_cfg, dict):
+            self._config = LcmConfig.from_dict(lcm_cfg)
+        elif isinstance(lcm_cfg, LcmConfig):
+            self._config = lcm_cfg
+        else:
+            self._config = LcmConfig()
+
+        self._engine = LcmEngine(
+            config=self._config,
+            model=model,
+            provider=provider,
+            context_length=context_length,
+        )
+
+        # Try to init HRR persistent store (L3)
+        try:
+            from plugins.context_engine.lcm.hrr.store import MemoryStore as _HrrStore
+            self._engine.hrr_store = _HrrStore()
+        except (ImportError, Exception):
+            pass
+
+        # Track ingestion state — how many messages we've ingested so far
+        self._ingested_count: int = 0
+
+        # Map ABC attributes to engine state
+        self.context_length = context_length
+        self.threshold_percent = self._config.tau_soft
+        self.protect_last_n = self._config.protect_last_n
+        self.threshold_tokens = int(context_length * self._config.tau_soft)
+
+        # Try to init DAM retriever (L2)
+        self._try_init_dam()
+
+    def _try_init_dam(self) -> None:
+        """Best-effort DAM initialization (requires numpy)."""
+        try:
+            from plugins.context_engine.lcm.dam import DenseAssociativeMemory, MessageEncoder, DAMRetriever
+            self._engine.retriever = DAMRetriever(
+                net=DenseAssociativeMemory(nv=2048, nh=64),
+                enc=MessageEncoder(nv=2048),
+            )
+        except (ImportError, Exception):
+            pass
+
+    # ── Identity ──────────────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return "lcm"
+
+    # ── Core ABC interface ────────────────────────────────────────────────
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        """Update token tracking from API response usage."""
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+        total = prompt_tokens + completion_tokens
+
+        self.last_prompt_tokens = prompt_tokens
+        self.last_completion_tokens = completion_tokens
+        self.last_total_tokens = total
+
+        # Also update the engine's token estimator if it tracks real usage
+        self._engine.token_estimator._last_prompt_tokens = prompt_tokens
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        """Check if compaction should fire (covers both async and blocking)."""
+        if prompt_tokens is not None:
+            self.last_prompt_tokens = prompt_tokens
+
+        action = self._engine.check_thresholds()
+        return action != CompactionAction.NONE
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+    ) -> List[Dict[str, Any]]:
+        """Ingest any new messages, then compact if needed.
+
+        This is the main entry point called by run_agent.py.
+        We ingest messages the engine hasn't seen yet, then
+        run compaction and return the active message list.
+        """
+        # Ingest new messages since last call
+        new_count = len(messages) - self._ingested_count
+        if new_count > 0:
+            for msg in messages[self._ingested_count:]:
+                self._engine.ingest(msg)
+            self._ingested_count = len(messages)
+
+        # Check if compaction should fire
+        action = self._engine.check_thresholds()
+        if action != CompactionAction.NONE:
+            self._engine.auto_compact()
+            self.compression_count += 1
+
+        # Return the engine's active message list
+        result = self._engine.active_messages()
+
+        # Update token tracking
+        active_tokens = self._engine.active_tokens()
+        self.last_prompt_tokens = active_tokens
+        self.threshold_tokens = int(self.context_length * self._config.tau_soft)
+
+        return result
+
+    def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
+        """Quick estimate before the API call."""
+        active_tokens = self._engine.active_tokens()
+        return active_tokens > int(self.context_length * self._config.tau_soft)
+
+    # ── Session lifecycle ─────────────────────────────────────────────────
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        """Load persisted state and config for the session."""
+        # Try to load LCM config from config.yaml
+        try:
+            from hermes_cli.config import load_config
+            _config = load_config()
+            _lcm_cfg = _config.get("lcm", {})
+            if isinstance(_lcm_cfg, dict) and _lcm_cfg:
+                self._config = LcmConfig.from_dict(_lcm_cfg)
+                self.threshold_percent = self._config.tau_soft
+                self.protect_last_n = self._config.protect_last_n
+        except Exception:
+            pass  # Config not available, use defaults
+
+        # Update context length from kwargs or config
+        context_length = kwargs.get("context_length")
+        if context_length:
+            self.context_length = context_length
+            self._engine.token_estimator.config.context_length = context_length
+
+        self.threshold_tokens = int(self.context_length * self._config.tau_soft)
+
+        # Try session rebuild from persisted state
+        hermes_home = kwargs.get("hermes_home")
+        if hermes_home and session_id:
+            try:
+                self._engine.rebuild_from_session(hermes_home, session_id)
+            except Exception as e:
+                logger.debug("Session rebuild failed (starting fresh): %s", e)
+
+        # Update model info if provided
+        model = kwargs.get("model")
+        if model:
+            self._engine.model = model
+
+        logger.info(
+            "LCM session started (session=%s, context_length=%d, tau_soft=%.2f)",
+            session_id, self.context_length, self._config.tau_soft,
+        )
+
+    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        """Flush state, persist DAG/HRR for next session."""
+        # Ingest any final messages
+        new_count = len(messages) - self._ingested_count
+        if new_count > 0:
+            for msg in messages[self._ingested_count:]:
+                self._engine.ingest(msg)
+            self._ingested_count = len(messages)
+
+        # Flush HRR store
+        if hasattr(self._engine, "hrr_store") and self._engine.hrr_store:
+            try:
+                self._engine.hrr_store.flush()
+            except Exception as e:
+                logger.debug("HRR flush failed: %s", e)
+
+    def on_session_reset(self) -> None:
+        """Reset per-session state."""
+        self._engine.reset()
+        self._ingested_count = 0
+        super().on_session_reset()
+
+    # ── Tools ─────────────────────────────────────────────────────────────
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return all 7 LCM tool schemas."""
+        return list(LCM_TOOL_SCHEMAS.values())
+
+    def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+        """Dispatch LCM tool calls."""
+        # Route to the internal tool handlers via the engine
+        from plugins.context_engine.lcm import tools as lcm_tools
+
+        # Ensure the engine is registered for tool handlers
+        lcm_tools.set_engine(self._engine)
+
+        handlers = {
+            "lcm_expand": lcm_tools.handle_lcm_expand,
+            "lcm_pin": lcm_tools.handle_lcm_pin,
+            "lcm_forget": lcm_tools.handle_lcm_forget,
+            "lcm_search": lcm_tools.handle_lcm_search,
+            "lcm_budget": lcm_tools.handle_lcm_budget,
+            "lcm_toc": lcm_tools.handle_lcm_toc,
+            "lcm_focus": lcm_tools.handle_lcm_focus,
+        }
+
+        handler = handlers.get(name)
+        if handler is None:
+            import json
+            return json.dumps({"error": f"Unknown LCM tool: {name}"})
+
+        return handler(args)
+
+    # ── Status / display ──────────────────────────────────────────────────
+
+    def get_status(self) -> Dict[str, Any]:
+        """Extended status including store/DAG info."""
+        status = super().get_status()
+        status.update({
+            "store_count": len(self._engine.store),
+            "active_entries": len(self._engine.active),
+            "pinned_ids": sorted(self._engine._pinned_ids),
+            "tau_soft": self._config.tau_soft,
+            "tau_hard": self._config.tau_hard,
+        })
+        return status
+
+    # ── Model switch support ──────────────────────────────────────────────
+
+    def update_model(
+        self,
+        model: str,
+        context_length: int,
+        base_url: str = "",
+        api_key: str = "",
+        provider: str = "",
+    ) -> None:
+        """Propagate model switch to the engine internals."""
+        self.context_length = context_length
+        self.threshold_tokens = int(context_length * self._config.tau_soft)
+        self._engine.model = model
+        self._engine.provider = provider
+        self._engine.token_estimator.config.model = model
+        self._engine.token_estimator.config.provider = provider
+        self._engine.token_estimator.config.context_length = context_length
+        if self._config.summary_model:
+            self._engine.summarizer.config.model = self._config.summary_model
+        else:
+            self._engine.summarizer.config.model = model
+
+    # ── Availability check ────────────────────────────────────────────────
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """LCM is always available — it has no required external deps."""
+        return True
+
+
+# ── Plugin registration ───────────────────────────────────────────────────
+
+def register(ctx) -> None:
+    """Plugin entry point — register LCM as the context engine.
+
+    The plugin system or plugins/context_engine/ loader calls this.
+    We create an LcmContextEngine instance and register it.
+    """
+    engine = LcmContextEngine()
+    if hasattr(ctx, "register_context_engine"):
+        ctx.register_context_engine(engine)
+    else:
+        logger.warning("LCM plugin: context engine registration not supported by this plugin context")

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -112,10 +112,27 @@ class LcmContextEngine(ContextEngine):
         self._engine.token_estimator._last_prompt_tokens = prompt_tokens
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
-        """Check if compaction should fire (covers both async and blocking)."""
+        """Check if compaction should fire (covers both async and blocking).
+
+        Uses the real token count from the API response (prompt_tokens) when
+        available, falling back to the engine's internal active_tokens(). The
+        engine's active list may be empty before the first compress() call
+        (messages are only ingested during compress()), so relying solely on
+        active_tokens() creates a chicken-and-egg where compression never fires.
+        """
         if prompt_tokens is not None:
             self.last_prompt_tokens = prompt_tokens
 
+        # Use real API-reported token count if available — it reflects the
+        # actual context size including messages the engine hasn't ingested yet.
+        real_tokens = prompt_tokens if prompt_tokens and prompt_tokens > 0 else None
+
+        if real_tokens is not None:
+            budget = self._engine.context_length
+            ratio = real_tokens / budget if budget > 0 else 0.0
+            return ratio >= self._config.tau_soft
+
+        # Fallback: check engine's internal state (works after first compress())
         action = self._engine.check_thresholds()
         return action != CompactionAction.NONE
 
@@ -154,9 +171,19 @@ class LcmContextEngine(ContextEngine):
         return result
 
     def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
-        """Quick estimate before the API call."""
-        active_tokens = self._engine.active_tokens()
-        return active_tokens > int(self.context_length * self._config.tau_soft)
+        """Quick estimate before the API call.
+
+        Checks real messages since the engine's active list may be empty
+        before the first compress() call.
+        """
+        # If engine has ingested messages, use its active token count
+        if self._engine.active:
+            active_tokens = self._engine.active_tokens()
+            return active_tokens > int(self.context_length * self._config.tau_soft)
+
+        # Otherwise estimate from the raw messages passed in
+        estimated = self._engine.token_estimator.estimate(messages)
+        return estimated > int(self.context_length * self._config.tau_soft)
 
     # ── Session lifecycle ─────────────────────────────────────────────────
 

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -220,6 +220,9 @@ class LcmContextEngine(ContextEngine):
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
         """Load persisted state and config for the session."""
+        # Capture pre-reload enabled state so we can detect transitions.
+        _was_disabled = self._disabled
+
         # Try to load LCM config from config.yaml
         try:
             from hermes_cli.config import load_config
@@ -244,6 +247,19 @@ class LcmContextEngine(ContextEngine):
                     self._engine.summarizer.config.model = self._config.summary_model
         except Exception:
             pass  # Config not available, use defaults
+
+        # Warn when the engine transitions enabled→disabled at runtime.
+        # The agent's tool list is populated once at startup and cannot be
+        # retracted without a restart; tool calls against a now-disabled engine
+        # return {"error": "LCM is disabled"} (handled in handle_tool_call), but
+        # the model will still see the stale schemas until the process restarts.
+        if _was_disabled is False and self._disabled is True:
+            logger.warning(
+                "LCM was disabled via config reload (lcm.enabled=false). "
+                "LCM tool schemas already advertised to the model will not be "
+                "retracted until the agent is restarted. All LCM tool calls "
+                "will return an error in the meantime."
+            )
 
         # Update context length from kwargs or config
         context_length = kwargs.get("context_length")

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -229,6 +229,10 @@ class LcmContextEngine(ContextEngine):
                 self._config = LcmConfig.from_dict(_lcm_cfg)
                 self.threshold_percent = self._config.tau_soft
                 self.protect_last_n = self._config.protect_last_n
+                # Re-evaluate _disabled so a config change (e.g. lcm.enabled=false)
+                # takes effect immediately for this session without requiring a
+                # process restart.
+                self._disabled = not self._config.enabled
                 # Propagate the reloaded config to the live engine so compaction
                 # reads the user-supplied thresholds (tau_soft, tau_hard, etc.)
                 # rather than the constructor-time defaults.

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -178,6 +178,9 @@ class LcmContextEngine(ContextEngine):
         action = self._engine.check_thresholds()
         if action == CompactionAction.ASYNC:
             self._engine.async_compact()
+            # Count when scheduled so the status display reflects "X compactions
+            # triggered" for both async and blocking paths, not just blocking ones.
+            self.compression_count += 1
         elif action == CompactionAction.BLOCKING:
             self._engine.auto_compact()
             self.compression_count += 1

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -185,6 +185,15 @@ class LcmContextEngine(ContextEngine):
         # Return the engine's active message list
         result = self._engine.active_messages()
 
+        # After compaction the active list is shorter than the original input.
+        # run_agent uses `result` as the new messages list for the next
+        # iteration, so the cursor must track *that* length.  Without this,
+        # the next compress() call computes new_count = len(result_next) -
+        # len(messages_original), which can be negative and silently skips
+        # fresh turns until the conversation re-grows past the old length.
+        if action in (CompactionAction.ASYNC, CompactionAction.BLOCKING):
+            self._ingested_count = len(result)
+
         # Update token tracking
         active_tokens = self._engine.active_tokens()
         self.last_prompt_tokens = active_tokens

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -222,6 +222,12 @@ class LcmContextEngine(ContextEngine):
 
         self.threshold_tokens = int(self.context_length * self._config.tau_soft)
 
+        # Distinguish fresh session start from compression-driven rollover.
+        # During compression rollover run_agent.py passes boundary_reason="compression"
+        # so we preserve existing engine state instead of re-initializing.
+        boundary_reason = kwargs.get("boundary_reason", "")
+        is_compression_rollover = boundary_reason == "compression"
+
         # Try session rebuild from persisted state
         hermes_home = kwargs.get("hermes_home")
         if hermes_home and session_id:
@@ -245,12 +251,15 @@ class LcmContextEngine(ContextEngine):
                     # compress() to re-ingest already-stored messages on the next call.
                     lcm_meta = session_data.get("lcm") or {}
                     self._ingested_count = len(lcm_meta.get("original_messages") or [])
-                else:
-                    # No save file — this is a fresh session, nothing ingested yet.
+                elif not is_compression_rollover:
+                    # No save file and not a compression rollover — fresh session,
+                    # nothing ingested yet.  Compression rollovers keep existing
+                    # engine state so already-compacted messages are not re-ingested.
                     self._ingested_count = 0
             except Exception as e:
                 logger.warning("LCM session rebuild failed (starting fresh): %s", e)
-                self._ingested_count = 0
+                if not is_compression_rollover:
+                    self._ingested_count = 0
 
         # Update model info if provided
         model = kwargs.get("model")

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -207,6 +207,10 @@ class LcmContextEngine(ContextEngine):
                 self._config = LcmConfig.from_dict(_lcm_cfg)
                 self.threshold_percent = self._config.tau_soft
                 self.protect_last_n = self._config.protect_last_n
+                # Propagate the reloaded config to the live engine so compaction
+                # reads the user-supplied thresholds (tau_soft, tau_hard, etc.)
+                # rather than the constructor-time defaults.
+                self._engine.config = self._config
         except Exception:
             pass  # Config not available, use defaults
 

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -228,10 +228,19 @@ class LcmContextEngine(ContextEngine):
                         provider=self._engine.provider,
                         context_length=self.context_length,
                     )
-                    # Sync ingested count to match rebuilt engine
-                    self._ingested_count = len(self._engine.active)
+                    # Sync ingested count to the number of input messages that were
+                    # originally fed into this engine instance.  Using active list
+                    # length would be wrong: after compaction the active list is
+                    # shorter than the number of messages that were ingested, causing
+                    # compress() to re-ingest already-stored messages on the next call.
+                    lcm_meta = session_data.get("lcm") or {}
+                    self._ingested_count = len(lcm_meta.get("original_messages") or [])
+                else:
+                    # No save file — this is a fresh session, nothing ingested yet.
+                    self._ingested_count = 0
             except Exception as e:
                 logger.warning("LCM session rebuild failed (starting fresh): %s", e)
+                self._ingested_count = 0
 
         # Update model info if provided
         model = kwargs.get("model")

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -274,7 +274,14 @@ class LcmContextEngine(ContextEngine):
                     # shorter than the number of messages that were ingested, causing
                     # compress() to re-ingest already-stored messages on the next call.
                     lcm_meta = session_data.get("lcm") or {}
-                    self._ingested_count = len(lcm_meta.get("original_messages") or [])
+                    original = lcm_meta.get("original_messages")
+                    if original:
+                        self._ingested_count = len(original)
+                    else:
+                        # Legacy session (no original_messages key): rebuild() appended
+                        # each raw active message to the store.  Seed from store size so
+                        # compress() doesn't re-ingest everything that was just restored.
+                        self._ingested_count = len(self._engine.store)
                 elif not is_compression_rollover:
                     # No save file and not a compression rollover — fresh session,
                     # nothing ingested yet.  Compression rollovers keep existing

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -244,6 +244,17 @@ class LcmContextEngine(ContextEngine):
                         provider=self._engine.provider,
                         context_length=self.context_length,
                     )
+                    # Re-attach L3 HRR store — rebuild() returns a fresh LcmEngine
+                    # that has no hrr_store; without this, resumed sessions lose all
+                    # cross-session memory (same root cause as config not propagating
+                    # after rebuild, fixed in round-3).
+                    try:
+                        from plugins.context_engine.lcm.hrr.store import MemoryStore as _HrrStore
+                        self._engine.hrr_store = _HrrStore()
+                    except (ImportError, Exception):
+                        pass
+                    # Re-attach L2 DAM retriever for the same reason.
+                    self._try_init_dam()
                     # Sync ingested count to the number of input messages that were
                     # originally fed into this engine instance.  Using active list
                     # length would be wrong: after compaction the active list is

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -237,6 +237,11 @@ class LcmContextEngine(ContextEngine):
                 # reads the user-supplied thresholds (tau_soft, tau_hard, etc.)
                 # rather than the constructor-time defaults.
                 self._engine.config = self._config
+                # Re-sync the live Summarizer's model so a config.yaml change to
+                # lcm.summary_model reaches the already-constructed instance.
+                # summarizer.config.model is the field that _try_llm_summarize reads.
+                if self._config.summary_model:
+                    self._engine.summarizer.config.model = self._config.summary_model
         except Exception:
             pass  # Config not available, use defaults
 

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -25,6 +25,12 @@ from plugins.context_engine.lcm.engine import LcmEngine, CompactionAction, Conte
 from plugins.context_engine.lcm.dag import SummaryDag, SummaryNode, MessageId
 from plugins.context_engine.lcm.store import ImmutableStore
 from plugins.context_engine.lcm.tools import LCM_TOOL_SCHEMAS
+try:
+    from plugins.context_engine.lcm.hrr.tools import MEMORY_TOOL_HANDLERS
+    from plugins.context_engine.lcm.hrr.schemas import MEMORY_TOOL_SCHEMAS
+except (ImportError, Exception):
+    MEMORY_TOOL_HANDLERS: dict = {}  # type: ignore[assignment]
+    MEMORY_TOOL_SCHEMAS: dict = {}  # type: ignore[assignment]
 from plugins.context_engine.lcm.summarizer import Summarizer, SummarizerConfig
 from plugins.context_engine.lcm.tokens import TokenEstimator, TokenEstimatorConfig, estimate_messages_tokens_rough
 from plugins.context_engine.lcm.semantic import SemanticIndex, SemanticIndexConfig, NoOpSemanticIndex, create_semantic_index
@@ -277,15 +283,24 @@ class LcmContextEngine(ContextEngine):
     # ── Tools ─────────────────────────────────────────────────────────────
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        """Return all 7 LCM tool schemas."""
-        return list(LCM_TOOL_SCHEMAS.values())
+        """Return LCM and memory_* tool schemas.
+
+        Combines the 7 lcm_* schemas with the 5 memory_* schemas so the agent
+        has access to all unified memory tools.  The memory_* schemas are
+        imported at module load time and fall back to an empty dict when the
+        HRR sub-package is not installed.
+        """
+        return list(LCM_TOOL_SCHEMAS.values()) + list(MEMORY_TOOL_SCHEMAS.values())
 
     def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
-        """Dispatch LCM tool calls."""
+        """Dispatch LCM and memory_* tool calls."""
+        import json as _json
+
         # Route to the internal tool handlers via the engine
         from plugins.context_engine.lcm import tools as lcm_tools
 
-        # Ensure the engine is registered for tool handlers
+        # Ensure the engine is registered for tool handlers (used by both lcm_*
+        # and memory_* handlers — memory handlers call get_engine() internally)
         lcm_tools.set_engine(self._engine)
 
         handlers = {
@@ -298,10 +313,13 @@ class LcmContextEngine(ContextEngine):
             "lcm_focus": lcm_tools.handle_lcm_focus,
         }
 
+        # Merge memory_* handlers (imported at module level; empty dict when HRR
+        # sub-package is unavailable so this is always safe)
+        handlers.update(MEMORY_TOOL_HANDLERS)
+
         handler = handlers.get(name)
         if handler is None:
-            import json
-            return json.dumps({"error": f"Unknown LCM tool: {name}"})
+            return _json.dumps({"error": f"Unknown LCM tool: {name}"})
 
         return handler(args)
 

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -157,7 +157,9 @@ class LcmContextEngine(ContextEngine):
 
         # Check if compaction should fire
         action = self._engine.check_thresholds()
-        if action != CompactionAction.NONE:
+        if action == CompactionAction.ASYNC:
+            self._engine.async_compact()
+        elif action == CompactionAction.BLOCKING:
             self._engine.auto_compact()
             self.compression_count += 1
 

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -341,13 +341,15 @@ class LcmContextEngine(ContextEngine):
 
 # ── Plugin registration ───────────────────────────────────────────────────
 
-def register(ctx) -> None:
+def register(ctx, **kwargs) -> None:
     """Plugin entry point — register LCM as the context engine.
 
     The plugin system or plugins/context_engine/ loader calls this.
     We create an LcmContextEngine instance and register it.
+    kwargs are forwarded to the engine constructor (e.g. lcm_config, model,
+    provider, context_length).
     """
-    engine = LcmContextEngine()
+    engine = LcmContextEngine(**kwargs)
     if hasattr(ctx, "register_context_engine"):
         ctx.register_context_engine(engine)
     else:

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -59,6 +59,11 @@ class LcmContextEngine(ContextEngine):
         else:
             self._config = LcmConfig()
 
+        # Honour lcm.enabled=false — build a stub engine only so other methods
+        # (reset, get_status) remain safe to call, but skip all heavy init and
+        # suppress tool surface.
+        self._disabled: bool = not self._config.enabled
+
         self._engine = LcmEngine(
             config=self._config,
             model=model,
@@ -66,12 +71,13 @@ class LcmContextEngine(ContextEngine):
             context_length=context_length,
         )
 
-        # Try to init HRR persistent store (L3)
-        try:
-            from plugins.context_engine.lcm.hrr.store import MemoryStore as _HrrStore
-            self._engine.hrr_store = _HrrStore()
-        except (ImportError, Exception):
-            pass
+        if not self._disabled:
+            # Try to init HRR persistent store (L3)
+            try:
+                from plugins.context_engine.lcm.hrr.store import MemoryStore as _HrrStore
+                self._engine.hrr_store = _HrrStore()
+            except (ImportError, Exception):
+                pass
 
         # Track ingestion state — how many messages we've ingested so far
         self._ingested_count: int = 0
@@ -82,8 +88,9 @@ class LcmContextEngine(ContextEngine):
         self.protect_last_n = self._config.protect_last_n
         self.threshold_tokens = int(context_length * self._config.tau_soft)
 
-        # Try to init DAM retriever (L2)
-        self._try_init_dam()
+        if not self._disabled:
+            # Try to init DAM retriever (L2)
+            self._try_init_dam()
 
     def _try_init_dam(self) -> None:
         """Best-effort DAM initialization (requires numpy)."""
@@ -117,7 +124,7 @@ class LcmContextEngine(ContextEngine):
         # Also update the engine's token estimator if it tracks real usage
         self._engine.token_estimator._last_prompt_tokens = prompt_tokens
 
-    def should_compress(self, prompt_tokens: int = None) -> bool:
+    def should_compress(self, prompt_tokens: int = None) -> bool:  # type: ignore[override]
         """Check if compaction should fire (covers both async and blocking).
 
         Uses the real token count from the API response (prompt_tokens) when
@@ -126,6 +133,9 @@ class LcmContextEngine(ContextEngine):
         (messages are only ingested during compress()), so relying solely on
         active_tokens() creates a chicken-and-egg where compression never fires.
         """
+        if self._disabled:
+            return False
+
         if prompt_tokens is not None:
             self.last_prompt_tokens = prompt_tokens
 
@@ -154,6 +164,9 @@ class LcmContextEngine(ContextEngine):
         We ingest messages the engine hasn't seen yet, then
         run compaction and return the active message list.
         """
+        if self._disabled:
+            return messages
+
         # Ingest new messages since last call
         new_count = len(messages) - self._ingested_count
         if new_count > 0:
@@ -314,11 +327,16 @@ class LcmContextEngine(ContextEngine):
         imported at module load time and fall back to an empty dict when the
         HRR sub-package is not installed.
         """
+        if self._disabled:
+            return []
         return list(LCM_TOOL_SCHEMAS.values()) + list(MEMORY_TOOL_SCHEMAS.values())
 
     def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
         """Dispatch LCM and memory_* tool calls."""
         import json as _json
+
+        if self._disabled:
+            return _json.dumps({"error": "LCM is disabled"})
 
         # Route to the internal tool handlers via the engine
         from plugins.context_engine.lcm import tools as lcm_tools

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -214,9 +214,22 @@ class LcmContextEngine(ContextEngine):
         hermes_home = kwargs.get("hermes_home")
         if hermes_home and session_id:
             try:
-                self._engine.rebuild_from_session(hermes_home, session_id)
+                import json
+                from pathlib import Path
+                session_file = Path(hermes_home) / "sessions" / f"session_{session_id}.json"
+                if session_file.exists():
+                    session_data = json.loads(session_file.read_text(encoding="utf-8"))
+                    self._engine = LcmEngine.rebuild_from_session(
+                        session_data,
+                        self._config,
+                        model=self._engine.model,
+                        provider=self._engine.provider,
+                        context_length=self.context_length,
+                    )
+                    # Sync ingested count to match rebuilt engine
+                    self._ingested_count = len(self._engine.active)
             except Exception as e:
-                logger.debug("Session rebuild failed (starting fresh): %s", e)
+                logger.warning("LCM session rebuild failed (starting fresh): %s", e)
 
         # Update model info if provided
         model = kwargs.get("model")

--- a/plugins/context_engine/lcm/config.py
+++ b/plugins/context_engine/lcm/config.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass
+class LcmConfig:
+    """Configuration for LCM context management.
+
+    Attributes:
+        enabled: Whether LCM is active (default True for new unified system)
+        tau_soft: Soft threshold ratio for async compaction (0.0-1.0)
+        tau_hard: Hard threshold ratio for blocking compaction (0.0-1.0)
+        deterministic_target: Target tokens for deterministic summaries
+        protect_last_n: Number of tail messages to always protect
+        summary_model: Override model for summarization (empty = use main model)
+        max_pinned: Maximum number of messages that can be pinned
+        semantic_search: Enable embedding-based search (requires OPENAI_API_KEY)
+    """
+    enabled: bool = True
+    tau_soft: float = 0.50
+    tau_hard: float = 0.85
+    deterministic_target: int = 512
+    protect_last_n: int = 4
+    summary_model: str = ""
+    max_pinned: int = 20
+    semantic_search: bool = False
+    max_store_size: int = 1000
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "LcmConfig":
+        return cls(
+            enabled=str(d.get("enabled", True)).lower() in ("true", "1", "yes"),
+            tau_soft=float(d.get("tau_soft", 0.50)),
+            tau_hard=float(d.get("tau_hard", 0.85)),
+            deterministic_target=int(d.get("deterministic_target", 512)),
+            protect_last_n=int(d.get("protect_last_n", 4)),
+            summary_model=str(d.get("summary_model", "")),
+            max_pinned=int(d.get("max_pinned", 20)),
+            semantic_search=str(d.get("semantic_search", False)).lower() in ("true", "1", "yes"),
+            max_store_size=int(d.get("max_store_size", 1000)),
+        )

--- a/plugins/context_engine/lcm/dag.py
+++ b/plugins/context_engine/lcm/dag.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+
+MessageId = int
+
+
+@dataclass
+class SummaryNode:
+    id: int
+    source_ids: list[MessageId]
+    child_summaries: list[int] = field(default_factory=list)
+    text: str = ""
+    tokens: int = 0
+    level: int = 1
+
+
+@dataclass
+class SummaryDag:
+    nodes: list[SummaryNode] = field(default_factory=list)
+    _next_id: int = 0
+
+    def create_node(
+        self,
+        source_ids: list[MessageId],
+        text: str,
+        level: int,
+        tokens: int = 0,
+        children: list[int] | None = None,
+    ) -> SummaryNode:
+        node = SummaryNode(
+            id=self._next_id,
+            source_ids=source_ids,
+            child_summaries=children or [],
+            text=text,
+            tokens=tokens,
+            level=level,
+        )
+        self.nodes.append(node)
+        self._next_id += 1
+        return node
+
+    def get(self, node_id: int) -> SummaryNode | None:
+        for node in self.nodes:
+            if node.id == node_id:
+                return node
+        return None
+
+    def all_source_ids(self, node_id: int) -> list[MessageId]:
+        node = self.get(node_id)
+        if node is None:
+            return []
+        result = list(node.source_ids)
+        for child_id in node.child_summaries:
+            result.extend(self.all_source_ids(child_id))
+        return result
+
+    def __len__(self) -> int:
+        return len(self.nodes)
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self.nodes) == 0

--- a/plugins/context_engine/lcm/dam/__init__.py
+++ b/plugins/context_engine/lcm/dam/__init__.py
@@ -1,0 +1,17 @@
+"""Bundled Dense Associative Memory package for Hermes LCM.
+
+Provides the core DAM components as a first-party package under agent.lcm.dam,
+eliminating the need for sys.path hacks in tests and enabling clean imports.
+"""
+from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
+from plugins.context_engine.lcm.dam.encoder import MessageEncoder
+from plugins.context_engine.lcm.dam.retrieval import DAMRetriever
+from plugins.context_engine.lcm.dam.persistence import save_state, load_state
+
+__all__ = [
+    "DenseAssociativeMemory",
+    "MessageEncoder",
+    "DAMRetriever",
+    "save_state",
+    "load_state",
+]

--- a/plugins/context_engine/lcm/dam/encoder.py
+++ b/plugins/context_engine/lcm/dam/encoder.py
@@ -1,0 +1,67 @@
+"""Message encoder: text -> fixed-size vector via character trigram hashing."""
+import numpy as np
+from typing import Any
+import hashlib
+
+
+class MessageEncoder:
+    """Encodes messages as Nv-dimensional unit vectors.
+
+    Uses character trigram hashing for zero-dependency text vectorization.
+    Similar texts produce similar vectors (shared trigrams -> shared indices).
+    """
+
+    def __init__(self, nv: int = 2048, role_weight: float = 0.3):
+        self.nv = nv
+        self.role_weight = role_weight
+
+    def _trigram_hash(self, text: str) -> np.ndarray:
+        """Hash character trigrams into a Nv-dimensional count vector."""
+        v = np.zeros(self.nv, dtype=np.float32)
+        text = text.lower()
+        if len(text) < 3:
+            # For very short text, use character-level
+            for ch in text:
+                idx = int(hashlib.md5(ch.encode()).hexdigest(), 16) % self.nv
+                v[idx] += 1.0
+            return v
+
+        for i in range(len(text) - 2):
+            trigram = text[i:i + 3]
+            # Use md5 for deterministic cross-platform hashing
+            idx = int(hashlib.md5(trigram.encode()).hexdigest(), 16) % self.nv
+            v[idx] += 1.0
+        return v
+
+    def _role_vector(self, role: str) -> np.ndarray:
+        """Encode the message role as a sparse vector."""
+        v = np.zeros(self.nv, dtype=np.float32)
+        role_hash = hashlib.md5(f"role:{role}".encode()).hexdigest()
+        # Spread across 4 indices
+        for i in range(4):
+            chunk = role_hash[i * 8:(i + 1) * 8]
+            idx = int(chunk, 16) % self.nv
+            v[idx] += 1.0
+        return v
+
+    def encode(self, message: dict[str, Any]) -> np.ndarray:
+        """Encode a message dict to a unit vector."""
+        content = str(message.get("content", "") or "")
+        role = str(message.get("role", "unknown"))
+
+        v = self._trigram_hash(content)
+        if self.role_weight > 0:
+            v += self.role_weight * self._role_vector(role)
+
+        norm = np.linalg.norm(v)
+        if norm > 1e-8:
+            v /= norm
+        return v
+
+    def encode_text(self, text: str) -> np.ndarray:
+        """Encode a raw text string (for queries)."""
+        v = self._trigram_hash(text)
+        norm = np.linalg.norm(v)
+        if norm > 1e-8:
+            v /= norm
+        return v

--- a/plugins/context_engine/lcm/dam/network.py
+++ b/plugins/context_engine/lcm/dam/network.py
@@ -1,0 +1,147 @@
+"""Dense Associative Memory network -- implements the paper's bipartite architecture.
+
+Reference: "Biologically Plausible Dense Associative Memory with Exponential Capacity"
+arxiv 2601.00984v2
+"""
+import numpy as np
+from typing import Any
+
+
+class DenseAssociativeMemory:
+    """Two-layer bipartite network with exponential storage capacity.
+
+    Nv visible neurons, Nh hidden neurons. Weight matrix xi: (Nv, Nh).
+    Theoretical capacity: 2^Nh patterns when Nv >> Nh.
+    """
+
+    def __init__(self, nv: int = 2048, nh: int = 64, theta: float = 0.5,
+                 beta: float = 10.0, lr: float = 0.005):
+        self.nv = nv
+        self.nh = nh
+        self.theta = theta
+        self.beta = beta  # Sigmoid sharpness for training
+        self.lr = lr
+        self.n_patterns_trained = 0
+
+        # Xavier initialization
+        scale = np.sqrt(2.0 / (nv + nh))
+        self.xi = (np.random.randn(nv, nh) * scale).astype(np.float32)
+
+    def get_hidden_activations(self, v: np.ndarray) -> np.ndarray:
+        """Compute binary hidden activations: s = Theta(sqrt(Nh)/Nv * xi^T * v - theta)"""
+        h = (np.sqrt(self.nh) / self.nv) * (self.xi.T @ v)
+        return (h >= self.theta).astype(np.float32)
+
+    def _sigmoid_hidden(self, v: np.ndarray) -> np.ndarray:
+        """Soft hidden activations for training: sigma(beta*(h - theta))"""
+        h = (np.sqrt(self.nh) / self.nv) * (self.xi.T @ v)
+        return 1.0 / (1.0 + np.exp(-self.beta * (h - self.theta)))
+
+    def _reconstruct(self, s: np.ndarray) -> np.ndarray:
+        """Reconstruct visible from hidden: v = (1/sqrt(Nh)) * xi * s, then L2 normalize"""
+        v_out = (1.0 / np.sqrt(self.nh)) * (self.xi @ s)
+        norm = np.linalg.norm(v_out)
+        if norm > 1e-8:
+            v_out /= norm
+        return v_out
+
+    def recall(self, v: np.ndarray, max_iter: int = 10, eps: float = 1e-6) -> tuple:
+        """Pattern completion: iterate update rules to convergence.
+
+        Returns (v_recalled, s_hidden).
+        """
+        v = v.copy().astype(np.float32)
+        norm = np.linalg.norm(v)
+        if norm > 1e-8:
+            v /= norm
+
+        s = self.get_hidden_activations(v)
+        for _ in range(max_iter):
+            s = self.get_hidden_activations(v)
+            v_new = self._reconstruct(s)
+            if np.linalg.norm(v_new - v) < eps:
+                return v_new, s
+            v = v_new
+
+        return v, s
+
+    def learn(self, patterns: np.ndarray, epochs: int = 5) -> float:
+        """Train weights to store patterns via gradient descent.
+
+        Uses sigmoid approximation for differentiable Heaviside.
+        Returns final mean reconstruction error.
+        """
+        n = patterns.shape[0]
+        lr_eff = self.lr / (1.0 + self.n_patterns_trained / 1000.0)  # Decay
+
+        last_loss = float('inf')
+        for epoch in range(epochs):
+            total_loss = 0.0
+            for i in range(n):
+                v = patterns[i]
+
+                # Forward (soft activations for gradient)
+                s_soft = self._sigmoid_hidden(v)
+                v_recon = (1.0 / np.sqrt(self.nh)) * (self.xi @ s_soft)
+                norm = np.linalg.norm(v_recon)
+                if norm > 1e-8:
+                    v_recon_normed = v_recon / norm
+                else:
+                    v_recon_normed = v_recon
+
+                # Loss: ||v - v_recon_normed||^2
+                error = v - v_recon_normed
+                loss = float(np.sum(error ** 2))
+                total_loss += loss
+
+                # Gradient through reconstruction
+                # d_loss/d_v_recon_normed = -2 * error
+                # Gradient of L2-normalize: (I - v_hat v_hat^T) / ||v_recon||
+                d_loss_d_vhat = -2.0 * error
+                if norm > 1e-8:
+                    d_loss_d_vrecon = (d_loss_d_vhat - np.dot(d_loss_d_vhat, v_recon_normed) * v_recon_normed) / norm
+                else:
+                    d_loss_d_vrecon = d_loss_d_vhat
+
+                # v_recon = (1/sqrt(Nh)) * xi @ s_soft
+                # d_loss/d_xi (direct, treating s_soft as const) = (1/sqrt(Nh)) * d_loss_d_vrecon outer s_soft
+                grad_direct = (1.0 / np.sqrt(self.nh)) * np.outer(d_loss_d_vrecon, s_soft)
+
+                # Gradient through s_soft = sigma(beta*(xi^T v * sqrt(Nh)/Nv - theta))
+                # d_s_soft/d_xi = diag(ds_dh) * (sqrt(Nh)/Nv) * v^T  => shape (Nh, Nv)
+                # d_loss/d_s_soft = (1/sqrt(Nh)) * xi^T @ d_loss_d_vrecon
+                d_loss_d_ssoft = (1.0 / np.sqrt(self.nh)) * (self.xi.T @ d_loss_d_vrecon)
+                ds_dh = self.beta * s_soft * (1.0 - s_soft)  # sigmoid derivative, shape (Nh,)
+                # d_loss/d_xi via s_soft path: outer(v, ds_dh * d_loss_d_ssoft) * sqrt(Nh)/Nv
+                grad_sigmoid = (np.sqrt(self.nh) / self.nv) * np.outer(v, ds_dh * d_loss_d_ssoft)
+
+                # Update
+                self.xi -= lr_eff * (grad_direct + grad_sigmoid)
+
+            last_loss = total_loss / n
+
+        self.n_patterns_trained += n
+        return last_loss
+
+    def get_state(self) -> dict:
+        """Serialize network state."""
+        return {
+            'xi': self.xi.copy(),
+            'nv': self.nv,
+            'nh': self.nh,
+            'theta': self.theta,
+            'beta': self.beta,
+            'lr': self.lr,
+            'n_patterns_trained': self.n_patterns_trained,
+        }
+
+    @classmethod
+    def from_state(cls, state: dict) -> 'DenseAssociativeMemory':
+        """Reconstruct from serialized state."""
+        net = cls(
+            nv=state['nv'], nh=state['nh'],
+            theta=state['theta'], beta=state['beta'], lr=state['lr'],
+        )
+        net.xi = state['xi'].copy()
+        net.n_patterns_trained = state['n_patterns_trained']
+        return net

--- a/plugins/context_engine/lcm/dam/persistence.py
+++ b/plugins/context_engine/lcm/dam/persistence.py
@@ -1,0 +1,60 @@
+"""Save and load DAM network state to disk."""
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def save_state(retriever, path: Path) -> bool:
+    """Save retriever state to a .npz file."""
+    try:
+        import numpy as np
+        net = getattr(retriever, 'net', None) or getattr(retriever, 'network')
+        state = {
+            'xi': net.xi,
+            'nv': np.array(net.nv),
+            'nh': np.array(net.nh),
+            'theta': np.array(net.theta),
+            'beta': np.array(net.beta),
+            'lr': np.array(net.lr),
+            'n_patterns_trained': np.array(net.n_patterns_trained),
+            'last_indexed_id': np.array(retriever._last_indexed_id),
+        }
+        if retriever._pattern_cache:
+            cache_ids = np.array(sorted(retriever._pattern_cache.keys()), dtype=np.int64)
+            cache_vectors = np.stack([retriever._pattern_cache[i] for i in cache_ids])
+            state['cache_ids'] = cache_ids
+            state['cache_vectors'] = cache_vectors
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(str(path), **state)
+        return True
+    except Exception as e:
+        logger.warning("Failed to save DAM state: %s", e)
+        return False
+
+
+def load_state(path: Path) -> Optional[dict]:
+    """Load retriever state from a .npz file."""
+    try:
+        import numpy as np
+        if not path.exists():
+            return None
+        data = np.load(str(path), allow_pickle=False)
+        state = {
+            'xi': data['xi'],
+            'nv': int(data['nv']),
+            'nh': int(data['nh']),
+            'theta': float(data['theta']),
+            'beta': float(data['beta']),
+            'lr': float(data['lr']),
+            'n_patterns_trained': int(data['n_patterns_trained']),
+            'last_indexed_id': int(data['last_indexed_id']),
+            'cache_ids': data.get('cache_ids'),
+            'cache_vectors': data.get('cache_vectors'),
+        }
+        return state
+    except Exception as e:
+        logger.warning("Failed to load DAM state: %s", e)
+        return None

--- a/plugins/context_engine/lcm/dam/retrieval.py
+++ b/plugins/context_engine/lcm/dam/retrieval.py
@@ -1,0 +1,230 @@
+"""DAM Retrieval Engine — semantic search over the LCM conversation store.
+
+Integrates DenseAssociativeMemory and MessageEncoder with the LcmEngine's
+ImmutableStore to provide associative retrieval over conversation history.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
+from plugins.context_engine.lcm.dam.encoder import MessageEncoder
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Cosine similarity between two vectors. Returns 0 if either is zero."""
+    na = np.linalg.norm(a)
+    nb = np.linalg.norm(b)
+    if na < 1e-8 or nb < 1e-8:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))
+
+
+class DAMRetriever:
+    """Semantic retrieval engine backed by a DenseAssociativeMemory.
+
+    Keeps a pattern cache mapping msg_id -> encoded vector so that cosine
+    ranking after DAM recall is fast and doesn't re-encode every message.
+
+    Parameters
+    ----------
+    net:
+        The DenseAssociativeMemory network to train and query.
+    enc:
+        The MessageEncoder used to vectorize messages and query strings.
+    storage_dir:
+        Directory for any optional state persistence (not required for core ops).
+    """
+
+    def __init__(
+        self,
+        net: DenseAssociativeMemory,
+        enc: MessageEncoder,
+        storage_dir: Path | None = None,
+    ) -> None:
+        self.net = net
+        self.enc = enc
+        self.storage_dir = storage_dir
+
+        # msg_id -> unit vector
+        self._pattern_cache: dict[int, np.ndarray] = {}
+        # Tracks how many store messages have been indexed so far
+        self._last_indexed_id: int = 0
+
+    # ------------------------------------------------------------------
+    # Sync
+    # ------------------------------------------------------------------
+
+    def sync_from_store(self, store: Any) -> int:
+        """Index any new messages from an explicit store reference.
+
+        Avoids the circular dependency introduced by ``sync_with_store()``
+        (which calls ``get_engine()``).  The engine passes ``self.store``
+        directly so there is no global state involved.
+
+        Returns the count of newly indexed messages.
+        """
+        total = len(store)
+        new_messages: list[np.ndarray] = []
+        new_ids: list[int] = []
+
+        for msg_id in range(self._last_indexed_id, total):
+            msg = store.get(msg_id)
+            if msg is None:
+                continue
+            vec = self.enc.encode(msg)
+            self._pattern_cache[msg_id] = vec
+            new_messages.append(vec)
+            new_ids.append(msg_id)
+
+        if new_messages:
+            patterns = np.stack(new_messages, axis=0)
+            self.net.learn(patterns)
+            self._last_indexed_id = total
+
+        return len(new_ids)
+
+    def sync_with_store(self) -> int:
+        """Index any new messages from the active LcmEngine's store.
+
+        Reads messages from ``_last_indexed_id`` up to the current store
+        length, encodes them, and trains the network on the new batch.
+
+        Returns the count of newly indexed messages.
+        """
+        try:
+            from plugins.context_engine.lcm.tools import get_engine
+        except ImportError:
+            return 0
+
+        engine = get_engine()
+        if engine is None:
+            return 0
+
+        return self.sync_from_store(engine.store)
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(self, query: str, limit: int = 10) -> list[tuple[int, float]]:
+        """Encode query string, run DAM recall, rank cache by cosine similarity.
+
+        Returns a list of (msg_id, score) sorted by descending score.
+        An empty query returns an empty list.
+        """
+        if not query.strip():
+            return []
+
+        if not self._pattern_cache:
+            return []
+
+        q_vec = self.enc.encode_text(query)
+        recalled, _ = self.net.recall(q_vec)
+
+        scores = [
+            (msg_id, _cosine_similarity(recalled, vec))
+            for msg_id, vec in self._pattern_cache.items()
+        ]
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return scores[:limit]
+
+    # ------------------------------------------------------------------
+    # Recall similar
+    # ------------------------------------------------------------------
+
+    def recall_similar(self, msg_id: int, limit: int = 5) -> list[tuple[int, float]]:
+        """Find messages similar to the one at msg_id using DAM recall.
+
+        Looks up the cached vector for msg_id, runs recall, then ranks
+        all other cached messages by cosine similarity to the recalled vector.
+
+        Returns a list of (msg_id, score) excluding the query message itself,
+        sorted by descending score.
+        """
+        if msg_id not in self._pattern_cache:
+            return []
+
+        anchor_vec = self._pattern_cache[msg_id]
+        recalled, _ = self.net.recall(anchor_vec)
+
+        scores = [
+            (mid, _cosine_similarity(recalled, vec))
+            for mid, vec in self._pattern_cache.items()
+            if mid != msg_id
+        ]
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return scores[:limit]
+
+    # ------------------------------------------------------------------
+    # Compose
+    # ------------------------------------------------------------------
+
+    def compose(
+        self,
+        queries: list[str],
+        operation: str = "AND",
+        limit: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Multi-term composition using hidden-layer activation algebra.
+
+        Each query is encoded and projected to binary hidden activations.
+        Activations are combined:
+          - AND: element-wise min (intersection — all terms must fire)
+          - OR:  element-wise max (union — any term may fire)
+
+        The composed activation is used to reconstruct a visible vector which
+        is then ranked against the cache by cosine similarity.
+
+        Returns a list of (msg_id, score) sorted by descending score.
+        """
+        if not queries or not self._pattern_cache:
+            return []
+
+        hidden_acts: list[np.ndarray] = []
+        for q in queries:
+            if not q.strip():
+                continue
+            q_vec = self.enc.encode_text(q)
+            h = self.net.get_hidden_activations(q_vec)
+            hidden_acts.append(h)
+
+        if not hidden_acts:
+            return []
+
+        if operation.upper() == "AND":
+            composed = hidden_acts[0]
+            for h in hidden_acts[1:]:
+                composed = np.minimum(composed, h)
+        else:  # OR
+            composed = hidden_acts[0]
+            for h in hidden_acts[1:]:
+                composed = np.maximum(composed, h)
+
+        # Reconstruct a visible vector from the composed hidden state
+        # Use the network's internal reconstruct path directly
+        recon = self.net._reconstruct(composed)
+
+        scores = [
+            (msg_id, _cosine_similarity(recon, vec))
+            for msg_id, vec in self._pattern_cache.items()
+        ]
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return scores[:limit]
+
+    # ------------------------------------------------------------------
+    # Status
+    # ------------------------------------------------------------------
+
+    def get_status(self) -> dict[str, Any]:
+        """Return a dictionary of network and retriever statistics."""
+        return {
+            "nv": self.net.nv,
+            "nh": self.net.nh,
+            "patterns_stored": len(self._pattern_cache),
+            "n_patterns_trained": self.net.n_patterns_trained,
+            "last_indexed_id": self._last_indexed_id,
+        }

--- a/plugins/context_engine/lcm/dam/retrieval.py
+++ b/plugins/context_engine/lcm/dam/retrieval.py
@@ -5,10 +5,13 @@ ImmutableStore to provide associative retrieval over conversation history.
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
 from plugins.context_engine.lcm.dam.encoder import MessageEncoder
@@ -195,14 +198,30 @@ class DAMRetriever:
         if not hidden_acts:
             return []
 
-        if operation.upper() == "AND":
+        op = operation.upper()
+        if op == "AND":
             composed = hidden_acts[0]
             for h in hidden_acts[1:]:
                 composed = np.minimum(composed, h)
-        else:  # OR
+        elif op == "OR":
             composed = hidden_acts[0]
             for h in hidden_acts[1:]:
                 composed = np.maximum(composed, h)
+        elif op == "NOT":
+            # NOT is defined only for a single query (invert its binary activations).
+            # Multi-query NOT is semantically ambiguous — reject to avoid silent wrong results.
+            if len(hidden_acts) != 1:
+                logger.warning(
+                    "compose(operation='NOT') requires exactly 1 query; "
+                    "got %d — returning empty results",
+                    len(hidden_acts),
+                )
+                return []
+            # Hidden activations are binary (0.0 / 1.0 float32); inversion is exact.
+            composed = 1.0 - hidden_acts[0]
+        else:
+            logger.warning("compose(): unknown operation %r — returning empty results", operation)
+            return []
 
         # Reconstruct a visible vector from the composed hidden state
         # Use the network's internal reconstruct path directly

--- a/plugins/context_engine/lcm/dam/schemas.py
+++ b/plugins/context_engine/lcm/dam/schemas.py
@@ -1,0 +1,80 @@
+"""Tool schemas for the DAM plugin (OpenAI function-calling format)."""
+
+DAM_SEARCH = {
+    "name": "dam_search",
+    "description": (
+        "Semantic search across conversation messages using neural pattern completion. "
+        "Finds messages with similar meaning even when exact words differ."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural language search query.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 10).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+DAM_RECALL = {
+    "name": "dam_recall",
+    "description": "Find messages similar to a specific message by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_id": {
+                "type": "integer",
+                "description": "Message ID to find similar messages for.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 5).",
+            },
+        },
+        "required": ["message_id"],
+    },
+}
+
+DAM_COMPOSE = {
+    "name": "dam_compose",
+    "description": (
+        "Compositional search: find messages matching combinations of concepts "
+        "with AND/OR/NOT."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "queries": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Concepts to compose (at least 2 required).",
+            },
+            "operation": {
+                "type": "string",
+                "enum": ["AND", "OR", "NOT"],
+                "description": "How to combine concepts (default AND).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 10).",
+            },
+        },
+        "required": ["queries"],
+    },
+}
+
+DAM_STATUS = {
+    "name": "dam_status",
+    "description": "Show Dense Associative Memory network status and statistics.",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}

--- a/plugins/context_engine/lcm/dam/tools.py
+++ b/plugins/context_engine/lcm/dam/tools.py
@@ -1,0 +1,134 @@
+"""DAM tool handlers."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_retriever = None
+
+
+def _get_retriever():
+    return _retriever
+
+
+def _format_snippet(msg_id: int) -> str:
+    """Look up a message by ID from the active LCM engine and format a snippet."""
+    try:
+        from plugins.context_engine.lcm.tools import get_engine
+        engine = get_engine()
+        if engine is None:
+            return f"[msg {msg_id}]"
+        msg = engine.store.get(msg_id)
+        if msg is None:
+            return f"[msg {msg_id}]"
+        role = msg.get("role", "unknown")
+        content = str(msg.get("content", "") or "")
+        snippet = content[:120].replace("\n", " ")
+        return f"[msg {msg_id}] {role}: {snippet}"
+    except Exception:
+        return f"[msg {msg_id}]"
+
+
+def handle_dam_search(args: dict[str, Any], **kwargs) -> str:
+    """Semantic search across conversation messages."""
+    r = _get_retriever()
+    if r is None:
+        try:
+            from plugins.context_engine.lcm.tools import handle_lcm_search
+            return handle_lcm_search(args)
+        except Exception:
+            return json.dumps({"error": "DAM not initialized and LCM fallback unavailable"})
+
+    query = str(args.get("query", "")).strip()
+    if not query:
+        return json.dumps({"error": "query is required"})
+
+    try:
+        limit = int(args.get("limit", 10))
+        results = r.search(query, limit=limit)
+        if not results:
+            try:
+                from plugins.context_engine.lcm.tools import handle_lcm_search
+                fallback = handle_lcm_search({"query": query, "limit": limit})
+                return f"(keyword fallback)\n{fallback}"
+            except Exception:
+                return f"No matches for: {query!r}"
+
+        lines = [f"DAM search ({len(results)} matches):"]
+        for msg_id, score in results:
+            lines.append(_format_snippet(msg_id))
+        return "\n".join(lines)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def handle_dam_recall(args: dict[str, Any], **kwargs) -> str:
+    """Find messages similar to a specific message by ID."""
+    r = _get_retriever()
+    if r is None:
+        return json.dumps({"error": "DAM not initialized"})
+
+    msg_id = args.get("message_id")
+    if msg_id is None:
+        return json.dumps({"error": "message_id is required"})
+
+    try:
+        results = r.recall_similar(int(msg_id), limit=int(args.get("limit", 5)))
+        if not results:
+            return f"No similar messages found for msg {msg_id}"
+
+        lines = [f"Messages similar to msg {msg_id}:"]
+        for similar_id, score in results:
+            lines.append(_format_snippet(similar_id))
+        return "\n".join(lines)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def handle_dam_compose(args: dict[str, Any], **kwargs) -> str:
+    """Compositional search combining multiple concept queries."""
+    r = _get_retriever()
+    if r is None:
+        return json.dumps({"error": "DAM not initialized"})
+
+    queries = args.get("queries", [])
+    if not queries or len(queries) < 2:
+        return json.dumps({"error": "At least 2 queries required"})
+
+    op = str(args.get("operation", "AND")).upper()
+    if op not in ("AND", "OR", "NOT"):
+        return json.dumps({"error": f"Invalid operation: {op!r}. Must be AND, OR, or NOT"})
+
+    try:
+        limit = int(args.get("limit", 10))
+        results = r.compose(queries, operation=op, limit=limit)
+        if not results:
+            return f"No matches for {op} of: {queries}"
+
+        lines = [f"DAM {op} ({', '.join(queries)}):"]
+        for msg_id, score in results:
+            lines.append(_format_snippet(msg_id))
+        return "\n".join(lines)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def handle_dam_status(args: dict[str, Any], **kwargs) -> str:
+    """Return Dense Associative Memory network statistics."""
+    r = _get_retriever()
+    if r is None:
+        return "DAM plugin loaded but not initialized (LCM disabled or numpy unavailable)"
+
+    try:
+        s = r.get_status()
+        nh = s["nh"]
+        return "\n".join([
+            "Dense Associative Memory Status:",
+            f"  Nv={s['nv']}, Nh={nh}",
+            f"  Capacity: 2^{nh} = {2 ** nh:,}",
+            f"  Patterns stored: {s['patterns_stored']}",
+            f"  Patterns trained: {s.get('n_patterns_trained', 'N/A')}",
+            f"  Last indexed: msg {s['last_indexed_id']}",
+        ])
+    except Exception as e:
+        return json.dumps({"error": str(e)})

--- a/plugins/context_engine/lcm/engine.py
+++ b/plugins/context_engine/lcm/engine.py
@@ -1,0 +1,591 @@
+"""LCM Engine — manages active context, compaction, and expansion.
+
+This is the core of the unified LCM system, combining:
+- ImmutableStore: append-only archive of all messages
+- SummaryDag: tracks summary→source mappings for reversibility
+- TokenEstimator: accurate token counting
+- Summarizer: structured summary generation
+- SemanticIndex: optional embedding-based search
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum, auto
+from typing import Any, Optional
+
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.dag import MessageId, SummaryDag, SummaryNode
+from plugins.context_engine.lcm.format import LcmFormatMixin
+from plugins.context_engine.lcm.query import LcmQueryMixin
+from plugins.context_engine.lcm.session import LcmSessionMixin
+from plugins.context_engine.lcm.store import ImmutableStore
+from plugins.context_engine.lcm.summarizer import Summarizer, SummarizerConfig
+from plugins.context_engine.lcm.tokens import TokenEstimator, TokenEstimatorConfig
+from plugins.context_engine.lcm.semantic import SemanticIndex, SemanticIndexConfig, create_semantic_index
+
+logger = logging.getLogger(__name__)
+
+
+class CompactionAction(Enum):
+    NONE = auto()
+    ASYNC = auto()
+    BLOCKING = auto()
+
+
+@dataclass
+class ContextEntry:
+    kind: str  # "raw" | "summary"
+    msg_id: MessageId | None
+    node_id: int | None
+    message: dict[str, Any]
+
+    @classmethod
+    def raw(cls, msg_id: MessageId, message: dict[str, Any]) -> "ContextEntry":
+        return cls(kind="raw", msg_id=msg_id, node_id=None, message=message)
+
+    @classmethod
+    def summary(cls, node_id: int, message: dict[str, Any]) -> "ContextEntry":
+        return cls(kind="summary", msg_id=None, node_id=node_id, message=message)
+
+
+class LcmEngine(LcmQueryMixin, LcmFormatMixin, LcmSessionMixin):
+    """Core context management engine.
+
+    Maintains an append-only store of all ingested messages and a mutable
+    active list that may contain raw or summary entries. Compaction
+    replaces a contiguous run of raw entries with a single summary entry,
+    recording the mapping in the DAG so originals can always be recovered.
+
+    Query, formatting, and session persistence are provided by mixins:
+    - LcmQueryMixin: active_messages, active_tokens, search, ...
+    - LcmFormatMixin: format_expanded, format_toc, format_budget
+    - LcmSessionMixin: rebuild_from_session, to_session_metadata, reset
+    """
+
+    def __init__(
+        self,
+        config: LcmConfig,
+        model: str = "",
+        provider: str = "",
+        context_length: int = 128_000,
+    ) -> None:
+        self.config = config
+        self.model = model
+        self.provider = provider
+
+        # Core components
+        self.store: ImmutableStore = ImmutableStore()
+        self.dag: SummaryDag = SummaryDag()
+        self.active: list[ContextEntry] = []
+
+        # State
+        self._async_compaction_pending: bool = False
+        self._pinned_ids: set[int] = set()
+        self._last_summary: Optional[str] = None
+        self._compact_lock: threading.Lock = threading.Lock()
+
+        # Token estimator
+        token_config = TokenEstimatorConfig(
+            model=model,
+            provider=provider,
+            context_length=context_length,
+        )
+        self.token_estimator = TokenEstimator(token_config)
+
+        # Summarizer
+        summarizer_config = SummarizerConfig(
+            model=config.summary_model or model,
+        )
+        self.summarizer = Summarizer(summarizer_config, self.token_estimator)
+
+        # Semantic index (optional)
+        semantic_config = SemanticIndexConfig(enabled=config.semantic_search)
+        self.semantic_index = create_semantic_index(semantic_config)
+
+        # DAM retriever (optional — requires numpy)
+        self.retriever = None
+        self._dam_sync_interval: int = 5
+        self._dam_messages_since_sync: int = 0
+        try:
+            from plugins.context_engine.lcm.dam import DenseAssociativeMemory, MessageEncoder, DAMRetriever
+            self.retriever = DAMRetriever(
+                net=DenseAssociativeMemory(nv=2048, nh=64),
+                enc=MessageEncoder(nv=2048),
+            )
+        except (ImportError, Exception):
+            pass  # numpy not available or DAM init failed
+
+        # HRR persistent store for cross-session knowledge crystallization
+        self.hrr_store = None
+
+        # Compaction effectiveness metrics
+        self.metrics: dict = self._empty_metrics()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def context_length(self) -> int:
+        """Get the context length from the token estimator."""
+        return self.token_estimator.context_length
+
+    @context_length.setter
+    def context_length(self, value: int):
+        """Set the context length."""
+        self.token_estimator.context_length = value
+
+    # ------------------------------------------------------------------
+    # Metrics helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _empty_metrics() -> dict:
+        """Return a fresh zeroed metrics dict."""
+        return {
+            "total_compactions": 0,
+            "tokens_saved": 0,
+            "tokens_before_total": 0,
+            "tokens_after_total": 0,
+            "levels": {1: 0, 2: 0, 3: 0},
+            "last_compaction_time": None,
+            "avg_compression_ratio": 0.0,
+        }
+
+    def _crystallize_to_hrr(self, node) -> None:
+        """Store compaction summary as a persistent fact in the HRR store.
+
+        Failures are logged and silently swallowed to never block compaction.
+        """
+        if self.hrr_store is None:
+            return
+        try:
+            self.hrr_store.add_fact(
+                content=node.text,
+                category="compaction",
+                tags=f"level:{node.level},sources:{len(node.source_ids)}",
+            )
+        except Exception as exc:
+            logger.warning("HRR crystallization failed: %s", exc)
+
+    def _record_compaction_metrics(
+        self,
+        original_tokens: int,
+        summary_text: str,
+        level: int,
+    ) -> None:
+        """Update self.metrics after a successful compaction.
+
+        Uses ``len(summary_text) // 4`` as a rough token estimate for the
+        summary so we don't pay for expensive counting in the hot path.
+        """
+        summary_tokens = len(summary_text) // 4
+
+        self.metrics["total_compactions"] += 1
+        self.metrics["tokens_before_total"] += original_tokens
+        self.metrics["tokens_after_total"] += summary_tokens
+        self.metrics["tokens_saved"] += max(0, original_tokens - summary_tokens)
+        self.metrics["levels"][level] = self.metrics["levels"].get(level, 0) + 1
+        self.metrics["last_compaction_time"] = datetime.now(timezone.utc).isoformat()
+
+        # Running average: avg = total_after / total_before
+        before_total = self.metrics["tokens_before_total"]
+        after_total = self.metrics["tokens_after_total"]
+        self.metrics["avg_compression_ratio"] = (
+            after_total / before_total if before_total > 0 else 0.0
+        )
+
+    # ------------------------------------------------------------------
+    # Ingestion
+    # ------------------------------------------------------------------
+
+    def ingest(self, message: dict[str, Any]) -> MessageId:
+        """Append a message to the store and active list.
+
+        Returns the stable MessageId assigned by the store.
+        After appending, auto-prunes the store if it exceeds max_store_size.
+        Periodically syncs the DAM retriever (every _dam_sync_interval messages).
+        """
+        msg_id = self.store.append(message)
+        self.active.append(ContextEntry.raw(msg_id, message))
+        self._maybe_prune_store()
+
+        # Auto-sync DAM retriever every N messages
+        self._dam_messages_since_sync += 1
+        if self.retriever is not None and self._dam_messages_since_sync >= self._dam_sync_interval:
+            self._sync_dam()
+
+        return msg_id
+
+    def _sync_dam(self) -> None:
+        """Sync the DAM retriever with the current store contents."""
+        if self.retriever is None:
+            return
+        try:
+            self.retriever.sync_from_store(self.store)
+            self._dam_messages_since_sync = 0
+        except Exception as exc:
+            logger.warning("DAM sync failed: %s", exc)
+
+    def _referenced_store_ids(self) -> set[int]:
+        """Collect all MessageIds referenced by active DAG summaries."""
+        referenced: set[int] = set()
+        for node in self.dag.nodes:
+            referenced.update(self.dag.all_source_ids(node.id))
+        return referenced
+
+    def _maybe_prune_store(self) -> int:
+        """Prune the store if it exceeds config.max_store_size.
+
+        Protected IDs = pinned + referenced by active summaries.
+
+        Returns the number of messages pruned (0 if no pruning needed).
+        """
+        if self.store.active_count <= self.config.max_store_size:
+            return 0
+
+        keep_ids = self._pinned_ids | self._referenced_store_ids()
+        pruned = self.store.prune(keep_ids=keep_ids, max_size=self.config.max_store_size)
+        if pruned:
+            logger.info(
+                "LCM: Auto-pruned %d messages from store (active=%d, limit=%d)",
+                pruned, self.store.active_count, self.config.max_store_size,
+            )
+        return pruned
+
+    # ------------------------------------------------------------------
+    # Threshold checking
+    # ------------------------------------------------------------------
+
+    def check_thresholds(self, token_budget: int | None = None) -> CompactionAction:
+        """Determine whether compaction is needed given the token budget.
+
+        Args:
+            token_budget: Optional override for context length. Uses
+                         self.context_length if not provided.
+
+        Returns:
+            BLOCKING  — above tau_hard, must compact before next turn
+            ASYNC     — above tau_soft, should compact in background (once)
+            NONE      — below tau_soft, or ASYNC already pending
+        """
+        budget = token_budget or self.context_length
+        usage = self.active_tokens()
+        ratio = usage / budget if budget > 0 else 0.0
+
+        if ratio >= self.config.tau_hard:
+            logger.info(
+                "LCM: Blocking compaction triggered (usage=%d, budget=%d, ratio=%.2f >= tau_hard=%.2f)",
+                usage, budget, ratio, self.config.tau_hard,
+            )
+            return CompactionAction.BLOCKING
+
+        if ratio >= self.config.tau_soft:
+            if self._async_compaction_pending:
+                return CompactionAction.NONE
+            self._async_compaction_pending = True
+            logger.info(
+                "LCM: Async compaction suggested (usage=%d, budget=%d, ratio=%.2f >= tau_soft=%.2f)",
+                usage, budget, ratio, self.config.tau_soft,
+            )
+            return CompactionAction.ASYNC
+
+        return CompactionAction.NONE
+
+    # ------------------------------------------------------------------
+    # Block finding
+    # ------------------------------------------------------------------
+
+    def find_compactable_block(self) -> tuple[int, int] | None:
+        """Find the oldest contiguous block of raw entries that can be compacted.
+
+        Rules:
+        - The tail of protect_last_n entries is never touched.
+        - The block must start after any leading summary entries.
+        - Tool-call/result pairs are never split: if the candidate end would
+          leave a tool-result entry without its preceding tool-call entry,
+          the boundary is moved backwards until the pair is intact.
+        - Returns None if there is nothing useful to compact.
+
+        Returns (start, end) slice indices into self.active [start, end).
+        """
+        protect = self.config.protect_last_n
+        total = len(self.active)
+
+        if total < protect + 2:
+            return None
+
+        compactable_limit = total - protect
+
+        start = 0
+        while start < compactable_limit and (
+            self.active[start].kind == "summary"
+            or self.active[start].msg_id in self._pinned_ids
+        ):
+            start += 1
+
+        if start >= compactable_limit:
+            return None
+
+        end = start
+        while end < compactable_limit and self.active[end].msg_id not in self._pinned_ids:
+            end += 1
+
+        if end - start < 1:
+            return None
+
+        end = self._retreat_from_tool_result(start, end)
+        if end is None or end - start < 1:
+            return None
+
+        return (start, end)
+
+    def _retreat_from_tool_result(self, start: int, end: int) -> int | None:
+        """Retreat `end` so the block does not end mid-pair.
+
+        A "tool" role message must be immediately preceded (in the block) by
+        the assistant message carrying its tool_calls. If the proposed end
+        would cut between the assistant-with-tool_calls and the tool result,
+        we pull end back to exclude that pair entirely.
+        """
+        while end > start:
+            last_entry = self.active[end - 1]
+            if last_entry.message.get("role") == "tool":
+                if end - 1 > start:
+                    preceding = self.active[end - 2]
+                    if preceding.message.get("tool_calls"):
+                        break
+                end -= 1
+            else:
+                break
+        return end if end > start else None
+
+    # ------------------------------------------------------------------
+    # Compaction
+    # ------------------------------------------------------------------
+
+    def compact(
+        self,
+        summary_text: str,
+        level: int,
+        block_start: int,
+        block_end: int,
+    ) -> SummaryNode:
+        """Replace active[block_start:block_end] with a single summary entry.
+
+        The original MessageIds are recorded in the DAG node so they can be
+        expanded later. Returns the new SummaryNode.
+
+        This is the low-level compact method. Use compact_block() for
+        automatic summarization.
+        """
+        with self._compact_lock:
+            block = self.active[block_start:block_end]
+            source_ids: list[MessageId] = [
+                e.msg_id for e in block if e.msg_id is not None
+            ]
+
+            tokens = self.token_estimator.estimate([e.message for e in block])
+            node = self.dag.create_node(
+                source_ids=source_ids,
+                text=summary_text,
+                level=level,
+                tokens=tokens,
+            )
+
+            summary_message: dict[str, Any] = {
+                "role": "user",
+                "content": f"[Summary of {len(source_ids)} messages]\n{summary_text}",
+                "_lcm_summary": True,
+                "_lcm_node_id": node.id,
+            }
+            summary_entry = ContextEntry.summary(node.id, summary_message)
+
+            self.active[block_start:block_end] = [summary_entry]
+            self._async_compaction_pending = False
+
+        self._record_compaction_metrics(tokens, summary_text, level)
+        self._crystallize_to_hrr(node)
+
+        logger.info(
+            "LCM: Compacted %d messages into summary node %d (~%d tokens saved)",
+            len(source_ids), node.id, tokens - len(summary_text) // 4,
+        )
+
+        return node
+
+    def compact_block(self, start: int, end: int) -> SummaryNode | None:
+        """Compact a block with automatic summarization.
+
+        Uses the Summarizer to generate a structured summary of the block,
+        then replaces the block with a single summary entry.
+
+        Returns the new SummaryNode, or None if summarization fails.
+        """
+        if start >= end:
+            logger.warning("LCM: Invalid block range [%d, %d)", start, end)
+            return None
+
+        block = self.active[start:end]
+        block_messages = [e.message for e in block]
+
+        summary = self.summarizer.summarize(
+            block_messages,
+            previous_summary=self._last_summary,
+        )
+
+        if summary is None:
+            logger.warning("LCM: Summarization failed, block not compacted")
+            return None
+
+        self._last_summary = summary
+
+        return self.compact(summary, level=1, block_start=start, block_end=end)
+
+    def auto_compact(self) -> SummaryNode | None:
+        """Find and compact the oldest compactable block.
+
+        This is the main entry point for automatic compaction triggered
+        by threshold checks.
+
+        Returns the new SummaryNode, or None if no block found or
+        summarization fails.
+        """
+        block = self.find_compactable_block()
+        if block is None:
+            return None
+        return self.compact_block(block[0], block[1])
+
+    def async_compact(self, callback=None) -> "threading.Thread | None":
+        """Run compaction in a background thread.
+
+        If a compaction is already in progress (``_async_compaction_pending``
+        is True), this method returns ``None`` immediately without launching
+        a second thread.
+
+        Args:
+            callback: Optional callable(SummaryNode | None).  Called with the
+                      result when the background thread finishes.  Receives
+                      ``None`` if compaction raised an exception.
+
+        Returns:
+            The ``threading.Thread`` that was started, or ``None`` if the call
+            was skipped because a compaction was already pending.
+        """
+        with self._compact_lock:
+            if self._async_compaction_pending:
+                return None
+            self._async_compaction_pending = True
+
+        def _worker() -> None:
+            try:
+                result = self.auto_compact()
+                if callback is not None:
+                    callback(result)
+            except Exception as exc:
+                logger.error("Async compaction failed: %s", exc)
+                if callback is not None:
+                    callback(None)
+            finally:
+                self._async_compaction_pending = False
+
+        thread = threading.Thread(target=_worker, daemon=True)
+        thread.start()
+        return thread
+
+    # ------------------------------------------------------------------
+    # Expansion
+    # ------------------------------------------------------------------
+
+    def expand(self, msg_ids: list[MessageId]) -> list[tuple[MessageId, dict[str, Any]]]:
+        """Return (id, message) tuples for the given MessageIds from the store."""
+        return self.store.get_many(msg_ids)
+
+    def expand_summary(self, node_id: int) -> list[tuple[MessageId, dict[str, Any]]]:
+        """Recursively expand all source messages for a DAG node.
+
+        Pruned messages are returned as placeholder entries with content
+        '[Message pruned from store]' so callers always receive a result
+        for every source ID.
+        """
+        all_ids = self.dag.all_source_ids(node_id)
+        result: list[tuple[MessageId, dict[str, Any]]] = []
+        for mid in all_ids:
+            msg = self.store.get(mid)
+            if msg is None:
+                placeholder: dict[str, Any] = {
+                    "role": "user",
+                    "content": "[Message pruned from store]",
+                    "_lcm_pruned": True,
+                }
+                result.append((mid, placeholder))
+            else:
+                result.append((mid, msg))
+        return result
+
+    def focus_summary(self, node_id: int) -> bool:
+        """Expand a summary entry back into raw messages in the active list.
+
+        Returns True if successful, False if node not found.
+        """
+        summary_index: int | None = None
+        for i, entry in enumerate(self.active):
+            if entry.kind == "summary" and entry.node_id == node_id:
+                summary_index = i
+                break
+
+        if summary_index is None:
+            return False
+
+        pairs = self.expand_summary(node_id)
+        if not pairs:
+            return False
+
+        expanded_entries = [
+            ContextEntry.raw(mid, msg) for mid, msg in pairs
+        ]
+
+        self.active[summary_index:summary_index + 1] = expanded_entries
+
+        self._async_compaction_pending = False
+
+        logger.info(
+            "LCM: Expanded summary node %d into %d raw messages",
+            node_id, len(expanded_entries),
+        )
+
+        return True
+
+    # ------------------------------------------------------------------
+    # Pinning
+    # ------------------------------------------------------------------
+
+    def pin(self, msg_ids: list[int]) -> int:
+        """Pin message IDs so they are never compacted.
+
+        Returns the number of newly pinned IDs.
+        """
+        new_ids = set(msg_ids) - self._pinned_ids
+
+        if len(self._pinned_ids) + len(new_ids) > self.config.max_pinned:
+            remaining = self.config.max_pinned - len(self._pinned_ids)
+            new_ids = set(list(new_ids)[:remaining])
+
+        self._pinned_ids.update(new_ids)
+        return len(new_ids)
+
+    def unpin(self, msg_ids: list[int]) -> int:
+        """Unpin message IDs.
+
+        Returns the number of IDs that were unpinned.
+        """
+        removed = len(self._pinned_ids.intersection(msg_ids))
+        self._pinned_ids.difference_update(msg_ids)
+        return removed
+
+    def get_pinned(self) -> list[int]:
+        """Return sorted list of pinned message IDs."""
+        return sorted(self._pinned_ids)

--- a/plugins/context_engine/lcm/engine.py
+++ b/plugins/context_engine/lcm/engine.py
@@ -343,24 +343,66 @@ class LcmEngine(LcmQueryMixin, LcmFormatMixin, LcmSessionMixin):
 
         return (start, end)
 
-    def _retreat_from_tool_result(self, start: int, end: int) -> int | None:
-        """Retreat `end` so the block does not end mid-pair.
+    @staticmethod
+    def _has_tool_calls(message: dict[str, Any]) -> bool:
+        """Return True if *message* carries tool-call requests.
 
-        A "tool" role message must be immediately preceded (in the block) by
-        the assistant message carrying its tool_calls. If the proposed end
-        would cut between the assistant-with-tool_calls and the tool result,
-        we pull end back to exclude that pair entirely.
+        Handles both formats used in this codebase:
+        - OpenAI-style: top-level ``tool_calls`` list.
+        - Anthropic-style: ``content`` is a list with at least one item whose
+          ``type`` is ``"tool_use"``.
+        """
+        if message.get("tool_calls"):
+            return True
+        content = message.get("content")
+        if isinstance(content, list):
+            return any(
+                isinstance(block, dict) and block.get("type") == "tool_use"
+                for block in content
+            )
+        return False
+
+    def _retreat_from_tool_result(self, start: int, end: int) -> int | None:
+        """Retreat ``end`` so the block does not end mid tool-call/result pair.
+
+        Two cases to guard against:
+
+        1. The block's last entry is a ``tool`` role message whose paired
+           ``assistant+tool_calls`` is *not* inside the block (it would be left
+           orphaned in the protected tail).  Back off until the pair is either
+           both inside the block or both outside.
+
+        2. The block's last entry is an ``assistant`` message that carries
+           ``tool_calls`` *and* the first entry of the protected tail (i.e.
+           ``self.active[end]``) is a ``tool`` result for that call.  Compacting
+           the assistant away would leave an orphan ``tool`` message at the
+           start of the tail.  Back off by 1 (and repeat so rule 1 is
+           re-checked for the new boundary).
         """
         while end > start:
             last_entry = self.active[end - 1]
-            if last_entry.message.get("role") == "tool":
+            last_msg = last_entry.message
+
+            # Rule 1: block ends with a bare tool-result — its paired
+            # tool_calls must also be in the block.
+            if last_msg.get("role") == "tool":
                 if end - 1 > start:
                     preceding = self.active[end - 2]
-                    if preceding.message.get("tool_calls"):
-                        break
+                    if self._has_tool_calls(preceding.message):
+                        break  # pair is intact inside the block
                 end -= 1
-            else:
-                break
+                continue
+
+            # Rule 2: block ends with an assistant+tool_calls whose result
+            # sits in the protected tail.
+            if self._has_tool_calls(last_msg) and end < len(self.active):
+                next_entry = self.active[end]
+                if next_entry.message.get("role") == "tool":
+                    end -= 1
+                    continue
+
+            break
+
         return end if end > start else None
 
     # ------------------------------------------------------------------

--- a/plugins/context_engine/lcm/escalation.py
+++ b/plugins/context_engine/lcm/escalation.py
@@ -1,0 +1,212 @@
+"""Three-level summary escalation for LCM.
+
+Level 1: LLM summarize with mode="preserve_details"
+Level 2: LLM summarize with mode="bullet_points"
+Level 3: Deterministic truncation — no LLM, guaranteed convergence
+"""
+from __future__ import annotations
+import logging
+import re
+from typing import Any
+
+from agent.auxiliary_client import call_llm
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.refusal import contains_refusal
+
+logger = logging.getLogger(__name__)
+
+_STRUCTURED_TEMPLATE = "## Goal\n## Progress\n## Decisions\n## Files\n## Next Steps"
+
+_PROMPTS = {
+    "preserve_details": (
+        "Summarize the following conversation preserving key details, "
+        "decisions, file paths, and code references. Use this structure:\n"
+        + _STRUCTURED_TEMPLATE
+    ),
+    "bullet_points": (
+        "Condense the following conversation into concise bullet points. "
+        "Use this structure:\n"
+        + _STRUCTURED_TEMPLATE
+    ),
+}
+
+
+def _call_summary_llm(
+    messages: list[dict],
+    *,
+    mode: str,
+    budget: int,
+    config: LcmConfig | None = None,
+) -> str | None:
+    """Call auxiliary LLM for summarization.
+
+    Returns the summary text, or None on failure (triggers escalation to next level).
+    """
+    model = config.summary_model if config and config.summary_model else None
+    system_prompt = _PROMPTS.get(mode, _PROMPTS["bullet_points"])
+    formatted = _format_messages_for_summary(messages)
+
+    extra_kwargs: dict = {}
+    if model:
+        extra_kwargs["model"] = model
+
+    try:
+        response = call_llm(
+            task="lcm_summary",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": formatted},
+            ],
+            max_tokens=budget,
+            temperature=0.3,
+            **extra_kwargs,
+        )
+        if response:
+            text = response.choices[0].message.content
+            if text:
+                return text.strip()
+    except Exception:
+        return None
+    return None
+
+
+def _estimate_input_tokens(messages: list[dict]) -> int:
+    """Rough token count for a list of messages."""
+    total = sum(len(str(m.get("content", "") or "")) for m in messages)
+    return total // 4
+
+
+def _format_messages_for_summary(messages: list[dict]) -> str:
+    """Format messages into a text block for the summarizer."""
+    parts = []
+    for msg in messages:
+        role = msg.get("role", "unknown")
+        content = str(msg.get("content", "") or "")
+        parts.append(f"{role}: {content}")
+    return "\n\n".join(parts)
+
+
+def escalated_summary(
+    messages: list[dict],
+    target_tokens: int,
+    deterministic_target: int,
+    summary_model: str = "",
+    config: LcmConfig | None = None,
+) -> tuple[str, int]:
+    """Three-level escalation. Returns (summary_text, level).
+
+    Level 1: LLM with mode="preserve_details"
+    Level 2: LLM with mode="bullet_points" (half the token budget)
+    Level 3: Deterministic truncation (no LLM, guaranteed convergence)
+    """
+    # Build an effective config for model resolution.
+    # summary_model kwarg (legacy) takes precedence over config.summary_model.
+    if summary_model and (config is None or not config.summary_model):
+        if config is None:
+            config = LcmConfig(summary_model=summary_model)
+        else:
+            config = LcmConfig(
+                enabled=config.enabled,
+                tau_soft=config.tau_soft,
+                tau_hard=config.tau_hard,
+                deterministic_target=config.deterministic_target,
+                protect_last_n=config.protect_last_n,
+                summary_model=summary_model,
+                max_pinned=config.max_pinned,
+                semantic_search=config.semantic_search,
+            )
+
+    input_tokens = _estimate_input_tokens(messages)
+    # 5% floor: reject Level 1 summaries that are suspiciously short (vacuous)
+    min_acceptable_tokens = max(1, int(input_tokens * 0.05))
+    # Upper-bound: a summary must fit within the requested token budget.
+    # Using target_tokens * 4 (chars) as the ceiling avoids rounding issues
+    # with short inputs where integer token division loses precision.
+    l1_max_chars = target_tokens * 4
+    l2_max_chars = (target_tokens // 2) * 4
+
+    # Level 1: preserve_details
+    summary = _call_summary_llm(messages, mode="preserve_details",
+                                budget=target_tokens, config=config)
+    if summary is not None:
+        summary_tokens = len(summary) // 4
+        if (not contains_refusal(summary)
+                and len(summary) <= l1_max_chars  # within budget
+                and summary_tokens >= min_acceptable_tokens):  # not vacuous
+            return summary, 1
+        logger.debug("Level 1 summary rejected (refusal=%s, len=%d max=%d, tokens=%d min=%d)",
+                     contains_refusal(summary), len(summary), l1_max_chars,
+                     summary_tokens, min_acceptable_tokens)
+    else:
+        logger.debug("Level 1 summary failed (returned None)")
+
+    # Level 2: bullet_points (half budget)
+    # Vacuous check uses a lower floor (3%) since bullet-point summaries are shorter.
+    min_acceptable_l2 = max(1, int(input_tokens * 0.03))
+    summary = _call_summary_llm(messages, mode="bullet_points",
+                                budget=target_tokens // 2, config=config)
+    if summary is not None:
+        summary_tokens_l2 = len(summary) // 4
+        if (not contains_refusal(summary)
+                and len(summary) <= l2_max_chars
+                and summary_tokens_l2 >= min_acceptable_l2):
+            return summary, 2
+        logger.debug("Level 2 summary rejected (refusal=%s, len=%d max=%d, tokens=%d min=%d)",
+                     contains_refusal(summary), len(summary), l2_max_chars,
+                     summary_tokens_l2, min_acceptable_l2)
+    else:
+        logger.debug("Level 2 summary failed (returned None)")
+
+    # Level 3: deterministic (always succeeds)
+    return deterministic_truncate(messages, deterministic_target), 3
+
+# Sentence boundary pattern
+_SENTENCE_END = re.compile(r'[.!?](?:\s|$)')
+
+def first_sentence(text: str) -> str:
+    """Extract the first sentence from text."""
+    if not text:
+        return ""
+    match = _SENTENCE_END.search(text)
+    if match:
+        return text[:match.end()].rstrip()
+    return text
+
+def deterministic_truncate(messages: list[dict[str, Any]], target_tokens: int) -> str:
+    """Level 3: Extract key facts without any LLM call.
+
+    Keeps first sentence of each message with role attribution.
+    Guaranteed output <= target_tokens (estimated as ~4 chars/token).
+    """
+    if not messages:
+        return ""
+
+    char_budget = target_tokens * 4  # conservative chars-per-token estimate
+    parts: list[str] = []
+    used = 0
+
+    for msg in messages:
+        role = msg.get("role", "unknown")
+        content = str(msg.get("content", "") or "")
+
+        # For tool messages, take a brief extract
+        if role == "tool":
+            extract = content[:80].replace("\n", " ")
+            if len(content) > 80:
+                extract += "..."
+            line = f"[tool]: {extract}"
+        else:
+            sentence = first_sentence(content)
+            line = f"{role}: {sentence}"
+
+        if used + len(line) > char_budget:
+            # Try to fit a truncated version
+            remaining = char_budget - used
+            if remaining > 20:  # only add if meaningful
+                parts.append(line[:remaining])
+            break
+
+        parts.append(line)
+        used += len(line) + 1  # +1 for newline
+
+    return "\n".join(parts)

--- a/plugins/context_engine/lcm/format.py
+++ b/plugins/context_engine/lcm/format.py
@@ -1,0 +1,94 @@
+"""LCM Format mixin — formatting capabilities for LcmEngine."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from plugins.context_engine.lcm.dag import MessageId
+
+
+class LcmFormatMixin:
+    """Formatting capabilities.
+
+    Expects the host class to provide:
+    - self.active: list[ContextEntry]
+    - self.context_length: int
+    - self.expand(msg_ids) -> list[tuple[MessageId, dict]]
+    - self.active_token_breakdown() -> dict
+    - self.get_pinned() -> list[int]
+    - self.metrics: dict  (for format_metrics)
+    """
+
+    def format_expanded(self, msg_ids: list) -> str:
+        """Format expanded messages as '[msg N] role: content' lines."""
+        pairs = self.expand(msg_ids)
+        lines: list[str] = []
+        for mid, msg in pairs:
+            role = msg.get("role", "unknown")
+            content = str(msg.get("content", "") or "")
+            lines.append(f"[msg {mid}] {role}: {content}")
+        return "\n".join(lines)
+
+    def format_toc(self) -> str:
+        """Format a table of contents of the active context."""
+        if not self.active:
+            return "Active context is empty."
+
+        lines = ["Conversation Timeline:"]
+        for i, entry in enumerate(self.active):
+            if entry.kind == "raw":
+                role = entry.message.get("role", "?")
+                content = str(entry.message.get("content", "") or "")
+                snippet = content[:60].replace("\n", " ")
+                lines.append(f"  [{i}] msg {entry.msg_id} ({role}): {snippet}")
+            else:
+                content = str(entry.message.get("content", "") or "")
+                snippet = content[:60].replace("\n", " ")
+                lines.append(f"  [{i}] summary node={entry.node_id}: {snippet}")
+
+        return "\n".join(lines)
+
+    def format_budget(self) -> str:
+        """Format a token budget summary."""
+        breakdown = self.active_token_breakdown()
+
+        lines = [
+            "LCM Context Budget:",
+            f"  Active entries : {len(self.active)} ({breakdown['raw_count']} raw, {breakdown['summary_count']} summaries)",
+            f"  Active tokens  : ~{breakdown['total']}",
+            f"  Raw tokens     : ~{breakdown['raw']}",
+            f"  Summary tokens : ~{breakdown['summary']}",
+            f"  Store total    : {len(self.store)} messages (immutable)",
+            f"  Context limit  : {self.context_length:,} tokens",
+            f"  Pinned IDs     : {self.get_pinned() or 'none'}",
+        ]
+        return "\n".join(lines)
+
+    def format_metrics(self) -> str:
+        """Format a human-readable summary of compaction effectiveness metrics."""
+        m = self.metrics
+        total = m["total_compactions"]
+        saved = m["tokens_saved"]
+        before = m["tokens_before_total"]
+        after = m["tokens_after_total"]
+        avg_ratio = m.get("avg_compression_ratio", 0.0)
+        last_time = m["last_compaction_time"] or "never"
+        levels: dict = m.get("levels", {})
+
+        level_parts = ", ".join(
+            f"L{lvl}={count}" for lvl, count in sorted(levels.items())
+        )
+
+        compression_pct = round((1.0 - avg_ratio) * 100, 1) if before > 0 else 0.0
+
+        lines = [
+            "LCM Compaction Metrics:",
+            f"  Total compactions    : {total}",
+            f"  Tokens before (total): {before}",
+            f"  Tokens after  (total): {after}",
+            f"  Tokens saved  (total): {saved}",
+            f"  Avg compression      : {compression_pct}% ({avg_ratio:.3f} ratio)",
+            f"  Level distribution   : {level_parts or 'none'}",
+            f"  Last compaction      : {last_time}",
+        ]
+        return "\n".join(lines)

--- a/plugins/context_engine/lcm/hrr/__init__.py
+++ b/plugins/context_engine/lcm/hrr/__init__.py
@@ -1,0 +1,5 @@
+"""Holographic Reduced Representations — cross-session persistent knowledge store."""
+from plugins.context_engine.lcm.hrr.store import MemoryStore
+from plugins.context_engine.lcm.hrr.retrieval import FactRetriever
+
+__all__ = ["MemoryStore", "FactRetriever"]

--- a/plugins/context_engine/lcm/hrr/holographic.py
+++ b/plugins/context_engine/lcm/hrr/holographic.py
@@ -1,0 +1,203 @@
+"""Holographic Reduced Representations (HRR) with phase encoding.
+
+HRRs are a vector symbolic architecture for encoding compositional structure
+into fixed-width distributed representations. This module uses *phase vectors*:
+each concept is a vector of angles in [0, 2π). The algebraic operations are:
+
+  bind   — circular convolution (phase addition)  — associates two concepts
+  unbind — circular correlation (phase subtraction) — retrieves a bound value
+  bundle — superposition (circular mean)           — merges multiple concepts
+
+Phase encoding is numerically stable, avoids the magnitude collapse of
+traditional complex-number HRRs, and maps cleanly to cosine similarity.
+
+Atoms are generated deterministically from SHA-256 so representations are
+identical across processes, machines, and language versions.
+
+References:
+  Plate (1995) — Holographic Reduced Representations
+  Gayler (2004) — Vector Symbolic Architectures answer Jackendoff's challenges
+"""
+
+import hashlib
+import logging
+import struct
+import math
+
+try:
+    import numpy as np
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+
+logger = logging.getLogger(__name__)
+
+_TWO_PI = 2.0 * math.pi
+
+
+def _require_numpy() -> None:
+    if not _HAS_NUMPY:
+        raise RuntimeError("numpy is required for holographic operations")
+
+
+def encode_atom(word: str, dim: int = 1024) -> "np.ndarray":
+    """Deterministic phase vector via SHA-256 counter blocks.
+
+    Uses hashlib (not numpy RNG) for cross-platform reproducibility.
+
+    Algorithm:
+    - Generate enough SHA-256 blocks by hashing f"{word}:{i}" for i=0,1,2,...
+    - Concatenate digests, interpret as uint16 values via struct.unpack
+    - Scale to [0, 2π): phases = values * (2π / 65536)
+    - Truncate to dim elements
+    - Returns np.float64 array of shape (dim,)
+    """
+    _require_numpy()
+
+    # Each SHA-256 digest is 32 bytes = 16 uint16 values.
+    values_per_block = 16
+    blocks_needed = math.ceil(dim / values_per_block)
+
+    uint16_values: list[int] = []
+    for i in range(blocks_needed):
+        digest = hashlib.sha256(f"{word}:{i}".encode()).digest()
+        uint16_values.extend(struct.unpack("<16H", digest))
+
+    phases = np.array(uint16_values[:dim], dtype=np.float64) * (_TWO_PI / 65536.0)
+    return phases
+
+
+def bind(a: "np.ndarray", b: "np.ndarray") -> "np.ndarray":
+    """Circular convolution = element-wise phase addition.
+
+    Binding associates two concepts into a single composite vector.
+    The result is dissimilar to both inputs (quasi-orthogonal).
+    """
+    _require_numpy()
+    return (a + b) % _TWO_PI
+
+
+def unbind(memory: "np.ndarray", key: "np.ndarray") -> "np.ndarray":
+    """Circular correlation = element-wise phase subtraction.
+
+    Unbinding retrieves the value associated with a key from a memory vector.
+    unbind(bind(a, b), a) ≈ b  (up to superposition noise)
+    """
+    _require_numpy()
+    return (memory - key) % _TWO_PI
+
+
+def bundle(*vectors: "np.ndarray") -> "np.ndarray":
+    """Superposition via circular mean of complex exponentials.
+
+    Bundling merges multiple vectors into one that is similar to each input.
+    The result can hold O(sqrt(dim)) items before similarity degrades.
+    """
+    _require_numpy()
+    complex_sum = np.sum([np.exp(1j * v) for v in vectors], axis=0)
+    return np.angle(complex_sum) % _TWO_PI
+
+
+def similarity(a: "np.ndarray", b: "np.ndarray") -> float:
+    """Phase cosine similarity. Range [-1, 1].
+
+    Returns 1.0 for identical vectors, near 0.0 for random (unrelated) vectors,
+    and -1.0 for perfectly anti-correlated vectors.
+    """
+    _require_numpy()
+    return float(np.mean(np.cos(a - b)))
+
+
+def encode_text(text: str, dim: int = 1024) -> "np.ndarray":
+    """Bag-of-words: bundle of atom vectors for each token.
+
+    Tokenizes by lowercasing, splitting on whitespace, and stripping
+    leading/trailing punctuation from each token.
+
+    Returns bundle of all token atom vectors.
+    If text is empty or produces no tokens, returns encode_atom("__hrr_empty__", dim).
+    """
+    _require_numpy()
+
+    tokens = [
+        token.strip(".,!?;:\"'()[]{}")
+        for token in text.lower().split()
+    ]
+    tokens = [t for t in tokens if t]
+
+    if not tokens:
+        return encode_atom("__hrr_empty__", dim)
+
+    atom_vectors = [encode_atom(token, dim) for token in tokens]
+    return bundle(*atom_vectors)
+
+
+def encode_fact(content: str, entities: list[str], dim: int = 1024) -> "np.ndarray":
+    """Structured encoding: content bound to ROLE_CONTENT, each entity bound to ROLE_ENTITY, all bundled.
+
+    Role vectors are reserved atoms: "__hrr_role_content__", "__hrr_role_entity__"
+
+    Components:
+    1. bind(encode_text(content, dim), encode_atom("__hrr_role_content__", dim))
+    2. For each entity: bind(encode_atom(entity.lower(), dim), encode_atom("__hrr_role_entity__", dim))
+    3. bundle all components together
+
+    This enables algebraic extraction:
+        unbind(fact, bind(entity, ROLE_ENTITY)) ≈ content_vector
+    """
+    _require_numpy()
+
+    role_content = encode_atom("__hrr_role_content__", dim)
+    role_entity = encode_atom("__hrr_role_entity__", dim)
+
+    components: list[np.ndarray] = [
+        bind(encode_text(content, dim), role_content)
+    ]
+
+    for entity in entities:
+        components.append(bind(encode_atom(entity.lower(), dim), role_entity))
+
+    return bundle(*components)
+
+
+def phases_to_bytes(phases: "np.ndarray") -> bytes:
+    """Serialize phase vector to bytes. float64 tobytes — 8 KB at dim=1024."""
+    _require_numpy()
+    return phases.tobytes()
+
+
+def bytes_to_phases(data: bytes) -> "np.ndarray":
+    """Deserialize bytes back to phase vector. Inverse of phases_to_bytes.
+
+    The .copy() call is required because frombuffer returns a read-only view
+    backed by the bytes object; callers expect a mutable array.
+    """
+    _require_numpy()
+    return np.frombuffer(data, dtype=np.float64).copy()
+
+
+def snr_estimate(dim: int, n_items: int) -> float:
+    """Signal-to-noise ratio estimate for holographic storage.
+
+    SNR = sqrt(dim / n_items) when n_items > 0, else inf.
+
+    The SNR falls below 2.0 when n_items > dim / 4, meaning retrieval
+    errors become likely. Logs a warning when this threshold is crossed.
+    """
+    _require_numpy()
+
+    if n_items <= 0:
+        return float("inf")
+
+    snr = math.sqrt(dim / n_items)
+
+    if snr < 2.0:
+        logger.warning(
+            "HRR storage near capacity: SNR=%.2f (dim=%d, n_items=%d). "
+            "Retrieval accuracy may degrade. Consider increasing dim or reducing stored items.",
+            snr,
+            dim,
+            n_items,
+        )
+
+    return snr

--- a/plugins/context_engine/lcm/hrr/retrieval.py
+++ b/plugins/context_engine/lcm/hrr/retrieval.py
@@ -1,0 +1,603 @@
+"""Hybrid keyword/BM25 retrieval for the memory store.
+
+Ported from KIK memory_agent.py — combines FTS5 full-text search with
+Jaccard similarity reranking and trust-weighted scoring.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .store import MemoryStore
+
+try:
+    from . import holographic as hrr
+except ImportError:
+    from plugins.context_engine.lcm.hrr import holographic as hrr  # type: ignore[no-redef]
+
+
+class FactRetriever:
+    """Multi-strategy fact retrieval with trust-weighted scoring."""
+
+    def __init__(
+        self,
+        store: MemoryStore,
+        temporal_decay_half_life: int = 0,  # days, 0 = disabled
+        fts_weight: float = 0.4,
+        jaccard_weight: float = 0.3,
+        hrr_weight: float = 0.3,
+        hrr_dim: int = 1024,
+    ):
+        self.store = store
+        self.half_life = temporal_decay_half_life
+        self.hrr_dim = hrr_dim
+
+        # Auto-redistribute weights if numpy unavailable
+        if hrr_weight > 0 and not hrr._HAS_NUMPY:
+            logger.warning(
+                "numpy unavailable — HRR vector search disabled, using FTS5+Jaccard only"
+            )
+            fts_weight = 0.6
+            jaccard_weight = 0.4
+            hrr_weight = 0.0
+
+        self.fts_weight = fts_weight
+        self.jaccard_weight = jaccard_weight
+        self.hrr_weight = hrr_weight
+
+    def search(
+        self,
+        query: str,
+        category: str | None = None,
+        min_trust: float = 0.3,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Hybrid search: FTS5 candidates → Jaccard rerank → trust weighting.
+
+        Pipeline:
+        1. FTS5 search: Get limit*3 candidates from SQLite full-text search
+        2. Jaccard boost: Token overlap between query and fact content
+        3. Trust weighting: final_score = relevance * trust_score
+        4. Temporal decay (optional): decay = 0.5^(age_days / half_life)
+
+        Returns list of dicts with fact data + 'score' field, sorted by score desc.
+        """
+        # Stage 1: Get FTS5 candidates (more than limit for reranking headroom)
+        candidates = self._fts_candidates(query, category, min_trust, limit * 3)
+
+        if not candidates:
+            return []
+
+        # Stage 2: Rerank with Jaccard + trust + optional decay
+        query_tokens = self._tokenize(query)
+        scored = []
+
+        for fact in candidates:
+            content_tokens = self._tokenize(fact["content"])
+            tag_tokens = self._tokenize(fact.get("tags", ""))
+            all_tokens = content_tokens | tag_tokens
+
+            jaccard = self._jaccard_similarity(query_tokens, all_tokens)
+            fts_score = fact.get("fts_rank", 0.0)
+
+            # HRR similarity
+            if self.hrr_weight > 0 and fact.get("hrr_vector"):
+                fact_vec = hrr.bytes_to_phases(fact["hrr_vector"])
+                query_vec = hrr.encode_text(query, self.hrr_dim)
+                hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0  # shift to [0,1]
+            else:
+                hrr_sim = 0.5  # neutral
+
+            # Combine FTS5 + Jaccard + HRR
+            relevance = (self.fts_weight * fts_score
+                        + self.jaccard_weight * jaccard
+                        + self.hrr_weight * hrr_sim)
+
+            # Trust weighting
+            score = relevance * fact["trust_score"]
+
+            # Optional temporal decay
+            if self.half_life > 0:
+                score *= self._temporal_decay(fact.get("updated_at") or fact.get("created_at"))
+
+            fact["score"] = score
+            scored.append(fact)
+
+        # Sort by score descending, return top limit
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        results = scored[:limit]
+        # Strip raw HRR bytes — callers expect JSON-serializable dicts
+        for fact in results:
+            fact.pop("hrr_vector", None)
+        return results
+
+    def probe(
+        self,
+        entity: str,
+        category: str | None = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Compositional entity query using HRR algebra.
+
+        Unbinds entity from memory bank to extract associated content.
+        This is NOT keyword search — it uses algebraic structure to find facts
+        where the entity plays a structural role.
+
+        Falls back to FTS5 search if numpy unavailable.
+        """
+        if not hrr._HAS_NUMPY:
+            # Fallback to keyword search on entity name
+            return self.search(entity, category=category, limit=limit)
+
+        conn = self.store._conn
+
+        # Encode entity as role-bound vector
+        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
+        entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
+        probe_key = hrr.bind(entity_vec, role_entity)
+
+        # Try category-specific bank first, then all facts
+        if category:
+            bank_name = f"cat:{category}"
+            bank_row = conn.execute(
+                "SELECT vector FROM memory_banks WHERE bank_name = ?",
+                (bank_name,),
+            ).fetchone()
+            if bank_row:
+                bank_vec = hrr.bytes_to_phases(bank_row["vector"])
+                extracted = hrr.unbind(bank_vec, probe_key)
+                # Use extracted signal to score individual facts
+                return self._score_facts_by_vector(
+                    extracted, category=category, limit=limit
+                )
+
+        # Score against individual fact vectors directly
+        where = "WHERE hrr_vector IS NOT NULL"
+        params: list = []
+        if category:
+            where += " AND category = ?"
+            params.append(category)
+
+        rows = conn.execute(
+            f"""
+            SELECT fact_id, content, category, tags, trust_score,
+                   retrieval_count, helpful_count, created_at, updated_at,
+                   hrr_vector
+            FROM facts
+            {where}
+            """,
+            params,
+        ).fetchall()
+
+        if not rows:
+            # Final fallback: keyword search
+            return self.search(entity, category=category, limit=limit)
+
+        scored = []
+        for row in rows:
+            fact = dict(row)
+            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
+            # Unbind probe key from fact to see if entity is structurally present
+            residual = hrr.unbind(fact_vec, probe_key)
+            # Compare residual against content signal
+            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+            content_vec = hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)
+            sim = hrr.similarity(residual, content_vec)
+            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            scored.append(fact)
+
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        return scored[:limit]
+
+    def related(
+        self,
+        entity: str,
+        category: str | None = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Discover facts that share structural connections with an entity.
+
+        Unlike probe (which finds facts *about* an entity), related finds
+        facts that are connected through shared context — e.g., other entities
+        mentioned alongside this one, or content that overlaps structurally.
+
+        Falls back to FTS5 search if numpy unavailable.
+        """
+        if not hrr._HAS_NUMPY:
+            return self.search(entity, category=category, limit=limit)
+
+        conn = self.store._conn
+
+        # Encode entity as a bare atom (not role-bound — we want ANY structural match)
+        entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
+
+        # Get all facts with vectors
+        where = "WHERE hrr_vector IS NOT NULL"
+        params: list = []
+        if category:
+            where += " AND category = ?"
+            params.append(category)
+
+        rows = conn.execute(
+            f"""
+            SELECT fact_id, content, category, tags, trust_score,
+                   retrieval_count, helpful_count, created_at, updated_at,
+                   hrr_vector
+            FROM facts
+            {where}
+            """,
+            params,
+        ).fetchall()
+
+        if not rows:
+            return self.search(entity, category=category, limit=limit)
+
+        # Score each fact by how much the entity's atom appears in its vector
+        # This catches both role-bound entity matches AND content word matches
+        scored = []
+        for row in rows:
+            fact = dict(row)
+            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
+
+            # Check structural similarity: unbind entity from fact
+            residual = hrr.unbind(fact_vec, entity_vec)
+            # A high-similarity residual to ANY known role vector means this entity
+            # plays a structural role in the fact
+            role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
+            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+
+            entity_role_sim = hrr.similarity(residual, role_entity)
+            content_role_sim = hrr.similarity(residual, role_content)
+            # Take the max — entity could appear in either role
+            best_sim = max(entity_role_sim, content_role_sim)
+
+            fact["score"] = (best_sim + 1.0) / 2.0 * fact["trust_score"]
+            scored.append(fact)
+
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        return scored[:limit]
+
+    def reason(
+        self,
+        entities: list[str],
+        category: str | None = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Multi-entity compositional query — vector-space JOIN.
+
+        Given multiple entities, algebraically intersects their structural
+        connections to find facts related to ALL of them simultaneously.
+        This is compositional reasoning that no embedding DB can do.
+
+        Example: reason(["peppi", "backend"]) finds facts where peppi AND
+        backend both play structural roles — without keyword matching.
+
+        Falls back to FTS5 search if numpy unavailable.
+        """
+        if not hrr._HAS_NUMPY or not entities:
+            # Fallback: search with all entities as keywords
+            query = " ".join(entities)
+            return self.search(query, category=category, limit=limit)
+
+        conn = self.store._conn
+        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
+
+        # For each entity, compute what the bank "remembers" about it
+        # by unbinding entity+role from each fact vector
+        entity_residuals = []
+        for entity in entities:
+            entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
+            probe_key = hrr.bind(entity_vec, role_entity)
+            entity_residuals.append(probe_key)
+
+        # The intersection key: bundle all probe keys, then use it to find
+        # facts that are structurally connected to ALL entities
+        intersection_key = hrr.bundle(*entity_residuals) if len(entity_residuals) > 1 else entity_residuals[0]
+
+        # Get all facts with vectors
+        where = "WHERE hrr_vector IS NOT NULL"
+        params: list = []
+        if category:
+            where += " AND category = ?"
+            params.append(category)
+
+        rows = conn.execute(
+            f"""
+            SELECT fact_id, content, category, tags, trust_score,
+                   retrieval_count, helpful_count, created_at, updated_at,
+                   hrr_vector
+            FROM facts
+            {where}
+            """,
+            params,
+        ).fetchall()
+
+        if not rows:
+            query = " ".join(entities)
+            return self.search(query, category=category, limit=limit)
+
+        # Score each fact: unbind the intersection key and check if the
+        # residual is coherent (high self-similarity = structured match)
+        scored = []
+        for row in rows:
+            fact = dict(row)
+            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
+
+            # Unbind intersection key from fact
+            residual = hrr.unbind(fact_vec, intersection_key)
+
+            # Score by how much EACH entity is present in this fact
+            # A fact scores high only if ALL entities have structural presence
+            entity_scores = []
+            for entity in entities:
+                entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
+                probe_key = hrr.bind(entity_vec, role_entity)
+                single_residual = hrr.unbind(fact_vec, probe_key)
+                # Check residual against content role (does this entity participate?)
+                role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+                sim = hrr.similarity(single_residual, role_content)
+                entity_scores.append(sim)
+
+            # Use minimum score — fact must match ALL entities, not just some
+            # This is the AND semantics (vs OR which would use mean/max)
+            min_sim = min(entity_scores)
+            fact["score"] = (min_sim + 1.0) / 2.0 * fact["trust_score"]
+            scored.append(fact)
+
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        return scored[:limit]
+
+    def contradict(
+        self,
+        category: str | None = None,
+        threshold: float = 0.3,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Find potentially contradictory facts via entity overlap + content divergence.
+
+        Two facts contradict when they share entities (same subject) but have
+        low content-vector similarity (different claims). This is automated
+        memory hygiene — no other memory system does this.
+
+        Returns pairs of facts with a contradiction score.
+        Falls back to empty list if numpy unavailable.
+        """
+        if not hrr._HAS_NUMPY:
+            return []
+
+        conn = self.store._conn
+
+        # Get all facts with vectors and their linked entities
+        where = "WHERE f.hrr_vector IS NOT NULL"
+        params: list = []
+        if category:
+            where += " AND f.category = ?"
+            params.append(category)
+
+        rows = conn.execute(
+            f"""
+            SELECT f.fact_id, f.content, f.category, f.tags, f.trust_score,
+                   f.created_at, f.updated_at, f.hrr_vector
+            FROM facts f
+            {where}
+            """,
+            params,
+        ).fetchall()
+
+        if len(rows) < 2:
+            return []
+
+        # Build entity sets per fact
+        fact_entities: dict[int, set[str]] = {}
+        for row in rows:
+            fid = row["fact_id"]
+            entity_rows = conn.execute(
+                """
+                SELECT e.name FROM entities e
+                JOIN fact_entities fe ON fe.entity_id = e.entity_id
+                WHERE fe.fact_id = ?
+                """,
+                (fid,),
+            ).fetchall()
+            fact_entities[fid] = {r["name"].lower() for r in entity_rows}
+
+        # Compare all pairs: high entity overlap + low content similarity = contradiction
+        facts = [dict(r) for r in rows]
+        contradictions = []
+
+        for i in range(len(facts)):
+            for j in range(i + 1, len(facts)):
+                f1, f2 = facts[i], facts[j]
+                ents1 = fact_entities.get(f1["fact_id"], set())
+                ents2 = fact_entities.get(f2["fact_id"], set())
+
+                if not ents1 or not ents2:
+                    continue
+
+                # Entity overlap (Jaccard)
+                entity_overlap = len(ents1 & ents2) / len(ents1 | ents2) if (ents1 | ents2) else 0.0
+
+                if entity_overlap < 0.3:
+                    continue  # Not enough entity overlap to be contradictory
+
+                # Content similarity via HRR vectors
+                v1 = hrr.bytes_to_phases(f1["hrr_vector"])
+                v2 = hrr.bytes_to_phases(f2["hrr_vector"])
+                content_sim = hrr.similarity(v1, v2)
+
+                # High entity overlap + low content similarity = potential contradiction
+                # contradiction_score: higher = more contradictory
+                contradiction_score = entity_overlap * (1.0 - (content_sim + 1.0) / 2.0)
+
+                if contradiction_score >= threshold:
+                    # Strip hrr_vector from output (not JSON serializable)
+                    f1_clean = {k: v for k, v in f1.items() if k != "hrr_vector"}
+                    f2_clean = {k: v for k, v in f2.items() if k != "hrr_vector"}
+                    contradictions.append({
+                        "fact_a": f1_clean,
+                        "fact_b": f2_clean,
+                        "entity_overlap": round(entity_overlap, 3),
+                        "content_similarity": round(content_sim, 3),
+                        "contradiction_score": round(contradiction_score, 3),
+                        "shared_entities": sorted(ents1 & ents2),
+                    })
+
+        contradictions.sort(key=lambda x: x["contradiction_score"], reverse=True)
+        return contradictions[:limit]
+
+    def _score_facts_by_vector(
+        self,
+        target_vec: "np.ndarray",
+        category: str | None = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Score facts by similarity to a target vector."""
+        conn = self.store._conn
+
+        where = "WHERE hrr_vector IS NOT NULL"
+        params: list = []
+        if category:
+            where += " AND category = ?"
+            params.append(category)
+
+        rows = conn.execute(
+            f"""
+            SELECT fact_id, content, category, tags, trust_score,
+                   retrieval_count, helpful_count, created_at, updated_at,
+                   hrr_vector
+            FROM facts
+            {where}
+            """,
+            params,
+        ).fetchall()
+
+        scored = []
+        for row in rows:
+            fact = dict(row)
+            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
+            sim = hrr.similarity(target_vec, fact_vec)
+            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            scored.append(fact)
+
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        return scored[:limit]
+
+    def _fts_candidates(
+        self,
+        query: str,
+        category: str | None,
+        min_trust: float,
+        limit: int,
+    ) -> list[dict]:
+        """Get raw FTS5 candidates from the store.
+
+        Uses the store's database connection directly for FTS5 MATCH
+        with rank scoring. Normalizes FTS5 rank to [0, 1] range.
+        """
+        conn = self.store._conn
+
+        # Build query - FTS5 rank is negative (lower = better match)
+        # We need to join facts_fts with facts to get all columns
+        params: list = []
+        where_clauses = ["facts_fts MATCH ?"]
+        params.append(query)
+
+        if category:
+            where_clauses.append("f.category = ?")
+            params.append(category)
+
+        where_clauses.append("f.trust_score >= ?")
+        params.append(min_trust)
+
+        where_sql = " AND ".join(where_clauses)
+
+        sql = f"""
+            SELECT f.*, facts_fts.rank as fts_rank_raw
+            FROM facts_fts
+            JOIN facts f ON f.fact_id = facts_fts.rowid
+            WHERE {where_sql}
+            ORDER BY facts_fts.rank
+            LIMIT ?
+        """
+        params.append(limit)
+
+        try:
+            rows = conn.execute(sql, params).fetchall()
+        except Exception:
+            # FTS5 MATCH can fail on malformed queries — fall back to empty
+            return []
+
+        if not rows:
+            return []
+
+        # Normalize FTS5 rank: rank is negative, lower = better
+        # Convert to positive score in [0, 1] range
+        raw_ranks = [abs(row["fts_rank_raw"]) for row in rows]
+        max_rank = max(raw_ranks) if raw_ranks else 1.0
+        max_rank = max(max_rank, 1e-6)  # avoid div by zero
+
+        results = []
+        for row, raw_rank in zip(rows, raw_ranks):
+            fact = dict(row)
+            fact.pop("fts_rank_raw", None)
+            fact["fts_rank"] = raw_rank / max_rank  # normalize to [0, 1]
+            results.append(fact)
+
+        return results
+
+    @staticmethod
+    def _tokenize(text: str) -> set[str]:
+        """Simple whitespace tokenization with lowercasing.
+
+        Strips common punctuation. No stemming/lemmatization (Phase 1).
+        """
+        if not text:
+            return set()
+        # Split on whitespace, lowercase, strip punctuation
+        tokens = set()
+        for word in text.lower().split():
+            cleaned = word.strip(".,;:!?\"'()[]{}#@<>")
+            if cleaned:
+                tokens.add(cleaned)
+        return tokens
+
+    @staticmethod
+    def _jaccard_similarity(set_a: set, set_b: set) -> float:
+        """Jaccard similarity coefficient: |A ∩ B| / |A ∪ B|."""
+        if not set_a or not set_b:
+            return 0.0
+        intersection = len(set_a & set_b)
+        union = len(set_a | set_b)
+        return intersection / union if union > 0 else 0.0
+
+    def _temporal_decay(self, timestamp_str: str | None) -> float:
+        """Exponential decay: 0.5^(age_days / half_life_days).
+
+        Returns 1.0 if decay is disabled or timestamp is missing.
+        """
+        if not self.half_life or not timestamp_str:
+            return 1.0
+
+        try:
+            if isinstance(timestamp_str, str):
+                # Parse ISO format timestamp from SQLite
+                ts = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+            else:
+                ts = timestamp_str
+
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+
+            age_days = (datetime.now(timezone.utc) - ts).total_seconds() / 86400
+            if age_days < 0:
+                return 1.0
+
+            return math.pow(0.5, age_days / self.half_life)
+        except (ValueError, TypeError):
+            return 1.0

--- a/plugins/context_engine/lcm/hrr/schemas.py
+++ b/plugins/context_engine/lcm/hrr/schemas.py
@@ -1,0 +1,162 @@
+"""Tool schemas for the unified memory_* tool surface (OpenAI function-calling format).
+
+These five tools replace 11 fragmented lcm_* / dam_* tools with a single surface
+that auto-routes across three memory layers:
+- DAM  (in-session, fast)        via engine.retriever
+- HRR  (cross-session, persistent) via engine.hrr_store
+- LCM  (context management)       via the engine directly
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+MEMORY_SEARCH: dict[str, Any] = {
+    "name": "memory_search",
+    "description": (
+        "Search across session memory and persistent knowledge. "
+        "Use 'session' for current conversation, 'memory' for past sessions, "
+        "or 'auto' to search both."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural language search query.",
+            },
+            "source": {
+                "type": "string",
+                "enum": ["auto", "session", "memory"],
+                "description": (
+                    "Which memory layer(s) to search. "
+                    "'session' = current conversation (DAM), "
+                    "'memory' = persistent cross-session knowledge (HRR), "
+                    "'auto' = both (default)."
+                ),
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+MEMORY_PIN: dict[str, Any] = {
+    "name": "memory_pin",
+    "description": (
+        "Pin messages to prevent compaction and save them as persistent knowledge."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "List of message IDs to pin.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Why these messages are important (used as tags in persistent memory).",
+            },
+        },
+        "required": ["message_ids"],
+    },
+}
+
+MEMORY_EXPAND: dict[str, Any] = {
+    "name": "memory_expand",
+    "description": (
+        "Expand compacted summaries to see original messages, "
+        "or recall facts from persistent memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Message IDs to expand (for session source).",
+            },
+            "query": {
+                "type": "string",
+                "description": "Query for recalling persistent memories (for memory source).",
+            },
+            "source": {
+                "type": "string",
+                "enum": ["session", "memory"],
+                "description": (
+                    "'session' = expand compacted summaries in current context (default), "
+                    "'memory' = recall facts from persistent cross-session storage."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+MEMORY_FORGET: dict[str, Any] = {
+    "name": "memory_forget",
+    "description": (
+        "Compact specified messages immediately. "
+        "Optionally reduce trust of related persistent memories."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "List of message IDs to compact/forget.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Brief reason for forgetting (recorded in the summary placeholder).",
+            },
+            "lower_trust": {
+                "type": "boolean",
+                "description": (
+                    "If true, also reduce trust score of related persistent memories "
+                    "(default false)."
+                ),
+            },
+        },
+        "required": ["message_ids"],
+    },
+}
+
+MEMORY_REASON: dict[str, Any] = {
+    "name": "memory_reason",
+    "description": (
+        "Compositional reasoning across persistent knowledge. "
+        "Find facts connected to entities through algebraic vector operations."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "entities": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Entities to reason about (one or more names/concepts).",
+            },
+            "action": {
+                "type": "string",
+                "enum": ["probe", "related", "reason", "contradict"],
+                "description": (
+                    "'probe' = find facts structurally involving one entity (role-bound), "
+                    "'related' = find facts connected to an entity in any structural role, "
+                    "'reason' = multi-entity AND intersection (default), "
+                    "'contradict' = find pairs of contradictory facts."
+                ),
+            },
+        },
+        "required": ["entities"],
+    },
+}
+
+# Registry dict — used by the tool registration layer
+MEMORY_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "memory_search": MEMORY_SEARCH,
+    "memory_pin": MEMORY_PIN,
+    "memory_expand": MEMORY_EXPAND,
+    "memory_forget": MEMORY_FORGET,
+    "memory_reason": MEMORY_REASON,
+}

--- a/plugins/context_engine/lcm/hrr/store.py
+++ b/plugins/context_engine/lcm/hrr/store.py
@@ -1,0 +1,572 @@
+"""
+SQLite-backed fact store with entity resolution and trust scoring.
+Single-user Hermes memory store plugin.
+"""
+
+import re
+import sqlite3
+import threading
+from datetime import datetime
+from pathlib import Path
+
+try:
+    from . import holographic as hrr
+except ImportError:
+    from plugins.context_engine.lcm.hrr import holographic as hrr  # type: ignore[no-redef]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS facts (
+    fact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    content         TEXT NOT NULL UNIQUE,
+    category        TEXT DEFAULT 'general',
+    tags            TEXT DEFAULT '',
+    trust_score     REAL DEFAULT 0.5,
+    retrieval_count INTEGER DEFAULT 0,
+    helpful_count   INTEGER DEFAULT 0,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    hrr_vector      BLOB
+);
+
+CREATE TABLE IF NOT EXISTS entities (
+    entity_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL,
+    entity_type TEXT DEFAULT 'unknown',
+    aliases     TEXT DEFAULT '',
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS fact_entities (
+    fact_id   INTEGER REFERENCES facts(fact_id),
+    entity_id INTEGER REFERENCES entities(entity_id),
+    PRIMARY KEY (fact_id, entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_facts_trust    ON facts(trust_score DESC);
+CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
+CREATE INDEX IF NOT EXISTS idx_entities_name  ON entities(name);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts
+    USING fts5(content, tags, content=facts, content_rowid=fact_id);
+
+CREATE TRIGGER IF NOT EXISTS facts_ai AFTER INSERT ON facts BEGIN
+    INSERT INTO facts_fts(rowid, content, tags)
+        VALUES (new.fact_id, new.content, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_ad AFTER DELETE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, content, tags)
+        VALUES ('delete', old.fact_id, old.content, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS facts_au AFTER UPDATE ON facts BEGIN
+    INSERT INTO facts_fts(facts_fts, rowid, content, tags)
+        VALUES ('delete', old.fact_id, old.content, old.tags);
+    INSERT INTO facts_fts(rowid, content, tags)
+        VALUES (new.fact_id, new.content, new.tags);
+END;
+
+CREATE TABLE IF NOT EXISTS memory_banks (
+    bank_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    bank_name  TEXT NOT NULL UNIQUE,
+    vector     BLOB NOT NULL,
+    dim        INTEGER NOT NULL,
+    fact_count INTEGER DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+# Trust adjustment constants
+_HELPFUL_DELTA   =  0.05
+_UNHELPFUL_DELTA = -0.10
+_TRUST_MIN       =  0.0
+_TRUST_MAX       =  1.0
+
+# Entity extraction patterns
+_RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
+_RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
+_RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
+_RE_AKA          = re.compile(
+    r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
+    re.IGNORECASE,
+)
+
+
+def _clamp_trust(value: float) -> float:
+    return max(_TRUST_MIN, min(_TRUST_MAX, value))
+
+
+class MemoryStore:
+    """SQLite-backed fact store with entity resolution and trust scoring."""
+
+    def __init__(
+        self,
+        db_path: "str | Path" = "~/.hermes/memory_store.db",
+        default_trust: float = 0.5,
+        hrr_dim: int = 1024,
+    ) -> None:
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.default_trust = _clamp_trust(default_trust)
+        self.hrr_dim = hrr_dim
+        self._hrr_available = hrr._HAS_NUMPY
+        self._conn: sqlite3.Connection = sqlite3.connect(
+            str(self.db_path),
+            check_same_thread=False,
+            timeout=10.0,
+        )
+        self._lock = threading.RLock()
+        self._conn.row_factory = sqlite3.Row
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Initialisation
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        """Create tables, indexes, and triggers if they do not exist. Enable WAL mode."""
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_SCHEMA)
+        # Migrate: add hrr_vector column if missing (safe for existing databases)
+        columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
+        if "hrr_vector" not in columns:
+            self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def add_fact(
+        self,
+        content: str,
+        category: str = "general",
+        tags: str = "",
+    ) -> int:
+        """Insert a fact and return its fact_id.
+
+        Deduplicates by content (UNIQUE constraint). On duplicate, returns
+        the existing fact_id without modifying the row. Extracts entities from
+        the content and links them to the fact.
+        """
+        with self._lock:
+            content = content.strip()
+            if not content:
+                raise ValueError("content must not be empty")
+
+            try:
+                cur = self._conn.execute(
+                    """
+                    INSERT INTO facts (content, category, tags, trust_score)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (content, category, tags, self.default_trust),
+                )
+                self._conn.commit()
+                fact_id: int = cur.lastrowid  # type: ignore[assignment]
+            except sqlite3.IntegrityError:
+                # Duplicate content — return existing id
+                row = self._conn.execute(
+                    "SELECT fact_id FROM facts WHERE content = ?", (content,)
+                ).fetchone()
+                return int(row["fact_id"])
+
+            # Entity extraction and linking
+            for name in self._extract_entities(content):
+                entity_id = self._resolve_entity(name)
+                self._link_fact_entity(fact_id, entity_id)
+
+            # Compute HRR vector after entity linking
+            self._compute_hrr_vector(fact_id, content)
+            self._rebuild_bank(category)
+
+            return fact_id
+
+    def search_facts(
+        self,
+        query: str,
+        category: str | None = None,
+        min_trust: float = 0.3,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Full-text search over facts using FTS5.
+
+        Returns a list of fact dicts ordered by FTS5 rank, then trust_score
+        descending. Also increments retrieval_count for matched facts.
+        """
+        with self._lock:
+            query = query.strip()
+            if not query:
+                return []
+
+            params: list = [query, min_trust]
+            category_clause = ""
+            if category is not None:
+                category_clause = "AND f.category = ?"
+                params.append(category)
+            params.append(limit)
+
+            sql = f"""
+                SELECT f.fact_id, f.content, f.category, f.tags,
+                       f.trust_score, f.retrieval_count, f.helpful_count,
+                       f.created_at, f.updated_at
+                FROM facts f
+                JOIN facts_fts fts ON fts.rowid = f.fact_id
+                WHERE facts_fts MATCH ?
+                  AND f.trust_score >= ?
+                  {category_clause}
+                ORDER BY fts.rank, f.trust_score DESC
+                LIMIT ?
+            """
+
+            rows = self._conn.execute(sql, params).fetchall()
+            results = [self._row_to_dict(r) for r in rows]
+
+            if results:
+                ids = [r["fact_id"] for r in results]
+                placeholders = ",".join("?" * len(ids))
+                self._conn.execute(
+                    f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
+                    ids,
+                )
+                self._conn.commit()
+
+            return results
+
+    def update_fact(
+        self,
+        fact_id: int,
+        content: str | None = None,
+        trust_delta: float | None = None,
+        tags: str | None = None,
+        category: str | None = None,
+    ) -> bool:
+        """Partially update a fact. Trust is clamped to [0, 1].
+
+        Returns True if the row existed, False otherwise.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT fact_id, trust_score FROM facts WHERE fact_id = ?", (fact_id,)
+            ).fetchone()
+            if row is None:
+                return False
+
+            assignments: list[str] = ["updated_at = CURRENT_TIMESTAMP"]
+            params: list = []
+
+            if content is not None:
+                assignments.append("content = ?")
+                params.append(content.strip())
+            if tags is not None:
+                assignments.append("tags = ?")
+                params.append(tags)
+            if category is not None:
+                assignments.append("category = ?")
+                params.append(category)
+            if trust_delta is not None:
+                new_trust = _clamp_trust(row["trust_score"] + trust_delta)
+                assignments.append("trust_score = ?")
+                params.append(new_trust)
+
+            params.append(fact_id)
+            self._conn.execute(
+                f"UPDATE facts SET {', '.join(assignments)} WHERE fact_id = ?",
+                params,
+            )
+            self._conn.commit()
+
+            # If content changed, re-extract entities
+            if content is not None:
+                self._conn.execute(
+                    "DELETE FROM fact_entities WHERE fact_id = ?", (fact_id,)
+                )
+                for name in self._extract_entities(content):
+                    entity_id = self._resolve_entity(name)
+                    self._link_fact_entity(fact_id, entity_id)
+                self._conn.commit()
+
+            # Recompute HRR vector if content changed
+            if content is not None:
+                self._compute_hrr_vector(fact_id, content)
+            # Rebuild bank for relevant category
+            cat = category or self._conn.execute(
+                "SELECT category FROM facts WHERE fact_id = ?", (fact_id,)
+            ).fetchone()["category"]
+            self._rebuild_bank(cat)
+
+            return True
+
+    def remove_fact(self, fact_id: int) -> bool:
+        """Delete a fact and its entity links. Returns True if the row existed."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT fact_id, category FROM facts WHERE fact_id = ?", (fact_id,)
+            ).fetchone()
+            if row is None:
+                return False
+
+            self._conn.execute(
+                "DELETE FROM fact_entities WHERE fact_id = ?", (fact_id,)
+            )
+            self._conn.execute("DELETE FROM facts WHERE fact_id = ?", (fact_id,))
+            self._conn.commit()
+            self._rebuild_bank(row["category"])
+            return True
+
+    def list_facts(
+        self,
+        category: str | None = None,
+        min_trust: float = 0.0,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Browse facts ordered by trust_score descending.
+
+        Optionally filter by category and minimum trust score.
+        """
+        with self._lock:
+            params: list = [min_trust]
+            category_clause = ""
+            if category is not None:
+                category_clause = "AND category = ?"
+                params.append(category)
+            params.append(limit)
+
+            sql = f"""
+                SELECT fact_id, content, category, tags, trust_score,
+                       retrieval_count, helpful_count, created_at, updated_at
+                FROM facts
+                WHERE trust_score >= ?
+                  {category_clause}
+                ORDER BY trust_score DESC
+                LIMIT ?
+            """
+            rows = self._conn.execute(sql, params).fetchall()
+            return [self._row_to_dict(r) for r in rows]
+
+    def record_feedback(self, fact_id: int, helpful: bool) -> dict:
+        """Record user feedback and adjust trust asymmetrically.
+
+        helpful=True  -> trust += 0.05, helpful_count += 1
+        helpful=False -> trust -= 0.10
+
+        Returns a dict with fact_id, old_trust, new_trust, helpful_count.
+        Raises KeyError if fact_id does not exist.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT fact_id, trust_score, helpful_count FROM facts WHERE fact_id = ?",
+                (fact_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"fact_id {fact_id} not found")
+
+            old_trust: float = row["trust_score"]
+            delta = _HELPFUL_DELTA if helpful else _UNHELPFUL_DELTA
+            new_trust = _clamp_trust(old_trust + delta)
+
+            helpful_increment = 1 if helpful else 0
+            self._conn.execute(
+                """
+                UPDATE facts
+                SET trust_score    = ?,
+                    helpful_count  = helpful_count + ?,
+                    updated_at     = CURRENT_TIMESTAMP
+                WHERE fact_id = ?
+                """,
+                (new_trust, helpful_increment, fact_id),
+            )
+            self._conn.commit()
+
+            return {
+                "fact_id":      fact_id,
+                "old_trust":    old_trust,
+                "new_trust":    new_trust,
+                "helpful_count": row["helpful_count"] + helpful_increment,
+            }
+
+    # ------------------------------------------------------------------
+    # Entity helpers
+    # ------------------------------------------------------------------
+
+    def _extract_entities(self, text: str) -> list[str]:
+        """Extract entity candidates from text using simple regex rules.
+
+        Rules applied (in order):
+        1. Capitalized multi-word phrases  e.g. "John Doe"
+        2. Double-quoted terms             e.g. "Python"
+        3. Single-quoted terms             e.g. 'pytest'
+        4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
+
+        Returns a deduplicated list preserving first-seen order.
+        """
+        seen: set[str] = set()
+        candidates: list[str] = []
+
+        def _add(name: str) -> None:
+            stripped = name.strip()
+            if stripped and stripped.lower() not in seen:
+                seen.add(stripped.lower())
+                candidates.append(stripped)
+
+        for m in _RE_CAPITALIZED.finditer(text):
+            _add(m.group(1))
+
+        for m in _RE_DOUBLE_QUOTE.finditer(text):
+            _add(m.group(1))
+
+        for m in _RE_SINGLE_QUOTE.finditer(text):
+            _add(m.group(1))
+
+        for m in _RE_AKA.finditer(text):
+            _add(m.group(1))
+            _add(m.group(2))
+
+        return candidates
+
+    def _resolve_entity(self, name: str) -> int:
+        """Find an existing entity by name or alias (case-insensitive) or create one.
+
+        Returns the entity_id.
+        """
+        # Exact name match
+        row = self._conn.execute(
+            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+        ).fetchone()
+        if row is not None:
+            return int(row["entity_id"])
+
+        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        alias_row = self._conn.execute(
+            """
+            SELECT entity_id FROM entities
+            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            """,
+            (name,),
+        ).fetchone()
+        if alias_row is not None:
+            return int(alias_row["entity_id"])
+
+        # Create new entity
+        cur = self._conn.execute(
+            "INSERT INTO entities (name) VALUES (?)", (name,)
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)  # type: ignore[return-value]
+
+    def _link_fact_entity(self, fact_id: int, entity_id: int) -> None:
+        """Insert into fact_entities, silently ignore if the link already exists."""
+        self._conn.execute(
+            """
+            INSERT OR IGNORE INTO fact_entities (fact_id, entity_id)
+            VALUES (?, ?)
+            """,
+            (fact_id, entity_id),
+        )
+        self._conn.commit()
+
+    def _compute_hrr_vector(self, fact_id: int, content: str) -> None:
+        """Compute and store HRR vector for a fact. No-op if numpy unavailable."""
+        with self._lock:
+            if not self._hrr_available:
+                return
+
+            # Get entities linked to this fact
+            rows = self._conn.execute(
+                """
+                SELECT e.name FROM entities e
+                JOIN fact_entities fe ON fe.entity_id = e.entity_id
+                WHERE fe.fact_id = ?
+                """,
+                (fact_id,),
+            ).fetchall()
+            entities = [row["name"] for row in rows]
+
+            vector = hrr.encode_fact(content, entities, self.hrr_dim)
+            self._conn.execute(
+                "UPDATE facts SET hrr_vector = ? WHERE fact_id = ?",
+                (hrr.phases_to_bytes(vector), fact_id),
+            )
+            self._conn.commit()
+
+    def _rebuild_bank(self, category: str) -> None:
+        """Full rebuild of a category's memory bank from all its fact vectors."""
+        with self._lock:
+            if not self._hrr_available:
+                return
+
+            bank_name = f"cat:{category}"
+            rows = self._conn.execute(
+                "SELECT hrr_vector FROM facts WHERE category = ? AND hrr_vector IS NOT NULL",
+                (category,),
+            ).fetchall()
+
+            if not rows:
+                self._conn.execute("DELETE FROM memory_banks WHERE bank_name = ?", (bank_name,))
+                self._conn.commit()
+                return
+
+            vectors = [hrr.bytes_to_phases(row["hrr_vector"]) for row in rows]
+            bank_vector = hrr.bundle(*vectors)
+            fact_count = len(vectors)
+
+            # Check SNR
+            hrr.snr_estimate(self.hrr_dim, fact_count)
+
+            self._conn.execute(
+                """
+                INSERT INTO memory_banks (bank_name, vector, dim, fact_count, updated_at)
+                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(bank_name) DO UPDATE SET
+                    vector = excluded.vector,
+                    dim = excluded.dim,
+                    fact_count = excluded.fact_count,
+                    updated_at = excluded.updated_at
+                """,
+                (bank_name, hrr.phases_to_bytes(bank_vector), self.hrr_dim, fact_count),
+            )
+            self._conn.commit()
+
+    def rebuild_all_vectors(self, dim: int | None = None) -> int:
+        """Recompute all HRR vectors + banks from text. For recovery/migration.
+
+        Returns the number of facts processed.
+        """
+        with self._lock:
+            if not self._hrr_available:
+                return 0
+
+            if dim is not None:
+                self.hrr_dim = dim
+
+            rows = self._conn.execute(
+                "SELECT fact_id, content, category FROM facts"
+            ).fetchall()
+
+            categories: set[str] = set()
+            for row in rows:
+                self._compute_hrr_vector(row["fact_id"], row["content"])
+                categories.add(row["category"])
+
+            for category in categories:
+                self._rebuild_bank(category)
+
+            return len(rows)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def _row_to_dict(self, row: sqlite3.Row) -> dict:
+        """Convert a sqlite3.Row to a plain dict."""
+        return dict(row)
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    def __enter__(self) -> "MemoryStore":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()

--- a/plugins/context_engine/lcm/hrr/store.py
+++ b/plugins/context_engine/lcm/hrr/store.py
@@ -101,11 +101,19 @@ class MemoryStore:
 
     def __init__(
         self,
-        db_path: "str | Path" = "~/.hermes/memory_store.db",
+        db_path: "str | Path | None" = None,
         default_trust: float = 0.5,
         hrr_dim: int = 1024,
     ) -> None:
-        self.db_path = Path(db_path).expanduser()
+        if db_path is None:
+            try:
+                from hermes_constants import get_hermes_home
+                resolved = get_hermes_home() / "memory_store.db"
+            except ImportError:
+                resolved = Path.home() / ".hermes" / "memory_store.db"
+            self.db_path = resolved
+        else:
+            self.db_path = Path(db_path).expanduser()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.default_trust = _clamp_trust(default_trust)
         self.hrr_dim = hrr_dim

--- a/plugins/context_engine/lcm/hrr/tools.py
+++ b/plugins/context_engine/lcm/hrr/tools.py
@@ -1,0 +1,312 @@
+"""Unified memory tools — auto-route across LCM, DAM, and HRR layers.
+
+Five tools replace 11 fragmented lcm_* / dam_* tools:
+  memory_search  — unified search (DAM -> HRR -> keyword fallback)
+  memory_pin     — pin in LCM + crystallize to HRR
+  memory_expand  — expand summaries (session) or recall facts (cross-session)
+  memory_forget  — compact in LCM + optionally lower HRR trust
+  memory_reason  — HRR compositional query (probe/related/reason/contradict)
+
+The old lcm_* and dam_* tools remain fully functional (backward compat).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from plugins.context_engine.lcm.tools import get_engine
+
+logger = logging.getLogger(__name__)
+
+
+def _require_engine():
+    """Return the active engine or raise RuntimeError."""
+    engine = get_engine()
+    if engine is None:
+        raise RuntimeError("Memory system not initialized. No LCM engine registered.")
+    return engine
+
+
+def _normalize_ids(raw) -> list[int]:
+    """Normalize message_ids from various input formats to list[int]."""
+    if isinstance(raw, int):
+        return [raw]
+    if isinstance(raw, (list, tuple)):
+        return [int(i) for i in raw]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# memory_search
+# ---------------------------------------------------------------------------
+
+
+def handle_memory_search(args: dict[str, Any]) -> str:
+    """Unified search across DAM (session) and HRR (persistent) layers."""
+    engine = _require_engine()
+    query = str(args.get("query", "")).strip()
+    source = args.get("source", "auto")
+    limit = 10
+
+    if not query:
+        return "Error: query is required."
+
+    results: list[str] = []
+
+    # Layer 1: DAM (in-session semantic search) — skip when source == "memory"
+    if source in ("auto", "session") and engine.retriever is not None:
+        try:
+            dam_results = engine.retriever.search(query, limit=limit)
+            for msg_id, score in dam_results:
+                msg = engine.store.get(msg_id)
+                if msg:
+                    role = msg.get("role", "unknown")
+                    snippet = str(msg.get("content", "") or "")[:200].replace("\n", " ")
+                    results.append(
+                        f"[Session msg#{msg_id} score={score:.2f}] {role}: {snippet}"
+                    )
+        except Exception as exc:
+            logger.warning("DAM search failed, falling back: %s", exc)
+
+    # Layer 2: HRR (cross-session persistent knowledge) — skip when source == "session"
+    if source in ("auto", "memory") and engine.hrr_store is not None:
+        try:
+            from plugins.context_engine.lcm.hrr.retrieval import FactRetriever
+
+            retriever = FactRetriever(store=engine.hrr_store)
+            hrr_results = retriever.search(query, limit=limit - len(results))
+            for fact in hrr_results:
+                results.append(
+                    f"[Memory fact#{fact['fact_id']} trust={fact.get('trust_score', '?')}]"
+                    f" {fact['content']}"
+                )
+        except Exception as exc:
+            logger.warning("HRR search failed, falling back: %s", exc)
+
+    # Layer 3: Keyword fallback (LCM store linear scan)
+    if not results:
+        try:
+            from plugins.context_engine.lcm.tools import handle_lcm_search
+
+            return handle_lcm_search({"query": query})
+        except Exception as exc:
+            logger.warning("LCM keyword fallback failed: %s", exc)
+
+    if not results:
+        return f"No results found for '{query}'."
+
+    return "\n".join(results)
+
+
+# ---------------------------------------------------------------------------
+# memory_pin
+# ---------------------------------------------------------------------------
+
+
+def handle_memory_pin(args: dict[str, Any]) -> str:
+    """Pin messages in LCM and crystallize them as persistent HRR facts."""
+    engine = _require_engine()
+    message_ids = _normalize_ids(args.get("message_ids", []))
+    reason = str(args.get("reason", "")).strip()
+
+    ids_str = ",".join(str(i) for i in message_ids)
+
+    # Delegate to LCM pin
+    from plugins.context_engine.lcm.tools import handle_lcm_pin
+
+    result = handle_lcm_pin({"message_ids": ids_str})
+
+    # Auto-crystallize to HRR persistent store
+    if engine.hrr_store is not None:
+        crystallized = 0
+        for mid in message_ids:
+            try:
+                msg = engine.store.get(mid)
+                if msg and msg.get("content"):
+                    engine.hrr_store.add_fact(
+                        content=str(msg["content"]),
+                        category="pinned",
+                        tags=reason or "memory_pin",
+                    )
+                    crystallized += 1
+            except Exception as exc:
+                logger.warning(
+                    "Failed to crystallize pinned message %s: %s", mid, exc
+                )
+        if crystallized:
+            result += f" Crystallized {crystallized} message(s) to persistent memory."
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# memory_expand
+# ---------------------------------------------------------------------------
+
+
+def handle_memory_expand(args: dict[str, Any]) -> str:
+    """Expand session summaries or recall persistent facts by query."""
+    engine = _require_engine()
+    source = args.get("source", "session")
+
+    if source == "session":
+        # Delegate to LCM expand — normalize list[int] to comma-separated string
+        expand_args = dict(args)
+        raw_ids = expand_args.get("message_ids")
+        if raw_ids is not None:
+            expand_args["message_ids"] = ",".join(
+                str(i) for i in _normalize_ids(raw_ids)
+            )
+        from plugins.context_engine.lcm.tools import handle_lcm_expand
+
+        return handle_lcm_expand(expand_args)
+
+    # Cross-session: query HRR persistent store
+    query = str(args.get("query", "")).strip()
+    if not query:
+        return "No query provided. Supply 'query' when using source='memory'."
+
+    if engine.hrr_store is None:
+        return "Persistent memory not available for cross-session recall."
+
+    try:
+        from plugins.context_engine.lcm.hrr.retrieval import FactRetriever
+
+        retriever = FactRetriever(store=engine.hrr_store)
+        results = retriever.search(query, limit=5)
+        if not results:
+            return f"No persistent memories found for '{query}'."
+
+        lines = [
+            f"- [{r.get('category', 'general')}] {r['content']}"
+            f" (trust: {r.get('trust_score', '?')})"
+            for r in results
+        ]
+        return "Persistent memories:\n" + "\n".join(lines)
+    except Exception as exc:
+        return f"Error querying persistent memory: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# memory_forget
+# ---------------------------------------------------------------------------
+
+
+def handle_memory_forget(args: dict[str, Any]) -> str:
+    """Compact messages in LCM and optionally lower HRR trust for related facts."""
+    engine = _require_engine()
+    lower_trust = bool(args.get("lower_trust", False))
+    message_ids = _normalize_ids(args.get("message_ids", []))
+
+    ids_str = ",".join(str(i) for i in message_ids)
+
+    from plugins.context_engine.lcm.tools import handle_lcm_forget
+
+    forget_args = dict(args)
+    forget_args["message_ids"] = ids_str
+    result = handle_lcm_forget(forget_args)
+
+    # Optionally lower HRR trust for related persistent facts
+    if lower_trust and engine.hrr_store is not None:
+        for mid in message_ids:
+            try:
+                msg = engine.store.get(mid)
+                if msg and msg.get("content"):
+                    content_snippet = str(msg["content"])[:100]
+                    matches = engine.hrr_store.search_facts(content_snippet, limit=3)
+                    for match in matches:
+                        engine.hrr_store.record_feedback(match["fact_id"], helpful=False)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to lower trust for message %s: %s", mid, exc
+                )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# memory_reason
+# ---------------------------------------------------------------------------
+
+
+def handle_memory_reason(args: dict[str, Any]) -> str:
+    """Compositional reasoning over persistent HRR knowledge."""
+    engine = _require_engine()
+    entities = [str(e).strip() for e in args.get("entities", []) if isinstance(e, str) and str(e).strip()]
+    action = str(args.get("action", "reason")).strip()
+
+    if not entities:
+        return "No valid entities provided. Pass a list of entity names."
+
+    if engine.hrr_store is None:
+        return (
+            "Persistent memory not available. "
+            "The memory_reason tool requires cross-session knowledge (hrr_store)."
+        )
+
+    try:
+        from plugins.context_engine.lcm.hrr.retrieval import FactRetriever
+
+        retriever = FactRetriever(store=engine.hrr_store)
+
+        if action == "probe":
+            if len(entities) != 1:
+                return "Error: 'probe' action requires exactly one entity."
+            results = retriever.probe(entities[0], limit=10)
+
+        elif action == "related":
+            if len(entities) != 1:
+                return "Error: 'related' action requires exactly one entity."
+            results = retriever.related(entities[0], limit=10)
+
+        elif action == "contradict":
+            contradictions = retriever.contradict(limit=10)
+            if not contradictions:
+                return "No contradictions found in persistent memory."
+            lines: list[str] = []
+            for c in contradictions:
+                lines.append(
+                    f"Contradiction (score={c['contradiction_score']}):"
+                )
+                lines.append(f"  A: {c['fact_a']['content']}")
+                lines.append(f"  B: {c['fact_b']['content']}")
+                shared = ", ".join(c.get("shared_entities", []))
+                lines.append(f"  Shared entities: {shared or 'none'}")
+            return "\n".join(lines)
+
+        else:
+            # Default: "reason" — multi-entity AND intersection
+            results = retriever.reason(entities, limit=10)
+
+        if not results:
+            return f"No facts found for entities: {', '.join(entities)}"
+
+        lines = [
+            f"- {r['content']}"
+            f" (score: {r.get('score', 0.0):.2f}, trust: {r.get('trust_score', '?')})"
+            for r in results
+        ]
+        return f"Facts related to {', '.join(entities)}:\n" + "\n".join(lines)
+
+    except Exception as exc:
+        return f"Error in compositional reasoning: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Schema dict for tool registration
+# ---------------------------------------------------------------------------
+
+try:
+    from plugins.context_engine.lcm.hrr.schemas import MEMORY_TOOL_SCHEMAS
+except ImportError:
+    MEMORY_TOOL_SCHEMAS: dict[str, Any] = {}  # type: ignore[no-redef]
+
+# Handler dispatch table — maps tool name to handler function
+MEMORY_TOOL_HANDLERS: dict[str, Any] = {
+    "memory_search": handle_memory_search,
+    "memory_pin": handle_memory_pin,
+    "memory_expand": handle_memory_expand,
+    "memory_forget": handle_memory_forget,
+    "memory_reason": handle_memory_reason,
+}

--- a/plugins/context_engine/lcm/hrr/tools.py
+++ b/plugins/context_engine/lcm/hrr/tools.py
@@ -84,8 +84,12 @@ def handle_memory_search(args: dict[str, Any]) -> str:
         except Exception as exc:
             logger.warning("HRR search failed, falling back: %s", exc)
 
-    # Layer 3: Keyword fallback (LCM store linear scan)
-    if not results:
+    # Layer 3: Keyword fallback (LCM store linear scan).
+    # Only used for source="auto" or source="session".  When the caller
+    # explicitly requests source="memory" (cross-session HRR only) we must
+    # not fall back to the in-session store — that would leak session content
+    # into what the caller expects to be persistent-memory results.
+    if not results and source != "memory":
         try:
             from plugins.context_engine.lcm.tools import handle_lcm_search
 

--- a/plugins/context_engine/lcm/plugin.yaml
+++ b/plugins/context_engine/lcm/plugin.yaml
@@ -1,0 +1,15 @@
+name: lcm
+version: 1.0.0
+description: >
+  Lossless Context Management — three-layer memory hierarchy (L1 Hot / L2 Warm DAM / L3 Cold HRR)
+  with reversible compaction via SummaryDAG, 7 agent-facing tools (expand, pin, forget, search,
+  budget, toc, focus), and cross-session persistent knowledge.
+author: dusterbloom
+provides_tools:
+  - lcm_expand
+  - lcm_pin
+  - lcm_forget
+  - lcm_search
+  - lcm_budget
+  - lcm_toc
+  - lcm_focus

--- a/plugins/context_engine/lcm/primer.py
+++ b/plugins/context_engine/lcm/primer.py
@@ -1,0 +1,56 @@
+"""Session primer — inject cross-session knowledge into fresh LCM context."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plugins.context_engine.lcm.engine import LcmEngine
+
+logger = logging.getLogger(__name__)
+
+
+def prime_from_hrr(
+    engine: "LcmEngine",
+    hrr_store,
+    topic: str,
+    max_facts: int = 5,
+) -> int:
+    """Query HRR store for relevant facts and inject into active context.
+
+    Inserts a single primer message at position 0 of engine.active so the
+    model sees cross-session knowledge before any current-turn messages.
+
+    Returns the number of facts injected (0 if store is None/empty/error).
+    """
+    if hrr_store is None or not topic.strip():
+        return 0
+
+    try:
+        from plugins.context_engine.lcm.hrr.retrieval import FactRetriever
+        retriever = FactRetriever(store=hrr_store)
+        results = retriever.search(topic, limit=max_facts)
+    except Exception as exc:
+        logger.warning("Session primer failed to query HRR store: %s", exc)
+        return 0
+
+    if not results:
+        return 0
+
+    facts_text = "\n".join(
+        f"- {r['content']} (trust: {r.get('trust_score', '?')})"
+        for r in results
+    )
+
+    primer_message = {
+        "role": "user",
+        "content": f"[Prior Knowledge from previous sessions]\n{facts_text}",
+        "_lcm_primer": True,
+    }
+
+    from plugins.context_engine.lcm.engine import ContextEntry
+    msg_id = engine.store.append(primer_message)
+    engine.active.insert(0, ContextEntry.raw(msg_id, primer_message))
+
+    logger.info("Session primer: injected %d facts from HRR store", len(results))
+    return len(results)

--- a/plugins/context_engine/lcm/query.py
+++ b/plugins/context_engine/lcm/query.py
@@ -1,0 +1,103 @@
+"""LCM Query mixin — query and search capabilities for LcmEngine."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from plugins.context_engine.lcm.dag import MessageId
+
+
+class LcmQueryMixin:
+    """Query and search capabilities.
+
+    Expects the host class to provide:
+    - self.active: list[ContextEntry]
+    - self.store: ImmutableStore
+    - self.token_estimator: TokenEstimator
+    - self.semantic_index: SemanticIndex
+    - self.config: LcmConfig
+    """
+
+    # ------------------------------------------------------------------
+    # Active context queries
+    # ------------------------------------------------------------------
+
+    def active_messages(self) -> list[dict[str, Any]]:
+        """Return message dicts for all active entries, in order."""
+        return [entry.message for entry in self.active]
+
+    def active_tokens(self) -> int:
+        """Estimate tokens currently in the active context."""
+        return self.token_estimator.estimate(self.active_messages())
+
+    def active_token_breakdown(self) -> dict[str, int]:
+        """Return token breakdown for active context."""
+        raw_entries = [e for e in self.active if e.kind == "raw"]
+        summary_entries = [e for e in self.active if e.kind == "summary"]
+
+        raw_tokens = self.token_estimator.estimate([e.message for e in raw_entries])
+        summary_tokens = self.token_estimator.estimate([e.message for e in summary_entries])
+
+        return {
+            "total": raw_tokens + summary_tokens,
+            "raw": raw_tokens,
+            "summary": summary_tokens,
+            "raw_count": len(raw_entries),
+            "summary_count": len(summary_entries),
+        }
+
+    # ------------------------------------------------------------------
+    # Store search
+    # ------------------------------------------------------------------
+
+    def search(self, query: str, limit: int = 10) -> list[tuple[int, dict[str, Any]]]:
+        """Search messages in the store.
+
+        Priority order:
+        1. Semantic index (if enabled and available)
+        2. DAM retriever (if initialized and has indexed messages)
+        3. Keyword fallback
+
+        Returns list of (msg_id, message) tuples.
+        """
+        if self.semantic_index.is_available() and self.config.semantic_search:
+            ids = self.semantic_index.search(query, k=limit)
+            if ids:
+                return self.store.get_many(ids)
+
+        retriever = getattr(self, "retriever", None)
+        if retriever is not None and retriever._pattern_cache:
+            scores = retriever.search(query, limit=limit)
+            if scores:
+                ids = [msg_id for msg_id, _ in scores]
+                results = self.store.get_many(ids)
+                if results:
+                    return results
+
+        return self._keyword_search(query, limit)
+
+    def _keyword_search(self, query: str, limit: int) -> list[tuple[int, dict[str, Any]]]:
+        """Fallback keyword search."""
+        query_lower = query.lower()
+        results: list[tuple[int, dict[str, Any]]] = []
+
+        for msg_id in range(len(self.store)):
+            msg = self.store.get(msg_id)
+            if msg is None:
+                continue
+            content = str(msg.get("content", "") or "")
+            if query_lower in content.lower():
+                results.append((msg_id, msg))
+                if len(results) >= limit:
+                    break
+
+        return results
+
+    def build_semantic_index(self) -> bool:
+        """Build the semantic index for the store.
+
+        Returns True if indexing succeeded.
+        """
+        if not self.semantic_index.is_available():
+            return False
+        return self.semantic_index.index(self.store)

--- a/plugins/context_engine/lcm/refusal.py
+++ b/plugins/context_engine/lcm/refusal.py
@@ -1,0 +1,19 @@
+"""LLM refusal pattern detection for LCM summaries."""
+from __future__ import annotations
+
+REFUSAL_PATTERNS: list[str] = [
+    "i cannot", "i can't", "i'm unable", "i am unable",
+    "i apologize", "i'm sorry", "as an ai", "as a language model",
+    "unable to help", "cannot assist", "can't assist",
+    "cannot fulfill", "can't fulfill", "not able to provide",
+    "unable to provide", "i won't", "i will not",
+    "against my guidelines", "violates my",
+    "i'm not comfortable", "i am not comfortable",
+]
+
+def contains_refusal(text: str) -> bool:
+    """Check if text contains an LLM refusal pattern."""
+    if not text:
+        return False
+    lower = text.lower()
+    return any(pattern in lower for pattern in REFUSAL_PATTERNS)

--- a/plugins/context_engine/lcm/semantic.py
+++ b/plugins/context_engine/lcm/semantic.py
@@ -1,0 +1,248 @@
+"""Optional semantic search for LCM context management.
+
+Provides embedding-based similarity search over the immutable message store.
+This is a stub implementation that can be enabled when embedding APIs are
+available.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+    from plugins.context_engine.lcm.store import ImmutableStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SemanticIndexConfig:
+    """Configuration for SemanticIndex."""
+    enabled: bool = False
+    model: str = "text-embedding-3-small"
+    min_messages: int = 50  # Only build index if store has this many messages
+    batch_size: int = 100
+
+
+class SemanticIndex:
+    """Optional embedding-based search for the immutable store.
+
+    This allows semantic similarity search across all messages, including
+    those already compacted into summaries. Falls back gracefully when
+    embedding APIs are unavailable.
+    """
+
+    def __init__(self, config: SemanticIndexConfig):
+        self.config = config
+        self.embeddings: List[Any] = []  # List of numpy arrays
+        self.msg_ids: List[int] = []
+        self._client = None
+        self._indexed_count = 0
+
+    def is_available(self) -> bool:
+        """Check if semantic search is available."""
+        if not self.config.enabled:
+            return False
+
+        # Check for API key (OpenAI embeddings)
+        if not os.getenv("OPENAI_API_KEY"):
+            return False
+
+        return True
+
+    def should_index(self, store: "ImmutableStore") -> bool:
+        """Check if the store is large enough to warrant indexing."""
+        return len(store) >= self.config.min_messages
+
+    def index(self, store: "ImmutableStore") -> bool:
+        """Build index for all messages in store.
+
+        Returns True if indexing succeeded.
+        """
+        if not self.is_available():
+            logger.debug("Semantic index not available (disabled or no API key)")
+            return False
+
+        if not self.should_index(store):
+            logger.debug(
+                "Store too small for semantic indexing (%d < %d messages)",
+                len(store), self.config.min_messages
+            )
+            return False
+
+        try:
+            self._do_index(store)
+            return True
+        except Exception as e:
+            logger.warning("Semantic indexing failed: %s", e)
+            return False
+
+    def _do_index(self, store: "ImmutableStore"):
+        """Actual indexing implementation."""
+        # Lazy import to avoid loading numpy/embedding libs unless needed
+        try:
+            import numpy as np
+        except ImportError:
+            logger.debug("numpy not installed, skipping semantic indexing")
+            return
+
+        self.embeddings = []
+        self.msg_ids = []
+        self._indexed_count = 0
+
+        # Batch messages for embedding
+        batch_texts = []
+        batch_ids = []
+
+        for msg_id in range(len(store)):
+            msg = store.get(msg_id)
+            if msg is None:
+                continue
+
+            content = str(msg.get("content") or "")
+            if not content.strip():
+                continue
+
+            batch_texts.append(content)
+            batch_ids.append(msg_id)
+
+            # Process batch
+            if len(batch_texts) >= self.config.batch_size:
+                self._index_batch(batch_texts, batch_ids)
+                batch_texts = []
+                batch_ids = []
+
+        # Process remaining
+        if batch_texts:
+            self._index_batch(batch_texts, batch_ids)
+
+        logger.info(
+            "Semantic index built: %d messages indexed",
+            self._indexed_count
+        )
+
+    def _index_batch(self, texts: List[str], ids: List[int]):
+        """Index a batch of texts."""
+        try:
+            import numpy as np
+        except ImportError:
+            return
+
+        embeddings = self._get_embeddings(texts)
+        if embeddings is None:
+            return
+
+        for emb, msg_id in zip(embeddings, ids):
+            self.embeddings.append(np.array(emb))
+            self.msg_ids.append(msg_id)
+            self._indexed_count += 1
+
+    def _get_embeddings(self, texts: List[str]) -> Optional[List[List[float]]]:
+        """Get embeddings for a batch of texts."""
+        if self._client is None:
+            self._client = self._create_client()
+
+        if self._client is None:
+            return None
+
+        try:
+            response = self._client.embeddings.create(
+                model=self.config.model,
+                input=texts,
+            )
+            return [item.embedding for item in response.data]
+        except Exception as e:
+            logger.warning("Embedding API call failed: %s", e)
+            return None
+
+    def _create_client(self):
+        """Create OpenAI client for embeddings."""
+        try:
+            from openai import OpenAI
+            return OpenAI()
+        except ImportError:
+            logger.debug("openai package not installed")
+            return None
+        except Exception as e:
+            logger.debug("Failed to create OpenAI client: %s", e)
+            return None
+
+    def search(self, query: str, k: int = 10) -> List[int]:
+        """Return top-k message IDs by semantic similarity.
+
+        Returns empty list if semantic search is unavailable.
+        """
+        if not self.embeddings:
+            return []
+
+        try:
+            import numpy as np
+        except ImportError:
+            return []
+
+        # Get query embedding
+        query_embeddings = self._get_embeddings([query])
+        if not query_embeddings:
+            return []
+
+        query_emb = np.array(query_embeddings[0])
+
+        # Compute cosine similarities
+        similarities = []
+        for i, emb in enumerate(self.embeddings):
+            sim = np.dot(query_emb, emb) / (
+                np.linalg.norm(query_emb) * np.linalg.norm(emb)
+            )
+            similarities.append((sim, self.msg_ids[i]))
+
+        # Sort by similarity (descending)
+        similarities.sort(reverse=True, key=lambda x: x[0])
+
+        # Return top-k message IDs
+        return [msg_id for _, msg_id in similarities[:k]]
+
+    def clear(self):
+        """Clear the index."""
+        self.embeddings = []
+        self.msg_ids = []
+        self._indexed_count = 0
+
+
+# Stub implementation for when semantic search is disabled
+class NoOpSemanticIndex:
+    """No-op semantic index that always returns empty results."""
+
+    def is_available(self) -> bool:
+        return False
+
+    def index(self, store: "ImmutableStore") -> bool:
+        return False
+
+    def search(self, query: str, k: int = 10) -> List[int]:
+        return []
+
+    def clear(self):
+        pass
+
+
+def create_semantic_index(config: SemanticIndexConfig) -> SemanticIndex:
+    """Factory function to create a semantic index.
+
+    Returns a working SemanticIndex if dependencies are available,
+    or a NoOpSemanticIndex otherwise.
+    """
+    if not config.enabled:
+        return NoOpSemanticIndex()
+
+    if not os.getenv("OPENAI_API_KEY"):
+        logger.debug("No OPENAI_API_KEY, semantic search disabled")
+        return NoOpSemanticIndex()
+
+    try:
+        return SemanticIndex(config)
+    except Exception as e:
+        logger.warning("Failed to create semantic index: %s", e)
+        return NoOpSemanticIndex()

--- a/plugins/context_engine/lcm/session.py
+++ b/plugins/context_engine/lcm/session.py
@@ -1,0 +1,175 @@
+"""LCM Session mixin — session persistence for LcmEngine."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.store import ImmutableStore
+from plugins.context_engine.lcm.dag import SummaryDag
+
+logger = logging.getLogger(__name__)
+
+
+class LcmSessionMixin:
+    """Session persistence capabilities.
+
+    Expects the host class to provide:
+    - self.store: ImmutableStore
+    - self.dag: SummaryDag
+    - self.active: list[ContextEntry]
+    - self._pinned_ids: set[int]
+    - self._async_compaction_pending: bool
+    - self._last_summary: Optional[str]
+    - self.summarizer: Summarizer (has .reset())
+    - self.semantic_index: SemanticIndex (has .clear())
+    - cls(config, model, provider, context_length) constructor
+    """
+
+    @classmethod
+    def rebuild_from_session(
+        cls,
+        session_data: dict,
+        config: LcmConfig,
+        model: str = "",
+        provider: str = "",
+        context_length: int = 128_000,
+    ) -> "LcmSessionMixin":
+        """Reconstruct engine state from persisted session data.
+
+        Two modes:
+        - With ``lcm.original_messages``: the full store backup is restored
+          first; raw entries in the active list reference those store positions.
+        - Without it (legacy or no prior compaction): each raw message in the
+          active list is appended to the store directly.
+        """
+        # Import here to avoid circular imports; ContextEntry lives in engine
+        from plugins.context_engine.lcm.engine import ContextEntry
+
+        engine = cls(config, model, provider, context_length)
+        messages = session_data.get("messages") or []
+        # Tolerate "lcm": null (JSON null → Python None) and missing key
+        lcm_meta = session_data.get("lcm") or {}
+        summaries = lcm_meta.get("summaries") or []
+        original_messages = lcm_meta.get("original_messages") or []
+
+        for msg in original_messages:
+            engine.store.append(msg)
+
+        for s in sorted(summaries, key=lambda x: x.get("node_id", 0)):
+            engine.dag.create_node(
+                source_ids=s.get("source_ids", []),
+                text=s.get("text", ""),
+                level=s.get("level", 1),
+                tokens=s.get("tokens", 0),
+                children=s.get("child_summaries", []),
+            )
+
+        if original_messages:
+            raw_in_active = sum(1 for m in messages if not m.get("_lcm_summary"))
+            next_raw_id = len(engine.store) - raw_in_active
+        else:
+            next_raw_id = 0
+
+        for msg in messages:
+            if msg.get("_lcm_summary"):
+                node_id = msg.get("_lcm_node_id", 0)
+                engine.active.append(ContextEntry.summary(node_id, msg))
+            else:
+                if original_messages:
+                    msg_id = next_raw_id
+                    next_raw_id += 1
+                else:
+                    msg_id = engine.store.append(msg)
+                engine.active.append(ContextEntry.raw(msg_id, msg))
+
+        pinned_ids = lcm_meta.get("pinned") or []
+        store_size = len(engine.store)
+        valid_pins = {pid for pid in pinned_ids if 0 <= pid < store_size}
+        dropped_pins = set(pinned_ids) - valid_pins
+        if dropped_pins:
+            logger.warning(
+                "LCM: Dropped %d out-of-range pinned ID(s) during rebuild: %s",
+                len(dropped_pins),
+                sorted(dropped_pins),
+            )
+        engine._pinned_ids = valid_pins
+
+        engine._last_summary = lcm_meta.get("last_summary")
+
+        # Restore metrics if present
+        saved_metrics = lcm_meta.get("metrics")
+        if saved_metrics:
+            # Import here to avoid circular imports; _empty_metrics lives in engine
+            from plugins.context_engine.lcm.engine import LcmEngine as _LcmEngine
+            base = _LcmEngine._empty_metrics()
+            base.update(saved_metrics)
+            # Ensure levels dict has all expected keys
+            for lvl in (1, 2, 3):
+                base["levels"].setdefault(lvl, 0)
+            engine.metrics = base
+
+        # Restore DAM retriever state to avoid re-indexing on restart
+        saved_dam = lcm_meta.get("dam") or {}
+        if saved_dam and getattr(engine, "retriever", None) is not None:
+            last_indexed_id = saved_dam.get("last_indexed_id", 0)
+            engine.retriever._last_indexed_id = last_indexed_id
+
+        logger.info(
+            "LCM: Rebuilt from session: %d messages, %d summaries, %d pinned",
+            len(engine.active), len(engine.dag.nodes), len(engine._pinned_ids),
+        )
+
+        return engine
+
+    def to_session_metadata(self) -> dict:
+        """Serialize engine state for session JSON persistence."""
+        summaries = []
+        for node in self.dag.nodes:
+            summaries.append({
+                "node_id": node.id,
+                "source_ids": node.source_ids,
+                "child_summaries": node.child_summaries,
+                "text": node.text,
+                "level": node.level,
+                "tokens": node.tokens,
+            })
+
+        original_messages = []
+        for i in range(len(self.store)):
+            msg = self.store.get(i)
+            if msg is not None:
+                original_messages.append(msg)
+
+        # Persist DAM retriever state so rebuild can skip re-indexing
+        dam_state: dict = {}
+        retriever = getattr(self, "retriever", None)
+        if retriever is not None:
+            dam_state = {
+                "last_indexed_id": retriever._last_indexed_id,
+                "n_patterns_trained": retriever.net.n_patterns_trained,
+            }
+
+        return {
+            "summaries": summaries,
+            "original_messages": original_messages,
+            "store_size": len(self.store),
+            "pinned": sorted(self._pinned_ids),
+            "last_summary": self._last_summary,
+            "metrics": dict(self.metrics),
+            "dam": dam_state,
+        }
+
+    def reset(self):
+        """Reset engine state for a new session."""
+        self.store = ImmutableStore()
+        self.dag = SummaryDag()
+        self.active = []
+        self._async_compaction_pending = False
+        self._pinned_ids = set()
+        self._last_summary = None
+        self.summarizer.reset()
+        self.semantic_index.clear()
+        # Import here to avoid circular imports; _empty_metrics lives in engine
+        from plugins.context_engine.lcm.engine import LcmEngine as _LcmEngine
+        self.metrics = _LcmEngine._empty_metrics()

--- a/plugins/context_engine/lcm/session.py
+++ b/plugins/context_engine/lcm/session.py
@@ -66,6 +66,7 @@ class LcmSessionMixin:
             )
 
         if original_messages:
+            # Compute suffix-offset fallback for legacy sessions (no _lcm_raw_id)
             raw_in_active = sum(1 for m in messages if not m.get("_lcm_summary"))
             next_raw_id = len(engine.store) - raw_in_active
         else:
@@ -77,11 +78,20 @@ class LcmSessionMixin:
                 engine.active.append(ContextEntry.summary(node_id, msg))
             else:
                 if original_messages:
-                    msg_id = next_raw_id
-                    next_raw_id += 1
+                    # Prefer the embedded id written by active_messages_for_session().
+                    # Fall back to the suffix-offset formula for sessions saved before
+                    # this fix was deployed (backward compatibility).
+                    if "_lcm_raw_id" in msg:
+                        msg_id = msg["_lcm_raw_id"]
+                    else:
+                        msg_id = next_raw_id
+                        next_raw_id += 1
                 else:
                     msg_id = engine.store.append(msg)
-                engine.active.append(ContextEntry.raw(msg_id, msg))
+                # Strip the internal annotation before storing in active (it's
+                # only meaningful for serialization, not at runtime).
+                clean_msg = {k: v for k, v in msg.items() if k != "_lcm_raw_id"}
+                engine.active.append(ContextEntry.raw(msg_id, clean_msg))
 
         pinned_ids = lcm_meta.get("pinned") or []
         store_size = len(engine.store)
@@ -121,6 +131,26 @@ class LcmSessionMixin:
         )
 
         return engine
+
+    def active_messages_for_session(self) -> list[dict]:
+        """Return active message dicts annotated for session persistence.
+
+        Raw entries receive a ``_lcm_raw_id`` key so their store position can
+        be restored exactly on rebuild, even when the active list is
+        non-contiguous (e.g. after ``focus_summary`` pulls expanded entries
+        back in).  Summary entries already carry ``_lcm_summary`` /
+        ``_lcm_node_id`` markers set at compaction time and are returned as-is.
+        """
+        result = []
+        for entry in self.active:
+            if entry.kind == "raw" and entry.msg_id is not None:
+                # Shallow-copy to avoid mutating the live message dict
+                annotated = dict(entry.message)
+                annotated["_lcm_raw_id"] = entry.msg_id
+                result.append(annotated)
+            else:
+                result.append(entry.message)
+        return result
 
     def to_session_metadata(self) -> dict:
         """Serialize engine state for session JSON persistence."""

--- a/plugins/context_engine/lcm/store.py
+++ b/plugins/context_engine/lcm/store.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any
+
+MessageId = int
+
+_PRUNED_SENTINEL = None  # slots in _messages are set to None when pruned
+
+
+@dataclass
+class ImmutableStore:
+    _messages: list[dict[str, Any] | None] = field(default_factory=list)
+    _pruned: set[MessageId] = field(default_factory=set)
+
+    def append(self, message: dict[str, Any]) -> MessageId:
+        msg_id = len(self._messages)
+        self._messages.append(message)
+        return msg_id
+
+    def get(self, msg_id: MessageId) -> dict[str, Any] | None:
+        if 0 <= msg_id < len(self._messages) and msg_id not in self._pruned:
+            return self._messages[msg_id]
+        return None
+
+    def get_many(
+        self, msg_ids: list[MessageId]
+    ) -> list[tuple[MessageId, dict[str, Any]]]:
+        return [
+            (mid, self._messages[mid])
+            for mid in msg_ids
+            if 0 <= mid < len(self._messages) and mid not in self._pruned
+        ]
+
+    def prune(self, keep_ids: set[MessageId], max_size: int) -> int:
+        """Mark old unreferenced messages as pruned until active_count <= max_size.
+
+        Pruning is performed in ascending order (oldest first).  Messages in
+        keep_ids are never pruned regardless of age.
+
+        Args:
+            keep_ids: MessageIds that must not be pruned (referenced + pinned).
+            max_size: Target maximum for active_count after pruning.
+
+        Returns:
+            Number of newly pruned messages.
+        """
+        to_prune = max(0, self.active_count - max_size)
+        if to_prune == 0:
+            return 0
+
+        newly_pruned = 0
+        for msg_id in range(len(self._messages)):
+            if newly_pruned >= to_prune:
+                break
+            if msg_id in self._pruned:
+                continue  # already pruned
+            if msg_id in keep_ids:
+                continue  # protected
+            # Prune it
+            self._messages[msg_id] = _PRUNED_SENTINEL
+            self._pruned.add(msg_id)
+            newly_pruned += 1
+
+        return newly_pruned
+
+    @property
+    def pruned_ids(self) -> set[MessageId]:
+        """Return the set of currently pruned MessageIds."""
+        return set(self._pruned)
+
+    @property
+    def active_count(self) -> int:
+        """Number of non-pruned messages in the store."""
+        return len(self._messages) - len(self._pruned)
+
+    def __len__(self) -> int:
+        return len(self._messages)

--- a/plugins/context_engine/lcm/summarizer.py
+++ b/plugins/context_engine/lcm/summarizer.py
@@ -1,0 +1,300 @@
+"""Summarization logic for LCM context compaction.
+
+Extracted from ContextCompressor for reuse and testability.
+Uses structured templates (Goal, Progress, Decisions, Files, Next Steps)
+inspired by Pi-mono and OpenCode.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agent.auxiliary_client import call_llm
+
+logger = logging.getLogger(__name__)
+
+# Token budget limits for summaries
+MIN_SUMMARY_TOKENS = 512
+MAX_SUMMARY_TOKENS = 4000
+SUMMARY_RATIO = 0.20  # Proportion of compressed content for summary
+
+# Placeholder for pruned tool outputs
+PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
+
+# Prefix for summary messages in conversation
+SUMMARY_PREFIX = (
+    "[CONTEXT COMPACTION] Earlier turns in this conversation were compacted "
+    "to save context space. The summary below describes work that was "
+    "already completed, and the current session state may still reflect "
+    "that work (for example, files may already be changed). Use the summary "
+    "and the current state to continue from where things left off, and "
+    "avoid repeating work:"
+)
+
+
+@dataclass
+class SummarizerConfig:
+    """Configuration for the Summarizer."""
+    model: str = ""
+    min_tokens: int = MIN_SUMMARY_TOKENS
+    max_tokens: int = MAX_SUMMARY_TOKENS
+    ratio: float = SUMMARY_RATIO
+    timeout: float = 45.0
+    temperature: float = 0.3
+
+
+class Summarizer:
+    """Generate structured summaries of conversation turns for context compaction.
+
+    Supports iterative updates: when a previous summary exists, the new
+    summary incorporates both the old content and new turns, preserving
+    important context across multiple compactions.
+    """
+
+    def __init__(
+        self,
+        config: SummarizerConfig,
+        token_estimator: Optional["TokenEstimator"] = None,
+    ):
+        self.config = config
+        self.token_estimator = token_estimator
+        self._previous_summary: Optional[str] = None
+
+    def compute_summary_budget(self, turns: List[Dict[str, Any]]) -> int:
+        """Scale summary token budget with the amount of content being compressed."""
+        if self.token_estimator:
+            content_tokens = self.token_estimator.estimate(turns)
+        else:
+            # Fallback: rough char-based estimate
+            total_chars = sum(len(str(m.get("content", "") or "")) for m in turns)
+            content_tokens = total_chars // 4
+
+        budget = int(content_tokens * self.config.ratio)
+        return max(self.config.min_tokens, min(budget, self.config.max_tokens))
+
+    def serialize_for_summary(self, turns: List[Dict[str, Any]], max_chars: int = 3000) -> str:
+        """Serialize conversation turns into labeled text for the summarizer.
+
+        Includes tool call arguments and result content (up to max_chars
+        per message) so the summarizer can preserve specific details like
+        file paths, commands, and outputs.
+        """
+        parts = []
+        for msg in turns:
+            role = msg.get("role", "unknown")
+            content = msg.get("content") or ""
+
+            # Tool results: keep more content
+            if role == "tool":
+                tool_id = msg.get("tool_call_id", "")
+                if len(content) > max_chars:
+                    content = self._truncate_middle(content, max_chars)
+                parts.append(f"[TOOL RESULT {tool_id}]: {content}")
+                continue
+
+            # Assistant messages: include tool call names AND arguments
+            if role == "assistant":
+                if len(content) > max_chars:
+                    content = self._truncate_middle(content, max_chars)
+                tool_calls = msg.get("tool_calls", [])
+                if tool_calls:
+                    tc_parts = []
+                    for tc in tool_calls:
+                        if isinstance(tc, dict):
+                            fn = tc.get("function", {})
+                            name = fn.get("name", "?")
+                            args = fn.get("arguments", "")
+                            # Truncate long arguments but keep enough for context
+                            if len(args) > 500:
+                                args = args[:400] + "..."
+                            tc_parts.append(f"  {name}({args})")
+                        else:
+                            # Handle object-style tool calls
+                            fn = getattr(tc, "function", None)
+                            name = getattr(fn, "name", "?") if fn else "?"
+                            tc_parts.append(f"  {name}(...)")
+                    content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
+                parts.append(f"[ASSISTANT]: {content}")
+                continue
+
+            # User and other roles
+            if len(content) > max_chars:
+                content = self._truncate_middle(content, max_chars)
+            parts.append(f"[{role.upper()}]: {content}")
+
+        return "\n\n".join(parts)
+
+    def summarize(
+        self,
+        turns: List[Dict[str, Any]],
+        previous_summary: Optional[str] = None,
+    ) -> Optional[str]:
+        """Generate a structured summary of conversation turns.
+
+        Uses a structured template (Goal, Progress, Decisions, Files, Next Steps).
+        When a previous summary exists, generates an iterative update instead
+        of summarizing from scratch.
+
+        Returns None if all attempts fail - the caller should drop
+        the middle turns without a summary rather than inject a useless
+        placeholder.
+        """
+        if not turns:
+            return None
+
+        summary_budget = self.compute_summary_budget(turns)
+        content_to_summarize = self.serialize_for_summary(turns)
+
+        # Use provided previous_summary or stored one
+        prev = previous_summary or self._previous_summary
+
+        if prev:
+            prompt = self._build_iterative_prompt(prev, content_to_summarize, summary_budget)
+        else:
+            prompt = self._build_initial_prompt(content_to_summarize, summary_budget)
+
+        try:
+            call_kwargs = {
+                "task": "compression",
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": self.config.temperature,
+                "max_tokens": summary_budget * 2,
+                "timeout": self.config.timeout,
+            }
+            if self.config.model:
+                call_kwargs["model"] = self.config.model
+
+            response = call_llm(**call_kwargs)
+            content = response.choices[0].message.content
+
+            # Handle cases where content is not a string (e.g., dict from llama.cpp)
+            if not isinstance(content, str):
+                content = str(content) if content else ""
+
+            summary = content.strip()
+
+            # Store for iterative updates on next compaction
+            self._previous_summary = summary
+
+            return self._with_summary_prefix(summary)
+
+        except RuntimeError:
+            logger.warning(
+                "Context compression: no provider available for summary. "
+                "Middle turns will be dropped without summary."
+            )
+            return None
+        except Exception as e:
+            logger.warning("Failed to generate context summary: %s", e)
+            return None
+
+    def reset(self):
+        """Clear stored previous summary for a new session."""
+        self._previous_summary = None
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _truncate_middle(self, text: str, max_len: int) -> str:
+        """Truncate middle of text, keeping head and tail."""
+        if len(text) <= max_len:
+            return text
+        head_len = int(max_len * 0.67)  # ~2000 chars for 3000 max
+        tail_len = max_len - head_len
+        return text[:head_len] + "\n...[truncated]...\n" + text[-tail_len:]
+
+    def _build_initial_prompt(self, content: str, budget: int) -> str:
+        """Build prompt for first-time summarization."""
+        return f"""Create a structured handoff summary for a later assistant that will continue this conversation after earlier turns are compacted.
+
+TURNS TO SUMMARIZE:
+{content}
+
+Use this exact structure:
+
+## Goal
+[What the user is trying to accomplish]
+
+## Constraints & Preferences
+[User preferences, coding style, constraints, important decisions]
+
+## Progress
+### Done
+[Completed work - include specific file paths, commands run, results obtained]
+### In Progress
+[Work currently underway]
+### Blocked
+[Any blockers or issues encountered]
+
+## Key Decisions
+[Important technical decisions and why they were made]
+
+## Relevant Files
+[Files read, modified, or created - with brief note on each]
+
+## Next Steps
+[What needs to happen next to continue the work]
+
+## Critical Context
+[Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
+
+Target ~{budget} tokens. Be specific - include file paths, command outputs, error messages, and concrete values rather than vague descriptions. The goal is to prevent the next assistant from repeating work or losing important details.
+
+Write only the summary body. Do not include any preamble or prefix."""
+
+    def _build_iterative_prompt(
+        self, previous_summary: str, new_content: str, budget: int
+    ) -> str:
+        """Build prompt for iterative summary update."""
+        return f"""You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
+
+PREVIOUS SUMMARY:
+{previous_summary}
+
+NEW TURNS TO INCORPORATE:
+{new_content}
+
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new progress. Move items from "In Progress" to "Done" when completed. Remove information only if it is clearly obsolete.
+
+## Goal
+[What the user is trying to accomplish - preserve from previous summary, update if goal evolved]
+
+## Constraints & Preferences
+[User preferences, coding style, constraints, important decisions - accumulate across compactions]
+
+## Progress
+### Done
+[Completed work - include specific file paths, commands run, results obtained]
+### In Progress
+[Work currently underway]
+### Blocked
+[Any blockers or issues encountered]
+
+## Key Decisions
+[Important technical decisions and why they were made]
+
+## Relevant Files
+[Files read, modified, or created - with brief note on each. Accumulate across compactions.]
+
+## Next Steps
+[What needs to happen next to continue the work]
+
+## Critical Context
+[Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
+
+Target ~{budget} tokens. Be specific - include file paths, command outputs, error messages, and concrete values rather than vague descriptions.
+
+Write only the summary body. Do not include any preamble or prefix."""
+
+    @staticmethod
+    def _with_summary_prefix(summary: str) -> str:
+        """Normalize summary text to the current compaction handoff format."""
+        text = (summary or "").strip()
+        # Remove any existing prefix
+        for prefix in (SUMMARY_PREFIX, "[CONTEXT SUMMARY]:"):
+            if text.startswith(prefix):
+                text = text[len(prefix):].lstrip()
+                break
+        return f"{SUMMARY_PREFIX}\n{text}" if text else SUMMARY_PREFIX

--- a/plugins/context_engine/lcm/summarizer.py
+++ b/plugins/context_engine/lcm/summarizer.py
@@ -154,6 +154,28 @@ class Summarizer:
         else:
             prompt = self._build_initial_prompt(content_to_summarize, summary_budget)
 
+        # ── Layer 1: call_llm with full provider fallback chain ────────
+        # call_llm already tries OpenRouter → Nous → Custom → Codex → Anthropic
+        # etc. plus payment exhaustion fallback. If ANY provider is available,
+        # it will be used.
+        summary = self._try_llm_summarize(prompt, summary_budget)
+        if summary is not None:
+            return self._with_summary_prefix(summary)
+
+        # ── Layer 2: Deterministic extractive fallback ─────────────────
+        # No LLM available at all. Build a structured summary by extracting
+        # key information from the turns directly. Not as good as LLM but
+        # preserves critical context (file paths, commands, decisions).
+        logger.info("LCM: Using deterministic extractive fallback for summary")
+        summary = self._deterministic_summary(turns, prev)
+        if summary is not None:
+            self._previous_summary = summary
+            return self._with_summary_prefix(summary)
+
+        return None
+
+    def _try_llm_summarize(self, prompt: str, summary_budget: int) -> Optional[str]:
+        """Try to summarize using call_llm with the full provider chain."""
         try:
             call_kwargs = {
                 "task": "compression",
@@ -173,21 +195,148 @@ class Summarizer:
                 content = str(content) if content else ""
 
             summary = content.strip()
-
-            # Store for iterative updates on next compaction
             self._previous_summary = summary
-
-            return self._with_summary_prefix(summary)
+            return summary
 
         except RuntimeError:
             logger.warning(
-                "Context compression: no provider available for summary. "
-                "Middle turns will be dropped without summary."
+                "Context compression: no provider available for LLM summary. "
+                "Falling back to deterministic extractive summary."
             )
             return None
         except Exception as e:
-            logger.warning("Failed to generate context summary: %s", e)
+            logger.warning("Failed to generate LLM context summary: %s. "
+                         "Falling back to deterministic extractive summary.", e)
             return None
+
+    def _deterministic_summary(
+        self,
+        turns: List[Dict[str, Any]],
+        previous_summary: Optional[str] = None,
+    ) -> Optional[str]:
+        """Build a structured summary without any LLM call.
+
+        Uses sumy's LexRank algorithm (graph-based sentence centrality)
+        for extractive summarization. Falls back to simple extraction
+        if sumy is unavailable.
+
+        LexRank ranks sentences by their centrality in a similarity graph —
+        sentences most representative of the whole content get selected.
+        This is significantly better than naive concatenation because it:
+        - Scores and ranks sentences by importance
+        - Selects a budget-fitting subset
+        - Preserves the most informative content
+        """
+        if not turns:
+            return None
+
+        # Serialize turns to text for sumy
+        all_text = self.serialize_for_summary(turns, max_chars=1500)
+
+        # Try sumy extractive summarization first
+        summary = self._sumy_extract(all_text, sentence_count=6)
+        if summary is None:
+            # sumy not available — fall back to simple extraction
+            summary = self._simple_extract(turns)
+
+        if summary is None:
+            return None
+
+        parts: List[str] = []
+        if previous_summary:
+            parts.append(previous_summary)
+            parts.append("--- Updates since last compaction ---")
+
+        parts.append(summary)
+        result = "\n".join(parts)
+        return result if result.strip() else None
+
+    def _sumy_extract(self, text: str, sentence_count: int = 6) -> Optional[str]:
+        """Extract key sentences using sumy's LexRank algorithm.
+
+        Returns None if sumy is not available or produces no output.
+        """
+        try:
+            from sumy.parsers.plaintext import PlaintextParser
+            from sumy.nlp.tokenizers import Tokenizer
+            from sumy.summarizers.lex_rank import LexRankSummarizer
+            from sumy.nlp.stemmers import Stemmer
+            from sumy.utils import get_stop_words
+
+            if not text or len(text.strip()) < 50:
+                return None
+
+            parser = PlaintextParser.from_string(text, Tokenizer("english"))
+            stemmer = Stemmer("english")
+            summarizer = LexRankSummarizer(stemmer)
+            summarizer.stop_words = get_stop_words("english")
+
+            sentences = list(summarizer(parser.document, sentence_count))
+            if not sentences:
+                return None
+
+            return " ".join(str(s).strip() for s in sentences)
+
+        except ImportError:
+            logger.debug("sumy not available for extractive summarization, using simple fallback")
+            return None
+        except Exception as exc:
+            logger.debug("sumy extractive summary failed: %s", exc)
+            return None
+
+    def _simple_extract(self, turns: List[Dict[str, Any]]) -> Optional[str]:
+        """Simple keyword-based extraction fallback when sumy is unavailable.
+
+        Extracts tool calls, user intents, and key results by role-based
+        partitioning. Less intelligent than sumy but zero-dependency.
+        """
+        parts: List[str] = []
+
+        user_msgs = []
+        tool_calls_seen = []
+        tool_results = []
+        assistant_msgs = []
+
+        for msg in turns:
+            role = msg.get("role", "")
+            content = str(msg.get("content", "") or "")[:500]
+
+            if role == "user":
+                user_msgs.append(content)
+            elif role == "assistant":
+                assistant_msgs.append(content)
+                for tc in msg.get("tool_calls", []):
+                    if isinstance(tc, dict):
+                        fn = tc.get("function", {})
+                        name = fn.get("name", "?")
+                        args = str(fn.get("arguments", ""))[:200]
+                        tool_calls_seen.append(f"{name}({args})")
+            elif role == "tool":
+                tool_results.append(content[:300])
+
+        if user_msgs:
+            parts.append("## User Messages")
+            for i, m in enumerate(user_msgs[-5:], 1):
+                parts.append(f"  {i}. {m[:200]}")
+
+        if tool_calls_seen:
+            parts.append("## Tool Calls Made")
+            for tc in tool_calls_seen[-10:]:
+                parts.append(f"  - {tc}")
+
+        if tool_results:
+            parts.append("## Key Tool Results")
+            for r in tool_results[-5:]:
+                parts.append(f"  - {r[:200]}")
+
+        if assistant_msgs:
+            parts.append("## Assistant Responses")
+            for m in assistant_msgs[-3:]:
+                if m.strip():
+                    parts.append(f"  - {m[:200]}")
+
+        result = "\n".join(parts)
+        return result if result.strip() else None
 
     def reset(self):
         """Clear stored previous summary for a new session."""

--- a/plugins/context_engine/lcm/tokens.py
+++ b/plugins/context_engine/lcm/tokens.py
@@ -1,0 +1,257 @@
+"""Accurate token estimation for LCM context management.
+
+Uses tiktoken for OpenAI models with fallbacks for other providers.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import tiktoken
+
+logger = logging.getLogger(__name__)
+
+# Character-to-token ratios for different model families
+# Based on empirical measurements
+CHAR_RATIOS = {
+    "claude": 3.5,      # Claude tends to have fewer tokens per char
+    "gpt": 4.0,         # OpenAI GPT models
+    "llama": 4.0,       # LLaMA family
+    "qwen": 4.0,        # Qwen models
+    "gemini": 3.8,      # Google Gemini
+    "mistral": 4.0,     # Mistral
+    "default": 4.0,     # Default fallback
+}
+
+# Per-message overhead for role/metadata
+MESSAGE_OVERHEAD_TOKENS = 4
+
+
+@dataclass
+class TokenEstimatorConfig:
+    """Configuration for TokenEstimator."""
+    model: str = ""
+    provider: str = ""
+    context_length: int = 128_000
+    use_tiktoken: bool = True  # Can disable for testing
+
+
+class TokenEstimator:
+    """Accurate token estimation with model-specific handling.
+
+    Uses tiktoken for OpenAI models, with character-ratio fallbacks
+    for other providers.
+    """
+
+    def __init__(self, config: TokenEstimatorConfig):
+        self.config = config
+        self._encoding: Optional["tiktoken.Encoding"] = None
+        self._initialized = False
+
+    def _lazy_init(self):
+        """Lazily initialize tiktoken encoding on first use."""
+        if self._initialized:
+            return
+
+        self._initialized = True
+
+        if not self.config.use_tiktoken:
+            return
+
+        # Try to use tiktoken for OpenAI models
+        if self._should_use_tiktoken():
+            self._encoding = self._get_tiktoken_encoding()
+
+    def _should_use_tiktoken(self) -> bool:
+        """Check if tiktoken should be used for this model."""
+        model_lower = self.config.model.lower()
+        provider_lower = self.config.provider.lower()
+
+        # OpenAI models benefit from tiktoken
+        if provider_lower == "openai" or "gpt" in model_lower:
+            return True
+
+        # Some OpenRouter models also use cl100k_base
+        if provider_lower == "openrouter" and "gpt" in model_lower:
+            return True
+
+        return False
+
+    def _get_tiktoken_encoding(self) -> Optional["tiktoken.Encoding"]:
+        """Get tiktoken encoding for the model."""
+        try:
+            import tiktoken
+        except ImportError:
+            logger.debug("tiktoken not installed, using character-based estimation")
+            return None
+
+        model = self.config.model.lower()
+
+        # Map model names to tiktoken encodings
+        encoding_name = None
+
+        # GPT-4 models
+        if "gpt-4" in model or "gpt-4o" in model:
+            encoding_name = "cl100k_base"
+        # GPT-3.5-turbo
+        elif "gpt-3.5" in model:
+            encoding_name = "cl100k_base"
+        # Default OpenAI encoding
+        elif "gpt" in model:
+            encoding_name = "cl100k_base"
+
+        if encoding_name:
+            try:
+                return tiktoken.get_encoding(encoding_name)
+            except Exception as e:
+                logger.debug(f"Failed to get tiktoken encoding: {e}")
+
+        # Try model-specific encoding
+        try:
+            return tiktoken.encoding_for_model(self.config.model)
+        except Exception:
+            pass
+
+        # Fall back to cl100k_base for unknown OpenAI models
+        try:
+            return tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            return None
+
+    def estimate(self, messages: List[Dict[str, Any]]) -> int:
+        """Estimate token count for a list of messages.
+
+        This is the main entry point for token estimation.
+        """
+        self._lazy_init()
+
+        if self._encoding:
+            return self._estimate_with_tiktoken(messages)
+        else:
+            return self._estimate_with_char_ratio(messages)
+
+    def estimate_single(self, content: str) -> int:
+        """Estimate tokens for a single string."""
+        self._lazy_init()
+
+        if not content:
+            return 0
+
+        if self._encoding:
+            return len(self._encoding.encode(content))
+        else:
+            return len(content) // self._get_char_ratio()
+
+    def _estimate_with_tiktoken(self, messages: List[Dict[str, Any]]) -> int:
+        """Accurate estimation using tiktoken."""
+        total = 0
+
+        for msg in messages:
+            # Content — handle multimodal (list of parts) separately from plain strings
+            content = msg.get("content") or ""
+            if isinstance(content, list):
+                # Multimodal: count text parts only; skip image/binary parts
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") in ("text", "input_text"):
+                        total += len(self._encoding.encode(str(part.get("text", ""))))
+            else:
+                total += len(self._encoding.encode(str(content)))
+
+            # Tool calls
+            for tc in msg.get("tool_calls") or []:
+                if isinstance(tc, dict):
+                    fn = tc.get("function", {})
+                    args = fn.get("arguments", "")
+                    if args:
+                        total += len(self._encoding.encode(str(args)))
+                else:
+                    # Object-style tool call
+                    fn = getattr(tc, "function", None)
+                    if fn:
+                        args = getattr(fn, "arguments", "")
+                        if args:
+                            total += len(self._encoding.encode(str(args)))
+
+            # Message overhead
+            total += MESSAGE_OVERHEAD_TOKENS
+
+        return total
+
+    def _estimate_with_char_ratio(self, messages: List[Dict[str, Any]]) -> int:
+        """Fallback estimation using character ratio."""
+        ratio = self._get_char_ratio()
+        total = 0
+
+        for msg in messages:
+            # Content
+            content = str(msg.get("content") or "")
+            total += len(content) // ratio
+
+            # Tool calls
+            for tc in msg.get("tool_calls") or []:
+                if isinstance(tc, dict):
+                    args = tc.get("function", {}).get("arguments", "")
+                    if args:
+                        total += len(str(args)) // ratio
+                else:
+                    fn = getattr(tc, "function", None)
+                    if fn:
+                        args = getattr(fn, "arguments", "")
+                        if args:
+                            total += len(str(args)) // ratio
+
+            # Message overhead
+            total += MESSAGE_OVERHEAD_TOKENS
+
+        return total
+
+    def _get_char_ratio(self) -> int:
+        """Get character-to-token ratio for the model."""
+        model_lower = self.config.model.lower()
+        provider_lower = self.config.provider.lower()
+
+        # Check by provider first
+        for key, ratio in CHAR_RATIOS.items():
+            if key in provider_lower:
+                return ratio
+
+        # Check by model name  
+        for key, ratio in CHAR_RATIOS.items():
+            if key in model_lower:
+                return ratio
+
+        return CHAR_RATIOS["default"]
+
+    @property
+    def context_length(self) -> int:
+        """Get the context length for this model."""
+        return self.config.context_length
+
+    @context_length.setter
+    def context_length(self, value: int):
+        """Set the context length."""
+        self.config.context_length = value
+
+
+def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
+    """Quick rough estimate without model-specific handling.
+
+    Used for pre-flight checks where speed matters more than accuracy.
+    """
+    total = 0
+    for msg in messages:
+        content = str(msg.get("content") or "")
+        total += len(content) // 4  # Rough estimate
+
+        # Tool calls
+        for tc in msg.get("tool_calls") or []:
+            if isinstance(tc, dict):
+                args = tc.get("function", {}).get("arguments", "")
+                total += len(str(args)) // 4
+
+        total += MESSAGE_OVERHEAD_TOKENS
+
+    return total

--- a/plugins/context_engine/lcm/tools.py
+++ b/plugins/context_engine/lcm/tools.py
@@ -1,0 +1,402 @@
+"""LCM agent tools — give the agent active control over its context window."""
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Any
+
+from plugins.context_engine.lcm.engine import LcmEngine
+
+# ---------------------------------------------------------------------------
+# Per-context engine reference (thread- and task-safe via ContextVar)
+# ---------------------------------------------------------------------------
+
+_engine_var: ContextVar[LcmEngine | None] = ContextVar("lcm_engine", default=None)
+
+
+def set_engine(engine: LcmEngine | None) -> None:
+    """Register the active LcmEngine instance used by all tool handlers."""
+    _engine_var.set(engine)
+
+
+def get_engine() -> LcmEngine | None:
+    """Return the currently registered LcmEngine, or None."""
+    return _engine_var.get()
+
+
+def _require_engine() -> LcmEngine | str:
+    """Return engine or an error string if not active."""
+    e = get_engine()
+    if e is None:
+        return "Error: LCM not active. No engine registered."
+    return e
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_lcm_expand(args: dict[str, Any]) -> str:
+    """Expand raw message IDs back from the immutable store."""
+    result = _require_engine()
+    if isinstance(result, str):
+        return result
+
+    engine = result
+    raw = args.get("message_ids", "")
+    try:
+        ids = [int(x.strip()) for x in str(raw).split(",") if x.strip()]
+    except (ValueError, AttributeError):
+        return "Invalid message_ids: must be comma-separated integers."
+
+    if not ids:
+        return "Invalid message_ids: no valid integers found."
+
+    return engine.format_expanded(ids)
+
+
+def handle_lcm_pin(args: dict[str, Any]) -> str:
+    """Pin message IDs so they are never compacted away."""
+    engine = _require_engine()
+    if isinstance(engine, str):
+        return engine
+
+    raw = args.get("message_ids", "")
+    try:
+        new_ids = [int(x.strip()) for x in str(raw).split(",") if x.strip()]
+    except (ValueError, AttributeError):
+        return "Invalid message_ids: must be comma-separated integers."
+
+    if not new_ids:
+        return "Invalid message_ids: no valid integers found."
+
+    if len(engine._pinned_ids) + len(new_ids) > engine.config.max_pinned:
+        return (
+            f"Cannot pin: would exceed limit of {engine.config.max_pinned} pinned messages. "
+            f"Currently {len(engine._pinned_ids)} pinned."
+        )
+
+    engine._pinned_ids.update(new_ids)
+    id_list = ", ".join(str(i) for i in sorted(new_ids))
+    return f"Pinned message IDs: {id_list}. Total pinned: {len(engine._pinned_ids)}."
+
+
+def handle_lcm_forget(args: dict[str, Any]) -> str:
+    """Immediately compact specified messages out of the active context."""
+    result = _require_engine()
+    if isinstance(result, str):
+        return result
+
+    engine = result
+    raw = args.get("message_ids", "")
+    reason = args.get("reason", "agent-requested forget")
+
+    try:
+        target_ids = set(int(x.strip()) for x in str(raw).split(",") if x.strip())
+    except (ValueError, AttributeError):
+        return "Invalid message_ids: must be comma-separated integers."
+
+    if not target_ids:
+        return "Invalid message_ids: no valid integers found."
+
+    # Find active entries that match the target ids
+    indices = [
+        i for i, entry in enumerate(engine.active)
+        if entry.msg_id is not None and entry.msg_id in target_ids
+    ]
+
+    if not indices:
+        return "No matching active entries found for the given message IDs."
+
+    # Compact contiguous runs; process from oldest to newest
+    compacted_count = 0
+    # Group consecutive indices into runs
+    runs: list[list[int]] = []
+    current_run: list[int] = []
+    for idx in sorted(indices):
+        if not current_run or idx == current_run[-1] + 1:
+            current_run.append(idx)
+        else:
+            runs.append(current_run)
+            current_run = [idx]
+    if current_run:
+        runs.append(current_run)
+
+    # Process runs in reverse order so indices stay valid
+    for run in reversed(runs):
+        block_start = run[0]
+        block_end = run[-1] + 1
+        summary_text = f"[Forgotten: {reason}]"
+        engine.compact(summary_text, level=1, block_start=block_start, block_end=block_end)
+        compacted_count += len(run)
+
+    return f"Compacted {compacted_count} message(s) with reason: {reason}."
+
+
+def handle_lcm_search(args: dict[str, Any]) -> str:
+    """Keyword search across all ingested messages in the immutable store."""
+    result = _require_engine()
+    if isinstance(result, str):
+        return result
+
+    engine = result
+    query = str(args.get("query", "")).strip()
+    limit = int(args.get("limit", 10))
+
+    if not query:
+        return "Error: query is required."
+
+    query_lower = query.lower()
+    matches: list[str] = []
+
+    for msg_id in range(len(engine.store)):
+        msg = engine.store.get(msg_id)
+        if msg is None:
+            continue
+        content = str(msg.get("content", "") or "")
+        if query_lower in content.lower():
+            role = msg.get("role", "unknown")
+            snippet = content[:120].replace("\n", " ")
+            matches.append(f"[msg {msg_id}] {role}: {snippet}")
+            if len(matches) >= limit:
+                break
+
+    if not matches:
+        return f"No matches found for query: {query!r}"
+
+    return "\n".join(matches)
+
+
+def handle_lcm_budget(args: dict[str, Any]) -> str:
+    """Return token usage breakdown for the current active context."""
+    result = _require_engine()
+    if isinstance(result, str):
+        return result
+
+    engine = result
+
+    raw_entries = [e for e in engine.active if e.kind == "raw"]
+    summary_entries = [e for e in engine.active if e.kind == "summary"]
+
+    raw_tokens = sum(
+        len(str(e.message.get("content", "") or "")) // 4 + 4
+        for e in raw_entries
+    )
+    summary_tokens = sum(
+        len(str(e.message.get("content", "") or "")) // 4 + 4
+        for e in summary_entries
+    )
+    active_tokens = engine.active_tokens()
+    store_count = len(engine.store)
+
+    lines = [
+        "LCM Context Budget:",
+        f"  Active entries : {len(engine.active)} ({len(raw_entries)} raw, {len(summary_entries)} summaries)",
+        f"  Active tokens  : ~{active_tokens}",
+        f"  Raw tokens     : ~{raw_tokens}",
+        f"  Summary tokens : ~{summary_tokens}",
+        f"  Store total    : {store_count} messages (immutable)",
+        f"  Pinned IDs     : {sorted(engine._pinned_ids) or 'none'}",
+    ]
+    return "\n".join(lines)
+
+
+def handle_lcm_toc(args: dict[str, Any]) -> str:
+    """Return a table of contents / timeline of the active conversation."""
+    result = _require_engine()
+    if isinstance(result, str):
+        return result
+
+    engine = result
+
+    if not engine.active:
+        return "Active context is empty."
+
+    lines = ["Conversation Timeline:"]
+    for i, entry in enumerate(engine.active):
+        if entry.kind == "raw":
+            role = entry.message.get("role", "?")
+            content = str(entry.message.get("content", "") or "")
+            snippet = content[:60].replace("\n", " ")
+            lines.append(f"  [{i}] msg {entry.msg_id} ({role}): {snippet}")
+        else:
+            content = str(entry.message.get("content", "") or "")
+            snippet = content[:60].replace("\n", " ")
+            lines.append(f"  [{i}] summary node={entry.node_id}: {snippet}")
+
+    return "\n".join(lines)
+
+
+def handle_lcm_focus(args: dict[str, Any]) -> str:
+    """Expand a summary node back into its original raw entries in the active context."""
+    result = _require_engine()
+    if isinstance(result, str):
+        return result
+
+    engine = result
+    raw_node_id = args.get("node_id")
+    if raw_node_id is None:
+        return "Error: node_id is required."
+
+    try:
+        node_id = int(raw_node_id)
+    except (ValueError, TypeError):
+        return "Invalid node_id: must be an integer."
+
+    # Find the summary entry in active
+    summary_index: int | None = None
+    for i, entry in enumerate(engine.active):
+        if entry.kind == "summary" and entry.node_id == node_id:
+            summary_index = i
+            break
+
+    if summary_index is None:
+        return f"No active summary entry found for node_id={node_id}."
+
+    # Retrieve original messages for this node
+    pairs = engine.expand_summary(node_id)
+    if not pairs:
+        return f"Summary node {node_id} has no source messages to expand."
+
+    from plugins.context_engine.lcm.engine import ContextEntry
+
+    expanded_entries = [
+        ContextEntry.raw(mid, msg) for mid, msg in pairs
+    ]
+
+    # Replace the summary entry with the expanded raw entries
+    engine.active[summary_index : summary_index + 1] = expanded_entries
+
+    # Expanding a summary increases token count; clear the pending flag so the
+    # next check_thresholds() call can trigger async compaction if needed.
+    engine._async_compaction_pending = False
+
+    return (
+        f"Expanded summary node {node_id} into {len(expanded_entries)} raw message(s). "
+        f"Active context now has {len(engine.active)} entries."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+LCM_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "lcm_expand": {
+        "name": "lcm_expand",
+        "description": (
+            "Retrieve the full original text of one or more messages by their numeric IDs. "
+            "Use this when a summary references earlier content you need to read verbatim."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "message_ids": {
+                    "type": "string",
+                    "description": "Comma-separated message IDs to expand (e.g. '0,1,5').",
+                },
+            },
+            "required": ["message_ids"],
+        },
+    },
+    "lcm_pin": {
+        "name": "lcm_pin",
+        "description": (
+            "Pin message IDs so they are never automatically compacted away. "
+            "Use for critical reference material that must stay verbatim."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "message_ids": {
+                    "type": "string",
+                    "description": "Comma-separated message IDs to pin (e.g. '2,3').",
+                },
+            },
+            "required": ["message_ids"],
+        },
+    },
+    "lcm_forget": {
+        "name": "lcm_forget",
+        "description": (
+            "Immediately compact specified messages out of the active context. "
+            "Use when you know a conversation segment is no longer relevant."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "message_ids": {
+                    "type": "string",
+                    "description": "Comma-separated message IDs to forget (e.g. '0,1,2').",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Brief reason for forgetting (recorded in the summary placeholder).",
+                },
+            },
+            "required": ["message_ids"],
+        },
+    },
+    "lcm_search": {
+        "name": "lcm_search",
+        "description": (
+            "Keyword search across all ingested messages, including those already compacted. "
+            "Returns matching message IDs and snippets."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Keyword or phrase to search for.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (default 10).",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    "lcm_budget": {
+        "name": "lcm_budget",
+        "description": (
+            "Show the current token usage breakdown: active entries, raw vs summary split, "
+            "store size, and pinned IDs."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    "lcm_toc": {
+        "name": "lcm_toc",
+        "description": (
+            "Show a table of contents / timeline of all active context entries. "
+            "Lists each entry with its index, type, role, and a short snippet."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    "lcm_focus": {
+        "name": "lcm_focus",
+        "description": (
+            "Expand a summary node back into its original raw messages in the active context. "
+            "Use when you need full detail from a section that was previously summarised."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "integer",
+                    "description": "The summary node ID to expand (visible in lcm_toc output).",
+                },
+            },
+            "required": ["node_id"],
+        },
+    },
+}

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -602,9 +602,12 @@ RLM_TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
 # ── Plugin Registration ─────────────────────────────────────────────────
 
 
-def register(ctx) -> None:
-    """Plugin entry point — register RLM as a context engine."""
-    engine = RlmContextEngine()
+def register(ctx, **kwargs) -> None:
+    """Plugin entry point — register RLM as a context engine.
+
+    kwargs are forwarded to the engine constructor (e.g. rlm_config).
+    """
+    engine = RlmContextEngine(**kwargs)
     if hasattr(ctx, "register_context_engine"):
         ctx.register_context_engine(engine)
     else:

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -485,6 +485,11 @@ class CompositeContextEngine(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]) -> None:
         self._compression_engine.update_from_response(usage)
+        # Re-sync wrapper-mirrored token attributes so callers reading
+        # composite.last_prompt_tokens etc. see up-to-date values.
+        self.last_prompt_tokens = getattr(self._compression_engine, "last_prompt_tokens", 0)
+        self.last_completion_tokens = getattr(self._compression_engine, "last_completion_tokens", 0)
+        self.last_total_tokens = getattr(self._compression_engine, "last_total_tokens", 0)
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
         return self._compression_engine.should_compress(prompt_tokens)
@@ -519,6 +524,12 @@ class CompositeContextEngine(ContextEngine):
         self._compression_engine.on_session_reset()
         if self._rlm_engine:
             self._rlm_engine.on_session_reset()
+        # Re-sync wrapper-mirrored token and counter attributes from the inner
+        # compression engine so the next compression decision uses fresh values.
+        self.last_prompt_tokens = getattr(self._compression_engine, "last_prompt_tokens", 0)
+        self.last_completion_tokens = getattr(self._compression_engine, "last_completion_tokens", 0)
+        self.last_total_tokens = getattr(self._compression_engine, "last_total_tokens", 0)
+        self.compression_count = getattr(self._compression_engine, "compression_count", 0)
 
     def update_model(self, **kwargs) -> None:
         """Update model info on both engines and re-sync wrapper-mirrored fields."""

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -267,11 +267,16 @@ class RlmContextEngine(ContextEngine):
         """Rebuild the REPL context from the latest messages.
 
         Call this before each API call to keep the context fresh.
+        If _rlm_env has not been created yet (no rlm_context was passed to
+        on_session_start), initialize it now from the current messages.
         """
         context = self.build_context_from_messages(messages)
         if context:
             self._session_context = context
-            if self._rlm_env:
+            if self._rlm_env is None:
+                # First call after a session start without rlm_context — bootstrap.
+                self._init_rlm_env(context)
+            else:
                 self._rlm_env.context = context
                 self._rlm_env.namespace["__context__"] = context
                 self._rlm_env.namespace["__context_length__"] = len(context)

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -399,6 +399,15 @@ class RlmContextEngine(ContextEngine):
         chunk_size = args.get("chunk_size", 8000)
         overlap = args.get("overlap", 500)
 
+        # Reject malformed bounds before entering the loop.  overlap >= chunk_size
+        # causes start to not advance (or move backwards), producing an infinite loop.
+        if not isinstance(chunk_size, int) or chunk_size <= 0:
+            return json.dumps({"error": f"chunk_size must be a positive integer, got {chunk_size!r}"})
+        if not isinstance(overlap, int) or overlap < 0:
+            return json.dumps({"error": f"overlap must be a non-negative integer, got {overlap!r}"})
+        if overlap >= chunk_size:
+            return json.dumps({"error": f"overlap ({overlap}) must be smaller than chunk_size ({chunk_size})"})
+
         try:
             context = self._session_context
             chunks = []
@@ -609,10 +618,12 @@ RLM_TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                 "chunk_size": {
                     "type": "integer",
                     "description": "Characters per chunk. Default: 8000",
+                    "minimum": 1,
                 },
                 "overlap": {
                     "type": "integer",
-                    "description": "Characters of overlap between chunks. Default: 500",
+                    "description": "Characters of overlap between chunks. Must be less than chunk_size. Default: 500",
+                    "minimum": 0,
                 },
             },
             "required": [],

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -247,6 +247,10 @@ class RlmContextEngine(ContextEngine):
 
         This is called by the agent so the RLM engine can populate
         its context with the actual conversation.
+
+        Handles both Anthropic-style content blocks
+        (``content: [{type: tool_use, ...}]``) and OpenAI-style
+        ``tool_calls: [{function: {name, arguments}}]`` on assistant messages.
         """
         parts = []
         for msg in messages:
@@ -261,6 +265,17 @@ class RlmContextEngine(ContextEngine):
                             parts.append(f"[{role}]: {item['text']}")
                         elif item.get("type") == "tool_use":
                             parts.append(f"[{role}]: {json.dumps(item.get('input', {}))}")
+            # OpenAI-style: tool_calls=[{function: {name, arguments}}]
+            # These appear alongside empty/null content on assistant messages.
+            tool_calls = msg.get("tool_calls")
+            if tool_calls and isinstance(tool_calls, list):
+                for tc in tool_calls:
+                    fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                    if fn:
+                        parts.append(
+                            f"[{role}]: tool_call {fn.get('name', '?')} "
+                            f"{fn.get('arguments', '')}"
+                        )
         return "\n\n".join(parts)
 
     def refresh_context(self, messages: List[Dict[str, Any]]) -> None:

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -497,10 +497,17 @@ class CompositeContextEngine(ContextEngine):
             self._rlm_engine.on_session_reset()
 
     def update_model(self, **kwargs) -> None:
-        """Update model info on both engines."""
+        """Update model info on both engines and re-sync wrapper-mirrored fields."""
         self._compression_engine.update_model(**kwargs)
         if self._rlm_engine:
             self._rlm_engine.update_model(**kwargs)
+        # Re-sync wrapper-mirrored attributes from the compression engine so
+        # callers that read composite.context_length / .threshold_tokens etc.
+        # get up-to-date values rather than the stale constructor-time copies.
+        self.context_length = getattr(self._compression_engine, "context_length", self.context_length)
+        self.threshold_tokens = getattr(self._compression_engine, "threshold_tokens", self.threshold_tokens)
+        self.threshold_percent = getattr(self._compression_engine, "threshold_percent", self.threshold_percent)
+        self.protect_last_n = getattr(self._compression_engine, "protect_last_n", self.protect_last_n)
 
     # ── Tools (combine from both engines) ───────────────────────────────
 

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -467,8 +467,11 @@ class CompositeContextEngine(ContextEngine):
         self,
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
+        focus_topic: str = None,
     ) -> List[Dict[str, Any]]:
-        return self._compression_engine.compress(messages, current_tokens)
+        return self._compression_engine.compress(
+            messages, current_tokens, focus_topic=focus_topic
+        )
 
     # ── Session lifecycle (delegate to both) ────────────────────────────
 

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -1,0 +1,437 @@
+"""Recursive Language Model context engine plugin.
+
+Implements the RLM paradigm (arXiv:2512.24601) as a ContextEngine plugin.
+Instead of compressing messages, the RLM treats the prompt as an external
+Python variable in a REPL environment, allowing the LLM to programmatically
+peek, grep, chunk, and recursively call sub-LLMs over the context.
+
+Activation: set ``context.engine: rlm`` in config.yaml.
+
+Requires an external LLM provider (OpenAI, custom, etc.) for the root and
+sub-LLM calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+import textwrap
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.context_engine import ContextEngine
+
+logger = logging.getLogger(__name__)
+
+# ── RLM REPL Environment ──────────────────────────────────────────────────
+
+
+class RLMAgentEnvironment:
+    """Python REPL environment for RLM context management.
+
+    Stores the context as a variable. The root LLM can:
+    - Peek at context snippets
+    - Grep/search with regex
+    - Chunk and map over context
+    - Call sub-LLMs via env.llm_batch() or env.llm_call()
+
+    The LLM provides its final answer via the answer dict:
+    answer = {"content": "...", "ready": True}
+    """
+
+    def __init__(
+        self,
+        context: str,
+        max_iterations: int = 20,
+        output_limit: int = 8192,
+    ):
+        self.context = context
+        self.max_iterations = max_iterations
+        self.output_limit = output_limit
+
+        # REPL namespace
+        self.namespace: dict = {
+            "__context__": context,
+            "__context_length__": len(context),
+            "__context_token_length__": self._estimate_tokens(context),
+            "answer": {"content": "", "ready": False},
+            "llm_batch": self._llm_batch_handler,
+            "llm_call": self._llm_call_handler,
+        }
+
+        self.iteration_count = 0
+
+    @staticmethod
+    def _estimate_tokens(text: str) -> int:
+        """Rough token estimate: ~4 chars per token."""
+        return max(1, len(text) // 4)
+
+    def execute(self, code: str) -> str:
+        """Execute Python code in the REPL environment.
+
+        Returns truncated output visible to the LLM.
+        """
+        try:
+            compiled = compile(code, "<rlm>", "exec")
+            exec(compiled, self.namespace)
+
+            result = self.namespace.get("answer", "")
+            if isinstance(result, dict):
+                output = result.get("content", "")
+            else:
+                output = str(result)
+
+            if len(output) > self.output_limit:
+                output = output[: self.output_limit] + "...[truncated]"
+
+            return output
+
+        except Exception as e:
+            return f"REPL Error: {type(e).__name__}: {e}"
+
+    def execute_expression(self, expression: str) -> str:
+        """Execute a Python expression and return the result."""
+        try:
+            result = eval(expression, self.namespace)
+            output = str(result)
+
+            if len(output) > self.output_limit:
+                output = output[: self.output_limit] + "...[truncated]"
+
+            return output
+
+        except Exception as e:
+            return f"Expression Error: {type(e).__name__}: {e}"
+
+    def _llm_batch_handler(self, prompts: list) -> list:
+        """Batch sub-LLM calls. Parallel execution.
+
+        Each prompt is a question about a subset of __context__.
+        Returns list of answers from sub-LLMs.
+
+        Note: This is a stub — the real implementation in
+        RLMAgentEnvironment delegates to RLMAgent._call_sub_llm.
+        """
+        # Placeholder — will be replaced when the environment is connected
+        # to the actual LLM client
+        return []
+
+    def _llm_call_handler(self, prompt: str) -> str:
+        """Recursive sub-LLM call stub."""
+        return ""
+
+    def set_answer(self, content: str, ready: bool = False):
+        """Set the final answer."""
+        self.namespace["answer"]["content"] = content
+        self.namespace["answer"]["ready"] = ready
+
+    def check_iteration_limit(self) -> bool:
+        """Whether we've hit max iterations."""
+        self.iteration_count += 1
+        return self.iteration_count >= self.max_iterations
+
+
+# ── RLM ContextEngine Plugin ─────────────────────────────────────────────
+
+
+class RlmContextEngine(ContextEngine):
+    """RLM adapter that implements the ContextEngine ABC.
+
+    Unlike LCM which compresses messages, the RLM treats the context as
+    an external Python variable and allows the root LLM to programmatically
+    interact with it via a REPL environment.
+
+    Key design decisions:
+    - Never compresses messages (returns them unchanged)
+    - Exposes rlm_peek, rlm_grep, rlm_partition tools to the agent
+    - Sub-LLMs get tools, root LLM does not (keeps root context clean)
+    - Parallel batch sub-LLM calls via llm_batch()
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._config: dict = kwargs.get("rlm_config", {})
+        self._max_iterations = self._config.get("max_iterations", 20)
+        self._output_limit = self._config.get("output_limit", 8192)
+
+        # Token tracking (required by ABC)
+        self.last_prompt_tokens: int = 0
+        self.last_completion_tokens: int = 0
+        self.last_total_tokens: int = 0
+        self.threshold_tokens: int = 0
+        self.context_length: int = 0
+        self.compression_count: int = 0
+        self.threshold_percent: float = 1.0  # Never triggers compression
+        self.protect_last_n: int = 6
+
+        # Store context for this session
+        self._session_context: Optional[str] = None
+        self._rlm_env: Optional[RLMAgentEnvironment] = None
+
+    # ── Identity ────────────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return "rlm"
+
+    # ── Core ABC interface ──────────────────────────────────────────────
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        """Update tracked token usage from API response."""
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+        total = prompt_tokens + completion_tokens
+
+        self.last_prompt_tokens = prompt_tokens
+        self.last_completion_tokens = completion_tokens
+        self.last_total_tokens = total
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        """RLM never compresses — it handles unbounded context via REPL."""
+        return False
+
+    def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
+        """RLM preflight check — always False."""
+        return False
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+    ) -> List[Dict[str, Any]]:
+        """Return messages unchanged.
+
+        RLM doesn't compress — it delegates context management to the
+        REPL environment. The agent interacts with context via tools
+        (rlm_peek, rlm_grep, etc.).
+        """
+        return list(messages)
+
+    # ── Session lifecycle ───────────────────────────────────────────────
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        """Initialize RLM environment for the session."""
+        self.context_length = kwargs.get("context_length", 128_000)
+        self.threshold_tokens = self.context_length
+
+        # Extract context from config if provided
+        context = kwargs.get("rlm_context")
+        if context:
+            self._session_context = context
+            self._init_rlm_env(context)
+
+        logger.info(
+            "RLM session started (session=%s, max_iter=%d, output_limit=%d)",
+            session_id,
+            self._max_iterations,
+            self._output_limit,
+        )
+
+    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        """Session end — context is ephemeral (RLM stores in memory)."""
+        pass
+
+    def on_session_reset(self) -> None:
+        """Reset per-session state."""
+        super().on_session_reset()
+        self._session_context = None
+        self._rlm_env = None
+
+    def _init_rlm_env(self, context: str) -> None:
+        """Create the REPL environment for the given context."""
+        self._session_context = context
+        self._rlm_env = RLMAgentEnvironment(
+            context=context,
+            max_iterations=self._max_iterations,
+            output_limit=self._output_limit,
+        )
+
+    # ── Tools ───────────────────────────────────────────────────────────
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return RLM tool schemas (rlm_peek, rlm_grep, rlm_partition)."""
+        return list(RLM_TOOL_SCHEMAS.values())
+
+    def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+        """Dispatch RLM tool calls."""
+        handlers = {
+            "rlm_peek": self._handle_peek,
+            "rlm_grep": self._handle_grep,
+            "rlm_partition": self._handle_partition,
+        }
+
+        handler = handlers.get(name)
+        if handler is None:
+            return json.dumps({"error": f"Unknown RLM tool: {name}"})
+
+        return handler(args)
+
+    def _handle_peek(self, args: Dict[str, Any]) -> str:
+        """Peek at a section of the context.
+
+        Args:
+            start: Start character index
+            length: Number of characters to read
+
+        Returns the context snippet.
+        """
+        if not self._rlm_env or not self._session_context:
+            return json.dumps({"error": "No context loaded"})
+
+        start = args.get("start", 0)
+        length = args.get("length", 2000)
+
+        try:
+            context = self._session_context
+            snippet = context[start : start + length]
+            return json.dumps({"snippet": snippet, "start": start, "length": len(snippet)})
+        except Exception as e:
+            return json.dumps({"error": f"Peek failed: {e}"})
+
+    def _handle_grep(self, args: Dict[str, Any]) -> str:
+        """Grep the context for regex patterns.
+
+        Args:
+            pattern: Regex pattern to search for
+            max_matches: Maximum number of matches to return (default: 20)
+
+        Returns list of matching lines.
+        """
+        if not self._rlm_env or not self._session_context:
+            return json.dumps({"error": "No context loaded"})
+
+        pattern = args.get("pattern", "")
+        max_matches = args.get("max_matches", 20)
+
+        try:
+            context = self._session_context
+            lines = context.split("\n")
+            matches = []
+
+            for i, line in enumerate(lines):
+                if re.search(pattern, line):
+                    matches.append({"line_num": i, "content": line})
+                    if len(matches) >= max_matches:
+                        break
+
+            return json.dumps({
+                "pattern": pattern,
+                "matches": matches,
+                "total_found": len([l for l in lines if re.search(pattern, l)]),
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Grep failed: {e}"})
+
+    def _handle_partition(self, args: Dict[str, Any]) -> str:
+        """Partition context into chunks and return chunk boundaries.
+
+        Args:
+            chunk_size: Characters per chunk (default: 8000)
+            overlap: Characters of overlap between chunks (default: 500)
+
+        Returns list of chunk metadata (index, start, length).
+        """
+        if not self._rlm_env or not self._session_context:
+            return json.dumps({"error": "No context loaded"})
+
+        chunk_size = args.get("chunk_size", 8000)
+        overlap = args.get("overlap", 500)
+
+        try:
+            context = self._session_context
+            chunks = []
+            start = 0
+
+            while start < len(context):
+                end = min(start + chunk_size, len(context))
+                chunk_text = context[start:end]
+
+                chunks.append({
+                    "index": len(chunks),
+                    "start": start,
+                    "end": end,
+                    "length": len(chunk_text),
+                })
+
+                start = end - overlap if end < len(context) else end
+
+            return json.dumps({
+                "total_chunks": len(chunks),
+                "chunk_size": chunk_size,
+                "overlap": overlap,
+                "chunks": chunks,
+            })
+        except Exception as e:
+            return json.dumps({"error": f"Partition failed: {e}"})
+
+
+# ── Tool Schemas ────────────────────────────────────────────────────────
+
+RLM_TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
+    "rlm_peek": {
+        "name": "rlm_peek",
+        "description": "Peek at a section of the external context stored in the RLM REPL environment. Returns a snippet of characters from the context. Use this to understand the structure of the context before deciding how to process it.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "start": {
+                    "type": "integer",
+                    "description": "Start character index (0-based). Default: 0",
+                },
+                "length": {
+                    "type": "integer",
+                    "description": "Number of characters to return. Default: 2000",
+                },
+            },
+            "required": [],
+        },
+    },
+    "rlm_grep": {
+        "name": "rlm_grep",
+        "description": "Grep the context for regex pattern matches. Returns up to max_matches matching lines with line numbers. Use this to find specific IDs, keywords, or patterns in the context without loading the entire context into the model's window.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for.",
+                },
+                "max_matches": {
+                    "type": "integer",
+                    "description": "Maximum matches to return. Default: 20",
+                },
+            },
+            "required": ["pattern"],
+        },
+    },
+    "rlm_partition": {
+        "name": "rlm_partition",
+        "description": "Partition the context into fixed-size chunks with optional overlap. Returns metadata about each chunk (index, start, end, length). Use this before rlm_batch_sub_llm to prepare chunks for parallel processing.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chunk_size": {
+                    "type": "integer",
+                    "description": "Characters per chunk. Default: 8000",
+                },
+                "overlap": {
+                    "type": "integer",
+                    "description": "Characters of overlap between chunks. Default: 500",
+                },
+            },
+            "required": [],
+        },
+    },
+}
+
+
+# ── Plugin Registration ─────────────────────────────────────────────────
+
+
+def register(ctx) -> None:
+    """Plugin entry point — register RLM as the context engine."""
+    engine = RlmContextEngine()
+    if hasattr(ctx, "register_context_engine"):
+        ctx.register_context_engine(engine)
+    else:
+        logger.warning("RLM plugin: context engine registration not supported")

--- a/plugins/context_engine/rlm/__init__.py
+++ b/plugins/context_engine/rlm/__init__.py
@@ -1,28 +1,32 @@
 """Recursive Language Model context engine plugin.
 
 Implements the RLM paradigm (arXiv:2512.24601) as a ContextEngine plugin.
-Instead of compressing messages, the RLM treats the prompt as an external
-Python variable in a REPL environment, allowing the LLM to programmatically
-peek, grep, chunk, and recursively call sub-LLMs over the context.
+The RLM treats the prompt as an external Python variable in a REPL
+environment, allowing the LLM to programmatically peek, grep, chunk,
+and recursively call sub-LLMs over the context.
 
-Activation: set ``context.engine: rlm`` in config.yaml.
+Usage:
+  - As a standalone engine: set context.engine: rlm in config.yaml
+  - As a companion to LCM: set context.engine: lcm + context.rlm: true
 
-Requires an external LLM provider (OpenAI, custom, etc.) for the root and
-sub-LLM calls.
+When used with LCM, RLM provides peek/grep/partition tools while LCM
+handles message compression. This is the recommended configuration.
+
+Requires an external LLM provider (OpenAI, custom, etc.) for sub-LLM calls.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import math
 import re
 import textwrap
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from agent.context_engine import ContextEngine
 
 logger = logging.getLogger(__name__)
+
 
 # ── RLM REPL Environment ──────────────────────────────────────────────────
 
@@ -110,11 +114,9 @@ class RLMAgentEnvironment:
         Each prompt is a question about a subset of __context__.
         Returns list of answers from sub-LLMs.
 
-        Note: This is a stub — the real implementation in
-        RLMAgentEnvironment delegates to RLMAgent._call_sub_llm.
+        Note: This is a stub — the real implementation delegates to
+        the connected LLM client.
         """
-        # Placeholder — will be replaced when the environment is connected
-        # to the actual LLM client
         return []
 
     def _llm_call_handler(self, prompt: str) -> str:
@@ -142,8 +144,11 @@ class RlmContextEngine(ContextEngine):
     an external Python variable and allows the root LLM to programmatically
     interact with it via a REPL environment.
 
+    When used as a companion to LCM, RLM provides tools (rlm_peek,
+    rlm_grep, rlm_partition) while LCM handles compression.
+
     Key design decisions:
-    - Never compresses messages (returns them unchanged)
+    - Never compresses messages (delegates to companion engine)
     - Exposes rlm_peek, rlm_grep, rlm_partition tools to the agent
     - Sub-LLMs get tools, root LLM does not (keeps root context clean)
     - Parallel batch sub-LLM calls via llm_batch()
@@ -187,7 +192,7 @@ class RlmContextEngine(ContextEngine):
         self.last_total_tokens = total
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
-        """RLM never compresses — it handles unbounded context via REPL."""
+        """RLM never compresses on its own — delegates to companion."""
         return False
 
     def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
@@ -199,11 +204,11 @@ class RlmContextEngine(ContextEngine):
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
     ) -> List[Dict[str, Any]]:
-        """Return messages unchanged.
+        """Pass messages through unchanged.
 
-        RLM doesn't compress — it delegates context management to the
-        REPL environment. The agent interacts with context via tools
-        (rlm_peek, rlm_grep, etc.).
+        When used as a companion to LCM, LCM handles compression.
+        When used standalone, RLM doesn't compress — it delegates
+        context management to the REPL environment.
         """
         return list(messages)
 
@@ -214,7 +219,7 @@ class RlmContextEngine(ContextEngine):
         self.context_length = kwargs.get("context_length", 128_000)
         self.threshold_tokens = self.context_length
 
-        # Extract context from config if provided
+        # Extract context from kwargs — passed by the agent
         context = kwargs.get("rlm_context")
         if context:
             self._session_context = context
@@ -236,6 +241,43 @@ class RlmContextEngine(ContextEngine):
         super().on_session_reset()
         self._session_context = None
         self._rlm_env = None
+
+    def build_context_from_messages(self, messages: List[Dict[str, Any]]) -> str:
+        """Build a flat context string from LLM messages for the REPL.
+
+        This is called by the agent so the RLM engine can populate
+        its context with the actual conversation.
+        """
+        parts = []
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if isinstance(content, str) and content.strip():
+                parts.append(f"[{role}]: {content}")
+            elif isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict):
+                        if item.get("type") == "text" and item.get("text"):
+                            parts.append(f"[{role}]: {item['text']}")
+                        elif item.get("type") == "tool_use":
+                            parts.append(f"[{role}]: {json.dumps(item.get('input', {}))}")
+        return "\n\n".join(parts)
+
+    def refresh_context(self, messages: List[Dict[str, Any]]) -> None:
+        """Rebuild the REPL context from the latest messages.
+
+        Call this before each API call to keep the context fresh.
+        """
+        context = self.build_context_from_messages(messages)
+        if context:
+            self._session_context = context
+            if self._rlm_env:
+                self._rlm_env.context = context
+                self._rlm_env.namespace["__context__"] = context
+                self._rlm_env.namespace["__context_length__"] = len(context)
+                self._rlm_env.namespace["__context_token_length__"] = self._rlm_env._estimate_tokens(
+                    context
+                )
 
     def _init_rlm_env(self, context: str) -> None:
         """Create the REPL environment for the given context."""
@@ -329,7 +371,7 @@ class RlmContextEngine(ContextEngine):
             chunk_size: Characters per chunk (default: 8000)
             overlap: Characters of overlap between chunks (default: 500)
 
-        Returns list of chunk metadata (index, start, length).
+        Returns list of chunk metadata (index, start, end, length).
         """
         if not self._rlm_env or not self._session_context:
             return json.dumps({"error": "No context loaded"})
@@ -365,12 +407,136 @@ class RlmContextEngine(ContextEngine):
             return json.dumps({"error": f"Partition failed: {e}"})
 
 
+# ── Composite Engine (LCM + RLM) ────────────────────────────────────────
+
+
+class CompositeContextEngine(ContextEngine):
+    """Combines LCM (compression) and RLM (tools/REPL) into one engine.
+
+    When LCM is enabled for compression, this wrapper adds RLM's
+    peek/grep/partition tools alongside LCM's 7 tools. The agent gets
+    all 10 tools and LCM handles all compression automatically.
+
+    Usage in run_agent.py:
+        lcm_engine = load_context_engine("lcm", config=lcm_cfg)
+        rlm_engine = RlmContextEngine(config=rlm_cfg)
+        engine = CompositeContextEngine(lcm_engine, rlm_engine)
+    """
+
+    def __init__(
+        self,
+        compression_engine: ContextEngine,
+        rlm_engine: Optional[RlmContextEngine] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._compression_engine = compression_engine
+        self._rlm_engine = rlm_engine
+
+        # Name reflects which engines are active
+        if rlm_engine is not None:
+            self._name = f"{compression_engine.name}+rlm"
+        else:
+            self._name = compression_engine.name
+
+        # Copy token tracking from compression engine
+        self.last_prompt_tokens = getattr(compression_engine, "last_prompt_tokens", 0)
+        self.last_completion_tokens = getattr(compression_engine, "last_completion_tokens", 0)
+        self.last_total_tokens = getattr(compression_engine, "last_total_tokens", 0)
+        self.context_length = getattr(compression_engine, "context_length", 0)
+        self.threshold_tokens = getattr(compression_engine, "threshold_tokens", 0)
+        self.compression_count = getattr(compression_engine, "compression_count", 0)
+        self.threshold_percent = getattr(compression_engine, "threshold_percent", 1.0)
+        self.protect_last_n = getattr(compression_engine, "protect_last_n", 3)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    # ── Core ABC interface (delegate to compression engine) ────────────
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        self._compression_engine.update_from_response(usage)
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        return self._compression_engine.should_compress(prompt_tokens)
+
+    def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
+        return self._compression_engine.should_compress_preflight(messages)
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+    ) -> List[Dict[str, Any]]:
+        return self._compression_engine.compress(messages, current_tokens)
+
+    # ── Session lifecycle (delegate to both) ────────────────────────────
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        self._compression_engine.on_session_start(session_id, **kwargs)
+        if self._rlm_engine:
+            # Pass the session messages as context for RLM
+            self._rlm_engine.on_session_start(session_id, **kwargs)
+
+    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        self._compression_engine.on_session_end(session_id, messages)
+        if self._rlm_engine:
+            self._rlm_engine.on_session_end(session_id, messages)
+
+    def on_session_reset(self) -> None:
+        self._compression_engine.on_session_reset()
+        if self._rlm_engine:
+            self._rlm_engine.on_session_reset()
+
+    def update_model(self, **kwargs) -> None:
+        """Update model info on both engines."""
+        self._compression_engine.update_model(**kwargs)
+        if self._rlm_engine:
+            self._rlm_engine.update_model(**kwargs)
+
+    # ── Tools (combine from both engines) ───────────────────────────────
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return combined tool schemas from LCM and RLM."""
+        schemas = list(self._compression_engine.get_tool_schemas())
+        if self._rlm_engine:
+            schemas.extend(self._rlm_engine.get_tool_schemas())
+        return schemas
+
+    def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+        """Dispatch to the appropriate engine based on tool name."""
+        if self._rlm_engine and name.startswith("rlm_"):
+            try:
+                return self._rlm_engine.handle_tool_call(name, args, **kwargs)
+            except Exception as e:
+                return json.dumps({"error": f"RLM tool '{name}' failed: {e}"})
+        else:
+            return self._compression_engine.handle_tool_call(name, args, **kwargs)
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return combined status from both engines."""
+        status = self._compression_engine.get_status()
+        if self._rlm_engine:
+            rlm_status = self._rlm_engine.get_status()
+            status["rlm_enabled"] = True
+            status["rlm_max_iterations"] = self._rlm_engine._max_iterations
+            status["rlm_output_limit"] = self._rlm_engine._output_limit
+            status["rlm_context_loaded"] = self._rlm_engine._session_context is not None
+        return status
+
+    def refresh_context(self, messages: List[Dict[str, Any]]) -> None:
+        """Refresh the RLM context from the latest messages."""
+        if self._rlm_engine:
+            self._rlm_engine.refresh_context(messages)
+
+
 # ── Tool Schemas ────────────────────────────────────────────────────────
+
 
 RLM_TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
     "rlm_peek": {
         "name": "rlm_peek",
-        "description": "Peek at a section of the external context stored in the RLM REPL environment. Returns a snippet of characters from the context. Use this to understand the structure of the context before deciding how to process it.",
+        "description": "Peek at a section of the context stored in the RLM REPL environment. Returns a snippet of characters from the context. Use this to understand the structure of the context before deciding how to process it.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -406,7 +572,7 @@ RLM_TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
     },
     "rlm_partition": {
         "name": "rlm_partition",
-        "description": "Partition the context into fixed-size chunks with optional overlap. Returns metadata about each chunk (index, start, end, length). Use this before rlm_batch_sub_llm to prepare chunks for parallel processing.",
+        "description": "Partition the context into fixed-size chunks with optional overlap. Returns metadata about each chunk (index, start, end, length). Use this to prepare chunks for parallel processing.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -429,9 +595,20 @@ RLM_TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
 
 
 def register(ctx) -> None:
-    """Plugin entry point — register RLM as the context engine."""
+    """Plugin entry point — register RLM as a context engine."""
     engine = RlmContextEngine()
     if hasattr(ctx, "register_context_engine"):
         ctx.register_context_engine(engine)
     else:
         logger.warning("RLM plugin: context engine registration not supported")
+
+
+# ── Export ──────────────────────────────────────────────────────────────
+
+__all__ = [
+    "RlmContextEngine",
+    "RLMAgentEnvironment",
+    "CompositeContextEngine",
+    "RLM_TOOL_SCHEMAS",
+    "register",
+]

--- a/run_agent.py
+++ b/run_agent.py
@@ -11372,6 +11372,29 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+            elif self._context_engine_tool_names and function_name in self._context_engine_tool_names:
+                # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
+                spinner = None
+                if self.quiet_mode and not self.tool_progress_callback:
+                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    emoji = _get_tool_emoji(function_name)
+                    preview = _build_tool_preview(function_name, function_args) or function_name
+                    spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
+                    spinner.start()
+                _ce_result = None
+                try:
+                    function_result = self.context_compressor.handle_tool_call(function_name, function_args, messages=messages)
+                    _ce_result = function_result
+                except Exception as tool_error:
+                    function_result = json.dumps({"error": f"Context engine tool '{function_name}' failed: {tool_error}"})
+                    logger.error("context_engine.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                finally:
+                    tool_duration = time.time() - tool_start_time
+                    cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_ce_result)
+                    if spinner:
+                        spinner.stop(cute_msg)
+                    elif self.quiet_mode:
+                        self._vprint(f"  {cute_msg}")
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2281,8 +2281,12 @@ class AIAgent:
         except Exception:
             pass
 
-        # Load plugin engine(s)
-        if _engine_name == "compressor" or _engine_name not in ("lcm", "rlm"):
+        # Load plugin engine(s).
+        # Default: any engine name is loaded via load_context_engine(name).
+        # Special cases: "compressor" uses the built-in; "rlm" is standalone.
+        # "lcm" (and any other compression engine) also supports the composite
+        # path when _rlm_enabled is True.
+        if _engine_name == "compressor":
             # Explicitly using built-in compressor (default)
             pass
         elif _engine_name == "rlm":
@@ -2293,7 +2297,8 @@ class AIAgent:
             except Exception as _ce_load_err:
                 logger.debug("Context engine load from plugins/context_engine/: %s", _ce_load_err)
         else:
-            # LCM or other engine name — check if RLM companion is requested
+            # Generic: lcm, or any plugin engine under plugins/context_engine/<name>/.
+            # Also supports composite mode (engine + RLM) when _rlm_enabled is True.
             rlm_kwargs = {}
             rlm_config = _ctx_cfg.get("rlm_config", {})
             rlm_kwargs["rlm_config"] = rlm_config

--- a/run_agent.py
+++ b/run_agent.py
@@ -2281,6 +2281,16 @@ class AIAgent:
         except Exception:
             pass
 
+        # Read lcm config section BEFORE constructing the engine.
+        # This ensures that lcm.enabled=false suppresses tool registration
+        # at construction time rather than waiting for on_session_start().
+        _lcm_cfg: dict = {}
+        try:
+            if isinstance(_agent_cfg, dict):
+                _lcm_cfg = _agent_cfg.get("lcm", {}) or {}
+        except Exception:
+            pass
+
         # Load plugin engine(s).
         # Default: any engine name is loaded via load_context_engine(name).
         # Special cases: "compressor" uses the built-in; "rlm" is standalone.
@@ -2302,6 +2312,10 @@ class AIAgent:
             rlm_kwargs = {}
             rlm_config = _ctx_cfg.get("rlm_config", {})
             rlm_kwargs["rlm_config"] = rlm_config
+            # Pass lcm_config only for the lcm engine so custom engines whose
+            # register() does not accept lcm_config don't receive it here.
+            if _engine_name == "lcm":
+                rlm_kwargs["lcm_config"] = _lcm_cfg
 
             if _rlm_enabled:
                 # Composite mode: LCM + RLM
@@ -2322,7 +2336,7 @@ class AIAgent:
                     from plugins.context_engine import load_context_engine
                     _selected_engine = load_context_engine(
                         _engine_name,
-                        rlm_config=rlm_kwargs.get("rlm_config"),
+                        **rlm_kwargs,
                     )
                 except Exception as _ce_load_err:
                     logger.debug("Context engine load from plugins/context_engine/: %s", _ce_load_err)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2266,42 +2266,77 @@ class AIAgent:
 
 
         # Select context engine: config-driven (like memory providers).
-        # 1. Check config.yaml context.engine setting
-        # 2. Check plugins/context_engine/<name>/ directory (repo-shipped)
-        # 3. Check general plugin system (user-installed plugins)
-        # 4. Fall back to built-in ContextCompressor
+        # 1. Check config.yaml context.engine setting (lcm/rlm/compressor)
+        # 2. Check config.yaml context.rlm (enable RLM companion)
+        # 3. Check plugins/context_engine/<name>/ directory (repo-shipped)
+        # 4. Check general plugin system (user-installed plugins)
+        # 5. Fall back to built-in ContextCompressor
         _selected_engine = None
         _engine_name = "compressor"  # default
+        _rlm_enabled = False  # RLM companion mode flag
         try:
             _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
             _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
+            _rlm_enabled = bool(_ctx_cfg.get("rlm", False))
         except Exception:
             pass
 
-        if _engine_name != "compressor":
-            # Try loading from plugins/context_engine/<name>/
+        # Load plugin engine(s)
+        if _engine_name == "compressor" or _engine_name not in ("lcm", "rlm"):
+            # Explicitly using built-in compressor (default)
+            pass
+        elif _engine_name == "rlm":
+            # Standalone RLM mode (no compression, uses REPL)
             try:
                 from plugins.context_engine import load_context_engine
-                _selected_engine = load_context_engine(_engine_name)
+                _selected_engine = load_context_engine("rlm", rlm_config=_ctx_cfg.get("rlm_config", {}))
             except Exception as _ce_load_err:
                 logger.debug("Context engine load from plugins/context_engine/: %s", _ce_load_err)
+        else:
+            # LCM or other engine name — check if RLM companion is requested
+            rlm_kwargs = {}
+            rlm_config = _ctx_cfg.get("rlm_config", {})
+            rlm_kwargs["rlm_config"] = rlm_config
 
-            # Try general plugin system as fallback
-            if _selected_engine is None:
+            if _rlm_enabled:
+                # Composite mode: LCM + RLM
                 try:
-                    from hermes_cli.plugins import get_plugin_context_engine
-                    _candidate = get_plugin_context_engine()
-                    if _candidate and _candidate.name == _engine_name:
-                        _selected_engine = _candidate
-                except Exception:
-                    pass
+                    from plugins.context_engine import load_composite_engine
+                    _selected_engine = load_composite_engine(
+                        compression_name=_engine_name,
+                        rlm_enabled=True,
+                        **rlm_kwargs,
+                    )
+                except Exception as _ce_load_err:
+                    logger.debug("Composite engine load failed (%s), falling back to RLM only", _ce_load_err)
+                    _selected_engine = None
 
             if _selected_engine is None:
-                logger.warning(
-                    "Context engine '%s' not found — falling back to built-in compressor",
-                    _engine_name,
-                )
-        # else: config says "compressor" — use built-in, don't auto-activate plugins
+                # Pure engine mode (no RLM)
+                try:
+                    from plugins.context_engine import load_context_engine
+                    _selected_engine = load_context_engine(
+                        _engine_name,
+                        rlm_config=rlm_kwargs.get("rlm_config"),
+                    )
+                except Exception as _ce_load_err:
+                    logger.debug("Context engine load from plugins/context_engine/: %s", _ce_load_err)
+
+        # Try general plugin system as fallback
+        if _selected_engine is None:
+            try:
+                from hermes_cli.plugins import get_plugin_context_engine
+                _candidate = get_plugin_context_engine()
+                if _candidate and _candidate.name == _engine_name:
+                    _selected_engine = _candidate
+            except Exception:
+                pass
+
+        if _selected_engine is None:
+            logger.warning(
+                "Context engine '%s' not found — falling back to built-in compressor",
+                _engine_name,
+            )
 
         if _selected_engine is not None:
             self.context_compressor = _selected_engine
@@ -12491,7 +12526,7 @@ class AIAgent:
                     native_anthropic=self._use_native_cache_layout,
                 )
 
-            # Safety net: strip orphaned tool results / add stubs for missing
+                       # Safety net: strip orphaned tool results / add stubs for missing
             # results before sending to the API.  Runs unconditionally — not
             # gated on context_compressor — so orphans from session loading or
             # manual message manipulation are always caught.
@@ -12506,6 +12541,17 @@ class AIAgent:
             # stored conversation history keeps the reasoning block for the
             # UI transcript and session persistence.
             api_messages = self._drop_thinking_only_and_merge_users(api_messages)
+
+            # ── Refresh RLM context ────────────────────────────────────────
+            # Update the RLM REPL environment with the latest messages
+            # so peek/grep/partition work on current context.
+            try:
+                if hasattr(self, "context_compressor") and self.context_compressor:
+                    refresh = getattr(self.context_compressor, "refresh_context", None)
+                    if refresh and callable(refresh):
+                        refresh(api_messages)
+            except Exception as _refresh_err:
+                logger.debug("RLM context refresh failed: %s", _refresh_err)
 
             # Normalize message whitespace and tool-call JSON for consistent
             # prefix matching.  Ensures bit-perfect prefixes across turns,

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -426,6 +426,34 @@ class TestQueryLocalContextLengthLmStudio:
             "max_context_length (1048576) must not win over loaded_instances."
         )
 
+    def test_lmstudio_unloaded_model_uses_max_context_length(self):
+        """Unloaded LM Studio models still advertise max_context_length."""
+        from agent.model_metadata import _query_local_context_length
+
+        native_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "key": "nvidia/nvidia-nemotron-3-nano-4b",
+                    "id": "nvidia/nvidia-nemotron-3-nano-4b",
+                    "max_context_length": 1_048_576,
+                    "loaded_instances": [],
+                },
+            ]
+        })
+        client_mock = self._make_client(
+            native_resp,
+            self._make_resp(404, {}),
+            self._make_resp(404, {}),
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "nvidia-nemotron-3-nano-4b", "http://192.168.1.22:1234/v1"
+            )
+
+        assert result == 1_048_576
+
 
 class TestDetectLocalServerTypeAuth:
     def test_passes_bearer_token_to_probe_requests(self):
@@ -490,6 +518,32 @@ class TestFetchEndpointModelMetadataLmStudio:
         }
         assert result["lmstudio-community/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf"]["context_length"] == 131072
         assert result["Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf"]["context_length"] == 131072
+
+    def test_unloaded_model_uses_native_max_context_length(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        native_resp = self._make_resp(
+            {
+                "models": [
+                    {
+                        "key": "lmstudio-community/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf",
+                        "id": "lmstudio-community/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf",
+                        "max_context_length": 1_048_576,
+                        "loaded_instances": [],
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("agent.model_metadata.requests.get", return_value=native_resp):
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:1234/v1",
+                force_refresh=True,
+            )
+
+        model = "lmstudio-community/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf"
+        assert result[model]["context_length"] == 1_048_576
 
 
 class TestQueryLocalContextLengthNetworkError:

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -609,10 +609,13 @@ class TestBlockingApprovalE2E:
         resolve_gateway_approval(session_key, "once")   # oldest
         resolve_gateway_approval(session_key, "deny")   # next
 
-        for t in threads:
-            t.join(timeout=5)
+        # Small sleep to let threads wake from condition waits
+        time.sleep(0.3)
 
-        assert all(r is not None for r in results)
+        for t in threads:
+            t.join(timeout=10)
+
+        assert all(r is not None for r in results), f"Results not ready: {results}"
         assert sorted(r["approved"] for r in results) == [False, True]
         assert sum("BLOCKED" in (r.get("message") or "") for r in results) == 1
         unregister_gateway_notify(session_key)

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -380,6 +380,7 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
             chat_type="group",
             thread_id="17585",
             user_id="12345",
+            user_id="test_user",
         ),
         message_id="1",
     )

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -380,7 +380,6 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
             chat_type="group",
             thread_id="17585",
             user_id="12345",
-            user_id="test_user",
         ),
         message_id="1",
     )

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -53,10 +53,10 @@ def _clear_cache():
     import hermes_cli.models as mod
 
     mod._copilot_context_cache = {}
-    mod._copilot_context_cache_time = 0.0
+    mod._copilot_context_cache_time = {}
     yield
     mod._copilot_context_cache = {}
-    mod._copilot_context_cache_time = 0.0
+    mod._copilot_context_cache_time = {}
 
 
 class TestGetCopilotModelContext:
@@ -86,6 +86,34 @@ class TestGetCopilotModelContext:
         # Only one API call despite two lookups
         assert mock_fetch.call_count == 1
 
+    def test_cache_is_scoped_by_token(self):
+        def fetch_for_token(api_key=None):
+            if api_key == "token-a":
+                return [
+                    {
+                        "id": "gpt-4.1",
+                        "capabilities": {
+                            "type": "chat",
+                            "limits": {"max_prompt_tokens": 128000},
+                        },
+                    }
+                ]
+            return [
+                {
+                    "id": "gpt-4.1",
+                    "capabilities": {
+                        "type": "chat",
+                        "limits": {"max_prompt_tokens": 64000},
+                    },
+                }
+            ]
+
+        with patch("hermes_cli.models.fetch_github_model_catalog", side_effect=fetch_for_token) as mock_fetch:
+            assert get_copilot_model_context("gpt-4.1", api_key="token-a") == 128_000
+            assert get_copilot_model_context("gpt-4.1", api_key="token-b") == 64_000
+
+        assert mock_fetch.call_count == 2
+
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
     def test_cache_expires(self, mock_fetch):
         import hermes_cli.models as mod
@@ -94,7 +122,8 @@ class TestGetCopilotModelContext:
         assert mock_fetch.call_count == 1
 
         # Expire the cache
-        mod._copilot_context_cache_time = time.time() - 7200
+        scope = mod._copilot_context_cache_scope(None)
+        mod._copilot_context_cache_time[scope] = time.time() - 7200
         get_copilot_model_context("gpt-4.1")
         assert mock_fetch.call_count == 2
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -7,6 +7,7 @@ from hermes_cli.models import (
     copilot_model_api_mode,
     fetch_github_model_catalog,
     curated_models_for_provider,
+    detect_static_provider_for_model,
     fetch_api_models,
     fetch_lmstudio_models,
     github_model_reasoning_efforts,
@@ -125,6 +126,14 @@ class TestParseModelInput:
         # Empty model after second colon → no triple match, falls through
         assert provider == "custom"
         assert model == "name:"
+
+
+class TestDetectStaticProviderForModel:
+    def test_bare_provider_alias_wins_over_model_family_alias(self):
+        provider, model = detect_static_provider_for_model("claude", "openrouter")
+
+        assert provider == "anthropic"
+        assert model == "claude-opus-4-7"
 
 
 # -- curated_models_for_provider ---------------------------------------------

--- a/tests/plugins/context_engine/lcm/test_compaction_boundaries.py
+++ b/tests/plugins/context_engine/lcm/test_compaction_boundaries.py
@@ -1,0 +1,207 @@
+"""Regression tests: compaction must never split tool-call / tool-result pairs.
+
+Fix 1: _retreat_from_tool_result must also retreat when the block's last entry
+is an assistant message with tool_calls and the first protected-tail entry is
+the matching tool result.  Previously only the "block ends with bare tool"
+case was handled; the "block ends with assistant+tool_calls whose result is
+in the protected zone" case was missed.
+
+Both OpenAI-style (top-level tool_calls) and Anthropic-style (content list with
+type=tool_use blocks) assistant messages are exercised.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.engine import LcmEngine
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_engine(protect_last_n: int = 3) -> LcmEngine:
+    cfg = LcmConfig(enabled=True, protect_last_n=protect_last_n)
+    eng = LcmEngine(config=cfg, context_length=10_000)
+    eng.summarizer.summarize = MagicMock(return_value="MOCK SUMMARY")
+    return eng
+
+
+def _ingest_all(engine: LcmEngine, messages: list[dict]) -> None:
+    for m in messages:
+        engine.ingest(m)
+
+
+def _active_roles(engine: LcmEngine) -> list[str]:
+    return [e.message.get("role", "?") for e in engine.active]
+
+
+def _assert_no_orphan_tool(engine: LcmEngine) -> None:
+    """Assert every 'tool' message in active is immediately preceded by assistant+tool_calls."""
+    active = engine.active
+    for i, entry in enumerate(active):
+        if entry.message.get("role") == "tool":
+            assert i > 0, "tool message at index 0 has no preceding assistant"
+            prev_msg = active[i - 1].message
+            assert LcmEngine._has_tool_calls(prev_msg), (
+                f"tool message at index {i} is not preceded by assistant+tool_calls; "
+                f"preceding role={prev_msg.get('role')!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _openai_style_sequence() -> list[dict]:
+    """Returns: [user, assistant+tool_calls(X), tool(X), user]."""
+    return [
+        {"role": "user", "content": "Please check the weather."},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_X", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_X", "content": "Sunny, 22C"},
+        {"role": "user", "content": "Great, thanks!"},
+    ]
+
+
+def _anthropic_style_sequence() -> list[dict]:
+    """Returns: [user, assistant+tool_use(Y), tool(Y), user]."""
+    return [
+        {"role": "user", "content": "Translate hello."},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "tool_Y", "name": "translate", "input": {"text": "hello"}},
+            ],
+        },
+        {"role": "tool", "tool_use_id": "tool_Y", "content": "Hola"},
+        {"role": "user", "content": "Perfect."},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests: find_compactable_block boundary safety
+# ---------------------------------------------------------------------------
+
+class TestCompactionBoundaryOpenAI:
+    """OpenAI-style tool_calls must not be split from their tool result."""
+
+    def test_block_does_not_end_at_assistant_tool_calls_when_result_in_tail(self):
+        """When protect_last_n covers the tool result, the assistant+tool_calls
+        must also be excluded from the compactable block."""
+        # Sequence: [padding...] + [assistant(tool_calls)] + [tool] + [user]
+        # protect_last_n=3 -> tail = [assistant(tool_calls), tool, user]
+        # The compactable block candidate ends just before the tail, which is
+        # the assistant+tool_calls entry.  The block must retreat further.
+        engine = _make_engine(protect_last_n=3)
+        padding = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"padding {i}"}
+            for i in range(10)
+        ]
+        tail = _openai_style_sequence()[1:]  # [assistant+tool_calls, tool, user]
+        _ingest_all(engine, padding + tail)
+
+        block = engine.find_compactable_block()
+        if block is not None:
+            start, end = block
+            # The block must not include the assistant+tool_calls entry (index 10)
+            # because active[10] is the assistant whose result is in the tail.
+            for i in range(start, end):
+                entry = engine.active[i]
+                assert not LcmEngine._has_tool_calls(entry.message), (
+                    f"Block [{start}:{end}) includes assistant+tool_calls at index {i}, "
+                    "whose tool result is in the protected tail."
+                )
+
+    def test_active_list_has_no_orphan_tool_after_compact(self):
+        """After auto_compact fires, no 'tool' message should lack a preceding
+        assistant+tool_calls in the active list."""
+        # Use a tiny context so compaction fires.
+        cfg = LcmConfig(enabled=True, tau_hard=0.5, protect_last_n=3)
+        engine = LcmEngine(config=cfg, context_length=500)
+        engine.summarizer.summarize = MagicMock(return_value="MOCK SUMMARY")
+
+        filler = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": "x " * 30}
+            for i in range(20)
+        ]
+        tail = _openai_style_sequence()[1:]  # ends with user
+        _ingest_all(engine, filler + tail)
+
+        engine.auto_compact()
+        _assert_no_orphan_tool(engine)
+
+
+class TestCompactionBoundaryAnthropic:
+    """Anthropic-style content[{type:tool_use}] must not be split from result."""
+
+    def test_block_does_not_end_at_anthropic_tool_calls_when_result_in_tail(self):
+        engine = _make_engine(protect_last_n=3)
+        padding = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"padding {i}"}
+            for i in range(10)
+        ]
+        tail = _anthropic_style_sequence()[1:]  # [assistant+tool_use, tool, user]
+        _ingest_all(engine, padding + tail)
+
+        block = engine.find_compactable_block()
+        if block is not None:
+            start, end = block
+            for i in range(start, end):
+                entry = engine.active[i]
+                assert not LcmEngine._has_tool_calls(entry.message), (
+                    f"Block [{start}:{end}) includes Anthropic assistant+tool_use at index {i}."
+                )
+
+    def test_active_list_has_no_orphan_tool_after_compact_anthropic(self):
+        cfg = LcmConfig(enabled=True, tau_hard=0.5, protect_last_n=3)
+        engine = LcmEngine(config=cfg, context_length=500)
+        engine.summarizer.summarize = MagicMock(return_value="MOCK SUMMARY")
+
+        filler = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": "y " * 30}
+            for i in range(20)
+        ]
+        tail = _anthropic_style_sequence()[1:]
+        _ingest_all(engine, filler + tail)
+
+        engine.auto_compact()
+        _assert_no_orphan_tool(engine)
+
+
+class TestHasToolCallsHelper:
+    """Unit tests for the _has_tool_calls static helper."""
+
+    def test_openai_style_detected(self):
+        msg = {"role": "assistant", "tool_calls": [{"id": "c1"}]}
+        assert LcmEngine._has_tool_calls(msg) is True
+
+    def test_anthropic_style_detected(self):
+        msg = {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": "fn", "input": {}}],
+        }
+        assert LcmEngine._has_tool_calls(msg) is True
+
+    def test_plain_assistant_not_detected(self):
+        msg = {"role": "assistant", "content": "Just text"}
+        assert LcmEngine._has_tool_calls(msg) is False
+
+    def test_user_message_not_detected(self):
+        msg = {"role": "user", "content": "Hello"}
+        assert LcmEngine._has_tool_calls(msg) is False
+
+    def test_content_list_without_tool_use_not_detected(self):
+        msg = {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello"}],
+        }
+        assert LcmEngine._has_tool_calls(msg) is False

--- a/tests/plugins/context_engine/lcm/test_config.py
+++ b/tests/plugins/context_engine/lcm/test_config.py
@@ -1,0 +1,63 @@
+from plugins.context_engine.lcm.config import LcmConfig
+
+
+def test_lcm_package_exports():
+    """All public types should be importable from plugins.context_engine.lcm."""
+    from plugins.context_engine.lcm import (
+        LcmConfig,
+        LcmEngine,
+        CompactionAction,
+        ContextEntry,
+        SummaryDag,
+        SummaryNode,
+        MessageId,
+        ImmutableStore,
+    )
+    assert LcmConfig is not None
+    assert LcmEngine is not None
+    assert CompactionAction is not None
+    assert ContextEntry is not None
+    assert SummaryDag is not None
+    assert SummaryNode is not None
+    assert MessageId is not None
+    assert ImmutableStore is not None
+
+
+def test_defaults():
+    cfg = LcmConfig()
+    assert cfg.enabled is True
+    assert cfg.tau_soft == 0.50
+    assert cfg.tau_hard == 0.85
+    assert cfg.deterministic_target == 512
+    assert cfg.protect_last_n == 4
+    assert cfg.summary_model == ""
+
+
+def test_from_dict():
+    d = {
+        "enabled": "true",
+        "tau_soft": "0.6",
+        "tau_hard": "0.9",
+        "deterministic_target": "1024",
+        "protect_last_n": "8",
+        "summary_model": "claude-haiku-3",
+    }
+    cfg = LcmConfig.from_dict(d)
+    assert cfg.enabled is True
+    assert cfg.tau_soft == 0.6
+    assert cfg.tau_hard == 0.9
+    assert cfg.deterministic_target == 1024
+    assert cfg.protect_last_n == 8
+    assert cfg.summary_model == "claude-haiku-3"
+
+
+def test_from_dict_partial_overrides():
+    d = {"enabled": "1", "tau_soft": "0.75"}
+    cfg = LcmConfig.from_dict(d)
+    assert cfg.enabled is True
+    assert cfg.tau_soft == 0.75
+    # unspecified keys keep defaults
+    assert cfg.tau_hard == 0.85
+    assert cfg.deterministic_target == 512
+    assert cfg.protect_last_n == 4
+    assert cfg.summary_model == ""

--- a/tests/plugins/context_engine/lcm/test_config_integration.py
+++ b/tests/plugins/context_engine/lcm/test_config_integration.py
@@ -1,0 +1,23 @@
+"""Test that LCM config integrates with hermes config system."""
+
+
+def test_lcm_defaults_in_config():
+    """LCM section should exist in DEFAULT_CONFIG with correct defaults."""
+    from hermes_cli.config import DEFAULT_CONFIG
+    assert "lcm" in DEFAULT_CONFIG
+    lcm = DEFAULT_CONFIG["lcm"]
+    assert lcm["enabled"] is True
+    assert lcm["tau_soft"] == 0.50
+    assert lcm["tau_hard"] == 0.85
+    assert lcm["deterministic_target"] == 512
+    assert lcm["protect_last_n"] == 4
+
+
+def test_lcm_config_from_hermes_config():
+    """LcmConfig.from_dict should work with hermes config format."""
+    from plugins.context_engine.lcm.config import LcmConfig
+    from hermes_cli.config import DEFAULT_CONFIG
+    lcm_dict = DEFAULT_CONFIG.get("lcm", {})
+    config = LcmConfig.from_dict(lcm_dict)
+    assert config.enabled is True
+    assert config.tau_soft == 0.50

--- a/tests/plugins/context_engine/lcm/test_dag.py
+++ b/tests/plugins/context_engine/lcm/test_dag.py
@@ -1,0 +1,69 @@
+from plugins.context_engine.lcm.dag import SummaryDag, SummaryNode, MessageId
+
+
+def test_create_node():
+    dag = SummaryDag()
+    node = dag.create_node(source_ids=[0, 1, 2], text="summary text", level=1, tokens=42)
+    assert node.id == 0
+    assert node.source_ids == [0, 1, 2]
+    assert node.text == "summary text"
+    assert node.tokens == 42
+    assert node.level == 1
+
+
+def test_create_multiple_nodes():
+    dag = SummaryDag()
+    n0 = dag.create_node(source_ids=[0], text="first", level=1)
+    n1 = dag.create_node(source_ids=[1], text="second", level=1)
+    n2 = dag.create_node(source_ids=[2], text="third", level=1)
+    assert n0.id == 0
+    assert n1.id == 1
+    assert n2.id == 2
+
+
+def test_get_existing():
+    dag = SummaryDag()
+    dag.create_node(source_ids=[5, 6], text="hello", level=2, tokens=10)
+    node = dag.get(0)
+    assert node is not None
+    assert node.id == 0
+    assert node.source_ids == [5, 6]
+    assert node.text == "hello"
+    assert node.level == 2
+    assert node.tokens == 10
+
+
+def test_get_nonexistent():
+    dag = SummaryDag()
+    dag.create_node(source_ids=[0], text="only node", level=1)
+    assert dag.get(99) is None
+    assert dag.get(-1) is None
+
+
+def test_all_source_ids_flat():
+    dag = SummaryDag()
+    dag.create_node(source_ids=[10, 11, 12], text="leaf", level=1)
+    result = dag.all_source_ids(0)
+    assert result == [10, 11, 12]
+
+
+def test_all_source_ids_recursive():
+    dag = SummaryDag()
+    # child summaries: node 0 and node 1
+    child0 = dag.create_node(source_ids=[0, 1], text="child0", level=1)
+    child1 = dag.create_node(source_ids=[2, 3], text="child1", level=1)
+    # parent references both children as child_summaries, no direct source_ids
+    parent = dag.create_node(
+        source_ids=[],
+        text="parent",
+        level=2,
+        children=[child0.id, child1.id],
+    )
+    result = dag.all_source_ids(parent.id)
+    assert sorted(result) == [0, 1, 2, 3]
+
+
+def test_empty_dag():
+    dag = SummaryDag()
+    assert len(dag) == 0
+    assert dag.is_empty is True

--- a/tests/plugins/context_engine/lcm/test_dam_compose.py
+++ b/tests/plugins/context_engine/lcm/test_dam_compose.py
@@ -1,0 +1,153 @@
+"""Regression tests: DAMRetriever.compose() operation handling.
+
+Fix 4: the previous else-branch silently treated any unknown operation (including
+'NOT') as OR.  Now NOT, AND, OR each have explicit branches; any unrecognised
+operation returns an empty list.
+
+Tests confirm:
+- NOT with 1 query returns a list (possibly empty if no patterns stored).
+- NOT with 2+ queries returns [] (multi-NOT is undefined/rejected).
+- Unknown operation string returns [].
+- AND and OR still work correctly.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
+from plugins.context_engine.lcm.dam.encoder import MessageEncoder
+from plugins.context_engine.lcm.dam.retrieval import DAMRetriever
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_retriever(nv: int = 512, nh: int = 64) -> DAMRetriever:
+    net = DenseAssociativeMemory(nv=nv, nh=nh)
+    enc = MessageEncoder(nv=nv)
+    return DAMRetriever(net=net, enc=enc)
+
+
+def _seed_patterns(retriever: DAMRetriever, messages: list[dict]) -> None:
+    """Manually populate the pattern cache (without a store)."""
+    vecs = [retriever.enc.encode(m) for m in messages]
+    if vecs:
+        retriever.net.learn(np.stack(vecs))
+    for i, v in enumerate(vecs):
+        retriever._pattern_cache[i] = v
+
+
+# ---------------------------------------------------------------------------
+# Tests: NOT operation
+# ---------------------------------------------------------------------------
+
+class TestComposeNOT:
+    def test_not_single_query_returns_list(self):
+        """compose(['foo'], operation='NOT') must return a list (not crash or silently OR)."""
+        r = _make_retriever()
+        _seed_patterns(r, [
+            {"role": "user", "content": "hello world"},
+            {"role": "assistant", "content": "goodbye world"},
+        ])
+        result = r.compose(["hello"], operation="NOT")
+        assert isinstance(result, list), f"Expected list, got {type(result)}"
+
+    def test_not_single_query_result_differs_from_or(self):
+        """compose(['foo'], operation='NOT') must differ from operation='OR'.
+
+        If NOT is still silently treated as OR the scores will be identical —
+        which is the bug we're fixing.
+        """
+        r = _make_retriever()
+        _seed_patterns(r, [
+            {"role": "user", "content": "alpha beta gamma"},
+            {"role": "assistant", "content": "delta epsilon zeta"},
+            {"role": "user", "content": "totally unrelated keywords here"},
+        ])
+        result_not = r.compose(["alpha"], operation="NOT")
+        result_or  = r.compose(["alpha"], operation="OR")
+
+        # Both return lists of (msg_id, score) tuples — if they're identical,
+        # NOT is still being executed as OR.
+        scores_not = {mid: score for mid, score in result_not}
+        scores_or  = {mid: score for mid, score in result_or}
+
+        # They should differ (NOT inverts activations; OR does not).
+        assert scores_not != scores_or, (
+            "compose('NOT') returned the same scores as compose('OR') — "
+            "NOT is still treated as OR (the bug is not fixed)"
+        )
+
+    def test_not_multi_query_returns_empty(self):
+        """compose(['foo', 'bar'], operation='NOT') must return [] — multi-NOT is rejected."""
+        r = _make_retriever()
+        _seed_patterns(r, [{"role": "user", "content": "test"}])
+        result = r.compose(["foo", "bar"], operation="NOT")
+        assert result == [], (
+            f"Multi-query NOT must be rejected with empty list, got: {result}"
+        )
+
+    def test_not_zero_queries_returns_empty(self):
+        """compose([], operation='NOT') must return [] — no queries to invert."""
+        r = _make_retriever()
+        result = r.compose([], operation="NOT")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: unknown / garbage operation
+# ---------------------------------------------------------------------------
+
+class TestComposeUnknownOperation:
+    def test_unknown_op_returns_empty(self):
+        r = _make_retriever()
+        _seed_patterns(r, [{"role": "user", "content": "hello"}])
+        result = r.compose(["hello"], operation="XOR")
+        assert result == [], f"Unknown op must return [], got: {result}"
+
+    def test_empty_op_returns_empty(self):
+        r = _make_retriever()
+        _seed_patterns(r, [{"role": "user", "content": "hello"}])
+        result = r.compose(["hello"], operation="")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: AND and OR still work (no regression)
+# ---------------------------------------------------------------------------
+
+class TestComposeAndOr:
+    def test_and_returns_list(self):
+        r = _make_retriever()
+        _seed_patterns(r, [
+            {"role": "user", "content": "alpha beta"},
+            {"role": "assistant", "content": "gamma delta"},
+        ])
+        result = r.compose(["alpha", "gamma"], operation="AND")
+        assert isinstance(result, list)
+
+    def test_or_returns_list(self):
+        r = _make_retriever()
+        _seed_patterns(r, [
+            {"role": "user", "content": "alpha beta"},
+            {"role": "assistant", "content": "gamma delta"},
+        ])
+        result = r.compose(["alpha", "gamma"], operation="OR")
+        assert isinstance(result, list)
+
+    def test_and_case_insensitive(self):
+        r = _make_retriever()
+        _seed_patterns(r, [{"role": "user", "content": "hello"}])
+        result_upper = r.compose(["hello"], operation="AND")
+        result_lower = r.compose(["hello"], operation="and")
+        # Both should return the same type (list), not error
+        assert isinstance(result_upper, list)
+        assert isinstance(result_lower, list)
+
+    def test_not_case_insensitive(self):
+        r = _make_retriever()
+        _seed_patterns(r, [{"role": "user", "content": "hello"}])
+        result = r.compose(["hello"], operation="not")
+        assert isinstance(result, list)

--- a/tests/plugins/context_engine/lcm/test_engine.py
+++ b/tests/plugins/context_engine/lcm/test_engine.py
@@ -1,0 +1,235 @@
+"""Tests for LCM Engine core."""
+import pytest
+from plugins.context_engine.lcm.engine import LcmEngine, CompactionAction, ContextEntry
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.dag import MessageId
+
+
+@pytest.fixture
+def config():
+    return LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85, protect_last_n=4)
+
+
+@pytest.fixture
+def engine(config):
+    return LcmEngine(config)
+
+
+@pytest.fixture
+def populated_engine(engine):
+    """Engine with 20 messages ingested (10 user + 10 assistant)."""
+    for i in range(10):
+        engine.ingest({"role": "user", "content": f"User message {i} " + "x" * 100})
+        engine.ingest({"role": "assistant", "content": f"Assistant reply {i} " + "y" * 100})
+    return engine
+
+
+class TestIngest:
+    def test_returns_sequential_ids(self, engine):
+        id0 = engine.ingest({"role": "user", "content": "hello"})
+        id1 = engine.ingest({"role": "assistant", "content": "hi"})
+        assert id0 == 0
+        assert id1 == 1
+
+    def test_adds_to_store_and_active(self, engine):
+        msg = {"role": "user", "content": "test"}
+        engine.ingest(msg)
+        assert len(engine.store) == 1
+        assert len(engine.active) == 1
+        assert engine.active[0].kind == "raw"
+        assert engine.active[0].message == msg
+
+
+class TestActiveMessages:
+    def test_returns_message_dicts(self, engine):
+        engine.ingest({"role": "user", "content": "hello"})
+        engine.ingest({"role": "assistant", "content": "hi"})
+        msgs = engine.active_messages()
+        assert len(msgs) == 2
+        assert msgs[0]["content"] == "hello"
+        assert msgs[1]["content"] == "hi"
+
+    def test_empty_engine(self, engine):
+        assert engine.active_messages() == []
+
+
+class TestCheckThresholds:
+    def test_none_below_soft(self, engine):
+        # Small message, huge budget
+        engine.ingest({"role": "user", "content": "hi"})
+        assert engine.check_thresholds(100000) == CompactionAction.NONE
+
+    def test_async_between_soft_and_hard(self):
+        config = LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85, protect_last_n=2)
+        engine = LcmEngine(config)
+        # Ingest enough to be > 50% of a small budget
+        for i in range(10):
+            engine.ingest({"role": "user", "content": "x" * 200})
+        # With a budget of ~2000 tokens, 10 msgs of ~50 tokens each = ~500 tokens
+        # tau_soft = 0.5 * 2000 = 1000. Need to be above that.
+        # Let's use a budget where our content is between soft and hard
+        tokens = engine.active_tokens()
+        budget = int(tokens / 0.6)  # puts us at 60%, above soft (50%), below hard (85%)
+        action = engine.check_thresholds(budget)
+        assert action == CompactionAction.ASYNC
+
+    def test_blocking_above_hard(self):
+        config = LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85, protect_last_n=2)
+        engine = LcmEngine(config)
+        for i in range(20):
+            engine.ingest({"role": "user", "content": "x" * 200})
+        tokens = engine.active_tokens()
+        budget = int(tokens / 0.9)  # puts us at 90%, above hard (85%)
+        action = engine.check_thresholds(budget)
+        assert action == CompactionAction.BLOCKING
+
+    def test_async_not_retriggered_when_pending(self):
+        config = LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85, protect_last_n=2)
+        engine = LcmEngine(config)
+        for i in range(10):
+            engine.ingest({"role": "user", "content": "x" * 200})
+        tokens = engine.active_tokens()
+        budget = int(tokens / 0.6)
+        assert engine.check_thresholds(budget) == CompactionAction.ASYNC
+        # Second call should return NONE (pending flag set)
+        assert engine.check_thresholds(budget) == CompactionAction.NONE
+
+
+class TestFindCompactableBlock:
+    def test_returns_none_when_too_few_messages(self, engine):
+        engine.ingest({"role": "user", "content": "hi"})
+        engine.ingest({"role": "assistant", "content": "hello"})
+        assert engine.find_compactable_block() is None
+
+    def test_protects_last_n(self, populated_engine):
+        result = populated_engine.find_compactable_block()
+        assert result is not None
+        start, end = result
+        # Should not include the last protect_last_n (4) entries
+        assert end <= len(populated_engine.active) - populated_engine.config.protect_last_n
+
+    def test_returns_oldest_raw_block(self, populated_engine):
+        result = populated_engine.find_compactable_block()
+        assert result is not None
+        start, end = result
+        assert start == 0  # oldest messages first
+
+    def test_does_not_split_tool_call_result_pair(self, engine):
+        """Tool call and its result must stay together."""
+        engine.ingest({"role": "user", "content": "read file"})
+        engine.ingest({"role": "assistant", "content": "", "tool_calls": [{"id": "tc1", "function": {"name": "read", "arguments": "{}"}}]})
+        engine.ingest({"role": "tool", "content": "file contents", "tool_call_id": "tc1"})
+        engine.ingest({"role": "assistant", "content": "Here's the file"})
+        engine.ingest({"role": "user", "content": "thanks"})
+        engine.ingest({"role": "assistant", "content": "welcome"})
+        engine.ingest({"role": "user", "content": "next q"})
+        engine.ingest({"role": "assistant", "content": "sure"})
+        # With protect_last_n=4, compactable block is messages 0-3
+        # The tool_call (msg 1) and tool result (msg 2) must be together
+        result = engine.find_compactable_block()
+        if result:
+            start, end = result
+            block_entries = engine.active[start:end]
+            # Check no tool result is orphaned from its tool call
+            for i, entry in enumerate(block_entries):
+                if entry.message.get("role") == "tool":
+                    # The preceding entry should be an assistant with tool_calls
+                    assert i > 0
+                    prev = block_entries[i - 1]
+                    assert prev.message.get("tool_calls") is not None
+
+    def test_skips_existing_summaries(self, engine):
+        """Block should start after any existing summary entries."""
+        # Ingest some messages
+        for i in range(8):
+            engine.ingest({"role": "user", "content": f"msg {i}"})
+        # Manually insert a summary at position 0-1 (simulating prior compaction)
+        summary_msg = {"role": "user", "content": "[Summary of messages 0-3]"}
+        node = engine.dag.create_node(source_ids=[0, 1, 2, 3], text="summary", level=1, tokens=10)
+        engine.active[0] = ContextEntry.summary(node.id, summary_msg)
+        # Remove entries 1-3 (they're now covered by the summary)
+        del engine.active[1:4]
+
+        result = engine.find_compactable_block()
+        if result:
+            start, end = result
+            # Should not try to compact the summary entry
+            for entry in engine.active[start:end]:
+                assert entry.kind == "raw"
+
+
+class TestCompact:
+    def test_replaces_block_with_summary(self, populated_engine):
+        block = populated_engine.find_compactable_block()
+        assert block is not None
+        start, end = block
+        original_len = len(populated_engine.active)
+        block_size = end - start
+
+        node = populated_engine.compact("This is a summary", level=1, block_start=start, block_end=end)
+
+        # Active should shrink: removed block_size entries, added 1 summary
+        assert len(populated_engine.active) == original_len - block_size + 1
+        # The entry at start should now be a summary
+        assert populated_engine.active[start].kind == "summary"
+        assert populated_engine.active[start].node_id == node.id
+
+    def test_updates_dag(self, populated_engine):
+        block = populated_engine.find_compactable_block()
+        start, end = block
+        assert len(populated_engine.dag) == 0
+
+        node = populated_engine.compact("Summary text", level=1, block_start=start, block_end=end)
+
+        assert len(populated_engine.dag) == 1
+        assert node.text == "Summary text"
+        assert node.level == 1
+        assert len(node.source_ids) == end - start
+
+    def test_preserves_tail(self, populated_engine):
+        block = populated_engine.find_compactable_block()
+        start, end = block
+        tail_before = [e.message for e in populated_engine.active[-4:]]
+
+        populated_engine.compact("Summary", level=1, block_start=start, block_end=end)
+
+        tail_after = [e.message for e in populated_engine.active[-4:]]
+        assert tail_before == tail_after
+
+    def test_clears_async_pending_flag(self, populated_engine):
+        populated_engine._async_compaction_pending = True
+        block = populated_engine.find_compactable_block()
+        populated_engine.compact("Summary", level=1, block_start=block[0], block_end=block[1])
+        assert populated_engine._async_compaction_pending is False
+
+
+class TestExpand:
+    def test_returns_originals(self, populated_engine):
+        result = populated_engine.expand([0, 1, 2])
+        assert len(result) == 3
+        assert result[0][0] == 0
+        assert result[0][1]["role"] == "user"
+        assert result[1][0] == 1
+        assert result[1][1]["role"] == "assistant"
+
+    def test_expand_summary_recursive(self, populated_engine):
+        # Create a compacted summary
+        block = populated_engine.find_compactable_block()
+        node = populated_engine.compact("Summary", level=1, block_start=block[0], block_end=block[1])
+
+        # Expand should return all original messages
+        result = populated_engine.expand_summary(node.id)
+        assert len(result) == len(node.source_ids)
+
+    def test_expand_nonexistent_ids(self, engine):
+        result = engine.expand([99, 100])
+        assert result == []
+
+
+class TestFormatExpanded:
+    def test_formats_with_role_and_id(self, populated_engine):
+        result = populated_engine.format_expanded([0, 1])
+        assert "[msg 0]" in result
+        assert "[msg 1]" in result
+        assert "user:" in result.lower() or "User" in result
+        assert "assistant:" in result.lower() or "Assistant" in result

--- a/tests/plugins/context_engine/lcm/test_escalation.py
+++ b/tests/plugins/context_engine/lcm/test_escalation.py
@@ -1,0 +1,181 @@
+"""Tests for LCM deterministic truncation (Level 3)."""
+from unittest.mock import patch, MagicMock
+from plugins.context_engine.lcm.escalation import deterministic_truncate, first_sentence, escalated_summary
+
+class TestFirstSentence:
+    def test_period_boundary(self):
+        assert first_sentence("Hello world. This is more.") == "Hello world."
+
+    def test_question_mark(self):
+        assert first_sentence("What is Rust? It's a language.") == "What is Rust?"
+
+    def test_exclamation(self):
+        assert first_sentence("Great job! Keep going.") == "Great job!"
+
+    def test_no_boundary(self):
+        assert first_sentence("Just a fragment") == "Just a fragment"
+
+    def test_empty(self):
+        assert first_sentence("") == ""
+
+    def test_multiple_sentences(self):
+        result = first_sentence("First. Second. Third.")
+        assert result == "First."
+
+    def test_preserves_whitespace_after_boundary(self):
+        # Should NOT include trailing whitespace
+        result = first_sentence("Hello.   More text.")
+        assert result == "Hello."
+
+
+class TestDeterministicTruncate:
+    def test_respects_token_budget(self):
+        messages = [
+            {"role": "user", "content": "Tell me about Python async patterns and how they work with asyncio library in detail"},
+            {"role": "assistant", "content": "Python async uses coroutines with the async/await syntax. The asyncio library provides the event loop."},
+            {"role": "user", "content": "What about error handling in async code? How do you catch exceptions?"},
+            {"role": "assistant", "content": "You can use try/except blocks within async functions. Gather exceptions can be handled with return_exceptions=True."},
+        ]
+        result = deterministic_truncate(messages, target_tokens=50)
+        # Rough estimate: 50 tokens ≈ 200 chars
+        assert len(result) <= 250  # generous char budget
+
+    def test_extracts_from_user_messages(self):
+        messages = [
+            {"role": "user", "content": "How does garbage collection work in Python? I want details."},
+            {"role": "assistant", "content": "Python uses reference counting as its primary mechanism. When references reach zero, memory is freed immediately."},
+        ]
+        result = deterministic_truncate(messages, target_tokens=100)
+        assert "garbage collection" in result.lower() or "python" in result.lower()
+
+    def test_handles_empty_messages(self):
+        result = deterministic_truncate([], target_tokens=100)
+        assert result == ""
+
+    def test_handles_tool_messages(self):
+        messages = [
+            {"role": "user", "content": "Read the file."},
+            {"role": "tool", "content": '{"file": "main.py", "content": "def hello(): print(\'world\')"}'},
+            {"role": "assistant", "content": "The file contains a hello function."},
+        ]
+        result = deterministic_truncate(messages, target_tokens=100)
+        assert len(result) > 0
+
+    def test_very_small_budget(self):
+        messages = [
+            {"role": "user", "content": "This is a very long message about many topics including databases and APIs."},
+            {"role": "assistant", "content": "Here is a detailed response covering all those topics in great depth."},
+        ]
+        result = deterministic_truncate(messages, target_tokens=10)
+        # Should still produce something, just very truncated
+        assert len(result) <= 60  # ~10 tokens * ~6 chars
+
+    def test_preserves_message_attribution(self):
+        messages = [
+            {"role": "user", "content": "Question about Rust."},
+            {"role": "assistant", "content": "Rust is a systems language. It focuses on safety."},
+        ]
+        result = deterministic_truncate(messages, target_tokens=100)
+        # Should have role attribution
+        assert "user:" in result.lower() or "assistant:" in result.lower()
+
+
+class TestEscalatedSummary:
+    def test_level1_success(self):
+        """When LLM returns a good summary shorter than input, use it."""
+        messages = [
+            {"role": "user", "content": "Tell me about Python " + "x" * 200},
+            {"role": "assistant", "content": "Python is great " + "y" * 200},
+        ]
+        with patch("plugins.context_engine.lcm.escalation._call_summary_llm") as mock_llm:
+            mock_llm.return_value = "User asked about Python. Assistant explained it."
+            text, level = escalated_summary(messages, target_tokens=100, deterministic_target=50)
+            assert level == 1
+            assert "Python" in text
+            mock_llm.assert_called_once()
+
+    def test_level1_refusal_falls_to_level2(self):
+        """If LLM refuses at Level 1, try Level 2."""
+        messages = [
+            {"role": "user", "content": "Some content " + "x" * 200},
+            {"role": "assistant", "content": "Response " + "y" * 200},
+        ]
+        with patch("plugins.context_engine.lcm.escalation._call_summary_llm") as mock_llm:
+            mock_llm.side_effect = [
+                "I'm sorry, I cannot summarize that content.",  # L1 refusal
+                "- User asked about something\n- Assistant responded",  # L2 success
+            ]
+            text, level = escalated_summary(messages, target_tokens=100, deterministic_target=50)
+            assert level == 2
+            assert mock_llm.call_count == 2
+
+    def test_level2_failure_falls_to_level3(self):
+        """If both LLM levels fail, use deterministic truncation."""
+        messages = [
+            {"role": "user", "content": "Content " + "x" * 200},
+            {"role": "assistant", "content": "Reply " + "y" * 200},
+        ]
+        with patch("plugins.context_engine.lcm.escalation._call_summary_llm") as mock_llm:
+            mock_llm.side_effect = [
+                "I cannot help with that.",  # L1 refusal
+                "I'm unable to summarize.",  # L2 refusal
+            ]
+            text, level = escalated_summary(messages, target_tokens=100, deterministic_target=50)
+            assert level == 3
+            assert len(text) > 0  # deterministic always produces output
+
+    def test_llm_exception_falls_through(self):
+        """If LLM call returns None (signals failure), fall through to Level 3."""
+        messages = [
+            {"role": "user", "content": "Content " + "x" * 200},
+            {"role": "assistant", "content": "Reply " + "y" * 200},
+        ]
+        with patch("plugins.context_engine.lcm.escalation._call_summary_llm") as mock_llm:
+            # _call_summary_llm catches exceptions internally and returns None.
+            # Returning None from both L1 and L2 should trigger L3 fallback.
+            mock_llm.return_value = None
+            text, level = escalated_summary(messages, target_tokens=100, deterministic_target=50)
+            assert level == 3  # fell all the way to deterministic
+
+    def test_summary_larger_than_input_rejected(self):
+        """If LLM summary is larger than the original, reject and try next level."""
+        messages = [{"role": "user", "content": "Short."}]
+        with patch("plugins.context_engine.lcm.escalation._call_summary_llm") as mock_llm:
+            mock_llm.side_effect = [
+                "This is a much longer summary than the original " * 10,  # L1 too long
+                "- Short message",  # L2 OK
+            ]
+            text, level = escalated_summary(messages, target_tokens=100, deterministic_target=50)
+            assert level == 2
+
+    def test_vacuous_summary_rejected(self):
+        """If L1 summary is < 5% of input tokens, reject as vacuous and fall to L2."""
+        messages = [
+            {"role": "user", "content": "x " * 500},
+            {"role": "assistant", "content": "y " * 500},
+        ]
+        # Input: ~1000 tokens. L1 floor = 50 tokens, L2 floor = 30 tokens.
+        # L2 response must be >= 30 tokens (~120 chars) to pass the 3% vacuous check.
+        l2_response = "- User sent a long message with repeated content\n- Assistant responded with repeated content\n- Exchange was uneventful"
+        with patch("plugins.context_engine.lcm.escalation._call_summary_llm") as mock_llm:
+            mock_llm.side_effect = [
+                "Ok.",       # L1 vacuous (< 5% of ~1000 tokens)
+                l2_response, # L2 OK (> 3% of ~1000 tokens)
+            ]
+            text, level = escalated_summary(messages, target_tokens=200, deterministic_target=50)
+            assert level == 2
+
+    def test_level2_vacuous_falls_to_level3(self):
+        """If L2 summary is also vacuous (< 3% of input), fall through to L3 deterministic."""
+        messages = [
+            {"role": "user", "content": "x " * 500},
+            {"role": "assistant", "content": "y " * 500},
+        ]
+        with patch("plugins.context_engine.lcm.escalation._call_summary_llm") as mock_llm:
+            mock_llm.side_effect = [
+                "Ok.",  # L1 vacuous (< 5% of ~250 tokens)
+                ".",    # L2 vacuous (< 3% of ~250 tokens)
+            ]
+            text, level = escalated_summary(messages, target_tokens=200, deterministic_target=50)
+            assert level == 3
+            assert len(text) > 0  # deterministic always produces output

--- a/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
@@ -298,3 +298,75 @@ class TestSummarizerModelPropagation:
         assert engine._engine.summarizer.config.model == "pre-set-model", (
             "summarizer.config.model was overwritten despite no summary_model in config"
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix: runtime enable→disable transition logs a warning about tool retraction
+# ---------------------------------------------------------------------------
+
+class TestRuntimeDisableTransitionWarning:
+    """When on_session_start detects enabled→disabled, a warning must be logged.
+
+    The agent tool list cannot be retracted at runtime (it was populated once
+    at startup).  The warning tells the user to restart for the change to take
+    effect.  All LCM tool calls already return {"error": "LCM is disabled"} so
+    the behaviour is safe; this is purely a visibility fix.
+    """
+
+    def test_warning_logged_on_enabled_to_disabled_transition(self, caplog):
+        """A warning containing 'restart' must be emitted when transitioning
+        from enabled to disabled via config reload."""
+        import logging
+        engine = LcmContextEngine(lcm_config={"enabled": True})
+        assert engine._disabled is False, "precondition: engine starts enabled"
+
+        fake_cfg = {"lcm": {"enabled": "false"}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            with caplog.at_level(logging.WARNING, logger="plugins.context_engine.lcm"):
+                engine.on_session_start("s-warn-test")
+
+        assert engine._disabled is True, "precondition: engine is now disabled"
+        assert any(
+            "restart" in record.message.lower()
+            for record in caplog.records
+        ), (
+            "Expected a warning containing 'restart' when LCM transitions "
+            f"enabled→disabled at runtime; got: {[r.message for r in caplog.records]!r}"
+        )
+
+    def test_no_warning_when_already_disabled(self, caplog):
+        """No spurious warning when the engine was already disabled before reload."""
+        import logging
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        assert engine._disabled is True
+
+        fake_cfg = {"lcm": {"enabled": "false"}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            with caplog.at_level(logging.WARNING, logger="plugins.context_engine.lcm"):
+                engine.on_session_start("s-no-warn-test")
+
+        restart_warnings = [
+            r for r in caplog.records if "restart" in r.message.lower()
+        ]
+        assert restart_warnings == [], (
+            "Unexpected 'restart' warning when engine was already disabled: "
+            f"{[r.message for r in restart_warnings]!r}"
+        )
+
+    def test_no_warning_on_disable_to_enable_transition(self, caplog):
+        """Enabling an already-disabled engine must not emit a 'restart' warning."""
+        import logging
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+
+        fake_cfg = {"lcm": {"enabled": "true"}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            with caplog.at_level(logging.WARNING, logger="plugins.context_engine.lcm"):
+                engine.on_session_start("s-enable-no-warn")
+
+        restart_warnings = [
+            r for r in caplog.records if "restart" in r.message.lower()
+        ]
+        assert restart_warnings == [], (
+            "Unexpected 'restart' warning on disabled→enabled transition: "
+            f"{[r.message for r in restart_warnings]!r}"
+        )

--- a/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
@@ -3,6 +3,9 @@
 Fix: after rebuilding self._config in on_session_start, propagate it to
 self._engine.config so compaction reads the user-supplied thresholds, not the
 constructor-time defaults.
+
+Fix 2: lcm.enabled=false must be honoured — no tools exposed, compress() is a
+pass-through, should_compress() always returns False.
 """
 from __future__ import annotations
 
@@ -89,3 +92,59 @@ class TestConfigPropagationOnSessionStart:
             engine.on_session_start("test-session-no-cfg")
         # Engine should still be usable
         assert engine._engine is not None
+
+
+class TestEnabledFalseDisablesEngine:
+    """lcm.enabled=false must suppress tool surface, pass-through compress,
+    and prevent should_compress() from ever returning True."""
+
+    def test_get_tool_schemas_returns_empty_when_disabled(self):
+        """No LCM or memory tools exposed when enabled=False."""
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        schemas = engine.get_tool_schemas()
+        assert schemas == [], (
+            f"get_tool_schemas() returned {len(schemas)} schemas; expected [] when disabled"
+        )
+
+    def test_compress_is_passthrough_when_disabled(self):
+        """compress() must return the input messages unchanged when enabled=False."""
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        msgs = [
+            {"role": "user", "content": f"msg {i}"}
+            for i in range(5)
+        ]
+        result = engine.compress(msgs)
+        assert result == msgs, (
+            f"compress() changed messages when disabled: got {result!r}"
+        )
+
+    def test_compress_passthrough_for_large_context(self):
+        """compress() still passes through even at very high token counts."""
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        msgs = [{"role": "user", "content": "x" * 100} for _ in range(200)]
+        result = engine.compress(msgs)
+        assert result == msgs
+
+    def test_should_compress_false_when_disabled(self):
+        """should_compress() always returns False when enabled=False."""
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        # Even at 10,000,000 tokens — far above any threshold
+        assert engine.should_compress(prompt_tokens=10_000_000) is False, (
+            "should_compress() returned True despite enabled=False"
+        )
+
+    def test_handle_tool_call_returns_error_when_disabled(self):
+        """handle_tool_call() must return an error JSON when enabled=False."""
+        import json as _json
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        result = engine.handle_tool_call("lcm_search", {"query": "test"})
+        parsed = _json.loads(result)
+        assert "error" in parsed, (
+            f"handle_tool_call() did not return an error dict when disabled: {parsed!r}"
+        )
+
+    def test_enabled_true_still_works_normally(self):
+        """Sanity: enabled=True (default) must still expose tools."""
+        engine = LcmContextEngine(lcm_config={"enabled": True})
+        schemas = engine.get_tool_schemas()
+        assert len(schemas) > 0, "get_tool_schemas() returned [] for enabled=True engine"

--- a/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
@@ -148,3 +148,58 @@ class TestEnabledFalseDisablesEngine:
         engine = LcmContextEngine(lcm_config={"enabled": True})
         schemas = engine.get_tool_schemas()
         assert len(schemas) > 0, "get_tool_schemas() returned [] for enabled=True engine"
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 — _disabled re-evaluated when config reloads in on_session_start
+# ---------------------------------------------------------------------------
+
+class TestDisabledFlagOnConfigReload:
+    """on_session_start must re-evaluate _disabled after reloading config.
+
+    Previously only tau_soft/tau_hard/protect_last_n were propagated;
+    _disabled was only set in __init__, so changing lcm.enabled in config.yaml
+    had no effect on a running session.
+    """
+
+    def test_enabled_to_disabled_via_on_session_start(self):
+        """Engine inited with enabled=True, config reloads enabled=False -> _disabled=True."""
+        engine = LcmContextEngine(lcm_config={"enabled": True})
+        assert engine._disabled is False, "precondition: engine starts enabled"
+
+        fake_cfg = {"lcm": {"enabled": "false"}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            engine.on_session_start("s-disable-test")
+
+        assert engine._disabled is True, (
+            f"_disabled={engine._disabled!r} after reloading enabled=False; "
+            "expected True — _disabled was not re-evaluated from the reloaded config"
+        )
+
+    def test_compress_passthrough_when_disabled_via_reload(self):
+        """After reload sets _disabled=True, compress() must be a no-op pass-through."""
+        engine = LcmContextEngine(lcm_config={"enabled": True})
+
+        fake_cfg = {"lcm": {"enabled": "false"}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            engine.on_session_start("s-compress-passthrough")
+
+        msg = {"role": "user", "content": "hello"}
+        result = engine.compress([msg])
+        assert result == [msg], (
+            f"compress() did not pass through unchanged after _disabled=True; got: {result!r}"
+        )
+
+    def test_disabled_to_enabled_via_on_session_start(self):
+        """Engine inited with enabled=False, config reloads enabled=True -> _disabled=False."""
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        assert engine._disabled is True, "precondition: engine starts disabled"
+
+        fake_cfg = {"lcm": {"enabled": "true"}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            engine.on_session_start("s-enable-test")
+
+        assert engine._disabled is False, (
+            f"_disabled={engine._disabled!r} after reloading enabled=True; "
+            "expected False"
+        )

--- a/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
@@ -258,3 +258,43 @@ class TestDisabledAtConstructionTimeViaLcmConfig:
             "load_context_engine with enabled=True returned no schemas; "
             "enabled engines must expose their tools"
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix: summarizer model must be re-synced when config reloads in on_session_start
+# ---------------------------------------------------------------------------
+
+class TestSummarizerModelPropagation:
+    """After on_session_start reloads config, the live Summarizer must pick up
+    the new lcm.summary_model value instead of keeping its constructor-time model.
+    """
+
+    def test_summary_model_propagated_on_session_start(self):
+        """engine._engine.summarizer.config.model reflects the reloaded summary_model."""
+        engine = LcmContextEngine()
+        # Confirm the summarizer starts with no forced model (empty string default)
+        assert engine._engine.summarizer.config.model != "custom-model-x"
+
+        fake_cfg = {"lcm": {"summary_model": "custom-model-x"}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            engine.on_session_start("s1")
+
+        assert engine._engine.summarizer.config.model == "custom-model-x", (
+            f"summarizer.config.model={engine._engine.summarizer.config.model!r} "
+            "but expected 'custom-model-x' — summary_model not re-synced after config reload"
+        )
+
+    def test_summary_model_not_overwritten_when_not_set(self):
+        """When config reloads without summary_model, the summarizer keeps its current model."""
+        engine = LcmContextEngine()
+        # Manually set a model to verify it isn't wiped by a config without summary_model
+        engine._engine.summarizer.config.model = "pre-set-model"
+
+        fake_cfg = {"lcm": {"tau_soft": "0.55"}}  # no summary_model key
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            engine.on_session_start("s2")
+
+        # summary_model is falsy (empty string) so the branch must NOT overwrite
+        assert engine._engine.summarizer.config.model == "pre-set-model", (
+            "summarizer.config.model was overwritten despite no summary_model in config"
+        )

--- a/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
@@ -203,3 +203,58 @@ class TestDisabledFlagOnConfigReload:
             f"_disabled={engine._disabled!r} after reloading enabled=True; "
             "expected False"
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix 6 — lcm_config passed to constructor so disabled mode suppresses tools
+#          at registration time (before on_session_start is ever called)
+# ---------------------------------------------------------------------------
+
+class TestDisabledAtConstructionTimeViaLcmConfig:
+    """lcm_config passed to LcmContextEngine at construction time must suppress
+    tool registration immediately — no on_session_start() call required.
+
+    Regression: previously the engine was constructed with default kwargs (enabled=True),
+    then on_session_start() would re-evaluate _disabled.  This meant get_tool_schemas()
+    returned non-empty tools between construction and the first on_session_start call.
+    """
+
+    def test_get_tool_schemas_empty_before_session_start(self):
+        """Tools must be suppressed purely from constructor kwargs, before any session."""
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        # Do NOT call on_session_start — that was the previous dependency
+        schemas = engine.get_tool_schemas()
+        assert schemas == [], (
+            f"get_tool_schemas() returned {len(schemas)} schemas before any "
+            "on_session_start() call; disabled mode must suppress tools at construction"
+        )
+
+    def test_disabled_flag_set_at_construction(self):
+        """_disabled=True must be set immediately in __init__ from lcm_config."""
+        engine = LcmContextEngine(lcm_config={"enabled": False})
+        assert engine._disabled is True, (
+            "_disabled should be True immediately after construction with enabled=False"
+        )
+
+    def test_load_context_engine_with_lcm_config_disabled(self):
+        """load_context_engine('lcm', lcm_config={'enabled': False}) must return
+        an engine whose get_tool_schemas() is empty without any session lifecycle call."""
+        from plugins.context_engine import load_context_engine
+        engine = load_context_engine("lcm", lcm_config={"enabled": False})
+        assert engine is not None, "load_context_engine should return an engine instance"
+        schemas = engine.get_tool_schemas()
+        assert schemas == [], (
+            f"load_context_engine with enabled=False returned {len(schemas)} schemas; "
+            "expected [] — lcm_config must be forwarded through the loader to the constructor"
+        )
+
+    def test_load_context_engine_with_lcm_config_enabled(self):
+        """Sanity: load_context_engine('lcm', lcm_config={'enabled': True}) must expose tools."""
+        from plugins.context_engine import load_context_engine
+        engine = load_context_engine("lcm", lcm_config={"enabled": True})
+        assert engine is not None
+        schemas = engine.get_tool_schemas()
+        assert len(schemas) > 0, (
+            "load_context_engine with enabled=True returned no schemas; "
+            "enabled engines must expose their tools"
+        )

--- a/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_config_apply.py
@@ -1,0 +1,91 @@
+"""Regression test: config loaded in on_session_start must reach the live LcmEngine.
+
+Fix: after rebuilding self._config in on_session_start, propagate it to
+self._engine.config so compaction reads the user-supplied thresholds, not the
+constructor-time defaults.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from plugins.context_engine.lcm.__init__ import LcmContextEngine
+from plugins.context_engine.lcm.config import LcmConfig
+
+
+class TestConfigPropagationOnSessionStart:
+    """on_session_start must write the reloaded config back to the live engine."""
+
+    def test_tau_soft_propagated_to_engine(self):
+        """engine._engine.config.tau_soft reflects the value from config.yaml."""
+        default_config = LcmConfig()
+        assert default_config.tau_soft != 0.42, "pick a non-default value for this test"
+
+        engine = LcmContextEngine()
+
+        fake_cfg = {"lcm": {"tau_soft": "0.42"}}
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=fake_cfg,
+        ):
+            engine.on_session_start("test-session-cfg1")
+
+        assert engine._engine.config.tau_soft == pytest.approx(0.42), (
+            f"engine._engine.config.tau_soft={engine._engine.config.tau_soft!r} "
+            "but expected 0.42 — config was not propagated to the live engine"
+        )
+
+    def test_tau_hard_propagated_to_engine(self):
+        """engine._engine.config.tau_hard reflects the value from config.yaml."""
+        engine = LcmContextEngine()
+        fake_cfg = {"lcm": {"tau_hard": "0.95"}}
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=fake_cfg,
+        ):
+            engine.on_session_start("test-session-cfg2")
+
+        assert engine._engine.config.tau_hard == pytest.approx(0.95), (
+            f"engine._engine.config.tau_hard={engine._engine.config.tau_hard!r} "
+            "but expected 0.95"
+        )
+
+    def test_protect_last_n_propagated_to_engine(self):
+        """engine._engine.config.protect_last_n reflects config.yaml."""
+        engine = LcmContextEngine()
+        fake_cfg = {"lcm": {"protect_last_n": "10"}}
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=fake_cfg,
+        ):
+            engine.on_session_start("test-session-cfg3")
+
+        assert engine._engine.config.protect_last_n == 10, (
+            f"engine._engine.config.protect_last_n={engine._engine.config.protect_last_n!r} "
+            "but expected 10"
+        )
+
+    def test_wrapper_attributes_also_updated(self):
+        """threshold_percent and protect_last_n on the wrapper also sync."""
+        engine = LcmContextEngine()
+        fake_cfg = {"lcm": {"tau_soft": "0.60", "protect_last_n": "8"}}
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=fake_cfg,
+        ):
+            engine.on_session_start("test-session-cfg4")
+
+        assert engine.threshold_percent == pytest.approx(0.60)
+        assert engine.protect_last_n == 8
+
+    def test_no_config_does_not_crash(self):
+        """If load_config raises, on_session_start must not crash."""
+        engine = LcmContextEngine()
+        with patch(
+            "hermes_cli.config.load_config",
+            side_effect=RuntimeError("no config"),
+        ):
+            engine.on_session_start("test-session-no-cfg")
+        # Engine should still be usable
+        assert engine._engine is not None

--- a/tests/plugins/context_engine/lcm/test_lcm_integration.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_integration.py
@@ -1,0 +1,274 @@
+"""Integration tests for LCM in the agent loop."""
+import pytest
+from unittest.mock import MagicMock, patch
+from plugins.context_engine.lcm.engine import LcmEngine, CompactionAction
+from plugins.context_engine.lcm.config import LcmConfig
+
+
+class TestLcmInitialization:
+    def test_lcm_engine_created_when_enabled(self):
+        """When lcm.enabled=true in config, AIAgent should have an lcm_engine."""
+        config = {"lcm": {"enabled": True, "tau_soft": 0.5, "tau_hard": 0.85}}
+        lcm_config = LcmConfig.from_dict(config.get("lcm", {}))
+        assert lcm_config.enabled is True
+        engine = LcmEngine(lcm_config)
+        assert engine is not None
+
+    def test_lcm_engine_not_created_when_disabled(self):
+        """When lcm.enabled=false, no engine should be created."""
+        config = {"lcm": {"enabled": False}}
+        lcm_config = LcmConfig.from_dict(config.get("lcm", {}))
+        assert lcm_config.enabled is False
+
+    def test_lcm_config_defaults_enabled(self):
+        """Empty config section means LCM is enabled by default (unified system)."""
+        lcm_config = LcmConfig.from_dict({})
+        assert lcm_config.enabled is True
+
+    def test_lcm_config_from_agent_config_section(self):
+        """Verify LcmConfig reads the lcm section from agent config dict."""
+        agent_cfg = {
+            "compression": {"enabled": True},
+            "lcm": {"enabled": "true", "tau_soft": "0.6", "tau_hard": "0.9"},
+        }
+        lcm_section = agent_cfg.get("lcm", {})
+        if not isinstance(lcm_section, dict):
+            lcm_section = {}
+        lcm_config = LcmConfig.from_dict(lcm_section)
+        assert lcm_config.enabled is True
+        assert lcm_config.tau_soft == 0.6
+        assert lcm_config.tau_hard == 0.9
+
+    def test_lcm_config_handles_missing_section(self):
+        """When no 'lcm' key exists in agent config, LCM is enabled by default."""
+        agent_cfg = {}
+        lcm_section = agent_cfg.get("lcm", {})
+        if not isinstance(lcm_section, dict):
+            lcm_section = {}
+        lcm_config = LcmConfig.from_dict(lcm_section)
+        assert lcm_config.enabled is True
+
+    def test_lcm_config_handles_non_dict_section(self):
+        """When 'lcm' key is not a dict (e.g. None), defaults are used (enabled=True)."""
+        agent_cfg = {"lcm": None}
+        lcm_section = agent_cfg.get("lcm", {})
+        if not isinstance(lcm_section, dict):
+            lcm_section = {}
+        lcm_config = LcmConfig.from_dict(lcm_section)
+        assert lcm_config.enabled is True
+
+
+class TestLcmCompaction:
+    def test_lcm_compact_produces_summary(self):
+        """The _lcm_compact flow should find a block, summarize, and return fewer messages."""
+        config = LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85, protect_last_n=2)
+        engine = LcmEngine(config)
+
+        # Simulate a conversation
+        messages = []
+        for i in range(10):
+            msg = {"role": "user" if i % 2 == 0 else "assistant", "content": f"Message {i} " + "x" * 100}
+            messages.append(msg)
+            engine.ingest(msg)
+
+        # Engine should have 10 active entries
+        assert len(engine.active) == 10
+
+        # Find and compact
+        block = engine.find_compactable_block()
+        assert block is not None
+        start, end = block
+
+        from plugins.context_engine.lcm.escalation import deterministic_truncate
+        summary_text = deterministic_truncate(
+            [e.message for e in engine.active[start:end]],
+            target_tokens=100
+        )
+        node = engine.compact(summary_text, level=3, block_start=start, block_end=end)
+
+        # Should have fewer active entries now
+        assert len(engine.active) < 10
+        # But store still has all 10
+        assert len(engine.store) == 10
+        # Expand should recover originals
+        expanded = engine.expand_summary(node.id)
+        assert len(expanded) == end - start
+
+    def test_lcm_append_message_ingests(self):
+        """_append_message should add to both messages list and engine."""
+        config = LcmConfig(enabled=True)
+        engine = LcmEngine(config)
+
+        messages = []
+        msg = {"role": "user", "content": "hello"}
+
+        # Simulate _append_message behavior
+        messages.append(msg)
+        engine.ingest(msg)
+
+        assert len(messages) == 1
+        assert len(engine.store) == 1
+        assert len(engine.active) == 1
+
+    def test_append_message_no_engine(self):
+        """When lcm_engine is None, _append_message should behave like a plain append."""
+        lcm_engine = None
+        messages = []
+        msg = {"role": "user", "content": "hello"}
+
+        # Simulate _append_message when engine is None
+        messages.append(msg)
+        if lcm_engine is not None:
+            lcm_engine.ingest(msg)
+
+        assert len(messages) == 1
+
+    def test_check_thresholds_blocking(self):
+        """Engine returns BLOCKING when active tokens >= tau_hard * budget."""
+        config = LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85)
+        engine = LcmEngine(config)
+
+        # Ingest enough to fill 90% of a 1000-token budget
+        # ~4 chars/token, so 900 tokens = 3600 chars
+        msg = {"role": "user", "content": "x" * 3600}
+        engine.ingest(msg)
+
+        action = engine.check_thresholds(token_budget=1000)
+        assert action == CompactionAction.BLOCKING
+
+    def test_check_thresholds_none_below_soft(self):
+        """Engine returns NONE when active tokens < tau_soft * budget."""
+        config = LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85)
+        engine = LcmEngine(config)
+
+        # Ingest very little content — far below soft threshold
+        msg = {"role": "user", "content": "hello"}
+        engine.ingest(msg)
+
+        action = engine.check_thresholds(token_budget=100_000)
+        assert action == CompactionAction.NONE
+
+    def test_active_messages_after_compact(self):
+        """active_messages() returns only the active (post-compaction) messages."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        engine = LcmEngine(config)
+
+        for i in range(6):
+            engine.ingest({"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"})
+
+        block = engine.find_compactable_block()
+        assert block is not None
+        start, end = block
+
+        engine.compact("summary text", level=3, block_start=start, block_end=end)
+        active = engine.active_messages()
+
+        # There should be fewer messages now (block replaced by 1 summary)
+        assert len(active) < 6
+        # The summary message should appear
+        assert any("[Summary" in str(m.get("content", "")) for m in active)
+
+
+class TestLcmToolRegistration:
+    def test_tool_schemas_valid(self):
+        """All LCM tool schemas should be valid for registration."""
+        from plugins.context_engine.lcm.tools import LCM_TOOL_SCHEMAS
+        for name, schema in LCM_TOOL_SCHEMAS.items():
+            assert schema["name"] == name
+            assert "description" in schema
+            assert "parameters" in schema
+
+    def test_set_engine_enables_tools(self):
+        """After set_engine, tool handlers should work."""
+        from plugins.context_engine.lcm.tools import set_engine, handle_lcm_budget
+        config = LcmConfig(enabled=True)
+        engine = LcmEngine(config)
+        engine.ingest({"role": "user", "content": "test"})
+        set_engine(engine)
+        result = handle_lcm_budget({})
+        assert "token" in result.lower() or "active" in result.lower()
+        set_engine(None)  # cleanup
+
+    def test_set_engine_none_disables_tools(self):
+        """After set_engine(None), tool handlers should return an error string."""
+        from plugins.context_engine.lcm.tools import set_engine, handle_lcm_budget, get_engine
+        set_engine(None)
+        result = handle_lcm_budget({})
+        assert "not active" in result.lower() or "error" in result.lower()
+        assert get_engine() is None
+
+    def test_all_lcm_tool_names_in_schemas(self):
+        """All 7 expected LCM tools should be present in LCM_TOOL_SCHEMAS."""
+        from plugins.context_engine.lcm.tools import LCM_TOOL_SCHEMAS
+        expected = {"lcm_expand", "lcm_pin", "lcm_forget", "lcm_search", "lcm_budget", "lcm_toc", "lcm_focus"}
+        assert set(LCM_TOOL_SCHEMAS.keys()) == expected
+
+    def test_lcm_tools_formatted_for_openai(self):
+        """LCM tool schemas should be convertible to the OpenAI tool format."""
+        from plugins.context_engine.lcm.tools import LCM_TOOL_SCHEMAS
+        for name, schema in LCM_TOOL_SCHEMAS.items():
+            # Wrap in the OpenAI format structure
+            openai_tool = {
+                "type": "function",
+                "function": schema,
+            }
+            assert openai_tool["type"] == "function"
+            assert openai_tool["function"]["name"] == name
+            assert "parameters" in openai_tool["function"]
+
+
+class TestLcmAgentIntegration:
+    """Tests that verify the integration wiring in run_agent.py."""
+
+    def test_append_message_helper_simulation(self):
+        """Simulate the _append_message helper: both list and engine get the message."""
+        config = LcmConfig(enabled=True)
+        engine = LcmEngine(config)
+        messages = []
+
+        def _append_message(messages, msg, lcm_engine=None):
+            messages.append(msg)
+            if lcm_engine is not None:
+                lcm_engine.ingest(msg)
+
+        for i in range(5):
+            msg = {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i}"}
+            _append_message(messages, msg, engine)
+
+        assert len(messages) == 5
+        assert len(engine.active) == 5
+        assert len(engine.store) == 5
+
+    def test_lcm_compact_simulation(self):
+        """Simulate _lcm_compact: find block, deterministic truncate, compact, rebuild."""
+        from plugins.context_engine.lcm.escalation import escalated_summary
+
+        config = LcmConfig(enabled=True, tau_soft=0.5, tau_hard=0.85, protect_last_n=2)
+        engine = LcmEngine(config)
+
+        messages = []
+        for i in range(8):
+            msg = {"role": "user" if i % 2 == 0 else "assistant", "content": f"Message {i}: " + "detail " * 20}
+            messages.append(msg)
+            engine.ingest(msg)
+
+        block = engine.find_compactable_block()
+        assert block is not None
+        block_start, block_end = block
+        block_messages = [e.message for e in engine.active[block_start:block_end]]
+
+        # escalated_summary will fall through to deterministic (Level 3)
+        summary_text, level = escalated_summary(
+            block_messages,
+            target_tokens=200,
+            deterministic_target=100,
+            summary_model="",
+        )
+        assert level == 3  # Level 1/2 require LLM, always falls through to 3
+        assert len(summary_text) > 0
+
+        engine.compact(summary_text, level, block_start, block_end)
+        new_messages = engine.active_messages()
+
+        # Should have fewer messages after compaction
+        assert len(new_messages) < len(messages)

--- a/tests/plugins/context_engine/lcm/test_lcm_lifecycle.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_lifecycle.py
@@ -1,0 +1,440 @@
+"""Full LCM lifecycle test — ingest, compact, search, expand, pin, forget.
+
+Exercises the LcmEngine directly (no agent loop) with mock summarization
+to verify the lossless context management guarantees:
+  1. Ingested messages appear in the store
+  2. check_thresholds fires at the right time
+  3. auto_compact creates a DAG node and replaces raw entries
+  4. Search recovers compacted messages by keyword
+  5. Expand restores original raw messages from a summary node
+  6. Pinned messages survive compaction
+  7. lcm_forget compacts specific messages
+  8. Store retains all originals after compaction (lossless)
+"""
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.engine import LcmEngine, CompactionAction, ContextEntry
+from plugins.context_engine.lcm.tools import set_engine, get_engine
+from plugins.context_engine.lcm.dag import SummaryDag
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def config():
+    """LCM config with a tiny context length so thresholds fire quickly."""
+    return LcmConfig(
+        enabled=True,
+        tau_soft=0.50,
+        tau_hard=0.85,
+        protect_last_n=2,
+        max_pinned=20,
+        max_store_size=500,
+    )
+
+
+@pytest.fixture
+def engine(config):
+    """Fresh LcmEngine with mock summarizer."""
+    eng = LcmEngine(config=config, context_length=500)
+    # Patch summarizer to return deterministic text instead of calling LLM
+    eng.summarizer.summarize = MagicMock(return_value="MOCK SUMMARY: prior conversation turns.")
+    return eng
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_engine():
+    """Ensure the ContextVar engine reference is cleaned up after each test."""
+    yield
+    set_engine(None)
+
+
+# Helper to create a message
+def msg(role: str, content: str) -> dict:
+    return {"role": role, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# 1. Ingestion
+# ---------------------------------------------------------------------------
+
+class TestIngest:
+    def test_messages_appear_in_store(self, engine):
+        m = msg("user", "Hello world")
+        mid = engine.ingest(m)
+        assert mid == 0
+        assert len(engine.store) == 1
+        assert engine.store.get(0) == m
+
+    def test_multiple_ingest_sequential_ids(self, engine):
+        ids = [engine.ingest(msg("user", f"msg {i}")) for i in range(5)]
+        assert ids == [0, 1, 2, 3, 4]
+        assert len(engine.store) == 5
+
+    def test_ingest_adds_to_active(self, engine):
+        engine.ingest(msg("user", "alpha"))
+        engine.ingest(msg("assistant", "beta"))
+        assert len(engine.active) == 2
+        assert engine.active[0].kind == "raw"
+        assert engine.active[1].kind == "raw"
+
+
+# ---------------------------------------------------------------------------
+# 2. Threshold checking
+# ---------------------------------------------------------------------------
+
+class TestThresholds:
+    def test_none_when_below_soft(self, engine):
+        engine.ingest(msg("user", "short"))
+        action = engine.check_thresholds()
+        assert action == CompactionAction.NONE
+
+    def test_async_at_soft_threshold(self, engine):
+        # Fill up to ~50% of 500 token context (~250 tokens ≈ 1000 chars)
+        big = "x" * 1200
+        for i in range(5):
+            engine.ingest(msg("user", f"{big} msg {i}"))
+        action = engine.check_thresholds()
+        assert action in (CompactionAction.ASYNC, CompactionAction.BLOCKING)
+
+    def test_blocking_at_hard_threshold(self, engine):
+        # Fill well above 85% of 500 tokens (~425 tokens ≈ 1700 chars)
+        big = "y" * 500
+        for i in range(12):
+            engine.ingest(msg("user", f"{big} msg {i}"))
+        action = engine.check_thresholds()
+        assert action == CompactionAction.BLOCKING
+
+
+# ---------------------------------------------------------------------------
+# 3. Auto-compaction
+# ---------------------------------------------------------------------------
+
+class TestAutoCompact:
+    def test_compact_replaces_raw_with_summary(self, engine):
+        for i in range(6):
+            engine.ingest(msg("user", f"Message number {i} with some detail."))
+        # active: 6 raw entries
+        assert len(engine.active) == 6
+        assert all(e.kind == "raw" for e in engine.active)
+
+        node = engine.auto_compact()
+        assert node is not None
+        # protect_last_n=2, so at most 4 can be compacted into 1 summary
+        # Result: 1 summary + 2 protected raw = 3 entries
+        assert len(engine.active) <= 4
+        assert any(e.kind == "summary" for e in engine.active)
+        assert any(e.kind == "raw" for e in engine.active)
+
+    def test_compact_creates_dag_node(self, engine):
+        for i in range(6):
+            engine.ingest(msg("user", f"DAG test message {i}"))
+        node = engine.auto_compact()
+        assert node is not None
+        assert len(node.source_ids) > 0
+        assert len(engine.dag.nodes) == 1
+
+    def test_protected_tail_survives(self, engine):
+        msgs = [msg("user", f"protected tail {i}") for i in range(6)]
+        for m in msgs:
+            engine.ingest(m)
+        engine.auto_compact()
+        # Last protect_last_n (2) raw entries must still be in active
+        active_contents = [e.message["content"] for e in engine.active if e.kind == "raw"]
+        assert any("protected tail 5" in c for c in active_contents)
+        assert any("protected tail 4" in c for c in active_contents)
+
+
+# ---------------------------------------------------------------------------
+# 4. Lossless search after compaction
+# ---------------------------------------------------------------------------
+
+class TestSearchAfterCompaction:
+    def test_keyword_search_finds_compacted_content(self, engine):
+        unique = "UNIQUE_KEYWORD_XYZZY_42"
+        engine.ingest(msg("user", f"buried treasure {unique} in the compacted zone"))
+        # Fill to ensure compaction happens
+        for i in range(8):
+            engine.ingest(msg("user", f"filler message {i} " * 20))
+        engine.auto_compact()
+        # Search the store (not just active) for the unique keyword
+        results = engine.search(unique)
+        assert len(results) >= 1
+        found_content = results[0][1]["content"]
+        assert unique in found_content
+
+    def test_search_returns_empty_for_missing(self, engine):
+        engine.ingest(msg("user", "some content"))
+        results = engine.search("NONEXISTENT_KEYWORD_99999")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Expand restores original messages
+# ---------------------------------------------------------------------------
+
+class TestExpand:
+    def test_expand_returns_original_messages(self, engine):
+        originals = [msg("user", f"original expandable {i}") for i in range(5)]
+        for m in originals:
+            engine.ingest(m)
+        node = engine.auto_compact()
+        assert node is not None
+        source_ids = node.source_ids
+        # Retrieve each original from the store
+        for sid in source_ids:
+            original = engine.store.get(sid)
+            assert original is not None
+            assert "original expandable" in original["content"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Pinned messages survive compaction
+# ---------------------------------------------------------------------------
+
+class TestPin:
+    def test_pinned_message_not_compacted(self, engine):
+        engine.ingest(msg("user", "pin me please"))
+        for i in range(8):
+            engine.ingest(msg("user", f"bulk message {i} " * 15))
+        # Pin message 0
+        engine._pinned_ids.add(0)
+        engine.auto_compact()
+        # Message 0 must still be in active as raw
+        raw_ids = [e.msg_id for e in engine.active if e.kind == "raw"]
+        assert 0 in raw_ids
+
+    def test_pin_via_tool_handler(self, engine):
+        set_engine(engine)
+        from plugins.context_engine.lcm.tools import handle_lcm_pin
+        engine.ingest(msg("user", "to pin"))
+        result = handle_lcm_pin({"message_ids": "0"})
+        assert "Pinned" in result
+        assert 0 in engine._pinned_ids
+
+
+# ---------------------------------------------------------------------------
+# 7. Forget (manual compaction of specific messages)
+# ---------------------------------------------------------------------------
+
+class TestForget:
+    def test_forget_removes_from_active(self, engine):
+        for i in range(8):
+            engine.ingest(msg("user", f"forgettable {i}"))
+        # Forget messages 0,1,2
+        set_engine(engine)
+        from plugins.context_engine.lcm.tools import handle_lcm_forget
+        result = handle_lcm_forget({"message_ids": "0,1,2", "reason": "test forget"})
+        # After forget, those IDs should not be in active as raw
+        active_raw_ids = {e.msg_id for e in engine.active if e.kind == "raw" and e.msg_id is not None}
+        assert 0 not in active_raw_ids or any(e.kind == "summary" for e in engine.active)
+
+    def test_forget_preserves_in_store(self, engine):
+        for i in range(8):
+            engine.ingest(msg("user", f"store test {i}"))
+        set_engine(engine)
+        from plugins.context_engine.lcm.tools import handle_lcm_forget
+        handle_lcm_forget({"message_ids": "0,1,2", "reason": "test"})
+        # Store must still have them
+        for i in range(3):
+            assert engine.store.get(i) is not None
+
+
+# ---------------------------------------------------------------------------
+# 8. Store retains all originals (lossless guarantee)
+# ---------------------------------------------------------------------------
+
+class TestLosslessStore:
+    def test_store_grows_monotonically(self, engine):
+        count = 10
+        for i in range(count):
+            engine.ingest(msg("user", f"lossless {i}"))
+        assert len(engine.store) == count
+        engine.auto_compact()
+        # Store should NOT shrink after compaction
+        assert len(engine.store) == count
+
+    def test_all_messages_retrievable_after_multiple_compactions(self, engine):
+        total = 20
+        for i in range(total):
+            engine.ingest(msg("user", f"multi-compact {i}"))
+        # Compact multiple times
+        for _ in range(3):
+            engine.auto_compact()
+        # Every original must still be in the store
+        for i in range(total):
+            original = engine.store.get(i)
+            assert original is not None, f"Message {i} lost from store!"
+            assert f"multi-compact {i}" in original["content"]
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers integration
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Chicken-and-egg fix: should_compress uses real API token count
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Deterministic summarization fallback
+# ---------------------------------------------------------------------------
+
+class TestDeterministicFallback:
+    """Verify the extractive fallback works when no LLM is available."""
+
+    def test_deterministic_summary_produces_output(self, engine):
+        from plugins.context_engine.lcm.summarizer import Summarizer, SummarizerConfig
+        s = Summarizer(SummarizerConfig())
+        turns = [
+            {"role": "user", "content": "Check the filesystem"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"function": {"name": "terminal", "arguments": '{"command": "ls -la"}'},
+                 "type": "function"}
+            ]},
+            {"role": "tool", "content": "total 42\ndrwxr-xr-x 2 root root 4096 Apr 9 .bashrc"},
+            {"role": "assistant", "content": "Here are the files in your home directory."},
+        ]
+        result = s._deterministic_summary(turns)
+        assert result is not None
+        # Output should contain key content from the turns
+        assert "filesystem" in result or "Check" in result
+        # With sumy, output is extracted sentences; without, it uses sections
+        assert len(result) > 50
+
+    def test_deterministic_with_previous_summary(self, engine):
+        from plugins.context_engine.lcm.summarizer import Summarizer, SummarizerConfig
+        s = Summarizer(SummarizerConfig())
+        turns = [
+            {"role": "user", "content": "Run tests"},
+            {"role": "assistant", "content": "Running pytest now"},
+        ]
+        result = s._deterministic_summary(turns, previous_summary="## Goal\nFix the bug")
+        assert "## Goal\nFix the bug" in result
+        assert "Updates since last compaction" in result
+
+    def test_deterministic_empty_turns_returns_none(self, engine):
+        from plugins.context_engine.lcm.summarizer import Summarizer, SummarizerConfig
+        s = Summarizer(SummarizerConfig())
+        assert s._deterministic_summary([]) is None
+
+    def test_full_summarize_falls_back_to_deterministic(self, engine):
+        """When call_llm fails, summarize() returns deterministic output."""
+        from plugins.context_engine.lcm.summarizer import Summarizer, SummarizerConfig
+        s = Summarizer(SummarizerConfig())
+        turns = [
+            {"role": "user", "content": "Search for the bug"},
+            {"role": "assistant", "content": "Found it in utils.py"},
+        ]
+        # call_llm will fail (no provider), but deterministic fallback should work
+        result = s.summarize(turns)
+        assert result is not None
+        assert "Search for the bug" in result
+
+    def test_compaction_succeeds_with_deterministic_fallback(self, engine):
+        """End-to-end: auto_compact works even without LLM for summarization."""
+        for i in range(8):
+            engine.ingest({"role": "user", "content": f"fallback test message {i} with detail"})
+        # Mock summarizer to fail LLM but succeed with deterministic
+        original_summarize = engine.summarizer.summarize
+        call_count = [0]
+        def mock_summarize(turns, previous_summary=None):
+            call_count[0] += 1
+            # First call tries LLM (fails), then falls back to deterministic
+            return original_summarize(turns, previous_summary)
+        engine.summarizer.summarize = mock_summarize
+
+        node = engine.auto_compact()
+        assert node is not None, "auto_compact should succeed with deterministic fallback"
+        assert len(node.source_ids) > 0
+
+
+class TestShouldCompressWithRealTokens:
+    """Verify that should_compress() works before the first compress() call.
+
+    Regression test for the chicken-and-egg bug: the engine's active list is
+    empty before compress() ingests messages, so should_compress() must use
+    the prompt_tokens parameter (real API token count) instead of only
+    checking the engine's internal active_tokens().
+    """
+
+    def test_fires_with_real_tokens_before_ingest(self, engine):
+        """should_compress returns True when real tokens exceed tau_soft,
+        even though the engine has 0 ingested messages."""
+        from plugins.context_engine.lcm import LcmContextEngine
+        adapter = LcmContextEngine(
+            lcm_config={"tau_soft": 0.50, "tau_hard": 0.85, "protect_last_n": 2},
+            context_length=1000,
+        )
+        # Engine has 0 messages — active_tokens() = 0
+        assert adapter._engine.active_tokens() == 0
+
+        # But if the API reports 600 real tokens (> 50% of 1000), should fire
+        assert adapter.should_compress(prompt_tokens=600) is True
+
+    def test_does_not_fire_below_threshold(self, engine):
+        """should_compress returns False when real tokens are below tau_soft."""
+        from plugins.context_engine.lcm import LcmContextEngine
+        adapter = LcmContextEngine(
+            lcm_config={"tau_soft": 0.50, "tau_hard": 0.85},
+            context_length=1000,
+        )
+        assert adapter.should_compress(prompt_tokens=200) is False
+
+    def test_fallback_to_engine_after_ingest(self, engine):
+        """After first compress(), fallback path via engine state works."""
+        from plugins.context_engine.lcm import LcmContextEngine
+        adapter = LcmContextEngine(
+            lcm_config={"tau_soft": 0.50, "tau_hard": 0.85, "protect_last_n": 2},
+            context_length=500,
+        )
+        # Ingest enough messages to fill context
+        big = "z" * 400
+        messages = [{"role": "user", "content": f"{big} msg {i}"} for i in range(8)]
+        adapter.compress(messages)
+        # Now engine has ingested — should_compress without real tokens
+        # should use engine's active_tokens()
+        result = adapter.should_compress()
+        # Should fire because engine has ~3200 tokens in a 500 budget
+        assert result is True
+
+
+class TestToolHandlers:
+    def test_budget_tool(self, engine):
+        set_engine(engine)
+        from plugins.context_engine.lcm.tools import handle_lcm_budget
+        for i in range(5):
+            engine.ingest(msg("user", f"budget test {i}"))
+        result = handle_lcm_budget({})
+        assert "Active entries" in result or "active" in result.lower()
+
+    def test_toc_tool(self, engine):
+        set_engine(engine)
+        from plugins.context_engine.lcm.tools import handle_lcm_toc
+        for i in range(3):
+            engine.ingest(msg("user", f"toc test {i}"))
+        result = handle_lcm_toc({})
+        assert "toc" in result.lower() or "entry" in result.lower() or "raw" in result.lower()
+
+    def test_search_tool(self, engine):
+        set_engine(engine)
+        from plugins.context_engine.lcm.tools import handle_lcm_search
+        engine.ingest(msg("user", "needle in haystack"))
+        result = handle_lcm_search({"query": "needle"})
+        assert "needle" in result
+
+    def test_focus_tool(self, engine):
+        set_engine(engine)
+        from plugins.context_engine.lcm.tools import handle_lcm_focus
+        for i in range(6):
+            engine.ingest(msg("user", f"focus test {i}"))
+        node = engine.auto_compact()
+        assert node is not None
+        result = handle_lcm_focus({"node_id": node.id})
+        assert "focus" in result.lower() or str(node.id) in result

--- a/tests/plugins/context_engine/lcm/test_lcm_lifecycle.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_lifecycle.py
@@ -438,3 +438,72 @@ class TestToolHandlers:
         assert node is not None
         result = handle_lcm_focus({"node_id": node.id})
         assert "focus" in result.lower() or str(node.id) in result
+
+
+# ---------------------------------------------------------------------------
+# Fix: async_compact() must bump compression_count same as auto_compact()
+# ---------------------------------------------------------------------------
+
+class TestAsyncCompactionCount:
+    """compression_count must increment when ASYNC compaction is triggered.
+
+    Previously only BLOCKING incremented the counter, so the status display
+    showed zero compactions even after async background compactions fired.
+    """
+
+    def test_compression_count_increments_on_async(self):
+        """ASYNC compaction path must bump compression_count."""
+        from unittest.mock import MagicMock, patch
+        from plugins.context_engine.lcm import LcmContextEngine
+        from plugins.context_engine.lcm.engine import CompactionAction
+
+        # tau_soft=0.5, tau_hard=0.99 — ASYNC fires between 50% and 99%.
+        adapter = LcmContextEngine(
+            lcm_config={"tau_soft": 0.5, "tau_hard": 0.99, "protect_last_n": 2},
+            context_length=500,
+        )
+        # Mock summarizer to avoid LLM calls
+        adapter._engine.summarizer.summarize = MagicMock(
+            return_value="MOCK SUMMARY: async compaction test."
+        )
+        # Mock async_compact to be a no-op (we just want to verify the counter)
+        adapter._engine.async_compact = MagicMock()
+
+        # Force check_thresholds to return ASYNC
+        with patch.object(
+            adapter._engine, "check_thresholds", return_value=CompactionAction.ASYNC
+        ):
+            # Supply some messages — content doesn't matter since thresholds are mocked
+            messages = [{"role": "user", "content": f"msg {i}"} for i in range(5)]
+            adapter.compress(messages)
+
+        assert adapter.compression_count >= 1, (
+            f"compression_count={adapter.compression_count} after ASYNC compaction; "
+            "expected >= 1 — async_compact() must increment the counter"
+        )
+        adapter._engine.async_compact.assert_called_once()
+
+    def test_blocking_count_unchanged(self):
+        """BLOCKING compaction still increments compression_count (regression guard)."""
+        from unittest.mock import MagicMock, patch
+        from plugins.context_engine.lcm import LcmContextEngine
+        from plugins.context_engine.lcm.engine import CompactionAction
+
+        adapter = LcmContextEngine(
+            lcm_config={"tau_soft": 0.5, "tau_hard": 0.9, "protect_last_n": 2},
+            context_length=500,
+        )
+        adapter._engine.summarizer.summarize = MagicMock(
+            return_value="MOCK SUMMARY: blocking test."
+        )
+        adapter._engine.auto_compact = MagicMock(return_value=None)
+
+        with patch.object(
+            adapter._engine, "check_thresholds", return_value=CompactionAction.BLOCKING
+        ):
+            messages = [{"role": "user", "content": f"msg {i}"} for i in range(5)]
+            adapter.compress(messages)
+
+        assert adapter.compression_count >= 1, (
+            f"compression_count={adapter.compression_count} after BLOCKING compaction"
+        )

--- a/tests/plugins/context_engine/lcm/test_lcm_memory_tools.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_memory_tools.py
@@ -1,0 +1,101 @@
+"""Regression tests for Fix C: memory_* tools exposed via get_tool_schemas / handle_tool_call.
+
+Verifies:
+- get_tool_schemas() returns both lcm_* AND memory_* schemas.
+- handle_tool_call("memory_search", ...) dispatches correctly without raising
+  "Unknown tool" / "not active".
+"""
+from __future__ import annotations
+
+import json
+import pytest
+
+from plugins.context_engine.lcm.__init__ import LcmContextEngine
+from plugins.context_engine.lcm.config import LcmConfig
+
+
+@pytest.fixture
+def engine():
+    config = LcmConfig(enabled=True, protect_last_n=2)
+    e = LcmContextEngine(lcm_config=config)
+    # Pre-load a few messages so searches have something to find
+    e.compress([
+        {"role": "user", "content": "What is the capital of France?"},
+        {"role": "assistant", "content": "Paris is the capital of France."},
+        {"role": "user", "content": "Tell me about Python decorators."},
+        {"role": "assistant", "content": "Decorators are a Python feature for wrapping functions."},
+    ])
+    return e
+
+
+class TestGetToolSchemas:
+    def test_lcm_tools_present(self, engine):
+        """All 7 lcm_* tool names must appear in the schema list."""
+        schemas = engine.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        lcm_expected = {"lcm_expand", "lcm_pin", "lcm_forget", "lcm_search",
+                        "lcm_budget", "lcm_toc", "lcm_focus"}
+        assert lcm_expected.issubset(names), (
+            f"Missing lcm_* tools: {lcm_expected - names}"
+        )
+
+    def test_memory_tools_present(self, engine):
+        """All 5 memory_* tool names must appear in the schema list."""
+        schemas = engine.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        memory_expected = {"memory_search", "memory_pin", "memory_expand",
+                           "memory_forget", "memory_reason"}
+        assert memory_expected.issubset(names), (
+            f"Missing memory_* tools: {memory_expected - names}"
+        )
+
+    def test_schemas_have_required_fields(self, engine):
+        """Every schema must have name, description, and parameters."""
+        for schema in engine.get_tool_schemas():
+            assert "name" in schema, f"Schema missing 'name': {schema}"
+            assert "description" in schema, f"Schema {schema['name']} missing 'description'"
+            assert "parameters" in schema, f"Schema {schema['name']} missing 'parameters'"
+
+    def test_no_duplicate_names(self, engine):
+        """Tool names must be unique — no double-exposure from merging."""
+        schemas = engine.get_tool_schemas()
+        names = [s["name"] for s in schemas]
+        assert len(names) == len(set(names)), (
+            f"Duplicate tool names in schema list: {[n for n in names if names.count(n) > 1]}"
+        )
+
+
+class TestHandleToolCallMemory:
+    def test_memory_search_dispatches_without_error(self, engine):
+        """handle_tool_call('memory_search', ...) must not return 'Unknown LCM tool'."""
+        result = engine.handle_tool_call("memory_search", {"query": "France"})
+        # Should be valid JSON or a plain string result — not an "unknown tool" error
+        assert "Unknown LCM tool" not in result, (
+            f"memory_search was not dispatched: {result}"
+        )
+
+    def test_memory_search_returns_string(self, engine):
+        """handle_tool_call result must be a non-empty string."""
+        result = engine.handle_tool_call("memory_search", {"query": "Python"})
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_memory_search_no_results_is_not_error(self, engine):
+        """A query with no results must return a graceful message, not an exception."""
+        result = engine.handle_tool_call("memory_search", {"query": "nonexistent topic xyz"})
+        assert isinstance(result, str)
+        # Should not contain exception traceback markers
+        assert "Traceback" not in result
+        assert "Error" not in result or "No results" in result
+
+    def test_unknown_tool_returns_error_json(self, engine):
+        """A truly unknown tool must still return the 'Unknown LCM tool' error."""
+        result = engine.handle_tool_call("nonexistent_tool", {})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_lcm_tool_still_works_after_memory_integration(self, engine):
+        """Existing lcm_search must still work after the memory_* merge."""
+        result = engine.handle_tool_call("lcm_search", {"query": "Python"})
+        assert isinstance(result, str)
+        assert "Unknown LCM tool" not in result

--- a/tests/plugins/context_engine/lcm/test_lcm_memory_tools.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_memory_tools.py
@@ -99,3 +99,85 @@ class TestHandleToolCallMemory:
         result = engine.handle_tool_call("lcm_search", {"query": "Python"})
         assert isinstance(result, str)
         assert "Unknown LCM tool" not in result
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — source="memory" must not fall back to session store
+# ---------------------------------------------------------------------------
+
+class TestMemorySearchSourceGating:
+    """memory_search(source='memory') must not return session messages even when
+    HRR has no matches.  Only source='auto' (and source='session') may fall
+    back to the in-session keyword scan."""
+
+    @pytest.fixture
+    def engine_no_hrr(self):
+        """Engine with known session content and HRR store explicitly cleared.
+
+        Clearing hrr_store forces the handler to skip Layer 2 (HRR) so the only
+        way results can appear for a memory-only query is through the forbidden
+        Layer 3 session keyword fallback.
+        """
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        e = LcmContextEngine(lcm_config=config)
+        # Load distinctive session messages so the keyword fallback WOULD find them.
+        e.compress([
+            {"role": "user", "content": "Tell me about the UNIQUE_SESSION_KEYWORD concept."},
+            {"role": "assistant", "content": "UNIQUE_SESSION_KEYWORD is a test marker."},
+        ])
+        # Detach the HRR store so Layer 2 is skipped for all sources.
+        e._engine.hrr_store = None
+        return e
+
+    def test_source_memory_does_not_return_session_content(self, engine_no_hrr):
+        """With source='memory' and empty HRR, results must not include session messages.
+
+        The only allowed output is the "no results" sentinel string — session
+        role/content strings like "test marker" must not appear.
+        """
+        from plugins.context_engine.lcm.hrr.tools import handle_memory_search
+        from plugins.context_engine.lcm.tools import set_engine
+
+        set_engine(engine_no_hrr._engine)
+        try:
+            result = handle_memory_search({"query": "UNIQUE_SESSION_KEYWORD", "source": "memory"})
+        finally:
+            set_engine(None)
+
+        # The keyword fallback must NOT have fired; session-specific content
+        # like "test marker" or "[Session msg#" indicators must be absent.
+        assert "test marker" not in result, (
+            f"source='memory' returned session-specific content:\n{result}"
+        )
+        assert "[Session msg#" not in result, (
+            f"source='memory' returned DAM/session results:\n{result}"
+        )
+
+    def test_source_auto_can_return_session_content(self, engine_no_hrr):
+        """With source='auto', the keyword fallback fires and may return session messages."""
+        from plugins.context_engine.lcm.hrr.tools import handle_memory_search
+        from plugins.context_engine.lcm.tools import set_engine
+
+        set_engine(engine_no_hrr._engine)
+        try:
+            result = handle_memory_search({"query": "UNIQUE_SESSION_KEYWORD", "source": "auto"})
+        finally:
+            set_engine(None)
+
+        # The fallback fires; result should contain something (may vary by impl).
+        assert isinstance(result, str)
+        # We don't assert the exact content — just that session lookup was attempted.
+
+    def test_source_session_can_use_dam_layer(self, engine_no_hrr):
+        """source='session' uses the DAM layer (not just keyword fallback)."""
+        from plugins.context_engine.lcm.hrr.tools import handle_memory_search
+        from plugins.context_engine.lcm.tools import set_engine
+
+        set_engine(engine_no_hrr._engine)
+        try:
+            result = handle_memory_search({"query": "UNIQUE_SESSION_KEYWORD", "source": "session"})
+        finally:
+            set_engine(None)
+
+        assert isinstance(result, str)
+        # No error — DAM or fallback handled it without raising.

--- a/tests/plugins/context_engine/lcm/test_lcm_resume.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_resume.py
@@ -266,3 +266,92 @@ class TestRawIdPreservationAfterFocus:
         assert rebuilt.active[1].kind == "raw"
         assert rebuilt.active[1].msg_id == 3
         assert rebuilt.active[2].msg_id == 4
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — preserve _ingested_count across compression-rollover boundaries
+# ---------------------------------------------------------------------------
+
+class TestCompressionRolloverPreservesIngestedCount:
+    """on_session_start with boundary_reason='compression' must NOT reset
+    _ingested_count — the engine state already covers those messages."""
+
+    def test_compression_rollover_preserves_ingested_count(self):
+        """boundary_reason='compression' + no save file → _ingested_count unchanged."""
+        import tempfile
+        config = LcmConfig(enabled=True)
+        outer = LcmContextEngine(lcm_config=config)
+        msgs = _make_messages(100)
+        outer.compress(msgs)
+        assert outer._ingested_count == 100
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # new_session_id has no save file — simulate compression rollover
+            outer.on_session_start(
+                "new-session-after-compression",
+                hermes_home=tmpdir,
+                boundary_reason="compression",
+            )
+
+        assert outer._ingested_count == 100, (
+            f"_ingested_count={outer._ingested_count} — "
+            "should be preserved (100) across compression rollover"
+        )
+
+    def test_initial_session_start_resets_ingested_count(self):
+        """boundary_reason='initial' + no save file → _ingested_count reset to 0."""
+        import tempfile
+        config = LcmConfig(enabled=True)
+        outer = LcmContextEngine(lcm_config=config)
+        outer._ingested_count = 50  # simulate prior state
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outer.on_session_start(
+                "brand-new-session",
+                hermes_home=tmpdir,
+                boundary_reason="initial",
+            )
+
+        assert outer._ingested_count == 0, (
+            f"_ingested_count={outer._ingested_count} — "
+            "should be 0 for a brand-new session"
+        )
+
+    def test_no_boundary_reason_resets_ingested_count(self):
+        """Default (no boundary_reason kwarg) + no save file → _ingested_count=0."""
+        import tempfile
+        config = LcmConfig(enabled=True)
+        outer = LcmContextEngine(lcm_config=config)
+        outer._ingested_count = 50
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outer.on_session_start("another-new-session", hermes_home=tmpdir)
+
+        assert outer._ingested_count == 0, (
+            f"_ingested_count={outer._ingested_count} — "
+            "should be 0 when no boundary_reason is provided"
+        )
+
+    def test_compression_rollover_engine_state_unchanged(self):
+        """After compression rollover, engine's active list and store are intact."""
+        import tempfile
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        outer = LcmContextEngine(lcm_config=config)
+        msgs = _make_messages(20)
+        outer.compress(msgs)
+        store_size_before = len(outer._engine.store)
+        active_size_before = len(outer._engine.active)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outer.on_session_start(
+                "rolled-over-session",
+                hermes_home=tmpdir,
+                boundary_reason="compression",
+            )
+
+        assert len(outer._engine.store) == store_size_before, (
+            "Engine store was reset during compression rollover"
+        )
+        assert len(outer._engine.active) == active_size_before, (
+            "Engine active list was reset during compression rollover"
+        )

--- a/tests/plugins/context_engine/lcm/test_lcm_resume.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_resume.py
@@ -1,0 +1,170 @@
+"""Regression tests for LCM session resume / _ingested_count correctness.
+
+Fix A: _ingested_count must track input-message count, not active-entry count.
+Fix B: raw message ids must be preserved across save/rebuild when active list
+       contains non-contiguous raw entries (e.g. after lcm_focus).
+"""
+from __future__ import annotations
+
+import pytest
+
+from plugins.context_engine.lcm.engine import LcmEngine, ContextEntry
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.__init__ import LcmContextEngine
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_messages(n: int) -> list[dict]:
+    """Return n simple alternating user/assistant messages."""
+    msgs = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append({"role": role, "content": f"msg {i}"})
+    return msgs
+
+
+def _build_session_data(engine: LcmEngine) -> dict:
+    """Build a minimal session_data dict from a live engine (mimics on_session_end).
+
+    Uses active_messages_for_session() so raw entries carry _lcm_raw_id, exactly
+    as the real persistence layer does.
+    """
+    lcm_meta = engine.to_session_metadata()
+    # Use annotated messages so _lcm_raw_id is preserved across rebuild
+    active_msgs = engine.active_messages_for_session()
+    return {"messages": active_msgs, "lcm": lcm_meta}
+
+
+# ---------------------------------------------------------------------------
+# Fix A — _ingested_count across session rotation
+# ---------------------------------------------------------------------------
+
+class TestIngestedCountAfterRebuild:
+    """_ingested_count should equal the number of *input* messages that were
+    originally fed into the engine, not the active-list length."""
+
+    def test_rebuild_sets_ingested_count_to_original_message_count(self):
+        """After rebuild from disk, _ingested_count == len(original_messages)."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        outer = LcmContextEngine(lcm_config=config)
+
+        messages = _make_messages(100)
+        outer.compress(messages)
+        # Manually run a compaction to shrink the active list so active != 100
+        block = outer._engine.find_compactable_block()
+        if block:
+            outer._engine.compact("summary text", level=1, block_start=block[0], block_end=block[1])
+
+        active_after_compact = len(outer._engine.active)
+        assert active_after_compact < 100, "Need compaction to have fired for this test to be meaningful"
+
+        # Build session_data as on_session_end would
+        session_data = _build_session_data(outer._engine)
+
+        # Create a new engine instance and call on_session_start with the persisted data
+        import json, tempfile, pathlib
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "test-session-abc"
+            session_file = pathlib.Path(tmpdir) / "sessions" / f"session_{session_id}.json"
+            session_file.parent.mkdir(parents=True)
+            session_file.write_text(json.dumps(session_data), encoding="utf-8")
+
+            new_outer = LcmContextEngine(lcm_config=config)
+            new_outer.on_session_start(session_id, hermes_home=tmpdir)
+
+        # _ingested_count must equal len(original_messages) saved in lcm metadata
+        expected = len(session_data["lcm"]["original_messages"])
+        assert new_outer._ingested_count == expected, (
+            f"_ingested_count={new_outer._ingested_count} != "
+            f"len(original_messages)={expected} — cursor wrongly rebased on active list"
+        )
+
+    def test_no_saved_file_ingested_count_is_zero(self):
+        """Fresh session_start with no save file resets _ingested_count to 0."""
+        import tempfile
+        config = LcmConfig(enabled=True)
+        outer = LcmContextEngine(lcm_config=config)
+        # Simulate already having ingested some messages
+        outer._ingested_count = 50
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outer.on_session_start("nonexistent-session", hermes_home=tmpdir)
+
+        assert outer._ingested_count == 0, (
+            f"_ingested_count={outer._ingested_count} should be 0 for fresh session"
+        )
+
+    def test_no_new_messages_ingested_after_rebuild(self):
+        """After rebuild, calling compress() with the same 100 messages must not
+        ingest any new messages (store size must remain unchanged)."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        outer = LcmContextEngine(lcm_config=config)
+
+        messages = _make_messages(100)
+        outer.compress(messages)
+        block = outer._engine.find_compactable_block()
+        if block:
+            outer._engine.compact("summary text", level=1, block_start=block[0], block_end=block[1])
+
+        session_data = _build_session_data(outer._engine)
+        store_size_before_rebuild = len(outer._engine.store)
+
+        import json, tempfile, pathlib
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "test-no-reingest"
+            session_file = pathlib.Path(tmpdir) / "sessions" / f"session_{session_id}.json"
+            session_file.parent.mkdir(parents=True)
+            session_file.write_text(json.dumps(session_data), encoding="utf-8")
+
+            new_outer = LcmContextEngine(lcm_config=config)
+            new_outer.on_session_start(session_id, hermes_home=tmpdir)
+
+        # Calling compress with the same 100 messages must not add anything to store
+        new_outer.compress(messages)
+        store_size_after = len(new_outer._engine.store)
+
+        assert store_size_after == store_size_before_rebuild, (
+            f"store grew from {store_size_before_rebuild} to {store_size_after} — "
+            "messages were re-ingested after rebuild"
+        )
+
+    def test_new_messages_after_rebuild_are_ingested(self):
+        """After rebuild with 100 messages, compress with 110 ingests exactly 10 new."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        outer = LcmContextEngine(lcm_config=config)
+
+        messages = _make_messages(100)
+        outer.compress(messages)
+        block = outer._engine.find_compactable_block()
+        if block:
+            outer._engine.compact("summary text", level=1, block_start=block[0], block_end=block[1])
+
+        session_data = _build_session_data(outer._engine)
+        store_size_at_save = len(outer._engine.store)
+
+        import json, tempfile, pathlib
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "test-new-msgs"
+            session_file = pathlib.Path(tmpdir) / "sessions" / f"session_{session_id}.json"
+            session_file.parent.mkdir(parents=True)
+            session_file.write_text(json.dumps(session_data), encoding="utf-8")
+
+            new_outer = LcmContextEngine(lcm_config=config)
+            new_outer.on_session_start(session_id, hermes_home=tmpdir)
+
+        messages_110 = _make_messages(110)
+        new_outer.compress(messages_110)
+
+        store_size_after = len(new_outer._engine.store)
+        assert store_size_after == store_size_at_save + 10, (
+            f"Expected {store_size_at_save + 10} store entries, got {store_size_after}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix B — preserve raw message ids across save/rebuild after lcm_focus
+# ---------------------------------------------------------------------------
+

--- a/tests/plugins/context_engine/lcm/test_lcm_resume.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_resume.py
@@ -168,3 +168,101 @@ class TestIngestedCountAfterRebuild:
 # Fix B — preserve raw message ids across save/rebuild after lcm_focus
 # ---------------------------------------------------------------------------
 
+class TestRawIdPreservationAfterFocus:
+    """Raw message ids must survive serialization even when active is non-contiguous
+    (i.e. after focus_summary splices original raw entries back into active)."""
+
+    def _build_focused_engine(self) -> LcmEngine:
+        """Build an engine where active[5].msg_id == 5 after focus."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        engine = LcmEngine(config)
+        # Ingest 51 messages
+        for i in range(51):
+            role = "user" if i % 2 == 0 else "assistant"
+            engine.ingest({"role": role, "content": f"msg {i}"})
+
+        # Compact messages [0..20] into a summary
+        block = engine.find_compactable_block()
+        assert block is not None, "Expected a compactable block"
+        node = engine.compact("summary of early msgs", level=1, block_start=block[0], block_end=block[1])
+
+        # Expand the summary back (focus) — this makes active non-contiguous
+        ok = engine.focus_summary(node.id)
+        assert ok, "focus_summary should succeed"
+
+        return engine
+
+    def test_focused_engine_msg_ids_match_store_positions(self):
+        """After focus_summary, each raw entry's msg_id must match its store index."""
+        engine = self._build_focused_engine()
+        for entry in engine.active:
+            if entry.kind == "raw":
+                assert entry.msg_id is not None
+                msg = engine.store.get(entry.msg_id)
+                assert msg is not None, f"msg_id {entry.msg_id} not found in store"
+                # The message content must match
+                assert entry.message["content"] == msg["content"]
+
+    def test_active_position_5_msg_id_preserved_after_rebuild(self):
+        """After save+rebuild, engine.active[5].msg_id equals the original id."""
+        engine = self._build_focused_engine()
+
+        # Record the msg_id at position 5 before serialization
+        original_msg_id = engine.active[5].msg_id
+        assert original_msg_id is not None
+
+        session_data = _build_session_data(engine)
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        rebuilt = LcmEngine.rebuild_from_session(session_data, config)
+
+        assert rebuilt.active[5].msg_id == original_msg_id, (
+            f"msg_id at position 5 changed from {original_msg_id} "
+            f"to {rebuilt.active[5].msg_id} after rebuild"
+        )
+
+    def test_lcm_pin_after_rebuild_affects_correct_store_row(self):
+        """pin() on active[5] after rebuild must mark the same store id
+        that was originally at position 5, not a reassigned one."""
+        engine = self._build_focused_engine()
+        original_msg_id_5 = engine.active[5].msg_id
+        assert original_msg_id_5 is not None
+
+        session_data = _build_session_data(engine)
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        rebuilt = LcmEngine.rebuild_from_session(session_data, config)
+
+        rebuilt.pin([rebuilt.active[5].msg_id])
+        assert original_msg_id_5 in rebuilt._pinned_ids, (
+            f"Pinned msg_id {rebuilt.active[5].msg_id} but original was {original_msg_id_5}"
+        )
+
+    def test_rebuild_without_lcm_raw_id_falls_back_gracefully(self):
+        """Sessions saved WITHOUT _lcm_raw_id (legacy) still rebuild correctly
+        for the simple contiguous-suffix case."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        # Build a fresh session_data without any _lcm_raw_id keys
+        original_messages = [
+            {"role": "user", "content": f"msg {i}"}
+            for i in range(5)
+        ]
+        # active messages: 1 summary + 2 raw (no _lcm_raw_id keys)
+        active_messages = [
+            {"role": "user", "content": "[Summary]", "_lcm_summary": True, "_lcm_node_id": 0},
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+        ]
+        summaries = [
+            {"node_id": 0, "source_ids": [0, 1, 2], "text": "Early msgs", "level": 1, "tokens": 30}
+        ]
+        session_data = {
+            "messages": active_messages,
+            "lcm": {
+                "summaries": summaries,
+                "original_messages": original_messages,
+            }
+        }
+        rebuilt = LcmEngine.rebuild_from_session(session_data, config)
+        # Raw entries [1] and [2] map to store positions 3 and 4 (suffix fallback)
+        assert rebuilt.active[1].kind == "raw"
+        assert rebuilt.active[1].msg_id == 3
+        assert rebuilt.active[2].msg_id == 4

--- a/tests/plugins/context_engine/lcm/test_lcm_resume.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_resume.py
@@ -446,3 +446,126 @@ class TestHrrAndDamReattachedAfterRebuild:
         outer = LcmContextEngine(lcm_config=config)
         assert hasattr(outer._engine, "hrr_store") and outer._engine.hrr_store is not None
         assert hasattr(outer._engine, "retriever") and outer._engine.retriever is not None
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — legacy session files must seed _ingested_count from store size
+# ---------------------------------------------------------------------------
+
+class TestLegacySessionIngestedCount:
+    """When a session file has no lcm.original_messages (legacy format), the
+    rebuilt engine's store is populated from active raw messages.  _ingested_count
+    must be seeded from that store size so the next compress() call with the same
+    messages does NOT re-ingest them.
+
+    Without the fix: _ingested_count = 0, so compress() sees len(messages) - 0 = N
+    "new" messages and re-ingests everything, duplicating the store.
+    """
+
+    def _make_legacy_session_data(self, n: int) -> dict:
+        """Build a legacy-format session_data with n raw messages and no
+        lcm.original_messages key (or an empty list for it)."""
+        messages = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(n)
+        ]
+        # Legacy format: lcm block present but no original_messages
+        return {
+            "messages": messages,
+            "lcm": {
+                "summaries": [],
+                # Deliberately omit "original_messages" to simulate a legacy file
+            },
+        }
+
+    def test_ingested_count_seeded_from_store_for_legacy_session(self):
+        """After resuming a legacy session with 50 messages, _ingested_count==50."""
+        import json
+        import pathlib
+        import tempfile
+
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        session_data = self._make_legacy_session_data(50)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "legacy-seed-count"
+            session_file = (
+                pathlib.Path(tmpdir) / "sessions" / f"session_{session_id}.json"
+            )
+            session_file.parent.mkdir(parents=True, exist_ok=True)
+            session_file.write_text(json.dumps(session_data), encoding="utf-8")
+
+            outer = LcmContextEngine(lcm_config=config)
+            outer.on_session_start(session_id, hermes_home=tmpdir)
+
+        assert outer._ingested_count == 50, (
+            f"_ingested_count={outer._ingested_count} but expected 50 for legacy "
+            "session with 50 messages — cursor not seeded from store size"
+        )
+
+    def test_compress_does_not_reingest_after_legacy_resume(self):
+        """After legacy resume, compress(same_50_msgs) must not grow the store."""
+        import json
+        import pathlib
+        import tempfile
+
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        msgs = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(50)
+        ]
+        session_data = self._make_legacy_session_data(50)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "legacy-no-reingest"
+            session_file = (
+                pathlib.Path(tmpdir) / "sessions" / f"session_{session_id}.json"
+            )
+            session_file.parent.mkdir(parents=True, exist_ok=True)
+            session_file.write_text(json.dumps(session_data), encoding="utf-8")
+
+            outer = LcmContextEngine(lcm_config=config)
+            outer.on_session_start(session_id, hermes_home=tmpdir)
+
+        store_size_after_resume = len(outer._engine.store)
+        # Calling compress with the same 50 messages must not add anything
+        outer.compress(msgs)
+        store_size_after_compress = len(outer._engine.store)
+
+        assert store_size_after_compress == store_size_after_resume, (
+            f"Store grew from {store_size_after_resume} to {store_size_after_compress} "
+            "after compress() — legacy session messages were re-ingested"
+        )
+
+    def test_new_messages_after_legacy_resume_are_ingested(self):
+        """After legacy resume with 50 msgs, compress(60 msgs) ingests exactly 10."""
+        import json
+        import pathlib
+        import tempfile
+
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        session_data = self._make_legacy_session_data(50)
+        msgs_60 = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(60)
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "legacy-new-msgs"
+            session_file = (
+                pathlib.Path(tmpdir) / "sessions" / f"session_{session_id}.json"
+            )
+            session_file.parent.mkdir(parents=True, exist_ok=True)
+            session_file.write_text(json.dumps(session_data), encoding="utf-8")
+
+            outer = LcmContextEngine(lcm_config=config)
+            outer.on_session_start(session_id, hermes_home=tmpdir)
+
+        store_after_resume = len(outer._engine.store)
+        outer.compress(msgs_60)
+        store_after_compress = len(outer._engine.store)
+
+        assert store_after_compress == store_after_resume + 10, (
+            f"Expected {store_after_resume + 10} store entries after adding 10 new "
+            f"messages, got {store_after_compress}"
+        )

--- a/tests/plugins/context_engine/lcm/test_lcm_resume.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_resume.py
@@ -3,6 +3,10 @@
 Fix A: _ingested_count must track input-message count, not active-entry count.
 Fix B: raw message ids must be preserved across save/rebuild when active list
        contains non-contiguous raw entries (e.g. after lcm_focus).
+Fix 1: HRR store and DAM retriever must be re-attached after engine rebuild so
+       resumed sessions retain L2/L3 memory layers.
+Fix 3: Legacy session files (no lcm.original_messages) must seed _ingested_count
+       from store size to prevent re-ingestion on next compress() call.
 """
 from __future__ import annotations
 
@@ -355,3 +359,90 @@ class TestCompressionRolloverPreservesIngestedCount:
         assert len(outer._engine.active) == active_size_before, (
             "Engine active list was reset during compression rollover"
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — HRR store and DAM retriever must survive engine rebuild
+# ---------------------------------------------------------------------------
+
+class TestHrrAndDamReattachedAfterRebuild:
+    """After on_session_start() rebuilds the engine from a session file, the fresh
+    LcmEngine instance must have hrr_store (L3) and retriever (L2) re-attached.
+
+    Without the fix, rebuild_from_session() returns a plain LcmEngine with no
+    hrr_store / retriever, so all cross-session and per-session memory is lost.
+    """
+
+    def _save_and_reload(self, messages_n: int, tmpdir: str, session_id: str):
+        """Helper: build engine, compress messages, save, reload via on_session_start."""
+        import json
+        import pathlib
+
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        outer = LcmContextEngine(lcm_config=config)
+        msgs = _make_messages(messages_n)
+        outer.compress(msgs)
+
+        session_data = _build_session_data(outer._engine)
+        session_file = (
+            pathlib.Path(tmpdir) / "sessions" / f"session_{session_id}.json"
+        )
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text(json.dumps(session_data), encoding="utf-8")
+
+        new_outer = LcmContextEngine(lcm_config=config)
+        new_outer.on_session_start(session_id, hermes_home=tmpdir)
+        return new_outer
+
+    def test_hrr_store_reattached_after_rebuild(self):
+        """engine._engine.hrr_store must not be None after session resume."""
+        import tempfile
+
+        # Only meaningful when HRR sub-package is available; skip otherwise
+        try:
+            from plugins.context_engine.lcm.hrr.store import MemoryStore as _M
+        except (ImportError, Exception):
+            pytest.skip("HRR sub-package not installed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_outer = self._save_and_reload(20, tmpdir, "session-hrr-reattach")
+
+        assert hasattr(new_outer._engine, "hrr_store"), (
+            "engine._engine has no hrr_store attribute after rebuild"
+        )
+        assert new_outer._engine.hrr_store is not None, (
+            "engine._engine.hrr_store is None after rebuild — HRR store was dropped"
+        )
+
+    def test_dam_retriever_reattached_after_rebuild(self):
+        """engine._engine.retriever must not be None after session resume."""
+        import tempfile
+
+        # Only meaningful when DAM sub-package is available; skip otherwise
+        try:
+            from plugins.context_engine.lcm.dam import DAMRetriever as _D
+        except (ImportError, Exception):
+            pytest.skip("DAM sub-package not installed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_outer = self._save_and_reload(20, tmpdir, "session-dam-reattach")
+
+        assert hasattr(new_outer._engine, "retriever"), (
+            "engine._engine has no retriever attribute after rebuild"
+        )
+        assert new_outer._engine.retriever is not None, (
+            "engine._engine.retriever is None after rebuild — DAM retriever was dropped"
+        )
+
+    def test_fresh_session_no_file_still_has_hrr_and_dam(self):
+        """Baseline: a brand-new engine (no session file) has hrr_store and retriever."""
+        try:
+            from plugins.context_engine.lcm.hrr.store import MemoryStore as _M
+            from plugins.context_engine.lcm.dam import DAMRetriever as _D
+        except (ImportError, Exception):
+            pytest.skip("HRR or DAM sub-package not installed")
+
+        config = LcmConfig(enabled=True)
+        outer = LcmContextEngine(lcm_config=config)
+        assert hasattr(outer._engine, "hrr_store") and outer._engine.hrr_store is not None
+        assert hasattr(outer._engine, "retriever") and outer._engine.retriever is not None

--- a/tests/plugins/context_engine/lcm/test_lcm_resume.py
+++ b/tests/plugins/context_engine/lcm/test_lcm_resume.py
@@ -569,3 +569,84 @@ class TestLegacySessionIngestedCount:
             f"Expected {store_after_resume + 10} store entries after adding 10 new "
             f"messages, got {store_after_compress}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — _ingested_count aligned to compacted output after compress()
+# ---------------------------------------------------------------------------
+
+class TestIngestedCountAfterCompaction:
+    """After compress() triggers compaction, _ingested_count must equal the
+    length of the *returned* (compacted) list, not the original input length.
+
+    If the cursor stays at the original input length, the next compress() call
+    computes new_count = len(new_messages) - old_ingested_count, which can be
+    negative, silently skipping fresh turns.
+    """
+
+    def _make_compacting_engine(self) -> "LcmContextEngine":
+        """Return an engine that will compact when given ~100 simple messages."""
+        from unittest.mock import MagicMock
+        config = LcmConfig(
+            enabled=True,
+            tau_soft=0.30,
+            tau_hard=0.60,
+            protect_last_n=4,
+        )
+        outer = LcmContextEngine(lcm_config=config)
+        # Very short context so compaction fires with few messages.
+        outer.context_length = 400
+        outer._engine.token_estimator.config.context_length = 400
+        outer._engine.config = config
+        outer._engine.summarizer.summarize = MagicMock(return_value="MOCK SUMMARY")
+        return outer
+
+    def test_ingested_count_equals_returned_length_after_compaction(self):
+        """_ingested_count == len(result) when compaction fires."""
+        outer = self._make_compacting_engine()
+        # Feed enough messages to trigger auto_compact (blocking path).
+        messages = _make_messages(100)
+        result = outer.compress(messages)
+
+        # Compaction must have fired and shrunk the list.
+        assert len(result) < len(messages), (
+            "Expected compaction to shrink the list — increase message count or "
+            "reduce context_length if this assertion fails."
+        )
+        assert outer._ingested_count == len(result), (
+            f"_ingested_count={outer._ingested_count} but len(result)={len(result)}; "
+            "cursor should track the compacted output length, not the original input"
+        )
+
+    def test_next_compress_ingests_new_turns_after_compaction(self):
+        """After compaction, appending 3 messages and calling compress() must
+        ingest exactly 3 new messages into the store."""
+        outer = self._make_compacting_engine()
+        messages = _make_messages(100)
+        result = outer.compress(messages)
+        store_size_after_first = len(outer._engine.store)
+
+        # Append 3 new messages to the compacted result.
+        new_messages = result + [
+            {"role": "user", "content": "new turn A"},
+            {"role": "assistant", "content": "response A"},
+            {"role": "user", "content": "new turn B"},
+        ]
+        outer.compress(new_messages)
+        store_size_after_second = len(outer._engine.store)
+
+        assert store_size_after_second == store_size_after_first + 3, (
+            f"Expected store to grow by 3 (new turns), but grew by "
+            f"{store_size_after_second - store_size_after_first}; "
+            "new turns were skipped or double-counted"
+        )
+
+    def test_no_compaction_cursor_unchanged(self):
+        """When compaction does NOT fire, _ingested_count == len(messages)."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        outer = LcmContextEngine(lcm_config=config)
+        messages = _make_messages(3)  # Far below any threshold
+        outer.compress(messages)
+        assert outer._ingested_count == 3, (
+            f"_ingested_count={outer._ingested_count}, expected 3 when no compaction"
+        )

--- a/tests/plugins/context_engine/lcm/test_persistence.py
+++ b/tests/plugins/context_engine/lcm/test_persistence.py
@@ -1,0 +1,76 @@
+"""Tests for LCM session persistence."""
+import json
+import pytest
+from plugins.context_engine.lcm.engine import LcmEngine, ContextEntry
+from plugins.context_engine.lcm.config import LcmConfig
+
+
+@pytest.fixture
+def config():
+    return LcmConfig(enabled=True, protect_last_n=2)
+
+
+class TestSessionSerialization:
+    def test_serialize_lcm_metadata(self, config):
+        """Engine state should be serializable to a dict for session JSON."""
+        engine = LcmEngine(config)
+        for i in range(6):
+            engine.ingest({"role": "user" if i % 2 == 0 else "assistant",
+                           "content": f"Message {i}"})
+
+        block = engine.find_compactable_block()
+        engine.compact("Test summary", level=1, block_start=block[0], block_end=block[1])
+
+        metadata = engine.to_session_metadata()
+
+        assert "summaries" in metadata
+        assert "original_messages" in metadata
+        assert "store_size" in metadata
+        assert "pinned" in metadata
+        assert len(metadata["summaries"]) == 1
+        assert metadata["store_size"] == 6
+        # Should be JSON serializable
+        json.dumps(metadata)
+
+    def test_round_trip(self, config):
+        """Serialize then rebuild should produce equivalent state."""
+        engine = LcmEngine(config)
+        for i in range(6):
+            engine.ingest({"role": "user" if i % 2 == 0 else "assistant",
+                           "content": f"Message {i}"})
+        block = engine.find_compactable_block()
+        engine.compact("Summary text", level=1, block_start=block[0], block_end=block[1])
+
+        # Serialize
+        metadata = engine.to_session_metadata()
+        messages = engine.active_messages()
+
+        # Mark summary messages
+        for i, entry in enumerate(engine.active):
+            if entry.kind == "summary":
+                messages[i]["_lcm_summary"] = True
+                messages[i]["_lcm_node_id"] = entry.node_id
+
+        # Rebuild
+        session_data = {"messages": messages, "lcm": metadata}
+        rebuilt = LcmEngine.rebuild_from_session(session_data, config)
+
+        assert len(rebuilt.dag) == len(engine.dag)
+        assert len(rebuilt.active) == len(engine.active)
+        # Store should have all originals
+        assert len(rebuilt.store) >= len(engine.store)
+
+    def test_empty_engine_serializes(self, config):
+        """An engine with no messages should serialize cleanly."""
+        engine = LcmEngine(config)
+        metadata = engine.to_session_metadata()
+        assert metadata["summaries"] == []
+        assert metadata["store_size"] == 0
+
+    def test_pinned_ids_serialized(self, config):
+        """Pinned message IDs should be included in metadata."""
+        engine = LcmEngine(config)
+        engine.ingest({"role": "user", "content": "important"})
+        engine._pinned_ids.add(0)
+        metadata = engine.to_session_metadata()
+        assert 0 in metadata["pinned"]

--- a/tests/plugins/context_engine/lcm/test_rebuild.py
+++ b/tests/plugins/context_engine/lcm/test_rebuild.py
@@ -1,0 +1,121 @@
+"""Tests for LCM session rebuild."""
+import pytest
+from plugins.context_engine.lcm.engine import LcmEngine, ContextEntry
+from plugins.context_engine.lcm.config import LcmConfig
+
+
+@pytest.fixture
+def config():
+    return LcmConfig(enabled=True)
+
+
+class TestRebuildFromSession:
+    def test_empty_session(self, config):
+        session_data = {"messages": [], "lcm": {"summaries": [], "store_size": 0}}
+        engine = LcmEngine.rebuild_from_session(session_data, config)
+        assert len(engine.store) == 0
+        assert len(engine.active) == 0
+        assert len(engine.dag) == 0
+
+    def test_raw_messages_only(self, config):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "how are you"},
+        ]
+        session_data = {"messages": messages}
+        engine = LcmEngine.rebuild_from_session(session_data, config)
+        assert len(engine.store) == 3
+        assert len(engine.active) == 3
+        assert all(e.kind == "raw" for e in engine.active)
+        assert engine.active_messages() == messages
+
+    def test_with_summaries(self, config):
+        messages = [
+            {"role": "user", "content": "[Summary of 3 messages]", "_lcm_summary": True, "_lcm_node_id": 0},
+            {"role": "user", "content": "recent message 1"},
+            {"role": "assistant", "content": "recent reply 1"},
+        ]
+        summaries = [
+            {"node_id": 0, "source_ids": [0, 1, 2], "text": "Earlier conversation", "level": 1, "tokens": 50}
+        ]
+        session_data = {
+            "messages": messages,
+            "lcm": {"summaries": summaries, "store_size": 5}
+        }
+        engine = LcmEngine.rebuild_from_session(session_data, config)
+        # Should have 3 active entries: 1 summary + 2 raw
+        assert len(engine.active) == 3
+        assert engine.active[0].kind == "summary"
+        assert engine.active[0].node_id == 0
+        assert engine.active[1].kind == "raw"
+        assert engine.active[2].kind == "raw"
+        # DAG should have the summary node
+        assert len(engine.dag) == 1
+
+    def test_preserves_dag_structure(self, config):
+        """Multi-level summaries should reconstruct the DAG correctly."""
+        summaries = [
+            {"node_id": 0, "source_ids": [0, 1], "text": "First summary", "level": 1, "tokens": 30},
+            {"node_id": 1, "source_ids": [2, 3], "text": "Second summary", "level": 1, "tokens": 30},
+            {"node_id": 2, "source_ids": [], "text": "Merged summary", "level": 2, "tokens": 20,
+             "child_summaries": [0, 1]},
+        ]
+        messages = [
+            {"role": "user", "content": "[Merged summary]", "_lcm_summary": True, "_lcm_node_id": 2},
+            {"role": "user", "content": "latest"},
+        ]
+        session_data = {
+            "messages": messages,
+            "lcm": {"summaries": summaries, "store_size": 6}
+        }
+        engine = LcmEngine.rebuild_from_session(session_data, config)
+        assert len(engine.dag) == 3
+        # The merged node should reference children
+        merged = engine.dag.get(2)
+        assert merged is not None
+        assert merged.child_summaries == [0, 1]
+        # all_source_ids should recursively resolve
+        all_ids = engine.dag.all_source_ids(2)
+        assert sorted(all_ids) == [0, 1, 2, 3]
+
+    def test_missing_lcm_key_treats_as_legacy(self, config):
+        """Session without 'lcm' key should load as all-raw."""
+        messages = [
+            {"role": "user", "content": "old message"},
+            {"role": "assistant", "content": "old reply"},
+        ]
+        session_data = {"messages": messages}
+        engine = LcmEngine.rebuild_from_session(session_data, config)
+        assert len(engine.active) == 2
+        assert all(e.kind == "raw" for e in engine.active)
+        assert len(engine.dag) == 0
+
+    def test_rebuild_then_expand(self, config):
+        """After rebuild, expand should still work if store has the messages."""
+        original_messages = [
+            {"role": "user", "content": "msg 0"},
+            {"role": "assistant", "content": "msg 1"},
+            {"role": "user", "content": "msg 2"},
+            {"role": "user", "content": "recent"},
+        ]
+        summaries = [
+            {"node_id": 0, "source_ids": [0, 1, 2], "text": "Earlier chat", "level": 1, "tokens": 30}
+        ]
+        # The session stores ALL original messages (even summarized ones) plus recent
+        session_data = {
+            "messages": [
+                {"role": "user", "content": "[Summary]", "_lcm_summary": True, "_lcm_node_id": 0},
+                {"role": "user", "content": "recent"},
+            ],
+            "lcm": {
+                "summaries": summaries,
+                "store_size": 4,
+                "original_messages": original_messages,  # full store backup
+            }
+        }
+        engine = LcmEngine.rebuild_from_session(session_data, config)
+        # If original_messages are provided, expand should work
+        if len(engine.store) >= 3:
+            result = engine.expand([0, 1, 2])
+            assert len(result) == 3

--- a/tests/plugins/context_engine/lcm/test_refusal.py
+++ b/tests/plugins/context_engine/lcm/test_refusal.py
@@ -1,0 +1,30 @@
+"""Tests for LCM refusal detection."""
+from plugins.context_engine.lcm.refusal import contains_refusal
+
+class TestContainsRefusal:
+    def test_detects_i_cannot(self):
+        assert contains_refusal("I cannot assist with that request.") is True
+
+    def test_detects_as_an_ai(self):
+        assert contains_refusal("As an AI language model, I don't have access to that.") is True
+
+    def test_detects_im_sorry(self):
+        assert contains_refusal("I'm sorry, but I can't help with that.") is True
+
+    def test_detects_unable(self):
+        assert contains_refusal("I'm unable to provide that information.") is True
+
+    def test_detects_against_guidelines(self):
+        assert contains_refusal("That goes against my guidelines.") is True
+
+    def test_passes_clean_summary(self):
+        assert contains_refusal("The user discussed Python async patterns and error handling.") is False
+
+    def test_passes_code_content(self):
+        assert contains_refusal("def calculate_total(items): return sum(i.price for i in items)") is False
+
+    def test_case_insensitive(self):
+        assert contains_refusal("I CANNOT fulfill that request") is True
+
+    def test_empty_string(self):
+        assert contains_refusal("") is False

--- a/tests/plugins/context_engine/lcm/test_store.py
+++ b/tests/plugins/context_engine/lcm/test_store.py
@@ -1,0 +1,50 @@
+from plugins.context_engine.lcm.store import ImmutableStore
+
+
+def test_append_returns_sequential_ids():
+    store = ImmutableStore()
+    id0 = store.append({"role": "user", "content": "hello"})
+    id1 = store.append({"role": "assistant", "content": "hi"})
+    id2 = store.append({"role": "user", "content": "how are you?"})
+    assert id0 == 0
+    assert id1 == 1
+    assert id2 == 2
+
+
+def test_get_valid_id():
+    store = ImmutableStore()
+    store.append({"role": "user", "content": "message zero"})
+    store.append({"role": "assistant", "content": "message one"})
+    msg = store.get(1)
+    assert msg is not None
+    assert msg["content"] == "message one"
+
+
+def test_get_invalid_id():
+    store = ImmutableStore()
+    store.append({"role": "user", "content": "only message"})
+    assert store.get(5) is None
+    assert store.get(-1) is None
+
+
+def test_get_many_mixed():
+    store = ImmutableStore()
+    store.append({"role": "user", "content": "msg0"})
+    store.append({"role": "assistant", "content": "msg1"})
+    store.append({"role": "user", "content": "msg2"})
+    # IDs 0 and 2 are valid; 99 is not
+    results = store.get_many([0, 99, 2])
+    assert len(results) == 2
+    ids = [mid for mid, _ in results]
+    assert 0 in ids
+    assert 2 in ids
+    assert 99 not in ids
+
+
+def test_len():
+    store = ImmutableStore()
+    assert len(store) == 0
+    store.append({"role": "user", "content": "a"})
+    store.append({"role": "user", "content": "b"})
+    store.append({"role": "user", "content": "c"})
+    assert len(store) == 3

--- a/tests/plugins/context_engine/lcm/test_tools.py
+++ b/tests/plugins/context_engine/lcm/test_tools.py
@@ -1,0 +1,169 @@
+"""Tests for LCM agent tools."""
+import pytest
+from plugins.context_engine.lcm.engine import LcmEngine, ContextEntry
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.tools import (
+    handle_lcm_expand, handle_lcm_pin, handle_lcm_forget,
+    handle_lcm_search, handle_lcm_budget, handle_lcm_toc,
+    handle_lcm_focus, set_engine, LCM_TOOL_SCHEMAS,
+)
+
+
+@pytest.fixture
+def engine():
+    config = LcmConfig(enabled=True, protect_last_n=2)
+    e = LcmEngine(config)
+    # Populate with some messages
+    e.ingest({"role": "user", "content": "Tell me about Python async patterns"})
+    e.ingest({"role": "assistant", "content": "Python async uses coroutines with async/await"})
+    e.ingest({"role": "user", "content": "What about error handling in Rust?"})
+    e.ingest({"role": "assistant", "content": "Rust uses Result and Option types for error handling"})
+    e.ingest({"role": "user", "content": "Compare Python and Rust concurrency"})
+    e.ingest({"role": "assistant", "content": "Python has GIL limitations while Rust uses ownership"})
+    set_engine(e)
+    return e
+
+
+class TestToolSchemas:
+    def test_all_schemas_present(self):
+        expected = {"lcm_expand", "lcm_pin", "lcm_forget", "lcm_search", "lcm_budget", "lcm_toc", "lcm_focus"}
+        assert set(LCM_TOOL_SCHEMAS.keys()) == expected
+
+    def test_schemas_have_required_fields(self):
+        for name, schema in LCM_TOOL_SCHEMAS.items():
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+
+
+class TestExpand:
+    def test_returns_original_messages(self, engine):
+        result = handle_lcm_expand({"message_ids": "0,1"})
+        assert "[msg 0]" in result
+        assert "[msg 1]" in result
+        assert "Python async" in result
+
+    def test_invalid_ids(self, engine):
+        result = handle_lcm_expand({"message_ids": "abc"})
+        assert "error" in result.lower() or "invalid" in result.lower()
+
+    def test_no_engine(self):
+        set_engine(None)
+        result = handle_lcm_expand({"message_ids": "0"})
+        assert "not active" in result.lower() or "error" in result.lower()
+
+
+class TestPin:
+    def test_pins_messages(self, engine):
+        result = handle_lcm_pin({"message_ids": "0,1"})
+        assert "pinned" in result.lower()
+        assert 0 in engine._pinned_ids
+        assert 1 in engine._pinned_ids
+
+    def test_pinned_survives_find_compactable(self, engine):
+        handle_lcm_pin({"message_ids": "0"})
+        block = engine.find_compactable_block()
+        if block:
+            start, end = block
+            block_msg_ids = [e.msg_id for e in engine.active[start:end] if e.msg_id is not None]
+            assert 0 not in block_msg_ids
+
+
+class TestForget:
+    def test_forgets_messages(self, engine):
+        original_len = len(engine.active)
+        result = handle_lcm_forget({"message_ids": "0,1", "reason": "debug session done"})
+        assert "compacted" in result.lower() or "forgot" in result.lower()
+        assert len(engine.active) < original_len
+
+
+class TestSearch:
+    def test_finds_matching_messages(self, engine):
+        result = handle_lcm_search({"query": "Rust"})
+        assert "Rust" in result
+        assert "msg" in result.lower()
+
+    def test_no_matches(self, engine):
+        result = handle_lcm_search({"query": "JavaScript"})
+        assert "no match" in result.lower() or len(result.strip()) == 0 or "0 results" in result.lower()
+
+    def test_respects_limit(self, engine):
+        result = handle_lcm_search({"query": "Python", "limit": 1})
+        # Should return at most 1 result
+        lines = [l for l in result.strip().split("\n") if l.startswith("[msg")]
+        assert len(lines) <= 1
+
+
+class TestBudget:
+    def test_shows_usage(self, engine):
+        result = handle_lcm_budget({})
+        assert "token" in result.lower() or "message" in result.lower()
+        assert "raw" in result.lower() or "active" in result.lower()
+
+    def test_shows_summary_count(self, engine):
+        # Compact first to create a summary
+        block = engine.find_compactable_block()
+        if block:
+            engine.compact("Test summary", level=1, block_start=block[0], block_end=block[1])
+        result = handle_lcm_budget({})
+        assert "summar" in result.lower()
+
+
+class TestToc:
+    def test_shows_conversation_map(self, engine):
+        result = handle_lcm_toc({})
+        assert len(result) > 0
+        # Should reference messages
+        assert "msg" in result.lower() or "message" in result.lower()
+
+
+class TestFocus:
+    def test_expands_summary_into_active(self, engine):
+        # Create a summary first
+        block = engine.find_compactable_block()
+        if block:
+            node = engine.compact("Summary of early messages", level=1, block_start=block[0], block_end=block[1])
+            active_before = len(engine.active)
+            result = handle_lcm_focus({"node_id": node.id})
+            # Should expand the summary (more entries now)
+            assert len(engine.active) > active_before or "expanded" in result.lower() or "focus" in result.lower()
+
+
+class TestFocusRecompact:
+    def test_focus_clears_async_pending(self, engine):
+        """After focus expands a summary, async compaction should be re-enabled."""
+        block = engine.find_compactable_block()
+        if block:
+            engine.compact("Summary", level=1, block_start=block[0], block_end=block[1])
+            engine._async_compaction_pending = True  # Simulate pending state
+            handle_lcm_focus({"node_id": 0})
+            assert engine._async_compaction_pending is False
+
+
+class TestPinCap:
+    def test_pin_respects_cap(self, engine):
+        """Pinning beyond max_pinned should be rejected."""
+        engine.config.max_pinned = 3
+        handle_lcm_pin({"message_ids": "0,1,2"})
+        result = handle_lcm_pin({"message_ids": "3"})
+        assert "limit" in result.lower() or "exceed" in result.lower() or "cannot" in result.lower()
+
+    def test_pin_within_cap_succeeds(self, engine):
+        """Pinning within max_pinned should succeed."""
+        engine.config.max_pinned = 5
+        result = handle_lcm_pin({"message_ids": "0,1,2"})
+        assert "pinned" in result.lower()
+        assert 0 in engine._pinned_ids
+        assert 1 in engine._pinned_ids
+        assert 2 in engine._pinned_ids
+
+    def test_pin_exactly_at_cap_succeeds(self, engine):
+        """Pinning exactly up to the cap (but not over) should succeed."""
+        engine.config.max_pinned = 3
+        result = handle_lcm_pin({"message_ids": "0,1,2"})
+        assert "pinned" in result.lower()
+        assert len(engine._pinned_ids) == 3
+
+    def test_pin_default_cap_is_20(self, engine):
+        """Default max_pinned should be 20."""
+        assert engine.config.max_pinned == 20

--- a/tests/plugins/context_engine/test_engine_dispatch.py
+++ b/tests/plugins/context_engine/test_engine_dispatch.py
@@ -16,6 +16,8 @@ load_context_engine(_engine_name, ...).
 """
 
 import json
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
 
@@ -115,3 +117,87 @@ class TestEngineDispatch:
         assert mock_composite_load.call_args[1]["compression_name"] == "custom"
         mock_plain_load.assert_not_called()  # composite succeeded, no fallback needed
         assert result is mock_composite
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — loader filters kwargs by engine signature to avoid TypeError
+# ---------------------------------------------------------------------------
+
+class TestKwargsFiltering:
+    """_load_engine_from_dir must not pass kwargs that the engine's register()
+    does not declare, avoiding TypeError on custom engines.
+
+    Approach A (inspect.signature): only kwargs in the explicit parameter list
+    are forwarded; if register() has a **kwargs catch-all, everything passes.
+    """
+
+    def _make_fake_engine_module(self, register_fn, mod_name: str = "fake_engine"):
+        """Build a throwaway module with the given register function."""
+        from agent.context_engine import ContextEngine
+        mod = types.ModuleType(mod_name)
+        mod.register = register_fn
+        return mod
+
+    def test_register_no_kwargs_does_not_raise(self):
+        """A register(ctx) with no kwargs must not receive rlm_config / lcm_config."""
+        received = {}
+
+        def register(ctx):
+            # If any kwargs were forwarded this call would raise TypeError
+            received["called"] = True
+            from agent.context_engine import ContextEngine
+            class _E(ContextEngine):
+                @property
+                def name(self): return "fake"
+                def compress(self, m, **k): return m
+                def should_compress(self, p=None): return False
+                def should_compress_preflight(self, m): return False
+                def get_tool_schemas(self): return []
+                def handle_tool_call(self, n, a, **k): return "{}"
+            ctx.register_context_engine(_E())
+
+        from plugins.context_engine import _load_engine_from_dir, _filter_kwargs
+        import inspect
+
+        # Verify _filter_kwargs strips unknown keys
+        sig = inspect.signature(register)
+        filtered = _filter_kwargs({"rlm_config": {}, "lcm_config": {}}, sig)
+        assert filtered == {}, (
+            f"_filter_kwargs should strip all kwargs from a no-kwargs register(); got {filtered!r}"
+        )
+
+    def test_register_explicit_lcm_config_receives_only_lcm_config(self):
+        """register(ctx, lcm_config=None) must receive lcm_config but not rlm_config."""
+        from plugins.context_engine import _filter_kwargs
+        import inspect
+
+        def register(ctx, lcm_config=None):
+            pass
+
+        sig = inspect.signature(register)
+        filtered = _filter_kwargs({"rlm_config": {"x": 1}, "lcm_config": {"enabled": False}}, sig)
+        assert "lcm_config" in filtered, "lcm_config should pass through to a register that declares it"
+        assert "rlm_config" not in filtered, "rlm_config should be stripped from a register that doesn't declare it"
+
+    def test_register_with_var_keyword_receives_all_kwargs(self):
+        """register(ctx, **kwargs) must receive everything — the VAR_KEYWORD check."""
+        from plugins.context_engine import _filter_kwargs
+        import inspect
+
+        def register(ctx, **kwargs):
+            pass
+
+        sig = inspect.signature(register)
+        all_kwargs = {"rlm_config": {}, "lcm_config": {"enabled": True}, "model": "gpt-4"}
+        filtered = _filter_kwargs(all_kwargs, sig)
+        assert filtered == all_kwargs, (
+            "register(**kwargs) should receive all kwargs unchanged"
+        )
+
+    def test_load_context_engine_lcm_with_rlm_config_no_error(self):
+        """load_context_engine('lcm', rlm_config={...}, lcm_config={...}) must not
+        raise TypeError — lcm's register() accepts **kwargs so all pass through."""
+        from plugins.context_engine import load_context_engine
+        engine = load_context_engine("lcm", rlm_config={"max_iterations": 5}, lcm_config={"enabled": True})
+        assert engine is not None, "load_context_engine should return an LcmContextEngine"
+        assert engine.name == "lcm"

--- a/tests/plugins/context_engine/test_engine_dispatch.py
+++ b/tests/plugins/context_engine/test_engine_dispatch.py
@@ -1,0 +1,117 @@
+"""Regression tests for run_agent.py context-engine dispatch logic.
+
+Before the fix, the dispatch condition was:
+    if _engine_name == "compressor" or _engine_name not in ("lcm", "rlm"):
+        pass  # fall through to built-in compressor — BUG
+
+Any engine name that was not "lcm" or "rlm" silently fell into the no-op
+branch.  E.g. context.engine: "custom" would never call load_context_engine.
+
+After the fix the condition is simply:
+    if _engine_name == "compressor":
+        pass
+
+So any other name reaches the generic else branch that calls
+load_context_engine(_engine_name, ...).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+class TestEngineDispatch:
+    """Verify that custom engine names reach load_context_engine()."""
+
+    def _run_dispatch(self, engine_name: str, rlm_enabled: bool = False):
+        """Execute just the context-engine dispatch block from run_agent.py.
+
+        Replicated from run_agent.py lines ~1907-1966 so the logic can be
+        unit-tested without spinning up a full AIAgent.
+        """
+        _ctx_cfg = {"engine": engine_name, "rlm": rlm_enabled, "rlm_config": {}}
+        _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
+        _rlm_enabled = bool(_ctx_cfg.get("rlm", False))
+        _selected_engine = None
+
+        if _engine_name == "compressor":
+            pass
+        elif _engine_name == "rlm":
+            try:
+                from plugins.context_engine import load_context_engine  # noqa: F401
+                _selected_engine = load_context_engine(
+                    "rlm", rlm_config=_ctx_cfg.get("rlm_config", {})
+                )
+            except Exception:
+                pass
+        else:
+            rlm_kwargs = {"rlm_config": _ctx_cfg.get("rlm_config", {})}
+            if _rlm_enabled:
+                try:
+                    from plugins.context_engine import load_composite_engine  # noqa: F401
+                    _selected_engine = load_composite_engine(
+                        compression_name=_engine_name,
+                        rlm_enabled=True,
+                        **rlm_kwargs,
+                    )
+                except Exception:
+                    _selected_engine = None
+            if _selected_engine is None:
+                try:
+                    from plugins.context_engine import load_context_engine  # noqa: F401
+                    _selected_engine = load_context_engine(
+                        _engine_name,
+                        rlm_config=rlm_kwargs.get("rlm_config"),
+                    )
+                except Exception:
+                    pass
+
+        return _selected_engine
+
+    def test_compressor_name_uses_builtin(self):
+        """engine=compressor must never call load_context_engine."""
+        mock_engine = MagicMock(name="mock_engine")
+        with patch("plugins.context_engine.load_context_engine", return_value=mock_engine) as mock_load:
+            result = self._run_dispatch("compressor")
+        mock_load.assert_not_called()
+        assert result is None
+
+    def test_custom_engine_name_calls_load_context_engine(self):
+        """engine=custom must call load_context_engine('custom', ...)."""
+        mock_engine = MagicMock(name="mock_custom_engine")
+        with patch("plugins.context_engine.load_context_engine", return_value=mock_engine) as mock_load:
+            result = self._run_dispatch("custom")
+        mock_load.assert_called_once()
+        call_args = mock_load.call_args
+        assert call_args[0][0] == "custom", (
+            f"load_context_engine called with engine name {call_args[0][0]!r}, expected 'custom'"
+        )
+        assert result is mock_engine
+
+    def test_lcm_engine_still_calls_load_context_engine(self):
+        """engine=lcm must also reach load_context_engine (not broken by fix)."""
+        mock_engine = MagicMock(name="mock_lcm_engine")
+        with patch("plugins.context_engine.load_context_engine", return_value=mock_engine) as mock_load:
+            result = self._run_dispatch("lcm")
+        mock_load.assert_called_once()
+        assert mock_load.call_args[0][0] == "lcm"
+        assert result is mock_engine
+
+    def test_rlm_standalone_calls_load_context_engine_with_rlm(self):
+        """engine=rlm must call load_context_engine('rlm', ...)."""
+        mock_engine = MagicMock(name="mock_rlm_engine")
+        with patch("plugins.context_engine.load_context_engine", return_value=mock_engine) as mock_load:
+            result = self._run_dispatch("rlm")
+        mock_load.assert_called_once()
+        assert mock_load.call_args[0][0] == "rlm"
+        assert result is mock_engine
+
+    def test_custom_engine_with_rlm_tries_composite_first(self):
+        """engine=custom with rlm=True must try load_composite_engine first."""
+        mock_composite = MagicMock(name="mock_composite")
+        with patch("plugins.context_engine.load_composite_engine", return_value=mock_composite) as mock_composite_load, \
+             patch("plugins.context_engine.load_context_engine") as mock_plain_load:
+            result = self._run_dispatch("custom", rlm_enabled=True)
+        mock_composite_load.assert_called_once()
+        assert mock_composite_load.call_args[1]["compression_name"] == "custom"
+        mock_plain_load.assert_not_called()  # composite succeeded, no fallback needed
+        assert result is mock_composite

--- a/tests/plugins/context_engine/test_focus_topic_kwarg.py
+++ b/tests/plugins/context_engine/test_focus_topic_kwarg.py
@@ -1,0 +1,69 @@
+"""Regression test: compress() must accept focus_topic keyword argument.
+
+Covers the bug where CompositeContextEngine.compress() and
+LcmContextEngine.compress() rejected the focus_topic kwarg that
+run_agent.py passes through, raising TypeError.
+"""
+
+import inspect
+
+import pytest
+
+from agent.context_engine import ContextEngine
+from plugins.context_engine.lcm import LcmContextEngine
+from plugins.context_engine.rlm import CompositeContextEngine
+
+
+MESSAGES = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "hi"},
+]
+
+
+class TestFocusTopicSignature:
+    """Base ContextEngine.compress() must declare focus_topic."""
+
+    def test_base_compress_has_focus_topic_param(self):
+        sig = inspect.signature(ContextEngine.compress)
+        assert "focus_topic" in sig.parameters, (
+            "ContextEngine.compress() must declare focus_topic so subclasses "
+            "are not surprised by the kwarg"
+        )
+
+
+class TestLcmFocusTopic:
+    """LcmContextEngine.compress() must accept focus_topic without raising."""
+
+    def test_compress_accepts_focus_topic(self):
+        engine = LcmContextEngine()
+        # Must not raise TypeError
+        result = engine.compress(MESSAGES, current_tokens=100, focus_topic="test")
+        assert isinstance(result, list)
+
+    def test_compress_ignores_focus_topic_gracefully(self):
+        engine = LcmContextEngine()
+        result_plain = engine.compress(MESSAGES, current_tokens=100)
+        engine2 = LcmContextEngine()
+        result_focused = engine2.compress(MESSAGES, current_tokens=100, focus_topic="test")
+        # Both return valid message lists — behaviour is unchanged
+        assert isinstance(result_plain, list)
+        assert isinstance(result_focused, list)
+
+
+class TestCompositeFocusTopic:
+    """CompositeContextEngine.compress() must accept and forward focus_topic."""
+
+    def _make_composite(self):
+        lcm = LcmContextEngine()
+        return CompositeContextEngine(compression_engine=lcm)
+
+    def test_compress_accepts_focus_topic(self):
+        engine = self._make_composite()
+        # Must not raise TypeError
+        result = engine.compress(MESSAGES, current_tokens=100, focus_topic="test")
+        assert isinstance(result, list)
+
+    def test_compress_no_focus_topic_unchanged(self):
+        engine = self._make_composite()
+        result = engine.compress(MESSAGES, current_tokens=100)
+        assert isinstance(result, list)

--- a/tests/plugins/context_engine/test_lcm_abc_contract.py
+++ b/tests/plugins/context_engine/test_lcm_abc_contract.py
@@ -1,0 +1,237 @@
+"""ABC contract tests for LcmContextEngine.
+
+Verifies that LCM correctly implements the ContextEngine ABC interface
+and integrates with the plugin discovery system.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from agent.context_engine import ContextEngine
+from plugins.context_engine.lcm import LcmContextEngine
+from plugins.context_engine.lcm.engine import CompactionAction
+
+
+# ---------------------------------------------------------------------------
+# ABC contract
+# ---------------------------------------------------------------------------
+
+class TestAbcCompliance:
+    """Verify LcmContextEngine fulfills every abstract method."""
+
+    def test_is_subclass(self):
+        assert issubclass(LcmContextEngine, ContextEngine)
+
+    def test_instantiation(self):
+        engine = LcmContextEngine()
+        assert engine is not None
+
+    def test_name_property(self):
+        engine = LcmContextEngine()
+        assert engine.name == "lcm"
+        assert isinstance(engine.name, str)
+
+    def test_update_from_response(self):
+        engine = LcmContextEngine()
+        engine.update_from_response({
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+        })
+        assert engine.last_prompt_tokens == 100
+        assert engine.last_completion_tokens == 50
+        assert engine.last_total_tokens == 150
+
+    def test_should_compress_returns_bool(self):
+        engine = LcmContextEngine()
+        result = engine.should_compress(prompt_tokens=10)
+        assert isinstance(result, bool)
+
+    def test_compress_returns_list(self):
+        engine = LcmContextEngine()
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        result = engine.compress(msgs)
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_should_compress_preflight_returns_bool(self):
+        engine = LcmContextEngine()
+        result = engine.should_compress_preflight([])
+        assert isinstance(result, bool)
+
+    def test_on_session_start_noop(self):
+        engine = LcmContextEngine()
+        engine.on_session_start("test-session")
+
+    def test_on_session_end_noop(self):
+        engine = LcmContextEngine()
+        engine.on_session_end("test-session", [])
+
+    def test_on_session_reset(self):
+        engine = LcmContextEngine()
+        engine.compression_count = 5
+        engine.on_session_reset()
+        assert engine.compression_count == 0
+
+    def test_get_tool_schemas(self):
+        engine = LcmContextEngine()
+        schemas = engine.get_tool_schemas()
+        assert isinstance(schemas, list)
+        assert len(schemas) == 7
+        names = {s["name"] for s in schemas}
+        assert names == {
+            "lcm_expand", "lcm_pin", "lcm_forget",
+            "lcm_search", "lcm_budget", "lcm_toc", "lcm_focus",
+        }
+
+    def test_handle_tool_call_valid(self):
+        engine = LcmContextEngine()
+        result = engine.handle_tool_call("lcm_toc", {})
+        assert isinstance(result, str)
+        assert "empty" in result.lower() or "Timeline" in result
+
+    def test_handle_tool_call_unknown(self):
+        engine = LcmContextEngine()
+        result = engine.handle_tool_call("nonexistent_tool", {})
+        assert "error" in result.lower()
+
+    def test_get_status(self):
+        engine = LcmContextEngine()
+        status = engine.get_status()
+        assert isinstance(status, dict)
+        assert "last_prompt_tokens" in status
+        assert "context_length" in status
+        assert "compression_count" in status
+        # LCM-specific fields
+        assert "store_count" in status
+        assert "tau_soft" in status
+
+    def test_update_model(self):
+        engine = LcmContextEngine()
+        engine.update_model("new-model", 64000, base_url="http://test")
+        assert engine.context_length == 64000
+        assert engine.threshold_tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# Plugin discovery integration
+# ---------------------------------------------------------------------------
+
+class TestPluginDiscovery:
+
+    def test_discover_finds_lcm(self):
+        from plugins.context_engine import discover_context_engines
+        engines = discover_context_engines()
+        names = [name for name, _, _ in engines]
+        assert "lcm" in names
+
+    def test_load_lcm_engine(self):
+        from plugins.context_engine import load_context_engine
+        engine = load_context_engine("lcm")
+        assert engine is not None
+        assert engine.name == "lcm"
+
+    def test_load_nonexistent_returns_none(self):
+        from plugins.context_engine import load_context_engine
+        engine = load_context_engine("nonexistent")
+        assert engine is None
+
+    def test_is_available(self):
+        assert LcmContextEngine.is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# Compress/ingest flow
+# ---------------------------------------------------------------------------
+
+class TestCompressFlow:
+
+    def test_ingest_on_compress(self):
+        """Messages are ingested when compress is called."""
+        engine = LcmContextEngine()
+        msgs = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+        engine.compress(msgs)
+        assert engine._ingested_count == 2
+        assert len(engine._engine.store) == 2
+
+    def test_incremental_ingest(self):
+        """Only new messages are ingested on subsequent compress calls."""
+        engine = LcmContextEngine()
+        msgs_1 = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+        engine.compress(msgs_1)
+        assert engine._ingested_count == 2
+
+        msgs_2 = msgs_1 + [
+            {"role": "user", "content": "third"},
+            {"role": "assistant", "content": "fourth"},
+        ]
+        engine.compress(msgs_2)
+        assert engine._ingested_count == 4
+        assert len(engine._engine.store) == 4
+
+    def test_compress_returns_valid_messages(self):
+        """Compressed messages are valid OpenAI-format dicts."""
+        engine = LcmContextEngine()
+        msgs = [{"role": "user", "content": f"message {i}"} for i in range(10)]
+        result = engine.compress(msgs)
+        for msg in result:
+            assert "role" in msg
+            assert "content" in msg
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+class TestToolDispatch:
+
+    def _make_engine_with_messages(self):
+        engine = LcmContextEngine()
+        msgs = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "2+2 equals 4."},
+            {"role": "user", "content": "And 3+3?"},
+            {"role": "assistant", "content": "3+3 equals 6."},
+        ]
+        engine.compress(msgs)
+        return engine
+
+    def test_toc(self):
+        engine = self._make_engine_with_messages()
+        result = engine.handle_tool_call("lcm_toc", {})
+        assert "Timeline" in result
+        assert "msg 0" in result
+
+    def test_budget(self):
+        engine = self._make_engine_with_messages()
+        result = engine.handle_tool_call("lcm_budget", {})
+        assert "Active entries" in result
+        assert "Store total" in result
+
+    def test_search(self):
+        engine = self._make_engine_with_messages()
+        result = engine.handle_tool_call("lcm_search", {"query": "equals"})
+        assert "msg" in result
+
+    def test_pin(self):
+        engine = self._make_engine_with_messages()
+        result = engine.handle_tool_call("lcm_pin", {"message_ids": "0"})
+        assert "Pinned" in result
+
+    def test_expand(self):
+        engine = self._make_engine_with_messages()
+        result = engine.handle_tool_call("lcm_expand", {"message_ids": "0"})
+        assert "user" in result or "msg 0" in result
+
+    def test_forget(self):
+        engine = self._make_engine_with_messages()
+        result = engine.handle_tool_call("lcm_forget", {"message_ids": "0", "reason": "test"})
+        assert "Compacted" in result

--- a/tests/plugins/context_engine/test_lcm_abc_contract.py
+++ b/tests/plugins/context_engine/test_lcm_abc_contract.py
@@ -79,12 +79,12 @@ class TestAbcCompliance:
         engine = LcmContextEngine()
         schemas = engine.get_tool_schemas()
         assert isinstance(schemas, list)
-        assert len(schemas) == 7
         names = {s["name"] for s in schemas}
-        assert names == {
+        assert {
             "lcm_expand", "lcm_pin", "lcm_forget",
             "lcm_search", "lcm_budget", "lcm_toc", "lcm_focus",
-        }
+        }.issubset(names)
+        assert any(n.startswith("memory_") for n in names)
 
     def test_handle_tool_call_valid(self):
         engine = LcmContextEngine()

--- a/tests/plugins/context_engine/test_lcm_resume.py
+++ b/tests/plugins/context_engine/test_lcm_resume.py
@@ -1,0 +1,117 @@
+"""Regression test for LCM session resume via on_session_start.
+
+Bug: on_session_start called self._engine.rebuild_from_session(hermes_home, session_id)
+with wrong arguments (positional hermes_home/session_id instead of session_data dict)
+and discarded the returned engine. The exception was swallowed silently.
+
+Fix: load session_data from disk, call LcmEngine.rebuild_from_session(session_data, ...)
+and assign the returned engine to self._engine.
+"""
+import json
+import pytest
+from pathlib import Path
+
+from plugins.context_engine.lcm import LcmContextEngine
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.engine import LcmEngine
+
+
+@pytest.fixture
+def session_dir(tmp_path):
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    return tmp_path
+
+
+def _make_session_json(session_dir: Path, session_id: str, messages, lcm_meta: dict) -> Path:
+    """Write a fake session JSON file as run_agent.py would."""
+    session_file = session_dir / "sessions" / f"session_{session_id}.json"
+    data = {
+        "session_id": session_id,
+        "model": "test-model",
+        "messages": messages,
+        "lcm": lcm_meta,
+        "message_count": len(messages),
+    }
+    session_file.write_text(json.dumps(data), encoding="utf-8")
+    return session_file
+
+
+class TestLcmSessionResume:
+    def test_rebuild_restores_store_and_active(self, session_dir):
+        """After on_session_start with a valid session file, the engine
+        should have the same active entries as the original session."""
+        # Build an engine with some messages
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        engine = LcmEngine(config)
+        messages_raw = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "user", "content": "How are you?"},
+            {"role": "assistant", "content": "Fine, thanks!"},
+        ]
+        for msg in messages_raw:
+            engine.ingest(msg)
+
+        # Serialize engine state
+        lcm_meta = engine.to_session_metadata()
+        active_msgs = engine.active_messages()
+
+        session_id = "test-session-001"
+        _make_session_json(session_dir, session_id, active_msgs, lcm_meta)
+
+        # Create a fresh plugin and trigger resume
+        plugin = LcmContextEngine(lcm_config=config)
+        plugin.on_session_start(
+            session_id=session_id,
+            hermes_home=str(session_dir),
+        )
+
+        # The rebuilt engine should have the same number of active entries
+        assert len(plugin._engine.active) == len(engine.active)
+        # Store should be populated
+        assert len(plugin._engine.store) == len(engine.store)
+
+    def test_missing_session_file_starts_fresh(self, session_dir):
+        """If no session file exists, engine starts fresh without raising."""
+        plugin = LcmContextEngine()
+        # Should not raise; should log a warning and continue with fresh state
+        plugin.on_session_start(
+            session_id="nonexistent-session",
+            hermes_home=str(session_dir),
+        )
+        assert len(plugin._engine.active) == 0
+
+    def test_rebuild_with_summaries(self, session_dir):
+        """Session with summaries (compacted entries) is restored correctly."""
+        config = LcmConfig(enabled=True, protect_last_n=2)
+        engine = LcmEngine(config)
+        for i in range(6):
+            engine.ingest({
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"Message {i}",
+            })
+
+        block = engine.find_compactable_block()
+        if block:
+            engine.compact("Test summary", level=1, block_start=block[0], block_end=block[1])
+
+        lcm_meta = engine.to_session_metadata()
+        active_msgs = engine.active_messages()
+        # Mark summary entries
+        for i, entry in enumerate(engine.active):
+            if entry.kind == "summary":
+                active_msgs[i]["_lcm_summary"] = True
+                active_msgs[i]["_lcm_node_id"] = entry.node_id
+
+        session_id = "test-session-summaries"
+        _make_session_json(session_dir, session_id, active_msgs, lcm_meta)
+
+        plugin = LcmContextEngine(lcm_config=config)
+        plugin.on_session_start(
+            session_id=session_id,
+            hermes_home=str(session_dir),
+        )
+
+        assert len(plugin._engine.active) == len(engine.active)
+        assert len(plugin._engine.dag.nodes) == len(engine.dag.nodes)

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -462,6 +462,35 @@ class TestCompositeContextEngine:
         expected = "[system]: You are helpful.\n\n[user]: Hello, world!"
         assert engine._rlm_engine._session_context == expected
 
+    def test_update_model_resyncs_wrapper_fields(self):
+        """update_model() must re-sync context_length and threshold_tokens on the
+        composite wrapper after delegating to the compression engine."""
+        from plugins.context_engine.lcm.__init__ import LcmContextEngine
+
+        lcm = LcmContextEngine()
+        composite = CompositeContextEngine(lcm)
+
+        # Capture init values
+        init_context_length = composite.context_length
+
+        # Switch to a model with a larger context window
+        composite.update_model(
+            model="claude-opus-4-5",
+            context_length=200_000,
+            provider="anthropic",
+        )
+
+        assert composite.context_length == 200_000, (
+            f"composite.context_length={composite.context_length} — "
+            "wrapper was not re-synced after update_model"
+        )
+        # threshold_tokens should have been updated too
+        assert composite.threshold_tokens > 0, (
+            "composite.threshold_tokens should be positive after update_model"
+        )
+        # Sanity: inner engine was updated
+        assert lcm.context_length == 200_000
+
 
 # ── RLMAgentEnvironment Tests ───────────────────────────────────────────
 

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -1,7 +1,8 @@
 """Tests for the RLM ContextEngine plugin.
 
 Verifies that the RLM plugin correctly implements the ContextEngine ABC,
-exposes tool schemas, and handles tool calls.
+exposes tool schemas, handles tool calls, and works in composite mode
+with LCM.
 """
 
 import json
@@ -10,8 +11,9 @@ import textwrap
 
 from plugins.context_engine.rlm import (
     RlmContextEngine,
-    RLM_TOOL_SCHEMAS,
     RLMAgentEnvironment,
+    CompositeContextEngine,
+    RLM_TOOL_SCHEMAS,
 )
 
 
@@ -34,7 +36,9 @@ class TestRlmContextEngineIdentity:
         assert engine.threshold_percent == 1.0  # Never triggers compression
 
     def test_custom_config(self):
-        engine = RlmContextEngine(rlm_config={"max_iterations": 30, "output_limit": 4096})
+        engine = RlmContextEngine(
+            rlm_config={"max_iterations": 30, "output_limit": 4096}
+        )
         assert engine._max_iterations == 30
         assert engine._output_limit == 4096
 
@@ -225,6 +229,240 @@ class TestRlmContextEngineToolboxIntegration:
             assert "properties" in params or "required" in params
 
 
+# ── CompositeContextEngine Tests ─────────────────────────────────────────
+
+
+class TestCompositeContextEngine:
+    """Test the LCM + RLM composite engine."""
+
+    def test_composite_name(self):
+        """Composite engine should have a combined name."""
+        class MockCompression:
+            def __init__(self):
+                self.name = "lcm"
+            def get_tool_schemas(self):
+                return []
+            def handle_tool_call(self, name, args, **kwargs):
+                return json.dumps({"result": "ok"})
+            def should_compress(self, prompt_tokens=None):
+                return True
+            def should_compress_preflight(self, messages):
+                return True
+            def compress(self, messages, current_tokens=None):
+                return list(messages)
+            def on_session_start(self, *args, **kwargs):
+                pass
+            def on_session_end(self, *args, **kwargs):
+                pass
+            def on_session_reset(self):
+                pass
+            def update_from_response(self, usage):
+                pass
+            def update_model(self, **kwargs):
+                pass
+            def get_status(self):
+                return {}
+
+        engine = CompositeContextEngine(MockCompression())
+        assert engine.name == "lcm"
+
+        engine_with_rlm = CompositeContextEngine(MockCompression(), RlmContextEngine())
+        assert engine_with_rlm.name == "lcm+rlm"
+
+    def test_delegate_compression(self):
+        """Compression should delegate to the compression engine."""
+        class MockCompression:
+            def __init__(self):
+                self.name = "lcm"
+                self._should_compress_calls = 0
+            def get_tool_schemas(self):
+                return []
+            def handle_tool_call(self, name, args, **kwargs):
+                return json.dumps({"result": "ok"})
+            def should_compress(self, prompt_tokens=None):
+                self._should_compress_calls += 1
+                return True
+            def should_compress_preflight(self, messages):
+                return True
+            def compress(self, messages, current_tokens=None):
+                return list(messages)
+            def on_session_start(self, *args, **kwargs):
+                pass
+            def on_session_end(self, *args, **kwargs):
+                pass
+            def on_session_reset(self):
+                pass
+            def update_from_response(self, usage):
+                pass
+            def update_model(self, **kwargs):
+                pass
+            def get_status(self):
+                return {}
+
+        mock = MockCompression()
+        engine = CompositeContextEngine(mock)
+        assert engine.should_compress(1000) is True
+        assert mock._should_compress_calls == 1
+
+    def test_delegate_compress(self):
+        """compress() should delegate to compression engine."""
+        class MockCompression:
+            def __init__(self):
+                self.name = "lcm"
+            def get_tool_schemas(self):
+                return []
+            def handle_tool_call(self, name, args, **kwargs):
+                return json.dumps({"result": "ok"})
+            def should_compress(self, prompt_tokens=None):
+                return False
+            def should_compress_preflight(self, messages):
+                return False
+            def compress(self, messages, current_tokens=None):
+                # Modify messages to prove delegation
+                modified = list(messages)
+                modified.append({"role": "system", "content": "compressed"})
+                return modified
+            def on_session_start(self, *args, **kwargs):
+                pass
+            def on_session_end(self, *args, **kwargs):
+                pass
+            def on_session_reset(self):
+                pass
+            def update_from_response(self, usage):
+                pass
+            def update_model(self, **kwargs):
+                pass
+            def get_status(self):
+                return {}
+
+        mock = MockCompression()
+        engine = CompositeContextEngine(mock)
+        messages = [{"role": "user", "content": "hello"}]
+        result = engine.compress(messages)
+        assert len(result) == 2  # Original + compressed addition
+        assert result[-1]["content"] == "compressed"
+
+    def test_combine_tool_schemas(self):
+        """Tool schemas should combine from both engines."""
+        class MockCompression:
+            def __init__(self):
+                self.name = "lcm"
+            def get_tool_schemas(self):
+                return [
+                    {"name": "lcm_grep", "parameters": {}},
+                    {"name": "lcm_expand", "parameters": {}},
+                ]
+            def handle_tool_call(self, name, args, **kwargs):
+                return json.dumps({"result": "ok"})
+            def should_compress(self, prompt_tokens=None):
+                return True
+            def should_compress_preflight(self, messages):
+                return True
+            def compress(self, messages, current_tokens=None):
+                return list(messages)
+            def on_session_start(self, *args, **kwargs):
+                pass
+            def on_session_end(self, *args, **kwargs):
+                pass
+            def on_session_reset(self):
+                pass
+            def update_from_response(self, usage):
+                pass
+            def update_model(self, **kwargs):
+                pass
+            def get_status(self):
+                return {}
+
+        mock = MockCompression()
+        engine = CompositeContextEngine(mock, RlmContextEngine())
+        schemas = engine.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        assert "lcm_grep" in names
+        assert "lcm_expand" in names
+        assert "rlm_peek" in names
+        assert "rlm_grep" in names
+        assert "rlm_partition" in names
+
+    def test_dispatch_rlm_tools(self):
+        """RLM tool calls should be dispatched to the RLM engine."""
+        class MockCompression:
+            def __init__(self):
+                self.name = "lcm"
+            def get_tool_schemas(self):
+                return []
+            def handle_tool_call(self, name, args, **kwargs):
+                return json.dumps({"from": "compression"})
+            def should_compress(self, prompt_tokens=None):
+                return True
+            def should_compress_preflight(self, messages):
+                return True
+            def compress(self, messages, current_tokens=None):
+                return list(messages)
+            def on_session_start(self, *args, **kwargs):
+                pass
+            def on_session_end(self, *args, **kwargs):
+                pass
+            def on_session_reset(self):
+                pass
+            def update_from_response(self, usage):
+                pass
+            def update_model(self, **kwargs):
+                pass
+            def get_status(self):
+                return {}
+
+        mock = MockCompression()
+        rlm = RlmContextEngine()
+        rlm._session_context = "Hello World"
+        rlm._rlm_env = RLMAgentEnvironment("Hello World")
+
+        engine = CompositeContextEngine(mock, rlm)
+        result = engine.handle_tool_call("rlm_peek", {"start": 0, "length": 5})
+        data = json.loads(result)
+        assert data["snippet"] == "Hello"
+        assert "from" not in data  # Should be from RLM, not compression
+
+    def test_refresh_context(self):
+        """refresh_context should update the RLM environment."""
+        class MockCompression:
+            def __init__(self):
+                self.name = "lcm"
+            def get_tool_schemas(self):
+                return []
+            def handle_tool_call(self, name, args, **kwargs):
+                return json.dumps({"result": "ok"})
+            def should_compress(self, prompt_tokens=None):
+                return True
+            def should_compress_preflight(self, messages):
+                return True
+            def compress(self, messages, current_tokens=None):
+                return list(messages)
+            def on_session_start(self, *args, **kwargs):
+                pass
+            def on_session_end(self, *args, **kwargs):
+                pass
+            def on_session_reset(self):
+                pass
+            def update_from_response(self, usage):
+                pass
+            def update_model(self, **kwargs):
+                pass
+            def get_status(self):
+                return {}
+
+        mock = MockCompression()
+        engine = CompositeContextEngine(mock, RlmContextEngine())
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello, world!"},
+        ]
+        engine.refresh_context(messages)
+
+        expected = "[system]: You are helpful.\n\n[user]: Hello, world!"
+        assert engine._rlm_engine._session_context == expected
+
+
 # ── RLMAgentEnvironment Tests ───────────────────────────────────────────
 
 
@@ -334,3 +572,56 @@ class TestRlmToolboxSchemas:
     def test_schemas_descriptions_not_empty(self):
         for schema in RLM_TOOL_SCHEMAS.values():
             assert len(schema["description"]) > 50
+
+
+# ── build_context_from_messages Tests ───────────────────────────────────
+
+
+class TestBuildContextFromMessages:
+    """Test context building from conversation messages."""
+
+    def test_simple_messages(self):
+        engine = RlmContextEngine()
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        context = engine.build_context_from_messages(messages)
+        assert "[system]: You are helpful." in context
+        assert "[user]: Hello" in context
+        assert "[assistant]: Hi there!" in context
+
+    def test_structured_content(self):
+        """Test with multi-part content (text + tool_use)."""
+        engine = RlmContextEngine()
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    {"type": "tool_use", "name": "search", "input": {"q": "test"}},
+                ],
+            },
+        ]
+        context = engine.build_context_from_messages(messages)
+        assert "[user]: Hello" in context
+        assert "[user]: {\"q\": \"test\"}" in context  # tool_use input
+
+    def test_empty_messages(self):
+        engine = RlmContextEngine()
+        context = engine.build_context_from_messages([])
+        assert context == ""
+
+    def test_refresh_context(self):
+        """Test that refresh_context updates the REPL namespace."""
+        engine = RlmContextEngine()
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "User message"},
+        ]
+        engine.refresh_context(messages)
+        expected = "[system]: System prompt\n\n[user]: User message"
+        assert engine._session_context == expected
+        assert engine._rlm_env is None  # Not initialized yet
+        assert engine._session_context is not None  # But session context is set

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -655,3 +655,42 @@ class TestBuildContextFromMessages:
         # After refresh_context, _rlm_env is bootstrapped so rlm_peek works
         assert engine._rlm_env is not None
         assert engine._session_context is not None
+
+    def test_openai_style_tool_calls_included(self):
+        """OpenAI-shape tool_calls must appear in the flattened context.
+
+        Regression for: assistant messages with tool_calls=[...] and empty/null
+        content were silently dropped because the flattener only handled
+        Anthropic-style content blocks (content: [{type: tool_use, ...}]).
+        """
+        engine = RlmContextEngine()
+        messages = [
+            {"role": "user", "content": "What is the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Paris"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_abc123",
+                "content": "Sunny, 22°C",
+            },
+        ]
+        context = engine.build_context_from_messages(messages)
+
+        assert "get_weather" in context, (
+            f"Tool name 'get_weather' missing from flattened context.\nContext:\n{context}"
+        )
+        assert "Paris" in context, (
+            f"Tool arguments missing from flattened context.\nContext:\n{context}"
+        )

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -694,3 +694,104 @@ class TestBuildContextFromMessages:
         assert "Paris" in context, (
             f"Tool arguments missing from flattened context.\nContext:\n{context}"
         )
+
+
+# ── Partition Bounds Validation Tests ───────────────────────────────────
+
+
+class TestRlmPartitionBoundsValidation:
+    """Regression tests for _handle_partition() infinite-loop guard.
+
+    With overlap >= chunk_size the loop variable 'start' does not advance
+    (or moves backwards), causing an infinite loop.  The fix rejects
+    malformed bounds before entering the loop and returns a descriptive
+    error JSON instead of hanging.
+    """
+
+    def _engine_with_context(self, text: str = "A" * 10000) -> "RlmContextEngine":
+        engine = RlmContextEngine()
+        engine._session_context = text
+        engine._rlm_env = RLMAgentEnvironment(text)
+        return engine
+
+    def test_overlap_equal_to_chunk_size_returns_error(self):
+        """overlap == chunk_size must not loop; must return error JSON."""
+        engine = self._engine_with_context()
+        result = engine.handle_tool_call(
+            "rlm_partition", {"chunk_size": 500, "overlap": 500}
+        )
+        data = json.loads(result)
+        assert "error" in data, f"Expected error JSON, got: {data}"
+        assert "overlap" in data["error"].lower() or "chunk_size" in data["error"].lower()
+
+    def test_overlap_greater_than_chunk_size_returns_error(self):
+        """overlap > chunk_size is even worse; must return error JSON."""
+        engine = self._engine_with_context()
+        result = engine.handle_tool_call(
+            "rlm_partition", {"chunk_size": 100, "overlap": 200}
+        )
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_chunk_size_zero_returns_error(self):
+        """chunk_size=0 must return error JSON."""
+        engine = self._engine_with_context()
+        result = engine.handle_tool_call(
+            "rlm_partition", {"chunk_size": 0, "overlap": 0}
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "chunk_size" in data["error"]
+
+    def test_chunk_size_negative_returns_error(self):
+        """chunk_size=-1 must return error JSON."""
+        engine = self._engine_with_context()
+        result = engine.handle_tool_call(
+            "rlm_partition", {"chunk_size": -1, "overlap": 0}
+        )
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_overlap_negative_returns_error(self):
+        """Negative overlap is invalid; must return error JSON."""
+        engine = self._engine_with_context()
+        result = engine.handle_tool_call(
+            "rlm_partition", {"chunk_size": 1000, "overlap": -1}
+        )
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_valid_inputs_still_work(self):
+        """Sanity check: valid chunk_size=1000, overlap=100 must succeed."""
+        engine = self._engine_with_context("B" * 5000)
+        result = engine.handle_tool_call(
+            "rlm_partition", {"chunk_size": 1000, "overlap": 100}
+        )
+        data = json.loads(result)
+        assert "error" not in data, f"Unexpected error for valid inputs: {data}"
+        assert data["total_chunks"] > 0
+        assert data["chunk_size"] == 1000
+        assert data["overlap"] == 100
+
+    def test_zero_overlap_is_valid(self):
+        """overlap=0 (no overlap) is a valid configuration."""
+        engine = self._engine_with_context("C" * 3000)
+        result = engine.handle_tool_call(
+            "rlm_partition", {"chunk_size": 1000, "overlap": 0}
+        )
+        data = json.loads(result)
+        assert "error" not in data
+        assert data["total_chunks"] == 3
+
+    def test_partition_schema_has_minimum_constraints(self):
+        """JSON schema for rlm_partition must declare minimum values."""
+        engine = RlmContextEngine()
+        schemas = engine.get_tool_schemas()
+        partition_schema = next(s for s in schemas if s["name"] == "rlm_partition")
+        props = partition_schema["parameters"]["properties"]
+        assert props["chunk_size"].get("minimum") == 1, (
+            "chunk_size schema is missing 'minimum: 1'"
+        )
+        assert props["overlap"].get("minimum") == 0, (
+            "overlap schema is missing 'minimum: 0'"
+        )

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -491,6 +491,70 @@ class TestCompositeContextEngine:
         # Sanity: inner engine was updated
         assert lcm.context_length == 200_000
 
+    def test_on_session_reset_clears_token_counters_on_wrapper(self):
+        """on_session_reset() must zero the composite wrapper's token counters.
+
+        Regression: previously the wrapper's last_prompt_tokens etc. were only
+        set at construction time. After a session reset the inner compression
+        engine zeroed its counters but the wrapper still held the stale values,
+        causing the next compression decision to use a non-zero token count.
+        """
+        from plugins.context_engine.lcm.__init__ import LcmContextEngine
+
+        lcm = LcmContextEngine()
+        composite = CompositeContextEngine(lcm)
+
+        # Simulate a session that accumulated token usage
+        composite.last_prompt_tokens = 50_000
+        composite.last_completion_tokens = 2_000
+        composite.last_total_tokens = 52_000
+        composite.compression_count = 3
+
+        composite.on_session_reset()
+
+        assert composite.last_prompt_tokens == 0, (
+            f"composite.last_prompt_tokens={composite.last_prompt_tokens} after reset; "
+            "expected 0 — wrapper was not synced from inner engine after on_session_reset"
+        )
+        assert composite.last_completion_tokens == 0, (
+            f"composite.last_completion_tokens={composite.last_completion_tokens} after reset; expected 0"
+        )
+        assert composite.last_total_tokens == 0, (
+            f"composite.last_total_tokens={composite.last_total_tokens} after reset; expected 0"
+        )
+        assert composite.compression_count == 0, (
+            f"composite.compression_count={composite.compression_count} after reset; expected 0"
+        )
+
+    def test_update_from_response_syncs_token_fields_on_wrapper(self):
+        """update_from_response() must re-sync the wrapper's token fields.
+
+        Regression: update_from_response delegated to the inner engine but did
+        not copy the updated values back to the wrapper's mirrored attributes,
+        so composite.last_prompt_tokens remained stale.
+        """
+        from plugins.context_engine.lcm.__init__ import LcmContextEngine
+
+        lcm = LcmContextEngine()
+        composite = CompositeContextEngine(lcm)
+
+        # Pre-condition: wrapper starts at 0
+        assert composite.last_prompt_tokens == 0
+
+        usage = {"prompt_tokens": 80_000, "completion_tokens": 1_500}
+        composite.update_from_response(usage)
+
+        assert composite.last_prompt_tokens == 80_000, (
+            f"composite.last_prompt_tokens={composite.last_prompt_tokens} after "
+            "update_from_response; expected 80000 — wrapper was not re-synced"
+        )
+        assert composite.last_completion_tokens == 1_500, (
+            f"composite.last_completion_tokens={composite.last_completion_tokens}; expected 1500"
+        )
+        assert composite.last_total_tokens == 81_500, (
+            f"composite.last_total_tokens={composite.last_total_tokens}; expected 81500"
+        )
+
 
 # ── RLMAgentEnvironment Tests ───────────────────────────────────────────
 

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -248,7 +248,7 @@ class TestCompositeContextEngine:
                 return True
             def should_compress_preflight(self, messages):
                 return True
-            def compress(self, messages, current_tokens=None):
+            def compress(self, messages, current_tokens=None, focus_topic=None):
                 return list(messages)
             def on_session_start(self, *args, **kwargs):
                 pass
@@ -284,7 +284,7 @@ class TestCompositeContextEngine:
                 return True
             def should_compress_preflight(self, messages):
                 return True
-            def compress(self, messages, current_tokens=None):
+            def compress(self, messages, current_tokens=None, focus_topic=None):
                 return list(messages)
             def on_session_start(self, *args, **kwargs):
                 pass
@@ -317,7 +317,7 @@ class TestCompositeContextEngine:
                 return False
             def should_compress_preflight(self, messages):
                 return False
-            def compress(self, messages, current_tokens=None):
+            def compress(self, messages, current_tokens=None, focus_topic=None):
                 # Modify messages to prove delegation
                 modified = list(messages)
                 modified.append({"role": "system", "content": "compressed"})
@@ -358,7 +358,7 @@ class TestCompositeContextEngine:
                 return True
             def should_compress_preflight(self, messages):
                 return True
-            def compress(self, messages, current_tokens=None):
+            def compress(self, messages, current_tokens=None, focus_topic=None):
                 return list(messages)
             def on_session_start(self, *args, **kwargs):
                 pass
@@ -396,7 +396,7 @@ class TestCompositeContextEngine:
                 return True
             def should_compress_preflight(self, messages):
                 return True
-            def compress(self, messages, current_tokens=None):
+            def compress(self, messages, current_tokens=None, focus_topic=None):
                 return list(messages)
             def on_session_start(self, *args, **kwargs):
                 pass
@@ -435,7 +435,7 @@ class TestCompositeContextEngine:
                 return True
             def should_compress_preflight(self, messages):
                 return True
-            def compress(self, messages, current_tokens=None):
+            def compress(self, messages, current_tokens=None, focus_topic=None):
                 return list(messages)
             def on_session_start(self, *args, **kwargs):
                 pass

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -623,5 +623,6 @@ class TestBuildContextFromMessages:
         engine.refresh_context(messages)
         expected = "[system]: System prompt\n\n[user]: User message"
         assert engine._session_context == expected
-        assert engine._rlm_env is None  # Not initialized yet
-        assert engine._session_context is not None  # But session context is set
+        # After refresh_context, _rlm_env is bootstrapped so rlm_peek works
+        assert engine._rlm_env is not None
+        assert engine._session_context is not None

--- a/tests/plugins/context_engine/test_rlm_plugin.py
+++ b/tests/plugins/context_engine/test_rlm_plugin.py
@@ -1,0 +1,336 @@
+"""Tests for the RLM ContextEngine plugin.
+
+Verifies that the RLM plugin correctly implements the ContextEngine ABC,
+exposes tool schemas, and handles tool calls.
+"""
+
+import json
+import pytest
+import textwrap
+
+from plugins.context_engine.rlm import (
+    RlmContextEngine,
+    RLM_TOOL_SCHEMAS,
+    RLMAgentEnvironment,
+)
+
+
+# ── RLMContextEngine Tests ──────────────────────────────────────────────
+
+
+class TestRlmContextEngineIdentity:
+    """Test engine identity and configuration."""
+
+    def test_name_property(self):
+        engine = RlmContextEngine()
+        assert engine.name == "rlm"
+
+    def test_default_config(self):
+        engine = RlmContextEngine()
+        assert engine._max_iterations == 20
+        assert engine._output_limit == 8192
+        assert engine.context_length == 0
+        assert engine.compression_count == 0
+        assert engine.threshold_percent == 1.0  # Never triggers compression
+
+    def test_custom_config(self):
+        engine = RlmContextEngine(rlm_config={"max_iterations": 30, "output_limit": 4096})
+        assert engine._max_iterations == 30
+        assert engine._output_limit == 4096
+
+    def test_abc_compliance(self):
+        from agent.context_engine import ContextEngine
+        assert issubclass(RlmContextEngine, ContextEngine)
+
+    def test_is_available(self):
+        # RLM requires an LLM provider, so availability depends on config
+        engine = RlmContextEngine()
+        # At minimum, it should not crash
+        assert True
+
+
+class TestRlmContextEngineCompaction:
+    """Test that RLM never compresses (delegates to REPL)."""
+
+    def test_never_compresses(self):
+        engine = RlmContextEngine()
+        assert engine.should_compress() is False
+        assert engine.should_compress(prompt_tokens=1000) is False
+
+    def test_compress_returns_messages_unchanged(self):
+        engine = RlmContextEngine()
+        messages = [
+            {"role": "system", "content": "test"},
+            {"role": "user", "content": "hello"},
+        ]
+        result = engine.compress(messages)
+        assert result == messages
+
+    def test_preflight_always_false(self):
+        engine = RlmContextEngine()
+        assert engine.should_compress_preflight([]) is False
+
+
+class TestRlmContextEngineSessionLifecycle:
+    """Test session lifecycle methods."""
+
+    def test_session_start_init(self):
+        engine = RlmContextEngine()
+        engine.on_session_start("test-123", context_length=128_000)
+        assert engine.context_length == 128_000
+        assert engine.threshold_tokens == 128_000
+
+    def test_session_start_with_context(self):
+        engine = RlmContextEngine()
+        context = "A" * 1000
+        engine.on_session_start("test-123", context_length=64_000, rlm_context=context)
+        assert engine._session_context == context
+        assert engine._rlm_env is not None
+
+    def test_session_end_is_noop(self):
+        engine = RlmContextEngine()
+        # Should not crash
+        engine.on_session_end("test-123", [])
+
+    def test_session_reset(self):
+        engine = RlmContextEngine()
+        engine._session_context = "test"
+        engine._rlm_env = RLMAgentEnvironment("test")
+        engine.on_session_reset()
+        assert engine._session_context is None
+        assert engine._rlm_env is None
+        assert engine.compression_count == 0
+        assert engine.last_prompt_tokens == 0
+
+    def test_model_update(self):
+        engine = RlmContextEngine()
+        engine.on_session_start("test-123", context_length=128_000)
+        engine.update_model("gpt-5", 128_000)
+        assert engine.context_length == 128_000
+        assert engine.threshold_tokens == 128_000  # threshold_percent=1.0
+
+
+class TestRlmContextEngineTools:
+    """Test RLM tool schemas and handlers."""
+
+    def test_tool_schemas_count(self):
+        engine = RlmContextEngine()
+        schemas = engine.get_tool_schemas()
+        assert len(schemas) == 3
+        names = {s["name"] for s in schemas}
+        assert names == {"rlm_peek", "rlm_grep", "rlm_partition"}
+
+    def test_tool_schema_format(self):
+        engine = RlmContextEngine()
+        schemas = engine.get_tool_schemas()
+        for schema in schemas:
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+
+    def test_handle_peek_no_context(self):
+        engine = RlmContextEngine()
+        # No context loaded
+        result = engine.handle_tool_call("rlm_peek", {"start": 0, "length": 100})
+        data = json.loads(result)
+        assert "error" in data
+        assert "No context loaded" in data["error"]
+
+    def test_handle_grep_no_context(self):
+        engine = RlmContextEngine()
+        result = engine.handle_tool_call("rlm_grep", {"pattern": "test"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_handle_unknown_tool(self):
+        engine = RlmContextEngine()
+        result = engine.handle_tool_call("unknown_tool", {})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_handle_peek_with_context(self):
+        engine = RlmContextEngine()
+        context = "Hello World! This is a test context. 12345"
+        engine._session_context = context
+        engine._rlm_env = RLMAgentEnvironment(context)
+
+        result = engine.handle_tool_call("rlm_peek", {"start": 0, "length": 5})
+        data = json.loads(result)
+        assert data["snippet"] == "Hello"
+        assert data["start"] == 0
+
+    def test_handle_grep_with_context(self):
+        context_lines = textwrap.dedent("""
+            ID: 12345 User: Alice
+            ID: 67890 User: Bob
+            ID: 11111 User: Charlie
+        """).strip()
+
+        engine = RlmContextEngine()
+        engine._session_context = context_lines
+        engine._rlm_env = RLMAgentEnvironment(context_lines)
+
+        result = engine.handle_tool_call("rlm_grep", {"pattern": "Alice", "max_matches": 1})
+        data = json.loads(result)
+        assert len(data["matches"]) == 1
+        assert "Alice" in data["matches"][0]["content"]
+
+    def test_handle_partition_with_context(self):
+        context = "A" * 20000  # 20k chars
+        engine = RlmContextEngine()
+        engine._session_context = context
+        engine._rlm_env = RLMAgentEnvironment(context)
+
+        result = engine.handle_tool_call("rlm_partition", {"chunk_size": 5000, "overlap": 500})
+        data = json.loads(result)
+        assert data["total_chunks"] > 3
+        assert data["chunk_size"] == 5000
+
+
+class TestRlmContextEngineStatus:
+    """Test status display."""
+
+    def test_get_status(self):
+        engine = RlmContextEngine()
+        engine.context_length = 128_000
+        engine.last_prompt_tokens = 64_000
+        engine.last_completion_tokens = 1000
+        engine.last_total_tokens = 65_000
+        engine.compression_count = 5
+        engine.threshold_tokens = 128_000  # threshold_percent=1.0, so 128000 * 1.0 = 128000
+
+        status = engine.get_status()
+        assert status["context_length"] == 128_000
+        assert status["last_prompt_tokens"] == 64_000
+        assert status["threshold_tokens"] == 128_000  # Manually set in test
+        assert status["compression_count"] == 5
+        assert status["usage_percent"] == 50.0
+
+
+class TestRlmContextEngineToolboxIntegration:
+    """Test integration with the tool registry."""
+
+    def test_tool_schemas_match_registry_format(self):
+        """Ensure schemas match the format expected by model_tools.py."""
+        engine = RlmContextEngine()
+        schemas = engine.get_tool_schemas()
+
+        for schema in schemas:
+            # Must have 'name' and 'parameters'
+            assert isinstance(schema["name"], str)
+            assert isinstance(schema["parameters"], dict)
+
+            # Parameters must have properties
+            params = schema["parameters"]
+            assert "properties" in params or "required" in params
+
+
+# ── RLMAgentEnvironment Tests ───────────────────────────────────────────
+
+
+class TestRLMAgentEnvironment:
+    """Test the REPL environment."""
+
+    def test_init(self):
+        context = "Test context"
+        env = RLMAgentEnvironment(context)
+        assert env.context == context
+        assert env.namespace["__context__"] == context
+        assert env.namespace["answer"] == {"content": "", "ready": False}
+
+    def test_execute_simple(self):
+        context = "Hello World"
+
+        # Test 1: Setting answer['content'] returns the content
+        env1 = RLMAgentEnvironment(context)
+        result1 = env1.execute("answer['content'] = 'test'")
+        assert result1 == "test"  # execute() returns answer content
+
+        # Test 2: Subsequent execute() returns the new answer content
+        env2 = RLMAgentEnvironment(context)
+        env2.execute("answer['content'] = 'hello'")
+        result2 = env2.execute("pass")  # No-op, but returns current answer content
+        assert result2 == "hello"
+
+    def test_execute_with_answer(self):
+        context = "Context here"
+        env = RLMAgentEnvironment(context)
+
+        env.execute('answer["content"] = "Final answer"')
+        env.execute('answer["ready"] = True')
+
+        assert env.namespace["answer"]["content"] == "Final answer"
+        assert env.namespace["answer"]["ready"] is True
+
+    def test_execute_error_handling(self):
+        env = RLMAgentEnvironment("test")
+        result = env.execute("this_will_fail_undefined_var")
+        assert "Error" in result or "NameError" in result
+
+    def test_execute_expression(self):
+        context = "12345"
+        env = RLMAgentEnvironment(context)
+
+        result = env.execute_expression("len(__context__)")
+        assert result == "5"
+
+    def test_set_answer(self):
+        env = RLMAgentEnvironment("test")
+        env.set_answer("Hello", ready=True)
+        assert env.namespace["answer"]["content"] == "Hello"
+        assert env.namespace["answer"]["ready"] is True
+
+    def test_iteration_limit(self):
+        env = RLMAgentEnvironment("test", max_iterations=3)
+        assert env.iteration_count == 0
+        assert env.check_iteration_limit() is False  # 1st call
+        assert env.check_iteration_limit() is False  # 2nd call
+        assert env.check_iteration_limit() is True   # 3rd call (== max)
+
+    def test_token_estimation(self):
+        env = RLMAgentEnvironment("A" * 40000)  # ~10k tokens
+        assert env.namespace["__context_token_length__"] == 10000
+
+    def test_llm_batch_handler_returns_empty(self):
+        """The handler returns empty list (real impl in RLMAgent)."""
+        env = RLMAgentEnvironment("test")
+        result = env._llm_batch_handler([])
+        assert result == []
+
+    def test_llm_call_handler_returns_empty(self):
+        env = RLMAgentEnvironment("test")
+        result = env._llm_call_handler("test prompt")
+        assert result == ""
+
+    def test_output_limit_truncation(self):
+        context = "X" * 20000
+        env = RLMAgentEnvironment(context, output_limit=500)
+
+        # Execute code that sets a large answer
+        env.execute(f'answer["content"] = "{context}"')
+        env.execute('answer["ready"] = True')
+
+        # The execute() should have truncated
+        result = env.execute("pass")
+        # If the answer is large, it gets truncated in the execute() flow
+        # But we need to verify the truncate happens
+        pass  # Hard to test without mocking
+
+
+class TestRlmToolboxSchemas:
+    """Test that RLM_TOOL_SCHEMAS is properly formatted."""
+
+    def test_all_schemas_defined(self):
+        assert "rlm_peek" in RLM_TOOL_SCHEMAS
+        assert "rlm_grep" in RLM_TOOL_SCHEMAS
+        assert "rlm_partition" in RLM_TOOL_SCHEMAS
+
+    def test_schemas_have_required_fields(self):
+        for schema in RLM_TOOL_SCHEMAS.values():
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+
+    def test_schemas_descriptions_not_empty(self):
+        for schema in RLM_TOOL_SCHEMAS.values():
+            assert len(schema["description"]) > 50

--- a/tests/plugins/context_engine/test_rlm_refresh.py
+++ b/tests/plugins/context_engine/test_rlm_refresh.py
@@ -1,0 +1,96 @@
+"""Regression test for RLM _rlm_env initialization in refresh_context.
+
+Bug: on_session_start() only initialized _rlm_env when kwargs.get("rlm_context")
+was truthy. In normal agent flow it is not passed. refresh_context() only mutated
+an existing _rlm_env, never created one. Result: rlm_peek / rlm_grep / rlm_partition
+always returned "No context loaded".
+
+Fix: in refresh_context(), if _rlm_env is None and context was built, call
+self._init_rlm_env(context) to create it on first call.
+"""
+import json
+import pytest
+
+from plugins.context_engine.rlm import RlmContextEngine
+
+
+class TestRlmRefreshContextInit:
+    def test_rlm_peek_returns_content_after_refresh(self):
+        """After on_session_start (no rlm_context) + refresh_context, rlm_peek
+        should return real content, not 'No context loaded'."""
+        plugin = RlmContextEngine()
+        plugin.on_session_start(session_id="test-session-1")
+
+        messages = [
+            {"role": "user", "content": "What is the capital of France?"},
+            {"role": "assistant", "content": "The capital of France is Paris."},
+        ]
+        plugin.refresh_context(messages)
+
+        result_json = plugin.handle_tool_call("rlm_peek", {"start": 0, "length": 500})
+        result = json.loads(result_json)
+
+        assert "error" not in result, f"Expected content but got error: {result}"
+        assert "snippet" in result
+        assert len(result["snippet"]) > 0
+        assert "France" in result["snippet"] or "Paris" in result["snippet"]
+
+    def test_rlm_env_initialized_after_refresh(self):
+        """_rlm_env should be None before refresh, non-None after."""
+        plugin = RlmContextEngine()
+        plugin.on_session_start(session_id="test-session-2")
+
+        assert plugin._rlm_env is None
+
+        messages = [{"role": "user", "content": "Hello world"}]
+        plugin.refresh_context(messages)
+
+        assert plugin._rlm_env is not None
+        assert plugin._session_context is not None
+
+    def test_rlm_grep_returns_matches_after_refresh(self):
+        """rlm_grep should find matches from the refreshed context."""
+        plugin = RlmContextEngine()
+        plugin.on_session_start(session_id="test-session-3")
+
+        messages = [
+            {"role": "user", "content": "error: something went wrong"},
+            {"role": "assistant", "content": "I see the error in your code."},
+        ]
+        plugin.refresh_context(messages)
+
+        result_json = plugin.handle_tool_call("rlm_grep", {"pattern": "error"})
+        result = json.loads(result_json)
+
+        assert "error" not in result or result.get("error") is None, f"Got error: {result}"
+        assert "matches" in result
+        assert result["total_found"] >= 1
+
+    def test_rlm_context_passed_via_on_session_start_still_works(self):
+        """The original path (rlm_context in kwargs) should still work."""
+        plugin = RlmContextEngine()
+        plugin.on_session_start(
+            session_id="test-session-4",
+            rlm_context="Pre-loaded context content here."
+        )
+
+        assert plugin._rlm_env is not None
+        result_json = plugin.handle_tool_call("rlm_peek", {"start": 0, "length": 100})
+        result = json.loads(result_json)
+        assert "snippet" in result
+        assert "Pre-loaded" in result["snippet"]
+
+    def test_refresh_context_updates_existing_env(self):
+        """When _rlm_env already exists, refresh_context updates it in place."""
+        plugin = RlmContextEngine()
+        plugin.on_session_start(
+            session_id="test-session-5",
+            rlm_context="Old context."
+        )
+        first_env = plugin._rlm_env
+
+        plugin.refresh_context([{"role": "user", "content": "New context content."}])
+
+        # Same object is updated, not replaced
+        assert plugin._rlm_env is first_env
+        assert "New context content" in plugin._session_context

--- a/tests/plugins/test_dam_encoder.py
+++ b/tests/plugins/test_dam_encoder.py
@@ -1,0 +1,57 @@
+"""Tests for DAM message encoder."""
+import pytest
+import numpy as np
+
+from plugins.context_engine.lcm.dam.encoder import MessageEncoder
+
+
+class TestEncode:
+    def test_output_shape(self):
+        enc = MessageEncoder(nv=512)
+        v = enc.encode({"role": "user", "content": "hello world"})
+        assert v.shape == (512,)
+
+    def test_unit_norm(self):
+        enc = MessageEncoder(nv=512)
+        v = enc.encode({"role": "user", "content": "hello world"})
+        assert abs(np.linalg.norm(v) - 1.0) < 1e-6
+
+    def test_deterministic(self):
+        enc = MessageEncoder(nv=512)
+        v1 = enc.encode({"role": "user", "content": "test message"})
+        v2 = enc.encode({"role": "user", "content": "test message"})
+        assert np.allclose(v1, v2)
+
+    def test_similar_content_similar_vectors(self):
+        enc = MessageEncoder(nv=2048)
+        v1 = enc.encode({"role": "user", "content": "Python async error handling"})
+        v2 = enc.encode({"role": "user", "content": "Python async exception handling"})
+        v3 = enc.encode({"role": "user", "content": "Machine learning neural networks"})
+        sim_12 = float(np.dot(v1, v2))
+        sim_13 = float(np.dot(v1, v3))
+        assert sim_12 > sim_13
+
+    def test_empty_content(self):
+        enc = MessageEncoder(nv=512)
+        v = enc.encode({"role": "user", "content": ""})
+        assert v.shape == (512,)
+
+    def test_role_affects_encoding(self):
+        enc = MessageEncoder(nv=512, role_weight=0.5)
+        v_user = enc.encode({"role": "user", "content": "hello"})
+        v_asst = enc.encode({"role": "assistant", "content": "hello"})
+        assert not np.allclose(v_user, v_asst)
+
+
+class TestEncodeText:
+    def test_query_encoding(self):
+        enc = MessageEncoder(nv=512)
+        v = enc.encode_text("Python error handling")
+        assert v.shape == (512,)
+        assert abs(np.linalg.norm(v) - 1.0) < 1e-6
+
+    def test_long_text(self):
+        enc = MessageEncoder(nv=512)
+        v = enc.encode_text("x " * 10000)
+        assert v.shape == (512,)
+        assert abs(np.linalg.norm(v) - 1.0) < 1e-6

--- a/tests/plugins/test_dam_network.py
+++ b/tests/plugins/test_dam_network.py
@@ -1,0 +1,101 @@
+"""Tests for Dense Associative Memory network."""
+import pytest
+import numpy as np
+
+from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
+
+
+class TestInitialization:
+    def test_weight_matrix_shape(self):
+        net = DenseAssociativeMemory(nv=100, nh=10)
+        assert net.xi.shape == (100, 10)
+
+    def test_xavier_scale(self):
+        net = DenseAssociativeMemory(nv=1000, nh=50)
+        expected_std = np.sqrt(2.0 / (1000 + 50))
+        assert abs(net.xi.std() - expected_std) < 0.05
+
+
+class TestHiddenActivations:
+    def test_shape_and_binary(self):
+        net = DenseAssociativeMemory(nv=100, nh=10)
+        v = np.random.randn(100).astype(np.float32)
+        v /= np.linalg.norm(v)
+        s = net.get_hidden_activations(v)
+        assert s.shape == (10,)
+        assert set(np.unique(s)).issubset({0.0, 1.0})
+
+
+class TestRecall:
+    def test_convergence(self):
+        net = DenseAssociativeMemory(nv=100, nh=10)
+        v = np.random.randn(100).astype(np.float32)
+        v /= np.linalg.norm(v)
+        v_out, s = net.recall(v)
+        assert v_out.shape == (100,)
+
+    def test_recall_is_deterministic(self):
+        net = DenseAssociativeMemory(nv=100, nh=10)
+        v = np.random.randn(100).astype(np.float32)
+        v /= np.linalg.norm(v)
+        v1, _ = net.recall(v)
+        v2, _ = net.recall(v)
+        assert np.allclose(v1, v2)
+
+
+class TestLearning:
+    def test_learn_reduces_error(self):
+        net = DenseAssociativeMemory(nv=100, nh=10, lr=0.01)
+        patterns = np.random.randn(5, 100).astype(np.float32)
+        for i in range(5):
+            patterns[i] /= np.linalg.norm(patterns[i])
+        loss1 = net.learn(patterns, epochs=1)
+        loss2 = net.learn(patterns, epochs=10)
+        assert loss2 < loss1
+
+    def test_pattern_completion(self):
+        """Stored patterns recalled from noisy cues."""
+        net = DenseAssociativeMemory(nv=200, nh=20, lr=0.01)
+        patterns = []
+        for i in range(3):
+            v = np.zeros(200, dtype=np.float32)
+            v[i*60:(i+1)*60] = np.random.randn(60).astype(np.float32)
+            v /= np.linalg.norm(v)
+            patterns.append(v)
+        net.learn(np.stack(patterns), epochs=50)
+
+        # Noisy cue
+        noisy = patterns[0] + 0.3 * np.random.randn(200).astype(np.float32)
+        noisy /= np.linalg.norm(noisy)
+        recalled, _ = net.recall(noisy)
+
+        sims = [float(np.dot(recalled, p)) for p in patterns]
+        assert np.argmax(sims) == 0  # Most similar to pattern 0
+
+    def test_capacity_scales_with_nh(self):
+        np.random.seed(42)  # Fix seed for reproducibility
+        nv, n_patterns = 200, 20
+        patterns = np.random.randn(n_patterns, nv).astype(np.float32)
+        for i in range(n_patterns):
+            patterns[i] /= np.linalg.norm(patterns[i])
+
+        net_small = DenseAssociativeMemory(nv=nv, nh=8, lr=0.01)
+        net_large = DenseAssociativeMemory(nv=nv, nh=32, lr=0.01)
+        loss_small = net_small.learn(patterns, epochs=30)
+        loss_large = net_large.learn(patterns, epochs=30)
+        assert loss_large <= loss_small
+
+
+class TestSerialization:
+    def test_roundtrip(self):
+        net = DenseAssociativeMemory(nv=100, nh=10)
+        patterns = np.random.randn(3, 100).astype(np.float32)
+        for i in range(3):
+            patterns[i] /= np.linalg.norm(patterns[i])
+        net.learn(patterns, epochs=5)
+
+        state = net.get_state()
+        net2 = DenseAssociativeMemory.from_state(state)
+        assert np.allclose(net.xi, net2.xi)
+        assert net.nv == net2.nv
+        assert net.nh == net2.nh

--- a/tests/plugins/test_dam_persistence.py
+++ b/tests/plugins/test_dam_persistence.py
@@ -1,0 +1,58 @@
+"""Tests for DAM state persistence."""
+import pytest
+import numpy as np
+
+from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
+from plugins.context_engine.lcm.dam.persistence import save_state, load_state
+
+
+class MockRetriever:
+    """Minimal retriever-like object for persistence tests."""
+    def __init__(self, nv=100, nh=10):
+        self.network = DenseAssociativeMemory(nv=nv, nh=nh)
+        self._pattern_cache = {}
+        self._last_indexed_id = -1
+
+
+class TestSaveLoad:
+    def test_save_creates_file(self, tmp_path):
+        retriever = MockRetriever()
+        path = tmp_path / "dam_state.npz"
+        assert save_state(retriever, path) is True
+        assert path.exists()
+
+    def test_roundtrip(self, tmp_path):
+        retriever = MockRetriever(nv=100, nh=10)
+        # Train the network a bit
+        patterns = np.random.randn(3, 100).astype(np.float32)
+        for i in range(3):
+            patterns[i] /= np.linalg.norm(patterns[i])
+        retriever.network.learn(patterns, epochs=5)
+        retriever._last_indexed_id = 42
+        # Add some cached patterns
+        retriever._pattern_cache[0] = np.random.randn(100).astype(np.float32)
+        retriever._pattern_cache[5] = np.random.randn(100).astype(np.float32)
+
+        path = tmp_path / "dam_state.npz"
+        save_state(retriever, path)
+        loaded = load_state(path)
+
+        assert loaded is not None
+        assert np.allclose(loaded["xi"], retriever.network.xi)
+        assert loaded["nv"] == 100
+        assert loaded["nh"] == 10
+        assert loaded["last_indexed_id"] == 42
+        assert loaded["cache_ids"] is not None
+        assert len(loaded["cache_ids"]) == 2
+
+    def test_load_nonexistent(self, tmp_path):
+        path = tmp_path / "nonexistent.npz"
+        assert load_state(path) is None
+
+    def test_empty_cache_roundtrip(self, tmp_path):
+        retriever = MockRetriever()
+        path = tmp_path / "dam_state.npz"
+        save_state(retriever, path)
+        loaded = load_state(path)
+        assert loaded is not None
+        assert loaded["last_indexed_id"] == -1

--- a/tests/plugins/test_dam_retrieval.py
+++ b/tests/plugins/test_dam_retrieval.py
@@ -1,0 +1,99 @@
+"""Tests for DAM retrieval engine."""
+import pytest
+import numpy as np
+
+from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
+from plugins.context_engine.lcm.dam.encoder import MessageEncoder
+from plugins.context_engine.lcm.dam.retrieval import DAMRetriever
+from plugins.context_engine.lcm.engine import LcmEngine
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.tools import set_engine
+
+
+@pytest.fixture
+def lcm_engine():
+    config = LcmConfig(enabled=True, protect_last_n=2)
+    engine = LcmEngine(config)
+    engine.ingest({"role": "user", "content": "Python error handling with try except blocks"})
+    engine.ingest({"role": "assistant", "content": "Use try/except blocks for error handling in Python"})
+    engine.ingest({"role": "user", "content": "What is the weather forecast for tomorrow"})
+    engine.ingest({"role": "assistant", "content": "I don't have access to weather data"})
+    engine.ingest({"role": "user", "content": "Rust ownership and borrowing system"})
+    engine.ingest({"role": "assistant", "content": "Rust uses ownership rules to manage memory safely"})
+    set_engine(engine)
+    yield engine
+    set_engine(None)
+
+
+@pytest.fixture
+def retriever(lcm_engine, tmp_path):
+    net = DenseAssociativeMemory(nv=512, nh=16, lr=0.01)
+    enc = MessageEncoder(nv=512)
+    return DAMRetriever(net, enc, tmp_path)
+
+
+class TestSyncWithStore:
+    def test_indexes_new_messages(self, retriever, lcm_engine):
+        count = retriever.sync_with_store()
+        assert count == 6
+        assert len(retriever._pattern_cache) == 6
+
+    def test_incremental_sync(self, retriever, lcm_engine):
+        retriever.sync_with_store()
+        lcm_engine.ingest({"role": "user", "content": "new message"})
+        count = retriever.sync_with_store()
+        assert count == 1
+        assert len(retriever._pattern_cache) == 7
+
+    def test_no_engine_returns_zero(self, tmp_path):
+        set_engine(None)
+        net = DenseAssociativeMemory(nv=512, nh=16)
+        enc = MessageEncoder(nv=512)
+        r = DAMRetriever(net, enc, tmp_path)
+        assert r.sync_with_store() == 0
+
+
+class TestSearch:
+    def test_returns_relevant_results(self, retriever):
+        retriever.sync_with_store()
+        results = retriever.search("exception handling Python")
+        assert len(results) > 0
+        # Top results should be the Python error handling messages (ids 0 or 1)
+        top_ids = [r[0] for r in results[:2]]
+        assert 0 in top_ids or 1 in top_ids
+
+    def test_empty_query(self, retriever):
+        retriever.sync_with_store()
+        results = retriever.search("")
+        assert results == []
+
+
+class TestRecallSimilar:
+    def test_finds_related_messages(self, retriever):
+        retriever.sync_with_store()
+        results = retriever.recall_similar(0, limit=3)  # msg 0 is about Python errors
+        assert len(results) > 0
+        # msg 1 (assistant reply about error handling) should be most similar
+        top_ids = [r[0] for r in results]
+        assert 1 in top_ids
+
+
+class TestCompose:
+    def test_and_composition(self, retriever):
+        retriever.sync_with_store()
+        results = retriever.compose(["Python", "error"], operation="AND", limit=3)
+        assert len(results) > 0
+
+    def test_or_composition(self, retriever):
+        retriever.sync_with_store()
+        results = retriever.compose(["Python", "Rust"], operation="OR", limit=5)
+        assert len(results) > 0
+
+
+class TestStatus:
+    def test_returns_stats(self, retriever):
+        retriever.sync_with_store()
+        status = retriever.get_status()
+        assert status["nv"] == 512
+        assert status["nh"] == 16
+        assert status["patterns_stored"] == 6

--- a/tests/plugins/test_dam_tools.py
+++ b/tests/plugins/test_dam_tools.py
@@ -1,0 +1,156 @@
+"""Tests for DAM tool handlers and schemas."""
+import json
+import pytest
+
+from plugins.context_engine.lcm.dam import schemas as dam_schemas
+from plugins.context_engine.lcm.dam import tools as dam_tools
+from plugins.context_engine.lcm.dam.network import DenseAssociativeMemory
+from plugins.context_engine.lcm.dam.encoder import MessageEncoder
+from plugins.context_engine.lcm.dam.retrieval import DAMRetriever
+from plugins.context_engine.lcm.engine import LcmEngine
+from plugins.context_engine.lcm.config import LcmConfig
+from plugins.context_engine.lcm.tools import set_engine
+
+
+@pytest.fixture(autouse=True)
+def _reset_retriever():
+    """Ensure dam_tools._retriever is cleaned up between tests."""
+    original = dam_tools._retriever
+    yield
+    dam_tools._retriever = original
+    set_engine(None)
+
+
+@pytest.fixture
+def setup_dam(tmp_path):
+    """Set up LCM engine + DAM retriever and inject into dam_tools module."""
+    config = LcmConfig(enabled=True, protect_last_n=2)
+    engine = LcmEngine(config)
+    engine.ingest({"role": "user", "content": "Python error handling with try except"})
+    engine.ingest({"role": "assistant", "content": "Use try/except for error handling"})
+    engine.ingest({"role": "user", "content": "What is the weather today"})
+    engine.ingest({"role": "assistant", "content": "I cannot check weather"})
+    set_engine(engine)
+
+    net = DenseAssociativeMemory(nv=512, nh=16, lr=0.01)
+    enc = MessageEncoder(nv=512)
+    retriever = DAMRetriever(net, enc, tmp_path)
+    retriever.sync_with_store()
+    dam_tools._retriever = retriever
+
+    yield dam_tools
+
+    dam_tools._retriever = None
+    set_engine(None)
+
+
+class TestSchemas:
+    def test_all_schemas_present(self):
+        for schema in [dam_schemas.DAM_SEARCH, dam_schemas.DAM_RECALL, dam_schemas.DAM_COMPOSE, dam_schemas.DAM_STATUS]:
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+
+    def test_dam_search_has_required_query(self):
+        assert "query" in dam_schemas.DAM_SEARCH["parameters"]["required"]
+
+    def test_dam_recall_has_required_message_id(self):
+        assert "message_id" in dam_schemas.DAM_RECALL["parameters"]["required"]
+
+    def test_dam_compose_has_required_queries(self):
+        assert "queries" in dam_schemas.DAM_COMPOSE["parameters"]["required"]
+
+    def test_dam_status_no_required_params(self):
+        assert dam_schemas.DAM_STATUS["parameters"]["required"] == []
+
+
+class TestDamSearch:
+    def test_returns_results(self, setup_dam):
+        result = setup_dam.handle_dam_search({"query": "Python exception"})
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_result_is_not_error(self, setup_dam):
+        result = setup_dam.handle_dam_search({"query": "Python error handling"})
+        assert isinstance(result, str)
+
+    def test_empty_query_returns_error(self, setup_dam):
+        result = setup_dam.handle_dam_search({"query": ""})
+        assert "error" in result.lower()
+
+    def test_empty_query_strips_whitespace(self, setup_dam):
+        result = setup_dam.handle_dam_search({"query": "   "})
+        assert "error" in result.lower()
+
+    def test_no_retriever_falls_back_gracefully(self):
+        dam_tools._retriever = None
+        result = dam_tools.handle_dam_search({"query": "test"})
+        assert isinstance(result, str)
+
+    def test_respects_limit_parameter(self, setup_dam):
+        result = setup_dam.handle_dam_search({"query": "Python", "limit": 1})
+        assert isinstance(result, str)
+
+
+class TestDamRecall:
+    def test_finds_similar_messages(self, setup_dam):
+        result = setup_dam.handle_dam_recall({"message_id": 0})
+        assert isinstance(result, str)
+        # Should return a list header, not a JSON error object
+        assert result.startswith("Messages similar to") or "msg" in result.lower()
+
+    def test_missing_message_id_returns_error(self, setup_dam):
+        result = setup_dam.handle_dam_recall({})
+        assert "error" in result.lower()
+
+    def test_invalid_message_id_returns_gracefully(self, setup_dam):
+        result = setup_dam.handle_dam_recall({"message_id": 9999})
+        assert isinstance(result, str)
+
+    def test_no_retriever_returns_error(self):
+        dam_tools._retriever = None
+        result = dam_tools.handle_dam_recall({"message_id": 0})
+        assert "error" in result.lower()
+
+
+class TestDamCompose:
+    def test_and_operation_returns_string(self, setup_dam):
+        result = setup_dam.handle_dam_compose({"queries": ["Python", "error"], "operation": "AND"})
+        assert isinstance(result, str)
+
+    def test_or_operation_returns_string(self, setup_dam):
+        result = setup_dam.handle_dam_compose({"queries": ["Python", "weather"], "operation": "OR"})
+        assert isinstance(result, str)
+
+    def test_too_few_queries_returns_error(self, setup_dam):
+        result = setup_dam.handle_dam_compose({"queries": ["solo"]})
+        assert "error" in result.lower()
+
+    def test_empty_queries_returns_error(self, setup_dam):
+        result = setup_dam.handle_dam_compose({"queries": []})
+        assert "error" in result.lower()
+
+    def test_invalid_operation_returns_error(self, setup_dam):
+        result = setup_dam.handle_dam_compose({"queries": ["Python", "error"], "operation": "XOR"})
+        assert "error" in result.lower()
+
+    def test_no_retriever_returns_error(self):
+        dam_tools._retriever = None
+        result = dam_tools.handle_dam_compose({"queries": ["Python", "error"]})
+        assert "error" in result.lower()
+
+
+class TestDamStatus:
+    def test_shows_network_dimensions(self, setup_dam):
+        result = setup_dam.handle_dam_status({})
+        assert isinstance(result, str)
+        assert "512" in result or "Nv" in result or "dimension" in result.lower()
+
+    def test_shows_patterns_stored(self, setup_dam):
+        result = setup_dam.handle_dam_status({})
+        assert "pattern" in result.lower() or "stored" in result.lower()
+
+    def test_no_retriever_returns_inactive_message(self):
+        dam_tools._retriever = None
+        result = dam_tools.handle_dam_status({})
+        assert "not initialized" in result.lower() or "inactive" in result.lower()

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -72,6 +72,10 @@ def _make_agent(monkeypatch):
         def _has_stream_consumers(self):
             return False
 
+        def _apply_pending_steer_to_tool_results(self, messages, num_tools):
+            # No-op for stub — real implementation appends steer text to tool results
+            pass
+
     stub = _Stub()
     # Bind the real methods under test
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -35,7 +35,7 @@ def test_plugin_engine_gets_context_length_on_init():
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
-        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=engine),
         patch("agent.model_metadata.get_model_context_length", return_value=204_800),
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -65,7 +65,7 @@ def test_plugin_engine_update_model_args():
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
-        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=engine),
         patch("agent.model_metadata.get_model_context_length", return_value=131_072),
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),


### PR DESCRIPTION
## Summary

- Adds Lossless Context Management (LCM) as a pluggable `ContextEngine`, replacing the monolithic `ContextCompressor` with a DAG-based message store that supports compaction, expansion, pinning, and forgetting
- Implements Dense Associative Memory (DAM) and Holographic Reduced Representation (HRR) retrieval layers for semantic search over compressed context
- Introduces deterministic summarization fallback via sumy LexRank (no LLM required) and accurate token counting via tiktoken when available

Supersedes #4033 — cleaner commit history, same feature set.

## What's included

- **ContextEngine ABC** (`agent/context_engine.py`) — plugin interface with config-driven selection
- **LCM plugin** (`plugins/context_engine/lcm/`) — full implementation: engine, store, DAG, tokens, escalation, session persistence, primer, tools
- **DAM layer** — encoder, network, persistence, retrieval, schemas, tools
- **HRR layer** — holographic store, retrieval, schemas, tools
- **30+ lifecycle tests** — ingest, compact, search, expand, pin, forget
- **Plugin wiring** — `run_agent.py` and `hermes_cli/` updated for context engine plugin discovery

## Test plan

- [x] `pytest tests/plugins/context_engine/` — all LCM unit tests pass
- [x] `pytest tests/plugins/test_dam_*.py` — DAM layer tests pass
- [x] `pytest tests/agent/test_context_engine.py` — ABC contract tests pass
- [x] Verify no regressions in existing test suite

