### PR TITLE
feat(agent): global timeout for concurrent tool-call batches

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -536,6 +536,16 @@ platform_toolsets:
   signal: [hermes-signal]
   homeassistant: [hermes-homeassistant]
 
+# ── Tool execution ─────────────────────────────────────────────────────────────
+tools:
+  # Global ceiling on concurrent tool-call batches (seconds).
+  # When the model issues multiple tool calls in one turn, Hermes runs them
+  # in a thread pool.  If any tool hasn't responded within this window it is
+  # marked as timed out and the agent moves on; the background thread may
+  # still finish on its own.
+  # Omit or set to 0 to disable (default: no limit).
+  # call_timeout: 120
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)
 #

--- a/run_agent.py
+++ b/run_agent.py
@@ -209,6 +209,31 @@ class IterationBudget:
             return max(0, self.max_total - self._used)
 
 
+def _get_tool_call_timeout() -> Optional[float]:
+    """Return ``tools.call_timeout`` from config.yaml, or *None* if unset.
+
+    When set, concurrent tool batches are abandoned after this many seconds.
+    Timed-out slots receive an error result; background threads may still
+    finish on their own once the agent moves on.
+    """
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return None
+    try:
+        import yaml as _yaml
+        with open(config_path, encoding="utf-8") as _f:
+            _parsed = _yaml.safe_load(_f) or {}
+    except Exception:
+        return None
+    _tools_cfg = _parsed.get("tools")
+    if not isinstance(_tools_cfg, dict):
+        return None
+    _value = _tools_cfg.get("call_timeout")
+    if isinstance(_value, (int, float)) and _value > 0:
+        return float(_value)
+    return None
+
+
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.
 _NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
@@ -6299,16 +6324,38 @@ class AIAgent:
             spinner = KawaiiSpinner(f"{face} ⚡ running {num_tools} tools concurrently", spinner_type='dots', print_fn=self._print_fn)
             spinner.start()
 
+        _call_timeout = _get_tool_call_timeout()
         try:
             max_workers = min(num_tools, _MAX_TOOL_WORKERS)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+            try:
                 futures = []
                 for i, (tc, name, args) in enumerate(parsed_calls):
                     f = executor.submit(_run_tool, i, tc, name, args)
                     futures.append(f)
 
-                # Wait for all to complete (exceptions are captured inside _run_tool)
-                concurrent.futures.wait(futures)
+                # Wait for all to complete (exceptions are captured inside _run_tool).
+                # Honour tools.call_timeout when configured.
+                _done, _not_done = concurrent.futures.wait(futures, timeout=_call_timeout)
+
+                if _not_done:
+                    # Inject timeout errors for tools that didn't finish in time.
+                    _timed_out = {id(f) for f in _not_done}
+                    for _i, _f in enumerate(futures):
+                        if id(_f) in _timed_out:
+                            _tname = parsed_calls[_i][1]
+                            logger.warning(
+                                "tool %s exceeded call_timeout (%.1fs) — marking as timed out",
+                                _tname, _call_timeout,
+                            )
+                            results[_i] = (
+                                _tname, {},
+                                f"[Tool timed out after {_call_timeout:.0f}s]",
+                                _call_timeout, True,
+                            )
+            finally:
+                # Don't block on still-running threads; let them finish in background.
+                executor.shutdown(wait=False)
         finally:
             if spinner:
                 # Build a summary message for the spinner stop

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1401,6 +1401,108 @@ class TestConcurrentToolExecution:
         assert len(messages) == 2
         assert all("result_" in m["content"] for m in messages)
 
