### PR TITLE
feat(gateway): add MATTERMOST_IGNORE_DMS to skip direct messages

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -617,6 +617,15 @@ class MattermostAdapter(BasePlatformAdapter):
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
 
+        # Ignore DMs if configured.
+        if channel_type_raw == "D" and os.getenv(
+            "MATTERMOST_IGNORE_DMS", ""
+        ).lower() in ("true", "1", "yes"):
+            logger.debug(
+                "Mattermost: ignoring DM (MATTERMOST_IGNORE_DMS=true)"
+            )
+            return
+
         # Mention-gating for non-DM channels.
         # Config (env vars):
         #   MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -238,6 +238,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_TOKEN` | Bot token or personal access token for Mattermost |
 | `MATTERMOST_ALLOWED_USERS` | Comma-separated Mattermost user IDs allowed to message the bot |
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
+| `MATTERMOST_IGNORE_DMS` | Ignore direct messages (default: `false`). Set to `true` to make the bot only respond in channels. |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -150,6 +150,9 @@ MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 # Optional: reply mode (thread or off, default: off)
 # MATTERMOST_REPLY_MODE=thread
 
+# Optional: ignore direct messages (default: false)
+# MATTERMOST_IGNORE_DMS=true
+
 # Optional: respond without @mention (default: true = require mention)
 # MATTERMOST_REQUIRE_MENTION=false
 
@@ -212,13 +215,23 @@ Set it in your `~/.hermes/.env`:
 MATTERMOST_REPLY_MODE=thread
 ```
 
+## DM Behavior
+
+By default, the bot responds to direct messages. To make it channel-only:
+
+```bash
+MATTERMOST_IGNORE_DMS=true
+```
+
+This is useful for bots that should only operate in specific channels (e.g. a support bot that should not be used privately).
+
 ## Mention Behavior
 
 By default, the bot only responds in channels when `@mentioned`. You can change this:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MATTERMOST_REQUIRE_MENTION` | `true` | Set to `false` to respond to all messages in channels (DMs always work). |
+| `MATTERMOST_REQUIRE_MENTION` | `true` | Set to `false` to respond to all messages in channels (DMs always work unless `MATTERMOST_IGNORE_DMS` is set). |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | _(none)_ | Comma-separated channel IDs where the bot responds without `@mention`, even when require_mention is true. |
 
 To find a channel ID in Mattermost: open the channel, click the channel name header, and look for the ID in the URL or channel details.


### PR DESCRIPTION
## Summary

- Adds `MATTERMOST_IGNORE_DMS` env var that silently discards all direct messages when set to `true`
- Useful for channel-scoped bots (support, dev, migrations) that should not be used privately
- The check runs before mention-gating so DMs are discarded early with minimal overhead

## Motivation

When running multiple Mattermost bots with different responsibilities (e.g. one per team/channel), DMs create ambiguity about which bot should respond. This flag lets operators restrict specific bots to channel-only mode.

## Changes

- `gateway/platforms/mattermost.py`: early-return guard before the mention-gating block
- `website/docs/reference/environment-variables.md`: added to env var reference
- `website/docs/user-guide/messaging/mattermost.md`: added DM Behavior section with usage example

## Test plan

- [ ] Set `MATTERMOST_IGNORE_DMS=true` and send a DM → bot should not respond
- [ ] Set `MATTERMOST_IGNORE_DMS=false` (or unset) and send a DM → bot responds normally
- [ ] Channel messages unaffected in both cases