### PR TITLE
feat(stt): add whisper_cpp provider (voxtype / whisper-cli)

### DIFF
--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -23,6 +23,21 @@ def _clear_openai_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _disable_whisper_cpp_by_default(monkeypatch):
+    """Ensure whisper.cpp detection is off in tests unless explicitly enabled.
+
+    The ``whisper_cpp`` provider auto-detects binaries like ``voxtype`` on
+    PATH; on dev machines this would leak into provider-selection tests that
+    assume no local backend is available. Tests that need whisper_cpp should
+    patch ``_find_whisper_cpp_binary`` to return a concrete path.
+    """
+    monkeypatch.setattr(
+        "tools.transcription_tools._find_whisper_cpp_binary",
+        lambda preferred=None: None,
+    )
+
+
 class TestGetProvider:
     """_get_provider() picks the right backend based on config + availability."""
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -18,6 +18,22 @@ import pytest
 # Fixtures
 # ============================================================================
 
+
+@pytest.fixture(autouse=True)
+def _disable_whisper_cpp_by_default(monkeypatch):
+    """Ensure whisper.cpp detection is off in tests unless explicitly enabled.
+
+    The ``whisper_cpp`` provider auto-detects binaries like ``voxtype`` on
+    PATH; on dev machines this would leak into provider-selection tests that
+    assume no local backend is available. Tests that need whisper_cpp should
+    patch ``_find_whisper_cpp_binary`` to return a concrete path.
+    """
+    monkeypatch.setattr(
+        "tools.transcription_tools._find_whisper_cpp_binary",
+        lambda preferred=None: None,
+    )
+
+
 @pytest.fixture
 def sample_wav(tmp_path):
     """Create a minimal valid WAV file (1 second of silence at 16kHz)."""
@@ -57,14 +73,18 @@ def clean_env(monkeypatch):
 # _get_provider — full permutation matrix
 # ============================================================================
 
+
 class TestGetProviderGroq:
     """Groq-specific provider selection tests."""
 
     def test_groq_when_key_set(self, monkeypatch):
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("tools.transcription_tools._HAS_FASTER_WHISPER", False):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({"provider": "groq"}) == "groq"
 
     def test_groq_explicit_no_fallback(self, monkeypatch):
@@ -72,14 +92,18 @@ class TestGetProviderGroq:
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({"provider": "groq"}) == "none"
 
     def test_groq_nothing_available(self, monkeypatch):
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._HAS_OPENAI", False):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._HAS_OPENAI", False),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({"provider": "groq"}) == "none"
 
 
@@ -90,40 +114,50 @@ class TestGetProviderFallbackPriority:
         """Auto-detect prefers local over any cloud provider."""
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({}) == "local"
 
     def test_auto_detect_prefers_groq_over_openai(self, monkeypatch):
         """Auto-detect: groq (free) is preferred over openai (paid)."""
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({}) == "groq"
 
     def test_explicit_openai_no_key_returns_none(self, monkeypatch):
         """Explicit openai with no key returns none — no cross-provider fallback."""
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({"provider": "openai"}) == "none"
 
     def test_unknown_provider_passed_through(self):
         from tools.transcription_tools import _get_provider
+
         assert _get_provider({"provider": "custom-endpoint"}) == "custom-endpoint"
 
     def test_empty_config_defaults_to_local(self):
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({}) == "local"
 
 
 # ============================================================================
 # Explicit provider config respected  (GH-1774)
 # ============================================================================
+
 
 class TestExplicitProviderRespected:
     """When stt.provider is explicitly set, that choice is authoritative.
@@ -134,19 +168,25 @@ class TestExplicitProviderRespected:
         even when an OpenAI API key is set."""
         monkeypatch.setenv("OPENAI_API_KEY", "***")
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             result = _get_provider({"provider": "local"})
             assert result == "none", f"Expected 'none' but got {result!r}"
 
     def test_explicit_local_no_fallback_to_groq(self, monkeypatch):
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             result = _get_provider({"provider": "local"})
             assert result == "none"
 
@@ -158,15 +198,19 @@ class TestExplicitProviderRespected:
         )
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False):
             from tools.transcription_tools import _get_provider
+
             result = _get_provider({"provider": "local"})
             assert result == "local_command"
 
     def test_explicit_groq_no_fallback_to_openai(self, monkeypatch):
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-real-key")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             result = _get_provider({"provider": "groq"})
             assert result == "none"
 
@@ -174,9 +218,12 @@ class TestExplicitProviderRespected:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             result = _get_provider({"provider": "openai"})
             assert result == "none"
 
