### PR TITLE
fix(auth): check credential pool in get_nous_auth_status()

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2115,7 +2115,33 @@ def resolve_nous_runtime_credentials(
 # =============================================================================
 
 def get_nous_auth_status() -> Dict[str, Any]:
-    """Status snapshot for `hermes status` output."""
+    """Status snapshot for `hermes status` output.
+
+    Checks the credential pool first (where ``hermes auth add nous`` stores
+    credentials), then falls back to the legacy provider state.
+    """
+    # Check credential pool first — this is where `hermes auth add` stores
+    # device-code tokens.
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool("nous")
+        if pool and pool.has_credentials():
+            entry = pool.select()
+            if entry is not None:
+                access_token = getattr(entry, "access_token", "")
+                if access_token:
+                    return {
+                        "logged_in": True,
+                        "portal_base_url": getattr(entry, "portal_base_url", None),
+                        "inference_base_url": getattr(entry, "base_url", None),
+                        "access_expires_at": getattr(entry, "expires_at", None),
+                        "agent_key_expires_at": None,
+                        "has_refresh_token": bool(getattr(entry, "refresh_token", None)),
+                    }
+    except Exception:
+        pass
+
+    # Fall back to legacy provider state
     state = get_provider_auth_state("nous")
     if not state:
         return {


### PR DESCRIPTION
## Summary

- `hermes auth add nous` stores credentials in the **credential pool**, but `get_nous_auth_status()` only checked the legacy **provider state** (`providers["nous"]`). This caused `hermes doctor` to report "Nous Portal auth (not logged in)" even after a successful login.
- Applies the same credential-pool-first fallback pattern already used by `get_codex_auth_status()`.

## Repro

```
hermes auth add nous   # succeeds, stores in credential_pool
hermes doctor          # shows ⚠ Nous Portal auth (not logged in)
```

After this fix, `hermes doctor` correctly shows `✓ Nous Portal auth (logged in)`.

## Test plan

- [ ] `hermes auth add nous` → `hermes doctor` shows ✓ logged in
- [ ] Without any nous credentials → still shows ⚠ not logged in
- [ ] Legacy `hermes login nous` flow (if still used) → still works via provider state fallback
