### PR TITLE
Replace memo-based Apple Notes skill with native osascript workflow

### DIFF
--- a/skills/apple/apple-notes/SKILL.md
+++ b/skills/apple/apple-notes/SKILL.md
@@ -1,90 +1,103 @@
 ---
 name: apple-notes
-description: "Manage Apple Notes via memo CLI: create, search, edit."
-version: 1.0.0
-author: Hermes Agent
+description: Read, search, create, and organize Apple Notes on macOS.
+version: 1.1.0
+author: Li shixiong (lishix520); Hermes Agent
 license: MIT
 platforms: [macos]
 metadata:
   hermes:
     tags: [Notes, Apple, macOS, note-taking]
     related_skills: [obsidian]
-prerequisites:
-  commands: [memo]
 ---
 
-# Apple Notes
+# Apple Notes Skill
 
-Use `memo` to manage Apple Notes directly from the terminal. Notes sync across all Apple devices via iCloud.
-
-## Prerequisites
-
-- **macOS** with Notes.app
-- Install: `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
-- Grant Automation access to Notes.app when prompted (System Settings → Privacy → Automation)
+Use the `terminal` tool to drive Apple Notes natively through the helper script `scripts/apple_notes.py`, which runs `osascript` against Notes.app. This replaces third-party CLIs such as `memo`: no `brew tap` or install step, and every operation is noninteractive and parameterized. macOS only; notes sync to iPhone and iPad through iCloud.
 
 ## When to Use
 
-- User asks to create, view, or search Apple Notes
-- Saving information to Notes.app for cross-device access
-- Organizing notes into folders
-- Exporting notes to Markdown/HTML
+- Read, search, create, or append to Apple Notes
+- Save information to Notes.app for cross-device access
+- Organize notes into folders or move notes between folders
 
 ## When NOT to Use
 
-- Obsidian vault management → use the `obsidian` skill
-- Bear Notes → separate app (not supported here)
-- Quick agent-only notes → use the `memory` tool instead
+- Obsidian vault work -> use the `obsidian` skill
+- Bear Notes -> separate app, not supported
+- Agent-internal notes that do not need to sync -> use the `memory` tool
+
+## Prerequisites
+
+- macOS with Notes.app installed.
+- `osascript` ships with macOS; there is no install step.
+- Grant Automation access to Notes.app the first time `osascript` drives it (System Settings -> Privacy & Security -> Automation). The prompt appears once per binary.
+
+## How to Run
+
+Invoke the helper script with the `terminal` tool. Every subcommand takes explicit arguments and never prompts:
+
+```bash
+SCRIPT="skills/apple/apple-notes/scripts/apple_notes.py"
+
+# Inspect the vault
+python3 "$SCRIPT" list-folders
+python3 "$SCRIPT" list-notes --folder "Notes"
+python3 "$SCRIPT" search --query "standup"
+
+# Read
+python3 "$SCRIPT" read --title "Standup Notes" --folder "Notes"
+
+# Create and append (plain-text body is converted to Notes HTML)
+python3 "$SCRIPT" create --title "Standup Notes" --body "First entry" --folder "Notes"
+python3 "$SCRIPT" append --title "Standup Notes" --body "Second entry" --folder "Notes"
+
+# Folders and moves
+python3 "$SCRIPT" create-folder --name "Project Alpha"
+python3 "$SCRIPT" move --title "Standup Notes" --src "Notes" --dest "Project Alpha"
+```
+
+Pass `--body-html` instead of `--body` to write raw Notes HTML (for example a structured project-update template) without conversion.
 
 ## Quick Reference
 
-### View Notes
+| Action | Command |
+| --- | --- |
+| List folders | `list-folders` |
+| List notes in a folder | `list-notes --folder F` |
+| Search note titles | `search --query Q` |
+| Read a note | `read --title T [--folder F]` |
+| Create a note | `create --title T --body B [--folder F]` |
+| Append to a note | `append --title T --body B [--folder F]` |
+| Create a folder | `create-folder --name N` |
+| Move a note | `move --title T --dest D [--src S]` |
 
-```bash
-memo notes                        # List all notes
-memo notes -f "Folder Name"       # Filter by folder
-memo notes -s "query"             # Search notes (fuzzy)
-```
+When `--folder` is omitted, `create` writes to the default folder and `read`/`append`/`move` search across all folders.
 
-### Create Notes
+## Procedure
 
-```bash
-memo notes -a                     # Interactive editor
-memo notes -a "Note Title"        # Quick add with title
-```
+1. Run `list-folders` first to resolve the target folder. If the right folder does not exist, create it with `create-folder`.
+2. Before creating a note, run `search` by title to avoid duplicates.
+3. To update an existing note, prefer `append` over recreating it; only rewrite when the user explicitly asks.
+4. If `search` returns multiple matches, narrow by folder or keyword before acting. Do not guess.
+5. For moves, confirm source and destination with the user before executing bulk moves.
 
-### Edit Notes
+## Pitfalls
 
-```bash
-memo notes -e                     # Interactive selection to edit
-```
+- Notes returns the body as HTML-like content (`<div>`, `<br>`); `read` returns it verbatim.
+- `search` matches note titles only. To find text inside a note, `read` it and search locally.
+- Folder names resolve across accounts; if two accounts share a folder name, the first match is used.
+- Automation permission is per-binary. A different Python interpreter may re-trigger the permission prompt.
+- `append` concatenates HTML; very large notes may render slowly in Notes.app.
 
-### Delete Notes
+## Verification
 
-```bash
-memo notes -d                     # Interactive selection to delete
-```
+Confirm the skill end to end with the `terminal` tool against a scratch folder, then delete it:
 
-### Move Notes
-
-```bash
-memo notes -m                     # Move note to folder (interactive)
-```
-
-### Export Notes
-
-```bash
-memo notes -ex                    # Export to HTML/Markdown
-```
-
-## Limitations
-
-- Cannot edit notes containing images or attachments
-- Interactive prompts require terminal access (use pty=true if needed)
-- macOS only — requires Apple Notes.app
-
-## Rules
-
-1. Prefer Apple Notes when user wants cross-device sync (iPhone/iPad/Mac)
-2. Use the `memory` tool for agent-internal notes that don't need to sync
-3. Use the `obsidian` skill for Markdown-native knowledge management
+1. `list-folders` returns the current folders.
+2. `create-folder --name "Hermes Skill Test"` creates a scratch folder.
+3. `create --title "Skill Check" --body "hello" --folder "Hermes Skill Test"` creates a note.
+4. `append --title "Skill Check" --body "more" --folder "Hermes Skill Test"` appends.
+5. `read --title "Skill Check" --folder "Hermes Skill Test"` returns both entries.
+6. `move --title "Skill Check" --src "Hermes Skill Test" --dest "Notes"` moves it.
+7. Delete the scratch folder from Notes.app when finished.

--- a/skills/apple/apple-notes/SKILL.md
+++ b/skills/apple/apple-notes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: apple-notes
-description: Manage Apple Notes via the memo CLI on macOS (create, view, search, edit).
-version: 1.0.0
+description: Manage Apple Notes natively on macOS via osascript and Notes automation (read, search, create, append, organize, move).
+version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [macos]
@@ -10,81 +10,175 @@ metadata:
     tags: [Notes, Apple, macOS, note-taking]
     related_skills: [obsidian]
 prerequisites:
-  commands: [memo]
+  commands: [osascript]
 ---
 
 # Apple Notes
 
-Use `memo` to manage Apple Notes directly from the terminal. Notes sync across all Apple devices via iCloud.
+Use Apple Notes natively through `osascript` and macOS Notes automation.
+
+This version is optimized for agent-driven workflows on macOS:
+
+- no third-party Apple Notes CLI
+- no `brew tap` / `brew install` step
+- no interactive wrapper required for common tasks
+- better fit for repeated read, search, append, move, and organization workflows
 
 ## Prerequisites
 
 - **macOS** with Notes.app
-- Install: `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
-- Grant Automation access to Notes.app when prompted (System Settings → Privacy → Automation)
+- `osascript` available (built into macOS)
+- Grant Automation access to Notes.app when prompted (System Settings -> Privacy & Security -> Automation)
 
 ## When to Use
 
