### PR TITLE
fix: detect truncated tool call args in streaming mock builder, override finish_reason to 'length'

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4564,21 +4564,54 @@ class AIAgent:
             # Build mock response matching non-streaming shape
             full_content = "".join(content_parts) or None
             mock_tool_calls = None
+            _has_truncated_tool_args = False
             if tool_calls_acc:
                 mock_tool_calls = []
                 for idx in sorted(tool_calls_acc):
                     tc = tool_calls_acc[idx]
+                    tc_args = tc["function"]["arguments"]
+                    tc_name = tc["function"]["name"]
+                    # Detect truncated tool call arguments: if the stream was
+                    # cut mid-generation the accumulated JSON will be invalid.
+                    # Flag this so we can override finish_reason to "length"
+                    # and let the main loop handle it as a truncated response
+                    # instead of silently executing with broken arguments.
+                    if tc_args and tc_args.strip():
+                        try:
+                            json.loads(tc_args)
+                        except json.JSONDecodeError:
+                            _has_truncated_tool_args = True
+                            logger.warning(
+                                "Truncated tool call arguments detected in "
+                                "streaming response for tool '%s': %s…",
+                                tc_name, tc_args[:120],
+                            )
                     mock_tool_calls.append(SimpleNamespace(
                         id=tc["id"],
                         type=tc["type"],
                         extra_content=tc.get("extra_content"),
                         function=SimpleNamespace(
-                            name=tc["function"]["name"],
-                            arguments=tc["function"]["arguments"],
+                            name=tc_name,
+                            arguments=tc_args,
                         ),
                     ))
 
             full_reasoning = "".join(reasoning_parts) or None
+
+            # If the stream ended without a finish_reason (provider dropped
+            # connection gracefully) or with finish_reason="stop" but the tool
+            # call arguments are invalid JSON, override to "length" so the
+            # main agent loop treats this as a truncated response and retries
+            # instead of executing a tool with broken/empty arguments.
+            effective_finish_reason = finish_reason or "stop"
+            if _has_truncated_tool_args and effective_finish_reason != "length":
+                logger.warning(
+                    "Overriding finish_reason from '%s' to 'length' due to "
+                    "truncated tool call arguments (stream likely cut short)",
+                    effective_finish_reason,
+                )
+                effective_finish_reason = "length"
+
             mock_message = SimpleNamespace(
                 role=role,
                 content=full_content,
@@ -4588,7 +4621,7 @@ class AIAgent:
             mock_choice = SimpleNamespace(
                 index=0,
                 message=mock_message,
-                finish_reason=finish_reason or "stop",
+                finish_reason=effective_finish_reason,
             )
             return SimpleNamespace(
                 id="stream-" + str(uuid.uuid4()),


### PR DESCRIPTION
## Summary

Fix silent data loss when a provider cuts a streaming response mid-tool-call.

Fixes #6638

## Problem

When a provider (e.g. Copilot/OpenAI-compatible) drops a streaming connection mid-tool-call, the mock response builder at ~L4591 defaulted `finish_reason` to `"stop"`:

```python
finish_reason=finish_reason or "stop"
```

This caused the main agent loop to treat a **truncated** tool call as a **valid completed** response. The user would see "preparing write_file..." in the spinner, then the prompt would reset with no file written and no error shown.

### Cascade of failures:

1. **Mock builder** — masks truncation as valid (`finish_reason="stop"`)
2. **JSON validation** (L8858-8916) — catches invalid args but wastes 3 retries (all truncated if provider-side)
3. **json.loads fallback** (L6504-6507) — falls back to `{}`, silently executes tool with empty args

## Fix

After accumulating streaming tool calls in the mock builder, validate each tool's arguments with `json.loads()`. If **any** tool call has invalid JSON:

1. Set `_has_truncated_tool_args = True`
2. Override `finish_reason` to `"length"`
3. The main loop's existing truncation handler kicks in:
   - Rollback to last complete assistant turn
   - Return `partial=True` with clear error message
   - CLI shows: "Error: Response truncated due to output length limit"

This catches the problem at the **earliest possible point** (mock builder) instead of letting it cascade through 3 retry loops. The existing JSON validation at L8858 remains as a secondary safety net.

## Changes

- `run_agent.py` — 36 lines added, 3 modified in the streaming mock response builder (~L4564-4624)

## Testing

- Compiles clean
- Tested locally with Copilot provider — truncated responses now correctly trigger the truncation handler instead of silently failing
- **Needs broader testing**: different providers, edge cases with legitimately empty tool args, partial streams

## Checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Existing tests pass
- [ ] Additional test coverage for truncation detection (recommended)
