### PR TITLE
fix(cli): persist session messages on SIGTERM/SIGHUP/window close

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8474,6 +8474,16 @@ class HermesCLI:
                     self.agent.flush_memories(self.conversation_history)
                 except (Exception, KeyboardInterrupt):
                     pass
+            # Persist in-memory messages to session log + SQLite so
+            # conversations are not lost on SIGTERM / SIGHUP / window close.
+            if self.agent and self.conversation_history:
+                try:
+                    self.agent._persist_session(
+                        self.conversation_history,
+                        self.conversation_history,
+                    )
+                except (Exception, KeyboardInterrupt):
+                    pass
             # Shut down voice recorder (release persistent audio stream)
             if hasattr(self, '_voice_recorder') and self._voice_recorder:
                 try:


### PR DESCRIPTION
## Summary

Fixes #6481

The `finally` block in `cli.py` flushes memories and closes the session in SQLite but never calls `_persist_session()`. When a terminal window is closed mid-response (SIGHUP) or the process receives SIGTERM, all in-memory messages are lost — the session row exists but with `message_count=0` and no `.jsonl` file.

This adds a `_persist_session()` call in the finally block, matching the pattern already used in the MCP-reload code path (`cli.py:5652`).

## Changes

- `cli.py`: Add `_persist_session(conversation_history, conversation_history)` to the finally block, between memory flush and voice recorder cleanup (+7 LOC)

## Impact

All CLI users who close terminal mid-conversation (laptop lid close, accidental Cmd+W, SSH disconnect) will now have their conversation preserved in both the jsonl log and SQLite session store.