### PR TITLE
fix(agent): let context length resolution fall through when failed to get context_length from provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -904,13 +904,15 @@ def get_model_context_length(
                 if local_ctx and local_ctx > 0:
                     save_context_length(model, base_url, local_ctx)
                     return local_ctx
+            # Fall through to remaining resolution steps (4-8) instead of
+            # returning DEFAULT_FALLBACK_CONTEXT immediately. The hardcoded
+            # DEFAULT_CONTEXT_LENGTHS dict (step 8) may still resolve the
+            # context length correctly via substring matching.
             logger.info(
-                "Could not detect context length for model %r at %s — "
-                "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
-                model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
+                "Custom endpoint probe for model %r at %s did not return "
+                "context_length — falling through to remaining lookups.",
+                model, base_url,
             )
-            return DEFAULT_FALLBACK_CONTEXT
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -212,17 +212,20 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
-    def test_custom_endpoint_without_metadata_skips_name_based_default(self, mock_endpoint_fetch, mock_fetch):
+    def test_custom_endpoint_without_metadata_falls_through_to_hardcoded_default(self, mock_endpoint_fetch, mock_fetch):
+        """When custom endpoint returns no metadata, fall through to hardcoded defaults."""
         mock_fetch.return_value = {}
         mock_endpoint_fetch.return_value = {}
 
+        # Model "zai-org/GLM-5-TEE" falls through to DEFAULT_CONTEXT_LENGTHS
+        # where 'zai-org/GLM-5' matches → 202752
         result = get_model_context_length(
             "zai-org/GLM-5-TEE",
             base_url="https://llm.chutes.ai/v1",
             api_key="test-key",
         )
 
-        assert result == CONTEXT_PROBE_TIERS[0]
+        assert result == 202752
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
@@ -258,6 +261,50 @@ class TestGetModelContextLength:
         )
 
         assert result == 131072
+
+    @patch("agent.model_metadata._query_local_context_length", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_no_context_length_falls_through_to_defaults(self, mock_endpoint_fetch, mock_fetch, _mock_local):
+        """When custom endpoint returns model WITHOUT context_length, fall through to hardcoded defaults."""
+        mock_fetch.return_value = {}
+        # Endpoint returns model metadata but WITHOUT context_length field
+        mock_endpoint_fetch.return_value = {
+            "claude-opus-4.6-1m": {"id": "claude-opus-4.6-1m"}  # no context_length
+        }
+
+        result = get_model_context_length(
+            "claude-opus-4.6-1m",
+            base_url="http://localhost:7024/v1",
+            api_key="test-key",
+        )
+
+        # Should fall through to DEFAULT_CONTEXT_LENGTHS where 'claude-opus-4.6'
+        # is a substring of 'claude-opus-4.6-1m' → 1M
+        assert result == 1000000
+
+    @patch("agent.model_metadata._query_local_context_length", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_no_match_falls_through_to_defaults(self, mock_endpoint_fetch, mock_fetch, _mock_local):
+        """When custom endpoint returns no matching model, fall through to hardcoded defaults."""
+        mock_fetch.return_value = {}
+        # Endpoint returns multiple models (avoiding single-model fallback),
+        # none matching our requested model
+        mock_endpoint_fetch.return_value = {
+            "other-model-1": {"context_length": 32768},
+            "other-model-2": {"context_length": 65536},
+        }
+
+        result = get_model_context_length(
+            "claude-opus-4.6-1m",
+            base_url="http://localhost:7024/v1",
+            api_key="test-key",
+        )
+
+        # Should fall through to DEFAULT_CONTEXT_LENGTHS where 'claude-opus-4.6'
+        # is a substring of 'claude-opus-4.6-1m' → 1M
+        assert result == 1000000
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_config_context_length_overrides_all(self, mock_fetch):


### PR DESCRIPTION
## What does this PR do?

Fixes an early return in `get_model_context_length()` that causes custom endpoints without `context_length` in their `/v1/models` response to default to 128K, even when later resolution steps (hardcoded defaults, models.dev, OpenRouter) could correctly resolve the context length.

**Example:** A proxy serving `claude-opus-4.6-1m` that omits `context_length` from its model metadata would return 128K instead of 1M, because the hardcoded `DEFAULT_CONTEXT_LENGTHS` entry `"claude-opus-4.6"` (a valid substring match at step 8) was never reached.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/model_metadata.py`**: Remove the early `return DEFAULT_FALLBACK_CONTEXT` at the end of the custom endpoint probe block (step 2/3). The function now falls through to remaining resolution steps (4–8) when the endpoint probe does not yield a `context_length`. The `logger.info` message is preserved for observability.
- **`tests/agent/test_model_metadata.py`**: Update `test_custom_endpoint_without_metadata_falls_through_to_hardcoded_default` (formerly `..._skips_name_based_default`) to assert the new fall-through behavior. Add two new regression tests:
  - `test_custom_endpoint_no_context_length_falls_through_to_defaults` — endpoint returns model metadata without `context_length`
  - `test_custom_endpoint_no_match_falls_through_to_defaults` — endpoint returns unrelated models, requested model falls through to hardcoded defaults

## How to Test

```python
from agent.model_metadata import get_model_context_length

# Before fix: returns 128000
# After fix: returns 1000000
result = get_model_context_length(
    "claude-opus-4.6-1m",
    base_url="http://localhost:7024/v1",  # proxy without context_length in /models
    api_key="test-key",
)
assert result == 1000000
```

```bash
python -m pytest tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py -q
```

## Checklist

### Code
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I checked for duplicate PRs
- [x] Changes are focused and minimal
- [x] `pytest tests/ -q` passes
- [x] Tests added for the fix
- [x] Tested on macOS