### PR TITLE
fix: disable delegation toolset in cron to prevent inactivity timeout kill

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -661,7 +661,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
-            disabled_toolsets=["cronjob", "messaging", "clarify"],
+            disabled_toolsets=["cronjob", "messaging", "clarify", "delegation"],
             quiet_mode=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -879,6 +879,7 @@ class TestRunJobSkillBacked:
 
         kwargs = mock_agent_cls.call_args.kwargs
         assert "cronjob" in (kwargs["disabled_toolsets"] or [])
+        assert "delegation" in (kwargs["disabled_toolsets"] or [])
 
         prompt_arg = mock_agent.run_conversation.call_args.args[0]
         assert "blogwatcher" in prompt_arg


### PR DESCRIPTION
## Summary

Closes #6582

When a cron job's skill prompt calls `delegate_task`, the sub-agent's activity signals do not propagate back to the parent session's activity tracker. The parent's inactivity counter keeps rising while the sub-agent is actively working, and after 600s (default `HERMES_CRON_TIMEOUT`) the parent is killed — taking the sub-agent with it.

## Root cause

`cron/scheduler.py:664` disables `["cronjob", "messaging", "clarify"]` for cron agents but not `"delegation"`. The `delegation` toolset (`toolsets.py:189`) includes `delegate_task`, which creates a child agent whose `_touch_activity()` calls update the *child's* tracker, not the parent's.

## Fix

Add `"delegation"` to the hardcoded `disabled_toolsets` list, consistent with the existing pattern for `"cronjob"` (which prevents recursive cron spawning — same class of risk).

## Changes

- `cron/scheduler.py`: add `"delegation"` to `disabled_toolsets` (+1 word)
- `tests/cron/test_scheduler.py`: assert `delegation` is in `disabled_toolsets` (+1 line, mirrors existing `cronjob` assertion at L881)

## Known limitation

This is the minimal safe fix (disable the dangerous tool in cron context). A follow-up could make `disabled_toolsets` configurable via `config.yaml` so users can opt-in to delegation in cron with appropriate timeout tuning.