### PR TITLE
feat: add compress-summary plugin + pre/post_compress hooks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -59,6 +59,8 @@ VALID_HOOKS: Set[str] = {
     "post_llm_call",
     "pre_api_request",
     "post_api_request",
+    "pre_compress",
+    "post_compress",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",

--- a/plugins/compress-summary/README.md
+++ b/plugins/compress-summary/README.md
@@ -1,0 +1,40 @@
+# Compress Summary Plugin
+
+Injects a structured task-state summary into the conversation tail before
+context compression. The summary survives compression (tail messages are
+protected) and acts as an anchor so the model retains a clear picture of
+completed work and pending goals.
+
+## Problem
+
+When context compression fires during long sessions, the model often loses
+track of what was accomplished in the middle of the conversation. It remembers
+the original request (in the protected head) and recent messages (in the
+protected tail), but forgets intermediate progress — leading to repeated work
+or abandoned sub-tasks.
+
+## How It Works
+
+1. Hooks into the `pre_compress` event
+2. Scans messages to extract structured state:
+   - **Original request** — first substantive user message
+   - **Actions taken** — chronological log from tool calls (reliable, not regex)
+   - **Progress notes** — assistant's status updates
+   - **Recent instructions** — latest user messages
+   - **Key files** — file paths from write/patch/read tool calls
+3. Appends the summary as the last message, placing it in the compressor's
+   protected tail region
+
+## Requirements
+
+None — pure Python, no external dependencies.
+
+## Setup
+
+Drop this plugin into `~/.hermes/plugins/compress-summary/` or keep it in the
+repo's `plugins/compress-summary/` directory. It is discovered automatically.
+
+## Config
+
+No configuration needed. The plugin activates automatically when context
+compression is triggered and the conversation has 10+ messages.

--- a/plugins/compress-summary/__init__.py
+++ b/plugins/compress-summary/__init__.py
@@ -1,0 +1,259 @@
+"""compress-summary — pre-compression task-state anchor.
+
+Before context compression discards the middle of a conversation, this plugin
+scans messages and appends a structured task-state summary to the tail.
+Because the compressor protects tail messages, the summary survives and gives
+the model a clear picture of completed work and pending goals.
+
+No LLM call is needed — the summary is built heuristically from tool_calls
+(the most reliable signal) and assistant message text.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+_MARKER = "[TASK-STATE-SUMMARY]"
+
+
+def register(ctx):
+    """Plugin entry point — called by the Hermes plugin system."""
+    ctx.register_hook("pre_compress", _on_pre_compress)
+
+
+def _on_pre_compress(
+    session_id: str = "",
+    messages: Optional[List[Dict[str, Any]]] = None,
+    approx_tokens: Optional[int] = None,
+    **kwargs,
+) -> None:
+    """Build and inject a task-state summary before compression."""
+    if not messages or len(messages) < 10:
+        return
+
+    # Guard against double injection
+    for msg in messages[-5:]:
+        if _MARKER in (msg.get("content") or ""):
+            return
+
+    summary = _build_summary(messages)
+    if not summary:
+        return
+
+    messages.append({"role": "user", "content": summary})
+    logger.info(
+        "compress-summary: injected %d-char summary into tail (session=%s)",
+        len(summary),
+        session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Summary builder
+# ---------------------------------------------------------------------------
+
+
+def _build_summary(messages: List[Dict[str, Any]]) -> Optional[str]:
+    """Assemble a structured summary from conversation messages."""
+    original_goal = _find_original_goal(messages)
+    actions = _extract_actions(messages)
+    notes = _extract_progress_notes(messages)
+    recent = _extract_recent_user(messages)
+    files = _extract_key_files(messages)
+
+    if not original_goal and not actions:
+        return None
+
+    parts: List[str] = [_MARKER, ""]
+
+    if original_goal:
+        parts += [f"Original request: {original_goal}", ""]
+
+    if actions:
+        parts.append("Actions taken:")
+        for a in actions:
+            parts.append(f"  - {a}")
+        parts.append("")
+
+    if notes:
+        parts.append("Progress:")
+        for n in notes:
+            parts.append(f"  - {n}")
+        parts.append("")
+
+    if recent:
+        parts.append("Recent user instructions:")
+        for u in recent:
+            parts.append(f"  - {u}")
+        parts.append("")
+
+    if files:
+        parts.append("Key files:")
+        for f in sorted(files):
+            parts.append(f"  - {f}")
+        parts.append("")
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Extractors
+# ---------------------------------------------------------------------------
+
+
+def _find_original_goal(messages: List[Dict[str, Any]]) -> Optional[str]:
+    """Return the first substantive user message."""
+    for msg in messages[:10]:
+        if msg.get("role") != "user":
+            continue
+        content = (msg.get("content") or "").strip()
+        if len(content) < 8:
+            continue
+        # Skip injected system content
+        if content.startswith(("[", "<!--", "MEMORY", "{")):
+            continue
+        return _trunc(content, 500)
+    return None
+
+
+def _extract_actions(messages: List[Dict[str, Any]]) -> List[str]:
+    """Build a chronological action log from tool_calls."""
+    actions: List[str] = []
+    seen: Set[str] = set()
+
+    for msg in messages:
+        for tc in msg.get("tool_calls") or []:
+            func = tc.get("function", {})
+            name = func.get("name", "")
+            args = func.get("arguments", "")
+
+            line = _describe_tool_call(name, args)
+            if not line:
+                continue
+
+            key = line[:80].lower()
+            if key not in seen:
+                seen.add(key)
+                actions.append(line)
+
+    # Cap: keep first 5 + last 15 when too many
+    if len(actions) > 20:
+        actions = actions[:5] + ["(...earlier actions omitted...)"] + actions[-14:]
+
+    return actions
+
+
+def _describe_tool_call(name: str, args_str: str) -> Optional[str]:
+    """Human-readable one-liner for a tool call."""
+    if name in ("terminal", "execute_code"):
+        cmd = _jfield(args_str, "command") or _jfield(args_str, "code")
+        if cmd:
+            return f"[{name}] {_trunc(cmd, 120)}"
+    elif name in ("write_file", "patch"):
+        path = _jfield(args_str, "path") or "?"
+        return f"[{name}] {path}"
+    elif name == "read_file":
+        return f"[read] {_jfield(args_str, 'path') or '?'}"
+    elif name == "search_files":
+        pat = _jfield(args_str, "pattern") or "?"
+        return f"[search] pattern={_trunc(pat, 60)}"
+    elif name == "delegate_task":
+        goal = _jfield(args_str, "goal") or _trunc(args_str, 100)
+        return f"[delegate] {_trunc(goal, 120)}"
+    elif name == "browser_navigate":
+        return f"[browse] {_trunc(_jfield(args_str, 'url') or '?', 100)}"
+    elif name == "memory":
+        action = _jfield(args_str, "action") or "?"
+        return f"[memory:{action}]"
+    elif name == "todo":
+        return "[todo] updated"
+    elif name:
+        return f"[{name}]"
+    return None
+
+
+def _extract_progress_notes(messages: List[Dict[str, Any]]) -> List[str]:
+    """Extract the first sentence of each assistant message as a progress note."""
+    notes: List[str] = []
+    seen: Set[str] = set()
+
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        content = (msg.get("content") or "").strip()
+        if not content or len(content) < 8:
+            continue
+
+        # First line, then first sentence
+        line = content.split("\n")[0].strip()
+        for sep in ("\u3002", ".", "\uff01", "!", "\uff1b", ";"):
+            idx = line.find(sep)
+            if idx > 0:
+                line = line[: idx + 1]
+                break
+
+        line = _trunc(line, 150)
+        key = line[:60].lower()
+        if key not in seen and len(line) > 5:
+            seen.add(key)
+            notes.append(line)
+
+    return notes[-10:]
+
+
+def _extract_recent_user(messages: List[Dict[str, Any]]) -> List[str]:
+    """Last few user messages for current-context awareness."""
+    recent: List[str] = []
+    for msg in messages[-20:]:
+        if msg.get("role") != "user":
+            continue
+        content = (msg.get("content") or "").strip()
+        if len(content) < 5 or content.startswith("[") or _MARKER in content:
+            continue
+        recent.append(_trunc(content, 200))
+    return recent[-5:]
+
+
+def _extract_key_files(messages: List[Dict[str, Any]]) -> Set[str]:
+    """Collect file paths from write_file / patch / read_file tool calls."""
+    files: Set[str] = set()
+    for msg in messages:
+        for tc in msg.get("tool_calls") or []:
+            func = tc.get("function", {})
+            name = func.get("name", "")
+            if name in ("write_file", "patch", "read_file"):
+                path = _jfield(func.get("arguments", ""), "path")
+                if path:
+                    files.add(path)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _trunc(text: str, n: int) -> str:
+    """Collapse whitespace and truncate."""
+    text = text.replace("\n", " ").strip()
+    return text[:n] + "..." if len(text) > n else text
+
+
+def _jfield(json_str: str, field: str) -> Optional[str]:
+    """Quick regex extraction of a JSON string field value."""
+    if not json_str:
+        return None
+    m = re.search(rf'"{field}"\s*:\s*"((?:[^"\\]|\\.)*)"', json_str)
+    if m:
+        return (
+            m.group(1)
+            .replace('\\"', '"')
+            .replace("\\n", "\n")
+            .replace("\\\\", "\\")
+        )
+    return None

--- a/plugins/compress-summary/plugin.yaml
+++ b/plugins/compress-summary/plugin.yaml
@@ -1,0 +1,5 @@
+name: compress-summary
+version: 1.0.0
+description: "Injects a structured task-state summary before context compression to preserve task continuity."
+hooks:
+  - pre_compress

--- a/run_agent.py
+++ b/run_agent.py
@@ -5999,6 +5999,19 @@ class AIAgent:
             except Exception:
                 pass
 
+        # Fire pre_compress plugin hook — lets plugins inspect/modify messages
+        # before the compressor discards the middle section.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "pre_compress",
+                session_id=self.session_id,
+                messages=messages,
+                approx_tokens=approx_tokens,
+            )
+        except Exception:
+            pass
+
         compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
 
         todo_snapshot = self._todo_store.format_for_injection()
@@ -6083,6 +6096,21 @@ class AIAgent:
             self.session_id or "none", _pre_msg_count, len(compressed),
             f"{_compressed_est:,}",
         )
+
+        # Fire post_compress plugin hook
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "post_compress",
+                session_id=self.session_id,
+                messages=compressed,
+                pre_msg_count=_pre_msg_count,
+                post_msg_count=len(compressed),
+                approx_tokens=_compressed_est,
+            )
+        except Exception:
+            pass
+
         return compressed, new_system_prompt
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:

--- a/tests/plugins/test_compress_summary.py
+++ b/tests/plugins/test_compress_summary.py
@@ -1,0 +1,376 @@
+"""Tests for the compress-summary plugin.
+
+Covers: register(), _on_pre_compress(), _build_summary(), all extractors,
+helper functions, and edge cases.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure repo root is on sys.path so the plugin can be imported
+_repo_root = str(Path(__file__).resolve().parents[2])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+# Directory uses a hyphen ("compress-summary"), so we need importlib
+import importlib
+_mod = importlib.import_module("plugins.compress-summary")
+
+register = _mod.register
+_on_pre_compress = _mod._on_pre_compress
+_build_summary = _mod._build_summary
+_find_original_goal = _mod._find_original_goal
+_extract_actions = _mod._extract_actions
+_extract_progress_notes = _mod._extract_progress_notes
+_extract_recent_user = _mod._extract_recent_user
+_extract_key_files = _mod._extract_key_files
+_trunc = _mod._trunc
+_jfield = _mod._jfield
+_MARKER = _mod._MARKER
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _user(content):
+    return {"role": "user", "content": content}
+
+
+def _assistant(content, tool_calls=None):
+    msg = {"role": "assistant", "content": content}
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def _tool_call(name, arguments="{}"):
+    return {"function": {"name": name, "arguments": arguments}}
+
+
+def _make_conversation(n=15):
+    """Build a realistic conversation with tool calls."""
+    msgs = [
+        _user("帮我在 /tmp/app 下创建一个 Flask 项目"),
+        _assistant("好的，我来帮你创建 Flask 项目。", tool_calls=[
+            _tool_call("terminal", '{"command": "mkdir -p /tmp/app"}'),
+        ]),
+        _assistant(None, tool_calls=[
+            _tool_call("write_file", '{"path": "/tmp/app/app.py", "content": "from flask import Flask"}'),
+        ]),
+        _assistant("Flask 项目基础结构已创建。"),
+        _user("加上 requirements.txt"),
+        _assistant(None, tool_calls=[
+            _tool_call("write_file", '{"path": "/tmp/app/requirements.txt", "content": "flask==3.0"}'),
+        ]),
+        _assistant("requirements.txt 已添加。"),
+        _user("帮我加个 Dockerfile"),
+        _assistant(None, tool_calls=[
+            _tool_call("write_file", '{"path": "/tmp/app/Dockerfile", "content": "FROM python:3.12"}'),
+        ]),
+        _assistant("Dockerfile 已创建。"),
+        _user("运行测试看看"),
+        _assistant(None, tool_calls=[
+            _tool_call("terminal", '{"command": "cd /tmp/app && python -m pytest"}'),
+        ]),
+        _assistant("测试通过了。"),
+        _user("好的，现在部署到服务器"),
+        _assistant("开始部署流程。"),
+    ]
+    return msgs[:n] if n < len(msgs) else msgs
+
+
+# ===========================================================================
+# register()
+# ===========================================================================
+
+class TestRegister:
+    def test_registers_pre_compress_hook(self):
+        ctx = MagicMock()
+        register(ctx)
+        ctx.register_hook.assert_called_once_with("pre_compress", _on_pre_compress)
+
+
+# ===========================================================================
+# _on_pre_compress()
+# ===========================================================================
+
+class TestOnPreCompress:
+    def test_skips_when_messages_none(self):
+        _on_pre_compress(messages=None)  # should not raise
+
+    def test_skips_when_too_few_messages(self):
+        msgs = [_user("hi")] * 5
+        original_len = len(msgs)
+        _on_pre_compress(messages=msgs)
+        assert len(msgs) == original_len  # nothing appended
+
+    def test_injects_summary_for_long_conversation(self):
+        msgs = _make_conversation(15)
+        original_len = len(msgs)
+        _on_pre_compress(messages=msgs)
+        assert len(msgs) == original_len + 1
+        assert _MARKER in msgs[-1]["content"]
+        assert msgs[-1]["role"] == "user"
+
+    def test_no_double_injection(self):
+        msgs = _make_conversation(15)
+        _on_pre_compress(messages=msgs)
+        count_after_first = len(msgs)
+        _on_pre_compress(messages=msgs)
+        assert len(msgs) == count_after_first  # no second injection
+
+    def test_passes_session_id(self):
+        msgs = _make_conversation(15)
+        _on_pre_compress(session_id="test-123", messages=msgs)
+        assert len(msgs) > 15  # summary was injected
+
+
+# ===========================================================================
+# _build_summary()
+# ===========================================================================
+
+class TestBuildSummary:
+    def test_returns_none_for_empty(self):
+        assert _build_summary([]) is None
+
+    def test_returns_none_when_no_goal_no_actions(self):
+        msgs = [{"role": "system", "content": "you are helpful"}] * 5
+        assert _build_summary(msgs) is None
+
+    def test_includes_marker(self):
+        msgs = _make_conversation()
+        summary = _build_summary(msgs)
+        assert summary.startswith(_MARKER)
+
+    def test_includes_original_request(self):
+        msgs = _make_conversation()
+        summary = _build_summary(msgs)
+        assert "Original request:" in summary
+        assert "Flask" in summary
+
+    def test_includes_actions(self):
+        msgs = _make_conversation()
+        summary = _build_summary(msgs)
+        assert "Actions taken:" in summary
+        assert "[write_file]" in summary
+
+    def test_includes_key_files(self):
+        msgs = _make_conversation()
+        summary = _build_summary(msgs)
+        assert "Key files:" in summary
+        assert "/tmp/app/app.py" in summary
+
+    def test_includes_progress(self):
+        msgs = _make_conversation()
+        summary = _build_summary(msgs)
+        assert "Progress:" in summary
+
+
+# ===========================================================================
+# _find_original_goal()
+# ===========================================================================
+
+class TestFindOriginalGoal:
+    def test_finds_first_user_message(self):
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            _user("帮我创建一个 Python 项目"),
+        ]
+        assert "Python" in _find_original_goal(msgs)
+
+    def test_skips_short_messages(self):
+        msgs = [_user("ok"), _user("帮我创建一个完整的 Flask 应用")]
+        assert "Flask" in _find_original_goal(msgs)
+
+    def test_skips_injected_content(self):
+        msgs = [
+            _user("[MEMORY] some injected stuff"),
+            _user("帮我写一个脚本来处理数据"),
+        ]
+        assert "脚本" in _find_original_goal(msgs)
+
+    def test_returns_none_when_no_goal(self):
+        msgs = [_user("hi"), _user("ok")]
+        assert _find_original_goal(msgs) is None
+
+    def test_truncates_long_goal(self):
+        msgs = [_user("x" * 1000)]
+        result = _find_original_goal(msgs)
+        assert len(result) <= 503  # 500 + "..."
+
+
+# ===========================================================================
+# _extract_actions()
+# ===========================================================================
+
+class TestExtractActions:
+    def test_extracts_tool_calls(self):
+        msgs = [
+            _assistant(None, tool_calls=[
+                _tool_call("write_file", '{"path": "/tmp/test.py"}'),
+            ]),
+        ]
+        actions = _extract_actions(msgs)
+        assert len(actions) == 1
+        assert "[write_file]" in actions[0]
+
+    def test_deduplicates(self):
+        tc = _tool_call("write_file", '{"path": "/tmp/test.py"}')
+        msgs = [
+            _assistant(None, tool_calls=[tc]),
+            _assistant(None, tool_calls=[tc]),
+        ]
+        actions = _extract_actions(msgs)
+        assert len(actions) == 1
+
+    def test_caps_at_20(self):
+        msgs = []
+        for i in range(30):
+            msgs.append(_assistant(None, tool_calls=[
+                _tool_call("write_file", f'{{"path": "/tmp/file_{i}.py"}}'),
+            ]))
+        actions = _extract_actions(msgs)
+        assert len(actions) == 20  # 5 + marker + 14
+
+    def test_terminal_shows_command(self):
+        msgs = [_assistant(None, tool_calls=[
+            _tool_call("terminal", '{"command": "ls -la /tmp"}'),
+        ])]
+        actions = _extract_actions(msgs)
+        assert "ls -la" in actions[0]
+
+    def test_search_shows_pattern(self):
+        msgs = [_assistant(None, tool_calls=[
+            _tool_call("search_files", '{"pattern": "TODO"}'),
+        ])]
+        actions = _extract_actions(msgs)
+        assert "TODO" in actions[0]
+
+    def test_delegate_shows_goal(self):
+        msgs = [_assistant(None, tool_calls=[
+            _tool_call("delegate_task", '{"goal": "check upstream repo"}'),
+        ])]
+        actions = _extract_actions(msgs)
+        assert "check upstream" in actions[0]
+
+    def test_unknown_tool_still_logged(self):
+        msgs = [_assistant(None, tool_calls=[
+            _tool_call("some_new_tool", "{}"),
+        ])]
+        actions = _extract_actions(msgs)
+        assert "[some_new_tool]" in actions[0]
+
+
+# ===========================================================================
+# _extract_progress_notes()
+# ===========================================================================
+
+class TestExtractProgressNotes:
+    def test_extracts_first_sentence(self):
+        msgs = [_assistant("项目已创建。接下来配置数据库。")]
+        notes = _extract_progress_notes(msgs)
+        assert len(notes) == 1
+        assert notes[0] == "项目已创建。"
+
+    def test_skips_short_content(self):
+        msgs = [_assistant("ok")]
+        assert _extract_progress_notes(msgs) == []
+
+    def test_keeps_last_10(self):
+        msgs = [_assistant(f"步骤 {i} 已完成。") for i in range(20)]
+        notes = _extract_progress_notes(msgs)
+        assert len(notes) <= 10
+
+    def test_deduplicates(self):
+        msgs = [_assistant("这个任务已经完成了。"), _assistant("这个任务已经完成了。")]
+        notes = _extract_progress_notes(msgs)
+        assert len(notes) == 1
+
+
+# ===========================================================================
+# _extract_recent_user()
+# ===========================================================================
+
+class TestExtractRecentUser:
+    def test_extracts_recent_messages(self):
+        msgs = [_user(f"指令 {i}，请执行这个操作") for i in range(25)]
+        recent = _extract_recent_user(msgs)
+        assert len(recent) == 5  # last 5
+
+    def test_skips_injected(self):
+        msgs = [_user("[SYSTEM] injected"), _user("真正的用户消息来了")]
+        recent = _extract_recent_user(msgs)
+        assert len(recent) == 1
+
+    def test_skips_marker(self):
+        msgs = [_user(f"{_MARKER}\nsome summary"), _user("继续工作吧")]
+        recent = _extract_recent_user(msgs)
+        assert len(recent) == 1
+        assert "继续" in recent[0]
+
+
+# ===========================================================================
+# _extract_key_files()
+# ===========================================================================
+
+class TestExtractKeyFiles:
+    def test_collects_paths(self):
+        msgs = [
+            _assistant(None, tool_calls=[
+                _tool_call("write_file", '{"path": "/a.py"}'),
+                _tool_call("read_file", '{"path": "/b.py"}'),
+                _tool_call("patch", '{"path": "/c.py"}'),
+            ]),
+        ]
+        files = _extract_key_files(msgs)
+        assert files == {"/a.py", "/b.py", "/c.py"}
+
+    def test_ignores_non_file_tools(self):
+        msgs = [_assistant(None, tool_calls=[
+            _tool_call("terminal", '{"command": "ls"}'),
+        ])]
+        assert _extract_key_files(msgs) == set()
+
+    def test_deduplicates(self):
+        msgs = [
+            _assistant(None, tool_calls=[_tool_call("write_file", '{"path": "/a.py"}')]),
+            _assistant(None, tool_calls=[_tool_call("read_file", '{"path": "/a.py"}')]),
+        ]
+        assert len(_extract_key_files(msgs)) == 1
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+class TestTrunc:
+    def test_short_unchanged(self):
+        assert _trunc("hello", 10) == "hello"
+
+    def test_long_truncated(self):
+        assert _trunc("a" * 20, 10) == "a" * 10 + "..."
+
+    def test_newlines_collapsed(self):
+        assert _trunc("a\nb\nc", 100) == "a b c"
+
+
+class TestJfield:
+    def test_extracts_string_field(self):
+        assert _jfield('{"path": "/tmp/test.py"}', "path") == "/tmp/test.py"
+
+    def test_returns_none_for_missing(self):
+        assert _jfield('{"path": "/tmp"}', "command") is None
+
+    def test_returns_none_for_empty(self):
+        assert _jfield("", "path") is None
+        assert _jfield(None, "path") is None
+
+    def test_handles_escaped_quotes(self):
+        assert _jfield('{"cmd": "echo \\"hi\\""}', "cmd") == 'echo "hi"'
+
+    def test_handles_escaped_newlines(self):
+        assert _jfield('{"text": "line1\\nline2"}', "text") == "line1\nline2"


