### PR TITLE
[codex] Fix Ctrl+D EOF behavior in the CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7061,6 +7061,20 @@ class HermesCLI:
             completions_menu,
         ]
 
+    def _input_buffer_has_content(self, app) -> bool:
+        """Return whether the TUI input has pending text or attachments."""
+        current_buffer = getattr(app, "current_buffer", None)
+        text = getattr(current_buffer, "text", "")
+        return bool(text or self._attached_images)
+
+    def _exit_if_input_empty(self, app) -> bool:
+        """Exit only when the input buffer is truly empty."""
+        if self._input_buffer_has_content(app):
+            return False
+        self._should_exit = True
+        app.exit()
+        return True
+
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         # Push the entire TUI to the bottom of the terminal so the banner,
@@ -7448,19 +7462,17 @@ class HermesCLI:
             else:
                 # If there's text or images, clear them (like bash).
                 # If everything is already empty, exit.
-                if event.app.current_buffer.text or self._attached_images:
+                if self._input_buffer_has_content(event.app):
                     event.app.current_buffer.reset()
                     self._attached_images.clear()
                     event.app.invalidate()
                 else:
-                    self._should_exit = True
-                    event.app.exit()
+                    self._exit_if_input_empty(event.app)
         
         @kb.add('c-d')
         def handle_ctrl_d(event):
-            """Handle Ctrl+D - exit."""
-            self._should_exit = True
-            event.app.exit()
+            """Handle Ctrl+D - exit only when the input is empty."""
+            self._exit_if_input_empty(event.app)
 
         @kb.add('c-z')
         def handle_ctrl_z(event):

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -345,3 +345,39 @@ class TestProviderResolution:
         cli = _make_cli()
         assert isinstance(cli.model, str)
         assert isinstance(cli.model, str) and '/' in cli.model
+
+
+class TestCtrlDEofBehavior:
+    def test_ctrl_d_does_not_exit_when_buffer_has_text(self):
+        cli = _make_cli()
+        app = MagicMock()
+        app.current_buffer.text = "keep this draft"
+
+        exited = cli._exit_if_input_empty(app)
+
+        assert exited is False
+        assert cli._should_exit is False
+        app.exit.assert_not_called()
+
+    def test_ctrl_d_does_not_exit_when_images_are_attached(self):
+        cli = _make_cli()
+        app = MagicMock()
+        app.current_buffer.text = ""
+        cli._attached_images = ["clipboard-image.png"]
+
+        exited = cli._exit_if_input_empty(app)
+
+        assert exited is False
+        assert cli._should_exit is False
+        app.exit.assert_not_called()
+
+    def test_ctrl_d_exits_when_buffer_is_empty(self):
+        cli = _make_cli()
+        app = MagicMock()
+        app.current_buffer.text = ""
+
+        exited = cli._exit_if_input_empty(app)
+
+        assert exited is True
+        assert cli._should_exit is True
+        app.exit.assert_called_once_with()


### PR DESCRIPTION
## Summary
- stop treating `Ctrl+D` as an unconditional exit when the input buffer still has content
- share the buffer-content check between the idle `Ctrl+C` path and the `Ctrl+D` EOF path so text and image attachments are handled consistently
- add regression coverage for text-present, image-attached, and empty-buffer EOF behavior

## Root Cause
The CLI's `Ctrl+D` handler always exited immediately, instead of matching shell-style EOF behavior where exit should only happen when the prompt is empty. That meant partially typed prompts could be discarded by accident.

## Validation
- ran `pytest -n 0 tests/cli/test_cli_init.py`
- result: `29 passed in 38.33s`

Fixes #6448
