### PR TITLE
fix(cron): surface delivery failures in job status instead of swallowing them (#5861)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -590,8 +590,13 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         if job["id"] == job_id:
             now = _hermes_now().isoformat()
             job["last_run_at"] = now
-            job["last_status"] = "ok" if success else "error"
-            job["last_error"] = error if not success else None
+            job["last_status"] = "ok" if (success and not delivery_error) else "error"
+            if not success:
+                job["last_error"] = error
+            elif delivery_error:
+                job["last_error"] = f"delivery: {delivery_error}"
+            else:
+                job["last_error"] = None
             # Track delivery failures separately — cleared on successful delivery
             job["last_delivery_error"] = delivery_error
             

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -339,24 +339,26 @@ class TestMarkJobRun:
         assert updated["last_status"] == "error"
         assert updated["last_error"] == "timeout"
 
-    def test_delivery_error_tracked_separately(self, tmp_cron_dir):
-        """Agent succeeds but delivery fails — both tracked independently."""
+    def test_delivery_error_sets_error_status(self, tmp_cron_dir):
+        """Agent succeeds but delivery fails — status must reflect the delivery failure."""
         job = create_job(prompt="Report", schedule="every 1h")
         mark_job_run(job["id"], success=True, delivery_error="platform 'telegram' not configured")
         updated = get_job(job["id"])
-        assert updated["last_status"] == "ok"
-        assert updated["last_error"] is None
+        assert updated["last_status"] == "error"
+        assert updated["last_error"] == "delivery: platform 'telegram' not configured"
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
 
     def test_delivery_error_cleared_on_success(self, tmp_cron_dir):
-        """Successful delivery clears the previous delivery error."""
+        """Successful delivery clears the previous delivery error and restores ok status."""
         job = create_job(prompt="Report", schedule="every 1h")
         mark_job_run(job["id"], success=True, delivery_error="network timeout")
         updated = get_job(job["id"])
+        assert updated["last_status"] == "error"
         assert updated["last_delivery_error"] == "network timeout"
         # Next run delivers successfully
         mark_job_run(job["id"], success=True, delivery_error=None)
         updated = get_job(job["id"])
+        assert updated["last_status"] == "ok"
         assert updated["last_delivery_error"] is None
 
     def test_both_agent_and_delivery_error(self, tmp_cron_dir):


### PR DESCRIPTION
## Problem

Cron job status shows "ok" even when Discord or Telegram delivery fails. Users scheduling jobs with a delivery target have no indication their message was never sent — the failure is completely invisible in the status display.

## Root Cause

`mark_job_run()` in `cron/jobs.py` set `last_status` based solely on whether the agent execution succeeded, ignoring the `delivery_error` parameter entirely:

```python
job["last_status"] = "ok" if success else "error"
job["last_error"] = error if not success else None
```

Delivery errors were written to `last_delivery_error` but never promoted to the primary status field, so the status check always returned "ok" after a successful agent run — even when the message was never delivered.

## Fix

`last_status` now reflects delivery failures. If the agent succeeded but delivery failed, status becomes `"error"` and `last_error` is set to `"delivery: <reason>"` so it surfaces in the normal status display. A successful delivery continues to produce `"ok"`.

## Testing

Reproduce by configuring a cron job with a Discord or Telegram target that is unavailable or misconfigured, then triggering a run. Before this fix, status shows "ok". After this fix, status shows "error: delivery: <reason>".

Updated tests in `tests/cron/test_jobs.py` cover:
- Agent succeeds + delivery fails → `last_status == "error"` and `last_error == "delivery: <reason>"`
- Subsequent successful delivery → `last_status` restored to `"ok"`

Fixes #5861