### PR TITLE
fix(gateway): preserve user identity in process watcher notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5912,12 +5912,23 @@ class GatewayRunner:
         os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
         if context.source.chat_name:
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
+        if context.source.user_id:
+            os.environ["HERMES_SESSION_USER_ID"] = str(context.source.user_id)
+        if context.source.user_name:
+            os.environ["HERMES_SESSION_USER_NAME"] = context.source.user_name
         if context.source.thread_id:
             os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
+        for var in [
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_CHAT_NAME",
+            "HERMES_SESSION_USER_ID",
+            "HERMES_SESSION_USER_NAME",
+            "HERMES_SESSION_THREAD_ID",
+        ]:
             if var in os.environ:
                 del os.environ[var]
     
@@ -6097,6 +6108,8 @@ class GatewayRunner:
         session_key = watcher.get("session_key", "")
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
+        user_id = watcher.get("user_id", "")
+        user_name = watcher.get("user_name", "")
         thread_id = watcher.get("thread_id", "")
         agent_notify = watcher.get("notify_on_complete", False)
         notify_mode = self._load_background_notifications_mode()
@@ -6152,6 +6165,8 @@ class GatewayRunner:
                             _source = SessionSource(
                                 platform=_platform_enum,
                                 chat_id=chat_id,
+                                user_id=user_id or None,
+                                user_name=user_name or None,
                                 thread_id=thread_id or None,
                             )
                             synth_event = MessageEvent(

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -45,17 +45,20 @@ def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
     runner = GatewayRunner(GatewayConfig())
-    adapter = SimpleNamespace(send=AsyncMock())
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
     runner.adapters[Platform.TELEGRAM] = adapter
     return runner
 
 
-def _watcher_dict(session_id="proc_test", thread_id=""):
+def _watcher_dict(session_id="proc_test", thread_id="", user_id="user-123", user_name="alice", notify_on_complete=False):
     d = {
         "session_id": session_id,
         "check_interval": 0,
         "platform": "telegram",
         "chat_id": "123",
+        "user_id": user_id,
+        "user_name": user_name,
+        "notify_on_complete": notify_on_complete,
     }
     if thread_id:
         d["thread_id"] = thread_id
@@ -243,3 +246,27 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     assert adapter.send.await_count == 1
     _, kwargs = adapter.send.call_args
     assert kwargs["metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_agent_notify_injects_source_with_user_identity(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="sleep 1")]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict(thread_id="42", user_id="user-123", user_name="alice", session_id="proc_test", notify_on_complete=True))
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.user_id == "user-123"
+    assert event.source.user_name == "alice"
+    assert event.source.thread_id == "42"
+    assert event.text.startswith("[SYSTEM: Background process proc_test completed")

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -12,6 +12,8 @@ def test_set_session_env_includes_thread_id(monkeypatch):
         chat_id="-1001",
         chat_name="Group",
         chat_type="group",
+        user_id="123456",
+        user_name="alice",
         thread_id="17585",
     )
     context = SessionContext(source=source, connected_platforms=[], home_channels={})
@@ -19,6 +21,8 @@ def test_set_session_env_includes_thread_id(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
 
     runner._set_session_env(context)
@@ -26,6 +30,8 @@ def test_set_session_env_includes_thread_id(monkeypatch):
     assert os.getenv("HERMES_SESSION_PLATFORM") == "telegram"
     assert os.getenv("HERMES_SESSION_CHAT_ID") == "-1001"
     assert os.getenv("HERMES_SESSION_CHAT_NAME") == "Group"
+    assert os.getenv("HERMES_SESSION_USER_ID") == "123456"
+    assert os.getenv("HERMES_SESSION_USER_NAME") == "alice"
     assert os.getenv("HERMES_SESSION_THREAD_ID") == "17585"
 
 
@@ -35,6 +41,8 @@ def test_clear_session_env_removes_thread_id(monkeypatch):
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "-1001")
     monkeypatch.setenv("HERMES_SESSION_CHAT_NAME", "Group")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "123456")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "alice")
     monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "17585")
 
     runner._clear_session_env()
