### PR TITLE
feat: gateway native multimodal image passthrough

### DIFF
--- a/agent/multimodal.py
+++ b/agent/multimodal.py
@@ -1,0 +1,200 @@
+"""Helpers for native multimodal user input handling.
+
+Keeps gateway/runtime image passthrough logic small and reusable:
+- local image file -> data URL conversion
+- OpenAI chat content -> Responses API content conversion
+- conservative native-vision capability detection
+- text-only shadow messages for transcript persistence
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+from agent.models_dev import get_model_info, get_model_info_any_provider
+
+_NATIVE_VISION_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages"}
+_IMAGE_MIME_FALLBACKS = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".svg": "image/svg+xml",
+}
+
+
+def _candidate_model_ids(model: str) -> list[str]:
+    candidates: list[str] = []
+    raw = str(model or "").strip()
+    if not raw:
+        return candidates
+    candidates.append(raw)
+    if "/" in raw:
+        suffix = raw.split("/", 1)[1].strip()
+        if suffix and suffix not in candidates:
+            candidates.append(suffix)
+    return candidates
+
+
+def _guess_image_mime_type(path: Path) -> str:
+    guessed, _ = mimetypes.guess_type(path.name)
+    if guessed and guessed.startswith("image/"):
+        return guessed
+    return _IMAGE_MIME_FALLBACKS.get(path.suffix.lower(), "image/jpeg")
+
+
+def image_file_to_data_url(image_path: str | Path) -> str:
+    """Convert a local image file to a base64 data URL."""
+    path = Path(image_path).expanduser()
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    mime_type = _guess_image_mime_type(path)
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def build_multimodal_user_content(text: str, image_paths: list[str]) -> list[dict[str, Any]]:
+    """Build OpenAI-compatible multimodal content blocks for a user message."""
+    parts: list[dict[str, Any]] = []
+    clean_text = str(text or "").strip()
+    if clean_text:
+        parts.append({"type": "text", "text": clean_text})
+    for image_path in image_paths:
+        parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": image_file_to_data_url(image_path)},
+            }
+        )
+    return parts
+
+
+def build_persist_user_message(text: str, image_count: int) -> str:
+    """Build a text-only shadow message safe for transcripts/session DB."""
+    clean_text = str(text or "").strip()
+    if image_count <= 0:
+        return clean_text
+    note = f"[User attached {image_count} image{'s' if image_count != 1 else ''}]"
+    if clean_text:
+        return f"{clean_text}\n\n{note}"
+    return note
+
+
+def prepend_text_to_user_content(content: Any, text: str) -> Any:
+    """Prepend a plain text note to either string or multimodal content."""
+    note = str(text or "").strip()
+    if not note:
+        return content
+    if isinstance(content, list):
+        return [{"type": "text", "text": note}, *content]
+    if isinstance(content, str):
+        return f"{note}\n\n{content}" if content else note
+    return content
+
+
+def convert_chat_content_to_responses(content: Any) -> Any:
+    """Convert OpenAI chat content parts to Responses API content parts."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content) if content is not None else ""
+
+    converted: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        ptype = part.get("type", "")
+        if ptype == "text":
+            converted.append({"type": "input_text", "text": part.get("text", "")})
+        elif ptype == "image_url":
+            image_data = part.get("image_url", {})
+            url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data or "")
+            entry: dict[str, Any] = {"type": "input_image", "image_url": url}
+            detail = image_data.get("detail") if isinstance(image_data, dict) else None
+            if detail:
+                entry["detail"] = detail
+            converted.append(entry)
+        elif ptype in {"input_text", "input_image"}:
+            converted.append(dict(part))
+        else:
+            text = part.get("text", "")
+            if text:
+                converted.append({"type": "input_text", "text": text})
+
+    return converted or ""
+
+
+def describe_user_payload_for_log(user_message: Any, limit: int = 80) -> str:
+    """Human-readable preview for logs/debug output."""
+    if isinstance(user_message, str):
+        preview = user_message.replace("\n", " ")
+        return (preview[:limit] + "...") if len(preview) > limit else preview
+    if isinstance(user_message, list):
+        image_count = 0
+        text_count = 0
+        for part in user_message:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") in {"image_url", "input_image"}:
+                image_count += 1
+            elif part.get("type") in {"text", "input_text"}:
+                text_count += 1
+        preview = f"[multimodal user turn: {image_count} image{'s' if image_count != 1 else ''}, {text_count} text block{'s' if text_count != 1 else ''}]"
+        return (preview[:limit] + "...") if len(preview) > limit else preview
+    preview = str(user_message)
+    return (preview[:limit] + "...") if len(preview) > limit else preview
+
+
+def resolve_native_vision_support(
+    provider: str,
+    model: str,
+    api_mode: str,
+    base_url: str = "",
+) -> Tuple[Optional[bool], str]:
+    """Return whether native image passthrough is safe for this runtime.
+
+    Returns:
+      (True, reason)   -> native passthrough is supported
+      (False, reason)  -> known unsupported
+      (None, reason)   -> unknown / cannot determine safely
+    """
+    normalized_mode = str(api_mode or "").strip().lower()
+    if normalized_mode not in _NATIVE_VISION_API_MODES:
+        return False, f"api_mode '{api_mode or 'unknown'}' does not support native multimodal image input"
+
+    normalized_provider = str(provider or "").strip().lower()
+    model_candidates = _candidate_model_ids(model)
+    if not model_candidates:
+        return None, "No model configured for vision capability detection"
+
+    for candidate in model_candidates:
+        if normalized_provider:
+            try:
+                info = get_model_info(normalized_provider, candidate)
+            except Exception:
+                info = None
+            if info is not None:
+                return (
+                    True if info.supports_vision() else False,
+                    f"{info.id} {'supports' if info.supports_vision() else 'does not support'} vision",
+                )
+
+    for candidate in model_candidates:
+        try:
+            info = get_model_info_any_provider(candidate)
+        except Exception:
+            info = None
+        if info is not None:
+            return (
+                True if info.supports_vision() else False,
+                f"{info.id} {'supports' if info.supports_vision() else 'does not support'} vision",
+            )
+
+    base_label = str(base_url or "").strip() or "unknown endpoint"
+    return None, (
+        f"Could not determine vision support for provider={normalized_provider or 'unknown'}, "
+        f"model={model_candidates[0]!r}, endpoint={base_label}"
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -234,6 +234,12 @@ from gateway.session import (
 )
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from agent.multimodal import (
+    build_multimodal_user_content,
+    build_persist_user_message,
+    prepend_text_to_user_content,
+    resolve_native_vision_support,
+)
 
 
 def _normalize_whatsapp_identifier(value: str) -> str:
@@ -2711,16 +2717,17 @@ class GatewayRunner:
                     context_prompt += f"\n\n{vc_context}"
 
         # -----------------------------------------------------------------
-        # Auto-analyze images sent by the user
+        # Collect user-attached images.
         #
-        # If the user attached image(s), we run the vision tool eagerly so
-        # the conversation model always receives a text description.  The
-        # local file path is also included so the model can re-examine the
-        # image later with a more targeted question via vision_analyze.
+        # Gateway image handling is resolved later inside _run_agent(), after
+        # smart model routing chooses the actual runtime for this turn. That
+        # later step decides whether to:
+        #   - use auxiliary describe-first fallback, or
+        #   - send native multimodal image blocks to the main model.
         #
         # We filter to image paths only (by media_type) so that non-image
-        # attachments (documents, audio, etc.) are not sent to the vision
-        # tool even when they appear in the same message.
+        # attachments (documents, audio, etc.) are excluded from the vision
+        # path even when they appear in the same message.
         # -----------------------------------------------------------------
         message_text = event.text or ""
 
@@ -2740,8 +2747,8 @@ class GatewayRunner:
         if _is_shared_thread and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
+        image_paths = []
         if event.media_urls:
-            image_paths = []
             for i, path in enumerate(event.media_urls):
                 # Check media_types if available; otherwise infer from message type
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
@@ -2751,10 +2758,6 @@ class GatewayRunner:
                 )
                 if is_image:
                     image_paths.append(path)
