### PR TITLE
fix(sms): validate inbound Twilio webhook signatures

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -88,19 +88,33 @@ class SmsAdapter(BasePlatformAdapter):
         encoded = base64.b64encode(creds.encode("ascii")).decode("ascii")
         return f"Basic {encoded}"
 
-    def _validate_twilio_signature(self, url: str, params: Dict[str, str], signature: str) -> bool:
-        """Validate the Twilio webhook signature for an inbound request."""
-        if not signature:
-            return False
-        payload = url + "".join(k + v for k, v in sorted(params.items()))
-        expected = base64.b64encode(
-            hmac.new(
-                self._auth_token.encode("utf-8"),
-                payload.encode("utf-8"),
-                hashlib.sha1,
-            ).digest()
-        ).decode("ascii")
-        return hmac.compare_digest(expected, signature)
+    def _external_request_url(self, request) -> str:
+        """Best-effort external URL reconstruction for signature validation.
+
+        Twilio signs the public webhook URL. Behind a reverse proxy, aiohttp may
+        see an internal host/scheme, so prefer forwarded headers when present.
+        """
+        headers = getattr(request, "headers", {}) or {}
+        forwarded_proto = headers.get("X-Forwarded-Proto") or headers.get("x-forwarded-proto")
+        forwarded_host = headers.get("X-Forwarded-Host") or headers.get("x-forwarded-host")
+        forwarded_port = headers.get("X-Forwarded-Port") or headers.get("x-forwarded-port")
+        path = getattr(request, "path_qs", None) or getattr(request, "path", None)
+        if not path:
+            url_obj = getattr(request, "url", "")
+            path = getattr(url_obj, "path_qs", None) or str(url_obj)
+            if "://" in path:
+                path = "/" + path.split("://", 1)[1].split("/", 1)[1] if "/" in path.split("://", 1)[1] else "/"
+
+        if forwarded_host:
+            scheme = forwarded_proto or "https"
+            host = forwarded_host
+            if forwarded_port and ":" not in host:
+                default_port = "443" if scheme == "https" else "80"
+                if str(forwarded_port) != default_port:
+                    host = f"{host}:{forwarded_port}"
+            return f"{scheme}://{host}{path}"
+
+        return str(request.url)
 
     # ------------------------------------------------------------------
     # Required abstract methods
@@ -258,7 +272,7 @@ class SmsAdapter(BasePlatformAdapter):
         # Validate Twilio request signature before processing anything.
         params = {key: values[0] for key, values in form.items() if values}
         signature = request.headers.get("X-Twilio-Signature", "")