@@ -42,4 +50,6 @@ def test_clear_session_env_removes_thread_id(monkeypatch):
     assert os.getenv("HERMES_SESSION_PLATFORM") is None
     assert os.getenv("HERMES_SESSION_CHAT_ID") is None
     assert os.getenv("HERMES_SESSION_CHAT_NAME") is None
+    assert os.getenv("HERMES_SESSION_USER_ID") is None
+    assert os.getenv("HERMES_SESSION_USER_NAME") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -261,11 +261,30 @@ class TestTerminalSchema:
             assert kwargs["notify_on_complete"] is True
 
     def test_gateway_notify_watcher_captures_user_identity(self, monkeypatch):
+        from types import SimpleNamespace
+
         from tools.terminal_tool import terminal_tool
-        from tools.process_registry import ProcessRegistry
+        from tools.process_registry import ProcessRegistry, ProcessSession
 
         isolated_registry = ProcessRegistry()
         monkeypatch.setattr("tools.process_registry.process_registry", isolated_registry)
+        monkeypatch.setattr("tools.terminal_tool._create_environment", lambda **_kw: SimpleNamespace(env={}))
+        monkeypatch.setattr("tools.terminal_tool._check_all_guards", lambda *_a, **_kw: {"approved": True})
+        monkeypatch.setattr("tools.approval.get_current_session_key", lambda default="": "sess-key")
+
+        def _fake_spawn_local(command, cwd, task_id, session_key, env_vars=None, use_pty=False):
+            session = ProcessSession(
+                id="proc_test_notify_identity",
+                command=command,
+                task_id=task_id,
+                session_key=session_key,
+                started_at=time.time(),
+                pid=4242,
+            )
+            isolated_registry._running[session.id] = session
+            return session
+
+        monkeypatch.setattr(isolated_registry, "spawn_local", _fake_spawn_local)
 
         monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
         monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -262,15 +262,16 @@ class TestTerminalSchema:
 
     def test_gateway_notify_watcher_captures_user_identity(self, monkeypatch):
         from tools.terminal_tool import terminal_tool
-        from tools.process_registry import process_registry
+        from tools.process_registry import ProcessRegistry
+
+        isolated_registry = ProcessRegistry()
+        monkeypatch.setattr("tools.process_registry.process_registry", isolated_registry)
 
         monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
         monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")
         monkeypatch.setenv("HERMES_SESSION_USER_ID", "u123")
         monkeypatch.setenv("HERMES_SESSION_USER_NAME", "alice")
         monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "42")
-
-        process_registry.pending_watchers.clear()
 
         result = json.loads(
             terminal_tool(
@@ -282,7 +283,7 @@ class TestTerminalSchema:
             )
         )
 
-        watcher = next(w for w in process_registry.pending_watchers if w["session_id"] == result["session_id"])
+        watcher = next(w for w in isolated_registry.pending_watchers if w["session_id"] == result["session_id"])
         assert watcher["platform"] == "telegram"
         assert watcher["chat_id"] == "123"
         assert watcher["user_id"] == "u123"

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -207,6 +207,8 @@ class TestCheckpointNotify:
             "session_key": "sk1",
             "watcher_platform": "telegram",
             "watcher_chat_id": "123",
+            "watcher_user_id": "u123",
+            "watcher_user_name": "alice",
             "watcher_thread_id": "42",
             "watcher_interval": 5,
             "notify_on_complete": True,
@@ -216,6 +218,8 @@ class TestCheckpointNotify:
             assert recovered == 1
             assert len(registry.pending_watchers) == 1
             assert registry.pending_watchers[0]["notify_on_complete"] is True
+            assert registry.pending_watchers[0]["user_id"] == "u123"
+            assert registry.pending_watchers[0]["user_name"] == "alice"
 
     def test_recover_defaults_false(self, registry, tmp_path):
         """Old checkpoint entries without the field default to False."""
@@ -255,6 +259,35 @@ class TestTerminalSchema:
             )
             _, kwargs = mock_tt.call_args
             assert kwargs["notify_on_complete"] is True
