### PR TITLE
security: configurable sudo prompt timeout + SSH config metadata redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -97,6 +97,29 @@ _DB_CONNSTR_RE = re.compile(
 # Negative lookahead prevents matching hex strings or identifiers
 _SIGNAL_PHONE_RE = re.compile(r"(\+[1-9]\d{6,14})(?![A-Za-z0-9])")
 
+# SSH config sensitive-metadata fields.
+#
+# These directives reveal where private keys live on disk (IdentityFile,
+# IdentityAgent, CertificateFile) or which bastion hosts/commands are used
+# to reach internal networks (ProxyJump, ProxyCommand). An attacker who
+# reads ~/.ssh/config can use these to:
+#   - learn exact paths to steal for credential theft
+#   - enumerate internal infrastructure (bastions, jump hosts)
+#   - replay ProxyCommand scripts to reach protected networks
+#
+# We intentionally leave Host / HostName / User / Port visible because
+# they are frequently needed for legitimate debugging and logging, and
+# leaking them alone does not materially help an attacker who already
+# has read access to the file.
+#
+# Matching is case-insensitive (SSH config keywords are case-insensitive
+# per sshd_config(5)) and multiline-aware (each config line evaluated
+# independently). The value is replaced with "***" so the structure of
+# the config -- which keywords are set, and where -- remains visible.
+_SSH_CONFIG_SENSITIVE_RE = re.compile(
+    r"(?mi)^(\s*)(IdentityFile|IdentityAgent|CertificateFile|ProxyCommand|ProxyJump)(\s+)(.+)$"
+)
+
 # Compile known prefix patterns into one alternation
 _PREFIX_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
@@ -166,6 +189,12 @@ def redact_sensitive_text(text: str) -> str:
             return phone[:2] + "****" + phone[-2:]
         return phone[:4] + "****" + phone[-4:]
     text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
+
+    # SSH config sensitive metadata (IdentityFile, ProxyJump, ...)
+    text = _SSH_CONFIG_SENSITIVE_RE.sub(
+        lambda m: f"{m.group(1)}{m.group(2)}{m.group(3)}***",
+        text,
+    )
 
     return text
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -284,3 +284,98 @@ class TestElevenLabsTavilyExaKeys:
         assert "XYZ789abcdef" not in result
         assert "HOME=/home/user" in result
         assert "SHELL=/bin/bash" in result
+
+
+class TestSSHConfigRedaction:
+    """Reading an SSH config file should not leak private-key paths or
+    internal bastion hosts even though the file is on disk under the
+    user's own home directory. See security audit finding #2."""
+
+    def test_identity_file_redacted(self):
+        text = "  IdentityFile ~/.ssh/id_ed25519"
+        result = redact_sensitive_text(text)
+        assert "id_ed25519" not in result
+        assert "IdentityFile" in result
+        assert "***" in result
+
+    def test_identity_file_absolute_path_redacted(self):
+        text = "IdentityFile /home/alice/.ssh/production_key"
+        result = redact_sensitive_text(text)
+        assert "production_key" not in result
+        assert "/home/alice" not in result
+
+    def test_proxy_jump_redacted(self):
+        text = "  ProxyJump bastion.internal.corp:2222"
+        result = redact_sensitive_text(text)
+        assert "bastion.internal.corp" not in result
+        assert "ProxyJump" in result
+
+    def test_proxy_command_redacted(self):
+        text = "  ProxyCommand ssh -W %h:%p jump.example.com"
+        result = redact_sensitive_text(text)
+        assert "jump.example.com" not in result
+        assert "%h:%p" not in result
+        assert "ProxyCommand" in result
+
+    def test_identity_agent_redacted(self):
+        text = "IdentityAgent /tmp/ssh-agent.sock"
+        result = redact_sensitive_text(text)
+        assert "/tmp/ssh-agent.sock" not in result
+
+    def test_certificate_file_redacted(self):
+        text = "  CertificateFile ~/.ssh/id_ed25519-cert.pub"
+        result = redact_sensitive_text(text)
+        assert "id_ed25519-cert" not in result
+
+    def test_case_insensitive_keyword(self):
+        # SSH config keywords are case-insensitive per sshd_config(5)
+        text = "identityfile ~/.ssh/lowercase_key"
+        result = redact_sensitive_text(text)
+        assert "lowercase_key" not in result
+
+    def test_host_directive_not_redacted(self):
+        # Host/HostName/User/Port should stay visible for debugging
+        text = (
+            "Host github.com\n"
+            "  HostName github.com\n"
+            "  User git\n"
+            "  Port 22\n"
+        )
+        result = redact_sensitive_text(text)
+        assert "Host github.com" in result
+        assert "HostName github.com" in result
+        assert "User git" in result
+        assert "Port 22" in result
+
+    def test_full_ssh_config_preserves_structure(self):
+        config = (
+            "Host github.com\n"
+            "  HostName github.com\n"
+            "  User git\n"
+            "  IdentityFile ~/.ssh/id_ed25519\n"
+            "  AddKeysToAgent yes\n"
+            "\n"
+            "Host internal\n"
+            "  HostName 10.0.0.5\n"
+            "  ProxyJump bastion.corp:2222\n"
+            "  IdentityFile ~/.ssh/prod_key\n"
+        )
+        result = redact_sensitive_text(config)
+        # Keywords and block structure preserved
+        assert "Host github.com" in result
+        assert "Host internal" in result
+        assert "HostName github.com" in result
+        assert "AddKeysToAgent yes" in result
+        # Sensitive values masked
+        assert "id_ed25519" not in result
+        assert "prod_key" not in result
+        assert "bastion.corp" not in result
+        # Masked markers present for each sensitive line
+        assert result.count("***") >= 3
+
+    def test_unrelated_text_not_matched(self):
+        # The keyword must appear at line start (with optional whitespace).
+        # An inline mention inside prose should not be redacted.
+        text = "The IdentityFile directive points at the key path."
+        result = redact_sensitive_text(text)
+        assert result == text

--- a/tests/tools/test_terminal_sudo_timeout.py
+++ b/tests/tools/test_terminal_sudo_timeout.py
@@ -1,0 +1,117 @@
+"""Tests for configurable sudo password prompt timeout.
+
+Covers the HERMES_SUDO_TIMEOUT env var introduced to fix the hardcoded
+45s wait that blocked non-interactive automation (cron, gateway) on
+every accidental sudo invocation. See security audit finding #3.
+"""
+
+import pytest
+
+from tools.terminal_tool import (
+    _DEFAULT_SUDO_TIMEOUT,
+    _get_sudo_timeout,
+    _prompt_for_sudo_password,
+)
+
+
+class TestGetSudoTimeout:
+    def test_default_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SUDO_TIMEOUT", raising=False)
+        assert _get_sudo_timeout() == _DEFAULT_SUDO_TIMEOUT
+
+    def test_default_when_env_empty(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "")
+        assert _get_sudo_timeout() == _DEFAULT_SUDO_TIMEOUT
+
+    def test_default_when_env_whitespace(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "   ")
+        assert _get_sudo_timeout() == _DEFAULT_SUDO_TIMEOUT
+
+    def test_positive_integer_override(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "10")
+        assert _get_sudo_timeout() == 10
+
+    def test_zero_allowed_for_fast_skip(self, monkeypatch):
+        # 0 = "skip immediately without prompting" — fast path for cron/gateway
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "0")
+        assert _get_sudo_timeout() == 0
+
+    def test_negative_clamps_to_zero(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "-5")
+        assert _get_sudo_timeout() == 0
+
+    def test_invalid_value_falls_back_to_default(self, monkeypatch, caplog):
+        # A typo in config should not silently disable the prompt.
+        # Fall back to the default and log a warning.
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "not-a-number")
+        import logging
+        with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+            assert _get_sudo_timeout() == _DEFAULT_SUDO_TIMEOUT
+        assert any("HERMES_SUDO_TIMEOUT" in r.message for r in caplog.records)
+
+    def test_large_value_allowed(self, monkeypatch):
+        # No artificial upper bound -- user may want minutes for slow typists
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "600")
+        assert _get_sudo_timeout() == 600
+
+
+class TestPromptSkipsImmediatelyWhenTimeoutZero:
+    """With HERMES_SUDO_TIMEOUT=0, the prompt must not block at all.
+
+    Without this fix, the cron scheduler could be stalled for 45s per
+    accidental sudo invocation in a scheduled job.
+    """
+
+    def test_env_zero_skips_without_blocking(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "0")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        import time
+        start = time.monotonic()
+        result = _prompt_for_sudo_password()
+        elapsed = time.monotonic() - start
+
+        assert result == ""
+        # Must return essentially instantly -- anything above a small
+        # threshold means the prompt actually blocked.
+        assert elapsed < 0.5, f"Expected instant skip, took {elapsed:.2f}s"
+
+    def test_explicit_zero_arg_skips_immediately(self, monkeypatch):
+        # Even if env is unset, an explicit 0 arg should still skip.
+        monkeypatch.delenv("HERMES_SUDO_TIMEOUT", raising=False)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        import time
+        start = time.monotonic()
+        result = _prompt_for_sudo_password(timeout_seconds=0)
+        elapsed = time.monotonic() - start
+
+        assert result == ""
+        assert elapsed < 0.5
+
+    def test_negative_arg_also_skips(self, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        assert _prompt_for_sudo_password(timeout_seconds=-1) == ""
+
+    def test_callback_not_invoked_when_timeout_zero(self, monkeypatch):
+        """When timeout is 0, the registered UI callback must not run either.
+
+        Otherwise a cron job using a callback-based CLI could still get a
+        prompt via the callback path, defeating the point of the fast-skip.
+        """
+        monkeypatch.setenv("HERMES_SUDO_TIMEOUT", "0")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        called = {"value": False}
+
+        def fake_callback():
+            called["value"] = True
+            return "should-not-be-returned"
+
+        import tools.terminal_tool as tt
+        monkeypatch.setattr(tt, "_sudo_password_callback", fake_callback)
+
+        result = _prompt_for_sudo_password()
+
+        assert result == ""
+        assert called["value"] is False

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -111,6 +111,35 @@ def _check_disk_usage_warning():
 # Session-cached sudo password (persists until CLI exits)
 _cached_sudo_password: str = ""
 
+# Default timeout (seconds) for the interactive sudo password prompt.
+# Override via HERMES_SUDO_TIMEOUT env var. Set to 0 to skip the prompt
+# entirely -- useful for non-interactive automation (cron, gateway) where
+# a blocking prompt would waste time on every accidental sudo invocation.
+_DEFAULT_SUDO_TIMEOUT: int = 45
+
+
+def _get_sudo_timeout() -> int:
+    """Return the sudo password prompt timeout in seconds.
+
+    Reads ``HERMES_SUDO_TIMEOUT`` from the environment. Values <= 0 cause
+    the prompt to be skipped immediately (graceful-fail path). Invalid
+    values fall back to ``_DEFAULT_SUDO_TIMEOUT`` with a warning so a
+    typo in config cannot silently disable the prompt.
+    """
+    raw = os.getenv("HERMES_SUDO_TIMEOUT", "").strip()
+    if not raw:
+        return _DEFAULT_SUDO_TIMEOUT
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid HERMES_SUDO_TIMEOUT=%r (expected integer seconds), "
+            "falling back to %ds",
+            raw, _DEFAULT_SUDO_TIMEOUT,
+        )
+        return _DEFAULT_SUDO_TIMEOUT
+    return max(0, value)
+
 # Optional UI callbacks for interactive prompts. When set, these are called
 # instead of the default /dev/tty or input() readers. The CLI registers these
 # so prompts route through prompt_toolkit's event loop.