-        request_url = str(request.url)
+        request_url = self._external_request_url(request)
         if not self._validate_twilio_signature(request_url, params, signature):
             logger.warning("[sms] rejected webhook with invalid Twilio signature from %s", request.remote)
             return web.Response(

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -17,6 +17,8 @@ Gateway-specific env vars:
 
 import asyncio
 import base64
+import hashlib
+import hmac
 import logging
 import os
 import re
@@ -85,6 +87,20 @@ class SmsAdapter(BasePlatformAdapter):
         creds = f"{self._account_sid}:{self._auth_token}"
         encoded = base64.b64encode(creds.encode("ascii")).decode("ascii")
         return f"Basic {encoded}"
+
+    def _validate_twilio_signature(self, url: str, params: Dict[str, str], signature: str) -> bool:
+        """Validate the Twilio webhook signature for an inbound request."""
+        if not signature:
+            return False
+        payload = url + "".join(k + v for k, v in sorted(params.items()))
+        expected = base64.b64encode(
+            hmac.new(
+                self._auth_token.encode("utf-8"),
+                payload.encode("utf-8"),
+                hashlib.sha1,
+            ).digest()
+        ).decode("ascii")
+        return hmac.compare_digest(expected, signature)
 
     # ------------------------------------------------------------------
     # Required abstract methods
@@ -207,6 +223,23 @@ class SmsAdapter(BasePlatformAdapter):
     # Twilio webhook handler
     # ------------------------------------------------------------------
 
+    def _validate_twilio_signature(
+        self, request_url: str, params: Dict[str, str], signature: str
+    ) -> bool:
+        """Validate the X-Twilio-Signature header.
+
+        Algorithm: HMAC-SHA1( auth_token, url + sorted(k+v for k,v in params) )
+        See https://www.twilio.com/docs/usage/webhooks/webhooks-security
+        """
+        s = request_url + "".join(k + v for k, v in sorted(params.items()))
+        mac = hmac.new(
+            self._auth_token.encode("utf-8"),
+            s.encode("utf-8"),
+            hashlib.sha1,
+        )
+        expected = base64.b64encode(mac.digest()).decode("ascii")
+        return hmac.compare_digest(expected, signature)
+
     async def _handle_webhook(self, request) -> "aiohttp.web.Response":
         from aiohttp import web
 
@@ -220,6 +253,18 @@ class SmsAdapter(BasePlatformAdapter):
                 text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
                 content_type="application/xml",
                 status=400,
+            )
+
+        # Validate Twilio request signature before processing anything.
+        params = {key: values[0] for key, values in form.items() if values}
+        signature = request.headers.get("X-Twilio-Signature", "")
+        request_url = str(request.url)
+        if not self._validate_twilio_signature(request_url, params, signature):
+            logger.warning("[sms] rejected webhook with invalid Twilio signature from %s", request.remote)
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+                status=403,
             )
 
         # Extract fields (parse_qs returns lists)

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -245,12 +245,36 @@ def _twilio_signature(auth_token: str, url: str, params: dict) -> str:
 
 
 class TestTwilioSignatureValidation:
-    """Unit tests for _validate_twilio_signature."""
+    """Unit tests for Twilio request URL/signature helpers."""
+
+    def test_external_request_url_prefers_forwarded_headers(self):
+        adapter = _make_sms_adapter()
+        req = MagicMock()
+        req.headers = {
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "public.example.com",
+            "X-Forwarded-Port": "443",
+        }
+        req.path_qs = "/webhooks/twilio?foo=1"
+        req.url = "http://internal:8080/webhooks/twilio?foo=1"
+        assert adapter._external_request_url(req) == "https://public.example.com/webhooks/twilio?foo=1"
+
+    def test_external_request_url_keeps_non_default_forwarded_port(self):
+        adapter = _make_sms_adapter()
+        req = MagicMock()
+        req.headers = {
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "public.example.com",
+            "X-Forwarded-Port": "8443",
+        }
+        req.path_qs = "/webhooks/twilio"
+        req.url = "http://internal:8080/webhooks/twilio"
+        assert adapter._external_request_url(req) == "https://public.example.com:8443/webhooks/twilio"
 
     def test_valid_signature_returns_true(self):
         adapter = _make_sms_adapter()
         url = "https://example.com/webhooks/twilio"
-        params = {"From": "+15559876543", "Body": "hello", "To": "+15550001111"}
+        params = {"From": "+155****6543", "Body": "hello", "To": "+155****1111"}
         sig = _twilio_signature(adapter._auth_token, url, params)
         assert adapter._validate_twilio_signature(url, params, sig) is True
 
@@ -323,9 +347,27 @@ class TestTwilioWebhookSignatureEnforcement:
         adapter = _make_sms_adapter()
         adapter.handle_message = AsyncMock()
         url = "https://example.com/webhooks/twilio"
-        params = {"From": "+15559876543", "Body": "hi", "To": "+15550001111", "MessageSid": "SM1"}
+        params = {"From": "+155****6543", "Body": "hi", "To": "+155****1111", "MessageSid": "SM1"}
         sig = _twilio_signature(adapter._auth_token, url, params)
         req = self._make_request(params, sig)
         req.url = url