-            if image_paths:
-                message_text = await self._enrich_message_with_vision(
-                    message_text, image_paths
-                )
         
         # -----------------------------------------------------------------
         # Auto-transcribe voice/audio messages sent by the user
@@ -2909,6 +2912,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                image_paths=image_paths,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -5921,6 +5925,68 @@ class GatewayRunner:
             if var in os.environ:
                 del os.environ[var]
     
+    @staticmethod
+    def _resolve_gateway_vision_mode(user_config: dict) -> str:
+        """Return configured gateway image handling mode."""
+        raw = (
+            user_config.get("auxiliary", {})
+            .get("vision", {})
+            .get("gateway_mode", "describe")
+        )
+        mode = str(raw or "describe").strip().lower()
+        return mode if mode in {"describe", "auto", "passthrough"} else "describe"
+
+    async def _prepare_gateway_user_payload(
+        self,
+        user_text: str,
+        image_paths: List[str],
+        turn_route: dict,
+        user_config: dict,
+    ) -> tuple[Any, Optional[str], Optional[str]]:
+        """Build the current-turn user payload for gateway image inputs.
+
+        Returns:
+            (payload, persist_shadow, error_message)
+        """
+        if not image_paths:
+            return user_text, None, None
+
+        vision_mode = self._resolve_gateway_vision_mode(user_config)
+        if vision_mode == "describe":
+            enriched = await self._enrich_message_with_vision(user_text, image_paths)
+            return enriched, None, None
+
+        runtime = turn_route.get("runtime", {}) if isinstance(turn_route, dict) else {}
+        routed_model = (turn_route.get("model") if isinstance(turn_route, dict) else None) or ""
+        supported, reason = resolve_native_vision_support(
+            provider=runtime.get("provider", ""),
+            model=routed_model,
+            api_mode=runtime.get("api_mode", ""),
+            base_url=runtime.get("base_url", ""),
+        )
+
+        if supported is not True:
+            if vision_mode == "auto":
+                logger.info(
+                    "Gateway image auto-mode falling back to auxiliary describe path: %s",
+                    reason,
+                )
+                enriched = await self._enrich_message_with_vision(user_text, image_paths)
+                return enriched, None, None
+
+            model_label = routed_model or "current model"
+            provider_label = runtime.get("provider") or "current provider"
+            return None, None, (
+                "⚠️ Native image passthrough is forced, but the active runtime "
+                f"({provider_label} / {model_label}) is not known to support image input. "
+                f"Reason: {reason}. Either switch to a vision-capable model or set "
+                "`auxiliary.vision.gateway_mode` to `auto` or `describe`."
+            )
+
+        payload = build_multimodal_user_content(user_text, image_paths)
+        persist_shadow = build_persist_user_message(user_text, len(image_paths))
+        return payload, persist_shadow, None
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,
@@ -6266,7 +6332,7 @@ class GatewayRunner:
 
     async def _run_agent(
         self,
-        message: str,
+        message: Any,
         context_prompt: str,
         history: List[Dict[str, Any]],
         source: SessionSource,
@@ -6274,6 +6340,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        image_paths: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -6646,7 +6713,30 @@ class GatewayRunner:
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                message if isinstance(message, str) else "",
+                model,
+                runtime_kwargs,
+            )
+
+            user_payload = message
+            persist_user_message = None
+            if image_paths:
+                user_payload, persist_user_message, payload_error = asyncio.run(
+                    self._prepare_gateway_user_payload(
+                        message if isinstance(message, str) else "",
+                        image_paths,
+                        turn_route,
+                        user_config,
+                    )
+                )
+                if payload_error:
+                    return {
+                        "final_response": payload_error,
+                        "messages": history,
+                        "api_calls": 0,
+                        "completed": True,
+                    }
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -6870,13 +6960,25 @@ class GatewayRunner:
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                user_payload = prepend_text_to_user_content(user_payload, _msn)
+                if persist_user_message is not None:
+                    persist_user_message = f"{_msn}\n\n{persist_user_message}" if persist_user_message else _msn
+                elif isinstance(user_payload, str):
+                    persist_user_message = user_payload
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                if persist_user_message is None:
+                    result = agent.run_conversation(user_payload, conversation_history=agent_history, task_id=session_id)
+                else:
+                    result = agent.run_conversation(
+                        user_payload,
+                        conversation_history=agent_history,
+                        task_id=session_id,
+                        persist_user_message=persist_user_message,
+                    )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -315,6 +315,7 @@ DEFAULT_CONFIG = {
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
             "timeout": 30,         # seconds — LLM API call timeout; increase for slow local vision models
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
+            "gateway_mode": "describe",  # describe | auto | passthrough (gateway image handling only)
         },
         "web_extract": {
             "provider": "auto",

--- a/plans/gateway-native-multimodal-passthrough.md
+++ b/plans/gateway-native-multimodal-passthrough.md
@@ -1,0 +1,404 @@
+# Gateway Native Multimodal Image Passthrough — Implementation Spec
+
+## Goal
+Allow Hermes gateway platforms (Telegram, Discord, Slack, etc.) to pass user-attached images directly to the main conversation model when that runtime actually supports native vision, instead of always routing images through the auxiliary vision describer first.
+
+## Why this exists
+Today Hermes gateway image handling is lossy, slower, and more expensive than it needs to be:
+
+- `gateway/run.py:2743-2757` always collects image attachments and sends them through `_enrich_message_with_vision(...)`
+- `gateway/run.py:5924-5990` always calls `vision_analyze_tool(...)` and prepends a synthetic text description to the user message
+- the main model never sees the raw image in the gateway path
+
+That means a screenshot sent to Telegram currently becomes:
+1. gateway downloads image
+2. auxiliary vision model describes image
+3. description text is injected into the user message
+4. main model sees only text, not the real image
+
+This is bad for screenshots, charts, code, diagrams, and subtle visual layout questions.
+
+## Important correction to the existing issue
+Issue `#5661` is directionally correct, but two details are wrong or incomplete:
+
+1. It says the CLI already does native multimodal image passthrough.
+   - Current code does not.
+   - `cli.py:2954-3015` also pre-processes attached images through auxiliary vision.
+   - The docs currently claim native CLI passthrough, but the code path is still description-first.
+
+2. It treats this as a gateway-only switch.
+   - That is only half true.
+   - Even if the gateway starts sending multimodal content blocks, `run_agent.py:5203-5218` currently downgrades image blocks to text for `anthropic_messages` before the API call.
+   - `agent/anthropic_adapter.py:772-859` already knows how to convert image blocks to Anthropic-native image payloads, so the current unconditional fallback in `run_agent.py` is overly blunt.
+
+So the real feature is not just “skip `_enrich_message_with_vision()`”.
+It is “support native multimodal gateway input end-to-end, with conservative fallback when the active runtime cannot actually accept images.”
+
+## Scope
+
+### In scope for this implementation
+- Gateway platforms only
+- User-attached image inputs (`event.media_urls` where media type is image)
+- Native multimodal passthrough for main-model turns
+- Conservative fallback to the existing auxiliary description path
+- Clean transcript/session persistence without storing giant base64 blobs in session history
+- Capability detection for deciding when passthrough is safe
+- Tests for gateway, run-agent, and config behavior
+
+### Explicitly out of scope for this implementation
+- CLI image-input parity
+- Audio/video/omni-modal passthrough
+- Changing the `vision_analyze` tool itself
+- Making every provider support native images if its transport cannot already do so
+- Reworking transcript storage to persist multimodal payloads long-term
+
+CLI parity should be a separate follow-up issue/PR. The current docs can be corrected once the gateway behavior is fixed and the CLI plan is decided.
+
+## Non-negotiable constraints
+
+1. Do not break existing non-vision models.
+   - If the active runtime does not support native images, Hermes must keep working through the existing auxiliary description path.
+
+2. Do not persist multimodal content blocks or base64 image payloads into SQLite/JSONL transcripts.
+   - `hermes_state.py:857-930` stores `content` as `TEXT` and FTS5 indexes it.
+   - Persisting base64 image blocks would bloat session storage and wreck session search.
+
+3. Do not silently send invalid multimodal payloads to unsupported runtimes.
+   - Forced passthrough should fail loudly.
+   - Auto mode should degrade safely.
+
+4. Do not change the on-demand `vision_analyze` tool behavior.
+   - Native passthrough affects the main conversation path only.
+   - Tool-driven image analysis remains available.
+
+## Proposed config shape
+Add a gateway-specific mode under the existing auxiliary vision section:
+
+```yaml
+auxiliary:
+  vision:
+    gateway_mode: describe   # describe | auto | passthrough
+```
+
+### Semantics
+- `describe` (default)
+  - Current behavior.
+  - Always use auxiliary vision pre-description.
+
+- `auto`
+  - If the active main runtime is known to support native image input, send real multimodal content blocks.
+  - Otherwise fall back to `describe`.
+
+- `passthrough`
+  - Force native multimodal input.
+  - If the active runtime is known not to support image input, or Hermes cannot determine support safely, fail with a clear error message rather than silently describing the image.
+
+## Why `gateway_mode` instead of a generic `passthrough: true`
+The original issue proposed:
+
+```yaml
+auxiliary:
+  vision:
+    passthrough: true
+```
+
+That is too vague for Hermes.
+
+Problems with a plain boolean:
+- no conservative auto mode
+- no way to keep old behavior explicitly
+- implies this applies everywhere, even though this PR is gateway-only
+- makes failure policy ambiguous
+
+`gateway_mode` is explicit, backward-compatible, and leaves room for a future `cli_mode` or a later unification once both surfaces behave the same way.
+
+## High-level architecture
+
+### Current path
+`Gateway event -> _enrich_message_with_vision() -> auxiliary vision model -> synthetic text -> AIAgent.run_conversation(str)`
+
+### New path
+`Gateway event -> choose image input mode -> either describe fallback OR build multimodal content blocks -> AIAgent.run_conversation(multimodal content, persist_user_message=text shadow)`
+
+The key design choice is:
+- API payload can be multimodal
+- persisted transcript must remain clean text
+
+That means the gateway must pass two forms of the same turn:
+1. the real API-facing multimodal content
+2. a clean text-only shadow string for persistence and resume history
+
+## Proposed implementation by file
+
+### 1. `hermes_cli/config.py`
+Add the new default config key:
+
+```python
+"auxiliary": {
+    "vision": {
+        "provider": "auto",
+        "model": "",
+        "base_url": "",
+        "api_key": "",
+        "timeout": 30,
+        "download_timeout": 30,
+        "gateway_mode": "describe",
+    },
+    ...
+}
+```
+
+Also validate/document accepted values in the config comments.
+
+### 2. New helper module: `agent/multimodal.py`
+Create a shared helper module instead of burying this logic in `gateway/run.py`.
+
+Suggested responsibilities:
+
+- `image_file_to_data_url(path: str | Path) -> str`
+  - Convert a cached local image file into a `data:image/...;base64,...` URL
+  - Reuse the same MIME-detection logic as `tools/vision_tools.py` rather than duplicating ad hoc logic
+
+- `build_multimodal_user_content(text: str, image_paths: list[str]) -> list[dict]`
+  - Create content blocks in OpenAI-compatible format:
+    - leading `{ "type": "text", "text": ... }` block when text exists
+    - one `{ "type": "image_url", "image_url": { "url": data_url } }` block per image
+
+- `resolve_native_vision_support(provider: str, model: str, api_mode: str, base_url: str = "") -> tuple[bool | None, str]`
+  - Return `(supported, reason)` where `supported` is:
+    - `True` = safe to use native passthrough
+    - `False` = known unsupported
+    - `None` = unknown / cannot prove safely
+
+Suggested resolution order:
+1. transport guard:
+   - allow only `openai_chat`, `codex_responses`, `anthropic_messages`
+   - everything else returns `False` or `None`
+2. `agent.models_dev.get_model_info(provider, model)`
+3. fallback `agent.models_dev.get_model_info_any_provider(model)` for providers like `openai-codex` whose runtime model names map to OpenAI-family models but are not directly in `PROVIDER_TO_MODELS_DEV`
+4. conservative fallback:
+   - `auto` treats `None` as unsupported and falls back to describe
+   - `passthrough` treats `None` as a user-visible error
+
+This helper should be reusable later by the CLI follow-up.
+
+### 3. `gateway/run.py`
+Replace the current unconditional enrichment branch with a mode-aware flow.
+
+Current logic:
+- `gateway/run.py:2743-2757` collects `image_paths`
+- then always calls `_enrich_message_with_vision(...)`
+
+Replace it with a helper flow like:
+
+- gather `image_paths`
+- read `auxiliary.vision.gateway_mode`
+- inspect the active agent runtime/provider/model
+- branch:
+  - `describe` -> existing `_enrich_message_with_vision(...)`
+  - `auto` + native vision supported -> build multimodal content
+  - `auto` + unsupported/unknown -> existing `_enrich_message_with_vision(...)`
+  - `passthrough` + supported -> build multimodal content
+  - `passthrough` + unsupported/unknown -> fail loudly with a direct user-visible explanation
+
+Important: this code cannot keep assuming `message` is always a string.
+
+Add a small gateway-level helper, something like:
+- `_build_gateway_user_input(...) -> tuple[user_payload, persist_text]`
+
+Where:
+- `user_payload` is either `str` or `list[dict]`
+- `persist_text` is always a plain text string used for transcript/session persistence
+
+The gateway also needs to handle pending model switch notes when `message` is multimodal.
+Current code at `gateway/run.py:6869-6874` prepends `_msn` using string concatenation.
+That must become:
+- if payload is `str`: prepend as today
+- if payload is list content blocks: prepend `_msn` as an extra leading text block
+- persist shadow text should also include the note
+
+### 4. `run_agent.py`
+Broaden the input path so the main agent can accept a multimodal user turn without mangling persistence.
+
+Changes required:
+
+#### Signature / typing
+Change:
+```python
+def run_conversation(self, user_message: str, ...)
+```
+
+to something like:
+```python
+def run_conversation(self, user_message: Any, ..., persist_user_message: Optional[str] = None)
+```
+
+or preferably a tighter union type if convenient.
+
+#### Preview/logging safety
+Current code assumes `user_message` is a string in at least these places:
+- `run_agent.py:6883-6889`
+- `run_agent.py:6939`
+
+Add a helper like `_preview_user_message(user_message)` that:
+- returns the plain string preview for normal text
+- returns a short synthetic preview for list content, e.g.:
+  - `"[multimodal user turn: 2 images, 1 text block]"`
+
+#### Persistence safety
+The existing `persist_user_message` machinery is exactly what this feature needs.
+Keep using it.
+
+The gateway should pass:
+- `user_message=<multimodal content blocks>`
+- `persist_user_message=<plain text shadow>`
+
+That ensures:
+- the API sees the real multimodal payload
+- `_apply_persist_user_message_override()` rewrites the in-memory turn before transcript/DB flush
+- SQLite/JSONL/FTS stay text-only
+
+### 5. `run_agent.py` anthropic handling
+This is the most important “issue text was incomplete” part.
+
+Current behavior:
+- `run_agent.py:5203-5218` always converts image content to text for `anthropic_messages`
+- but `agent/anthropic_adapter.py:772-859` already supports native image conversion to Anthropic message blocks
+
+That means the current fallback is unconditional when it should be conditional.
+
+Proposed fix:
+- keep the existing text-describe fallback path
+- only apply it when Hermes has decided native image passthrough is unsafe for the active anthropic-compatible runtime/model
+- otherwise pass the original image blocks through to `build_anthropic_kwargs(...)`
+
+Suggested refactor:
+- replace the current unconditional `_prepare_anthropic_messages_for_api(...)` behavior with a capability-aware branch
+- pseudo-behavior:
+  - if no image parts: pass through unchanged
+  - if image parts and active runtime supports native vision: pass through unchanged
+  - if image parts and active runtime does not support native vision: use the existing image-to-text fallback
+
+This keeps old compatibility behavior available without permanently disabling native Anthropic vision.
+
+### 6. `agent/models_dev.py` or new helper tests
+If the current metadata lookup is not enough for `openai-codex`, add the smallest safe fallback needed.
+
+Do not hardcode giant provider/model allowlists in `gateway/run.py`.
+Capability resolution belongs in shared model/capability logic.
+
+At minimum the implementation must handle:
+- OpenAI Codex models like `gpt-5.4`
+- OpenAI chat-compatible providers via `openai_chat`
+- Anthropic-native models where native image support is actually available
+- conservative fallback for unknown providers/models
+
+### 7. Docs
+Update at least one user-facing doc to reflect reality.
+
+Suggested files:
+- `website/docs/user-guide/features/vision.md`
+- optionally `website/docs/user-guide/features/fallback-providers.md`
+
+Minimum doc updates:
+- Gateway can now use native multimodal image passthrough when configured
+- `auxiliary.vision.gateway_mode` values and behavior
+- Do not claim the CLI already has native passthrough unless the CLI code is fixed in the same PR
+
+## Acceptance criteria
+
+### Functional
+1. When a Telegram/Discord/etc. user sends an image and `auxiliary.vision.gateway_mode: describe`, Hermes behaves exactly as it does today.
+2. When the user sends an image and `gateway_mode: auto` with a known vision-capable main runtime, Hermes sends a multimodal content block to the main model and does not call auxiliary vision first.
+3. When `gateway_mode: auto` and the runtime is not known to support images, Hermes falls back to the current auxiliary description path.
+4. When `gateway_mode: passthrough` and the runtime is unsupported or unknown, Hermes returns a clear explanation instead of silently falling back.
+5. The persisted transcript/session history stores only plain text shadow content, not multimodal lists or base64 data URLs.
+6. `vision_analyze` still works unchanged as an on-demand tool.
+
+### Safety / compatibility
+7. Non-image attachments are unaffected.
+8. Voice/audio transcription flow is unaffected.
+9. Session search and transcript storage are unaffected by giant image payloads.
+10. Anthropic-compatible runtimes only receive native image blocks when Hermes has explicitly determined passthrough is safe.
+
+## Test plan
+
+### A. Gateway tests
+Add a new focused gateway test module, e.g.:
+- `tests/gateway/test_gateway_image_passthrough.py`
+
+Cover:
+1. `describe` mode still calls `_enrich_message_with_vision()`
+2. `auto` mode with supported runtime builds multimodal content blocks and skips auxiliary vision
+3. `auto` mode with unsupported runtime falls back to `_enrich_message_with_vision()`
+4. `passthrough` mode with unsupported runtime returns a clear error
+5. sender-prefix handling still works in shared threads when payload becomes multimodal
+6. pending model-switch note is prepended correctly for multimodal payloads
+
+### B. Agent persistence tests
+Add/extend run-agent tests, likely in:
+- `tests/run_agent/test_run_agent.py`
+
+Cover:
+1. `run_conversation()` accepts list-based user content without crashing preview/logging
+2. `persist_user_message` rewrites the current-turn user message before DB/transcript persistence
+3. returned message history is text-clean after persistence override
+
+### C. Anthropic routing tests
+Add tests proving the new behavior is conditional rather than unconditional:
+- native image blocks are preserved for a supported anthropic runtime
+- image blocks are converted to text only when fallback is required
+
+This likely belongs in:
+- `tests/run_agent/test_run_agent.py`
+- or a dedicated anthropic image-path test module if cleaner
+
+### D. Config tests
+Add a small config default test if the repo already covers config defaults near this area:
+- `gateway_mode` default is `describe`
+- invalid values are handled conservatively
+
+## Recommended implementation order
+
+### Phase 1: plumbing and safety
+1. Add config default for `auxiliary.vision.gateway_mode`
+2. Add shared multimodal helper module
+3. Update `run_agent.py` preview/persistence handling so non-string user payloads are safe
+
+### Phase 2: gateway passthrough
+4. Add gateway image mode resolver and multimodal payload builder
+5. Wire `persist_user_message` shadow text into the gateway `run_conversation(...)` call
+6. Handle pending model switch note for multimodal payloads
+
+### Phase 3: anthropic correction
+7. Make anthropic image fallback conditional instead of unconditional
+8. Add regression tests so native image blocks survive when allowed
+
+### Phase 4: docs and cleanup
+9. Update docs for gateway image mode
+10. Correct any stale claims that the CLI already does native passthrough, unless the CLI is fixed in the same PR
+
+## What must not be done
+
+1. Do not store multimodal content lists directly in the session DB.
+2. Do not add a hardcoded provider:model allowlist in gateway code.
+3. Do not silently switch `passthrough` into `describe` mode.
+4. Do not expand scope to CLI in the same PR unless the user explicitly wants that.
+5. Do not remove `_enrich_message_with_vision()` entirely; it remains the fallback path.
+
+## Follow-up issue after this PR
+Create a separate follow-up for CLI parity:
+- either bring CLI image input onto the same `gateway_mode`-style native path
+- or intentionally keep CLI description-first and fix the docs to match reality
+
+Right now the code and docs disagree. This PR should not pretend otherwise.
+
+## Summary
+The correct feature is:
+- gateway-native multimodal image passthrough
+- capability-aware
+- transcript-safe
+- fallback-preserving
+- not a blind boolean
+
+If implemented this way, Hermes gets the quality and latency win for vision-capable main models without breaking the conservative compatibility story that the current gateway behavior was protecting.

--- a/run_agent.py
+++ b/run_agent.py
@@ -104,6 +104,11 @@ from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
+from agent.multimodal import (
+    convert_chat_content_to_responses,
+    describe_user_payload_for_log,
+    resolve_native_vision_support,
+)
 from utils import atomic_json_write, env_var_enabled
 
 
@@ -3003,7 +3008,8 @@ class AIAgent:
 
             if role in {"user", "assistant"}:
                 content = msg.get("content", "")
-                content_text = str(content) if content is not None else ""
+                converted_content = convert_chat_content_to_responses(content)
+                content_text = converted_content if isinstance(converted_content, str) else None
 
                 if role == "assistant":
                     # Replay encrypted reasoning items from previous turns
@@ -3016,8 +3022,10 @@ class AIAgent:
                                 items.append(ri)
                                 has_codex_reasoning = True
 
-                    if content_text.strip():
+                    if isinstance(content_text, str) and content_text.strip():
                         items.append({"role": "assistant", "content": content_text})
+                    elif converted_content not in (None, "", []):
+                        items.append({"role": "assistant", "content": converted_content})
                     elif has_codex_reasoning:
                         # The Responses API requires a following item after each
                         # reasoning item (otherwise: missing_following_item error).
@@ -3069,7 +3077,7 @@ class AIAgent:
                             })
                     continue
 
