### PR TITLE
fix(bluebubbles): implement dedicated webhook secret and credential separation

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -965,6 +965,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
             "webhook_port": int(os.getenv("BLUEBUBBLES_WEBHOOK_PORT", "8645")),
             "webhook_path": os.getenv("BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"),
+            "webhook_secret": os.getenv("BLUEBUBBLES_WEBHOOK_SECRET", ""),
             "send_read_receipts": os.getenv("BLUEBUBBLES_SEND_READ_RECEIPTS", "true").lower() in ("true", "1", "yes"),
         })
     bluebubbles_home = os.getenv("BLUEBUBBLES_HOME_CHANNEL")

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -9,6 +9,8 @@ downloading from PR #4588 (YuhangLin).
 """
 
 import asyncio
+import hmac
+import ipaddress
 import json
 import logging
 import os
@@ -89,6 +91,19 @@ def _normalize_server_url(raw: str) -> str:
     return value.rstrip("/")
 
 
+def _is_loopback_host(host: str) -> bool:
+    """Return True when the webhook bind host resolves only to loopback."""
+    value = (host or "").strip()
+    if not value:
+        return False
+    if value.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
 def _strip_markdown(text: str) -> str:
     """Strip common markdown formatting for iMessage plain-text delivery."""
     text = re.sub(r"\*\*(.+?)\*\*", r"\1", text, flags=re.DOTALL)
@@ -122,6 +137,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             extra.get("webhook_host")
             or os.getenv("BLUEBUBBLES_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
         )
+        self.webhook_secret = str(
+            extra.get("webhook_secret")
+            or os.getenv("BLUEBUBBLES_WEBHOOK_SECRET", "")
+        ).strip()
         self.webhook_port = int(
             extra.get("webhook_port")
             or os.getenv("BLUEBUBBLES_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
@@ -138,6 +157,23 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: Dict[str, str] = {}
+
+    def _webhook_auth_secret(self) -> str:
+        """Return the secret expected on inbound webhooks.
+
+        Loopback-only deployments keep the historical password fallback for
+        backwards compatibility, but any explicit webhook secret takes
+        precedence.
+        """
+        return self.webhook_secret or self.password
+
+    def _requires_dedicated_webhook_secret(self) -> bool:
+        """Return True when the webhook listener is exposed off-loopback."""
+        return not _is_loopback_host(self.webhook_host)
+
+    def _has_valid_dedicated_webhook_secret(self) -> bool:
+        """Return True when the webhook secret is present and scoped separately."""
+        return bool(self.webhook_secret) and self.webhook_secret != self.password
 
     # ------------------------------------------------------------------
     # API helpers
@@ -167,6 +203,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not self.server_url or not self.password:
             logger.error(
                 "[bluebubbles] BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required"
+            )
+            return False
+        if (
+            self._requires_dedicated_webhook_secret()
+            and not self._has_valid_dedicated_webhook_secret()
+        ):
+            logger.error(
+                "[bluebubbles] Non-loopback webhook host %s requires "
+                "BLUEBUBBLES_WEBHOOK_SECRET, and it must be different from "
+                "BLUEBUBBLES_PASSWORD",
+                self.webhook_host,
             )
             return False
         from aiohttp import web
@@ -673,7 +720,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             or request.headers.get("x-guid")
             or request.headers.get("x-bluebubbles-guid")
         )
-        if token != self.password:
+        if not isinstance(token, str) or not hmac.compare_digest(
+            token,
+            self._webhook_auth_secret(),
+        ):
             return web.json_response({"error": "unauthorized"}, status=401)
         try:
             raw = await request.read()

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,4 +1,5 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
+import asyncio
 import pytest
 
 from gateway.config import Platform, PlatformConfig
@@ -30,6 +31,7 @@ class TestBlueBubblesConfigLoading:
         monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
         monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
         monkeypatch.setenv("BLUEBUBBLES_WEBHOOK_PORT", "9999")
+        monkeypatch.setenv("BLUEBUBBLES_WEBHOOK_SECRET", "webhook-secret")
         from gateway.config import GatewayConfig, _apply_env_overrides
 
         config = GatewayConfig()
@@ -40,6 +42,7 @@ class TestBlueBubblesConfigLoading:
         assert bc.extra["server_url"] == "http://localhost:1234"
         assert bc.extra["password"] == "secret"
         assert bc.extra["webhook_port"] == 9999
+        assert bc.extra["webhook_secret"] == "webhook-secret"
 
     def test_connected_platforms_includes_bluebubbles(self, monkeypatch):
         monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
@@ -108,8 +111,43 @@ class TestBlueBubblesHelpers:
         adapter = _make_adapter(monkeypatch, server_url="localhost:1234")
         assert adapter.server_url == "http://localhost:1234"
 
+    def test_non_loopback_webhook_requires_distinct_secret(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, webhook_host="0.0.0.0")
+        assert asyncio.run(adapter.connect()) is False
+
+    def test_non_loopback_webhook_rejects_password_reuse(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            webhook_host="0.0.0.0",
+            webhook_secret="secret",
+        )
+        assert asyncio.run(adapter.connect()) is False
+
+    def test_non_loopback_webhook_accepts_distinct_secret(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            webhook_host="0.0.0.0",
+            webhook_secret="hook-secret",
+        )
+        assert adapter._has_valid_dedicated_webhook_secret() is True
+        assert adapter._webhook_auth_secret() == "hook-secret"
+
 
 class TestBlueBubblesWebhookParsing:
+    def test_webhook_uses_dedicated_secret_when_configured(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, webhook_secret="hook-secret")
+
+        class _Request:
+            def __init__(self, token: str):
+                self.query = {"password": token}
+                self.headers = {}
+
+            async def read(self):
+                return b'{"type":"new-message","data":{"text":"hello","chatGuid":"iMessage;-;user@example.com","chatIdentifier":"user@example.com","handle":{"address":"user@example.com"}}}'
+
+        response = asyncio.run(adapter._handle_webhook(_Request("secret")))
+        assert response.status == 401
+
     def test_webhook_prefers_chat_guid_over_message_guid(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -229,6 +229,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `WECOM_HOME_CHANNEL` | WeCom chat ID for cron delivery and notifications |
 | `BLUEBUBBLES_SERVER_URL` | BlueBubbles server URL (e.g. `http://192.168.1.10:1234`) |
 | `BLUEBUBBLES_PASSWORD` | BlueBubbles server password |
+| `BLUEBUBBLES_WEBHOOK_SECRET` | Dedicated secret for inbound BlueBubbles webhooks (required when the webhook listener is not loopback-only) |
 | `BLUEBUBBLES_WEBHOOK_HOST` | Webhook listener bind address (default: `127.0.0.1`) |
 | `BLUEBUBBLES_WEBHOOK_PORT` | Webhook listener port (default: `8645`) |
 | `BLUEBUBBLES_HOME_CHANNEL` | Phone/email for cron/notification delivery |

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -36,6 +36,7 @@ Or set environment variables directly in `~/.hermes/.env`:
 ```bash
 BLUEBUBBLES_SERVER_URL=http://192.168.1.10:1234
 BLUEBUBBLES_PASSWORD=your-server-password
+BLUEBUBBLES_WEBHOOK_SECRET=separate-webhook-secret
 ```
 
 ### 4. Authorize Users
@@ -84,6 +85,7 @@ Hermes → BlueBubbles REST API → Messages.app → iMessage
 |----------|----------|---------|-------------|
 | `BLUEBUBBLES_SERVER_URL` | Yes | — | BlueBubbles server URL |
 | `BLUEBUBBLES_PASSWORD` | Yes | — | Server password |
+| `BLUEBUBBLES_WEBHOOK_SECRET` | No* | — | Dedicated webhook secret. Required when `BLUEBUBBLES_WEBHOOK_HOST` is not loopback-only. |
 | `BLUEBUBBLES_WEBHOOK_HOST` | No | `127.0.0.1` | Webhook listener bind address |
 | `BLUEBUBBLES_WEBHOOK_PORT` | No | `8645` | Webhook listener port |
 | `BLUEBUBBLES_WEBHOOK_PATH` | No | `/bluebubbles-webhook` | Webhook URL path |


### PR DESCRIPTION
📝 Summary
This PR addresses a critical authentication boundary issue within the BlueBubbles gateway adapter. Previously, the system used the same credential for both inbound webhook verification and outbound REST API control, leading to a collapse of two distinct trust domains.

🔐 The Problem: Privilege Overloading
The adapter used BLUEBUBBLES_PASSWORD for:

Webhook Event Authenticity: Verifying that incoming messages are from a legitimate source.

Full BlueBubbles API Access: Controlling the iMessage server (sending messages, managing settings).

In deployments where the webhook listener is exposed beyond loopback (e.g., 0.0.0.0), this created a high-risk escalation path. Any leak of the webhook secret would grant an attacker full administrative access to the BlueBubbles API.

🛠️ Changes
Credential Decoupling: Introduced BLUEBUBBLES_WEBHOOK_SECRET to separate inbound event verification from outbound API control.

Fail-Closed Validation:

Enforced a dedicated secret requirement for non-loopback bindings.

Added a check to ensure BLUEBUBBLES_WEBHOOK_SECRET is not identical to BLUEBUBBLES_PASSWORD in exposed environments.

Backward Compatibility: Loopback-only (127.0.0.1) deployments remain compatible by falling back to the password if no secret is configured.

Security Hardening: Switched to hmac.compare_digest() for secret comparisons to mitigate timing attacks.

Documentation: Updated BlueBubbles environment variable references and user guides.

🧪 Security Impact & Testing
This change effectively prevents privilege escalation. Even if a webhook secret is exposed via a proxy or relay, the core BlueBubbles API remains protected.

Validation Steps
Run the targeted regression suite:

Bash
uv run --extra dev --extra messaging pytest tests/gateway/test_bluebubbles.py -q
Expected Result: 31 passed

Regression Tests Added
✅ Environment override loading.
✅ Non-loopback startup rejection (when secret is missing).
✅ Rejection of secret/password reuse.
✅ Verification using the dedicated secret.