@@ -184,10 +231,13 @@ class TestExplicitProviderRespected:
         """When no provider is explicitly set, auto-detect cloud fallback works."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-real-key")
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             # Empty dict = no explicit provider, uses DEFAULT_PROVIDER auto-detect
             result = _get_provider({})
             assert result == "openai"
@@ -195,10 +245,13 @@ class TestExplicitProviderRespected:
     def test_auto_detect_prefers_groq_over_openai(self, monkeypatch):
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-real-key")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             result = _get_provider({})
             assert result == "groq"
 
@@ -207,10 +260,12 @@ class TestExplicitProviderRespected:
 # _transcribe_groq
 # ============================================================================
 
+
 class TestTranscribeGroq:
     def test_no_key(self, monkeypatch):
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         from tools.transcription_tools import _transcribe_groq
+
         result = _transcribe_groq("/tmp/test.ogg", "whisper-large-v3-turbo")
         assert result["success"] is False
         assert "GROQ_API_KEY" in result["error"]
@@ -219,6 +274,7 @@ class TestTranscribeGroq:
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
         with patch("tools.transcription_tools._HAS_OPENAI", False):
             from tools.transcription_tools import _transcribe_groq
+
             result = _transcribe_groq("/tmp/test.ogg", "whisper-large-v3-turbo")
         assert result["success"] is False
         assert "openai package" in result["error"]
@@ -229,9 +285,12 @@ class TestTranscribeGroq:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "hello world"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_groq
+
             result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
 
         assert result["success"] is True
@@ -245,9 +304,12 @@ class TestTranscribeGroq:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "  hello world  \n"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_groq
+
             result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
 
         assert result["transcript"] == "hello world"
@@ -258,9 +320,12 @@ class TestTranscribeGroq:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client) as mock_openai_cls:
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client) as mock_openai_cls,
+        ):
             from tools.transcription_tools import _transcribe_groq, GROQ_BASE_URL
+
             _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
 
         call_kwargs = mock_openai_cls.call_args
@@ -272,9 +337,12 @@ class TestTranscribeGroq:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.side_effect = Exception("API error")
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_groq
+
             result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
 
         assert result["success"] is False
@@ -287,9 +355,12 @@ class TestTranscribeGroq:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.side_effect = PermissionError("denied")
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_groq
+
             result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
 
         assert result["success"] is False
@@ -300,11 +371,13 @@ class TestTranscribeGroq:
 # _transcribe_openai — additional tests
 # ============================================================================
 
+
 class TestTranscribeOpenAIExtended:
     def test_openai_package_not_installed(self, monkeypatch):
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
         with patch("tools.transcription_tools._HAS_OPENAI", False):
             from tools.transcription_tools import _transcribe_openai
+
             result = _transcribe_openai("/tmp/test.ogg", "whisper-1")
         assert result["success"] is False
         assert "openai package" in result["error"]
@@ -315,9 +388,12 @@ class TestTranscribeOpenAIExtended:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client) as mock_openai_cls:
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client) as mock_openai_cls,
+        ):
             from tools.transcription_tools import _transcribe_openai, OPENAI_BASE_URL
+
             _transcribe_openai(sample_wav, "whisper-1")
 
         call_kwargs = mock_openai_cls.call_args
@@ -329,9 +405,12 @@ class TestTranscribeOpenAIExtended:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "  hello  \n"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_openai
+
             result = _transcribe_openai(sample_wav, "whisper-1")
 
         assert result["transcript"] == "hello"
@@ -343,9 +422,12 @@ class TestTranscribeOpenAIExtended:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.side_effect = PermissionError("denied")
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_openai
+
             result = _transcribe_openai(sample_wav, "whisper-1")
 
         assert result["success"] is False
@@ -356,7 +438,10 @@ class TestTranscribeOpenAIExtended:
 class TestTranscribeLocalCommand:
     def test_auto_detects_local_whisper_binary(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
-        monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: "/opt/homebrew/bin/whisper")
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_whisper_binary",
+            lambda: "/opt/homebrew/bin/whisper",
+        )
 
         from tools.transcription_tools import _get_local_command_template
 
@@ -394,11 +479,18 @@ class TestTranscribeLocalCommand:
                     handle.write(b"RIFF....WAVEfmt ")
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-            (out_dir / "test.txt").write_text("hello from local command\n", encoding="utf-8")
+            (out_dir / "test.txt").write_text(
+                "hello from local command\n", encoding="utf-8"
+            )
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
-        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/opt/homebrew/bin/ffmpeg")
+        monkeypatch.setattr(
+            "tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_ffmpeg_binary",
+            lambda: "/opt/homebrew/bin/ffmpeg",
+        )
         monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
 
         from tools.transcription_tools import _transcribe_local_command
@@ -413,6 +505,7 @@ class TestTranscribeLocalCommand:
 # ============================================================================
 # _transcribe_local — additional tests
 # ============================================================================
+
 
 class TestTranscribeLocalExtended:
     def test_model_reuse_on_second_call(self, tmp_path):
@@ -430,11 +523,14 @@ class TestTranscribeLocalExtended:
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
         mock_whisper_cls = MagicMock(return_value=mock_model)
 
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
-             patch("tools.transcription_tools._local_model", None), \
-             patch("tools.transcription_tools._local_model_name", None):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", True),
+            patch("faster_whisper.WhisperModel", mock_whisper_cls),
+            patch("tools.transcription_tools._local_model", None),
+            patch("tools.transcription_tools._local_model_name", None),
+        ):
             from tools.transcription_tools import _transcribe_local
+
             _transcribe_local(str(audio), "base")
             _transcribe_local(str(audio), "base")
 
@@ -456,11 +552,14 @@ class TestTranscribeLocalExtended:
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
         mock_whisper_cls = MagicMock(return_value=mock_model)
 
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
-             patch("tools.transcription_tools._local_model", None), \
-             patch("tools.transcription_tools._local_model_name", None):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", True),
+            patch("faster_whisper.WhisperModel", mock_whisper_cls),
+            patch("tools.transcription_tools._local_model", None),
+            patch("tools.transcription_tools._local_model_name", None),
+        ):
             from tools.transcription_tools import _transcribe_local
+
             _transcribe_local(str(audio), "base")
             _transcribe_local(str(audio), "small")
 
@@ -472,10 +571,13 @@ class TestTranscribeLocalExtended:
 
         mock_whisper_cls = MagicMock(side_effect=RuntimeError("CUDA out of memory"))
 
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
-             patch("tools.transcription_tools._local_model", None):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", True),
+            patch("faster_whisper.WhisperModel", mock_whisper_cls),
+            patch("tools.transcription_tools._local_model", None),
+        ):
             from tools.transcription_tools import _transcribe_local
+
             result = _transcribe_local(str(audio), "large-v3")
 
         assert result["success"] is False
@@ -496,10 +598,13 @@ class TestTranscribeLocalExtended:
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([seg1, seg2], mock_info)
 
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", return_value=mock_model), \
-             patch("tools.transcription_tools._local_model", None):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", True),
+            patch("faster_whisper.WhisperModel", return_value=mock_model),
+            patch("tools.transcription_tools._local_model", None),
+        ):
             from tools.transcription_tools import _transcribe_local
+
             result = _transcribe_local(str(audio), "base")
 
         assert result["success"] is True
@@ -510,6 +615,7 @@ class TestTranscribeLocalExtended:
 # Model auto-correction
 # ============================================================================
 
+
 class TestModelAutoCorrection:
     def test_groq_corrects_openai_model(self, monkeypatch, sample_wav):
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
@@ -517,9 +623,15 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "hello world"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
-            from tools.transcription_tools import _transcribe_groq, DEFAULT_GROQ_STT_MODEL
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
+            from tools.transcription_tools import (
+                _transcribe_groq,
+                DEFAULT_GROQ_STT_MODEL,
+            )
+
             _transcribe_groq(sample_wav, "whisper-1")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -531,9 +643,15 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
-            from tools.transcription_tools import _transcribe_groq, DEFAULT_GROQ_STT_MODEL
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
+            from tools.transcription_tools import (
+                _transcribe_groq,
+                DEFAULT_GROQ_STT_MODEL,
+            )
+
             _transcribe_groq(sample_wav, "gpt-4o-transcribe")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -545,9 +663,12 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "hello world"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_openai, DEFAULT_STT_MODEL
+
             _transcribe_openai(sample_wav, "whisper-large-v3-turbo")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -559,9 +680,12 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_openai, DEFAULT_STT_MODEL
+
             _transcribe_openai(sample_wav, "distil-whisper-large-v3-en")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -573,9 +697,12 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_groq
+
             _transcribe_groq(sample_wav, "whisper-large-v3")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -587,9 +714,12 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_openai
+
             _transcribe_openai(sample_wav, "gpt-4o-mini-transcribe")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -602,9 +732,12 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_groq
+
             _transcribe_groq(sample_wav, "my-custom-model")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -616,9 +749,12 @@ class TestModelAutoCorrection:
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = "test"
 
-        with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+        with (
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("openai.OpenAI", return_value=mock_client),
+        ):
             from tools.transcription_tools import _transcribe_openai
+
             _transcribe_openai(sample_wav, "my-custom-model")
 
         call_kwargs = mock_client.audio.transcriptions.create.call_args
@@ -629,17 +765,20 @@ class TestModelAutoCorrection:
 # _load_stt_config
 # ============================================================================
 
+
 class TestLoadSttConfig:
     def test_returns_dict_when_import_fails(self):
         with patch("tools.transcription_tools._load_stt_config") as mock_load:
             mock_load.return_value = {}
             from tools.transcription_tools import _load_stt_config
+
             assert _load_stt_config() == {}
 
     def test_real_load_returns_dict(self):
         """_load_stt_config should always return a dict, even on import error."""
         with patch.dict("sys.modules", {"hermes_cli": None, "hermes_cli.config": None}):
             from tools.transcription_tools import _load_stt_config
+
             result = _load_stt_config()
         assert isinstance(result, dict)
 
@@ -648,9 +787,11 @@ class TestLoadSttConfig:
 # _validate_audio_file — edge cases
 # ============================================================================
 
+
 class TestValidateAudioFileEdgeCases:
     def test_directory_is_not_a_file(self, tmp_path):
         from tools.transcription_tools import _validate_audio_file
+
         # tmp_path itself is a directory with an .ogg-ish name? No.
         # Create a directory with a valid audio extension
         d = tmp_path / "audio.ogg"
@@ -663,6 +804,7 @@ class TestValidateAudioFileEdgeCases:
         f = tmp_path / "test.ogg"
         f.write_bytes(b"data")
         from tools.transcription_tools import _validate_audio_file
+
         real_stat = f.stat()
         call_count = 0
 
@@ -681,13 +823,17 @@ class TestValidateAudioFileEdgeCases:
 
     def test_all_supported_formats_accepted(self, tmp_path):
         from tools.transcription_tools import _validate_audio_file, SUPPORTED_FORMATS
+
         for fmt in SUPPORTED_FORMATS:
             f = tmp_path / f"test{fmt}"
             f.write_bytes(b"data")
-            assert _validate_audio_file(str(f)) is None, f"Format {fmt} should be accepted"
+            assert _validate_audio_file(str(f)) is None, (
+                f"Format {fmt} should be accepted"
+            )
 
     def test_case_insensitive_extension(self, tmp_path):
         from tools.transcription_tools import _validate_audio_file
+
         f = tmp_path / "test.MP3"
         f.write_bytes(b"data")
         assert _validate_audio_file(str(f)) is None
@@ -697,13 +843,22 @@ class TestValidateAudioFileEdgeCases:
 # transcribe_audio — end-to-end dispatch
 # ============================================================================
 
+
 class TestTranscribeAudioDispatch:
     def test_dispatches_to_groq(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
-             patch("tools.transcription_tools._get_provider", return_value="groq"), \
-             patch("tools.transcription_tools._transcribe_groq",
-                   return_value={"success": True, "transcript": "hi", "provider": "groq"}) as mock_groq:
+        with (
+            patch(
+                "tools.transcription_tools._load_stt_config",
+                return_value={"provider": "groq"},
+            ),
+            patch("tools.transcription_tools._get_provider", return_value="groq"),
+            patch(
+                "tools.transcription_tools._transcribe_groq",
+                return_value={"success": True, "transcript": "hi", "provider": "groq"},
+            ) as mock_groq,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             result = transcribe_audio(sample_ogg)
 
         assert result["success"] is True
@@ -711,31 +866,51 @@ class TestTranscribeAudioDispatch:
         mock_groq.assert_called_once()
 
     def test_dispatches_to_local(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
-             patch("tools.transcription_tools._get_provider", return_value="local"), \
-             patch("tools.transcription_tools._transcribe_local",
-                   return_value={"success": True, "transcript": "hi"}) as mock_local:
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value={}),
+            patch("tools.transcription_tools._get_provider", return_value="local"),
+            patch(
+                "tools.transcription_tools._transcribe_local",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_local,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             result = transcribe_audio(sample_ogg)
 
         assert result["success"] is True
         mock_local.assert_called_once()
 
     def test_dispatches_to_openai(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "openai"}), \
-             patch("tools.transcription_tools._get_provider", return_value="openai"), \
-             patch("tools.transcription_tools._transcribe_openai",
-                   return_value={"success": True, "transcript": "hi", "provider": "openai"}) as mock_openai:
+        with (
+            patch(
+                "tools.transcription_tools._load_stt_config",
+                return_value={"provider": "openai"},
+            ),
+            patch("tools.transcription_tools._get_provider", return_value="openai"),
+            patch(
+                "tools.transcription_tools._transcribe_openai",
+                return_value={
+                    "success": True,
+                    "transcript": "hi",
+                    "provider": "openai",
+                },
+            ) as mock_openai,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             result = transcribe_audio(sample_ogg)
 
         assert result["success"] is True
         mock_openai.assert_called_once()
 
     def test_no_provider_returns_error(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
-             patch("tools.transcription_tools._get_provider", return_value="none"):
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value={}),
+            patch("tools.transcription_tools._get_provider", return_value="none"),
+        ):
             from tools.transcription_tools import transcribe_audio
+
             result = transcribe_audio(sample_ogg)
 
         assert result["success"] is False
@@ -748,10 +923,16 @@ class TestTranscribeAudioDispatch:
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "openai"}), \
-             patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+        with (
+            patch(
+                "tools.transcription_tools._load_stt_config",
+                return_value={"provider": "openai"},
+            ),
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+        ):
             from tools.transcription_tools import transcribe_audio
+
             result = transcribe_audio(sample_ogg)
 
         assert result["success"] is False
@@ -759,62 +940,143 @@ class TestTranscribeAudioDispatch:
 
     def test_invalid_file_short_circuits(self):
         from tools.transcription_tools import transcribe_audio
+
         result = transcribe_audio("/nonexistent/audio.wav")
         assert result["success"] is False
         assert "not found" in result["error"]
 
     def test_model_override_passed_to_groq(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
-             patch("tools.transcription_tools._get_provider", return_value="groq"), \
-             patch("tools.transcription_tools._transcribe_groq",
-                   return_value={"success": True, "transcript": "hi"}) as mock_groq:
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value={}),
+            patch("tools.transcription_tools._get_provider", return_value="groq"),
+            patch(
+                "tools.transcription_tools._transcribe_groq",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_groq,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             transcribe_audio(sample_ogg, model="whisper-large-v3")
 
         _, kwargs = mock_groq.call_args
-        assert kwargs.get("model_name") or mock_groq.call_args[0][1] == "whisper-large-v3"
+        assert (
+            kwargs.get("model_name") or mock_groq.call_args[0][1] == "whisper-large-v3"
+        )
 
     def test_model_override_passed_to_local(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
-             patch("tools.transcription_tools._get_provider", return_value="local"), \
-             patch("tools.transcription_tools._transcribe_local",
-                   return_value={"success": True, "transcript": "hi"}) as mock_local:
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value={}),
+            patch("tools.transcription_tools._get_provider", return_value="local"),
+            patch(
+                "tools.transcription_tools._transcribe_local",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_local,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             transcribe_audio(sample_ogg, model="large-v3")
 
         assert mock_local.call_args[0][1] == "large-v3"
 
     def test_default_model_used_when_none(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
-             patch("tools.transcription_tools._get_provider", return_value="groq"), \
-             patch("tools.transcription_tools._transcribe_groq",
-                   return_value={"success": True, "transcript": "hi"}) as mock_groq:
-            from tools.transcription_tools import transcribe_audio, DEFAULT_GROQ_STT_MODEL
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value={}),
+            patch("tools.transcription_tools._get_provider", return_value="groq"),
+            patch(
+                "tools.transcription_tools._transcribe_groq",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_groq,
+        ):
+            from tools.transcription_tools import (
+                transcribe_audio,
+                DEFAULT_GROQ_STT_MODEL,
+            )
+
             transcribe_audio(sample_ogg, model=None)
 
         assert mock_groq.call_args[0][1] == DEFAULT_GROQ_STT_MODEL
 
     def test_config_local_model_used(self, sample_ogg):
         config = {"local": {"model": "small"}}
-        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
-             patch("tools.transcription_tools._get_provider", return_value="local"), \
-             patch("tools.transcription_tools._transcribe_local",
-                   return_value={"success": True, "transcript": "hi"}) as mock_local:
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value=config),
+            patch("tools.transcription_tools._get_provider", return_value="local"),
+            patch(
+                "tools.transcription_tools._transcribe_local",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_local,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             transcribe_audio(sample_ogg, model=None)
 
         assert mock_local.call_args[0][1] == "small"
 
     def test_config_openai_model_used(self, sample_ogg):
         config = {"openai": {"model": "gpt-4o-transcribe"}}
-        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
-             patch("tools.transcription_tools._get_provider", return_value="openai"), \
-             patch("tools.transcription_tools._transcribe_openai",
-                   return_value={"success": True, "transcript": "hi"}) as mock_openai:
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value=config),
+            patch("tools.transcription_tools._get_provider", return_value="openai"),
+            patch(
+                "tools.transcription_tools._transcribe_openai",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_openai,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             transcribe_audio(sample_ogg, model=None)
 
         assert mock_openai.call_args[0][1] == "gpt-4o-transcribe"
+
+
+# ============================================================================
+# get_stt_model_from_config
+# ============================================================================
+
+
+class TestGetSttModelFromConfig:
+    def test_returns_model_from_config(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("stt:\n  model: whisper-large-v3\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+
+        assert get_stt_model_from_config() == "whisper-large-v3"
+
+    def test_returns_none_when_no_stt_section(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("tts:\n  provider: edge\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+
+        assert get_stt_model_from_config() is None
+
+    def test_returns_none_when_no_config_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+
+        assert get_stt_model_from_config() is None
+
+    def test_returns_none_on_invalid_yaml(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(": : :\n  bad yaml [[[")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+
+        assert get_stt_model_from_config() is None
+
+    def test_returns_none_when_model_key_missing(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("stt:\n  enabled: true\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+
+        assert get_stt_model_from_config() is None
 
 
 # ============================================================================
@@ -831,7 +1093,9 @@ def mock_mistral_module():
     mock_mistral_cls = MagicMock(return_value=mock_client)
     fake_module = MagicMock()
     fake_module.Mistral = mock_mistral_cls
-    with patch.dict("sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}):
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ):
         yield mock_client
 
 
@@ -839,11 +1103,14 @@ class TestTranscribeMistral:
     def test_no_key(self, monkeypatch):
         monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
         from tools.transcription_tools import _transcribe_mistral
+
         result = _transcribe_mistral("/tmp/test.ogg", "voxtral-mini-latest")
         assert result["success"] is False
         assert "MISTRAL_API_KEY" in result["error"]
 
-    def test_successful_transcription(self, monkeypatch, sample_ogg, mock_mistral_module):
+    def test_successful_transcription(
+        self, monkeypatch, sample_ogg, mock_mistral_module
+    ):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
 
         mock_result = MagicMock()
@@ -851,6 +1118,7 @@ class TestTranscribeMistral:
         mock_mistral_module.audio.transcriptions.complete.return_value = mock_result
 
         from tools.transcription_tools import _transcribe_mistral
+
         result = _transcribe_mistral(sample_ogg, "voxtral-mini-latest")
 
         assert result["success"] is True
@@ -859,11 +1127,16 @@ class TestTranscribeMistral:
         mock_mistral_module.audio.transcriptions.complete.assert_called_once()
         mock_mistral_module.__exit__.assert_called_once()
 
-    def test_api_error_returns_failure(self, monkeypatch, sample_ogg, mock_mistral_module):
+    def test_api_error_returns_failure(
+        self, monkeypatch, sample_ogg, mock_mistral_module
+    ):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
-        mock_mistral_module.audio.transcriptions.complete.side_effect = RuntimeError("secret-key-leaked")
+        mock_mistral_module.audio.transcriptions.complete.side_effect = RuntimeError(
+            "secret-key-leaked"
+        )
 
         from tools.transcription_tools import _transcribe_mistral
+
         result = _transcribe_mistral(sample_ogg, "voxtral-mini-latest")
 
         assert result["success"] is False
@@ -872,9 +1145,12 @@ class TestTranscribeMistral:
 
     def test_permission_error(self, monkeypatch, sample_ogg, mock_mistral_module):
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
-        mock_mistral_module.audio.transcriptions.complete.side_effect = PermissionError("denied")
+        mock_mistral_module.audio.transcriptions.complete.side_effect = PermissionError(
+            "denied"
+        )
 
         from tools.transcription_tools import _transcribe_mistral
+
         result = _transcribe_mistral(sample_ogg, "voxtral-mini-latest")
 
         assert result["success"] is False
@@ -885,6 +1161,7 @@ class TestTranscribeMistral:
 # _get_provider — Mistral
 # ============================================================================
 
+
 class TestGetProviderMistral:
     """Mistral-specific provider selection tests."""
 
@@ -892,6 +1169,7 @@ class TestGetProviderMistral:
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
         with patch("tools.transcription_tools._HAS_MISTRAL", True):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({"provider": "mistral"}) == "mistral"
 
     def test_mistral_explicit_no_key_returns_none(self, monkeypatch):
@@ -899,6 +1177,7 @@ class TestGetProviderMistral:
         monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_MISTRAL", True):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({"provider": "mistral"}) == "none"
 
     def test_mistral_explicit_no_sdk_returns_none(self, monkeypatch):
@@ -906,6 +1185,7 @@ class TestGetProviderMistral:
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
         with patch("tools.transcription_tools._HAS_MISTRAL", False):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({"provider": "mistral"}) == "none"
 
     def test_auto_detect_mistral_after_openai(self, monkeypatch):
@@ -914,11 +1194,14 @@ class TestGetProviderMistral:
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", False), \
-             patch("tools.transcription_tools._HAS_MISTRAL", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", False),
+            patch("tools.transcription_tools._HAS_MISTRAL", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({}) == "mistral"
 
     def test_auto_detect_openai_preferred_over_mistral(self, monkeypatch):
@@ -926,22 +1209,28 @@ class TestGetProviderMistral:
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("tools.transcription_tools._HAS_MISTRAL", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("tools.transcription_tools._HAS_MISTRAL", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({}) == "openai"
 
     def test_auto_detect_groq_preferred_over_mistral(self, monkeypatch):
         """Auto-detect: groq (free) is preferred over mistral (paid)."""
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("tools.transcription_tools._HAS_MISTRAL", True):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", True),
+            patch("tools.transcription_tools._HAS_MISTRAL", True),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({}) == "groq"
 
     def test_auto_detect_skips_mistral_without_sdk(self, monkeypatch):
@@ -950,11 +1239,14 @@ class TestGetProviderMistral:
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._has_local_command", return_value=False), \
-             patch("tools.transcription_tools._HAS_OPENAI", False), \
-             patch("tools.transcription_tools._HAS_MISTRAL", False):
+        with (
+            patch("tools.transcription_tools._HAS_FASTER_WHISPER", False),
+            patch("tools.transcription_tools._has_local_command", return_value=False),
+            patch("tools.transcription_tools._HAS_OPENAI", False),
+            patch("tools.transcription_tools._HAS_MISTRAL", False),
+        ):
             from tools.transcription_tools import _get_provider
+
             assert _get_provider({}) == "none"
 
 
@@ -962,13 +1254,26 @@ class TestGetProviderMistral:
 # transcribe_audio — Mistral dispatch
 # ============================================================================
 
+
 class TestTranscribeAudioMistralDispatch:
     def test_dispatches_to_mistral(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "mistral"}), \
-             patch("tools.transcription_tools._get_provider", return_value="mistral"), \
-             patch("tools.transcription_tools._transcribe_mistral",
-                   return_value={"success": True, "transcript": "hi", "provider": "mistral"}) as mock_mistral:
+        with (
+            patch(
+                "tools.transcription_tools._load_stt_config",
+                return_value={"provider": "mistral"},
+            ),
+            patch("tools.transcription_tools._get_provider", return_value="mistral"),
+            patch(
+                "tools.transcription_tools._transcribe_mistral",
+                return_value={
+                    "success": True,
+                    "transcript": "hi",
+                    "provider": "mistral",
+                },
+            ) as mock_mistral,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             result = transcribe_audio(sample_ogg)
 
         assert result["success"] is True
@@ -977,21 +1282,206 @@ class TestTranscribeAudioMistralDispatch:
 
     def test_config_mistral_model_used(self, sample_ogg):
         config = {"provider": "mistral", "mistral": {"model": "voxtral-mini-2602"}}
-        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
-             patch("tools.transcription_tools._get_provider", return_value="mistral"), \
-             patch("tools.transcription_tools._transcribe_mistral",
-                   return_value={"success": True, "transcript": "hi"}) as mock_mistral:
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value=config),
+            patch("tools.transcription_tools._get_provider", return_value="mistral"),
+            patch(
+                "tools.transcription_tools._transcribe_mistral",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_mistral,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             transcribe_audio(sample_ogg, model=None)
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
 
     def test_model_override_passed_to_mistral(self, sample_ogg):
-        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
-             patch("tools.transcription_tools._get_provider", return_value="mistral"), \
-             patch("tools.transcription_tools._transcribe_mistral",
-                   return_value={"success": True, "transcript": "hi"}) as mock_mistral:
+        with (
+            patch("tools.transcription_tools._load_stt_config", return_value={}),
+            patch("tools.transcription_tools._get_provider", return_value="mistral"),
+            patch(
+                "tools.transcription_tools._transcribe_mistral",
+                return_value={"success": True, "transcript": "hi"},
+            ) as mock_mistral,
+        ):
             from tools.transcription_tools import transcribe_audio
+
             transcribe_audio(sample_ogg, model="voxtral-mini-2602")
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
+
+
+# ============================================================================
+# whisper_cpp provider (voxtype / whisper-cli)
+# ============================================================================
+
+
+class TestWhisperCppProvider:
+    """Tests for the whisper_cpp backend that reuses on-disk GGML models."""
+
+    def test_flavour_detection_voxtype(self):
+        from tools.transcription_tools import _whisper_cpp_flavour
+
+        assert _whisper_cpp_flavour("/home/x/.local/bin/voxtype") == "voxtype"
+
+    def test_flavour_detection_whisper_cli(self):
+        from tools.transcription_tools import _whisper_cpp_flavour
+
+        assert _whisper_cpp_flavour("/usr/bin/whisper-cli") == "whisper_cli"
+        assert _whisper_cpp_flavour("/opt/whisper.cpp/main") == "whisper_cli"
+
+    def test_parse_voxtype_output_prefers_full_transcript_over_log_preview(self):
+        """The log line has a truncated preview; the real transcript follows."""
+        from tools.transcription_tools import _parse_voxtype_output
+
+        stdout = (
+            'Loading audio file: "/tmp/x.wav"\n'
+            "Audio format: 16000 Hz, 1 channel(s), Int\n"
+            "2026-04-05T17:00:45Z  INFO Transcription completed in 0.57s: "
+            '"I want you to reply back to me each time I get a m..."\n'
+            "\n"
+            "I want you to reply back to me each time I get a message with "
+            "what you hear me say. Full sentence here.\n"
+        )
+        result = _parse_voxtype_output(stdout)
+        assert result.startswith(
+            "I want you to reply back to me each time I get a message"
+        )
+        assert result.endswith("Full sentence here.")
+        assert "..." not in result  # the log-preview truncation is gone
+
+    def test_parse_voxtype_output_strips_ansi_escapes(self):
+        from tools.transcription_tools import _parse_voxtype_output
+
+        stdout = (
+            "\x1b[2m2026-04-05T17:14:00Z\x1b[0m \x1b[32m INFO\x1b[0m "
+            "Model loaded in 0.80s\n"
+            "\n"
+            "Hello world.\n"
+        )
+        assert _parse_voxtype_output(stdout) == "Hello world."
+
+    def test_parse_voxtype_output_falls_back_to_log_line(self):
+        """If no bare transcript line exists, fall back to the log preview."""
+        from tools.transcription_tools import _parse_voxtype_output
+
+        stdout = '2026-04-05T17:00:45Z  INFO Transcription completed in 0.57s: "Just this."\n'
+        assert _parse_voxtype_output(stdout) == "Just this."
+
+    def test_parse_voxtype_output_empty_returns_empty(self):
+        from tools.transcription_tools import _parse_voxtype_output
+
+        assert _parse_voxtype_output("") == ""
+
+    def test_explicit_whisper_cpp_provider_selected_when_binary_available(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_whisper_cpp_binary",
+            lambda preferred=None: "/home/x/.local/bin/voxtype",
+        )
+        from tools.transcription_tools import _get_provider
+
+        assert _get_provider({"provider": "whisper_cpp"}) == "whisper_cpp"
+
+    def test_explicit_whisper_cpp_no_binary_returns_none(self):
+        # autouse fixture already stubs _find_whisper_cpp_binary to return None
+        from tools.transcription_tools import _get_provider
+
+        assert _get_provider({"provider": "whisper_cpp"}) == "none"
+
+    def test_local_falls_back_to_whisper_cpp_when_faster_whisper_missing(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_whisper_cpp_binary",
+            lambda preferred=None: "/home/x/.local/bin/voxtype",
+        )
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False):
+            from tools.transcription_tools import _get_provider
+
+            assert _get_provider({"provider": "local"}) == "whisper_cpp"
+
+    def test_whisper_cli_flavour_requires_model_path(self, monkeypatch, tmp_path):
+        """whisper-cli flavour is unusable without a valid model_path."""
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_whisper_cpp_binary",
+            lambda preferred=None: "/usr/bin/whisper-cli",
+        )
+        from tools.transcription_tools import _has_whisper_cpp
+
+        # No model_path -> not usable
+        assert _has_whisper_cpp({"whisper_cpp": {}}) is False
+        # Nonexistent model_path -> not usable
+        assert _has_whisper_cpp({"whisper_cpp": {"model_path": "/nope.bin"}}) is False
+        # Real file -> usable
+        ggml = tmp_path / "ggml-large.bin"
+        ggml.write_bytes(b"fake")
+        assert _has_whisper_cpp({"whisper_cpp": {"model_path": str(ggml)}}) is True
+
+    def test_voxtype_flavour_does_not_require_model_path(self, monkeypatch):
+        """voxtype manages its own model, so model_path is not required."""
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_whisper_cpp_binary",
+            lambda preferred=None: "/home/x/.local/bin/voxtype",
+        )
+        from tools.transcription_tools import _has_whisper_cpp
+
+        assert _has_whisper_cpp({"whisper_cpp": {}}) is True
+
+    def test_build_argv_voxtype(self):
+        from tools.transcription_tools import _build_whisper_cpp_argv
+
+        argv = _build_whisper_cpp_argv(
+            "voxtype",
+            "/home/x/.local/bin/voxtype",
+            "/tmp/a.wav",
+            {"engine": "whisper"},
+        )
+        assert argv == [
+            "/home/x/.local/bin/voxtype",
+            "transcribe",
+            "--engine",
+            "whisper",
+            "/tmp/a.wav",
+        ]
+
+    def test_build_argv_whisper_cli_with_language(self):
+        from tools.transcription_tools import _build_whisper_cpp_argv
+
+        argv = _build_whisper_cpp_argv(
+            "whisper_cli",
+            "/usr/bin/whisper-cli",
+            "/tmp/a.wav",
+            {"model_path": "/models/ggml-large.bin", "language": "en"},
+        )
+        assert argv[0] == "/usr/bin/whisper-cli"
+        assert "-m" in argv and "/models/ggml-large.bin" in argv
+        assert "-f" in argv and "/tmp/a.wav" in argv
+        assert "-nt" in argv and "-np" in argv
+        assert "-l" in argv and "en" in argv
+
+    def test_build_argv_whisper_cli_language_auto_omits_flag(self):
+        from tools.transcription_tools import _build_whisper_cpp_argv
+
+        argv = _build_whisper_cpp_argv(
+            "whisper_cli",
+            "/usr/bin/whisper-cli",
+            "/tmp/a.wav",
+            {"model_path": "/models/ggml-large.bin", "language": "auto"},
+        )
+        assert "-l" not in argv
+
+    def test_is_voxtype_log_line_detects_ansi_timestamp(self):
+        from tools.transcription_tools import _is_voxtype_log_line
+
+        assert (
+            _is_voxtype_log_line(
+                "\x1b[2m2026-04-05T17:14:00.105212Z\x1b[0m \x1b[32m INFO\x1b[0m Model loaded"
+            )
+            is True
+        )
+        assert _is_voxtype_log_line("This is the actual transcript.") is False
+        assert _is_voxtype_log_line("whisper_model_load: loading model") is True
+        assert _is_voxtype_log_line("") is True  # blank

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,10 +2,14 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with three providers:
+Provides speech-to-text transcription with four providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
+  - **whisper_cpp** (free, reuses existing GGML weights) — shells out to a
+    whisper.cpp-based binary (``voxtype`` or plain ``whisper-cli``). Lets you
+    reuse a ``ggml-*.bin`` model you already have on disk, with GPU acceleration
+    via Vulkan/CUDA/Metal when the binary supports it.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
 
@@ -25,17 +29,23 @@ Usage::
 
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from urllib.parse import urljoin
 
 from utils import is_truthy_value
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
-from tools.tool_backend_helpers import managed_nous_tools_enabled, resolve_openai_audio_api_key
+from tools.tool_backend_helpers import (
+    managed_nous_tools_enabled,
+    resolve_openai_audio_api_key,
+)
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -69,18 +79,44 @@ DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
-COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
+COMMON_LOCAL_BIN_DIRS = (
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    str(Path.home() / ".local" / "bin"),
+)
+
+# whisper.cpp backend binary candidates, in priority order. First match wins
+# during auto-detection. ``voxtype`` is a GPU-accelerated whisper.cpp wrapper
+# that ships its own GGML model; ``whisper-cli`` / ``whisper-cpp`` are the
+# stock whisper.cpp CLIs that require ``-m model_path``.
+WHISPER_CPP_BINARY_CANDIDATES = ("voxtype", "whisper-cli", "whisper-cpp")
+WHISPER_CPP_TARGET_SAMPLE_RATE = 16000  # whisper.cpp requires 16 kHz mono PCM
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
+SUPPORTED_FORMATS = {
+    ".mp3",
+    ".mp4",
+    ".mpeg",
+    ".mpga",
+    ".m4a",
+    ".wav",
+    ".webm",
+    ".ogg",
+    ".aac",
+    ".flac",
+}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 
 # Known model sets for auto-correction
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
-GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
+GROQ_MODELS = {
+    "whisper-large-v3",
+    "whisper-large-v3-turbo",
+    "distil-whisper-large-v3-en",
+}
 
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
@@ -91,11 +127,26 @@ _local_model_name: Optional[str] = None
 # ---------------------------------------------------------------------------
 
 
+def get_stt_model_from_config() -> Optional[str]:
+    """Read the STT model name from ~/.hermes/config.yaml.
+
+    Returns the value of ``stt.model`` if present, otherwise ``None``.
+    Silently returns ``None`` on any error (missing file, bad YAML, etc.).
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        return read_raw_config().get("stt", {}).get("model")
+    except Exception:
+        pass
+    return None
+
 
 def _load_stt_config() -> dict:
     """Load the ``stt`` section from user config, falling back to defaults."""
     try:
         from hermes_cli.config import load_config