+
+    def test_gateway_notify_watcher_captures_user_identity(self, monkeypatch):
+        from tools.terminal_tool import terminal_tool
+        from tools.process_registry import process_registry
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "u123")
+        monkeypatch.setenv("HERMES_SESSION_USER_NAME", "alice")
+        monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "42")
+
+        process_registry.pending_watchers.clear()
+
+        result = json.loads(
+            terminal_tool(
+                "python -c 'print(1)'",
+                background=True,
+                notify_on_complete=True,
+                timeout=30,
+                workdir="/tmp",
+            )
+        )
+
+        watcher = next(w for w in process_registry.pending_watchers if w["session_id"] == result["session_id"])
+        assert watcher["platform"] == "telegram"
+        assert watcher["chat_id"] == "123"
+        assert watcher["user_id"] == "u123"
+        assert watcher["user_name"] == "alice"
+        assert watcher["thread_id"] == "42"
 
 
 # =========================================================================

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -319,6 +319,8 @@ class TestCheckpoint:
             s = _make_session()
             s.watcher_platform = "telegram"
             s.watcher_chat_id = "999"
+            s.watcher_user_id = "u123"
+            s.watcher_user_name = "alice"
             s.watcher_thread_id = "42"
             s.watcher_interval = 60
             registry._running[s.id] = s
@@ -328,6 +330,8 @@ class TestCheckpoint:
             assert len(data) == 1
             assert data[0]["watcher_platform"] == "telegram"
             assert data[0]["watcher_chat_id"] == "999"
+            assert data[0]["watcher_user_id"] == "u123"
+            assert data[0]["watcher_user_name"] == "alice"
             assert data[0]["watcher_thread_id"] == "42"
             assert data[0]["watcher_interval"] == 60
 
@@ -341,6 +345,8 @@ class TestCheckpoint:
             "session_key": "sk1",
             "watcher_platform": "telegram",
             "watcher_chat_id": "123",
+            "watcher_user_id": "u123",
+            "watcher_user_name": "alice",
             "watcher_thread_id": "42",
             "watcher_interval": 60,
         }]))
@@ -352,6 +358,8 @@ class TestCheckpoint:
             assert w["session_id"] == "proc_live"
             assert w["platform"] == "telegram"
             assert w["chat_id"] == "123"
+            assert w["user_id"] == "u123"
+            assert w["user_name"] == "alice"
             assert w["thread_id"] == "42"
             assert w["check_interval"] == 60
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -80,6 +80,8 @@ class ProcessSession:
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
+    watcher_user_id: str = ""
+    watcher_user_name: str = ""
     watcher_thread_id: str = ""
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
@@ -813,6 +815,8 @@ class ProcessRegistry:
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
+                            "watcher_user_id": s.watcher_user_id,
+                            "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
                             "watcher_interval": s.watcher_interval,
                             "notify_on_complete": s.notify_on_complete,
@@ -873,6 +877,8 @@ class ProcessRegistry:
                     detached=True,  # Can't read output, but can report status + kill
                     watcher_platform=entry.get("watcher_platform", ""),
                     watcher_chat_id=entry.get("watcher_chat_id", ""),
+                    watcher_user_id=entry.get("watcher_user_id", ""),
+                    watcher_user_name=entry.get("watcher_user_name", ""),
                     watcher_thread_id=entry.get("watcher_thread_id", ""),
                     watcher_interval=entry.get("watcher_interval", 0),
                     notify_on_complete=entry.get("notify_on_complete", False),
@@ -890,6 +896,8 @@ class ProcessRegistry:
                         "session_key": session.session_key,
                         "platform": session.watcher_platform,
                         "chat_id": session.watcher_chat_id,
+                        "user_id": session.watcher_user_id,
+                        "user_name": session.watcher_user_name,
                         "thread_id": session.watcher_thread_id,
                         "notify_on_complete": session.notify_on_complete,
                     })

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1256,9 +1256,13 @@ def terminal_tool(
                     _gw_platform = os.getenv("HERMES_SESSION_PLATFORM", "")
                     if _gw_platform and not check_interval:
                         _gw_chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "")
