### PR TITLE
fix(install): honor --dir for HERMES_HOME state

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,8 @@ BOLD='\033[1m'
 # Configuration
 REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
 REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
-HERMES_HOME="$HOME/.hermes"
+DEFAULT_HERMES_HOME="$HOME/.hermes"
+HERMES_HOME="${HERMES_HOME:-$DEFAULT_HERMES_HOME}"
 INSTALL_DIR="${HERMES_INSTALL_DIR:-$HERMES_HOME/hermes-agent}"
 PYTHON_VERSION="3.11"
 NODE_VERSION="22"
@@ -64,6 +65,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --dir)
             INSTALL_DIR="$2"
+            if [ -z "${HERMES_HOME:-}" ] || [ "$HERMES_HOME" = "$DEFAULT_HERMES_HOME" ]; then
+                HERMES_HOME="$INSTALL_DIR"
+            fi
             shift 2
             ;;
         -h|--help)
@@ -809,30 +813,30 @@ setup_path() {
 copy_config_templates() {
     log_info "Setting up configuration files..."
 
-    # Create ~/.hermes directory structure (config at top level, code in subdir)
+    # Create Hermes home directory structure (config at top level, code in subdir)
     mkdir -p "$HERMES_HOME"/{cron,sessions,logs,pairing,hooks,image_cache,audio_cache,memories,skills,whatsapp/session}
 
-    # Create .env at ~/.hermes/.env (top level, easy to find)
+    # Create .env at $HERMES_HOME/.env (top level, easy to find)
     if [ ! -f "$HERMES_HOME/.env" ]; then
         if [ -f "$INSTALL_DIR/.env.example" ]; then
             cp "$INSTALL_DIR/.env.example" "$HERMES_HOME/.env"
-            log_success "Created ~/.hermes/.env from template"
+            log_success "Created $HERMES_HOME/.env from template"
         else
             touch "$HERMES_HOME/.env"
-            log_success "Created ~/.hermes/.env"
+            log_success "Created $HERMES_HOME/.env"
         fi
     else
-        log_info "~/.hermes/.env already exists, keeping it"
+        log_info "$HERMES_HOME/.env already exists, keeping it"
     fi
 
-    # Create config.yaml at ~/.hermes/config.yaml (top level, easy to find)
+    # Create config.yaml at $HERMES_HOME/config.yaml (top level, easy to find)
     if [ ! -f "$HERMES_HOME/config.yaml" ]; then
         if [ -f "$INSTALL_DIR/cli-config.yaml.example" ]; then
             cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
-            log_success "Created ~/.hermes/config.yaml from template"
+            log_success "Created $HERMES_HOME/config.yaml from template"
         fi
     else
-        log_info "~/.hermes/config.yaml already exists, keeping it"
+        log_info "$HERMES_HOME/config.yaml already exists, keeping it"
     fi
 
     # Create SOUL.md if it doesn't exist (global persona file)
@@ -854,20 +858,20 @@ This file is loaded fresh each message -- no restart needed.
 Delete the contents (or this file) to use the default personality.
 -->
 SOUL_EOF
-        log_success "Created ~/.hermes/SOUL.md (edit to customize personality)"
+        log_success "Created $HERMES_HOME/SOUL.md (edit to customize personality)"
     fi
 
-    log_success "Configuration directory ready: ~/.hermes/"
+    log_success "Configuration directory ready: $HERMES_HOME/"
 
-    # Seed bundled skills into ~/.hermes/skills/ (manifest-based, one-time per skill)
-    log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
-    if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
-        log_success "Skills synced to ~/.hermes/skills/"
+    # Seed bundled skills into $HERMES_HOME/skills/ (manifest-based, one-time per skill)
+    log_info "Syncing bundled skills to $HERMES_HOME/skills/ ..."
+    if HERMES_HOME="$HERMES_HOME" "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
+        log_success "Skills synced to $HERMES_HOME/skills/"
     else
         # Fallback: simple directory copy if Python sync fails
         if [ -d "$INSTALL_DIR/skills" ] && [ ! "$(ls -A "$HERMES_HOME/skills/" 2>/dev/null | grep -v '.bundled_manifest')" ]; then
             cp -r "$INSTALL_DIR/skills/"* "$HERMES_HOME/skills/" 2>/dev/null || true
-            log_success "Skills copied to ~/.hermes/skills/"
+            log_success "Skills copied to $HERMES_HOME/skills/"
         fi
     fi
 }
@@ -1051,12 +1055,13 @@ print_success() {
     echo ""
 
     # Show file locations
-    echo -e "${CYAN}${BOLD}📁 Your files (all in ~/.hermes/):${NC}"
+    echo -e "${CYAN}${BOLD}📁 Your Hermes home:${NC}"
     echo ""
-    echo -e "   ${YELLOW}Config:${NC}    ~/.hermes/config.yaml"
-    echo -e "   ${YELLOW}API Keys:${NC}  ~/.hermes/.env"
-    echo -e "   ${YELLOW}Data:${NC}      ~/.hermes/cron/, sessions/, logs/"
-    echo -e "   ${YELLOW}Code:${NC}      ~/.hermes/hermes-agent/"
+    echo -e "   ${YELLOW}Root:${NC}      $HERMES_HOME"
+    echo -e "   ${YELLOW}Config:${NC}    $HERMES_HOME/config.yaml"
+    echo -e "   ${YELLOW}API Keys:${NC}  $HERMES_HOME/.env"
+    echo -e "   ${YELLOW}Data:${NC}      $HERMES_HOME/cron/, sessions/, logs/"
+    echo -e "   ${YELLOW}Code:${NC}      $INSTALL_DIR"
     echo ""
 
     echo -e "${CYAN}─────────────────────────────────────────────────────────${NC}"

--- a/tests/test_install_script_dir_home_behavior.py
+++ b/tests/test_install_script_dir_home_behavior.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_prelude_end(lines: list[str]) -> int:
+    for idx, line in enumerate(lines):
+        if line.startswith("# ============================================================================") and idx > 0:
+            if idx + 1 < len(lines) and lines[idx + 1].strip() == "# Helper functions":
+                return idx
+    raise AssertionError("Could not locate helper-functions boundary in install.sh")
+
+
+def _run_shell(snippet: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-lc", snippet],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def test_dir_flag_sets_hermes_home_when_env_not_explicitly_set(tmp_path: Path) -> None:
+    install_dir = tmp_path / "custom-home"
+    lines = INSTALL_SCRIPT.read_text(encoding="utf-8").splitlines()
+    prelude = "\n".join(lines[: _extract_prelude_end(lines)])
+
+    result = _run_shell(
+        f"""
+set -e
+unset HERMES_HOME
+unset HERMES_INSTALL_DIR
+{prelude}
+set -- --dir {install_dir}
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-venv)
+            USE_VENV=false
+            shift
+            ;;
+        --skip-setup)
+            RUN_SETUP=false
+            shift
+            ;;
+        --branch)
+            BRANCH=\"$2\"
+            shift 2
+            ;;
+        --dir)
+            INSTALL_DIR=\"$2\"
+            if [ -z \"${{HERMES_HOME:-}}\" ] || [ \"$HERMES_HOME\" = \"$DEFAULT_HERMES_HOME\" ]; then
+                HERMES_HOME=\"$INSTALL_DIR\"
+            fi
+            shift 2
+            ;;
+        *)
+            exit 99
+            ;;
+    esac
+done
+printf '%s\n%s\n' "$INSTALL_DIR" "$HERMES_HOME"
+"""
+    )
+
+    install_value, hermes_home_value = result.stdout.strip().splitlines()
+    assert install_value == str(install_dir)
+    assert hermes_home_value == str(install_dir)
+
+
+def test_dir_flag_preserves_explicit_hermes_home_env(tmp_path: Path) -> None:
+    install_dir = tmp_path / "checkout"
+    hermes_home = tmp_path / "profile-home"
+    lines = INSTALL_SCRIPT.read_text(encoding="utf-8").splitlines()
+    prelude = "\n".join(lines[: _extract_prelude_end(lines)])
+
+    result = _run_shell(
+        f"""
+set -e
+export HERMES_HOME={hermes_home}
+unset HERMES_INSTALL_DIR
+{prelude}
+set -- --dir {install_dir}
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-venv)
+            USE_VENV=false
+            shift
+            ;;
+        --skip-setup)
+            RUN_SETUP=false
+            shift
+            ;;
+        --branch)
+            BRANCH=\"$2\"
+            shift 2
+            ;;
+        --dir)
+            INSTALL_DIR=\"$2\"
+            if [ -z \"${{HERMES_HOME:-}}\" ] || [ \"$HERMES_HOME\" = \"$DEFAULT_HERMES_HOME\" ]; then
+                HERMES_HOME=\"$INSTALL_DIR\"
+            fi
+            shift 2
+            ;;
+        *)
+            exit 99
+            ;;
+    esac
+done
+printf '%s\n%s\n' "$INSTALL_DIR" "$HERMES_HOME"
+"""
+    )
+
+    install_value, hermes_home_value = result.stdout.strip().splitlines()
+    assert install_value == str(install_dir)
+    assert hermes_home_value == str(hermes_home)


### PR DESCRIPTION
## Summary
- make `scripts/install.sh --dir` move Hermes state/config into the chosen home when `HERMES_HOME` is not explicitly set
- pass `HERMES_HOME` through the bundled skill sync step so the installer seeds the correct profile-scoped skill directory
- update installer success output and add regression tests for `--dir` vs explicit `HERMES_HOME`

## Testing
- `source venv/bin/activate && python -m pytest tests/test_install_script_dir_home_behavior.py -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_config.py -q`

Part of #5947 (Bug C).
