### PR TITLE
Block indirect Home Assistant execution via script and automation services

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -249,6 +249,34 @@ class TestDomainBlocklist:
     def test_blocked_domains_include_rest_command(self):
         assert "rest_command" in _BLOCKED_DOMAINS
 
+    @pytest.mark.parametrize(
+        ("domain", "service"),
+        [
+            ("script", "turn_on"),
+            ("automation", "trigger"),
+        ],
+    )
+    def test_indirect_execution_domains_are_blocked(self, domain, service, monkeypatch):
+        """Programmable HA workflows must not bypass the direct-domain blocklist."""
+        called = False
+
+        async def _fail_if_called(*args, **kwargs):
+            nonlocal called
+            called = True
+            raise AssertionError("network call should not happen for blocked workflow domains")
+
+        monkeypatch.setattr("tools.homeassistant_tool._async_call_service", _fail_if_called)
+
+        result = json.loads(_handle_call_service({
+            "domain": domain,
+            "service": service,
+            "entity_id": f"{domain}.unsafe_path",
+        }))
+
+        assert called is False
+        assert "error" in result
+        assert "blocked" in result["error"].lower()
+
 
 # ---------------------------------------------------------------------------
 # Security: entity_id validation

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -39,15 +39,18 @@ def _get_config():
 _ENTITY_ID_RE = re.compile(r"^[a-z_][a-z0-9_]*\.[a-z0-9_]+$")
 
 # Service domains blocked for security -- these allow arbitrary code/command
-# execution on the HA host or enable SSRF attacks on the local network.
+# execution on the HA host, SSRF attacks on the local network, or execution of
+# user-authored workflows that can call those dangerous primitives indirectly.
 # HA provides zero service-level access control; all safety must be in our layer.
 _BLOCKED_DOMAINS = frozenset({
+    "automation",       # user-authored workflows; automation.trigger can run unsafe actions
     "shell_command",    # arbitrary shell commands as root in HA container
     "command_line",     # sensors/switches that execute shell commands
     "python_script",    # sandboxed but can escalate via hass.services.call()
     "pyscript",         # scripting integration with broader access
     "hassio",           # addon control, host shutdown/reboot, stdin to containers
     "rest_command",     # HTTP requests from HA server (SSRF vector)
+    "script",           # user-authored workflows; script.turn_on can wrap blocked domains
 })
 
 
@@ -414,7 +417,7 @@ HA_CALL_SERVICE_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Service domain (e.g. 'light', 'switch', 'climate', "
-                    "'cover', 'media_player', 'fan', 'scene', 'script')."
+                    "'cover', 'media_player', 'fan', 'scene')."
                 ),
             },
             "service": {


### PR DESCRIPTION
## Summary

This closes a Home Assistant security gap where `ha_call_service` blocked a handful of directly dangerous service domains, but still allowed indirect execution through programmable workflow domains like `script` and `automation`.

In practice, an attacker could trigger a user-authored HA script or automation that internally calls blocked primitives such as `shell_command`, `python_script`, `hassio`, or `rest_command`, bypassing Hermes' safety layer.

## Security Impact

This was not just a policy mismatch. It weakened the trust boundary of the Home Assistant tool:

- `script.turn_on` could execute arbitrary user-authored workflows
- `automation.trigger` could run automations that wrap blocked actions
- That creates a realistic path to host command execution or HA-originated SSRF, depending on the HA configuration

Hermes already treats direct execution-oriented HA domains as unsafe. This change extends that protection to the obvious indirect execution pivots.

## Changes

- Added `script` and `automation` to the blocked Home Assistant service domains
- Updated the tool schema description so it no longer suggests `script` as a valid service domain
- Added a regression test proving these domains are rejected before any network call is attempted

## Tests

- `uv run --extra dev python -m pytest tests/tools/test_homeassistant_tool.py -q`
- `uv run --extra dev python -m pytest tests/gateway/test_homeassistant.py -q`


