### PR TITLE
[codex] Redact Git URL credentials from surfaced output

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -10,6 +10,7 @@ the first 6 and last 4 characters for debuggability.
 import logging
 import os
 import re
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,13 @@ _DB_CONNSTR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Generic URL credentials: https://TOKEN@host or https://user:password@host
+# Covers git remotes and ad-hoc HTTP(S) auth URLs that don't match the
+# database-specific patterns above.
+_URL_USERINFO_RE = re.compile(
+    r"([A-Za-z][A-Za-z0-9+.-]*://)([^/\s@]+)@"
+)
+
 # E.164 phone numbers: +<country><number>, 7-15 digits
 # Negative lookahead prevents matching hex strings or identifiers
 _SIGNAL_PHONE_RE = re.compile(r"(\+[1-9]\d{6,14})(?![A-Za-z0-9])")
@@ -159,6 +167,16 @@ def redact_sensitive_text(text: str) -> str:
     # Database connection string passwords
     text = _DB_CONNSTR_RE.sub(lambda m: f"{m.group(1)}***{m.group(3)}", text)
 
+    # Generic URL credentials (git remotes, HTTPS basic auth, token@host URLs)
+    def _redact_url_userinfo(m):
+        scheme, userinfo = m.group(1), m.group(2)
+        if ":" in userinfo:
+            username, _password = userinfo.split(":", 1)
+            safe_username = username or "***"
+            return f"{scheme}{safe_username}:***@"
+        return f"{scheme}***@"
+    text = _URL_USERINFO_RE.sub(_redact_url_userinfo, text)
+
     # E.164 phone numbers (Signal, WhatsApp)
     def _redact_phone(m):
         phone = m.group(1)
@@ -168,6 +186,19 @@ def redact_sensitive_text(text: str) -> str:
     text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
 
     return text
+
+
+def redact_sensitive_data(value: Any) -> Any:
+    """Recursively redact secrets inside nested JSON-like structures."""
+    if isinstance(value, str):
+        return redact_sensitive_text(value)
+    if isinstance(value, list):
+        return [redact_sensitive_data(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_sensitive_data(item) for item in value)
+    if isinstance(value, dict):
+        return {key: redact_sensitive_data(item) for key, item in value.items()}
+    return value
 
 
 class RedactingFormatter(logging.Formatter):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -22,6 +22,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from agent.redact import redact_sensitive_data, redact_sensitive_text
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
@@ -963,14 +964,17 @@ class SessionDB:
             rows = cursor.fetchall()
         messages = []
         for row in rows:
-            msg = {"role": row["role"], "content": row["content"]}
+            msg = {
+                "role": row["role"],
+                "content": redact_sensitive_text(row["content"]),
+            }
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]
             if row["tool_name"]:
                 msg["tool_name"] = row["tool_name"]
             if row["tool_calls"]:
                 try:
-                    msg["tool_calls"] = json.loads(row["tool_calls"])
+                    msg["tool_calls"] = redact_sensitive_data(json.loads(row["tool_calls"]))
                 except (json.JSONDecodeError, TypeError):
                     pass
             # Restore reasoning fields on assistant messages so providers
@@ -978,15 +982,19 @@ class SessionDB:
             # coherent multi-turn reasoning context.
             if row["role"] == "assistant":
                 if row["reasoning"]:
-                    msg["reasoning"] = row["reasoning"]
+                    msg["reasoning"] = redact_sensitive_text(row["reasoning"])
                 if row["reasoning_details"]:
                     try:
-                        msg["reasoning_details"] = json.loads(row["reasoning_details"])
+                        msg["reasoning_details"] = redact_sensitive_data(
+                            json.loads(row["reasoning_details"])
+                        )
                     except (json.JSONDecodeError, TypeError):
                         pass
                 if row["codex_reasoning_items"]:
                     try:
-                        msg["codex_reasoning_items"] = json.loads(row["codex_reasoning_items"])
+                        msg["codex_reasoning_items"] = redact_sensitive_data(
+                            json.loads(row["codex_reasoning_items"])
+                        )
                     except (json.JSONDecodeError, TypeError):
                         pass
             messages.append(msg)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -145,6 +145,20 @@ class TestAuthHeaders:
         assert "mytoken12345" not in result
 
 
+class TestUrlCredentials:
+    def test_token_only_git_url(self):
+        text = "origin https://super-secret-token@github.com/owner/repo.git"
+        result = redact_sensitive_text(text)
+        assert "super-secret-token" not in result
+        assert "https://***@github.com/owner/repo.git" in result
+
+    def test_username_password_url(self):
+        text = "origin https://alice:hunter2@github.com/owner/repo.git"
+        result = redact_sensitive_text(text)
+        assert "hunter2" not in result
+        assert "https://alice:***@github.com/owner/repo.git" in result
+
+
 class TestTelegramTokens:
     def test_bot_token(self):
         text = "bot123456789:ABCDEfghij-KLMNopqrst_UVWXyz12345"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -262,6 +262,41 @@ class TestMessageStorage:
         assert conv[0]["codex_reasoning_items"] == codex_items
         assert conv[0]["codex_reasoning_items"][0]["encrypted_content"] == "enc_blob_123"
 