-- User asks to create, view, or search Apple Notes
+- User asks to read, search, create, or update Apple Notes
 - Saving information to Notes.app for cross-device access
 - Organizing notes into folders
-- Exporting notes to Markdown/HTML
+- Moving notes between folders
+- Reusing existing notes as project continuity context
 
 ## When NOT to Use
 
-- Obsidian vault management → use the `obsidian` skill
-- Bear Notes → separate app (not supported here)
-- Quick agent-only notes → use the `memory` tool instead
+- Obsidian vault management -> use the `obsidian` skill
+- Bear Notes -> separate app (not supported here)
+- Quick agent-only notes -> use the `memory` tool instead
+- Summarization or translation itself -> do that first, then use this skill to save the result
+
+## Operating Rules
+
+1. Prefer Apple Notes when the user wants native Apple sync across iPhone, iPad, and Mac
+2. Search before creating when there is any chance the note already exists
+3. Prefer append/update over replacing the whole note
+4. Keep formatting structured and readable
+5. Be conservative with move and delete
+6. If the target note is ambiguous, stop and clarify instead of guessing
 
 ## Quick Reference
 
-### View Notes
+### List folders
 
 ```bash
-memo notes                        # List all notes
-memo notes -f "Folder Name"       # Filter by folder
-memo notes -s "query"             # Search notes (fuzzy)
+osascript -e 'tell application "Notes" to get name of every folder'
 ```
 
