### PR TITLE
Strip tool definitions from fallback provider requests

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5036,6 +5036,18 @@ class AIAgent:
         if self.tools:
             api_kwargs["tools"] = self.tools
 
+        # Strip tools when running on a fallback provider.  Fallback models
+        # (e.g. Grok on OpenRouter) often have smaller context windows and
+        # choke on the full tool payload, returning 400.  Text-only fallback
+        # is preferable to a hard failure.
+        if self._fallback_activated and "tools" in api_kwargs:
+            logging.warning(
+                "Stripping %d tool definitions for fallback provider %s/%s",
+                len(api_kwargs["tools"]), self.provider, self.model,
+            )
+            del api_kwargs["tools"]
+            api_kwargs.pop("tool_choice", None)
+
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
         elif self._is_openrouter_url() and "claude" in (self.model or "").lower():

--- a/tests/test_strip_tools_fallback.py
+++ b/tests/test_strip_tools_fallback.py
@@ -1,0 +1,64 @@
+"""Tests for stripping tools from fallback provider requests.
+
+When the agent falls back to a secondary provider, tool definitions are
+stripped from the API kwargs to avoid 400 errors from models with smaller
+context windows (e.g. Grok on OpenRouter).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _make_agent(tools=None):
+    """Create a minimal AIAgent with tools loaded."""
+    tool_defs = tools or _make_tool_defs("web_search", "read_file", "edit_file")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=tool_defs),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+class TestStripToolsOnFallback:
+    def test_tools_present_on_primary(self):
+        agent = _make_agent()
+        assert agent._fallback_activated is False
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "tools" in kwargs
+        assert len(kwargs["tools"]) == 3
+
+    def test_tools_stripped_on_fallback(self):
+        agent = _make_agent()
+        agent._fallback_activated = True
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+
+    def test_no_tools_no_error_on_fallback(self):
+        agent = _make_agent(tools=[])
+        agent._fallback_activated = True
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "tools" not in kwargs


### PR DESCRIPTION
## Summary

- When the agent falls back to a secondary provider, the full tool payload (70+ definitions) is sent unchanged, often exceeding the fallback model's context window and causing a 400 error
- This patch strips `tools` and `tool_choice` from API kwargs when `_fallback_activated` is True, making fallback text-only
- The response handler already gracefully handles responses without tool calls, so no downstream changes needed

## Motivation

Running with 53+ MCP tools plus 17 built-in tools, the payload is too large for fallback models like `x-ai/grok-4.1-fast` on OpenRouter. The fallback triggers correctly but immediately fails with a 400. Text-only degraded mode is preferable to a hard failure.

## Changes

- `run_agent.py`: Added tool stripping logic in `_build_api_kwargs()` when `_fallback_activated` is True, with a warning log
- `tests/test_strip_tools_fallback.py`: Three tests covering primary (tools preserved), fallback (tools stripped), and edge case (no tools, no error)

## Test plan

- [x] New tests pass (3/3)
- [x] Existing fallback tests pass (64/64 across test_fallback_model, test_provider_fallback, test_primary_runtime_restore)
- [ ] Manual verification: stop proxy, confirm fallback activates without 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)