### PR TITLE
fix(security): block protected-path deletes and moves in V4A patches

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -253,3 +253,65 @@ class TestAdditionOnlyHunks:
         assert result.success is True
         assert file_ops.written.endswith("def new_func():\n    return True\n")
         assert "existing = True" in file_ops.written
+
+
+class TestProtectedPathGuards:
+    def test_delete_denies_protected_path(self):
+        patch = """\
+*** Begin Patch
+*** Delete File: ~/.ssh/authorized_keys
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            def read_file(self, path, **kw):
+                raise AssertionError("protected delete should be blocked before reading")
+
+        result = apply_v4a_operations(ops, FakeFileOps())
+
+        assert result.success is False
+        assert "protected system/credential file" in result.error
+        assert result.files_deleted == []
+
+    def test_move_denies_protected_destination(self):
+        patch = """\
+*** Begin Patch
+*** Move File: safe.txt -> ~/.ssh/authorized_keys
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            def _exec(self, command):
+                raise AssertionError("protected move should be blocked before shell execution")
+
+            def _escape_shell_arg(self, value):
+                return value
+
+        result = apply_v4a_operations(ops, FakeFileOps())
+
+        assert result.success is False
+        assert "protected system/credential file" in result.error
+        assert result.files_modified == []
+
+    def test_move_denies_protected_source(self):
+        patch = """\
+*** Begin Patch
+*** Move File: ~/.ssh/authorized_keys -> safe.txt
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            def _exec(self, command):
+                raise AssertionError("protected move should be blocked before shell execution")
+
+            def _escape_shell_arg(self, value):
+                return value
+
+        result = apply_v4a_operations(ops, FakeFileOps())
+
+        assert result.success is False
+        assert "protected system/credential file" in result.error
+        assert result.files_modified == []

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -65,6 +65,15 @@ class PatchOperation:
     content: Optional[str] = None  # For add file operations
 
 
+def _protected_path_error(path: str) -> Optional[str]:
+    """Return a deny-list error for protected paths, or None if allowed."""
+    from tools.file_operations import _is_write_denied
+
+    if _is_write_denied(path):
+        return f"Write denied: '{path}' is a protected system/credential file."
+    return None
+
+
 def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[str]]:
     """
     Parse a V4A format patch.
@@ -317,6 +326,10 @@ def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
 
 def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     """Apply a delete file operation."""
+    protected_error = _protected_path_error(op.file_path)
+    if protected_error:
+        return False, protected_error
+
     # Read file first for diff
     read_result = file_ops.read_file(op.file_path)
     
@@ -336,6 +349,13 @@ def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
 
 def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     """Apply a move file operation."""
+    protected_error = _protected_path_error(op.file_path)
+    if protected_error:
+        return False, protected_error
+    protected_error = _protected_path_error(op.new_path or "")
+    if protected_error:
+        return False, protected_error
+
     # Use shell mv command
     mv_result = file_ops._exec(
         f"mv {file_ops._escape_shell_arg(op.file_path)} {file_ops._escape_shell_arg(op.new_path)}"


### PR DESCRIPTION
## Summary

This fixes a security bypass in the V4A patch flow.

`patch_tool` correctly enforced protected-path restrictions for normal write and replace operations, but `Delete File` and `Move File` operations inside `tools/patch_parser.py` could bypass those safeguards because they executed `rm` / `mv` directly without re-checking the deny list.

That meant a model-driven patch could target protected files such as:

- `~/.ssh/authorized_keys`
- `~/.ssh/id_rsa`
- `~/.hermes/.env`
- other protected credential/system paths already covered by the existing deny list

## Impact

This was not a trivial validation gap. It created an alternate destructive path through the patch engine, allowing protected files to be deleted or overwritten via move semantics even though the rest of the file toolchain explicitly forbids those paths.

In practice, this could have allowed:

- deleting SSH access controls
- clobbering credential files
- bypassing the intended safety boundary of the file tools

## Fix

- added a shared protected-path check in `tools/patch_parser.py`
- block `Delete File` when the target path is protected
- block `Move File` when either the source or destination path is protected

This keeps V4A patch operations aligned with the same protected-path policy already enforced by `write_file` and `patch_replace`.

## Tests

Added regression coverage for:

- protected-path delete attempts
- protected-path move to a protected destination
- protected-path move from a protected source

Validated with:

- `python -m pytest tests/tools/test_patch_parser.py -q`
- `python -m pytest tests/tools/test_file_operations.py tests/tools/test_file_tools.py -q`