+        resp = await adapter._handle_webhook(req)
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_forwarded_headers_allow_valid_signature_behind_proxy(self):
+        adapter = _make_sms_adapter()
+        adapter.handle_message = AsyncMock()
+        public_url = "https://public.example.com/webhooks/twilio"
+        params = {"From": "+155****6543", "Body": "hi", "To": "+155****1111", "MessageSid": "SM2"}
+        sig = _twilio_signature(adapter._auth_token, public_url, params)
+        req = self._make_request(params, sig)
+        req.url = "http://internal:8080/webhooks/twilio"
+        req.path_qs = "/webhooks/twilio"
+        req.headers.update({
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "public.example.com",
+            "X-Forwarded-Port": "443",
+        })
         resp = await adapter._handle_webhook(req)
         assert resp.status == 200

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -4,8 +4,12 @@ Covers config loading, format/truncate, echo prevention,
 requirements check, and toolset verification.
 """
 
+import base64
+import hashlib
+import hmac
 import os
-from unittest.mock import patch
+import urllib.parse
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -213,3 +217,115 @@ class TestSmsToolset:
         from tools.cronjob_tools import CRONJOB_SCHEMA
         deliver_desc = CRONJOB_SCHEMA["parameters"]["properties"]["deliver"]["description"]
         assert "sms" in deliver_desc.lower()
+
+
+# ── Signature validation ───────────────────────────────────────────
+
+def _make_sms_adapter():
+    """Return a bare SmsAdapter without starting a server."""
+    from gateway.platforms.sms import SmsAdapter
+
+    pc = PlatformConfig(enabled=True, api_key="test_auth_token")
+    adapter = object.__new__(SmsAdapter)
+    adapter.config = pc
+    adapter.platform = Platform.SMS
+    adapter._platform = Platform.SMS
+    adapter._account_sid = "ACtest"
+    adapter._auth_token = "test_auth_token"
+    adapter._from_number = "+15550001111"
+    adapter._background_tasks = set()
+    return adapter
+
+
+def _twilio_signature(auth_token: str, url: str, params: dict) -> str:
+    """Compute a valid Twilio request signature."""
+    s = url + "".join(k + v for k, v in sorted(params.items()))
+    mac = hmac.new(auth_token.encode("utf-8"), s.encode("utf-8"), hashlib.sha1)
+    return base64.b64encode(mac.digest()).decode("ascii")
+
+
+class TestTwilioSignatureValidation:
+    """Unit tests for _validate_twilio_signature."""
+
+    def test_valid_signature_returns_true(self):
+        adapter = _make_sms_adapter()
+        url = "https://example.com/webhooks/twilio"
+        params = {"From": "+15559876543", "Body": "hello", "To": "+15550001111"}
+        sig = _twilio_signature(adapter._auth_token, url, params)
+        assert adapter._validate_twilio_signature(url, params, sig) is True
+
+    def test_wrong_signature_returns_false(self):
+        adapter = _make_sms_adapter()
+        url = "https://example.com/webhooks/twilio"
+        params = {"From": "+15559876543", "Body": "hello"}
+        assert adapter._validate_twilio_signature(url, params, "badsig==") is False
+
+    def test_empty_signature_returns_false(self):
+        adapter = _make_sms_adapter()
+        url = "https://example.com/webhooks/twilio"
+        assert adapter._validate_twilio_signature(url, {}, "") is False
+
+    def test_tampered_body_returns_false(self):
+        adapter = _make_sms_adapter()
+        url = "https://example.com/webhooks/twilio"
+        params = {"From": "+15559876543", "Body": "hello"}
+        sig = _twilio_signature(adapter._auth_token, url, params)
+        tampered = {**params, "Body": "injected"}
+        assert adapter._validate_twilio_signature(url, tampered, sig) is False
+
+    def test_wrong_url_returns_false(self):
+        adapter = _make_sms_adapter()
+        params = {"From": "+15559876543", "Body": "hello"}
+        sig = _twilio_signature(adapter._auth_token, "https://real.example.com/webhooks/twilio", params)
+        assert adapter._validate_twilio_signature("https://evil.example.com/webhooks/twilio", params, sig) is False
+
+
+def _aiohttp_available() -> bool:
+    try:
+        import aiohttp  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _aiohttp_available(), reason="aiohttp not installed")
+class TestTwilioWebhookSignatureEnforcement:
+    """Integration-style tests for _handle_webhook signature gating."""
+
+    def _make_request(self, body_params: dict, signature: str) -> MagicMock:
+        """Build a mock aiohttp Request."""
+        encoded = urllib.parse.urlencode(body_params).encode("utf-8")
+        req = MagicMock()
+        req.read = AsyncMock(return_value=encoded)
+        req.headers = {"X-Twilio-Signature": signature}
+        req.url = "https://example.com/webhooks/twilio"
+        req.remote = "54.0.0.1"
+        return req
+
+    @pytest.mark.asyncio
+    async def test_missing_signature_returns_403(self):
+        adapter = _make_sms_adapter()
+        params = {"From": "+15559876543", "Body": "hi", "To": "+15550001111", "MessageSid": "SM1"}
+        req = self._make_request(params, "")
+        resp = await adapter._handle_webhook(req)
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_invalid_signature_returns_403(self):
+        adapter = _make_sms_adapter()
+        params = {"From": "+15559876543", "Body": "hi", "To": "+15550001111", "MessageSid": "SM1"}
+        req = self._make_request(params, "invalidsignature==")
+        resp = await adapter._handle_webhook(req)
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_valid_signature_returns_200(self):
+        adapter = _make_sms_adapter()
+        adapter.handle_message = AsyncMock()
+        url = "https://example.com/webhooks/twilio"
+        params = {"From": "+15559876543", "Body": "hi", "To": "+15550001111", "MessageSid": "SM1"}
+        sig = _twilio_signature(adapter._auth_token, url, params)
+        req = self._make_request(params, sig)
+        req.url = url
+        resp = await adapter._handle_webhook(req)
+        assert resp.status == 200


### PR DESCRIPTION
## Summary
- validate inbound Twilio SMS webhooks before scheduling message handling
- reject missing or forged `X-Twilio-Signature` requests with a fast 403 response
- add focused unit and integration-style regression tests for Twilio signature enforcement

## Problem
The SMS adapter accepted any POST to `/webhooks/twilio` and immediately scheduled `handle_message()` without verifying that the request actually came from Twilio.

That meant anyone who knew the webhook URL could forge inbound SMS payloads and impersonate arbitrary phone numbers.

## Investigation
Validated in a clean isolated worktree from current `origin/main`:
- searched for an existing issue/PR matching this specific Twilio signature-validation gap and did not find one
- confirmed `gateway/platforms/sms.py::_handle_webhook()` parsed form data and queued work without checking `X-Twilio-Signature`
- checked Twilio Python best practice: validate the full request URL + POST vars against the Auth Token (equivalent to `RequestValidator.validate(url, post_vars, signature)`)
- got a second opinion via Claude Code, which recommended the same minimal fix shape and test coverage

## Fix
- add `_validate_twilio_signature()` to `SmsAdapter`
- validate `X-Twilio-Signature` immediately after parsing the form body
- return empty TwiML with HTTP 403 on invalid or missing signature
- keep the webhook non-blocking for valid requests

## Validation
Ran locally in the isolated worktree:
- `pytest tests/gateway/test_sms.py -q -o addopts=`
- `python -m py_compile gateway/platforms/sms.py tests/gateway/test_sms.py`

Result:
- `29 passed`

## Tests added
- signature helper unit tests:
  - valid signature
  - wrong signature
  - empty signature
  - tampered body
  - wrong URL
- webhook enforcement tests:
  - missing signature -> 403
  - invalid signature -> 403
  - valid signature -> 200
