### PR TITLE
fix(models): add gpt-5.4 and gpt-5.4-mini to openai-codex static model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -87,6 +87,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-nano",
     ],
     "openai-codex": [
+        "gpt-5.4",
+        "gpt-5.4-mini",
         "gpt-5.3-codex",
         "gpt-5.2-codex",
         "gpt-5.1-codex-mini",


### PR DESCRIPTION
## Summary

Fixes #6595

## Root Cause

`_PROVIDER_MODELS["openai-codex"]` was stale (v0.7.0 era) and missing the current production models `gpt-5.4` and `gpt-5.4-mini`.

`provider_model_ids()` already calls `get_codex_model_ids()` for dynamic discovery, but when the Codex API is unreachable the fallback static list was shown in the `/model` picker — without `gpt-5.4`.

## Fix

Prepend `gpt-5.4` and `gpt-5.4-mini` to the static fallback list so they appear in the picker even when the live API is unavailable.

## Changes

- `hermes_cli/models.py`: prepend `gpt-5.4` and `gpt-5.4-mini` to `_PROVIDER_MODELS["openai-codex"]`