### PR TITLE
fix(cli): only exit on Ctrl+D when input buffer is empty

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7899,9 +7899,10 @@ class HermesCLI:
         
         @kb.add('c-d')
         def handle_ctrl_d(event):
-            """Handle Ctrl+D - exit."""
-            self._should_exit = True
-            event.app.exit()
+            """Handle Ctrl+D - exit only when the input buffer is empty (standard EOF behavior)."""
+            if not event.app.current_buffer.text:
+                self._should_exit = True
+                event.app.exit()
 
         @kb.add('c-z')
         def handle_ctrl_z(event):

--- a/tests/cli/test_ctrl_d_keybinding.py
+++ b/tests/cli/test_ctrl_d_keybinding.py
@@ -1,0 +1,44 @@
+"""Test Ctrl+D keybinding exits only on empty buffer."""
+
+
+def test_ctrl_d_handler_skips_exit_when_buffer_has_text():
+    """Ctrl+D with non-empty buffer must NOT trigger exit (standard EOF behavior)."""
+    from unittest.mock import MagicMock
+
+    # Simulate the handler logic inline (avoids importing the full CLI)
+    _should_exit = False
+
+    def handle_ctrl_d(event):
+        nonlocal _should_exit
+        if not event.app.current_buffer.text:
+            _should_exit = True
+            event.app.exit()
+
+    event = MagicMock()
+    event.app.current_buffer.text = "some typed text"
+
+    handle_ctrl_d(event)
+
+    assert not _should_exit
+    event.app.exit.assert_not_called()
+
+
+def test_ctrl_d_handler_exits_on_empty_buffer():
+    """Ctrl+D with empty buffer must trigger exit."""
+    from unittest.mock import MagicMock
+
+    _should_exit = False
+
+    def handle_ctrl_d(event):
+        nonlocal _should_exit
+        if not event.app.current_buffer.text:
+            _should_exit = True
+            event.app.exit()
+
+    event = MagicMock()
+    event.app.current_buffer.text = ""
+
+    handle_ctrl_d(event)
+
+    assert _should_exit
+    event.app.exit.assert_called_once()


### PR DESCRIPTION
## Summary

Gate the `Ctrl+D` keybinding handler on an empty input buffer, matching standard terminal EOF behavior (bash, zsh, Python REPL, etc.).

**Before:** `Ctrl+D` unconditionally exits the CLI session, even with text in the buffer — accidental presses lose the session and context.

**After:** `Ctrl+D` only exits when the buffer is empty. With text present, the keypress is ignored, preventing accidental session loss.

## Changes

- `cli.py`: Add `if not event.app.current_buffer.text` guard to `handle_ctrl_d`
- `tests/cli/test_ctrl_d_keybinding.py`: Two regression tests covering both empty and non-empty buffer cases

Fixes #6448
