### PR TITLE
fix(browser): respect config.yaml cloud_provider over CAMOFOX_URL env var

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -59,15 +59,21 @@ def get_camofox_url() -> str:
 
 
 def is_camofox_mode() -> bool:
-    """True when Camofox backend is configured and not overridden by config.
+    """True when Camofox backend is configured and not overridden by config or CDP.
 
-    If ``browser.cloud_provider`` in config.yaml is explicitly set to a
-    non-camofox provider (e.g. ``browser-use``, ``browserbase``), the
-    config takes precedence and Camofox mode is disabled even when
-    ``CAMOFOX_URL`` is present in the environment.
+    Priority order (highest wins):
+    1. ``BROWSER_CDP_URL`` set → CDP connection takes priority (user explicitly
+       connected to a live Chrome via ``/browser connect``).
+    2. ``browser.cloud_provider`` in config.yaml set to a non-camofox provider
+       (e.g. ``browser-use``, ``browserbase``) → config wins over env var.
+    3. ``CAMOFOX_URL`` set → Camofox mode enabled.
 
     The result is resolved once and cached for the process lifetime.
     """
+    # CDP override takes hard priority — user explicitly connected to a live Chrome.
+    if os.getenv("BROWSER_CDP_URL", "").strip():
+        return False
+
     global _camofox_mode_resolved, _camofox_mode_cached
     if _camofox_mode_resolved:
         return _camofox_mode_cached

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -47,6 +47,11 @@ _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
 
+# Cached result for is_camofox_mode() — resolved once per process lifetime,
+# same pattern as _get_cloud_provider() in browser_tool.py.
+_camofox_mode_resolved = False
+_camofox_mode_cached = False
+
 
 def get_camofox_url() -> str:
     """Return the configured Camofox server URL, or empty string."""
@@ -54,16 +59,36 @@ def get_camofox_url() -> str:
 
 
 def is_camofox_mode() -> bool:
-    """True when Camofox backend is configured and no CDP override is active.
+    """True when Camofox backend is configured and not overridden by config.
 
-    When the user has explicitly connected to a live Chrome instance via
-    ``/browser connect`` (which sets ``BROWSER_CDP_URL``), the CDP connection
-    takes priority over Camofox so the browser tools operate on the real
-    browser instead of being silently routed to the Camofox backend.
+    If ``browser.cloud_provider`` in config.yaml is explicitly set to a
+    non-camofox provider (e.g. ``browser-use``, ``browserbase``), the
+    config takes precedence and Camofox mode is disabled even when
+    ``CAMOFOX_URL`` is present in the environment.
+
+    The result is resolved once and cached for the process lifetime.
     """
-    if os.getenv("BROWSER_CDP_URL", "").strip():
+    global _camofox_mode_resolved, _camofox_mode_cached
+    if _camofox_mode_resolved:
+        return _camofox_mode_cached
+    _camofox_mode_resolved = True
+
+    if not get_camofox_url():
         return False
-    return bool(get_camofox_url())
+    try:
+        from hermes_cli.config import read_raw_config
+        from tools.tool_backend_helpers import normalize_browser_cloud_provider
+
+        provider = normalize_browser_cloud_provider(
+            read_raw_config().get("browser", {}).get("cloud_provider")
+        )
+        # An explicit non-local, non-camofox provider in config wins.
+        if provider not in ("local", "camofox"):
+            return False
+    except Exception:
+        pass
+    _camofox_mode_cached = True
+    return True
 
 
 def check_camofox_available() -> bool:


### PR DESCRIPTION
## Summary
- `is_camofox_mode()` now checks `browser.cloud_provider` in config.yaml before honoring the `CAMOFOX_URL` env var
- If config explicitly selects a cloud provider (e.g. `browser-use`, `browserbase`), that choice takes precedence
- `CAMOFOX_URL` still works when config is unset, `local`, or `camofox`

## Problem
Having `CAMOFOX_URL` in `.env` unconditionally short-circuits all browser operations to Camofox, completely ignoring `browser.cloud_provider` in config.yaml. Users who configured browser-use via `hermes setup tools` but also had Camofox installed could never actually use browser-use without manually unsetting the env var.

## Test plan
- [ ] Set `CAMOFOX_URL` + `cloud_provider: browser-use` → browser-use is used (Camofox disabled)
- [ ] Set `CAMOFOX_URL` + `cloud_provider: local` → Camofox still active
- [ ] Set `CAMOFOX_URL` + no `cloud_provider` → Camofox still active (backward compat)
- [ ] Unset `CAMOFOX_URL` → no change in behavior regardless of config