### PR TITLE
fix(gateway): make Slack platform note capability-aware when MCP tools present

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2143,8 +2143,13 @@ class GatewayRunner:
                 "session_key": session_key,
             })
         
-        # Build session context
-        context = build_session_context(source, self.config, session_entry)
+        # Build session context — pass available tool names for capability-aware platform notes
+        try:
+            from model_tools import get_all_tool_names as _get_tool_names
+            _available_tools = _get_tool_names()
+        except Exception:
+            _available_tools = None
+        context = build_session_context(source, self.config, session_entry, available_tools=_available_tools)
         
         # Set environment variables for tools
         self._set_session_env(context)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1040,7 +1040,8 @@ class SessionStore:
 def build_session_context(
     source: SessionSource,
     config: GatewayConfig,
-    session_entry: Optional[SessionEntry] = None
+    session_entry: Optional[SessionEntry] = None,
+    available_tools: Optional[List[str]] = None,
 ) -> SessionContext:
     """
     Build a full session context from a source and config.
@@ -1059,6 +1060,7 @@ def build_session_context(
         source=source,
         connected_platforms=connected,
         home_channels=home_channels,
+        available_tools=available_tools,
     )
     
     if session_entry:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -174,6 +174,10 @@ class SessionContext:
     session_id: str = ""
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+
+    # Runtime tool names — used to make platform notes capability-aware
+    # (e.g. Slack MCP tools detected → update Slack platform note)
+    available_tools: List[str] = None
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -266,13 +270,29 @@ def build_session_context_prompt(
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:
         lines.append("")
-        lines.append(
-            "**Platform notes:** You are running inside Slack. "
-            "You do NOT have access to Slack-specific APIs — you cannot search "
-            "channel history, pin/unpin messages, manage channels, or list users. "
-            "Do not promise to perform these actions. If the user asks, explain "
-            "that you can only read messages sent directly to you and respond."
-        )
+        # Check if scoped Slack MCP tools are available at runtime
+        _slack_tools = [
+            t for t in (getattr(context, "available_tools", None) or [])
+            if "slack" in t.lower()
+        ]
+        if _slack_tools:
+            lines.append(
+                "**Platform notes:** You are running inside Slack. "
+                "Scoped Slack tools are available (e.g. "
+                + ", ".join(f"`{t}`" for t in _slack_tools[:3])
+                + "). You MAY use these tools to resolve Slack permalinks, "
+                "fetch thread replies, or search messages. "
+                "Do NOT assume raw token access or unmanaged API calls — "
+                "only use the explicitly provided Slack tools."
+            )
+        else:
+            lines.append(
+                "**Platform notes:** You are running inside Slack. "
+                "You do NOT have access to Slack-specific APIs — you cannot search "
+                "channel history, pin/unpin messages, manage channels, or list users. "
+                "Do not promise to perform these actions. If the user asks, explain "
+                "that you can only read messages sent directly to you and respond."
+            )
     elif context.source.platform == Platform.DISCORD:
         lines.append("")
         lines.append(


### PR DESCRIPTION
Fixes #6533

## Problem
When Slack MCP tools are available at runtime, the gateway still injects a hardcoded platform note saying the agent has no Slack-specific API access. This causes false refusals even though Slack MCP tools are working.

## Root Cause
`build_session_context_prompt()` had a hardcoded Slack platform note that always said Slack-specific APIs are unavailable, regardless of runtime tool availability.

## Fix
- Added `available_tools: List[str]` field to `SessionContext`
- `build_session_context()` now accepts `available_tools` parameter
- `build_session_context_prompt()` checks for Slack tools (e.g. `mcp_slack_*`) in `available_tools`
- If Slack tools are present: injects a note acknowledging scoped tool access
- If no Slack tools: keeps the existing conservative note (no behavior change)
- `run.py` populates `available_tools` from `get_all_tool_names()` at message time

## Files Changed
- `gateway/session.py` — `SessionContext.available_tools` field + capability-aware Slack note + `build_session_context()` signature
- `gateway/run.py` — populate `available_tools` when building session context