+
         return load_config().get("stt", {})
     except Exception:
         return {}
@@ -154,29 +205,10 @@ def _has_local_command() -> bool:
     return _get_local_command_template() is not None
 
 
-def _normalize_local_model(model_name: Optional[str]) -> str:
-    """Return a valid faster-whisper model size, mapping cloud-only names to the default.
-
-    Cloud providers like OpenAI use names such as ``whisper-1`` which are not
-    valid for faster-whisper (which expects ``tiny``, ``base``, ``small``,
-    ``medium``, or ``large-v*``).  When such a name is detected we fall back to
-    the default local model and emit a warning so the user knows what happened.
-    """
+def _normalize_local_command_model(model_name: Optional[str]) -> str:
     if not model_name or model_name in OPENAI_MODELS or model_name in GROQ_MODELS:
-        if model_name and (model_name in OPENAI_MODELS or model_name in GROQ_MODELS):
-            logger.warning(
-                "STT model '%s' is a cloud-only name and cannot be used with the local "
-                "provider. Falling back to '%s'. Set stt.local.model to a valid "
-                "faster-whisper size (tiny, base, small, medium, large-v3).",
-                model_name,
-                DEFAULT_LOCAL_MODEL,
-            )
         return DEFAULT_LOCAL_MODEL
     return model_name