-### Create Notes
+### Search note titles in a folder
 
 ```bash
-memo notes -a                     # Interactive editor
-memo notes -a "Note Title"        # Quick add with title
+osascript -e 'tell application "Notes" to get name of every note of first folder whose name contains "Apple Notes"'
 ```
 
-### Edit Notes
+### Read a note body
 
 ```bash
-memo notes -e                     # Interactive selection to edit
+osascript -e 'tell application "Notes" to get body of note "Apple Notes Skill Reference" of first folder'
 ```
 
-### Delete Notes
+### Create a note
 
 ```bash
-memo notes -d                     # Interactive selection to delete
+osascript <<'EOF'
+tell application "Notes"
+    activate
+    tell first folder
+        make new note with properties {name:"Apple Notes Skill", body:"<h1>Apple Notes Skill</h1><br><div>Structured content goes here.</div>"}
+    end tell
+end tell
+EOF
 ```
+
+## Practical Workflows
+
+### Read or Search Existing Notes
+
+- Find the note first by title or nearby keywords
+- If multiple notes match, narrow before reading
+- Read only after identifying the target note confidently
+
+### Create a New Note
+
+- Search first if the title may already exist
+- Choose the correct folder if known
+- Use a clear title and readable structure
+
+### Append or Update
+
+- Prefer appending new sections rather than rewriting old content
+- Preserve existing structure unless the user explicitly asks for cleanup
+- Avoid destroying manually written content
+
+### Create Folders
+
+- Create folders only when a clear category does not already exist
+- Use simple, stable names
+- Prefer flat folder names over pseudo-nested folder names
 
 ### Move Notes
 
-```bash
-memo notes -m                     # Move note to folder (interactive)
-```
+- Identify the note first
+- Confirm the destination folder
+- For bulk moves, preview the mapping before executing
 
-### Export Notes
+### Organize Uncategorized Notes
 
