### PR TITLE
fix: add vision responses stream fallback

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -19,6 +19,7 @@ from tools.vision_tools import (
     _is_image_size_error,
     _MAX_BASE64_BYTES,
     _RESIZE_TARGET_BYTES,
+    _extract_streamed_responses_text,
     vision_analyze_tool,
     check_vision_requirements,
 )
@@ -364,6 +365,92 @@ class TestErrorLoggingExcInfo:
             ]
             assert len(warning_records) >= 1
             assert warning_records[0].exc_info is not None
+
+
+class _FakeAsyncStream:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        async def _gen():
+            for event in self._events:
+                yield event
+        return _gen()
+
+
+class _FakeStreamContext:
+    def __init__(self, events):
+        self._stream = _FakeAsyncStream(events)
+
+    async def __aenter__(self):
+        return self._stream
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestResponsesStreamFallback:
+    @pytest.mark.asyncio
+    async def test_extract_streamed_responses_text_concatenates_deltas(self):
+        events = [
+            MagicMock(type="response.output_item.added"),
+            MagicMock(type="response.output_text.delta", delta="一只"),
+            MagicMock(type="response.output_text.delta", delta="猫坐在"),
+            MagicMock(type="response.output_text.delta", delta="椅子上"),
+            MagicMock(type="response.completed"),
+        ]
+
+        text = await _extract_streamed_responses_text(_FakeAsyncStream(events))
+        assert text == "一只猫坐在椅子上"
+
+    @pytest.mark.asyncio
+    async def test_vision_analyze_uses_responses_stream_fallback_when_chat_content_empty(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        empty_response = MagicMock()
+        empty_choice = MagicMock()
+        empty_choice.message.content = None
+        empty_choice.message.reasoning = None
+        empty_choice.message.reasoning_content = None
+        empty_response.choices = [empty_choice]
+
+        stream_events = [
+            MagicMock(type="response.output_item.added"),
+            MagicMock(type="response.output_text.delta", delta="图中是一只"),
+            MagicMock(type="response.output_text.delta", delta="趴着的猫。"),
+            MagicMock(type="response.completed"),
+        ]
+        fake_client = MagicMock()
+        fake_client.responses.stream.return_value = _FakeStreamContext(stream_events)
+
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=[empty_response, empty_response],
+            ) as mock_llm,
+            patch(
+                "tools.vision_tools.resolve_vision_provider_client",
+                return_value=("custom", fake_client, "stream-model"),
+            ) as mock_resolve,
+        ):
+            result = await vision_analyze_tool(str(img), "describe this", "explicit-model")
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["analysis"] == "图中是一只趴着的猫。"
+        assert mock_llm.await_count == 2
+        mock_resolve.assert_called_once_with(async_mode=True)
+        fake_client.responses.stream.assert_called_once()
+        kwargs = fake_client.responses.stream.call_args.kwargs
+        assert kwargs["model"] == "explicit-model"
+        assert kwargs["input"][0]["content"][0] == {"type": "input_text", "text": "describe this"}
+        assert kwargs["input"][0]["content"][1] == {"type": "input_image", "image_url": "data:image/png;base64,abc"}
 
 
 class TestVisionConfig:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -33,11 +33,16 @@ import json
 import logging
 import os
 import uuid
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
 from urllib.parse import urlparse
 import httpx
-from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+from agent.auxiliary_client import (
+    async_call_llm,
+    extract_content_or_reasoning,
+    resolve_vision_provider_client,
+)
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
 
@@ -66,6 +71,63 @@ def _resolve_download_timeout() -> float:
     return 30.0
 
 _VISION_DOWNLOAD_TIMEOUT = _resolve_download_timeout()
+
+
+@asynccontextmanager
+async def _maybe_stream_response(response):
+    """Uniformly handle SDK stream context managers and bare responses."""
+    if hasattr(response, "__aenter__") and hasattr(response, "__aexit__"):
+        async with response as stream:
+            yield stream
+    else:
+        yield response
+
+
+async def _extract_streamed_responses_text(stream) -> str:
+    """Concatenate assistant text from `/responses` SSE delta events."""
+    deltas: list[str] = []
+
+    async for event in stream:
+        if getattr(event, "type", None) == "response.output_text.delta":
+            delta = getattr(event, "delta", None)
+            if isinstance(delta, str) and delta:
+                deltas.append(delta)
+
+    return "".join(deltas).strip()
+
+
+async def _responses_stream_fallback(
+    *,
+    user_prompt: str,
+    image_data_url: str,
+    model: Optional[str] = None,
+    timeout: float = 120.0,
+) -> str:
+    """Fallback to OpenAI `/responses` streaming when chat completions are empty."""
+    _provider, client, final_model = resolve_vision_provider_client(async_mode=True)
+    if client is None:
+        return ""
+
+    request_model = model or final_model
+    if not request_model:
+        return ""
+
+    stream_ctx = client.responses.stream(
+        model=request_model,
+        input=[{
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": user_prompt},
+                {"type": "input_image", "image_url": image_data_url},
+            ],
+        }],
+        max_output_tokens=2000,
+        timeout=timeout,
+    )
+
+    async with _maybe_stream_response(stream_ctx) as stream:
+        return await _extract_streamed_responses_text(stream)
+
 
 # Hard cap on downloaded image file size (50 MB). Prevents OOM from
 # attacker-hosted multi-gigabyte files or decompression bombs.
@@ -594,14 +656,24 @@ async def vision_analyze_tool(
             else:
                 raise
         
-        # Extract the analysis — fall back to reasoning if content is empty
+        # Extract the analysis — fall back to reasoning if content is empty.
+        # Some OpenAI-compatible providers only emit usable vision output in
+        # streamed `/responses` deltas, so retry chat-completions once before
+        # falling back to `/responses` streaming.
         analysis = extract_content_or_reasoning(response)
 
-        # Retry once on empty content (reasoning-only response)
         if not analysis:
-            logger.warning("Vision LLM returned empty content, retrying once")
+            logger.warning("Vision LLM returned empty content, retrying chat completion once")
             response = await async_call_llm(**call_kwargs)
             analysis = extract_content_or_reasoning(response)
+
+        if not analysis:
+            analysis = await _responses_stream_fallback(
+                user_prompt=user_prompt,
+                image_data_url=image_data_url,
+                model=model,
+                timeout=vision_timeout,
+            )
 
         analysis_length = len(analysis)
         


### PR DESCRIPTION
## Summary
- add a `/responses` streaming fallback for vision when chat completions return empty content
- extract text from `response.output_text.delta` events for OpenAI-compatible providers
- add regression tests covering streamed delta extraction and fallback behavior

## Problem
Some OpenAI-compatible providers accept the image request but return:
- `chat.completions`: `message.content = null`
- non-stream `/responses`: `output = []`
- streamed `/responses`: valid text in `response.output_text.delta`

That made `vision_analyze` fail even though the provider had actually generated the answer.

## Fix
The vision path now:
1. tries the normal chat-completions call
2. retries chat-completions once if content is empty
3. falls back to streamed `/responses` and concatenates `response.output_text.delta`

## Test Plan
- `pytest -q tests/tools/test_vision_tools.py`
- `pytest -q tests/tools/test_vision_tools.py tests/run_agent/test_run_agent.py -k vision`

Closes #6560