### PR TITLE
fix(telegram): require secret_token for webhook mode to prevent spoofing

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -490,6 +490,21 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self.config.token:
             logger.error("[%s] No bot token configured", self.name)
             return False
+
+        webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
+        webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
+        if webhook_url and not webhook_secret:
+            message = (
+                "Telegram webhook mode requires TELEGRAM_WEBHOOK_SECRET. "
+                "Without it, any client that can reach the webhook endpoint can forge updates."
+            )
+            self._set_fatal_error(
+                "telegram_webhook_secret_required",
+                message,
+                retryable=False,
+            )
+            logger.error("[%s] %s", self.name, message)
+            return False
         
         try:
             from gateway.status import acquire_scoped_lock
@@ -577,15 +592,12 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._app.start()
 
             # Decide between webhook and polling mode
-            webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
-
             if webhook_url:
                 # ── Webhook mode ─────────────────────────────────────
                 # Telegram pushes updates to our HTTP endpoint.  This
                 # enables cloud platforms (Fly.io, Railway) to auto-wake
                 # suspended machines on inbound HTTP traffic.
                 webhook_port = int(os.getenv("TELEGRAM_WEBHOOK_PORT", "8443"))
-                webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip() or None
                 from urllib.parse import urlparse
                 webhook_path = urlparse(webhook_url).path or "/telegram"
 

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -63,6 +63,27 @@ async def test_connect_rejects_same_host_token_lock(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_rejects_webhook_mode_without_secret(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="secret-token"))
+
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.test/telegram")
+    monkeypatch.delenv("TELEGRAM_WEBHOOK_SECRET", raising=False)
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (_ for _ in ()).throw(
+            AssertionError("token lock should not be acquired before webhook secret validation")
+        ),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.fatal_error_code == "telegram_webhook_secret_required"
+    assert adapter.has_fatal_error is True
+    assert "TELEGRAM_WEBHOOK_SECRET" in adapter.fatal_error_message
+
+
+@pytest.mark.asyncio
 async def test_polling_conflict_retries_before_fatal(monkeypatch):
     """A single 409 should trigger a retry, not an immediate fatal error."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))


### PR DESCRIPTION
🛡️ The Spoofing Surface: Telegram Webhook Integrity
This PR closes a critical authentication gap in the Telegram adapter where the webhook listener could be initialized without a verification secret.

🕵️ The Finding
Previously, if TELEGRAM_WEBHOOK_URL was configured without a TELEGRAM_WEBHOOK_SECRET, the adapter would bind to 0.0.0.0 with no inbound validation. Since python-telegram-bot only enforces header checks when a secret is explicitly provided, the gateway was left in an "Open Door" state.

Impact: Any external actor capable of reaching the webhook endpoint could POST forged Telegram Update JSONs. This allows an attacker to:

Impersonate any User or Group ID.

Trigger agent tools and skills under fraudulent identities.

Bypass the core trust model of the messaging gateway.

🛠️ (The Fix)
Fail-Closed Architecture: Modified TelegramAdapter.connect() to treat a missing secret as a fatal configuration error. If you want a public webhook, you must provide a secret.

Strict Validation: The adapter now refuses to proceed to the token-locking or server-startup phase unless inbound authentication is guaranteed.

Regression Suite: Integrated a specialized test case in tests/gateway/test_telegram_conflict.py to ensure that insecure configurations are caught and blocked during the pre-flight check.

✅ Verification Results
Targeted Test: python -m pytest tests/gateway/test_telegram_conflict.py -q -> 7 Passed.

Security Check: Confirmed that the secret_token header is now a hard requirement for the underlying webhook server to process any incoming data.