-
-
-def _normalize_local_command_model(model_name: Optional[str]) -> str:
-    return _normalize_local_model(model_name)
 
 
 def _get_provider(stt_config: dict) -> str:
@@ -198,11 +230,23 @@ def _get_provider(stt_config: dict) -> str:
         if provider == "local":
             if _HAS_FASTER_WHISPER:
                 return "local"
+            if _has_whisper_cpp(stt_config):
+                logger.info("faster-whisper unavailable, falling back to whisper_cpp")
+                return "whisper_cpp"
             if _has_local_command():
                 return "local_command"
             logger.warning(
                 "STT provider 'local' configured but unavailable "
                 "(install faster-whisper or set HERMES_LOCAL_STT_COMMAND)"
+            )
+            return "none"
+
+        if provider == "whisper_cpp":
+            if _has_whisper_cpp(stt_config):
+                return "whisper_cpp"
+            logger.warning(
+                "STT provider 'whisper_cpp' configured but no compatible binary "
+                "(voxtype/whisper-cli) was found or model_path is invalid"
             )
             return "none"
 
@@ -212,25 +256,19 @@ def _get_provider(stt_config: dict) -> str:
             if _HAS_FASTER_WHISPER:
                 logger.info("Local STT command unavailable, using local faster-whisper")
                 return "local"