@@ -202,23 +231,39 @@ def _handle_sudo_failure(output: str, env_type: str) -> str:
     return output
 
 
-def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
+def _prompt_for_sudo_password(timeout_seconds: int | None = None) -> str:
     """
     Prompt user for sudo password with timeout.
-    
+
     Returns the password if entered, or empty string if:
     - User presses Enter without input (skip)
-    - Timeout expires (45s default)
+    - Timeout expires (see HERMES_SUDO_TIMEOUT, default 45s)
+    - HERMES_SUDO_TIMEOUT=0 — skipped immediately without prompting
     - Any error occurs
-    
+
     Only works in interactive mode (HERMES_INTERACTIVE=1).
     If a _sudo_password_callback is registered (by the CLI), delegates to it
     so the prompt integrates with prompt_toolkit's UI.  Otherwise reads
     directly from /dev/tty with echo disabled.
+
+    When ``timeout_seconds`` is None (the default), the timeout is read from
+    ``HERMES_SUDO_TIMEOUT`` on each call via :func:`_get_sudo_timeout`, so
+    the env var takes effect without restarting the process. Callers that
+    want to force a specific timeout may pass it explicitly.
     """
     import sys
     import time as time_module
-    
+
+    if timeout_seconds is None:
+        timeout_seconds = _get_sudo_timeout()
+
+    # Timeout of 0 (or negative) means "skip immediately without prompting".
+    # This is the fast-fail path for cron, gateway, and other non-interactive
+    # automation where a blocking prompt would just waste 45s on every
+    # accidental sudo invocation before failing anyway.
+    if timeout_seconds <= 0:
+        return ""
+
     # Use the registered callback when available (prompt_toolkit-compatible)
     if _sudo_password_callback is not None:
         try:
