### PR TITLE
fix(agent): catch PermissionError in subdirectory hint discovery

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -159,7 +159,10 @@ class SubdirectoryHintTracker:
 
     def _is_valid_subdir(self, path: Path) -> bool:
         """Check if path is a valid directory to scan for hints."""
-        if not path.is_dir():
+        try:
+            if not path.is_dir():
+                return False
+        except OSError:
             return False
         if path in self._loaded_dirs:
             return False
@@ -172,7 +175,10 @@ class SubdirectoryHintTracker:
         found_hints = []
         for filename in _HINT_FILENAMES:
             hint_path = directory / filename
-            if not hint_path.is_file():
+            try:
+                if not hint_path.is_file():
+                    continue
+            except OSError:
                 continue
             try:
                 content = hint_path.read_text(encoding="utf-8").strip()

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -3,6 +3,7 @@
 import os
 import pytest
 from pathlib import Path
+from unittest.mock import patch
 
 from agent.subdirectory_hints import SubdirectoryHintTracker
 
@@ -189,3 +190,45 @@ class TestSubdirectoryHintTracker:
             "terminal", {"command": "curl https://example.com/frontend/api"}
         )
         assert result is None
+
+
+class TestPermissionErrorHandling:
+    """Regression tests for PermissionError in filesystem checks (ref #6214)."""
+
+    def test_is_valid_subdir_permission_error(self, tmp_path):
+        """_is_valid_subdir should return False when is_dir() raises PermissionError."""
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        restricted = tmp_path / "restricted"
+        restricted.mkdir()
+        with patch.object(Path, "is_dir", side_effect=PermissionError("Permission denied")):
+            assert tracker._is_valid_subdir(restricted) is False
+
+    def test_load_hints_permission_error_on_is_file(self, tmp_path):
+        """_load_hints_for_directory should skip files when is_file() raises PermissionError."""
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        restricted = tmp_path / "restricted"
+        restricted.mkdir()
+        original_is_file = Path.is_file
+        def patched_is_file(self):
+            if "restricted" in str(self):
+                raise PermissionError("Permission denied")
+            return original_is_file(self)
+        with patch.object(Path, "is_file", patched_is_file):
+            result = tracker._load_hints_for_directory(restricted)
+        assert result is None
+
+    def test_check_tool_call_survives_inaccessible_path(self, project):
+        """Full check_tool_call should not crash when a path is inaccessible."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        original_is_dir = Path.is_dir
+        def patched_is_dir(self):
+            if "backend" in str(self) and "src" not in str(self):
+                raise PermissionError("Permission denied")
+            return original_is_dir(self)
+        with patch.object(Path, "is_dir", patched_is_dir):
+            # Should not raise — gracefully skip the inaccessible directory
+            result = tracker.check_tool_call(
+                "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+            )
+            # Result may be None (backend skipped) — the key point is no crash
+            assert result is None or isinstance(result, str)


### PR DESCRIPTION
## Summary

Cherry-pick of #6425 by @konsisumer onto current main.

Wraps unguarded `Path.is_dir()` and `Path.is_file()` calls in `agent/subdirectory_hints.py` with `try/except OSError` so that inaccessible directories (e.g. `/root` from a non-root Daytona user) don't crash the agent.

## Changes

- **`_is_valid_subdir()`** — wrap `path.is_dir()` in `try/except OSError`
- **`_load_hints_for_directory()`** — wrap `hint_path.is_file()` in `try/except OSError`
- **Tests** — 3 new regression tests covering PermissionError in both methods and end-to-end via `check_tool_call()`

## Testing

All 18 tests in `tests/agent/test_subdirectory_hints.py` pass (15 existing + 3 new).

Refs #6214
Closes #6425