### PR TITLE
fix(session-search): preserve child-hit recall and lineage exclusion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -62,6 +62,7 @@ LongOddCode <haolong@microsoft.com> <haolong@microsoft.com>
 Cafexss <coffeemjj@gmail.com> <coffeemjj@gmail.com>
 Cygra <sjtuwbh@gmail.com> <sjtuwbh@gmail.com>
 DomGrieco <dgrieco@redhat.com> <dgrieco@redhat.com>
+MestreY0d4-Uninter <MestreY0d4-Uninter@users.noreply.github.com> <MestreY0d4-Uninter@users.noreply.github.com>
 
 # Duplicate email mapping (same person, multiple emails)
 Sertug17 <104278804+Sertug17@users.noreply.github.com> <srhtsrht17@gmail.com>

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "258577966+voidborne-d@users.noreply.github.com": "voidborne-d",
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     # contributors (manual mapping from git names)
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -2,6 +2,8 @@
 
 import json
 import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from tools.session_search_tool import (
@@ -318,3 +320,90 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+    def test_child_hit_uses_child_transcript_for_fallback_preview(self):
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "child_sid",
+                "content": "needle in child",
+                "source": "telegram",
+                "session_started": 1709500000,
+                "model": "test",
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {"parent_session_id": "root_sid"}
+            if session_id == "root_sid":
+                return {"parent_session_id": None}
+            return None
+
+        def _get_messages(session_id):
+            if session_id == "child_sid":
+                return [
+                    {"role": "user", "content": "this contains the needle in child"},
+                    {"role": "assistant", "content": "child-specific follow-up"},
+                ]
+            if session_id == "root_sid":
+                return [
+                    {"role": "user", "content": "root transcript without the keyword"},
+                    {"role": "assistant", "content": "older root context"},
+                ]
+            return []
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.side_effect = _get_messages
+
+        with patch("tools.session_search_tool.async_call_llm", new_callable=AsyncMock, side_effect=RuntimeError("no provider")):
+            result = json.loads(session_search(query="needle", db=mock_db))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "root_sid"
+        assert "needle in child" in result["results"][0]["summary"]
+        assert "root transcript without the keyword" not in result["results"][0]["summary"]
+
+    def test_recent_sessions_excludes_current_parent_lineage(self):
+        from tools.session_search_tool import _list_recent_sessions
+
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = [
+            {
+                "id": "parent",
+                "title": "Parent session",
+                "source": "telegram",
+                "started_at": "2026-04-09T10:00:00",
+                "last_active": "2026-04-09T10:10:00",
+                "message_count": 4,
+                "preview": "parent preview",
+                "parent_session_id": None,
+            },
+            {
+                "id": "other-session",
+                "title": "Other session",
+                "source": "cli",
+                "started_at": "2026-04-08T10:00:00",
+                "last_active": "2026-04-08T10:10:00",
+                "message_count": 2,
+                "preview": "other preview",
+                "parent_session_id": None,
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child-longer-id":
+                return {"parent_session_id": "parent"}
+            if session_id == "parent":
+                return {"parent_session_id": None}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+
+        result = json.loads(_list_recent_sessions(mock_db, limit=5, current_session_id="child-longer-id"))
+
+        assert result["success"] is True
+        assert [r["session_id"] for r in result["results"]] == ["other-session"]

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -253,12 +253,14 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             try:
                 sid = current_session_id
                 visited = set()
+                root_sid = current_session_id
                 while sid and sid not in visited:
                     visited.add(sid)
+                    root_sid = sid
                     s = db.get_session(sid)
                     parent = s.get("parent_session_id") if s else None
                     sid = parent if parent else None
-                current_root = max(visited, key=len) if visited else current_session_id
+                current_root = root_sid
             except Exception:
                 current_root = current_session_id
 
@@ -390,7 +392,9 @@ def session_search(
             if resolved_sid not in seen_sessions:
                 result = dict(result)
                 result["session_id"] = resolved_sid
+                result["match_session_id"] = raw_sid
                 seen_sessions[resolved_sid] = result
+
             if len(seen_sessions) >= limit:
                 break
 
@@ -398,7 +402,12 @@ def session_search(
         tasks = []
         for session_id, match_info in seen_sessions.items():
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                # Load from the matched session (child if that's where FTS hit),
+                # falling back to the resolved root if the child has no messages.
+                match_session_id = match_info.get("match_session_id") or session_id
+                messages = db.get_messages_as_conversation(match_session_id)
+                if not messages and match_session_id != session_id:
+                    messages = db.get_messages_as_conversation(session_id)
                 if not messages:
                     continue
                 session_meta = db.get_session(session_id) or {}


### PR DESCRIPTION
## Summary
- fix `session_search` so child-session hits are summarized from the hit-bearing transcript instead of always from the resolved root
- fix recent-session lineage exclusion so the current parent/root chain is skipped reliably
- add focused regressions for both the child-hit recall path and the recent-sessions lineage path

## Problem
There were two related lineage bugs in `tools/session_search_tool.py`:

1. Search hits from child/continuation sessions were deduped to the lineage root, then summarized from `db.get_messages_as_conversation(root_sid)`.
   - If the query only existed in the child session, recall could return the wrong preview/summary.

2. Recent-session browsing resolved the current lineage root using `max(visited, key=len)`.
   - That is not a root-resolution rule; it just picks the longest session ID string.
   - In some parent/child chains, the active lineage could leak back into the recent-session results.

## Fix
- keep the resolved root only as the dedup/display session id
- preserve the raw hit-bearing session id as `match_session_id`
- load messages from the hit-bearing session first, falling back to the resolved root only if needed
- resolve the current recent-session lineage root by tracking the last real ancestor reached during parent walking

## Validation
Ran locally in a clean isolated worktree from current `origin/main`:
- `pytest tests/tools/test_session_search.py -q -o addopts=`
- `python -m py_compile tools/session_search_tool.py tests/tools/test_session_search.py`

Result:
- `27 passed`

## Tests added
- child-session hit falls back to preview text from the child transcript instead of unrelated root-only text
- recent-session browsing excludes the current parent lineage even when the child session ID is longer than the parent/root ID

## Notes
- I checked for an obvious existing issue/PR covering this exact lineage-handling fix shape and did not find one before opening this PR.
- This stays intentionally focused on the lineage/preview logic and does not broaden into a larger session-search redesign.
