### PR TITLE
Add proxy support for Telegram

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -534,6 +534,13 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
+                # Telegram-specific settings
+                if "proxy_url" in platform_cfg:
+                    bridged["proxy_url"] = platform_cfg["proxy_url"]
+                if "allowed_users" in platform_cfg:
+                    bridged["allowed_users"] = platform_cfg["allowed_users"]
+                if "webhook_mode" in platform_cfg:
+                    bridged["webhook_mode"] = platform_cfg["webhook_mode"]
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -514,7 +514,13 @@ class TelegramAdapter(BasePlatformAdapter):
             # Build the application
             builder = Application.builder().token(self.config.token)
             fallback_ips = self._fallback_ips()
-            if not fallback_ips:
+            httpx_kwargs = {}
+            # Pass proxy from config if available
+            proxy_url = self.config.extra.get("proxy_url")
+            if proxy_url:
+                httpx_kwargs["proxy"] = proxy_url
+            # When proxy is already configured don't do fallback IPs - proxy already handles routing
+            if not proxy_url and not fallback_ips:
                 fallback_ips = await discover_fallback_ips()
                 logger.info(
                     "[%s] Auto-discovered Telegram fallback IPs: %s",
@@ -527,9 +533,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name,
                     ", ".join(fallback_ips),
                 )
-                transport = TelegramFallbackTransport(fallback_ips)
+                transport = TelegramFallbackTransport(fallback_ips, **httpx_kwargs)
                 request = HTTPXRequest(httpx_kwargs={"transport": transport})
                 get_updates_request = HTTPXRequest(httpx_kwargs={"transport": transport})
+                builder = builder.request(request).get_updates_request(get_updates_request)
+            elif proxy_url:
+                # No fallback IPs but proxy configured - just add proxy
+                request = HTTPXRequest(httpx_kwargs={"proxy": proxy_url})
+                get_updates_request = HTTPXRequest(httpx_kwargs={"proxy": proxy_url})
                 builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -465,9 +465,28 @@ You usually don't need to configure this manually. The auto-discovery via DoH ha
 
 ## Proxy Support
 
-If your network requires an HTTP proxy to reach the internet (common in corporate environments), the Telegram adapter automatically reads standard proxy environment variables and routes all connections through the proxy.
+If your network requires an HTTP proxy to reach the internet (common in restricted networks/corporate environments), Hermes supports two ways to configure a proxy for Telegram:
 
-### Supported variables
+### Option 1: Config File (Recommended)
+
+Add `proxy_url` directly in your `config.yaml` under the `telegram` section. This keeps the proxy configuration with your other Hermes settings and doesn't affect other applications:
+
+```yaml
+telegram:
+  proxy_url: "http://your-proxy-host:port"
+```
+
+Example with authentication:
+```yaml
+telegram:
+  proxy_url: "http://username:password@proxy.example.com:8080"
+```
+
+When `proxy_url` is configured, Hermes automatically routes all Telegram API requests through the proxy and skips the fallback IP discovery logic (since the proxy already handles network routing).
+
+### Option 2: Environment Variables
+
+The Telegram adapter also automatically reads standard proxy environment variables and routes all connections through the proxy:
 
 The adapter checks these environment variables in order, using the first one that is set:
 
@@ -475,8 +494,6 @@ The adapter checks these environment variables in order, using the first one tha
 2. `HTTP_PROXY`
 3. `ALL_PROXY`
 4. `https_proxy` / `http_proxy` / `all_proxy` (lowercase variants)
-
-### Configuration
 
 Set the proxy in your environment before starting the gateway:
 
@@ -491,7 +508,11 @@ Or add it to `~/.hermes/.env`:
 HTTPS_PROXY=http://proxy.example.com:8080
 ```
 
-The proxy applies to both the primary transport and all fallback IP transports. No additional Hermes configuration is needed — if the environment variable is set, it's used automatically.
+The proxy applies to both the primary transport and all fallback IP transports.
+
+:::note
+`proxy_url` in the config takes precedence over environment variables. This lets you configure a proxy specifically for Telegram without affecting other network requests made by Hermes.
+:::
 
 :::note
 This covers the custom fallback transport layer that Hermes uses for Telegram connections. The standard `httpx` client used elsewhere already respects proxy env vars natively.


### PR DESCRIPTION
Add proxy_url configuration for Telegram. This allows users behind firewalls to use Telegram with an HTTP/HTTPS proxy.

   Changes:
   - Add proxy_url to extra config in gateway/config.py
   - Pass proxy to HTTPXRequest in telegram.py
   - Skip fallback IP logic when proxy is configured (proxy already handles routing)