### PR TITLE
fix(gateway): resolve NameError in fallback model tracking

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -289,7 +289,11 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
-def _resolve_runtime_agent_kwargs() -> dict:
+def _resolve_runtime_agent_kwargs(
+    *,
+    requested: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+) -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances."""
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
@@ -298,7 +302,8 @@ def _resolve_runtime_agent_kwargs() -> dict:
 
     try:
         runtime = resolve_runtime_provider(
-            requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
+            requested=requested or os.getenv("HERMES_INFERENCE_PROVIDER"),
+            explicit_base_url=explicit_base_url,
         )
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
@@ -312,6 +317,31 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+
+
+def _resolve_session_runtime_config(
+    session_overrides: Optional[Dict[str, Any]],
+    config: dict | None = None,
+) -> tuple[str, dict]:
+    """Resolve the effective model/runtime for a session-aware gateway turn.
+
+    Reads the in-memory ``_session_model_overrides`` dict (populated by
+    ``/model``) and, when present, uses the session-scoped provider and
+    base_url instead of the global defaults.
+    """
+    session_model = session_overrides.get("model") if session_overrides else None
+    session_provider = session_overrides.get("provider") if session_overrides else None
+    session_base_url = session_overrides.get("base_url") if session_overrides else None
+
+    model = session_model or _resolve_gateway_model(config)
+    if session_provider or session_base_url:
+        runtime_kwargs = _resolve_runtime_agent_kwargs(
+            requested=session_provider,
+            explicit_base_url=session_base_url,
+        )
+    else:
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+    return model, runtime_kwargs
 
 
 def _build_media_placeholder(event) -> str:
@@ -3043,12 +3073,13 @@ class GatewayRunner:
                 pass  # Skip all transcript writes — don't grow a broken session
             elif not history:
                 tool_defs = agent_result.get("tools", [])
+                resolved_model = agent_result.get("model")
                 self.session_store.append_to_transcript(
                     session_entry.session_id,
                     {
                         "role": "session_meta",
                         "tools": tool_defs or [],
-                        "model": _resolve_gateway_model(),
+                        "model": resolved_model or "",
                         "platform": source.platform.value if source.platform else "",
                         "timestamp": ts,
                     }
@@ -6291,6 +6322,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        session_overrides: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -6651,6 +6683,15 @@ class GatewayRunner:
                     "tools": [],
                 }
 
+            # Override model/runtime with session-scoped settings from /model.
+            # _session_model_overrides is populated by _handle_model_command and
+            # cleared on /new or /reset.
+            _effective_overrides = session_overrides
+            if _effective_overrides is None and session_key:
+                _effective_overrides = getattr(self, "_session_model_overrides", {}).get(session_key)
+            if _effective_overrides:
+                model, runtime_kwargs = _resolve_session_runtime_config(_effective_overrides, user_config)
+
             pr = self._provider_routing
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
@@ -6931,11 +6972,21 @@ class GatewayRunner:
             _input_toks = 0
             _output_toks = 0
             _agent = agent_holder[0]
+            _requested_turn = _effective_overrides or {}
+            _requested_runtime = {}
             if _agent and hasattr(_agent, "context_compressor"):
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _resolved_provider = getattr(_agent, "provider", None) if _agent else None
+            _resolved_base_url = getattr(_agent, "base_url", None) if _agent else None
+            if _resolved_model is None:
+                _resolved_model = _requested_turn.get("model")
+            if _resolved_provider is None:
+                _resolved_provider = _requested_turn.get("provider")
+            if _resolved_base_url is None:
+                _resolved_base_url = _requested_turn.get("base_url")
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else "(No response generated)"
@@ -6949,6 +7000,8 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "provider": _resolved_provider,
+                    "base_url": _resolved_base_url,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -7038,6 +7091,8 @@ class GatewayRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": _resolved_provider,
+                "base_url": _resolved_base_url,
                 "session_id": effective_session_id,
             }
         
@@ -7269,8 +7324,11 @@ class GatewayRunner:
             # the actually-active model instead of the config default.
             _agent = agent_holder[0]
             if _agent is not None and hasattr(_agent, 'model'):
-                _cfg_model = _resolve_gateway_model()
-                if _agent.model != _cfg_model:
+                _req_overrides = session_overrides
+                if _req_overrides is None and session_key:
+                    _req_overrides = getattr(self, "_session_model_overrides", {}).get(session_key)
+                _requested_model = (_req_overrides or {}).get("model") or _resolve_gateway_model()
+                if _requested_model and _agent.model != _requested_model:
                     self._effective_model = _agent.model
                     self._effective_provider = getattr(_agent, 'provider', None)
                     # Fallback activated — evict cached agent so the next
@@ -7285,49 +7343,53 @@ class GatewayRunner:
             result = result_holder[0]
             adapter = self.adapters.get(source.platform)
             
-            # Get pending message from adapter.
-            # Use session_key (not source.chat_id) to match adapter's storage keys.
+            # Get any pending follow-up from the adapter.
+            # Use session_key (not source.chat_id) to match adapter storage keys.
+            pending_event = None
             pending = None
             if result and adapter and session_key:
                 if result.get("interrupted"):
-                    pending = _dequeue_pending_text(adapter, session_key)
+                    # Interrupted — consume the interrupt message.
+                    pending_event = adapter.get_pending_message(session_key)
+                    if pending_event:
+                        pending = pending_event.text
+                        if not pending and getattr(pending_event, "media_urls", None):
+                            pending = _build_media_placeholder(pending_event)
                     if not pending and result.get("interrupt_message"):
                         pending = result.get("interrupt_message")
                 else:
-                    pending = _dequeue_pending_text(adapter, session_key)
-                    if pending:
-                        logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
-            
-            # Safety net: if the pending text is a slash command (e.g. "/stop",
-            # "/new"), discard it — commands should never be passed to the agent
-            # as user input.  The primary fix is in base.py (commands bypass the
-            # active-session guard), but this catches edge cases where command
-            # text leaks through the interrupt_message fallback.
-            if pending and pending.strip().startswith("/"):
-                _pending_parts = pending.strip().split(None, 1)
-                _pending_cmd_word = _pending_parts[0][1:].lower() if _pending_parts else ""
-                if _pending_cmd_word:
-                    try:
-                        from hermes_cli.commands import resolve_command as _rc_pending
-                        if _rc_pending(_pending_cmd_word):
-                            logger.info(
-                                "Discarding command '/%s' from pending queue — "
-                                "commands must not be passed as agent input",
-                                _pending_cmd_word,
-                            )
-                            pending = None
-                    except Exception:
-                        pass
+                    pending_event = adapter.get_pending_message(session_key)
+                    if pending_event:
+                        pending = pending_event.text
+                        if not pending and getattr(pending_event, "media_urls", None):
+                            pending = _build_media_placeholder(pending_event)
+                        if pending:
+                            logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
 
-            if pending:
-                logger.debug("Processing pending message: '%s...'", pending[:40])
-                
-                # Clear the adapter's interrupt event so the next _run_agent call
-                # doesn't immediately re-trigger the interrupt before the new agent
-                # even makes its first API call (this was causing an infinite loop).
+            if pending_event or pending:
+                if pending:
+                    logger.debug("Processing pending message: '%s...'", pending[:40])
+
+                # Clear the adapter's interrupt event so the next turn doesn't
+                # immediately re-trigger before the follow-up is dispatched.
                 if adapter and hasattr(adapter, '_active_sessions') and session_key and session_key in adapter._active_sessions:
                     adapter._active_sessions[session_key].clear()
-                
+
+                # If the queued follow-up is a slash command (e.g. /new, /model),
+                # redispatch it through _handle_message so it keeps its command
+                # semantics instead of being demoted to plain text input.
+                if pending_event and pending_event.is_command():
+                    logger.debug(
+                        "Dispatching queued command follow-up directly: '%s'",
+                        pending_event.text[:40],
+                    )
+                    # Clear the running-agent marker before re-dispatching so
+                    # commands like /new and /model aren't blocked by the
+                    # active-session guard.
+                    if session_key and session_key in self._running_agents:
+                        del self._running_agents[session_key]
+                    return await self._handle_message(pending_event)
+
                 # Cap recursion depth to prevent resource exhaustion when the
                 # user sends multiple messages while the agent keeps failing. (#816)
                 if _interrupt_depth >= self._MAX_INTERRUPT_DEPTH:
@@ -7338,7 +7400,7 @@ class GatewayRunner:
                     )
                     # Queue the pending message for normal processing on next turn
                     adapter = self.adapters.get(source.platform)
-                    if adapter and hasattr(adapter, 'queue_message'):
+                    if adapter and hasattr(adapter, 'queue_message') and pending:
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}
 
@@ -7370,6 +7432,7 @@ class GatewayRunner:
                     session_id=session_id,
                     session_key=session_key,
                     _interrupt_depth=_interrupt_depth + 1,
+                    session_overrides=session_overrides,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/tests/gateway/test_interrupt_command_preservation.py
+++ b/tests/gateway/test_interrupt_command_preservation.py
@@ -1,0 +1,142 @@
+"""Regression test: queued slash commands must stay commands after an interrupt.
+
+Before this fix, `_run_agent()` pulled a queued `MessageEvent` from the adapter,
+extracted only `pending_event.text`, and recursively called `_run_agent()` with the
+plain string. That silently demoted `/new`, `/model`, etc. into normal chat text,
+so Telegram topic commands looked unresponsive while a turn was active.
+"""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+class _InterruptedAgent:
+    """Fake agent that always returns an interrupted result."""
+
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None):
+        return {
+            "interrupted": True,
+            "messages": [],
+            "final_response": "",
+            "interrupt_message": None,
+        }
+
+
+class _AdapterWithQueuedCommand:
+    def __init__(self, queued_event: MessageEvent, session_key: str):
+        self._queued_event = queued_event
+        self._active_sessions = {session_key: asyncio.Event()}
+
+    def get_pending_message(self, session_key: str):
+        event, self._queued_event = self._queued_event, None
+        return event
+
+    async def send(self, chat_id, text, **kwargs):
+        return None
+
+
+def _make_runner(handle_message_mock):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._background_tasks = set()
+    runner._voice_mode = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._MAX_INTERRUPT_DEPTH = 4
+    runner._tool_wrapper = None
+    runner._status_tracker = None
+    runner._progress_topics = {}
+    runner._active_progress_tasks = {}
+    runner._session_vars = {}
+    runner._assistant_title = None
+    runner._paired_sessions = {}
+    runner._personality_overrides = {}
+    runner._session_model_overrides = {}
+    runner._session_model_settings = {}
+    runner._session_provider_settings = {}
+    runner._session_base_url_settings = {}
+    runner._session_api_key_settings = {}
+    runner._session_reasoning_settings = {}
+    runner._session_show_reasoning_settings = {}
+    runner._session_verbosity_settings = {}
+    runner._approval_timeout_tasks = {}
+    runner._honcho_managers = {}
+    runner._honcho_configs = {}
+    runner._evict_cached_agent = lambda session_key: None
+    runner._shutdown_gateway_honcho = lambda session_key: None
+    runner._format_session_info = lambda entry: ""
+    runner._is_user_authorized = lambda source: True
+    runner._handle_message = handle_message_mock
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_interrupted_queued_command_is_redispatched_as_message_event(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _InterruptedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda **kw: {"provider": "openai", "api_mode": "responses", "api_key": "test-key"},
+    )
+
+    handle_message_mock = AsyncMock(return_value="reset ok")
+    runner = _make_runner(handle_message_mock)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = "agent:main:telegram:dm:12345"
+    queued_command = MessageEvent(
+        text="/new",
+        source=source,
+        message_type=MessageType.COMMAND,
+    )
+    runner.adapters[Platform.TELEGRAM] = _AdapterWithQueuedCommand(queued_command, session_key)
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key=session_key,
+    )
+
+    assert result == "reset ok"
+    handle_message_mock.assert_awaited_once()
+    dispatched_event = handle_message_mock.await_args.args[0]
+    assert isinstance(dispatched_event, MessageEvent)
+    assert dispatched_event.is_command() is True
+    assert dispatched_event.get_command() == "new"

--- a/tests/gateway/test_session_model_runtime_wireup.py
+++ b/tests/gateway/test_session_model_runtime_wireup.py
@@ -1,0 +1,311 @@
+"""Regression tests for session-scoped gateway model/runtime wiring."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import types
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+ZAI_MODEL = "z-ai/glm-5-turbo"
+ZAI_PROVIDER = "zai"
+ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+GLOBAL_MODEL = "gpt-5.4"
+GLOBAL_PROVIDER = "openai-codex"
+GLOBAL_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-10012345",
+        chat_type="group",
+        thread_id="17585",
+        user_id="user-1",
+        user_name="tester",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.base_url = kwargs.get("base_url")
+        self.tools = []
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class _InterruptThenCompleteAgent(_CapturingAgent):
+    run_calls = 0
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        type(self).run_calls += 1
+        if type(self).run_calls == 1:
+            return {
+                "final_response": "Operation interrupted.",
+                "messages": [{"role": "user", "content": user_message}],
+                "api_calls": 1,
+                "interrupted": True,
+                "interrupt_message": "follow-up",
+            }
+        return {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "api_calls": 1,
+        }
+
+
+def _make_run_agent_runner(config: GatewayConfig) -> gateway_run.GatewayRunner:
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = config
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_uses_session_model_override(monkeypatch, tmp_path):
+    """A session /model selection must drive the agent creation with correct runtime."""
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="test")}
+    )
+    runner = _make_run_agent_runner(config)
+    runner.session_store = MagicMock()
+    runner._background_tasks = set()
+    runner._async_flush_memories = AsyncMock()
+    runner._shutdown_gateway_honcho = lambda _session_key: None
+    runner._evict_cached_agent = MagicMock()
+    runner._format_session_info = MagicMock(return_value="")
+    runner._session_model_overrides = {}
+
+    source = _make_source()
+    session_key = "agent:main:telegram:group:-10012345:17585"
+
+    # Set up a session model override (as /model command would)
+    runner._session_model_overrides[session_key] = {
+        "model": ZAI_MODEL,
+        "provider": ZAI_PROVIDER,
+        "api_key": "zai-key",
+        "base_url": ZAI_BASE_URL,
+        "api_mode": "chat_completions",
+    }
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: GLOBAL_MODEL)
+
+    runtime_requests = []
+
+    def _fake_runtime_kwargs(*, requested=None, explicit_base_url=None):
+        runtime_requests.append(
+            {
+                "requested": requested,
+                "explicit_base_url": explicit_base_url,
+            }
+        )
+        if requested == ZAI_PROVIDER:
+            return {
+                "provider": ZAI_PROVIDER,
+                "api_mode": "chat_completions",
+                "base_url": explicit_base_url or ZAI_BASE_URL,
+                "api_key": "zai-key",
+            }
+        return {
+            "provider": GLOBAL_PROVIDER,
+            "api_mode": "codex_responses",
+            "base_url": GLOBAL_BASE_URL,
+            "api_key": "global-key",
+        }
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _fake_runtime_kwargs)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    _CapturingAgent.last_init = None
+
+    result = await runner._run_agent(
+        message="What model are you?",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["model"] == ZAI_MODEL
+    assert _CapturingAgent.last_init["provider"] == ZAI_PROVIDER
+    assert _CapturingAgent.last_init["base_url"] == ZAI_BASE_URL
+    assert result["model"] == ZAI_MODEL
+    assert result["provider"] == ZAI_PROVIDER
+    assert result["base_url"] == ZAI_BASE_URL
+    # The runtime resolver must have been called with the session-scoped provider
+    assert any(
+        r["requested"] == ZAI_PROVIDER and r["explicit_base_url"] == ZAI_BASE_URL
+        for r in runtime_requests
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_agent_recursive_followup_keeps_session_runtime(monkeypatch, tmp_path):
+    """Interrupted follow-up turns must keep the session-scoped runtime."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="test")}
+    )
+    runner = _make_run_agent_runner(config)
+    runner.session_store = MagicMock()
+
+    source = _make_source()
+    session_key = "agent:main:telegram:group:-10012345:17585"
+
+    # Session model override
+    session_overrides = {
+        "model": ZAI_MODEL,
+        "provider": ZAI_PROVIDER,
+        "api_key": "zai-key",
+        "base_url": ZAI_BASE_URL,
+        "api_mode": "chat_completions",
+    }
+
+    pending_event = _make_event("follow-up")
+    adapter = MagicMock()
+    adapter.has_pending_interrupt.return_value = False
+    adapter.get_pending_message = MagicMock(side_effect=[pending_event, None])
+    adapter._active_sessions = {session_key: asyncio.Event()}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: GLOBAL_MODEL)
+
+    runtime_requests = []
+
+    def _fake_runtime_kwargs(*, requested=None, explicit_base_url=None):
+        runtime_requests.append(
+            {
+                "requested": requested,
+                "explicit_base_url": explicit_base_url,
+            }
+        )
+        if requested == ZAI_PROVIDER:
+            return {
+                "provider": ZAI_PROVIDER,
+                "api_mode": "chat_completions",
+                "base_url": explicit_base_url or ZAI_BASE_URL,
+                "api_key": "zai-key",
+            }
+        return {
+            "provider": GLOBAL_PROVIDER,
+            "api_mode": "codex_responses",
+            "base_url": GLOBAL_BASE_URL,
+            "api_key": "global-key",
+        }
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _fake_runtime_kwargs)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _InterruptThenCompleteAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    _InterruptThenCompleteAgent.last_init = None
+    _InterruptThenCompleteAgent.run_calls = 0
+
+    result = await runner._run_agent(
+        message="first turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-recursive",
+        session_key=session_key,
+        session_overrides=session_overrides,
+    )
+
+    assert result["final_response"] == "ok"
+    assert _InterruptThenCompleteAgent.run_calls == 2
+    # Both the initial and recursive calls should use the session-scoped runtime
+    assert runtime_requests == [
+        {
+            "requested": ZAI_PROVIDER,
+            "explicit_base_url": ZAI_BASE_URL,
+        },
+        {
+            "requested": ZAI_PROVIDER,
+            "explicit_base_url": ZAI_BASE_URL,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_runtime_config_falls_back_to_global(monkeypatch):
+    """Without session overrides, _resolve_session_runtime_config uses global config."""
+    from gateway.run import _resolve_session_runtime_config
+
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: GLOBAL_MODEL)
+
+    runtime_calls = []
+
+    def _fake_runtime_kwargs(*, requested=None, explicit_base_url=None):
+        runtime_calls.append({"requested": requested, "explicit_base_url": explicit_base_url})
+        return {"provider": GLOBAL_PROVIDER, "api_key": "key"}
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _fake_runtime_kwargs)
+
+    model, runtime = _resolve_session_runtime_config(None)
+    assert model == GLOBAL_MODEL
+    assert runtime_calls == [{"requested": None, "explicit_base_url": None}]
+
+    # With overrides
+    runtime_calls.clear()
+    model, runtime = _resolve_session_runtime_config({
+        "model": ZAI_MODEL,
+        "provider": ZAI_PROVIDER,
+        "base_url": ZAI_BASE_URL,
+    })
+    assert model == ZAI_MODEL
+    assert runtime_calls == [{"requested": ZAI_PROVIDER, "explicit_base_url": ZAI_BASE_URL}]


### PR DESCRIPTION
## Problem

After commit `ba20a0bb` ("fix(gateway): preserve queued commands on interrupt, honor session model runtime"), every agent turn that completes with tool calls triggers:

```
NameError: name '_requested_turn' is not defined
```

at `gateway/run.py:7329` in `_run_agent()`.

## Root Cause

`_requested_turn` is assigned at line 6977 **inside** the nested `run_sync()` closure:

```python
# line 6642 — outer async scope
def run_sync():
    ...
    _requested_turn = _effective_overrides or {}  # line 6977
    ...
    return { ... }                                # line 7085 — exits run_sync

# line 7324 — outer async scope, AFTER run_sync returned
_agent = agent_holder[0]
if _agent is not None and hasattr(_agent, 'model'):
    _requested_model = _requested_turn.get("model")  # NameError
```

The fallback model tracking at line 7329 runs in `_run_agent()`'s async scope, after `run_sync()` has already returned. `_requested_turn` is a local of `run_sync()` and is not accessible.

## Fix

Resolve the effective session overrides inline using `session_overrides` and `self._session_model_overrides` — the same resolution logic `run_sync()` uses at lines 6691-6693:

```python
_req_overrides = session_overrides
if _req_overrides is None and session_key:
    _req_overrides = getattr(self, "_session_model_overrides", {}).get(session_key)
_requested_model = (_req_overrides or {}).get("model") or _resolve_gateway_model()
```

## Verified

- Full traceback confirmed in gateway error logs matching line 7329
- Fix restores the pre-`ba20a0bb` behavior (global `_resolve_gateway_model()`) while preserving session-aware model resolution intent
- No changes to `run_sync()` internals — all existing references to `_requested_turn` within the closure remain correct
