### PR TITLE
docs: add hermes dump and hermes logs to CLI commands reference

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -43,6 +43,8 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes cron` | Inspect and tick the cron scheduler. |
 | `hermes webhook` | Manage dynamic webhook subscriptions for event-driven activation. |
 | `hermes doctor` | Diagnose config and dependency issues. |
+| `hermes dump` | Copy-pasteable setup summary for support/debugging. |
+| `hermes logs` | View, tail, and filter agent/gateway/error log files. |
 | `hermes config` | Show, edit, migrate, and query configuration files. |
 | `hermes pairing` | Approve or revoke messaging pairing codes. |
 | `hermes skills` | Browse, install, publish, audit, and configure skills. |
@@ -271,6 +273,149 @@ hermes doctor [--fix]
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+
+## `hermes dump`
+
+```bash
+hermes dump [--show-keys]
+```
+
+Outputs a compact, plain-text summary of your entire Hermes setup. Designed to be copy-pasted into Discord, GitHub issues, or Telegram when asking for support — no ANSI colors, no special formatting, just data.
+
+| Option | Description |
+|--------|-------------|
+| `--show-keys` | Show redacted API key prefixes (first and last 4 characters) instead of just `set`/`not set`. |
+
+### What it includes
+
+| Section | Details |
+|---------|---------|
+| **Header** | Hermes version, release date, git commit hash |
+| **Environment** | OS, Python version, OpenAI SDK version |
+| **Identity** | Active profile name, HERMES_HOME path |
+| **Model** | Configured default model and provider |
+| **Terminal** | Backend type (local, docker, ssh, etc.) |
+| **API keys** | Presence check for all 22 provider/tool API keys |
+| **Features** | Enabled toolsets, MCP server count, memory provider |
+| **Services** | Gateway status, configured messaging platforms |
+| **Workload** | Cron job counts, installed skill count |
+| **Config overrides** | Any config values that differ from defaults |
+
+### Example output
+
+```
+--- hermes dump ---
+version:          0.8.0 (2026.4.8) [af4abd2f]
+os:               Linux 6.14.0-37-generic x86_64
+python:           3.11.14
+openai_sdk:       2.24.0
+profile:          default
+hermes_home:      ~/.hermes
+model:            anthropic/claude-opus-4.6
+provider:         openrouter
+terminal:         local
+
+api_keys:
+  openrouter           set
+  openai               not set
+  anthropic            set
+  nous                 not set
+  firecrawl            set
+  ...
+
+features:
+  toolsets:           all
+  mcp_servers:        0
+  memory_provider:    built-in
+  gateway:            running (systemd)
+  platforms:          telegram, discord
+  cron_jobs:          3 active / 5 total
+  skills:             42
+
+config_overrides:
+  agent.max_turns: 250
+  compression.threshold: 0.85
+  display.streaming: True
+--- end dump ---
+```
+
+### When to use
+
+- Reporting a bug on GitHub — paste the dump into your issue
+- Asking for help in Discord — share it in a code block
+- Comparing your setup to someone else's
+- Quick sanity check when something isn't working
+
+:::tip
+`hermes dump` is specifically designed for sharing. For interactive diagnostics, use `hermes doctor`. For a visual overview, use `hermes status`.
+:::
+
+## `hermes logs`
+
+```bash
+hermes logs [log_name] [options]
+```
+
+View, tail, and filter Hermes log files. All logs are stored in `~/.hermes/logs/` (or `<profile>/logs/` for non-default profiles).
+
+### Log files
+
+| Name | File | What it captures |
+|------|------|-----------------|
+| `agent` (default) | `agent.log` | All agent activity — API calls, tool dispatch, session lifecycle (INFO and above) |
+| `errors` | `errors.log` | Warnings and errors only — a filtered subset of agent.log |
+| `gateway` | `gateway.log` | Messaging gateway activity — platform connections, message dispatch, webhook events |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `log_name` | Which log to view: `agent` (default), `errors`, `gateway`, or `list` to show available files with sizes. |
+| `-n`, `--lines <N>` | Number of lines to show (default: 50). |
+| `-f`, `--follow` | Follow the log in real time, like `tail -f`. Press Ctrl+C to stop. |
+| `--level <LEVEL>` | Minimum log level to show: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
+| `--session <ID>` | Filter lines containing a session ID substring. |
+| `--since <TIME>` | Show lines from a relative time ago: `30m`, `1h`, `2d`, etc. Supports `s` (seconds), `m` (minutes), `h` (hours), `d` (days). |
+
+### Examples
+
+```bash
+# View the last 50 lines of agent.log (default)
+hermes logs
+
+# Follow agent.log in real time
+hermes logs -f
+
+# View the last 100 lines of gateway.log
+hermes logs gateway -n 100
+
+# Show only warnings and errors from the last hour
+hermes logs --level WARNING --since 1h
+
+# Filter by a specific session
+hermes logs --session abc123
+
+# Follow errors.log, starting from 30 minutes ago
+hermes logs errors --since 30m -f
+
+# List all log files with their sizes
+hermes logs list
+```
+
+### Filtering
+
+Filters can be combined. When multiple filters are active, a log line must pass **all** of them to be shown:
+
+```bash
+# WARNING+ lines from the last 2 hours containing session "tg-12345"
+hermes logs --level WARNING --since 2h --session tg-12345
+```
+
+Lines without a parseable timestamp are included when `--since` is active (they may be continuation lines from a multi-line log entry). Lines without a detectable level are included when `--level` is active.
+
+### Log rotation
+
+Hermes uses Python's `RotatingFileHandler`. Old logs are rotated automatically — look for `agent.log.1`, `agent.log.2`, etc. The `hermes logs list` subcommand shows all log files including rotated ones.
 
 ## `hermes config`
 


### PR DESCRIPTION
## Summary

Adds documentation for the two debugging CLI commands to the CLI Commands Reference page:

**`hermes dump`** — full section with:
- Option table (`--show-keys`)
- "What it includes" breakdown of all 10 sections in the output
- Full example output block
- "When to use" guidance (bug reports, Discord support, setup comparison)
- Tip callout distinguishing dump vs doctor vs status

**`hermes logs`** — full section with:
- Log files table (agent, errors, gateway) with what each captures
- Complete options table (log_name, -n, -f, --level, --session, --since)
- 7 usage examples covering common scenarios
- Filtering behavior explanation (AND logic, handling of unparseable lines)
- Log rotation notes

Also adds both commands to the top-level commands summary table.

Docusaurus build verified clean (only pre-existing broken anchors in hooks page).