### PR TITLE
fix(telegram): surface Codex and custom provider models in pickers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3784,12 +3784,12 @@ class HermesCLI:
 
             # Show authenticated providers with top models
             try:
-                # Load user providers from config
+                # Load user providers from config (providers: + custom_providers:)
                 user_provs = None
                 try:
-                    from hermes_cli.config import load_config
+                    from hermes_cli.config import load_config, build_model_picker_user_providers
                     cfg = load_config()
-                    user_provs = cfg.get("providers")
+                    user_provs = build_model_picker_user_providers(cfg)
                 except Exception:
                     pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3556,7 +3556,8 @@ class GatewayRunner:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
-                user_provs = cfg.get("providers")
+                from hermes_cli.config import build_model_picker_user_providers
+                user_provs = build_model_picker_user_providers(cfg)
         except Exception:
             pass
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1919,6 +1919,58 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 
+def _normalize_custom_provider_name(name: str) -> str:
+    return str(name).strip().lower().replace(" ", "-")
+
+
+def build_model_picker_user_providers(config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Dict[str, Any]]]:
+    """Combine providers: and custom_providers: into one picker-friendly map.
+
+    - ``providers`` entries are kept as-is.
+    - ``custom_providers`` entries become ``custom:<normalized-name>`` slugs.
+    - Custom entries expose ``api``/``base_url`` so the model picker can probe
+      the endpoint for its live ``/v1/models`` list.
+    """
+    if not isinstance(config, dict):
+        return None
+
+    merged: Dict[str, Dict[str, Any]] = {}
+
+    providers = config.get("providers")
+    if isinstance(providers, dict):
+        for slug, entry in providers.items():
+            if isinstance(slug, str) and isinstance(entry, dict):
+                merged[slug] = dict(entry)
+
+    custom_providers = config.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            base_url = str(entry.get("base_url") or entry.get("url") or "").strip()
+            if not isinstance(name, str) or not name.strip() or not base_url:
+                continue
+            slug = f"custom:{_normalize_custom_provider_name(name)}"
+            picker_entry = {
+                "name": name.strip(),
+                "api": base_url,
+                "base_url": base_url,
+            }
+            default_model = str(entry.get("default_model") or entry.get("model") or "").strip()
+            if default_model:
+                picker_entry["default_model"] = default_model
+            api_key = str(entry.get("api_key") or "").strip()
+            if api_key:
+                picker_entry["api_key"] = api_key
+            api_mode = str(entry.get("api_mode") or "").strip()
+            if api_mode:
+                picker_entry["api_mode"] = api_mode
+            merged[slug] = picker_entry
+
+    return merged or None
+
+
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -803,8 +803,18 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list
+        # Use curated list by default, but prefer Codex live/discovered models so
+        # gateway model pickers stay aligned with /model and setup flows.
         model_ids = curated.get(pid, [])
+        if pid == "openai-codex":
+            try:
+                from hermes_cli.models import provider_model_ids
+
+                discovered = provider_model_ids(pid)
+                if discovered:
+                    model_ids = discovered
+            except Exception as exc:
+                logger.debug("Codex model discovery failed for picker list: %s", exc)
         total = len(model_ids)
         top = model_ids[:max_models]
 
