### PR TITLE
fix: add missing 'hermes pairing generate' command

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4772,6 +4772,12 @@ For more help on a command:
 
     pairing_sub.add_parser("list", help="Show pending + approved users")
 
+    # Generate subcommand - generates a new pairing code for a platform
+    pairing_generate_parser = pairing_sub.add_parser("generate", help="Generate a new pairing code")
+    pairing_generate_parser.add_argument("platform", help="Platform name (telegram, discord, slack, whatsapp, bluebubbles)")
+    pairing_generate_parser.add_argument("--user-id", default="", help="User ID to associate with the code (optional)")
+    pairing_generate_parser.add_argument("--user-name", default="", help="User name for display (optional)")
+
     pairing_approve_parser = pairing_sub.add_parser("approve", help="Approve a pairing code")
     pairing_approve_parser.add_argument("platform", help="Platform name (telegram, discord, slack, whatsapp)")
     pairing_approve_parser.add_argument("code", help="Pairing code to approve")

--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -3,6 +3,7 @@ CLI commands for the DM pairing system.
 
 Usage:
     hermes pairing list              # Show all pending + approved users
+    hermes pairing generate <platform> [user_id] [user_name]  # Generate a pairing code
     hermes pairing approve <platform> <code>  # Approve a pairing code
     hermes pairing revoke <platform> <user_id> # Revoke user access
     hermes pairing clear-pending     # Clear all expired/pending codes
@@ -17,6 +18,8 @@ def pairing_command(args):
 
     if action == "list":
         _cmd_list(store)
+    elif action == "generate":
+        _cmd_generate(store, args.platform, args.user_id, args.user_name)
     elif action == "approve":
         _cmd_approve(store, args.platform, args.code)
     elif action == "revoke":
@@ -24,7 +27,7 @@ def pairing_command(args):
     elif action == "clear-pending":
         _cmd_clear_pending(store)
     else:
-        print("Usage: hermes pairing {list|approve|revoke|clear-pending}")
+        print("Usage: hermes pairing {list|generate|approve|revoke|clear-pending}")
         print("Run 'hermes pairing --help' for details.")
 
 
@@ -59,6 +62,31 @@ def _cmd_list(store):
         print("\n  No approved users.")
 
     print()
+
+
+def _cmd_generate(store, platform: str, user_id: str, user_name: str = ""):
+    """Generate a new pairing code for a user."""
+    platform = platform.lower().strip()
+    user_id = user_id.strip() if user_id else ""
+    user_name = user_name.strip() if user_name else ""
+
+    if not user_id:
+        # Generate a placeholder user_id if not provided
+        import secrets
+        user_id = f"pending_{secrets.token_hex(4)}"
+
+    code = store.generate_code(platform, user_id, user_name)
+    if code:
+        display_name = user_name if user_name else user_id
+        print(f"\n  Generated pairing code for {display_name} on {platform}:")
+        print(f"  \n    {code}\n")
+        print(f"  Share this code with the user. They should text it to the agent.")
+        print(f"  Code expires in 1 hour.\n")
+    else:
+        print(f"\n  Could not generate code. Possible reasons:")
+        print(f"    - Max pending codes reached for {platform} (limit: 3)")
+        print(f"    - Platform is in lockout due to failed attempts")
+        print(f"    - Rate limit active for this user\n")
 
 
 def _cmd_approve(store, platform: str, code: str):


### PR DESCRIPTION
## Problem

The documentation at [BlueBubbles (iMessage) Integration Guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/bluebubbles) states that users can generate pairing codes via:

```bash
hermes pairing generate bluebubbles
```

However, running this command produces an error:

```
usage: hermes pairing [-h] {list,approve,revoke,clear-pending} ...
hermes pairing: error: argument pairing_action: invalid choice: 'generate' (choose from 'list', 'approve', 'revoke', 'clear-pending')
```

## Root Cause Analysis

1. **Backend exists**: The `PairingStore.generate_code()` method exists in `gateway/pairing.py` (lines 150-191) and is fully functional
2. **CLI interface missing**: The `generate` subcommand was never added to:
   - `hermes_cli/main.py` - Argument parser definition
   - `hermes_cli/pairing.py` - Command handler function

## Solution

This PR implements the missing `generate` subcommand by:

### 1. hermes_cli/main.py
Added the `generate` subparser to the pairing command with:
- `platform` argument (required) - the messaging platform
- `--user-id` optional argument
- `--user-name` optional argument

### 2. hermes_cli/pairing.py
- Updated docstring to document the new command
- Added `generate` case in `pairing_command()` handler
- Implemented `_cmd_generate()` function that:
  - Calls `store.generate_code()` from the backend
  - Displays the generated code with clear instructions
  - Handles error cases (rate limits, max pending, lockout)

## Usage Examples

```bash
# Generate a code for bluebubbles (admin will share this with user)
hermes pairing generate bluebubbles

# Generate with specific user info
hermes pairing generate telegram --user-id "123456" --user-name "Alice"

# List pending codes
hermes pairing list

# Approve a code when user texts it to the agent
hermes pairing approve bluebubbles ABC12345
```

## Testing

- [x] `hermes pairing generate bluebubbles` generates an 8-char code
- [x] `hermes pairing list` shows the pending code
- [x] Code appears in the pending list with correct platform
- [x] Code expires after 1 hour (as per backend logic)
- [x] Max 3 pending codes per platform enforced

## Documentation Alignment

This fix brings the CLI into alignment with the documented behavior at:
https://hermes-agent.nousresearch.com/docs/user-guide/messaging/bluebubbles

The docs state: "**DM Pairing (Recommended):** Generate a code via `hermes pairing generate bluebubbles`. The user texts this code to the agent to gain access."

After this PR, the documented command will work as expected.