### PR TITLE
fix(models): correct probed_url selection logic

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1474,7 +1474,11 @@ def _model_flow_custom(config):
             f"Hermes will still save it."
         )
         if probe.get("suggested_base_url"):
-            print(f"  If this server expects /v1, try base URL: {probe['suggested_base_url']}")
+            suggested = probe["suggested_base_url"]
+            if suggested.endswith("/v1"):
+                print(f"  If this server expects /v1 in the path, try base URL: {suggested}")
+            else:
+                print(f"  If /v1 should not be in the base URL, try: {suggested}")
 
     # Select model — use probe results when available, fall back to manual input
     model_name = ""

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1532,7 +1532,7 @@ def probe_api_models(
 
     return {
         "models": None,
-        "probed_url": tried[-1] if tried else normalized.rstrip("/") + "/models",
+        "probed_url": tried[0] if tried else normalized.rstrip("/") + "/models",
         "resolved_base_url": normalized,
         "suggested_base_url": alternate_base if alternate_base != normalized else None,
         "used_fallback": False,


### PR DESCRIPTION
Salvage of #6470 by @cokemine (cherry-picked onto current main).

## What this PR does

Fixes two UX bugs in the custom endpoint setup flow (`_model_flow_custom`):

1. **Wrong URL in failure warning** (`models.py`): When both probe attempts fail, the warning showed `tried[-1]` (the fallback URL) instead of `tried[0]` (the user's actual input). Fixed to `tried[0]`.

2. **Contradictory suggestion message** (`main.py`): The hint always said "If this server expects /v1, try base URL: ..." regardless of direction. Now context-aware — says "expects /v1" when suggesting to add it, "should not be in the base URL" when suggesting to remove it.

## Test plan

- 58/58 `test_model_validation.py` tests pass
- Full `hermes_cli/` suite: 1512 pass (4 pre-existing env_loader failures unrelated)