@@ -825,15 +835,24 @@ def list_authenticated_providers(
             if not isinstance(ep_cfg, dict):
                 continue
             display_name = ep_cfg.get("name", "") or ep_name
-            api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
+            api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ep_cfg.get("base_url", "") or ""
+            api_key = ep_cfg.get("api_key", "") or ""
             default_model = ep_cfg.get("default_model", "")
 
             models_list = []
             if default_model:
                 models_list.append(default_model)
 
-            # Try to probe /v1/models if URL is set (but don't block on it)
-            # For now just show what we know from config
+            if not models_list and api_url:
+                try:
+                    from hermes_cli.models import fetch_api_models
+
+                    live_models = fetch_api_models(str(api_key), api_url, timeout=4.0)
+                    if live_models:
+                        models_list = live_models
+                except Exception as exc:
+                    logger.debug("Custom provider model probe failed for %s: %s", ep_name, exc)
+
             results.append({
                 "slug": ep_name,
                 "name": display_name,

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -107,6 +107,72 @@ def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):
     assert captured["current_model"] == "openai/gpt-5.4"
 
 
+def test_list_authenticated_providers_uses_discovered_codex_models(monkeypatch):
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.providers.HERMES_OVERLAYS",
+        {
+            "openai-codex": type(
+                "Overlay",
+                (),
+                {"extra_env_vars": [], "auth_type": "oauth_external"},
+            )()
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {"openai-codex": {"access_token": "***"}}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda provider: ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"],
+    )
+
+    providers = list_authenticated_providers(max_models=8)
+
+    codex = next(p for p in providers if p["slug"] == "openai-codex")
+    assert codex["models"][:3] == ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
+    assert codex["total_models"] == 3
+
+
+def test_list_authenticated_providers_falls_back_to_curated_codex_models_on_discovery_error(monkeypatch):
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.providers.HERMES_OVERLAYS",
+        {
+            "openai-codex": type(
+                "Overlay",
+                (),
+                {"extra_env_vars": [], "auth_type": "oauth_external"},
+            )()
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {"openai-codex": {"access_token": "***"}}},
+    )
+
+    def _boom(provider):
+        raise RuntimeError("codex discovery unavailable")
+
+    monkeypatch.setattr("hermes_cli.models.provider_model_ids", _boom)
+
+    providers = list_authenticated_providers(max_models=8)
+
+    codex = next(p for p in providers if p["slug"] == "openai-codex")
+    assert codex["models"] == [
+        "gpt-5.3-codex",
+        "gpt-5.2-codex",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-codex-max",
+    ]
+    assert codex["total_models"] == 4
+
+
 # ── Tests for _normalize_model_for_provider ──────────────────────────
 
 

--- a/tests/hermes_cli/test_model_picker_custom_providers.py
+++ b/tests/hermes_cli/test_model_picker_custom_providers.py
@@ -1,0 +1,65 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hermes_cli.config import build_model_picker_user_providers
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def test_build_model_picker_user_providers_merges_custom_providers():
+    cfg = {
+        "providers": {
+            "lmstudio": {
+                "name": "LM Studio",
+                "api": "http://localhost:1234/v1",
+                "default_model": "llama-3.1-8b-instruct",
+            }
+        },
+        "custom_providers": [
+            {
+                "name": "My OpenAI Proxy",
+                "base_url": "http://localhost:8080/v1",
+                "api_key": "sk-test",
+                "default_model": "gpt-4o-mini",
+            }
+        ],
+    }
+
+    merged = build_model_picker_user_providers(cfg)
+
+    assert merged is not None
+    assert "lmstudio" in merged
+    assert merged["lmstudio"]["name"] == "LM Studio"
+    assert "custom:my-openai-proxy" in merged
+    assert merged["custom:my-openai-proxy"]["name"] == "My OpenAI Proxy"
+    assert merged["custom:my-openai-proxy"]["api"] == "http://localhost:8080/v1"
+    assert merged["custom:my-openai-proxy"]["api_key"] == "sk-test"
+    assert merged["custom:my-openai-proxy"]["default_model"] == "gpt-4o-mini"
+
+
+def test_list_authenticated_providers_probes_custom_provider_models(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, timeout=5.0: ["gpt-4o-mini", "gpt-4o"],
+    )
+
+    merged = build_model_picker_user_providers(
+        {
+            "custom_providers": [
+                {
+                    "name": "My OpenAI Proxy",
+                    "base_url": "http://localhost:8080/v1",
+                    "api_key": "sk-test",
+                }
+            ]
+        }
+    )
+
+    providers = list_authenticated_providers(user_providers=merged)
+    custom = next(p for p in providers if p["slug"] == "custom:my-openai-proxy")
+
+    assert custom["name"] == "My OpenAI Proxy"
+    assert custom["models"] == ["gpt-4o-mini", "gpt-4o"]
+    assert custom["total_models"] == 2


### PR DESCRIPTION
## Summary
- use discovered Codex models in Telegram/gateway provider pickers instead of the stale curated fallback when available
- include `custom_providers` entries in picker provider sources so custom OpenAI-compatible endpoints can surface live model lists
- add regression coverage for Codex discovery fallback and custom provider picker entries

## Testing
- pytest -q tests/hermes_cli/test_model_picker_custom_providers.py
- pytest -q tests/hermes_cli/test_codex_models.py -k "discovered_codex_models or curated_codex_models_on_discovery_error"