### PR TITLE
fix: remove dead LLM_MODEL env var + migration to clear stale .env entries

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -569,7 +569,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 12,
+    "_config_version": 13,
 }
 
 # =============================================================================
@@ -1700,6 +1700,21 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     for key in list(providers_dict.keys())[-migrated_count:]:
                         ep = providers_dict[key]
                         print(f"    → {key}: {ep.get('api', '')}")
+
+    # ── Version 12 → 13: clear dead LLM_MODEL / OPENAI_MODEL from .env ──
+    # These env vars were written by the old setup wizard but nothing reads
+    # them anymore (config.yaml is the sole source of truth since March 2026).
+    # Stale entries cause user confusion — see issue report.
+    if current_ver < 13:
+        for dead_var in ("LLM_MODEL", "OPENAI_MODEL"):
+            try:
+                old_val = get_env_value(dead_var)
+                if old_val:
+                    save_env_value(dead_var, "")
+                    if not quiet:
+                        print(f"  ✓ Cleared {dead_var} from .env (no longer used — config.yaml is source of truth)")
+            except Exception:
+                pass
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -230,7 +230,7 @@ model:
 ```
 
 :::warning Legacy env vars
-`OPENAI_BASE_URL` and `LLM_MODEL` in `.env` are **deprecated**. `OPENAI_BASE_URL` is no longer consulted for endpoint resolution — `config.yaml` is the single source of truth. The CLI ignores `LLM_MODEL` entirely (only the gateway reads it as a fallback). Use `hermes model` or edit `config.yaml` directly — both persist correctly across restarts and Docker containers.
+`OPENAI_BASE_URL` and `LLM_MODEL` in `.env` are **removed**. Neither is read by any part of Hermes — `config.yaml` is the single source of truth for model and endpoint configuration. If you have stale entries in your `.env`, they are automatically cleared on the next `hermes setup` or config migration. Use `hermes model` or edit `config.yaml` directly.
 :::
 
 Both approaches persist to `config.yaml`, which is the source of truth for model, provider, and base URL.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -53,8 +53,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `OPENCODE_GO_API_KEY` | OpenCode Go API key — $10/month subscription for open models ([opencode.ai](https://opencode.ai/auth)) |
 | `OPENCODE_GO_BASE_URL` | Override OpenCode Go base URL |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Explicit Claude Code token override if you export one manually |
-| `HERMES_MODEL` | Preferred model name (checked before `LLM_MODEL`, used by gateway) |
-| `LLM_MODEL` | Default model name (fallback when not set in config.yaml) |
+| `HERMES_MODEL` | Override model name at process level (used by cron scheduler; prefer `config.yaml` for normal use) |
 | `VOICE_TOOLS_OPENAI_KEY` | Preferred OpenAI key for OpenAI speech-to-text and text-to-speech providers |
 | `HERMES_LOCAL_STT_COMMAND` | Optional local speech-to-text command template. Supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders |
 | `HERMES_LOCAL_STT_LANGUAGE` | Default language passed to `HERMES_LOCAL_STT_COMMAND` or auto-detected local `whisper` CLI fallback (default: `en`) |


### PR DESCRIPTION
## Summary

The old setup wizard (pre-March 2026) wrote `LLM_MODEL` to `~/.hermes/.env` across 12 provider setup flows. Commit 9302690e removed the writes but never cleaned up existing `.env` files.

**The problem:** Users who ran `hermes setup` before March 2026 still have `LLM_MODEL=<some-model>` in their `.env`, written by our code. Nothing reads it anymore, but:
- The docs incorrectly said the gateway still used it as a fallback
- Users see it in `.env` and think it's active, creating false debugging trails
- `load_dotenv(override=True)` faithfully sets it in `os.environ` every session (doing nothing)

## Changes

**Config migration (version 12 → 13):**
- Clears `LLM_MODEL` and `OPENAI_MODEL` from `.env` (both dead since March 2026)
- Follows the established ANTHROPIC_TOKEN cleanup pattern (version 8→9)
- Preserves all other env vars

**Docs cleanup:**
- `environment-variables.md`: Removed `LLM_MODEL` row, updated `HERMES_MODEL` description
- `providers.md`: Changed deprecation notice from "deprecated" to "removed"

## Test plan
- E2E verified: migration clears both dead vars while preserving real API keys
- Config version bumps correctly to 13
- `test_config.py` + `test_setup.py` pass (50 tests)