### PR TITLE
fix(cli): add explicit UTF-8 encoding when reading config YAML on Windows

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -306,7 +306,7 @@ def load_cli_config() -> Dict[str, Any]:
     # Load from file if exists
     if config_path.exists():
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 file_config = yaml.safe_load(f) or {}
             
             _file_has_terminal_config = "terminal" in file_config
@@ -1267,7 +1267,7 @@ def save_config_value(key_path: str, value: any) -> bool:
         
         # Load existing config
         if config_path.exists():
-            with open(config_path, 'r') as f:
+            with open(config_path, 'r', encoding='utf-8') as f:
                 config = yaml.safe_load(f) or {}
         else:
             config = {}


### PR DESCRIPTION
## Summary

- `cli.py:load_cli_config()` and `cli.py:save_config_value()` open YAML config files with `open(path, "r")` which defaults to the system locale encoding on Windows (e.g. GBK on Chinese locale)
- When `~/.hermes/config.yaml` contains non-ASCII characters (emoji in personality presets, Unicode in comments), GBK decoding fails with `UnicodeDecodeError`
- The exception is silently caught, discarding the entire user config and falling back to defaults (`provider: "auto"` -> OpenRouter), causing a confusing HTTP 401 error

This fix adds `encoding="utf-8"` to both `open()` calls, matching the existing pattern in `hermes_cli/config.py:load_config()` (line 1913).

## Root Cause

```python
# cli.py:309 — BEFORE (broken on non-UTF-8 Windows locales)
with open(config_path, "r") as f:

# cli.py:309 — AFTER
with open(config_path, "r", encoding="utf-8") as f:
```

Same fix applied to `cli.py:1270` (`save_config_value`).

## Symptoms

On Windows with non-UTF-8 system locale:
```
WARNING cli: Failed to load cli-config.yaml: 'gbk' codec can't decode byte 0x80 in position 4324
```
Followed by:
```
Provider: openrouter  Model:
Endpoint: https://openrouter.ai/api/v1
Error: HTTP 401: Missing Authentication header
```

## Test plan

- [x] Verified on Windows 11 (Chinese locale, GBK default) with `provider: "custom"` in config
- [x] Config loads correctly after fix, provider resolves to custom endpoint
- [x] Grepped for other `open()` calls on config/YAML files — no remaining instances without explicit encoding