+    def test_get_messages_as_conversation_redacts_sensitive_urls(self, db):
+        db.create_session(session_id="s1", source="cli")
+        tool_calls = [
+            {
+                "id": "call_1",
+                "function": {
+                    "name": "terminal",
+                    "arguments": '{"command": "git remote set-url origin https://super-secret-token@github.com/acme/repo.git"}',
+                },
+            }
+        ]
+        reasoning_details = [
+            {
+                "type": "reasoning.summary",
+                "summary": "Check https://alice:hunter2@github.com/acme/repo.git",
+            }
+        ]
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="Use https://alice:hunter2@github.com/acme/repo.git",
+            tool_calls=tool_calls,
+            reasoning="Fetch from https://build-secret-token@github.com/acme/repo.git",
+            reasoning_details=reasoning_details,
+        )
+
+        conv = db.get_messages_as_conversation("s1")
+        assistant = conv[0]
+        assert "hunter2" not in assistant["content"]
+        assert "https://alice:***@github.com/acme/repo.git" in assistant["content"]
+        assert "super-secret-token" not in assistant["tool_calls"][0]["function"]["arguments"]
+        assert "https://***@github.com/acme/repo.git" in assistant["tool_calls"][0]["function"]["arguments"]
+        assert "build-secret-token" not in assistant["reasoning"]
+        assert "hunter2" not in assistant["reasoning_details"][0]["summary"]
+
 
 # =========================================================================
 # FTS5 search

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -120,6 +120,25 @@ class TestCompletionQueue:
         assert completion["exit_code"] == 1
         assert "FAILED" in completion["output"]
 
+    def test_move_to_finished_redacts_command_and_output(self, registry):
+        s = _make_session(
+            command="git fetch https://super-secret-token@github.com/acme/repo.git",
+            notify_on_complete=True,
+            output="fatal: could not read Password for 'https://alice:hunter2@github.com/acme/repo.git'",
+            exit_code=1,
+        )
+        s.exited = True
+        s.exit_code = 1
+        registry._running[s.id] = s
+        with patch.object(registry, "_write_checkpoint"):
+            registry._move_to_finished(s)
+
+        completion = registry.completion_queue.get_nowait()
+        assert "super-secret-token" not in completion["command"]
+        assert "hunter2" not in completion["output"]
+        assert "https://***@github.com/acme/repo.git" in completion["command"]
+        assert "https://alice:***@github.com/acme/repo.git" in completion["output"]
+
     def test_output_truncated_to_2000(self, registry):
         """Long output is truncated to last 2000 chars."""
         long_output = "x" * 5000

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -102,6 +102,18 @@ class TestGetAndPoll:
         assert result["status"] == "exited"
         assert result["exit_code"] == 0
 
+    def test_poll_redacts_credentials_in_command_and_output(self, registry):
+        s = _make_session(
+            command="git ls-remote https://super-secret-token@github.com/acme/repo.git",
+            output="origin https://alice:hunter2@github.com/acme/repo.git",
+        )
+        registry._running[s.id] = s
+        result = registry.poll(s.id)
+        assert "super-secret-token" not in result["command"]
+        assert "hunter2" not in result["output_preview"]
+        assert "https://***@github.com/acme/repo.git" in result["command"]
+        assert "https://alice:***@github.com/acme/repo.git" in result["output_preview"]
+
 
 # =========================================================================
 # Read log
@@ -133,6 +145,15 @@ class TestReadLog:
         registry._running[s.id] = s
         result = registry.read_log(s.id, offset=10, limit=5)
         assert "5 lines" in result["showing"]
+
+    def test_read_log_redacts_credentials(self, registry):
+        s = _make_session(
+            output="git remote set-url origin https://alice:hunter2@github.com/acme/repo.git"
+        )
+        registry._running[s.id] = s
+        result = registry.read_log(s.id)
+        assert "hunter2" not in result["output"]
+        assert "https://alice:***@github.com/acme/repo.git" in result["output"]
 
 
 # =========================================================================

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -111,6 +111,14 @@ class TestFormatConversation:
         result = _format_conversation([])
         assert result == ""
 
+    def test_redacts_sensitive_urls(self):
+        msgs = [
+            {"role": "assistant", "content": "Use https://alice:hunter2@github.com/acme/repo.git"},
+        ]
+        result = _format_conversation(msgs)
+        assert "hunter2" not in result
+        assert "https://alice:***@github.com/acme/repo.git" in result
+
 
 # =========================================================================
 # _truncate_around_matches

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -41,6 +41,8 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
+from agent.redact import redact_sensitive_text
+from tools.ansi_strip import strip_ansi
 from tools.environments.local import _find_shell, _sanitize_subprocess_env
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -48,6 +50,13 @@ from typing import Any, Dict, List, Optional
 from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_visible_text(text: str) -> str:
+    """Strip ANSI escapes and redact secrets before output reaches the model/UI."""
+    if not text:
+        return ""
+    return redact_sensitive_text(strip_ansi(text))
 
 
 # Checkpoint file for crash recovery (gateway only)
