### PR TITLE
feat(gateway): add MATTERMOST_FREE_RESPONSE_PREFIX for prefix-based mention gating

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -621,6 +621,7 @@ class MattermostAdapter(BasePlatformAdapter):
         # Config (env vars):
         #   MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
         #   MATTERMOST_FREE_RESPONSE_CHANNELS: Channel IDs where bot responds without mention
+        #   MATTERMOST_FREE_RESPONSE_PREFIX: Channel name prefixes for mention-free response
         if channel_type_raw != "D":
             require_mention = os.getenv(
                 "MATTERMOST_REQUIRE_MENTION", "true"
@@ -629,6 +630,23 @@ class MattermostAdapter(BasePlatformAdapter):
             free_channels_raw = os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS", "")
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
+
+            # Prefix-based matching (e.g. "dev-" matches dev-general, dev-backend, etc.)
+            if not is_free_channel:
+                prefix_raw = os.getenv("MATTERMOST_FREE_RESPONSE_PREFIX", "")
+                prefixes = [p.strip() for p in prefix_raw.split(",") if p.strip()]
+                if prefixes:
+                    if not hasattr(self, "_channel_name_cache"):
+                        self._channel_name_cache: Dict[str, str] = {}
+                    ch_name = self._channel_name_cache.get(channel_id)
+                    if ch_name is None:
+                        try:
+                            ch_data = await self._api_get(f"channels/{channel_id}")
+                            ch_name = ch_data.get("name", "")
+                        except Exception:
+                            ch_name = ""
+                        self._channel_name_cache[channel_id] = ch_name
+                    is_free_channel = any(ch_name.startswith(p) for p in prefixes)
 
             mention_patterns = [
                 f"@{self._bot_username}",

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -240,6 +240,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
+| `MATTERMOST_FREE_RESPONSE_PREFIX` | Comma-separated channel name prefixes for mention-free response (e.g. `dev-,sop-`) |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -155,6 +155,9 @@ MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 
 # Optional: channels where bot responds without @mention (comma-separated channel IDs)
 # MATTERMOST_FREE_RESPONSE_CHANNELS=channel_id_1,channel_id_2
+
+# Optional: channel name prefixes for mention-free response (comma-separated)
+# MATTERMOST_FREE_RESPONSE_PREFIX=dev-,sop-
 ```
 
 Optional behavior settings in `~/.hermes/config.yaml`:
@@ -220,8 +223,11 @@ By default, the bot only responds in channels when `@mentioned`. You can change 
 |----------|---------|-------------|
 | `MATTERMOST_REQUIRE_MENTION` | `true` | Set to `false` to respond to all messages in channels (DMs always work). |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | _(none)_ | Comma-separated channel IDs where the bot responds without `@mention`, even when require_mention is true. |
+| `MATTERMOST_FREE_RESPONSE_PREFIX` | _(none)_ | Comma-separated channel name prefixes (e.g. `dev-,sop-`). Any channel whose name starts with a listed prefix is treated as a free-response channel. |
 
 To find a channel ID in Mattermost: open the channel, click the channel name header, and look for the ID in the URL or channel details.
+
+`MATTERMOST_FREE_RESPONSE_PREFIX` is useful when you have many channels following a naming convention (e.g. `dev-general`, `dev-backend`, `dev-frontend`) and don't want to maintain a list of IDs. Channel names are cached in memory to avoid repeated API calls.
 
 When the bot is `@mentioned`, the mention is automatically stripped from the message before processing.
 


### PR DESCRIPTION
## Summary

- Adds `MATTERMOST_FREE_RESPONSE_PREFIX` env var: comma-separated channel name prefixes (e.g. `dev-,sop-`) treated as free-response channels
- Complements the existing `MATTERMOST_FREE_RESPONSE_CHANNELS` (ID-based) with a name-based alternative
- Channel names are cached in memory to avoid repeated API calls

## Motivation

When running bots scoped to a family of channels (e.g. all `dev-*` channels for a dev bot, all `sop-*` for a support bot), maintaining a list of channel IDs is fragile — it breaks every time a new channel is created. Prefix matching lets operators define the pattern once and have new channels automatically included.

## Changes

- `gateway/platforms/mattermost.py`: prefix-based check after the existing `FREE_RESPONSE_CHANNELS` ID check, with in-memory channel name cache
- `website/docs/reference/environment-variables.md`: added to env var reference
- `website/docs/user-guide/messaging/mattermost.md`: added to mention behavior table with usage explanation

## Test plan

- [ ] Set `MATTERMOST_FREE_RESPONSE_PREFIX=dev-` and send a message in `dev-general` without @mention → bot responds
- [ ] Send a message in a channel not matching the prefix without @mention → bot ignores
- [ ] Combine with `FREE_RESPONSE_CHANNELS` → both methods work together
- [ ] Multiple prefixes: `MATTERMOST_FREE_RESPONSE_PREFIX=dev-,sop-` → matches both