+    def test_call_timeout_all_tools_timeout(self, agent, tmp_path, monkeypatch):
+        """When every tool in the batch times out all slots get error results."""
+        import time as _time
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: 0.05\n")
+
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"a"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"b"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            _time.sleep(5)
+            return "should not appear"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert len(messages) == 2
+        assert all("timed out" in m["content"].lower() for m in messages)
+
+    def test_call_timeout_complete_callback_fires_for_timed_out_slot(self, agent, tmp_path, monkeypatch):
+        """tool_complete_callback should fire even for timed-out tools."""
+        import time as _time
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: 0.05\n")
+
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"slow"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1,
+            _mock_tool_call(name="web_search", arguments='{"q":"fast"}', call_id="c2")])
+        messages = []
+        completed = []
+        agent.tool_complete_callback = lambda tid, name, args, result: completed.append((tid, result))
+
+        def fake_handle(name, args, task_id, **kwargs):
+            if args.get("q") == "slow":
+                _time.sleep(5)
+            return "ok"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert len(completed) == 2
+        timed_out_result = next(r for tid, r in completed if tid == "c1")
+        assert "timed out" in timed_out_result.lower()
+
+
+class TestGetToolCallTimeout:
+    """Unit tests for the _get_tool_call_timeout() config reader."""
+
+    def test_returns_none_when_no_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from run_agent import _get_tool_call_timeout
+        assert _get_tool_call_timeout() is None
+
+    def test_returns_none_when_tools_section_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("model:\n  name: test\n")
+        from run_agent import _get_tool_call_timeout
+        assert _get_tool_call_timeout() is None
+
+    def test_returns_none_for_zero(self, tmp_path, monkeypatch):
+        """call_timeout: 0 should be treated as disabled."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: 0\n")
+        from run_agent import _get_tool_call_timeout
+        assert _get_tool_call_timeout() is None
+
+    def test_returns_none_for_negative(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: -1\n")
+        from run_agent import _get_tool_call_timeout
+        assert _get_tool_call_timeout() is None
+
+    def test_returns_none_for_string_value(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: '120'\n")
+        from run_agent import _get_tool_call_timeout
+        assert _get_tool_call_timeout() is None
+
+    def test_returns_float_for_valid_int(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: 120\n")
+        from run_agent import _get_tool_call_timeout
+        result = _get_tool_call_timeout()
+        assert result == 120.0
+        assert isinstance(result, float)
+
+    def test_returns_float_for_valid_float(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: 30.5\n")
+        from run_agent import _get_tool_call_timeout
+        assert _get_tool_call_timeout() == 30.5
+
+    def test_returns_none_for_malformed_yaml(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: [bad")
+        from run_agent import _get_tool_call_timeout
+        assert _get_tool_call_timeout() is None
+
 
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1352,6 +1352,55 @@ class TestConcurrentToolExecution:
             mock_todo.assert_called_once()
         assert "ok" in result
 
+    def test_call_timeout_injects_error_for_slow_tool(self, agent, tmp_path, monkeypatch):
+        """Slow tools should receive a timeout error when call_timeout is set."""
+        import time as _time
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("tools:\n  call_timeout: 0.05\n")
+
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"fast"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"slow"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            if args.get("q") == "slow":
+                _time.sleep(5)  # Much longer than the 50 ms timeout
+            return f"result_{args.get('q', '')}"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert len(messages) == 2
+        fast_msg = next(m for m in messages if m["tool_call_id"] == "c1")
+        assert "result_fast" in fast_msg["content"]
+        slow_msg = next(m for m in messages if m["tool_call_id"] == "c2")
+        assert "timed out" in slow_msg["content"].lower()
+
+    def test_no_call_timeout_waits_for_all_tools(self, agent, tmp_path, monkeypatch):
+        """Without call_timeout, concurrent path waits for all tools."""
+        import time as _time
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # No config.yaml → timeout disabled
+
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"fast"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"slow"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            if args.get("q") == "slow":
+                _time.sleep(0.05)
+            return f"result_{args.get('q', '')}"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert len(messages) == 2
+        assert all("result_" in m["content"] for m in messages)
+
 
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""


### PR DESCRIPTION
## Summary

- Adds `tools.call_timeout` config key: an optional ceiling (seconds) over the `ThreadPoolExecutor` used when the model emits multiple tool calls in one turn
- When the timeout fires, unfinished tools receive a `[Tool timed out after Xs]` error result and the agent continues; background threads may still finish on their own
- `executor.shutdown(wait=False)` ensures the timeout is real — the `with` block's implicit `shutdown(wait=True)` is replaced
- Default behaviour unchanged (no timeout unless configured); `call_timeout: 0` is treated as disabled

```yaml
tools:
  call_timeout: 120   # seconds; omit or 0 to disable
```

## Test plan

### Unit tests — `TestGetToolCallTimeout` (8 tests)
- [ ] Returns `None` when no config file exists
- [ ] Returns `None` when `tools:` section is missing from config
- [ ] Returns `None` for `call_timeout: 0` (zero is treated as disabled)
- [ ] Returns `None` for negative values
- [ ] Returns `None` when value is a quoted string (`'120'`)
- [ ] Returns `None` for malformed / unparseable YAML
- [ ] Returns `float` for valid integer (`120` → `120.0`)
- [ ] Returns `float` for valid float (`30.5` → `30.5`)

### Integration tests — `TestConcurrentToolExecution` additions (4 tests)
- [ ] `test_call_timeout_injects_error_for_slow_tool` — 50 ms limit; fast tool succeeds, slow tool gets `[Tool timed out after …]` error
- [ ] `test_no_call_timeout_waits_for_all_tools` — no config file → both tools complete normally, no timeouts
- [ ] `test_call_timeout_all_tools_timeout` — all tools sleep 5 s with 50 ms limit → every result contains "timed out"
- [ ] `test_call_timeout_complete_callback_fires_for_timed_out_slot` — `tool_complete_callback` fires for timed-out tools with the timeout error string as result

### Full suite
- [ ] All 30 tests pass (20 pre-existing concurrent execution tests + 8 unit + 4 integration added by this PR)
- [ ] No regressions to existing concurrent execution, sequential fallback, or spinner behaviour