-            logger.warning(
-                "STT provider 'local_command' configured but unavailable"
-            )
+            logger.warning("STT provider 'local_command' configured but unavailable")
             return "none"
 
         if provider == "groq":
             if _HAS_OPENAI and os.getenv("GROQ_API_KEY"):
                 return "groq"
-            logger.warning(
-                "STT provider 'groq' configured but GROQ_API_KEY not set"
-            )
+            logger.warning("STT provider 'groq' configured but GROQ_API_KEY not set")
             return "none"
 
         if provider == "openai":
             if _HAS_OPENAI and _has_openai_audio_backend():
                 return "openai"
-            logger.warning(
-                "STT provider 'openai' configured but no API key available"
-            )
+            logger.warning("STT provider 'openai' configured but no API key available")
             return "none"
 
         if provider == "mistral":
@@ -244,10 +282,12 @@ def _get_provider(stt_config: dict) -> str:
 
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral -
+    # --- Auto-detect (no explicit provider): local > whisper_cpp > groq > openai > mistral
 
     if _HAS_FASTER_WHISPER:
         return "local"
+    if _has_whisper_cpp(stt_config):
+        return "whisper_cpp"
     if _has_local_command():
         return "local_command"
     if _HAS_OPENAI and os.getenv("GROQ_API_KEY"):
