### PR TITLE
feat(auth): GitHub Enterprise Copilot support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -344,6 +344,36 @@ IMAGE_TOOLS_DEBUG=false
 # GITHUB_APP_PRIVATE_KEY_PATH=
 # GITHUB_APP_INSTALLATION_ID=
 
+# =============================================================================
+# GITHUB ENTERPRISE COPILOT (optional — only needed for GHE deployments)
+# =============================================================================
+# If your organization uses GitHub Enterprise with Copilot, set these to point
+# Hermes at your GHE instance. All defaults target public github.com.
+#
+# Copilot API base URL (found via CSP header inspection on your GHE instance)
+# COPILOT_API_BASE_URL=https://copilot-api.your-ghe.com
+#
+# OAuth device-code flow endpoints
+# COPILOT_DEVICE_CODE_URL=https://your-ghe.com/login/device/code
+# COPILOT_ACCESS_TOKEN_URL=https://your-ghe.com/login/oauth/access_token
+#
+# Token exchange URL (may not be needed for all GHE setups)
+# COPILOT_TOKEN_EXCHANGE_URL=https://your-ghe.com/api/v3/copilot_internal/v2/token
+#
+# OAuth client ID (override if your GHE app uses a different one)
+# COPILOT_OAUTH_CLIENT_ID=Ov23li8tweQw6odWQebz
+#
+# GHE hostname for gh CLI token lookup (so `gh auth token` targets the right host
+# when you're logged into both public GitHub and GHE)
+# COPILOT_GH_HOST=your-ghe.com
+#
+# Set to 'oauth' to always force the OAuth device-code flow, skipping env vars
+# and gh CLI token lookup. Useful when switching accounts or hosts.
+# COPILOT_AUTH_MODE=oauth
+#
+# Explicit Copilot token (use gho_* or github_pat_*, NOT classic ghp_* tokens)
+# COPILOT_GITHUB_TOKEN=gho_xxxxxxxxxxxxxxxxxxxx
+
 # Groq API key (free tier — used for Whisper STT in voice mode)
 # GROQ_API_KEY=
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -68,7 +68,7 @@ ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
-DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
+DEFAULT_GITHUB_MODELS_BASE_URL = os.getenv("COPILOT_API_BASE_URL", "https://api.githubcopilot.com")
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -128,6 +128,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url=DEFAULT_GITHUB_MODELS_BASE_URL,
         api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        base_url_env_var="COPILOT_API_BASE_URL",
     ),
     "copilot-acp": ProviderConfig(
         id="copilot-acp",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -960,6 +960,25 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    # ── GitHub Enterprise Copilot ──
+    "COPILOT_API_BASE_URL": {
+        "description": "Copilot API base URL (for GitHub Enterprise)",
+        "prompt": "Copilot API base URL (leave empty for github.com)",
+        "category": "provider",
+        "advanced": True,
+    },
+    "COPILOT_GH_HOST": {
+        "description": "GitHub hostname for gh CLI token lookup (e.g. your-ghe.com)",
+        "prompt": "GitHub Enterprise hostname (leave empty for github.com)",
+        "category": "provider",
+        "advanced": True,
+    },
+    "COPILOT_AUTH_MODE": {
+        "description": "Set to 'oauth' to force OAuth device-code flow, skipping env vars and gh CLI",
+        "prompt": "Copilot auth mode (leave empty for default)",
+        "category": "provider",
+        "advanced": True,
+    },
 
     # ── Honcho ──
     "HONCHO_API_KEY": {

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -30,13 +30,22 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 # OAuth device code flow constants (same client ID as opencode/Copilot CLI)
-COPILOT_OAUTH_CLIENT_ID = "Ov23li8tweQw6odWQebz"
-COPILOT_DEVICE_CODE_URL = "https://github.com/login/device/code"
-COPILOT_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+COPILOT_OAUTH_CLIENT_ID = os.getenv("COPILOT_OAUTH_CLIENT_ID", "Ov23li8tweQw6odWQebz")
+COPILOT_DEVICE_CODE_URL = os.getenv("COPILOT_DEVICE_CODE_URL", "https://github.com/login/device/code")
+COPILOT_ACCESS_TOKEN_URL = os.getenv("COPILOT_ACCESS_TOKEN_URL", "https://github.com/login/oauth/access_token")
 
 # Copilot API constants
-COPILOT_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
-COPILOT_API_BASE_URL = "https://api.githubcopilot.com"
+COPILOT_TOKEN_EXCHANGE_URL = os.getenv("COPILOT_TOKEN_EXCHANGE_URL", "https://api.github.com/copilot_internal/v2/token")
+COPILOT_API_BASE_URL = os.getenv("COPILOT_API_BASE_URL", "https://api.githubcopilot.com")
+
+
+def is_copilot_url(url: str) -> bool:
+    """Return True if *url* points to a Copilot / GitHub Models API endpoint."""
+    lower = (url or "").lower()
+    return (
+        "api.githubcopilot.com" in lower
+        or COPILOT_API_BASE_URL.lower().rstrip("/") in lower
+    )
 
 # Token type prefixes
 _CLASSIC_PAT_PREFIX = "ghp_"
@@ -81,7 +90,17 @@ def resolve_copilot_token() -> tuple[str, str]:
 
     Returns (token, source) where source describes where the token came from.
     Raises ValueError if only a classic PAT is available.
+
+    Respects ``COPILOT_AUTH_MODE``:
+      - ``oauth``  — skip env vars and ``gh auth token``; return empty so the
+                     caller falls through to the OAuth device-code flow.
+      - (unset)    — default behaviour: env vars → ``gh auth token``.
     """
+    auth_mode = os.getenv("COPILOT_AUTH_MODE", "").strip().lower()
+    if auth_mode == "oauth":
+        logger.debug("COPILOT_AUTH_MODE=oauth — skipping env vars and gh CLI")
+        return "", ""
+
     # 1. Check env vars in priority order
     for env_var in COPILOT_ENV_VARS:
         val = os.getenv(env_var, "").strip()
@@ -94,7 +113,7 @@ def resolve_copilot_token() -> tuple[str, str]:
                 continue
             return val, env_var
 
-    # 2. Fall back to gh auth token
+    # 2. Fall back to gh auth token (host-aware when COPILOT_GH_HOST is set)
     token = _try_gh_cli_token()
     if token:
         valid, msg = validate_copilot_token(token)
@@ -129,11 +148,20 @@ def _gh_cli_candidates() -> list[str]:
 
 
 def _try_gh_cli_token() -> Optional[str]:
-    """Return a token from ``gh auth token`` when the GitHub CLI is available."""
+    """Return a token from ``gh auth token`` when the GitHub CLI is available.
+
+    If ``COPILOT_GH_HOST`` is set (e.g. ``cancomictdev.ghe.com``), pass
+    ``--hostname`` so we get the token for the right GitHub instance instead
+    of whichever host happens to be the active default.
+    """
+    gh_host = os.getenv("COPILOT_GH_HOST", "").strip()
     for gh_path in _gh_cli_candidates():
+        cmd = [gh_path, "auth", "token"]
+        if gh_host:
+            cmd += ["--hostname", gh_host]
         try:
             result = subprocess.run(
-                [gh_path, "auth", "token"],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -164,8 +192,8 @@ def copilot_device_code_login(
     import urllib.parse
 
     domain = host.rstrip("/")
-    device_code_url = f"https://{domain}/login/device/code"
-    access_token_url = f"https://{domain}/login/oauth/access_token"
+    device_code_url = COPILOT_DEVICE_CODE_URL
+    access_token_url = COPILOT_ACCESS_TOKEN_URL
 
     # Step 1: Request device code
     data = urllib.parse.urlencode({

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1977,7 +1977,65 @@ def _model_flow_copilot(config, current_model=""):
         elif source == "gh auth token":
             print("  GitHub token: ✓ (from `gh auth token`)")
         else:
-            print("  GitHub token: ✓")
+            print(f"  GitHub token: ✓ ({source})" if source else "  GitHub token: ✓")
+        print()
+
+        # Offer re-authentication
+        print("  Current credentials will be used. To switch account/host:")
+        print("    1. Continue with current token")
+        print("    2. Re-authenticate (OAuth device code flow)")
+        print("    3. Enter a different token manually")
+        print()
+        try:
+            reauth = input("  Choice [1-3]: ").strip()
+        except (KeyboardInterrupt, EOFError, OSError):
+            print()
+            reauth = "1"
+
+        if reauth == "2":
+            try:
+                from hermes_cli.copilot_auth import copilot_device_code_login
+                token = copilot_device_code_login()
+                if token:
+                    save_env_value("COPILOT_GITHUB_TOKEN", token)
+                    print("  New Copilot token saved.")
+                    print()
+                    creds = resolve_api_key_provider_credentials(provider_id)
+                    api_key = creds.get("api_key", "")
+                    source = creds.get("source", "")
+                else:
+                    print("  Login cancelled — keeping existing token.")
+            except Exception as exc:
+                print(f"  Login failed: {exc} — keeping existing token.")
+        elif reauth == "3":
+            try:
+                import getpass
+                new_key = getpass.getpass("  Token (COPILOT_GITHUB_TOKEN): ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                new_key = ""
+            if new_key:
+                try:
+                    from hermes_cli.copilot_auth import validate_copilot_token
+                    valid, msg = validate_copilot_token(new_key)
+                    if not valid:
+                        print(f"  ✗ {msg} — keeping existing token.")
+                    else:
+                        save_env_value("COPILOT_GITHUB_TOKEN", new_key)
+                        print("  Token saved.")
+                        print()
+                        creds = resolve_api_key_provider_credentials(provider_id)
+                        api_key = creds.get("api_key", "")
+                        source = creds.get("source", "")
+                except ImportError:
+                    save_env_value("COPILOT_GITHUB_TOKEN", new_key)
+                    print("  Token saved.")
+                    creds = resolve_api_key_provider_credentials(provider_id)
+                    api_key = creds.get("api_key", "")
+                    source = creds.get("source", "")
+            else:
+                print("  Keeping existing token.")
+        # else choice "1" or anything else — continue with current token
         print()
 
     effective_base = pconfig.inference_base_url

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -8,13 +8,16 @@ Add, remove, or reorder entries here — both `hermes setup` and
 from __future__ import annotations
 
 import json
+import logging
 import os
 import urllib.request
 import urllib.error
 from difflib import get_close_matches
 from typing import Any, Optional
 
-COPILOT_BASE_URL = "https://api.githubcopilot.com"
+logger = logging.getLogger(__name__)
+
+COPILOT_BASE_URL = os.getenv("COPILOT_API_BASE_URL", "https://api.githubcopilot.com")
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
@@ -1198,6 +1201,7 @@ def fetch_github_model_catalog(
     attempts.append(copilot_default_headers())
 
     for headers in attempts:
+        logger.debug("Fetching Copilot model catalog from %s", COPILOT_MODELS_URL)
         req = urllib.request.Request(COPILOT_MODELS_URL, headers=headers)
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -1215,7 +1219,8 @@ def fetch_github_model_catalog(
                     models.append(item)
                 if models:
                     return models
-        except Exception:
+        except Exception as exc:
+            logger.debug("Copilot model catalog fetch failed (%s): %s", COPILOT_MODELS_URL, exc)
             continue
     return None
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -74,6 +74,15 @@ from tools.browser_tool import cleanup_browser
 
 from hermes_constants import OPENROUTER_BASE_URL
 
+
+def _is_copilot_base(url: str) -> bool:
+    """Check if *url* is a Copilot / GitHub Enterprise Copilot endpoint."""
+    try:
+        from hermes_cli.copilot_auth import is_copilot_url
+        return is_copilot_url(url)
+    except Exception:
+        return "api.githubcopilot.com" in (url or "").lower()
+
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block
 from agent.retry_utils import jittered_backoff
@@ -777,7 +786,7 @@ class AIAgent:
                         "X-OpenRouter-Title": "Hermes Agent",
                         "X-OpenRouter-Categories": "productivity,cli-agent",
                     }
-                elif "api.githubcopilot.com" in effective_base.lower():
+                elif _is_copilot_base(effective_base):
                     from hermes_cli.models import copilot_default_headers
 
                     client_kwargs["default_headers"] = copilot_default_headers()
@@ -4121,7 +4130,7 @@ class AIAgent:
         normalized = (base_url or "").lower()
         if "openrouter" in normalized:
             self._client_kwargs["default_headers"] = dict(_OR_HEADERS)
-        elif "api.githubcopilot.com" in normalized:
+        elif _is_copilot_base(normalized):
             from hermes_cli.models import copilot_default_headers
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
@@ -5379,7 +5388,7 @@ class AIAgent:
 
             is_github_responses = (
                 "models.github.ai" in self.base_url.lower()
-                or "api.githubcopilot.com" in self.base_url.lower()
+                or _is_copilot_base(self.base_url)
             )
 
             # Resolve reasoning effort: config > default (medium)
@@ -5533,7 +5542,7 @@ class AIAgent:
         _is_openrouter = self._is_openrouter_url()
         _is_github_models = (
             "models.github.ai" in self._base_url_lower
-            or "api.githubcopilot.com" in self._base_url_lower
+            or _is_copilot_base(self._base_url_lower)
         )
 
         # Provider preferences (only, ignore, order, sort) are OpenRouter-
@@ -5602,7 +5611,7 @@ class AIAgent:
             return True
         if "ai-gateway.vercel.sh" in self._base_url_lower:
             return True
-        if "models.github.ai" in self._base_url_lower or "api.githubcopilot.com" in self._base_url_lower:
+        if "models.github.ai" in self._base_url_lower or _is_copilot_base(self._base_url_lower):
             try:
                 from hermes_cli.models import github_model_reasoning_efforts
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -61,7 +61,7 @@ class TestProviderRegistry:
     def test_copilot_env_vars(self):
         pconfig = PROVIDER_REGISTRY["copilot"]
         assert pconfig.api_key_env_vars == ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
-        assert pconfig.base_url_env_var == ""
+        assert pconfig.base_url_env_var == "COPILOT_API_BASE_URL"
 
     def test_kimi_env_vars(self):
         pconfig = PROVIDER_REGISTRY["kimi-coding"]


### PR DESCRIPTION
## Summary

Adds full GitHub Enterprise (GHE) Copilot support by making all Copilot OAuth and API URLs configurable via environment variables. All defaults remain unchanged — public github.com users are unaffected.

## Motivation

Organizations using GitHub Enterprise with Copilot cannot use Hermes today because OAuth endpoints, API base URLs, and token exchange URLs are hardcoded to `github.com` / `api.githubcopilot.com`. This PR makes all of those configurable.

## Changes

### Core: configurable Copilot endpoints (`copilot_auth.py`)
- `COPILOT_API_BASE_URL`, `COPILOT_DEVICE_CODE_URL`, `COPILOT_ACCESS_TOKEN_URL`, `COPILOT_TOKEN_EXCHANGE_URL`, `COPILOT_OAUTH_CLIENT_ID` — all read from env vars with public GitHub defaults
- New `is_copilot_url()` helper matches both public and custom GHE endpoints

### Auth improvements (`copilot_auth.py`)
- **`COPILOT_AUTH_MODE=oauth`** — forces OAuth device-code flow, skipping env vars and `gh auth token`. Solves the problem where existing tokens from a different GitHub host block re-authentication
- **`COPILOT_GH_HOST`** — passes `--hostname` to `gh auth token` so the correct host's token is used when logged into both public GitHub and GHE simultaneously

### Provider resolution (`auth.py`)
- Added `base_url_env_var="COPILOT_API_BASE_URL"` to copilot `ProviderConfig` so the standard provider resolution pipeline picks up the custom base URL

### Agent endpoint matching (`run_agent.py`)
- New `_is_copilot_base()` helper replaces 5 hardcoded `"api.githubcopilot.com" in ...` checks
- Copilot headers, reasoning effort detection, and response mode detection all now work with custom GHE endpoints

### Setup UX (`main.py`)
- `hermes models setup` now offers a re-auth prompt when a Copilot token already exists: continue / OAuth re-login / enter token manually

### Model catalog (`models.py`)
- `COPILOT_BASE_URL` reads from `COPILOT_API_BASE_URL` env var
- Added debug logging for catalog fetch attempts and failures

### Config (`config.py`)
- Registered `COPILOT_API_BASE_URL`, `COPILOT_GH_HOST`, `COPILOT_AUTH_MODE` in `OPTIONAL_ENV_VARS` (advanced/provider category)

### Documentation (`.env.example`)
- Added a full "GitHub Enterprise Copilot" section with all env vars, placeholder values, and explanatory comments

## GHE Setup Example

```bash
# In ~/.hermes/.env
COPILOT_API_BASE_URL=https://copilot-api.your-ghe.com
COPILOT_DEVICE_CODE_URL=https://your-ghe.com/login/device/code
COPILOT_ACCESS_TOKEN_URL=https://your-ghe.com/login/oauth/access_token
COPILOT_GH_HOST=your-ghe.com

# Optional: force OAuth flow even when tokens exist
# COPILOT_AUTH_MODE=oauth

# Optional: override OAuth client ID for your GHE app
# COPILOT_OAUTH_CLIENT_ID=your-client-id

# Explicit token (if not using OAuth or gh CLI)
# COPILOT_GITHUB_TOKEN=gho_xxxxxxxxxxxxxxxxxxxx
```

Then run `hermes models setup` → select Copilot → OAuth login targets the GHE instance automatically.

## Files Changed

| File | Change |
|------|--------|
| `hermes_cli/copilot_auth.py` | Configurable URLs, `is_copilot_url()`, `COPILOT_AUTH_MODE`, `COPILOT_GH_HOST` |
| `hermes_cli/auth.py` | `base_url_env_var` on copilot provider, env-aware base URL default |
| `hermes_cli/models.py` | Env-aware `COPILOT_BASE_URL`, debug logging |
| `hermes_cli/main.py` | Re-auth prompt in `hermes models setup` |
| `hermes_cli/config.py` | New `OPTIONAL_ENV_VARS` entries |
| `run_agent.py` | `_is_copilot_base()` helper, 5 hardcoded checks replaced |
| `.env.example` | Full GHE Copilot documentation section |
| `tests/hermes_cli/test_api_key_providers.py` | Updated assertion for new `base_url_env_var` |

## Testing

- All existing tests pass (`pytest tests/ -q`: 4446 passed, 3 pre-existing flaky skipped)
- Updated `test_copilot_env_vars` to expect new `base_url_env_var`
- Tested manually against a GitHub Enterprise instance with Copilot

## Platform

Tested on Linux (WSL2/Debian).