### PR TITLE
fix #6447: /sethome writes to .env instead of config.yaml for DISCORD_HOME_CHANNEL

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4027,16 +4027,10 @@ class GatewayRunner:
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
         
-        # Save to config.yaml
+        # Save to .env (same as other *_HOME_CHANNEL and platform env vars)
         try:
-            import yaml
-            config_path = _hermes_home / 'config.yaml'
-            user_config = {}
-            if config_path.exists():
-                with open(config_path, encoding="utf-8") as f:
-                    user_config = yaml.safe_load(f) or {}
-            user_config[env_key] = chat_id
-            atomic_yaml_write(config_path, user_config)
+            from hermes_cli.config import save_env_value
+            save_env_value(env_key, str(chat_id))
             # Also set in the current environment so it takes effect immediately
             os.environ[env_key] = str(chat_id)
         except Exception as e:


### PR DESCRIPTION
## Bug #6447: /sethome writes to wrong file for DISCORD_HOME_CHANNEL

### Problem
The `_handle_set_home_command` function was writing `DISCORD_HOME_CHANNEL` to `config.yaml` instead of `.env`. This means the home channel setting was ignored on restart.

### Root Cause
Lines 4030-4039 wrote directly to `_hermes_home / 'config.yaml'`, but all other `\*_HOME_CHANNEL` env vars are stored in `.env` via `save_env_value()`.

### Fix
Replace the yaml write with `save_env_value(env_key, str(chat_id))`, consistent with how other platform home channels are stored.

### Verification
`/sethome` on Discord now persists across restarts by storing in `.env`.