+                        _gw_user_id = os.getenv("HERMES_SESSION_USER_ID", "")
+                        _gw_user_name = os.getenv("HERMES_SESSION_USER_NAME", "")
                         _gw_thread_id = os.getenv("HERMES_SESSION_THREAD_ID", "")
                         proc_session.watcher_platform = _gw_platform
                         proc_session.watcher_chat_id = _gw_chat_id
+                        proc_session.watcher_user_id = _gw_user_id
+                        proc_session.watcher_user_name = _gw_user_name
                         proc_session.watcher_thread_id = _gw_thread_id
                         proc_session.watcher_interval = 5
                         process_registry.pending_watchers.append({
@@ -1267,6 +1271,8 @@ def terminal_tool(
                             "session_key": session_key,
                             "platform": _gw_platform,
                             "chat_id": _gw_chat_id,
+                            "user_id": _gw_user_id,
+                            "user_name": _gw_user_name,
                             "thread_id": _gw_thread_id,
                             "notify_on_complete": True,
                         })
@@ -1280,11 +1286,15 @@ def terminal_tool(
                         )
                     watcher_platform = os.getenv("HERMES_SESSION_PLATFORM", "")
                     watcher_chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "")
+                    watcher_user_id = os.getenv("HERMES_SESSION_USER_ID", "")
+                    watcher_user_name = os.getenv("HERMES_SESSION_USER_NAME", "")
                     watcher_thread_id = os.getenv("HERMES_SESSION_THREAD_ID", "")
 
                     # Store on session for checkpoint persistence
                     proc_session.watcher_platform = watcher_platform
                     proc_session.watcher_chat_id = watcher_chat_id
+                    proc_session.watcher_user_id = watcher_user_id
+                    proc_session.watcher_user_name = watcher_user_name
                     proc_session.watcher_thread_id = watcher_thread_id
                     proc_session.watcher_interval = effective_interval
 


### PR DESCRIPTION
## Summary
- preserve user identity when background-process watchers inject synthetic completion messages
- propagate `user_id` / `user_name` through gateway session env -> terminal tool -> process watcher metadata
- add regression tests covering session env export, watcher persistence, and synthetic message injection

## Root cause
This PR addresses the same issue family described in:
- #6341
- #6485
- #6516

The core bug is that process watcher notifications were being reinjected into the gateway with a synthetic `SessionSource` that had:
- `chat_id`
- optional `thread_id`
- but **no `user_id` / `user_name`**

That breaks authorization in the gateway:
- `_is_user_authorized()` returns `False` when `source.user_id` is empty
- the unauthorized DM path can then issue a pairing code
- users see a spurious pairing request mid-conversation
- approvals can show up as `User None`

I verified the code path directly:
1. `GatewayRunner._set_session_env()` exported platform/chat/thread info, but not user identity
2. `tools.terminal_tool` registered `notify_on_complete` watchers using only platform/chat/thread metadata
3. `GatewayRunner._run_process_watcher()` rebuilt `SessionSource` without `user_id` / `user_name`
4. authorization then treated the synthetic completion as an unknown user

## Fix
- export `HERMES_SESSION_USER_ID` and `HERMES_SESSION_USER_NAME` from gateway session context
- store those fields in process watcher metadata
- persist/recover them through `ProcessSession` + checkpoint recovery
- include them when the watcher reinjects the synthetic completion event

## Validation
Focused tests run locally:
- `pytest tests/gateway/test_session_env.py tests/gateway/test_background_process_notifications.py tests/tools/test_process_registry.py tests/tools/test_notify_on_complete.py -q -o addopts=`
- `python -m py_compile gateway/run.py tools/terminal_tool.py tools/process_registry.py tests/gateway/test_session_env.py tests/gateway/test_background_process_notifications.py tests/tools/test_process_registry.py tests/tools/test_notify_on_complete.py`

These cover:
- session env now exporting user identity
- clearing those env vars correctly
- watcher metadata/checkpoint persistence of user identity
- recovery of watcher metadata after restart
- synthetic completion injection preserving `user_id`, `user_name`, and `thread_id`

## Scope
This PR is intentionally focused on the process-watcher identity loss path. It does not change the general pairing model or authorization rules.

Closes #6341
Relates to #6485 and #6516
