### PR TITLE
fix(discord): accept .log attachments and raise document size limit

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -298,6 +298,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
     ".md": "text/markdown",
     ".txt": "text/plain",
+    ".log": "text/plain",
     ".zip": "application/zip",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2382,7 +2382,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         ext or "unknown", content_type,
                     )
                 else:
-                    MAX_DOC_BYTES = 20 * 1024 * 1024
+                    MAX_DOC_BYTES = 32 * 1024 * 1024
                     if att.size and att.size > MAX_DOC_BYTES:
                         logger.warning(
                             "[Discord] Document too large (%s bytes), skipping: %s",
@@ -2406,9 +2406,9 @@ class DiscordAdapter(BasePlatformAdapter):
                             media_urls.append(cached_path)
                             media_types.append(doc_mime)
                             logger.info("[Discord] Cached user document: %s", cached_path)
-                            # Inject text content for .txt/.md files (capped at 100 KB)
+                            # Inject text content for plain-text documents (capped at 100 KB)
                             MAX_TEXT_INJECT_BYTES = 100 * 1024
-                            if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                            if ext in (".md", ".txt", ".log") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                                 try:
                                     text_content = raw_bytes.decode("utf-8")
                                     display_name = att.filename or f"document{ext}"

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -210,13 +210,30 @@ class TestIncomingDocumentHandling:
         assert "# Title" in event.text
 
     @pytest.mark.asyncio
+    async def test_log_content_injected(self, adapter):
+        """.log file under 100KB should be treated as text/plain and injected."""
+        file_content = b"BLE trace line 1\nBLE trace line 2"
+
+        with _mock_aiohttp_download(file_content):
+            msg = make_message(
+                attachments=[make_attachment(filename="btsnoop_hci.log", content_type="text/plain")],
+                content="please inspect this",
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "[Content of btsnoop_hci.log]:" in event.text
+        assert "BLE trace line 1" in event.text
+        assert "please inspect this" in event.text
+
+    @pytest.mark.asyncio
     async def test_oversized_document_skipped(self, adapter):
-        """A document over 20MB should be skipped — media_urls stays empty."""
+        """A document over 32MB should be skipped — media_urls stays empty."""
         msg = make_message([
             make_attachment(
                 filename="huge.pdf",
                 content_type="application/pdf",
-                size=25 * 1024 * 1024,
+                size=33 * 1024 * 1024,
             )
         ])
         await adapter._handle_message(msg)
@@ -225,6 +242,24 @@ class TestIncomingDocumentHandling:
         assert event.media_urls == []
         # handler must still be called
         adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mid_sized_zip_under_32mb_is_cached(self, adapter):
+        """A 25MB .zip should be accepted now that Discord documents allow up to 32MB."""
+        msg = make_message([
+            make_attachment(
+                filename="bugreport.zip",
+                content_type="application/zip",
+                size=25 * 1024 * 1024,
+            )
+        ])
+
+        with _mock_aiohttp_download(b"PK\x03\x04test"):
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["application/zip"]
 
     @pytest.mark.asyncio
     async def test_zip_document_cached(self, adapter):


### PR DESCRIPTION
## Bug Description

The Discord gateway was dropping two kinds of valid diagnostic attachments:
- ZIP documents larger than 20 MB
- `.log` files such as `btsnoop_hci.log`

This broke a real debugging workflow where a user sent an Android bugreport ZIP and then an extracted Bluetooth snoop log. Hermes skipped both files before ingestion.

Fixes #6466

## Root Cause

Two separate guards were too restrictive:

1. `gateway/platforms/discord.py` used a hardcoded 20 MB document limit for Discord attachment ingestion.
2. `gateway/platforms/base.py` did not classify `.log` as a supported document type, so log files were rejected before download and caching.

## Fix

- raise the Discord document ingest limit from 20 MB to 32 MB
- add `.log` to `SUPPORTED_DOCUMENT_TYPES` as `text/plain`
- treat `.log` like other small text documents for inline content injection
- add regression coverage for `.log` ingestion and 25 MB ZIP acceptance

## How to Verify

1. Send a Discord `.log` attachment such as `btsnoop_hci.log`.
2. Confirm the gateway accepts and caches the attachment instead of logging it as unsupported.
3. Send a Discord `.zip` attachment larger than 20 MB but smaller than 32 MB.
4. Confirm the gateway accepts the attachment instead of skipping it for size.

## Test Plan

- [x] Added regression tests for `.log` ingestion and mid-sized ZIP acceptance
- [x] Targeted gateway tests pass
- [x] Manual verification of the fix
- [x] Ran the full test suite
- [ ] Full suite is green

## Risk Assessment

Low — the change is narrowly scoped to Discord document ingestion and document type recognition. It does not change message routing, media delivery, or non-Discord platform behavior.

## Notes

`python -m pytest tests/ -q` is currently red on `origin/main` for unrelated pre-existing failures in non-Discord areas. The new/affected Discord document handling tests pass.