@@ -261,6 +301,7 @@ def _get_provider(stt_config: dict) -> str:
         return "mistral"
     return "none"
 
+
 # ---------------------------------------------------------------------------
 # Shared validation
 # ---------------------------------------------------------------------------
@@ -271,9 +312,17 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
     audio_path = Path(file_path)
 
     if not audio_path.exists():
-        return {"success": False, "transcript": "", "error": f"Audio file not found: {file_path}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Audio file not found: {file_path}",
+        }
     if not audio_path.is_file():
-        return {"success": False, "transcript": "", "error": f"Path is not a file: {file_path}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Path is not a file: {file_path}",
+        }
     if audio_path.suffix.lower() not in SUPPORTED_FORMATS:
         return {
             "success": False,
@@ -286,12 +335,17 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
             return {
                 "success": False,
                 "transcript": "",
-                "error": f"File too large: {file_size / (1024*1024):.1f}MB (max {MAX_FILE_SIZE / (1024*1024):.0f}MB)",
+                "error": f"File too large: {file_size / (1024 * 1024):.1f}MB (max {MAX_FILE_SIZE / (1024 * 1024):.0f}MB)",
             }
     except OSError as e:
-        return {"success": False, "transcript": "", "error": f"Failed to access file: {e}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Failed to access file: {e}",
+        }
 
     return None
+
 
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
@@ -303,13 +357,21 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
     global _local_model, _local_model_name
 
     if not _HAS_FASTER_WHISPER:
-        return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "faster-whisper not installed",
+        }
 
     try:
         from faster_whisper import WhisperModel
+
         # Lazy-load the model (downloads on first use, ~150 MB for 'base')
         if _local_model is None or _local_model_name != model_name:
-            logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
+            logger.info(
+                "Loading faster-whisper model '%s' (first load downloads the model)...",
+                model_name,
+            )
             _local_model = WhisperModel(model_name, device="auto", compute_type="auto")
             _local_model_name = model_name
 
@@ -328,17 +390,26 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
 
         logger.info(
             "Transcribed %s via local whisper (%s, lang=%s, %.1fs audio)",
-            Path(file_path).name, model_name, info.language, info.duration,
+            Path(file_path).name,
+            model_name,
+            info.language,
+            info.duration,
         )
 
         return {"success": True, "transcript": transcript, "provider": "local"}
 
     except Exception as e:
         logger.error("Local transcription failed: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Local transcription failed: {e}",
+        }
 
 
-def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:
+def _prepare_local_audio(
+    file_path: str, work_dir: str
+) -> tuple[Optional[str], Optional[str]]:
     """Normalize audio for local CLI STT when needed."""
     audio_path = Path(file_path)
     if audio_path.suffix.lower() in LOCAL_NATIVE_AUDIO_FORMATS:
@@ -346,7 +417,10 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
 
     ffmpeg = _find_ffmpeg_binary()
     if not ffmpeg:
-        return None, "Local STT fallback requires ffmpeg for non-WAV inputs, but ffmpeg was not found"
+        return (
+            None,
+            "Local STT fallback requires ffmpeg for non-WAV inputs, but ffmpeg was not found",
+        )
 
     converted_path = os.path.join(work_dir, f"{audio_path.stem}.wav")
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
@@ -392,7 +466,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 language=shlex.quote(language),
                 model=shlex.quote(normalized_model),
             )
-            subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+            subprocess.run(
+                command, shell=True, check=True, capture_output=True, text=True
+            )
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
             if not txt_files:
@@ -409,7 +485,11 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 normalized_model,
                 len(transcript_text),
             )
