### PR TITLE
fix(api-server): handle multimodal image input in runs endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1398,7 +1398,34 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        def _normalize_content(content: Any) -> str:
+            if isinstance(content, str):
+                return content
+            if not isinstance(content, list):
+                return ""
+
+            text_parts: List[str] = []
+            for part in content:
+                if isinstance(part, str):
+                    text_parts.append(part)
+                    continue
+                if not isinstance(part, dict):
+                    continue
+
+                ptype = part.get("type")
+                if ptype in {"text", "input_text", "output_text"}:
+                    text_parts.append(part.get("text", ""))
+
+            return "\n".join(part for part in text_parts if part)
+
+        raw_user_content: Any = raw_input
+        user_message = raw_input if isinstance(raw_input, str) else (
+            _normalize_content(raw_input[-1].get("content", "")) if isinstance(raw_input, list) and raw_input else ""
+        )
+        if isinstance(raw_input, list) and raw_input:
+            last_item = raw_input[-1]
+            if isinstance(last_item, dict):
+                raw_user_content = last_item.get("content", "")
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -1481,8 +1508,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=event_cb,
                 )
                 def _run_sync():
+                    effective_user_message = user_message
+                    if isinstance(raw_user_content, list) and hasattr(agent, "_preprocess_anthropic_content"):
+                        try:
+                            effective_user_message = agent._preprocess_anthropic_content(raw_user_content, "user")
+                        except Exception:
+                            effective_user_message = _normalize_content(raw_user_content)
+
                     r = agent.run_conversation(
-                        user_message=user_message,
+                        user_message=effective_user_message,
                         conversation_history=conversation_history,
                     )
                     u = {

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -15,6 +15,7 @@ Tests cover:
 import json
 import time
 import uuid
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -223,6 +224,8 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
     return app
@@ -874,6 +877,81 @@ class TestResponsesEndpoint:
                 json={"model": "hermes-agent", "input": 42},
             )
             assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# /v1/runs endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRunsEndpoint:
+    @pytest.mark.asyncio
+    async def test_runs_preprocesses_multimodal_final_turn_before_run_conversation(self, adapter):
+        app = _create_app(adapter)
+        fake_agent = MagicMock()
+        fake_agent._preprocess_anthropic_content.return_value = "described image\n\nplease analyze this"
+        fake_agent.run_conversation.return_value = {"final_response": "done"}
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=fake_agent):
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "please analyze this"},
+                                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+                assert resp.status == 202
+                await asyncio.sleep(0.1)
+
+        fake_agent._preprocess_anthropic_content.assert_called_once()
+        fake_agent.run_conversation.assert_called_once()
+        assert fake_agent.run_conversation.call_args.kwargs["user_message"] == "described image\n\nplease analyze this"
+
+    @pytest.mark.asyncio
+    async def test_runs_falls_back_to_text_blocks_when_multimodal_preprocessing_fails(self, adapter):
+        app = _create_app(adapter)
+        fake_agent = MagicMock()
+        fake_agent._preprocess_anthropic_content.side_effect = RuntimeError("boom")
+        fake_agent.run_conversation.return_value = {"final_response": "done"}
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=fake_agent):
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "first line"},
+                                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                                    {"type": "input_text", "text": "second line"},
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+                assert resp.status == 202
+                await asyncio.sleep(0.1)
+
+        fake_agent.run_conversation.assert_called_once()
+        assert fake_agent.run_conversation.call_args.kwargs["user_message"] == "first line\nsecond line"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes a crash in `/v1/runs` when web clients send multimodal input containing image content blocks.

## Problem
The runs endpoint accepted list-based multimodal input, but passed the last message content through to `run_conversation()` in a shape that could still be a list. The agent runtime later treated that value like a string and raised:

`AttributeError: 'list' object has no attribute 'replace'`

## Fix
- normalize text content from multimodal input blocks
- preserve the raw user content for the final turn
- preprocess multimodal user content before calling `run_conversation()` so image attachments no longer crash the runs path

## Notes
This is a focused crash fix for `/v1/runs`. It does not claim full end-to-end native multimodal support across the entire runtime, but it brings the runs endpoint in line with the existing multimodal handling expectations enough to prevent the failure.