### PR TITLE
fix: avoid poisoning credentials on soft 402 errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1886,6 +1886,24 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
+def _default_aux_max_tokens(task: Optional[str] = None) -> int:
+    """Return a safe default output budget for auxiliary LLM calls.
+
+    Auxiliary helpers should not inherit the provider/model native output cap
+    (e.g. Claude Sonnet 4.6 via OpenRouter defaults to 64k), because a single
+    summarization or vision request can then trip budget-based 402 errors like
+    "requested up to 64000 tokens, but can only afford ...". Those requests are
+    almost never intended to emit tens of thousands of tokens.
+
+    Keep the default modest for latency/cost, with slightly larger budgets for
+    tasks that legitimately produce longer prose.
+    """
+    task_name = (task or "").strip().lower()
+    if task_name in {"vision", "web_extract", "mcp"}:
+        return 8192
+    return 4096
+
+
 def _build_call_kwargs(
     provider: str,
     model: str,
@@ -1896,6 +1914,7 @@ def _build_call_kwargs(
     timeout: float = 30.0,
     extra_body: Optional[dict] = None,
     base_url: Optional[str] = None,
+    task: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -1907,17 +1926,18 @@ def _build_call_kwargs(
     if temperature is not None:
         kwargs["temperature"] = temperature
 
-    if max_tokens is not None:
+    effective_max_tokens = max_tokens if max_tokens is not None else _default_aux_max_tokens(task)
+    if effective_max_tokens is not None:
         # Codex adapter handles max_tokens internally; OpenRouter/Nous use max_tokens.
         # Direct OpenAI api.openai.com with newer models needs max_completion_tokens.
         if provider == "custom":
             custom_base = base_url or _current_custom_base_url()
             if "api.openai.com" in custom_base.lower():
-                kwargs["max_completion_tokens"] = max_tokens
+                kwargs["max_completion_tokens"] = effective_max_tokens
             else:
-                kwargs["max_tokens"] = max_tokens
+                kwargs["max_tokens"] = effective_max_tokens
         else:
-            kwargs["max_tokens"] = max_tokens
+            kwargs["max_tokens"] = effective_max_tokens
 
     if tools:
         kwargs["tools"] = tools
@@ -2042,7 +2062,7 @@ def call_llm(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+        base_url=resolved_base_url, task=task)
 
     # Handle max_tokens vs max_completion_tokens retry, then payment fallback.
     try:
@@ -2074,7 +2094,7 @@ def call_llm(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
-                    extra_body=extra_body)
+                    extra_body=extra_body, task=task)
                 return fb_client.chat.completions.create(**fb_kwargs)
         raise
 
@@ -2213,7 +2233,7 @@ async def async_call_llm(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+        base_url=resolved_base_url, task=task)
 
     try:
         return await client.chat.completions.create(**kwargs)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4110,6 +4110,27 @@ class AIAgent:
         self._apply_client_headers_for_base_url(self.base_url)
         self._replace_primary_openai_client(reason="credential_rotation")
 
+    @staticmethod
+    def _is_soft_402_affordability_error(error_context: Optional[Dict[str, Any]] = None) -> bool:
+        """Return True for 402s caused by oversized token budgets, not hard quota exhaustion.
+
+        OpenRouter can return 402 when a request asks for more output tokens than
+        the remaining credit can currently afford (for example: "requested up to
+        64000 tokens, but can only afford 50785"). That credential may still be
+        perfectly usable for normal requests, so marking it exhausted for 24 hours
+        disables auxiliary features unnecessarily.
+        """
+        if not isinstance(error_context, dict):
+            return False
+        message = str(error_context.get("message") or "").lower()
+        if not message:
+            return False
+        return (
+            "requested up to" in message and "can only afford" in message
+        ) or (
+            "fewer max_tokens" in message and "can only afford" in message
+        )
+
     def _recover_with_credential_pool(
         self,
         *,
@@ -4122,7 +4143,8 @@ class AIAgent:
         Returns (recovered, has_retried_429).
         On 429: first occurrence retries same credential (sets flag True).
                 second consecutive 429 rotates to next credential (resets flag).
-        On 402: immediately rotates (billing exhaustion won't resolve with retry).
+        On 402: rotate only for hard billing/quota exhaustion. Soft 402s caused
+                by oversized max_tokens requests should not poison the credential.
         On 401: attempts token refresh before rotating.
         """
         pool = self._credential_pool
@@ -4130,6 +4152,9 @@ class AIAgent:
             return False, has_retried_429
 
         if status_code == 402:
+            if self._is_soft_402_affordability_error(error_context):
+                logger.info("Credential 402 looks like a max_tokens affordability miss; leaving pool entry active")
+                return False, has_retried_429
             next_entry = pool.mark_exhausted_and_rotate(status_code=402, error_context=error_context)
             if next_entry is not None:
                 logger.info(f"Credential 402 (billing) — rotated to pool entry {getattr(next_entry, 'id', '?')}")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1231,6 +1231,44 @@ class TestTryPaymentFallback:
         assert label == "openai-codex"
 
 
+class TestCallLlmDefaultTokenBudget:
+    def test_call_llm_defaults_to_safe_aux_budget(self, monkeypatch):
+        client = MagicMock()
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(client, "google/gemini-3-flash-preview")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openrouter", "google/gemini-3-flash-preview", None, None)):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 4096
+
+    def test_call_llm_vision_gets_larger_default_budget(self, monkeypatch):
+        client = MagicMock()
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        with patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openrouter", client, "google/gemini-3-flash-preview")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openrouter", "google/gemini-3-flash-preview", None, None)):
+            result = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 8192
+
+
 class TestCallLlmPaymentFallback:
     """call_llm() retries with a different provider on 402 / payment errors."""
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2013,7 +2013,7 @@ class TestNousCredentialRefresh:
 
 
 class TestCredentialPoolRecovery:
-    def test_recover_with_pool_rotates_on_402(self, agent):
+    def test_recover_with_pool_rotates_on_hard_402(self, agent):
         current = SimpleNamespace(label="primary")
         next_entry = SimpleNamespace(label="secondary")
 
@@ -2023,7 +2023,7 @@ class TestCredentialPoolRecovery:
 
             def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
                 assert status_code == 402
-                assert error_context is None
+                assert error_context == {"message": "Payment Required: insufficient credits"}
                 return next_entry
 
         agent._credential_pool = _Pool()
@@ -2032,11 +2032,32 @@ class TestCredentialPoolRecovery:
         recovered, retry_same = agent._recover_with_credential_pool(
             status_code=402,
             has_retried_429=False,
+            error_context={"message": "Payment Required: insufficient credits"},
         )
 
         assert recovered is True
         assert retry_same is False
         agent._swap_credential.assert_called_once_with(next_entry)
+
+    def test_recover_with_pool_does_not_rotate_on_soft_402_affordability(self, agent):
+        class _Pool:
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                raise AssertionError("soft affordability 402 must not exhaust the credential")
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=402,
+            has_retried_429=False,
+            error_context={
+                "message": "This request requires more credits, or fewer max_tokens. You requested up to 64000 tokens, but can only afford 50785.",
+            },
+        )
+
+        assert recovered is False
+        assert retry_same is False
+        agent._swap_credential.assert_not_called()
 
     def test_recover_with_pool_retries_first_429_then_rotates(self, agent):
         next_entry = SimpleNamespace(label="secondary")


### PR DESCRIPTION
Summary:
- cap default auxiliary output budgets to avoid oversized helper requests
- treat OpenRouter affordability 402 errors as soft failures instead of exhausting the credential for 24h
- add regression tests for both behaviors

Validation:
- python -m pytest tests/agent/test_auxiliary_client.py -q
- python -m pytest tests/run_agent/test_run_agent.py -q

Note:
- Full tests/ run on this machine hit unrelated 'too many open files' errors outside the changed paths.