### PR DESCRIPTION
## What does this PR do?

Adds `pre_compress` and `post_compress` plugin hooks to the context compression lifecycle, plus a new **compress-summary** plugin that uses `pre_compress` to inject a structured task-state summary into the conversation tail before compression fires.

When long conversations are compressed, the model retains the head (system prompt) and tail (recent messages) but loses intermediate progress — completed sub-tasks, file paths, tool call history. This plugin captures that state heuristically (zero extra LLM calls) and places it in the protected tail region so it survives compression.

## Related Issue

Relates to #499 (Context Compaction Quality Overhaul)
Closes #3694 (Observable context truncation events for memory continuity)
Relates to #2817 (Plugin hooks documented but never invoked)
Relates to #5563 (Memory persistence and state loss in long sessions)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py` — add `pre_compress` and `post_compress` to `VALID_HOOKS`
- `run_agent.py` — fire `pre_compress` hook before compression, `post_compress` hook after
- `plugins/compress-summary/__init__.py` — plugin implementation (heuristic extractors for goal, actions, progress, files)
- `plugins/compress-summary/plugin.yaml` — plugin manifest
- `plugins/compress-summary/README.md` — plugin documentation
- `tests/plugins/test_compress_summary.py` — 43 tests covering all extractors, edge cases, and injection logic

## How to Test

1. Install the plugin: ensure `plugins/compress-summary/` is in the plugins directory
2. Start a long session (10+ messages with tool calls)
3. Trigger compression via `/compress` or let it auto-trigger
4. Verify the last message before compression contains the `[TASK STATE SUMMARY]` marker
5. After compression, confirm the model retains awareness of prior actions and file paths
6. Run tests: `pytest tests/plugins/test_compress_summary.py -v` (43 tests, all passing)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (43 tests covering all extractors and edge cases)
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README in plugin directory) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python, stdlib only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ pytest tests/plugins/test_compress_summary.py -v
43 passed in 0.68s
```
