### PR TITLE
fix: opencode.ai context window resolves to 128K instead of 1M (salvage #4681)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -197,6 +197,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
     "api.fireworks.ai": "fireworks",
+    "opencode.ai": "opencode-go",
 }
 
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -295,10 +295,16 @@ def _format_context_length(tokens: int) -> str:
     """Format a token count for display (e.g. 128000 → '128K', 1048576 → '1M')."""
     if tokens >= 1_000_000:
         val = tokens / 1_000_000
-        return f"{val:g}M"
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}M"
+        return f"{val:.1f}M"
     elif tokens >= 1_000:
         val = tokens / 1_000
-        return f"{val:g}K"
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}K"
+        return f"{val:.1f}K"
     return str(tokens)
 
 


### PR DESCRIPTION
## Summary

Cherry-picked from #4681 by @Hmbown onto current main.

**Problem:** `mimo-v2-pro` (served via opencode.ai) displays 128K context in the banner despite supporting 1M tokens. `opencode.ai` was missing from `_URL_TO_PROVIDER`, so Hermes treated it as a custom endpoint, probed `/models` (404), and fell back to 128K — never reaching the models.dev lookup that correctly returns 1M.

**Fix:**
1. Add `"opencode.ai": "opencode-go"` to `_URL_TO_PROVIDER` in `agent/model_metadata.py`
2. Clean up `_format_context_length` in `hermes_cli/banner.py` — use tolerance-based rounding instead of `:g` formatting (`1048576` → `1M` instead of `1.048576M`)

## Test plan
- All 79 existing tests in `test_model_metadata.py` + `test_banner.py` pass
- E2E verified: URL mapping resolves correctly, formatting outputs match expectations

Closes #4681