@@ -471,7 +516,8 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     how they handle the non-None sudo_stdin case.
 
     If SUDO_PASSWORD is not set and in interactive mode (HERMES_INTERACTIVE=1):
-      Prompts user for password with 45s timeout, caches for session.
+      Prompts user for password with a timeout (default 45s, configurable
+      via ``HERMES_SUDO_TIMEOUT``; set to 0 to skip the prompt entirely).
 
     If SUDO_PASSWORD is not set and NOT interactive:
       Command runs as-is (fails gracefully with "sudo: a password is required").
@@ -488,7 +534,8 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     sudo_password = os.environ.get("SUDO_PASSWORD", "") if has_configured_password else _cached_sudo_password
 
     if not has_configured_password and not sudo_password and os.getenv("HERMES_INTERACTIVE"):
-        sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
+        # timeout_seconds=None → honor HERMES_SUDO_TIMEOUT (default 45s)
+        sudo_password = _prompt_for_sudo_password()
         if sudo_password:
             _cached_sudo_password = sudo_password
 


### PR DESCRIPTION
## What does this PR do?

Two independent security hardenings surfaced by a user-authorised local security audit of `v0.8.0` (13/15 attack vectors blocked; full defense-in-depth review passed).

### 1. `fix(terminal)`: configurable sudo prompt timeout