-```bash
-memo notes -ex                    # Export to HTML/Markdown
+- First pass: move only high-confidence matches
+- Second pass: create a few practical flat folders for recurring themes
+- Final pass: move leftovers into a deliberate catch-all folder rather than leaving them unorganized forever
+
+Classification is allowed when it directly supports organization, but keep it practical. Do not turn this skill into a deep taxonomy exercise.
+
+## Formatting Rules
+
+Never write dense wall-of-text notes if the content is more than a few lines.
+
+Use:
+
+- a clear title
+- blank lines between paragraphs
+- bullets for lists
+- headings for sections
+
+### Project update pattern
+
+```md
+# Project Name
+
+## Update - YYYY-MM-DD
+
+### Status
+
+Short status summary.
+
+### Done
+
+- Item
+
+### In Progress
+
+- Item
+
+### Next
+
+- Item
+
+### Risks / Blockers
+
+- Item
 ```
 
 ## Limitations
 
-- Cannot edit notes containing images or attachments
-- Interactive prompts require terminal access (use pty=true if needed)
-- macOS only — requires Apple Notes.app
+- Apple Notes access depends on macOS Automation permission
+- Rich text body may be returned as HTML-like content
+- Raw body may include tags such as `<div>` or `<br>`
+- Apple Notes organization is flatter and simpler than a full document system
+- Avoid direct overwrite when append is safer
 
-## Rules
+## Error Handling
 
-1. Prefer Apple Notes when user wants cross-device sync (iPhone/iPad/Mac)
-2. Use the `memory` tool for agent-internal notes that don't need to sync
-3. Use the `obsidian` skill for Markdown-native knowledge management
+When an action fails:
+
+- check whether Automation permission is blocked
+- check whether the folder exists
+- check whether the note title is ambiguous
+- retry the same validated `osascript` method before inventing a new access path

--- a/skills/apple/apple-notes/scripts/apple_notes.py
+++ b/skills/apple/apple-notes/scripts/apple_notes.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Native Apple Notes helper for the ``apple-notes`` skill.
+
+All operations are parameterized and noninteractive: every command takes
+explicit arguments and never prompts the user. The AppleScript that drives
+Notes.app is assembled by pure functions (``build_*``) and executed by
+``run_applescript``, so the string-building logic is unit-testable without
+macOS or a live Notes database.
+
+Invoke through the Hermes ``terminal`` tool, for example::
+
+    terminal: python3 skills/apple/apple-notes/scripts/apple_notes.py list-folders
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import subprocess
+import sys
+from typing import Optional
+
+OSASCRIPT_TIMEOUT = 30
+
+
+def escape_applescript_string(value: str) -> str:
+    """Escape a string for an AppleScript double-quoted literal.
+
+    AppleScript requires backslash and double-quote to be escaped with a
+    leading backslash. Other characters pass through unchanged because body
+    text is first converted by ``text_to_notes_html``.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def text_to_notes_html(text: str) -> str:
+    """Convert plain text into Notes body HTML.
+
+    HTML-special characters are escaped so user content cannot inject markup,
+    then newlines become ``<br>`` line breaks.
+    """
+    escaped = html.escape(text, quote=False)
+    return escaped.replace("\n", "<br>")
+
+
+def _q(value: str) -> str:
+    """Wrap an escaped value in AppleScript double quotes."""
+    return '"' + escape_applescript_string(value) + '"'
+
+
+def build_list_folders_script() -> str:
+    return 'tell application "Notes" to get name of every folder'
+
+
+def build_list_notes_script(folder: str) -> str:
+    # Scope with a tell block: a one-liner like `every note of first folder
+    # whose name is F` parses the `whose` against the note, not the folder,
+    # and silently returns nothing.
+    f = _q(folder)
+    return (
+        'tell application "Notes"\n'
+        "    tell first folder whose name is " + f + "\n"
+        "        get name of every note\n"
+        "    end tell\n"
+        "end tell"
+    )
+
+
+def build_search_script(query: str) -> str:
+    # Title-only search: Notes `whose` on the rich-text body is unreliable.
+    return (
+        'tell application "Notes" to get name of every note '
+        "whose name contains " + _q(query)
+    )
+
+
+def build_read_note_script(title: str, folder: Optional[str] = None) -> str:
+    t = _q(title)
+    if folder:
+        f = _q(folder)
+        return (
+            'tell application "Notes"\n'
+            "    tell first folder whose name is " + f + "\n"
+            "        get body of first note whose name is " + t + "\n"
+            "    end tell\n"
+            "end tell"
+        )
+    return 'tell application "Notes" to get body of first note whose name is ' + t
+
+
+def build_create_note_script(title: str, body_html: str, folder: Optional[str] = None) -> str:
+    t = _q(title)
+    b = _q(body_html)
+    props = "{name:" + t + ", body:" + b + "}"
+    if folder:
+        f = _q(folder)
+        return (
+            'tell application "Notes"\n'
+            "    tell first folder whose name is " + f + "\n"
+            "        make new note with properties " + props + "\n"
+            "    end tell\n"
+            "end tell"
+        )
+    return (
+        'tell application "Notes"\n'
+        "    tell first folder\n"
+        "        make new note with properties " + props + "\n"
+        "    end tell\n"
+        "end tell"
+    )
+
+
+def build_append_note_script(title: str, body_html: str, folder: Optional[str] = None) -> str:
+    t = _q(title)
+    b = _q(body_html)
+    if folder:
+        f = _q(folder)
+        return (
+            'tell application "Notes"\n'
+            "    tell first folder whose name is " + f + "\n"
+            "        set n to first note whose name is " + t + "\n"
+            "        set body of n to (body of n) & " + b + "\n"
+            "    end tell\n"
+            "end tell"
+        )
+    return (
+        'tell application "Notes"\n'
+        "    set n to first note whose name is " + t + "\n"
+        "    set body of n to (body of n) & " + b + "\n"
+        "end tell"
+    )
+
+
+def build_create_folder_script(name: str) -> str:
+    return 'tell application "Notes" to make new folder with properties {name:' + _q(name) + "}"
+
+
+def build_move_note_script(title: str, dest: str, src: Optional[str] = None) -> str:
+    t = _q(title)
+    d = _q(dest)
+    if src:
+        s = _q(src)
+        return (
+            'tell application "Notes"\n'
+            "    set destFolder to first folder whose name is " + d + "\n"
+            "    tell first folder whose name is " + s + "\n"
+            "        move first note whose name is " + t + " to destFolder\n"
+            "    end tell\n"
+            "end tell"
+        )
+    return (
+        'tell application "Notes"\n'
+        "    set destFolder to first folder whose name is " + d + "\n"
+        "    move first note whose name is " + t + " to destFolder\n"
+        "end tell"
+    )
+
+
+def run_applescript(script: str) -> str:
+    """Run an AppleScript via ``osascript -`` (stdin) and return stdout."""
+    result = subprocess.run(
+        ["osascript", "-"],
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=OSASCRIPT_TIMEOUT,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("osascript failed: " + result.stderr.strip())
+    return result.stdout
+
+
+def _emit(text: str) -> int:
+    if text:
+        sys.stdout.write(text)
+        if not text.endswith("\n"):
+            sys.stdout.write("\n")
+    return 0
+
+
+def _body_arg(args: argparse.Namespace) -> str:
+    if args.body_html is not None:
+        return args.body_html
+    return text_to_notes_html(args.body)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="apple_notes.py",
+        description="Native, noninteractive Apple Notes helper.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list-folders", help="List every Notes folder.")
+
+    p = sub.add_parser("list-notes", help="List note titles in a folder.")
+    p.add_argument("--folder", required=True)
+
+    p = sub.add_parser("search", help="Search note titles by substring.")
+    p.add_argument("--query", required=True)
+
+    p = sub.add_parser("read", help="Read a note body.")
+    p.add_argument("--title", required=True)
+    p.add_argument("--folder")
+
+    p = sub.add_parser("create", help="Create a note.")
+    p.add_argument("--title", required=True)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--body", help="Plain-text body (converted to Notes HTML).")
+    g.add_argument("--body-html", help="Raw HTML body (no conversion).")
+    p.add_argument("--folder")
+
+    p = sub.add_parser("append", help="Append HTML to an existing note body.")
+    p.add_argument("--title", required=True)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--body", help="Plain-text body (converted to Notes HTML).")
+    g.add_argument("--body-html", help="Raw HTML body (no conversion).")
+    p.add_argument("--folder")
+
+    p = sub.add_parser("create-folder", help="Create a new folder.")
+    p.add_argument("--name", required=True)
+
+    p = sub.add_parser("move", help="Move a note to another folder.")
+    p.add_argument("--title", required=True)
+    p.add_argument("--dest", required=True)
+    p.add_argument("--src", help="Source folder (defaults to searching all folders).")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
+    cmd = args.command
+
+    if cmd == "list-folders":
+        return _emit(run_applescript(build_list_folders_script()))
+    if cmd == "list-notes":
+        return _emit(run_applescript(build_list_notes_script(args.folder)))
+    if cmd == "search":
+        return _emit(run_applescript(build_search_script(args.query)))
+    if cmd == "read":
+        return _emit(run_applescript(build_read_note_script(args.title, args.folder)))
+    if cmd == "create":
+        return _emit(run_applescript(build_create_note_script(args.title, _body_arg(args), args.folder)))
+    if cmd == "append":
+        return _emit(run_applescript(build_append_note_script(args.title, _body_arg(args), args.folder)))
+    if cmd == "create-folder":
+        return _emit(run_applescript(build_create_folder_script(args.name)))
+    if cmd == "move":
+        return _emit(run_applescript(build_move_note_script(args.title, args.dest, args.src)))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_apple_notes_skill.py
+++ b/tests/skills/test_apple_notes_skill.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "apple" / "apple-notes"
+SCRIPT_PATH = SKILL_DIR / "scripts" / "apple_notes.py"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("apple_notes_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frontmatter() -> str:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    m = re.search(r"^---\s*\n(.*?)\n---\s*$", text, re.MULTILINE | re.DOTALL)
+    assert m, "SKILL.md frontmatter not found"
+    return m.group(1)
+
+
+# --- skill metadata (HARDLINE authoring standards) ---
+
+
+def test_description_is_short_one_sentence_ending_with_period():
+    desc = None
+    for line in _frontmatter().splitlines():
+        m = re.match(r"^description:\s*(.*)$", line)
+        if m:
+            desc = m.group(1).strip()
+            break
+    assert desc, "description field missing from frontmatter"
+    assert len(desc) <= 60, f"description is {len(desc)} chars, must be <= 60: {desc!r}"
+    assert desc.endswith("."), f"description must end with a period: {desc!r}"
+    assert desc.count(".") == 1, f"description must be one sentence: {desc!r}"
+
+
+def test_platforms_gated_to_macos_only():
+    m = re.search(r"^platforms:\s*(.*)$", _frontmatter(), re.MULTILINE)
+    assert m, "platforms field missing"
+    platforms = m.group(1).lower()
+    assert "macos" in platforms, "osascript skill must declare macos"
+    assert "linux" not in platforms and "windows" not in platforms, (
+        "osascript is macOS-only; no other platforms may be claimed"
+    )
+
+
+def test_author_credits_human_contributor_first():
+    m = re.search(r"^author:\s*(.*)$", _frontmatter(), re.MULTILINE)
+    assert m, "author field missing"
+    author = m.group(1).strip()
+    assert "lishix520" in author, f"contributor handle missing from author: {author!r}"
+    handle_idx = author.find("lishix520")
+    hermes_idx = author.lower().find("hermes agent")
+    assert hermes_idx == -1 or handle_idx < hermes_idx, (
+        f"human contributor must be credited before 'Hermes Agent': {author!r}"
+    )
+
+
+def test_skill_md_names_terminal_tool_and_helper_script():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert "`terminal`" in text, "prose must name the Hermes `terminal` tool"
+    assert "scripts/apple_notes.py" in text, "SKILL.md must reference the helper script by path"
+    assert "scripts/apple_notes.py" in text
+
+
+# --- AppleScript string building (pure, no macOS needed) ---
+
+
+def test_escape_applescript_string():
+    mod = load_module()
+    assert mod.escape_applescript_string("plain") == "plain"
+    assert mod.escape_applescript_string('he said "hi"') == 'he said \\"hi\\"'
+    assert mod.escape_applescript_string("back\\slash") == "back\\\\slash"
+
+
+def test_text_to_notes_html_escapes_markup_and_breaks_lines():
+    mod = load_module()
+    out = mod.text_to_notes_html("<b>hi</b>\nline2")
+    assert out == "&lt;b&gt;hi&lt;/b&gt;<br>line2"
+    # user content must not survive as live markup
+    assert "<b>" not in out
+    malicious = "<script>alert(1)</script>"
+    assert "<script>" not in mod.text_to_notes_html(malicious)
+
+
+def test_build_create_note_script_escapes_title_and_scopes_to_folder():
+    mod = load_module()
+    script = mod.build_create_note_script('Title "X"', "<div>body</div>", folder="Notes")
+    assert "make new note with properties" in script
+    assert "tell first folder whose name is \"Notes\"" in script
+    # the unescaped title (with a raw double quote) must NOT appear
+    assert 'Title "X"' not in script
+    # the escaped form must appear
+    assert 'Title \\"X\\"' in script
+
+
+def test_build_create_note_script_defaults_to_first_folder():
+    mod = load_module()
+    script = mod.build_create_note_script("T", "body")
+    assert "tell first folder\n" in script
+    assert "whose name is" not in script
+
+
+def test_build_append_note_script_concatenates_existing_body():
+    mod = load_module()
+    script = mod.build_append_note_script("T", "<br>more", folder="F")
+    assert "set n to first note whose name is" in script
+    assert "set body of n to (body of n) &" in script
+    assert "<br>more" in script
+
+
+def test_build_append_note_script_without_folder_searches_all():
+    mod = load_module()
+    script = mod.build_append_note_script("T", "<br>more")
+    assert "set n to first note whose name is" in script
+    assert "tell first folder" not in script
+
+
+def test_build_move_note_script_uses_dest_variable_and_src_scope():
+    mod = load_module()
+    script = mod.build_move_note_script("T", dest="Dest", src="Src")
+    assert "set destFolder to first folder whose name is" in script
+    assert "tell first folder whose name is \"Src\"" in script
+    assert "move first note whose name is" in script
+    assert "to destFolder" in script
+
+
+def test_build_create_folder_script():
+    mod = load_module()
+    script = mod.build_create_folder_script("Project X")
+    assert "make new folder with properties" in script
+    assert "Project X" in script
+
+
+def test_build_list_folders_and_search_scripts():
+    mod = load_module()
+    folders = mod.build_list_folders_script()
+    assert folders.startswith('tell application "Notes"')
+    assert "every folder" in folders
+    assert "whose name contains" in mod.build_search_script("query")
+
+
+def test_build_list_notes_script_scopes_to_named_folder():
+    mod = load_module()
+    script = mod.build_list_notes_script("My Folder")
+    # must use a tell block so `whose` filters the folder, not the notes;
+    # the one-liner `every note of first folder whose name is F` mis-parses
+    # and silently returns nothing.
+    assert "tell first folder whose name is \"My Folder\"" in script
+    assert "get name of every note" in script
+    assert "every note of first folder whose" not in script
+
+
+# --- execution layer ---
+
+
+def test_run_applescript_raises_on_nonzero_exit():
+    mod = load_module()
+    fake = MagicMock(returncode=1, stdout="", stderr="not authorized")
+    with patch("subprocess.run", return_value=fake):
+        with pytest.raises(RuntimeError, match="not authorized"):
+            mod.run_applescript('tell application "Notes" to get name of every folder')
+
+
+def test_run_applescript_returns_stdout_on_success():
+    mod = load_module()
+    fake = MagicMock(returncode=0, stdout="Notes\nPersonal\n", stderr="")
+    with patch("subprocess.run", return_value=fake) as mock_run:
+        out = mod.run_applescript("tell application \"Notes\" to ...")
+    assert out == "Notes\nPersonal\n"
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == ["osascript", "-"]
+
+
+# --- CLI dispatch ---
+
+
+def test_cli_create_invokes_run_applescript_with_built_script(monkeypatch):
+    mod = load_module()
+    captured = []
+
+    def fake_run(script):
+        captured.append(script)
+        return "ok"
+
+    monkeypatch.setattr(mod, "run_applescript", fake_run)
+    rc = mod.main(["create", "--title", "T", "--body", "hello\nworld", "--folder", "Notes"])
+    assert rc == 0
+    assert captured, "run_applescript was not called"
+    assert "make new note" in captured[0]
+    assert "tell first folder whose name is \"Notes\"" in captured[0]
+    # plain-text body was converted to Notes HTML
+    assert "hello<br>world" in captured[0]
+
+
+def test_cli_append_accepts_raw_body_html(monkeypatch):
+    mod = load_module()
+    captured = []
+    monkeypatch.setattr(mod, "run_applescript", lambda s: captured.append(s) or "")
+    mod.main(["append", "--title", "T", "--body-html", "<br>raw", "--folder", "F"])
+    assert "set body of n to (body of n) &" in captured[0]
+    assert "<br>raw" in captured[0]
+
+
+def test_cli_create_folder_dispatches(monkeypatch):
+    mod = load_module()
+    captured = []
+    monkeypatch.setattr(mod, "run_applescript", lambda s: captured.append(s) or "")
+    mod.main(["create-folder", "--name", "Project X"])
+    assert "make new folder with properties" in captured[0]
+    assert "Project X" in captured[0]
+
+
+def test_cli_move_dispatches_with_src_and_dest(monkeypatch):
+    mod = load_module()
+    captured = []
+    monkeypatch.setattr(mod, "run_applescript", lambda s: captured.append(s) or "")
+    mod.main(["move", "--title", "T", "--src", "Src", "--dest", "Dest"])
+    assert "set destFolder to first folder whose name is \"Dest\"" in captured[0]
+    assert "tell first folder whose name is \"Src\"" in captured[0]
+
+
+def test_cli_body_and_body_html_are_mutually_exclusive():
+    mod = load_module()
+    with pytest.raises(SystemExit):
+        mod.main(["create", "--title", "T", "--body", "a", "--body-html", "<b>b</b>", "--folder", "F"])


### PR DESCRIPTION
This PR replaces the built-in Apple Notes skill guidance with a native `osascript` workflow on macOS.

Why make this change:
- much lower user friction
- no third-party Apple Notes CLI like `memo`
- no `brew tap` / `brew install` step
- better fit for agent automation than interactive terminal flows
- simpler for users who already have Notes.app and just want it to work

From a user-experience standpoint, this is the main improvement: the current skill asks the user to install and trust an extra wrapper CLI before the agent can do anything useful. The native `osascript` path removes that friction and gives the agent a single built-in access path it can reuse across sessions.

What this updated skill covers:
- read notes
- search notes
- create notes
- append/update existing notes
- create folders
- move notes
- organize uncategorized notes
- write cleaner structured content into Notes

It also keeps the guidance more agent-oriented by preferring append over overwrite, requiring clarification on ambiguity, and documenting practical organization workflows instead of relying on interactive prompts.

The only system requirement is standard macOS Automation permission for Notes, which users already need for any native Apple Notes automation.

I also opened an issue for discussion here: #6478