### PR TITLE
fix(gateway): use correct root_id for Mattermost thread replies

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -271,9 +271,14 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+            # Thread support: prefer thread_id from metadata (existing
+            # thread) over reply_to (creates a new thread).
+            if self._reply_mode == "thread":
+                thread_root = (
+                    (metadata or {}).get("thread_id") or reply_to
+                )
+                if thread_root:
+                    payload["root_id"] = thread_root
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -454,8 +459,12 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        if self._reply_mode == "thread":
+            thread_root = (
+                (metadata or {}).get("thread_id") or reply_to
+            )
+            if thread_root:
+                payload["root_id"] = thread_root
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -469,6 +478,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
@@ -492,8 +502,12 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        if self._reply_mode == "thread":
+            thread_root = (
+                (metadata or {}).get("thread_id") or reply_to
+            )
+            if thread_root:
+                payload["root_id"] = thread_root
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:


### PR DESCRIPTION
## Summary

Fixes Mattermost thread replies failing with `root_id.app_error` (400) when `MATTERMOST_REPLY_MODE=thread` is enabled.

## Problem

When a user messages the bot inside an existing Mattermost thread, `reply_to` is set to `event.message_id` — the ID of the individual reply post. But Mattermost requires `root_id` to be the **first post that started the thread**. Using a non-root post ID causes:

```json
{"id":"api.post.create_post.root_id.app_error","message":"Invalid RootId parameter","status_code":400}
```

## Fix

In `send()`, `_download_and_post_file()`, and `_send_local_file()`: prefer `metadata.thread_id` (which `base.py` already populates from `event.source.thread_id`, i.e. the actual thread root) over `reply_to`. This handles both cases:

- **New thread** (message in channel): no `thread_id` in metadata → falls back to `reply_to`, creating a new thread under the user's message
- **Existing thread** (reply in thread): `thread_id` is the root post → reply lands in the correct thread

## Test plan

- [ ] Send a message in a channel with `MATTERMOST_REPLY_MODE=thread` → bot creates a new thread (reply under user's message)
- [ ] Reply to the bot inside that thread → bot replies in the same thread (no 400 error)
- [ ] Send a DM → bot responds normally (no thread behavior)
- [ ] Send an image/file in a thread → attachment lands in the correct thread