### PR TITLE
fix(memory): support windows file locking

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,8 +1,12 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
-import pytest
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
 
 from tools.memory_tool import (
     MemoryStore,
@@ -209,6 +213,51 @@ class TestMemoryStorePersistence:
         store = MemoryStore()
         store.load_from_disk()
         assert len(store.memory_entries) == 2
+
+
+class TestMemoryStoreFileLock:
+    def test_uses_fcntl_when_available(self, monkeypatch, tmp_path):
+        flock = Mock()
+        fake_fcntl = SimpleNamespace(flock=flock, LOCK_EX=11, LOCK_UN=22)
+        monkeypatch.setattr("tools.memory_tool.fcntl", fake_fcntl)
+        monkeypatch.setattr("tools.memory_tool.msvcrt", None)
+
+        with MemoryStore._file_lock(tmp_path / "MEMORY.md"):
+            pass
+
+        assert flock.call_count == 2
+        assert flock.call_args_list[0].args[1] == fake_fcntl.LOCK_EX
+        assert flock.call_args_list[1].args[1] == fake_fcntl.LOCK_UN
+
+    def test_uses_msvcrt_when_fcntl_unavailable(self, monkeypatch, tmp_path):
+        locking = Mock()
+        fake_msvcrt = SimpleNamespace(locking=locking, LK_LOCK=1, LK_UNLCK=2)
+        monkeypatch.setattr("tools.memory_tool.fcntl", None)
+        monkeypatch.setattr("tools.memory_tool.msvcrt", fake_msvcrt)
+
+        with MemoryStore._file_lock(tmp_path / "MEMORY.md"):
+            pass
+
+        assert locking.call_count == 2
+        assert locking.call_args_list[0].args[1:] == (fake_msvcrt.LK_LOCK, 1)
+        assert locking.call_args_list[1].args[1:] == (fake_msvcrt.LK_UNLCK, 1)
+
+    def test_add_works_with_windows_locking(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("tools.memory_tool.MEMORY_DIR", tmp_path)
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        @contextmanager
+        def fake_lock(_path):
+            yield
+
+        monkeypatch.setattr(MemoryStore, "_file_lock", staticmethod(fake_lock))
+
+        store = MemoryStore()
+        store.load_from_disk()
+        result = store.add("memory", "windows-safe entry")
+
+        assert result["success"] is True
+        assert (tmp_path / "MEMORY.md").read_text().strip() == "windows-safe entry"
 
 
 class TestMemoryStoreSnapshot:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,6 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
 import json
 import logging
 import os
@@ -33,6 +32,16 @@ from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 
 logger = logging.getLogger(__name__)
 
@@ -140,17 +149,31 @@ class MemoryStore:
         """Acquire an exclusive file lock for read-modify-write safety.
 
         Uses a separate .lock file so the memory file itself can still be
-        atomically replaced via os.replace().
+        atomically replaced via os.replace(). Supports Unix via ``fcntl`` and
+        Windows via ``msvcrt``.
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = open(lock_path, "w")
+        fd = open(lock_path, "a+")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            elif msvcrt is not None:
+                fd.seek(0)
+                fd.write("0")
+                fd.flush()
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-            fd.close()
+            try:
+                if fcntl is not None:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                elif msvcrt is not None:
+                    fd.seek(0)
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+            finally:
+                fd.close()
 
     @staticmethod
     def _path_for(target: str) -> Path:


### PR DESCRIPTION
## Summary
- make `tools/memory_tool.py` import safely on Windows by guarding the Unix-only `fcntl` import
- add a Windows locking path via `msvcrt.locking` while preserving `fcntl.flock` on Unix
- cover both locking branches with targeted tests and verify `MemoryStore.add()` still persists correctly

## Testing
- `python -m pytest tests/tools/test_memory_tool.py -q`
- `python -m pytest tests/tools/ -q` *(fails on pre-existing unrelated test: `tests/tools/test_vision_tools.py::TestVisionRequirements::test_check_requirements_accepts_codex_auth`)*

Closes #3992