### PR TITLE
feat: add qwen/qwen3.6-plus (paid) to OpenRouter and KiloCode model lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -256,6 +256,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
+        "qwen/qwen3.6-plus",
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",


### PR DESCRIPTION
## Summary

Add `qwen/qwen3.6-plus` (paid tier) to the model catalogs for both OpenRouter and KiloCode providers. The `:free` variant remains listed alongside it.

## Changes

### hermes_cli/models.py
- Added `qwen/qwen3.6-plus` to `OPENROUTER_MODELS` with descriptor `"1M context, thinking"`
- Added `qwen/qwen3.6-plus` to the `kilocode` provider list in `_PROVIDER_MODELS`

### agent/model_metadata.py
- Added `"qwen3.6-plus": 1048576` to `DEFAULT_CONTEXT_LENGTHS` (1M context)

## Model Specs
- **Context**: 1,048,576 tokens (1M)
- **Thinking**: Supported (extended thinking / reasoning)
- **Pricing**: Fetched live from OpenRouter `/v1/models` endpoint
- **Availability**: OpenRouter + KiloCode

Both providers support this model ID natively -- no additional normalisation needed beyond the existing `qwen` vendor prefix detection in `model_normalize.py`.