`_prompt_for_sudo_password` hardcoded a 45s timeout. In cron / gateway sessions an accidental `sudo` invocation would block the whole run for 45s before failing. This adds `HERMES_SUDO_TIMEOUT` as an integer env var:

| Value                  | Behaviour                                          |
|------------------------|----------------------------------------------------|
| unset (default)        | 45s prompt — unchanged                             |
| `HERMES_SUDO_TIMEOUT=10` | 10s prompt                                         |
| `HERMES_SUDO_TIMEOUT=0`  | skip immediately, return empty (cron/gateway path) |
| `HERMES_SUDO_TIMEOUT=abc` | warn, fall back to 45s (typos cannot silently disable) |
| negative values          | clamp to 0                                         |

The callback path (prompt_toolkit UI) is also guarded — when timeout is 0 the UI callback is NOT invoked, so a `HERMES_SUDO_TIMEOUT=0` gateway session cannot accidentally prompt the user via the UI path either.

### 2. `fix(redact)`: mask sensitive SSH config directives on file read

Reading `~/.ssh/config` via `read_file` previously echoed the entire file verbatim. That leaks:

- `IdentityFile` → exact paths to the user's private keys (single most valuable enumeration target)
- `ProxyJump` / `ProxyCommand` → internal bastion hosts and the commands needed to reach protected networks
- `IdentityAgent` / `CertificateFile` → similar metadata

