### PR TITLE
fix: force relogin on 401/403 Codex token refresh failures

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1544,6 +1544,11 @@ def refresh_codex_oauth_pure(
                 "then run `hermes auth` to re-authenticate."
             )
             relogin_required = True
+        # A 401/403 from the token endpoint always means the refresh token
+        # is invalid/expired — force relogin even if the body error code
+        # wasn't one of the known strings above.
+        if response.status_code in (401, 403) and not relogin_required:
+            relogin_required = True
         raise AuthError(
             message,
             provider="openai-codex",


### PR DESCRIPTION
3-line fix. When the OAuth token endpoint returns 401/403 but the JSON body doesn't contain a known error code, `relogin_required` stayed `False` — user saw a bare error without guidance to re-authenticate.

Now any 401/403 forces `relogin_required=True`, so the user gets "Run `hermes model` to re-authenticate."

500+ errors correctly remain transient (no relogin prompt).

Reported by pry.