### PR TITLE
Fix (mixture_of_agents): replace deprecated Gemini model and forward …

### DIFF
--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 # Keep this list aligned with current top-tier OpenRouter frontier options.
 REFERENCE_MODELS = [
     "anthropic/claude-opus-4.6",
-    "google/gemini-3-pro-preview",
+    "google/gemini-2.5-pro",
     "openai/gpt-5.4-pro",
     "deepseek/deepseek-v3.2",
 ]
@@ -129,6 +129,7 @@ async def _run_reference_model_safe(
             api_params = {
                 "model": model,
                 "messages": [{"role": "user", "content": user_prompt}],
+                "max_tokens": max_tokens,
                 "extra_body": {
                     "reasoning": {
                         "enabled": True,
@@ -203,6 +204,7 @@ async def _run_aggregator_model(
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt}
         ],
+        "max_tokens": max_tokens,
         "extra_body": {
             "reasoning": {
                 "enabled": True,


### PR DESCRIPTION
…max_tokens to OpenRouter (#6621)

## What does this PR do?

Fixes #6621

This PR resolves two critical issues in the mixture_of_agents tool that were causing high latency and avoidable API failures.

1. Replaced Deprecated Gemini Model
Issue: google/gemini-3-pro-preview is deprecated on OpenRouter, resulting in constant 404 errors.

Impact: The tool would retry 6 times per call, adding ~30s of unnecessary latency and flooding logs with tracebacks.

Fix: Updated REFERENCE_MODELS to use the stable google/gemini-2.5-pro.

2. Fixed Missing max_tokens Forwarding
Issue: The max_tokens parameter was defined but never passed to the OpenRouter API payload.

Impact: OpenRouter would default to the model's maximum output (e.g., 64k+), triggering 402 Insufficient Funds for users with smaller balances, even when the actual response would fit.

Fix: Explicitly added max_tokens to api_params for both reference and aggregator model calls.

Summary of Changes
Updated REFERENCE_MODELS list to ensure 100% model availability.

Wired max_tokens through the entire MoA pipeline to ensure correct budget pre-checks on OpenRouter.