-                items.append({"role": role, "content": content_text})
+                items.append({"role": role, "content": converted_content})
                 continue
 
             if role == "tool":
@@ -5207,6 +5215,15 @@ class AIAgent:
         ):
             return api_messages
 
+        native_supported, _ = resolve_native_vision_support(
+            provider=self.provider,
+            model=self.model,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        )
+        if native_supported is True:
+            return api_messages
+
         transformed = copy.deepcopy(api_messages)
         for msg in transformed:
             if not isinstance(msg, dict):
@@ -6810,7 +6827,8 @@ class AIAgent:
         Run a complete conversation with tool calling until completion.
 
         Args:
-            user_message (str): The user's message/question
+            user_message: The user's message/question, or multimodal content blocks
+                for providers that support native image input.
             system_message (str): Custom system message (optional, overrides ephemeral_system_prompt if provided)
             conversation_history (List[Dict]): Previous conversation messages (optional)
             task_id (str): Unique identifier for this task to isolate VMs between concurrent tasks (optional, auto-generated if not provided)
@@ -6880,8 +6898,7 @@ class AIAgent:
         self.iteration_budget = IterationBudget(self.max_iterations)
 
         # Log conversation turn start for debugging/observability
-        _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
-        _msg_preview = _msg_preview.replace("\n", " ")
+        _msg_preview = describe_user_payload_for_log(user_message, limit=80)
         logger.info(
             "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
             self.session_id or "none", self.model, self.provider or "unknown",
@@ -6936,7 +6953,8 @@ class AIAgent:
         self._persist_user_message_idx = current_turn_user_idx
         
         if not self.quiet_mode:
-            self._safe_print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
+            _display_preview = describe_user_payload_for_log(user_message, limit=60)
+            self._safe_print(f"💬 Starting conversation: '{_display_preview}'")
         
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.

--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -262,8 +262,10 @@ class TestDefaultConfigShape:
         vision = DEFAULT_CONFIG["auxiliary"]["vision"]
         assert "provider" in vision
         assert "model" in vision
+        assert "gateway_mode" in vision
         assert vision["provider"] == "auto"
         assert vision["model"] == ""
+        assert vision["gateway_mode"] == "describe"
 
     def test_web_extract_task_structure(self):
         from hermes_cli.config import DEFAULT_CONFIG

--- a/tests/gateway/test_gateway_image_passthrough.py
+++ b/tests/gateway/test_gateway_image_passthrough.py
@@ -1,0 +1,242 @@
+import asyncio
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+class _CapturingAgent:
+    last_init = None
+    last_run = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+        type(self).last_run = {
+            "user_message": user_message,
+            "conversation_history": conversation_history,
+            "task_id": task_id,
+            "persist_user_message": persist_user_message,
+        }
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(streaming=None)
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+def _make_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+@pytest.mark.asyncio
+async def test_gateway_auto_mode_uses_multimodal_passthrough_for_supported_runtime(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"auxiliary": {"vision": {"gateway_mode": "auto"}}})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "***",
+        },
+    )
+    monkeypatch.setattr(gateway_run, "resolve_native_vision_support", lambda **kwargs: (True, "supports vision"))
+    monkeypatch.setattr(
+        gateway_run,
+        "build_multimodal_user_content",
+        lambda text, image_paths: [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA="}},
+        ],
+    )
+
+    _CapturingAgent.last_run = None
+    result = await runner._run_agent(
+        message="look at this",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+        image_paths=[str(tmp_path / "a.png")],
+    )
+
+    assert result["final_response"] == "ok"
+    assert isinstance(_CapturingAgent.last_run["user_message"], list)
+    assert _CapturingAgent.last_run["persist_user_message"] == "look at this\n\n[User attached 1 image]"
+    runner._enrich_message_with_vision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_auto_mode_falls_back_to_auxiliary_description_when_runtime_not_supported(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"auxiliary": {"vision": {"gateway_mode": "auto"}}})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "***",
+        },
+    )
+    monkeypatch.setattr(gateway_run, "resolve_native_vision_support", lambda **kwargs: (False, "no vision support"))
+
+    _CapturingAgent.last_run = None
+    result = await runner._run_agent(
+        message="look at this",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+        image_paths=[str(tmp_path / "a.png")],
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_run["user_message"] == "ENRICHED"
+    assert _CapturingAgent.last_run["persist_user_message"] is None
+    runner._enrich_message_with_vision.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_passthrough_mode_returns_clear_error_when_runtime_support_unknown(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"auxiliary": {"vision": {"gateway_mode": "passthrough"}}})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://example.invalid/v1",
+            "api_key": "***",
+        },
+    )
+    monkeypatch.setattr(gateway_run, "resolve_native_vision_support", lambda **kwargs: (None, "unknown model capabilities"))
+
+    _CapturingAgent.last_run = None
+    result = await runner._run_agent(
+        message="look at this",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+        image_paths=[str(tmp_path / "a.png")],
+    )
+
+    assert "Native image passthrough is forced" in result["final_response"]
+    assert _CapturingAgent.last_run is None
+    runner._enrich_message_with_vision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_model_switch_note_is_prepended_to_multimodal_payload_and_persist_shadow(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    session_key = "agent:main:telegram:dm:12345"
+    runner._pending_model_notes[session_key] = "[Switched to gpt-5.4]"
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"auxiliary": {"vision": {"gateway_mode": "auto"}}})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "***",
+        },
+    )
+    monkeypatch.setattr(gateway_run, "resolve_native_vision_support", lambda **kwargs: (True, "supports vision"))
+    monkeypatch.setattr(
+        gateway_run,
+        "build_multimodal_user_content",
+        lambda text, image_paths: [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA="}},
+        ],
+    )
+
+    _CapturingAgent.last_run = None
+    result = await runner._run_agent(
+        message="look at this",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key=session_key,
+        image_paths=[str(tmp_path / "a.png")],
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_run["user_message"][0] == {"type": "text", "text": "[Switched to gpt-5.4]"}
+    assert _CapturingAgent.last_run["persist_user_message"].startswith("[Switched to gpt-5.4]\n\n")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3249,6 +3249,70 @@ class TestPersistUserMessageOverride:
         first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
         assert first_db_write["content"] == "Hello there"
 
+    def test_persist_session_rewrites_multimodal_current_turn_user_message(self, agent):
+        agent._session_db = MagicMock()
+        agent.session_id = "session-123"
+        agent._last_flushed_db_idx = 0
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = "[User attached 1 image]"
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                ],
+            },
+            {"role": "assistant", "content": "Hi!"},
+        ]
+
+        with patch.object(agent, "_save_session_log") as mock_save:
+            agent._persist_session(messages, [])
+
+        assert messages[0]["content"] == "[User attached 1 image]"
+        saved_messages = mock_save.call_args.args[0]
+        assert saved_messages[0]["content"] == "[User attached 1 image]"
+        first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
+        assert first_db_write["content"] == "[User attached 1 image]"
+
+
+class TestNativeMultimodalInput:
+    def test_chat_messages_to_responses_input_preserves_user_image_blocks_for_codex(self, agent):
+        api_messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Can you inspect this?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+        }]
+
+        items = agent._chat_messages_to_responses_input(api_messages)
+
+        assert items == [{
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Can you inspect this?"},
+                {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+            ],
+        }]
+
+    def test_prepare_anthropic_messages_preserves_native_image_blocks_when_supported(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent.model = "claude-sonnet-4-20250514"
+        api_messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Can you inspect this?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ],
+        }]
+
+        with patch("run_agent.resolve_native_vision_support", return_value=(True, "supports vision")):
+            transformed = agent._prepare_anthropic_messages_for_api(api_messages)
+
+        assert transformed == api_messages
+
 
 # ---------------------------------------------------------------------------
 # Bugfix: _vprint force=True on error messages during TTS


### PR DESCRIPTION
## Summary
This adds native multimodal image passthrough for gateway inputs, with capability-aware fallback.

## What changed
- added shared multimodal helpers in `agent/multimodal.py`
- added `auxiliary.vision.gateway_mode` with `describe | auto | passthrough`
- updated the gateway so `auto` passes images through when the routed runtime supports vision, otherwise falls back cleanly
- updated `run_agent.py` so multimodal user payloads are handled safely and transcript persistence stays text-only
- made the Anthropic downgrade conditional instead of unconditional
- added focused regression tests

## Tests
- targeted py_compile check
- targeted gateway passthrough tests
- targeted run-agent multimodal/persistence tests
- targeted config/reasoning regression tests

## Notes
- scoped to gateway image inputs only
- CLI parity can be follow-up work
- detailed implementation notes live in `plans/gateway-native-multimodal-passthrough.md`

Closes #5661