-            return {"success": True, "transcript": transcript_text, "provider": "local_command"}
+            return {
+                "success": True,
+                "transcript": transcript_text,
+                "provider": "local_command",
+            }
 
     except KeyError as e:
         return {
@@ -420,10 +500,312 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
         logger.error("Local STT command failed for %s: %s", file_path, details)
-        return {"success": False, "transcript": "", "error": f"Local STT failed: {details}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Local STT failed: {details}",
+        }
     except Exception as e:
-        logger.error("Unexpected error during local command transcription: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
+        logger.error(
+            "Unexpected error during local command transcription: %s", e, exc_info=True
+        )
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Local transcription failed: {e}",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Provider: whisper_cpp (GGML model via voxtype / whisper-cli / whisper-cpp)
+# ---------------------------------------------------------------------------
+#
+# This provider reuses an existing ``ggml-*.bin`` whisper.cpp model already on
+# disk (e.g. the one voxtype maintains). It shells out to a whisper.cpp-based
+# binary, which handles GPU acceleration (Vulkan / CUDA / Metal). No Python
+# model is loaded, and no model is re-downloaded — the weights live exactly
+# where the existing tool put them.
+#
+# Two binary "flavours" are supported via adapters:
+#
+#   * voxtype      — self-configuring wrapper; manages its own model/config.
+#                    Transcript is embedded in stdout log lines as
+#                    ``Transcription completed in X.XXs: "…"``.
+#   * whisper-cli  — stock whisper.cpp CLI; requires ``-m <model_path>`` and
+#                    prints the transcript to stdout when invoked with ``-nt``.
+#
+# Auto-detection picks the first available candidate. Config can override:
+#
+#   stt:
+#     provider: whisper_cpp
+#     whisper_cpp:
+#       binary: voxtype              # path or name; optional
+#       engine: whisper              # voxtype --engine flag; optional
+#       model_path: /path/ggml.bin   # required for whisper-cli flavour
+#       language: auto               # BCP-47 or "auto"; optional
+
+
+def _find_whisper_cpp_binary(preferred: Optional[str] = None) -> Optional[str]:
+    """Locate a whisper.cpp-compatible binary.
+
+    If ``preferred`` is given, it is tried first (as an absolute path or a
+    name on PATH). Otherwise the known candidates are tried in priority order.
+    """
+    if preferred:
+        preferred = preferred.strip()
+        if preferred:
+            # Absolute or relative path
+            if os.sep in preferred or preferred.startswith("~"):
+                expanded = os.path.expanduser(preferred)
+                if os.path.isfile(expanded) and os.access(expanded, os.X_OK):
+                    return expanded
+                return None
+            # Bare name — resolve via PATH / common dirs
+            found = _find_binary(preferred)
+            if found:
+                return found
+            return None
+
+    for candidate in WHISPER_CPP_BINARY_CANDIDATES:
+        found = _find_binary(candidate)
+        if found:
+            return found
+    return None
+
+
+def _whisper_cpp_flavour(binary_path: str) -> str:
+    """Classify the binary so we know which CLI conventions to use."""
+    name = Path(binary_path).name.lower()
+    if "voxtype" in name:
+        return "voxtype"
+    # whisper-cli, whisper-cpp, main (whisper.cpp upstream default name)
+    return "whisper_cli"
+
+
+def _has_whisper_cpp(stt_config: Optional[dict] = None) -> bool:
+    cfg = (stt_config or {}).get("whisper_cpp", {}) if stt_config else {}
+    binary = _find_whisper_cpp_binary(cfg.get("binary"))
+    if not binary:
+        return False
+    flavour = _whisper_cpp_flavour(binary)
+    # whisper-cli requires an explicit model path to be useful
+    if flavour == "whisper_cli":
+        model_path = cfg.get("model_path")
+        if not model_path or not Path(os.path.expanduser(model_path)).is_file():
+            return False
+    return True
+
+
+def _prepare_whisper_cpp_audio(
+    file_path: str, work_dir: str
+) -> tuple[Optional[str], Optional[str]]:
+    """Convert audio to 16 kHz mono PCM WAV (whisper.cpp's required format)."""
+    ffmpeg = _find_ffmpeg_binary()
+    if not ffmpeg:
+        return (
+            None,
+            "whisper_cpp backend requires ffmpeg to resample audio to 16 kHz mono WAV",
+        )
+
+    converted_path = os.path.join(work_dir, f"{Path(file_path).stem}.16k.wav")
+    command = [
+        ffmpeg,
+        "-y",
+        "-i",
+        file_path,
+        "-ac",
+        "1",
+        "-ar",
+        str(WHISPER_CPP_TARGET_SAMPLE_RATE),
+        "-c:a",
+        "pcm_s16le",
+        converted_path,
+    ]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        return converted_path, None
+    except subprocess.CalledProcessError as e:
+        details = e.stderr.strip() or e.stdout.strip() or str(e)
+        logger.error("ffmpeg resample failed for %s: %s", file_path, details)
+        return None, f"Failed to prepare audio for whisper_cpp: {details}"
+
+
+def _build_whisper_cpp_argv(
+    flavour: str,
+    binary_path: str,
+    wav_path: str,
+    whisper_cpp_cfg: dict,
+) -> List[str]:
+    """Build the argv list for the chosen whisper.cpp flavour."""
+    if flavour == "voxtype":
+        engine = whisper_cpp_cfg.get("engine", "whisper")
+        argv = [binary_path, "transcribe", "--engine", engine, wav_path]
+        return argv
+
+    # whisper_cli flavour — stock whisper.cpp CLI
+    model_path = os.path.expanduser(whisper_cpp_cfg["model_path"])
+    argv = [
+        binary_path,
+        "-m",
+        model_path,
+        "-f",
+        wav_path,
+        "-nt",  # no timestamps in output
+        "-np",  # no extra prints
+    ]
+    language = whisper_cpp_cfg.get("language")
+    if language and language != "auto":
+        argv.extend(["-l", language])
+    return argv
+
+
+# Regex for extracting the transcript from voxtype's log line:
+#   INFO Transcription completed in 4.14s: "Hello world."
+_VOXTYPE_TRANSCRIPT_RE = re.compile(
+    r'Transcription completed in [0-9.]+s:\s*"(?P<text>.*)"\s*$'
+)
+
+
+# ANSI escape sequence stripper — voxtype colorizes logs on stdout.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def _is_voxtype_log_line(line: str) -> bool:
+    """Detect voxtype/whisper.cpp log output (vs. the actual transcript)."""
+    stripped = _strip_ansi(line).strip()
+    if not stripped:
+        return True  # blank lines aren't content
+    log_prefixes = (
+        "whisper_",
+        "ggml_",
+        "Loading ",
+        "Audio ",
+        "Processing ",
+        "main:",
+        "system_info:",
+    )
+    if any(stripped.startswith(p) for p in log_prefixes):
+        return True
+    # tracing-style timestamped log lines: 2026-04-05T17:13:22.573238Z  INFO …
+    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", stripped):
+        return True
+    if " INFO " in stripped or " WARN " in stripped or " ERROR " in stripped:
+        return True
+    return False
+
+
+def _parse_voxtype_output(stdout: str) -> str:
+    """Extract the transcript from voxtype's mixed log+text stdout.
+
+    Voxtype emits two representations of the transcript:
+
+      1. A log line like ``INFO Transcription completed in 0.56s: "…"`` where
+         the quoted text is TRUNCATED (~60 chars) for display readability.
+      2. The full, untruncated transcript as one or more bare stdout lines
+         printed AFTER all log output.
+
+    We collect all non-log lines (representation 2) and join them. The
+    log-embedded preview (representation 1) is only used as a last-resort
+    fallback if no bare transcript lines are present.
+    """
+    lines = stdout.splitlines()
+
+    # 1. Preferred: gather all non-log content lines (the real transcript)
+    content_lines = [
+        _strip_ansi(line).strip() for line in lines if not _is_voxtype_log_line(line)
+    ]
+    content_lines = [ln for ln in content_lines if ln]
+    if content_lines:
+        return " ".join(content_lines).strip()
+
+    # 2. Fallback: extract from the log line (may be truncated)
+    for line in reversed(lines):
+        match = _VOXTYPE_TRANSCRIPT_RE.search(line)
+        if match:
+            return match.group("text").strip()
+    return ""
+
+
+def _transcribe_whisper_cpp(file_path: str, stt_config: dict) -> Dict[str, Any]:
+    """Transcribe via a whisper.cpp-based binary, reusing an on-disk GGML model."""
+    whisper_cpp_cfg = stt_config.get("whisper_cpp", {}) or {}
+    binary = _find_whisper_cpp_binary(whisper_cpp_cfg.get("binary"))
+    if not binary:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                "whisper_cpp provider configured but no compatible binary found. "
+                f"Tried: {', '.join(WHISPER_CPP_BINARY_CANDIDATES)}. "
+                "Install voxtype or whisper.cpp, or set stt.whisper_cpp.binary."
+            ),
+        }
+
+    flavour = _whisper_cpp_flavour(binary)
+    if flavour == "whisper_cli":
+        model_path = whisper_cpp_cfg.get("model_path")
+        if not model_path or not Path(os.path.expanduser(model_path)).is_file():
+            return {
+                "success": False,
+                "transcript": "",
+                "error": (
+                    f"whisper_cpp binary '{binary}' requires stt.whisper_cpp.model_path "
+                    "to point at a valid ggml-*.bin file"
+                ),
+            }
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermes-whispercpp-") as work_dir:
+            wav_path, prep_error = _prepare_whisper_cpp_audio(file_path, work_dir)
+            if prep_error:
+                return {"success": False, "transcript": "", "error": prep_error}
+
+            argv = _build_whisper_cpp_argv(flavour, binary, wav_path, whisper_cpp_cfg)
+            logger.info(
+                "Running whisper_cpp (%s) on %s: %s",
+                flavour,
+                Path(file_path).name,
+                " ".join(shlex.quote(a) for a in argv),
+            )
+            result = subprocess.run(argv, check=True, capture_output=True, text=True)
+
+            if flavour == "voxtype":
+                transcript_text = _parse_voxtype_output(result.stdout)
+            else:
+                # whisper-cli with -nt -np prints just the transcript on stdout
+                transcript_text = result.stdout.strip()
+
+            logger.info(
+                "Transcribed %s via whisper_cpp (%s, %d chars)",
+                Path(file_path).name,
+                flavour,
+                len(transcript_text),
+            )
+            return {
+                "success": True,
+                "transcript": transcript_text,
+                "provider": "whisper_cpp",
+                "flavour": flavour,
+            }
+
+    except subprocess.CalledProcessError as e:
+        details = (e.stderr or "").strip() or (e.stdout or "").strip() or str(e)
+        logger.error("whisper_cpp command failed for %s: %s", file_path, details)
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"whisper_cpp failed: {details}",
+        }
+    except Exception as e:
+        logger.error(
+            "Unexpected error during whisper_cpp transcription: %s", e, exc_info=True
+        )
+        return {"success": False, "transcript": "", "error": f"whisper_cpp error: {e}"}
+
 
 # ---------------------------------------------------------------------------
 # Provider: groq (Whisper API — free tier)
@@ -437,16 +819,27 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": "GROQ_API_KEY not set"}
 
     if not _HAS_OPENAI:
-        return {"success": False, "transcript": "", "error": "openai package not installed"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "openai package not installed",
+        }
 
     # Auto-correct model if caller passed an OpenAI-only model
     if model_name in OPENAI_MODELS:
-        logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
+        logger.info(
+            "Model %s not available on Groq, using %s",
+            model_name,
+            DEFAULT_GROQ_STT_MODEL,
+        )
         model_name = DEFAULT_GROQ_STT_MODEL
 
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
-        client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
+
+        client = OpenAI(
+            api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0
+        )
         try:
             with open(file_path, "rb") as audio_file:
                 transcription = client.audio.transcriptions.create(
@@ -456,8 +849,12 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
                 )
 
             transcript_text = str(transcription).strip()
-            logger.info("Transcribed %s via Groq API (%s, %d chars)",
-                         Path(file_path).name, model_name, len(transcript_text))
+            logger.info(
+                "Transcribed %s via Groq API (%s, %d chars)",
+                Path(file_path).name,
+                model_name,
+                len(transcript_text),
+            )
 
             return {"success": True, "transcript": transcript_text, "provider": "groq"}
         finally:
@@ -466,7 +863,11 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
                 close()
 
     except PermissionError:
-        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Permission denied: {file_path}",
+        }
     except APIConnectionError as e:
         return {"success": False, "transcript": "", "error": f"Connection error: {e}"}
     except APITimeoutError as e:
@@ -475,7 +876,12 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"API error: {e}"}
     except Exception as e:
         logger.error("Groq transcription failed: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Transcription failed: {e}",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Provider: openai (Whisper API)
@@ -494,15 +900,22 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
         }
 
     if not _HAS_OPENAI:
-        return {"success": False, "transcript": "", "error": "openai package not installed"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "openai package not installed",
+        }
 
     # Auto-correct model if caller passed a Groq-only model
     if model_name in GROQ_MODELS:
