### PR TITLE
fix(gateway): prevent silent message delivery failures

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1075,6 +1075,18 @@ class BasePlatformAdapter(ABC):
         # Timeout errors are not safe to retry (message may have been
         # delivered) and not formatting errors — return the failure as-is.
         if not is_network and self._is_timeout_error(error_str):
+            logger.warning(
+                "[%s] Non-network timeout during send (not retrying): %s", self.name, error_str,
+            )
+            notice = (
+                "\u26a0\ufe0f Message delivery timed out. "
+                "Your request was processed but the response could not be sent. "
+                "Please try again."
+            )
+            try:
+                await self.send(chat_id=chat_id, content=notice, reply_to=reply_to, metadata=metadata)
+            except Exception as notify_err:
+                logger.debug("[%s] Could not send timeout delivery-failure notice: %s", self.name, notify_err)
             return result
 
         if is_network:
@@ -1493,8 +1505,11 @@ class BasePlatformAdapter(ABC):
                     ),
                     metadata=_thread_metadata,
                 )
-            except Exception:
-                pass  # Last resort — don't let error reporting crash the handler
+            except Exception as notify_err:
+                logger.error(
+                    "[%s] Failed to send error notification to user: %s",
+                    self.name, notify_err, exc_info=True,
+                )  # Last resort — don't let error reporting crash the handler
         finally:
             # Stop typing indicator
             typing_task.cancel()

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -159,10 +159,15 @@ class TestSendWithRetryNetworkRetry:
         ]
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=0)
-        # No retry, no fallback — timeout returns failure immediately
+        # No retry, no fallback — timeout returns failure immediately.
+        # A delivery-failure notice is sent to the user (2nd call).
         mock_sleep.assert_not_called()
         assert not result.success
-        assert len(adapter._send_calls) == 1
+        assert len(adapter._send_calls) == 2
+        # First call: the original message that timed out
+        assert adapter._send_calls[0] == ("chat1", "hello")
+        # Second call: delivery-failure notice to the user
+        assert "timed out" in adapter._send_calls[1][1].lower()
 
     @pytest.mark.asyncio
     async def test_connect_timeout_still_retried(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -507,6 +507,15 @@ def _run_single_child(
             except (ValueError, UnboundLocalError) as e:
                 logger.debug("Could not remove child from active_children: %s", e)
 
+        # Reset the parent's idle timer so the gateway poll loop doesn't
+        # kill the parent with "Agent inactive for 30 min" after a long
+        # child execution.  Safe to call even if parent_agent is None.
+        if parent_agent is not None and hasattr(parent_agent, '_touch_activity'):
+            try:
+                parent_agent._touch_activity("delegate child completed")
+            except Exception:
+                pass
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,


### PR DESCRIPTION
## Bug Description

Messages processed by the agent sometimes never reach the user. The system logs "response ready" and considers the task complete, but the user receives nothing. This is especially noticeable with `delegate_task` — subagents complete their work, but the parent's response never arrives or the parent gets killed by the inactivity timeout.

## Root Cause

Three bugs in the gateway message delivery pipeline:

1. **`_send_with_retry()` silently drops timeout failures** — When a non-network timeout occurs (e.g. `ReadTimeout`), the method returns the failed result without logging or notifying the user. The caller records `delivery_attempted=True` but `delivery_succeeded=False`, yet no user-facing indication is given. The user waits indefinitely.

2. **`delegate_task()` blocks parent activity tracking** — Subagent execution is synchronous (`child.run_conversation()`). During long-running child tasks, the parent's `_touch_activity()` is never called. The gateway's 5-second poll loop monitors idle time, and if the child runs longer than `_agent_timeout` (default 30 min), the parent is killed with "Agent inactive for 30 min".

3. **`_process_message_background()` silently swallows send failures** — The exception handler that tries to send error notifications to the user has `except Exception: pass` as its final catch. If the notification itself fails, there's zero trace in any log.

## Fix

1. **`_send_with_retry()`** — Added `logger.warning()` for timeout failures and a user-facing delivery-failure notice (matching the existing retry-exhaustion path at L1102-1112).

2. **`delegate_tool.py` `_run_single_child()`** — Added `parent_agent._touch_activity("delegate child completed")` in the finally block to reset the parent's idle timer after child execution completes.

3. **`_process_message_background()`** — Upgraded `except Exception: pass` to `except Exception as notify_err: logger.error(...)` with `exc_info=True` for post-mortem debugging.

## How to Verify

1. Run `pytest tests/gateway/test_send_retry.py tests/tools/test_delegate.py` — all 153 tests pass (including updated timeout test).
2. Reproduce timeout scenario: the user should now receive a "Message delivery timed out" notice instead of silence.
3. Run a long delegate_task (>5 min): the parent agent should no longer be killed by the inactivity timeout.

## Test Plan

- [x] Updated `test_timeout_not_retried_to_prevent_duplicates` to expect the new delivery-failure notice (2 send calls instead of 1)
- [x] Existing 152 gateway/delegate tests still pass
- [x] Full test suite: 2671 passed, 1 flaky (unrelated, passes in isolation — pre-existing `test_blocking_approval_approve_once` race)
- [ ] Manual verification of timeout notification delivery
- [ ] Manual verification of long delegate_task not triggering inactivity timeout

## Platforms Tested

- Linux (aarch64, Oracle Linux 9)

## Risk Assessment

Low — All changes are additive (logging + notice) or defensive (activity touch). No existing behavior is altered except the timeout path now sends a notice instead of silently returning. The `_touch_activity` call is wrapped in `hasattr`/`try-except` for safety.