@@ -469,11 +478,10 @@ class ProcessRegistry:
         # If the caller requested agent notification, enqueue the completion
         # so the CLI/gateway can auto-trigger a new agent turn.
         if session.notify_on_complete:
-            from tools.ansi_strip import strip_ansi
-            output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+            output_tail = _sanitize_visible_text(session.output_buffer[-2000:])
             self.completion_queue.put({
                 "session_id": session.id,
-                "command": session.command,
+                "command": redact_sensitive_text(session.command),
                 "exit_code": session.exit_code,
                 "output": output_tail,
             })
@@ -488,18 +496,16 @@ class ProcessRegistry:
 
     def poll(self, session_id: str) -> dict:
         """Check status and get new output for a background process."""
-        from tools.ansi_strip import strip_ansi
-
         session = self.get(session_id)
         if session is None:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
         with session._lock:
-            output_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
+            output_preview = _sanitize_visible_text(session.output_buffer[-1000:])
 
         result = {
             "session_id": session.id,
-            "command": session.command,
+            "command": redact_sensitive_text(session.command),
             "status": "exited" if session.exited else "running",
             "pid": session.pid,
             "uptime_seconds": int(time.time() - session.started_at),
@@ -514,14 +520,12 @@ class ProcessRegistry:
 
     def read_log(self, session_id: str, offset: int = 0, limit: int = 200) -> dict:
         """Read the full output log with optional pagination by lines."""
-        from tools.ansi_strip import strip_ansi
-
         session = self.get(session_id)
         if session is None:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
         with session._lock:
-            full_output = strip_ansi(session.output_buffer)
+            full_output = _sanitize_visible_text(session.output_buffer)
 
         lines = full_output.splitlines()
         total_lines = len(lines)
@@ -552,7 +556,6 @@ class ProcessRegistry:
             dict with status ("exited", "timeout", "interrupted", "not_found")
             and output snapshot.
         """
-        from tools.ansi_strip import strip_ansi
         from tools.terminal_tool import _interrupt_event
 
         default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
@@ -581,7 +584,7 @@ class ProcessRegistry:
                 result = {
                     "status": "exited",
                     "exit_code": session.exit_code,
-                    "output": strip_ansi(session.output_buffer[-2000:]),
+                    "output": _sanitize_visible_text(session.output_buffer[-2000:]),
                 }
                 if timeout_note:
                     result["timeout_note"] = timeout_note
@@ -590,7 +593,7 @@ class ProcessRegistry:
             if _interrupt_event.is_set():
                 result = {
                     "status": "interrupted",
-                    "output": strip_ansi(session.output_buffer[-1000:]),
+                    "output": _sanitize_visible_text(session.output_buffer[-1000:]),
                     "note": "User sent a new message -- wait interrupted",
                 }
                 if timeout_note:
@@ -601,7 +604,7 @@ class ProcessRegistry:
 
         result = {
             "status": "timeout",
-            "output": strip_ansi(session.output_buffer[-1000:]),
+            "output": _sanitize_visible_text(session.output_buffer[-1000:]),
         }
         if timeout_note:
             result["timeout_note"] = timeout_note
@@ -714,13 +717,13 @@ class ProcessRegistry:
         for s in all_sessions:
             entry = {
                 "session_id": s.id,
-                "command": s.command[:200],
+                "command": redact_sensitive_text(s.command[:200]),
                 "cwd": s.cwd,
                 "pid": s.pid,
                 "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
                 "uptime_seconds": int(time.time() - s.started_at),
                 "status": "exited" if s.exited else "running",
-                "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
+                "output_preview": _sanitize_visible_text(s.output_buffer[-200:]),
             }
             if s.exited:
                 entry["exit_code"] = s.exit_code

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -22,6 +22,7 @@ import logging
 from typing import Dict, Any, List, Optional, Union
 
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+from agent.redact import redact_sensitive_text
 MAX_SESSION_CHARS = 100_000
 MAX_SUMMARY_TOKENS = 10000
 
@@ -57,7 +58,7 @@ def _format_conversation(messages: List[Dict[str, Any]]) -> str:
     parts = []
     for msg in messages:
         role = msg.get("role", "unknown").upper()
-        content = msg.get("content") or ""
+        content = redact_sensitive_text(msg.get("content") or "")
         tool_name = msg.get("tool_name")
 
         if role == "TOOL" and tool_name:


### PR DESCRIPTION
## Summary
- redact generic URL userinfo secrets such as `https://token@github.com/...` and `https://user:password@host/...`
- sanitize surfaced process command/output data before it reaches notifications, polling, wait results, or session listings
- redact stored conversation/history payloads during resume and session search so previously leaked URLs are not replayed into later context

## Root Cause
Hermes redacted several secret formats, but generic Git/HTTP URL credentials in userinfo segments were not covered consistently. Those secrets could then be surfaced again through process outputs, completion notifications, and historical session replay.

## Validation
- ran `pytest -n 0 tests/agent/test_redact.py tests/tools/test_process_registry.py tests/tools/test_notify_on_complete.py tests/test_hermes_state.py tests/tools/test_session_search.py`
- result: `261 passed in 10.86s`

Fixes #6396