-        logger.info("Model %s not available on OpenAI, using %s", model_name, DEFAULT_STT_MODEL)
+        logger.info(
+            "Model %s not available on OpenAI, using %s", model_name, DEFAULT_STT_MODEL
+        )
         model_name = DEFAULT_STT_MODEL
 
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
+
         client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
         try:
             with open(file_path, "rb") as audio_file:
@@ -513,17 +926,29 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
                 )
 
             transcript_text = _extract_transcript_text(transcription)
-            logger.info("Transcribed %s via OpenAI API (%s, %d chars)",
-                         Path(file_path).name, model_name, len(transcript_text))
+            logger.info(
+                "Transcribed %s via OpenAI API (%s, %d chars)",
+                Path(file_path).name,
+                model_name,
+                len(transcript_text),
+            )
 
-            return {"success": True, "transcript": transcript_text, "provider": "openai"}
+            return {
+                "success": True,
+                "transcript": transcript_text,
+                "provider": "openai",
+            }
         finally:
             close = getattr(client, "close", None)
             if callable(close):
                 close()
 
     except PermissionError:
-        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Permission denied: {file_path}",
+        }
     except APIConnectionError as e:
         return {"success": False, "transcript": "", "error": f"Connection error: {e}"}
     except APITimeoutError as e:
@@ -532,7 +957,12 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"API error: {e}"}
     except Exception as e:
         logger.error("OpenAI transcription failed: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Transcription failed: {e}",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Provider: mistral (Voxtral Transcribe API)
@@ -562,15 +992,29 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
             transcript_text = _extract_transcript_text(result)
             logger.info(
                 "Transcribed %s via Mistral API (%s, %d chars)",
-                Path(file_path).name, model_name, len(transcript_text),
+                Path(file_path).name,
+                model_name,
+                len(transcript_text),
             )
-            return {"success": True, "transcript": transcript_text, "provider": "mistral"}
+            return {
+                "success": True,
+                "transcript": transcript_text,
+                "provider": "mistral",
+            }
 
     except PermissionError:
-        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Permission denied: {file_path}",
+        }
     except Exception as e:
         logger.error("Mistral transcription failed: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Mistral transcription failed: {type(e).__name__}"}
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Mistral transcription failed: {type(e).__name__}",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -615,10 +1059,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     if provider == "local":
         local_cfg = stt_config.get("local", {})
-        model_name = _normalize_local_model(
-            model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
-        )
+        model_name = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         return _transcribe_local(file_path, model_name)
+
+    if provider == "whisper_cpp":
+        return _transcribe_whisper_cpp(file_path, stt_config)
 
     if provider == "local_command":
         local_cfg = stt_config.get("local", {})


### PR DESCRIPTION
## Summary

Adds a fourth STT backend that reuses existing ``ggml-*.bin`` whisper.cpp models already on disk, with GPU acceleration (Vulkan/CUDA/Metal) via whatever wrapper binary is installed. Lets users with an existing whisper.cpp model get GPU-accelerated STT without Hermes re-downloading a separate faster-whisper copy.

Sits alongside the existing ``local`` (faster-whisper), ``groq``, ``openai``, and the newly-added ``mistral`` (Voxtral) providers — it does not replace any of them and conflicts with none of them. Auto-detect order: ``local > whisper_cpp > groq > openai > mistral``.

## Motivation

Many users (including me) already have ``voxtype`` or a similar whisper.cpp wrapper installed locally with GGML weights on disk. Hermes' existing ``local`` provider would re-download its own ~150 MB faster-whisper model and run it on CPU. Wiring whisper.cpp in as a backend avoids the duplicate download and gets free GPU acceleration where the user's binary supports it.

## Design

Two binary "flavours" supported via adapters:

- **voxtype** — self-configuring wrapper; manages its own model and config internally. Transcript is embedded in its stdout log lines as ``Transcription completed in X.XXs: "…"`` plus the full raw transcript on subsequent lines. The provider prefers the full transcript and falls back to the log-line preview if that's all that's emitted.
- **whisper-cli / whisper-cpp / main** — stock whisper.cpp CLIs. Require ``-m <model_path>`` and ``-nt -np`` for clean stdout transcript output. The provider auto-builds the argv with optional ``-l <language>`` when set, and omits the flag for ``language: auto``.

Auto-detection looks for a binary on ``PATH`` in this priority order: ``voxtype`` → ``whisper-cli`` → ``whisper-cpp``. Config can override the choice:

```yaml
stt:
  provider: whisper_cpp
  whisper_cpp:
    binary: voxtype              # path or bare name, optional
    engine: whisper              # voxtype's --engine flag, optional
    model_path: /path/ggml.bin   # required only for whisper-cli flavour
    language: auto               # BCP-47 or "auto", optional
```

Audio is normalized to 16 kHz mono PCM WAV via ``ffmpeg`` before handing to the binary (whisper.cpp's required input format). ``ffmpeg`` is a hard requirement for this provider and is detected at runtime.

### No new Python dependencies

The whole provider is shell-out + stdout parsing. No new packages in ``pyproject.toml``, no binary bundling, nothing to ``uv pip install``. Users who want it install ``voxtype`` / ``whisper-cli`` themselves, same as they would for any other local tool.

### Stdout parsing robustness

The voxtype parser handles:

- Raw transcript lines (preferred, full content)
- Log-line preview as fallback (``... INFO Transcription completed in 0.57s: "..."``)
- ANSI escape codes in log lines (``\x1b[2m...\x1b[0m``)
- Empty output → returns empty string (not a crash)

See ``_parse_voxtype_output`` and ``_is_voxtype_log_line`` in ``tools/transcription_tools.py``.

## How to test

### Automated

New ``TestWhisperCppProvider`` test class in ``tests/tools/test_transcription_tools.py`` covers:

- Flavour detection for both voxtype and whisper-cli binaries (``_whisper_cpp_flavour``)
- ``_parse_voxtype_output``: full transcript preferred over log preview, ANSI stripping, log-line fallback, empty output handling
- ``_get_provider`` explicit whisper_cpp selection when binary available
- ``_get_provider`` returns ``none`` when binary missing
- ``local`` provider falls back to ``whisper_cpp`` when faster-whisper unavailable
- whisper-cli flavour refuses to activate without a valid ``model_path``
- voxtype flavour does NOT require ``model_path`` (manages its own model)
- ``_build_whisper_cpp_argv`` produces correct argv for both flavours with language flag handling

Existing STT provider-selection tests in ``tests/tools/test_transcription.py`` and ``tests/tools/test_transcription_tools.py`` get an ``autouse`` ``_disable_whisper_cpp_by_default`` fixture so they don't leak into machines with ``voxtype`` on PATH — without this, provider-detection tests would see the real binary and fail intermittently depending on the dev's machine.

Run:
```bash
pytest tests/tools/ -k "transcription or WhisperCpp or Mistral" -v
```

123 passed, 4 skipped on this branch. Full suite: 9597 passed / 25 pre-existing failures (verified identical count on clean ``origin/main`` — the 25 failures are in unrelated modules like ``test_api_key_providers``, ``test_code_execution``, ``test_skill_manager_tool``, not introduced by this change).

### Manual

With ``voxtype`` or ``whisper-cli`` installed:

```bash
# Auto-detect (expect whisper_cpp when faster-whisper missing)
hermes --toolsets voice -q "transcribe /tmp/sample.ogg"

# Explicit override
cat >> ~/.hermes/config.yaml <<EOF
stt:
  provider: whisper_cpp
  whisper_cpp:
    binary: voxtype
    language: auto
EOF
hermes chat  # then send a voice message on any gateway platform
```

## Platforms tested

- Linux (Arch, kernel 6.18), Python 3.11.15, voxtype installed

No platform-specific code paths added. The provider shells out via ``subprocess`` and ``ffmpeg``, both already cross-platform.

## File surface

| File | Kind | Lines |
|---|---|---|
| ``tools/transcription_tools.py`` | New backend + parser + adapter helpers | +465 / -2 |
| ``tests/tools/test_transcription_tools.py`` | New ``TestWhisperCppProvider`` class + autouse fixture | +142 / -0 |
| ``tests/tools/test_transcription.py`` | Autouse fixture to hide real voxtype during other STT tests | +15 / -0 |

Net additive. Zero changes to existing ``local``, ``groq``, ``openai``, or ``mistral`` code paths.

## Related upstream work

- ``5f4b93c2`` ``feat(tools): add Voxtral Transcribe STT provider (Mistral AI)`` — sister provider addition. Both providers coexist in the auto-detect chain. No overlap.
- ``6e02fa73`` ``fix(discord): discard empty placeholder on voice transcription`` — adjacent but unrelated (transcription output handling, not provider wiring).

## License

By submitting this PR I agree my contributions are licensed under MIT per ``CONTRIBUTING.md``.