### PR TITLE
fix(gateway): re-inject topic-bound skill after /new session reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2134,7 +2134,11 @@ class GatewayRunner:
         _is_new_session = (
             session_entry.created_at == session_entry.updated_at
             or getattr(session_entry, "was_auto_reset", False)
+            or getattr(session_entry, "is_fresh_reset", False)
         )
+        # Consume is_fresh_reset flag so it doesn't persist across messages
+        if getattr(session_entry, "is_fresh_reset", False):
+            session_entry.is_fresh_reset = False
         if _is_new_session:
             await self.hooks.emit("session:start", {
                 "platform": source.platform.value if source.platform else "",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -361,6 +361,7 @@ class SessionEntry:
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
     was_auto_reset: bool = False
+    is_fresh_reset: bool = False  # set by reset_session(), consumed once by skill auto-load
     auto_reset_reason: Optional[str] = None  # "idle" or "daily"
     reset_had_activity: bool = False  # whether the expired session had any messages
     
@@ -818,6 +819,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                is_fresh_reset=True,
             )
 
             self._entries[session_key] = new_entry


### PR DESCRIPTION
Fixes #6508

## Problem
After `/new` session reset, topic-bound skills configured via `group_topics` were not re-injected into the new session. The bot fell back to its default persona instead of the topic-specific skill/role.

## Root Cause
`reset_session()` creates a new `SessionEntry` with `created_at == updated_at`. On the next inbound message, `get_or_create_session()` updates `updated_at`, making `created_at != updated_at` — so `_is_new_session = False` and skill auto-load was skipped.

## Fix (Option A from issue)
- Added `is_fresh_reset: bool = False` flag to `SessionEntry`
- `reset_session()` sets `is_fresh_reset=True` on the new entry
- `_is_new_session` check in `run.py` now also checks `is_fresh_reset`
- Flag is consumed (set to `False`) after first use — no persistence side effects

## Files Changed
- `gateway/session.py` — added `is_fresh_reset` field + set in `reset_session()`
- `gateway/run.py` — consume `is_fresh_reset` in `_is_new_session` check