PR #4168 (open) adds an approval-prompt pattern for `cat`/`head`/`tail` on `.ssh/`, which covers the terminal-tool path. **This patch is complementary**: it adds the `read_file` path by extending the existing `redact_sensitive_text` pipeline, which is the same layer that already masks API keys, tokens, DB connection strings, and private-key blocks.

Redaction is intentionally surgical — `Host`, `HostName`, `User`, `Port` stay visible because they are frequently needed for legitimate debugging, and leaking them *without* the identity-file path doesn't materially help an attacker. Matching is case-insensitive per `sshd_config(5)`.

**Before** (today):
```
Host github.com
  IdentityFile ~/.ssh/id_ed25519
  ProxyJump bastion.corp:2222
```

**After**:
```
Host github.com
  IdentityFile ***
  ProxyJump ***
```

## Related Issue

No open issue — findings come from an authorised local audit. Reproduction steps are in the "How to Test" section below.

Fixes #

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/terminal_tool.py`: add `_DEFAULT_SUDO_TIMEOUT`, `_get_sudo_timeout()`, make `_prompt_for_sudo_password` honour `HERMES_SUDO_TIMEOUT`
- `agent/redact.py`: add `_SSH_CONFIG_SENSITIVE_RE` and apply it inside `redact_sensitive_text`
- `tests/tools/test_terminal_sudo_timeout.py`: 12 new tests
- `tests/agent/test_redact.py`: 10 new tests in `TestSSHConfigRedaction`

## How to Test

**Fix #1 — sudo timeout reproduction:**
```bash
# Before this PR: blocks for 45s
hermes chat -q "run sudo cat /etc/sudoers"

# After this PR:
HERMES_SUDO_TIMEOUT=0 hermes chat -q "run sudo cat /etc/sudoers"
# → sudo fails immediately, no 45s wait
```

**Fix #2 — SSH config redaction reproduction:**
```bash
# Before this PR
hermes chat -q "read ~/.ssh/config"
# → IdentityFile / ProxyJump values visible

# After this PR
hermes chat -q "read ~/.ssh/config"
# → IdentityFile *** / ProxyJump ***
# Host / HostName / User still visible
```

**Test suite:**
```bash
pytest tests/agent/test_redact.py tests/tools/test_terminal_sudo_timeout.py -v
# 22 new tests pass

pytest tests/agent/test_redact.py tests/tools/test_terminal_*.py -q
# 113 passed (all existing + new)
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(terminal):`, `fix(redact):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (noted overlap with #4168 — deliberately scoped around it)
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/agent/test_redact.py tests/tools/test_terminal_*.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3.1 (Apple Silicon), Python 3.11.9

### Documentation & Housekeeping

- [x] Docstrings updated — `_prompt_for_sudo_password`, `_transform_sudo_command` note the new env var; `_SSH_CONFIG_SENSITIVE_RE` has a full design-rationale comment
- [x] No new config keys added (env var only) — cli-config.yaml.example unchanged, N/A
- [x] No architecture changes — `CONTRIBUTING.md`/`AGENTS.md` unchanged, N/A
- [x] Cross-platform considered: `HERMES_SUDO_TIMEOUT` parsing is stdlib-only; the regex in `redact.py` uses no platform-specific features
- [x] No tool schema changes, N/A

## Relationship to other open PRs

- **#4168** (open) adds `curl --data` / `cat .ssh/` patterns to `approval.py`. This PR is deliberately scoped to the *orthogonal* fixes (read-path masking + sudo timeout) so the two PRs do not conflict and can land in either order.