### PR TITLE
fix(security): resolve approval context-bleed and enforce session isolation in RPC workers

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -17,6 +17,7 @@ import pytest
 
 import json
 import os
+import base64
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -39,6 +40,7 @@ from unittest.mock import patch, MagicMock
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
     execute_code,
+    _rpc_poll_loop,
     generate_hermes_tools_module,
     check_sandbox_requirements,
     build_execute_code_schema,
@@ -65,6 +67,96 @@ def _mock_handle_function_call(function_name, function_args, task_id=None, user_
     if function_name == "web_extract":
         return json.dumps("# Extracted content\nSome text from the page.")
     return json.dumps({"error": f"Unknown tool in mock: {function_name}"})
+
+
+def test_rpc_poll_loop_uses_parent_approval_session(tmp_path, monkeypatch):
+    """Remote RPC threads must not fall back to another session's env var."""
+    from tools.approval import (
+        clear_session,
+        has_pending,
+        pop_pending,
+        reset_current_session_key,
+        set_current_session_key,
+    )
+
+    rpc_dir = tmp_path / "rpc"
+    rpc_dir.mkdir()
+    request_path = rpc_dir / "req_000001"
+    request_path.write_text(
+        json.dumps({"tool": "terminal", "args": {"command": "echo hi"}, "seq": 1}),
+        encoding="utf-8",
+    )
+
+    class _FakeRemoteEnv:
+        def execute(self, command, cwd="/", timeout=10):
+            if command.startswith("ls -1 "):
+                matches = sorted(str(p).replace("\\", "/") for p in rpc_dir.glob("req_*"))
+                return {"output": "\n".join(matches), "returncode": 0}
+            if command.startswith("cat "):
+                path = command[4:]
+                with open(path, encoding="utf-8") as handle:
+                    return {"output": handle.read(), "returncode": 0}
+            if command.startswith("rm -f "):
+                path = command[6:]
+                if os.path.exists(path):
+                    os.remove(path)
+                return {"output": "", "returncode": 0}
+            if "base64 -d > " in command and " && mv " in command:
+                encoded = command.split("echo '", 1)[1].split("' | base64 -d > ", 1)[0]
+                _, final_target = command.split("' | base64 -d > ", 1)[1].split(" && mv ", 1)
+                final_target = final_target.strip()
+                decoded = base64.b64decode(encoded).decode("utf-8")
+                with open(final_target, "w", encoding="utf-8") as handle:
+                    handle.write(decoded)
+                return {"output": "", "returncode": 0}
+            raise AssertionError(f"Unexpected fake env command: {command}")
+
+    def _dangerous_dispatch(_function_name, _function_args, task_id=None, user_task=None):
+        from tools.approval import check_all_command_guards
+
+        return json.dumps(check_all_command_guards("rm -rf /tmp/alice-secret", "local"))
+
+    clear_session("alice")
+    clear_session("bob")
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "bob")
+
+    stop_event = threading.Event()
+    token = set_current_session_key("alice")
+    try:
+        with patch("tools.tirith_security.check_command_security",
+                   return_value={"action": "allow", "findings": [], "summary": ""}), \
+             patch("model_tools.handle_function_call", side_effect=_dangerous_dispatch):
+            worker = threading.Thread(
+                target=_rpc_poll_loop,
+                args=(
+                    _FakeRemoteEnv(),
+                    str(rpc_dir).replace("\\", "/"),
+                    "approval-session-test",
+                    [],
+                    [0],
+                    5,
+                    frozenset({"terminal"}),
+                    stop_event,
+                    "alice",
+                ),
+                daemon=True,
+            )
+            worker.start()
+
+            for _ in range(40):
+                if has_pending("alice") or has_pending("bob"):
+                    break
+                time.sleep(0.05)
+            stop_event.set()
+            worker.join(timeout=2)
+    finally:
+        reset_current_session_key(token)
+
+    assert pop_pending("alice") is not None
+    assert pop_pending("bob") is None
+    clear_session("alice")
+    clear_session("bob")
 
 
 class TestSandboxRequirements(unittest.TestCase):
@@ -247,6 +339,47 @@ print(f"Found {len(results.get('results', []))} results")
         result = self._run(code)
         self.assertEqual(result["status"], "success")
         self.assertIn("Found 1 results", result["output"])
+
+    def test_execute_code_rpc_uses_parent_approval_session(self):
+        """Dangerous approvals raised inside RPC threads stay bound to the caller session."""
+        from tools.approval import (
+            clear_session,
+            pop_pending,
+            reset_current_session_key,
+            set_current_session_key,
+        )
+
+        clear_session("alice")
+        clear_session("bob")
+
+        def _dangerous_dispatch(_function_name, _function_args, task_id=None, user_task=None):
+            from tools.approval import check_all_command_guards
+
+            return json.dumps(check_all_command_guards("rm -rf /tmp/alice-secret", "local"))
+
+        code = """
+from hermes_tools import terminal
+print(terminal("echo hi"))
+"""
+        token = set_current_session_key("alice")
+        try:
+            with patch("tools.tirith_security.check_command_security",
+                       return_value={"action": "allow", "findings": [], "summary": ""}), \
+                 patch("model_tools.handle_function_call", side_effect=_dangerous_dispatch), \
+                 patch.dict(os.environ, {"HERMES_EXEC_ASK": "1", "HERMES_SESSION_KEY": "bob"}, clear=False):
+                result = json.loads(execute_code(
+                    code=code,
+                    task_id="approval-session-test",
+                    enabled_tools=["terminal"],
+                ))
+        finally:
+            reset_current_session_key(token)
+
+        self.assertIn(result["status"], {"success", "error"})
+        self.assertIsNotNone(pop_pending("alice"))
+        self.assertIsNone(pop_pending("bob"))
+        clear_session("alice")
+        clear_session("bob")
 
     def test_json_parse_helper(self):
         """json_parse handles control characters that json.loads(strict=True) rejects."""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -303,6 +303,19 @@ def _call(tool_name, args):
 _TERMINAL_BLOCKED_PARAMS = {"background", "check_interval", "pty", "notify_on_complete"}
 
 
+def _bind_approval_session(session_key: str):
+    """Bind the parent's approval session to an RPC worker thread."""
+    from tools.approval import (
+        get_current_session_key,
+        reset_current_session_key,
+        set_current_session_key,
+    )
+
+    effective_key = session_key or get_current_session_key()
+    token = set_current_session_key(effective_key)
+    return token, reset_current_session_key
+
+
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
@@ -310,6 +323,7 @@ def _rpc_server_loop(
     tool_call_counter: list,   # mutable [int] so the thread can increment
     max_tool_calls: int,
     allowed_tools: frozenset,
+    approval_session_key: str = "",
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -318,7 +332,10 @@ def _rpc_server_loop(
     from model_tools import handle_function_call
 
     conn = None
+    approval_token = None
+    reset_approval_session = None
     try:
+        approval_token, reset_approval_session = _bind_approval_session(approval_session_key)
         server_sock.settimeout(5)
         conn, _ = server_sock.accept()
         conn.settimeout(300)
@@ -416,6 +433,8 @@ def _rpc_server_loop(
     except OSError as e:
         logger.debug("RPC listener socket error: %s", e, exc_info=True)
     finally:
+        if approval_token is not None and reset_approval_session is not None:
+            reset_approval_session(approval_token)
         if conn:
             try:
                 conn.close()
@@ -552,6 +571,7 @@ def _rpc_poll_loop(
     max_tool_calls: int,
     allowed_tools: frozenset,
     stop_event: threading.Event,
+    approval_session_key: str = "",
 ):
     """Poll the remote filesystem for tool call requests and dispatch them.
 
@@ -562,124 +582,132 @@ def _rpc_poll_loop(
     from model_tools import handle_function_call
 
     poll_interval = 0.1  # 100 ms
+    approval_token = None
+    reset_approval_session = None
 
-    while not stop_event.is_set():
-        try:
-            # List pending request files (skip .tmp partials)
-            ls_result = env.execute(
-                f"ls -1 {rpc_dir}/req_* 2>/dev/null || true",
-                cwd="/",
-                timeout=10,
-            )
-            output = ls_result.get("output", "").strip()
-            if not output:
-                stop_event.wait(poll_interval)
-                continue
+    try:
+        approval_token, reset_approval_session = _bind_approval_session(approval_session_key)
 
-            req_files = sorted([
-                f.strip() for f in output.split("\n")
-                if f.strip()
-                and not f.strip().endswith(".tmp")
-                and "/req_" in f.strip()
-            ])
-
-            for req_file in req_files:
-                if stop_event.is_set():
-                    break
-
-                call_start = time.monotonic()
-
-                # Read request
-                read_result = env.execute(
-                    f"cat {req_file}",
+        while not stop_event.is_set():
+            try:
+                # List pending request files (skip .tmp partials)
+                ls_result = env.execute(
+                    f"ls -1 {rpc_dir}/req_* 2>/dev/null || true",
                     cwd="/",
                     timeout=10,
                 )
-                try:
-                    request = json.loads(read_result.get("output", ""))
-                except (json.JSONDecodeError, ValueError):
-                    logger.debug("Malformed RPC request in %s", req_file)
-                    # Remove bad request to avoid infinite retry
-                    env.execute(f"rm -f {req_file}", cwd="/", timeout=5)
+                output = ls_result.get("output", "").strip()
+                if not output:
+                    stop_event.wait(poll_interval)
                     continue
 
-                tool_name = request.get("tool", "")
-                tool_args = request.get("args", {})
-                seq = request.get("seq", 0)
-                seq_str = f"{seq:06d}"
-                res_file = f"{rpc_dir}/res_{seq_str}"
+                req_files = sorted([
+                    f.strip() for f in output.split("\n")
+                    if f.strip()
+                    and not f.strip().endswith(".tmp")
+                    and "/req_" in f.strip()
+                ])
 
-                # Enforce allow-list
-                if tool_name not in allowed_tools:
-                    available = ", ".join(sorted(allowed_tools))
-                    tool_result = json.dumps({
-                        "error": (
-                            f"Tool '{tool_name}' is not available in execute_code. "
-                            f"Available: {available}"
-                        )
-                    })
-                # Enforce tool call limit
-                elif tool_call_counter[0] >= max_tool_calls:
-                    tool_result = json.dumps({
-                        "error": (
-                            f"Tool call limit reached ({max_tool_calls}). "
-                            "No more tool calls allowed in this execution."
-                        )
-                    })
-                else:
-                    # Strip forbidden terminal parameters
-                    if tool_name == "terminal" and isinstance(tool_args, dict):
-                        for param in _TERMINAL_BLOCKED_PARAMS:
-                            tool_args.pop(param, None)
+                for req_file in req_files:
+                    if stop_event.is_set():
+                        break
 
-                    # Dispatch through the standard tool handler
+                    call_start = time.monotonic()
+
+                    # Read request
+                    read_result = env.execute(
+                        f"cat {req_file}",
+                        cwd="/",
+                        timeout=10,
+                    )
                     try:
-                        _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                        devnull = open(os.devnull, "w")
-                        try:
-                            sys.stdout = devnull
-                            sys.stderr = devnull
-                            tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                        request = json.loads(read_result.get("output", ""))
+                    except (json.JSONDecodeError, ValueError):
+                        logger.debug("Malformed RPC request in %s", req_file)
+                        # Remove bad request to avoid infinite retry
+                        env.execute(f"rm -f {req_file}", cwd="/", timeout=5)
+                        continue
+
+                    tool_name = request.get("tool", "")
+                    tool_args = request.get("args", {})
+                    seq = request.get("seq", 0)
+                    seq_str = f"{seq:06d}"
+                    res_file = f"{rpc_dir}/res_{seq_str}"
+
+                    # Enforce allow-list
+                    if tool_name not in allowed_tools:
+                        available = ", ".join(sorted(allowed_tools))
+                        tool_result = json.dumps({
+                            "error": (
+                                f"Tool '{tool_name}' is not available in execute_code. "
+                                f"Available: {available}"
                             )
-                        finally:
-                            sys.stdout, sys.stderr = _real_stdout, _real_stderr
-                            devnull.close()
-                    except Exception as exc:
-                        logger.error("Tool call failed in remote sandbox: %s",
-                                     exc, exc_info=True)
-                        tool_result = tool_error(str(exc))
+                        })
+                    # Enforce tool call limit
+                    elif tool_call_counter[0] >= max_tool_calls:
+                        tool_result = json.dumps({
+                            "error": (
+                                f"Tool call limit reached ({max_tool_calls}). "
+                                "No more tool calls allowed in this execution."
+                            )
+                        })
+                    else:
+                        # Strip forbidden terminal parameters
+                        if tool_name == "terminal" and isinstance(tool_args, dict):
+                            for param in _TERMINAL_BLOCKED_PARAMS:
+                                tool_args.pop(param, None)
 
-                    tool_call_counter[0] += 1
-                    call_duration = time.monotonic() - call_start
-                    tool_call_log.append({
-                        "tool": tool_name,
-                        "args_preview": str(tool_args)[:80],
-                        "duration": round(call_duration, 2),
-                    })
+                        # Dispatch through the standard tool handler
+                        try:
+                            _real_stdout, _real_stderr = sys.stdout, sys.stderr
+                            devnull = open(os.devnull, "w")
+                            try:
+                                sys.stdout = devnull
+                                sys.stderr = devnull
+                                tool_result = handle_function_call(
+                                    tool_name, tool_args, task_id=task_id
+                                )
+                            finally:
+                                sys.stdout, sys.stderr = _real_stdout, _real_stderr
+                                devnull.close()
+                        except Exception as exc:
+                            logger.error("Tool call failed in remote sandbox: %s",
+                                         exc, exc_info=True)
+                            tool_result = tool_error(str(exc))
 
-                # Write response atomically (tmp + rename).
-                # Use echo piping (not stdin_data) because Modal doesn't
-                # reliably deliver stdin to chained commands.
-                encoded_result = base64.b64encode(
-                    tool_result.encode("utf-8")
-                ).decode("ascii")
-                env.execute(
-                    f"echo '{encoded_result}' | base64 -d > {res_file}.tmp"
-                    f" && mv {res_file}.tmp {res_file}",
-                    cwd="/",
-                    timeout=60,
-                )
+                        tool_call_counter[0] += 1
+                        call_duration = time.monotonic() - call_start
+                        tool_call_log.append({
+                            "tool": tool_name,
+                            "args_preview": str(tool_args)[:80],
+                            "duration": round(call_duration, 2),
+                        })
 
-                # Remove the request file
-                env.execute(f"rm -f {req_file}", cwd="/", timeout=5)
+                    # Write response atomically (tmp + rename).
+                    # Use echo piping (not stdin_data) because Modal doesn't
+                    # reliably deliver stdin to chained commands.
+                    encoded_result = base64.b64encode(
+                        tool_result.encode("utf-8")
+                    ).decode("ascii")
+                    env.execute(
+                        f"echo '{encoded_result}' | base64 -d > {res_file}.tmp"
+                        f" && mv {res_file}.tmp {res_file}",
+                        cwd="/",
+                        timeout=60,
+                    )
 
-        except Exception as e:
+                    # Remove the request file
+                    env.execute(f"rm -f {req_file}", cwd="/", timeout=5)
+
+            except Exception as e:
+                if not stop_event.is_set():
+                    logger.debug("RPC poll error: %s", e, exc_info=True)
+
             if not stop_event.is_set():
-                logger.debug("RPC poll error: %s", e, exc_info=True)
-
-        if not stop_event.is_set():
-            stop_event.wait(poll_interval)
+                stop_event.wait(poll_interval)
+    finally:
+        if approval_token is not None and reset_approval_session is not None:
+            reset_approval_session(approval_token)
 
 
 def _execute_remote(
@@ -704,6 +732,9 @@ def _execute_remote(
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
 
     effective_task_id = task_id or "default"
+    from tools.approval import get_current_session_key
+
+    approval_session_key = get_current_session_key()
     env, env_type = _get_or_create_env(effective_task_id)
 
     sandbox_id = uuid.uuid4().hex[:12]
@@ -751,7 +782,7 @@ def _execute_remote(
             args=(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
-                sandbox_tools, stop_event,
+                sandbox_tools, stop_event, approval_session_key,
             ),
             daemon=True,
         )
@@ -914,6 +945,9 @@ def execute_code(
 
     if not sandbox_tools:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    from tools.approval import get_current_session_key
+
+    approval_session_key = get_current_session_key()
 
     # --- Set up temp directory with hermes_tools.py and script.py ---
     tmpdir = tempfile.mkdtemp(prefix="hermes_sandbox_")
@@ -950,6 +984,7 @@ def execute_code(
             args=(
                 server_sock, task_id, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools,
+                approval_session_key,
             ),
             daemon=True,
         )


### PR DESCRIPTION
Summary
This PR fixes a security bug in the execute_code tool where dangerous-command approvals could lose session isolation inside RPC worker threads.

execute_code dispatches tool calls from background RPC threads. The approval system is designed to be session-scoped, but these worker threads were not inheriting the parent approval session context. In concurrent gateway deployments, that meant a dangerous command triggered from inside execute_code could fall back to the process-wide HERMES_SESSION_KEY environment variable and end up attaching the approval request to the wrong active session.

This change ensures that both local and remote execute_code RPC workers explicitly inherit the parent approval session before dispatching tool calls.

Why this matters
Hermes runs in multi-user gateway environments where approval state must remain strictly isolated per session. Without explicit context propagation, execute_code created a gap between the main agent thread and the RPC worker threads that execute tool calls on its behalf.

In practice, this could cause:

approval prompts for dangerous commands to appear in the wrong user session
one user’s active session context to influence another user’s approval flow
a breakdown of the intended session-scoped security boundary around command approval
This is a real security fix, not just a hardening improvement.

What changed
Added explicit approval-session binding for execute_code RPC worker threads
Applied the fix to both:
local UDS-based RPC execution
remote file-based RPC polling execution
Added regression coverage to ensure RPC-triggered dangerous command checks stay attached to the originating session
Testing
Validated with:

python -m py_compile tools\code_execution_tool.py tests\tools\test_code_execution.py
python -m pytest tests\tools\test_code_execution.py -q -k "rpc_poll_loop_uses_parent_approval_session"
python -m pytest tests\tools\test_approval.py -q -k "context_session_key_overrides_process_env or context_keeps_pending_approval_attached_to_originating_session"
Notes
The new regression test for session-bound approval behavior passes.
Running the full tests/tools/test_code_execution.py file on Windows still surfaces pre-existing baseline failures unrelated to this PR (TestExecuteCodeEdgeCases::test_whitespace_only_code and some TestHeadTailTruncation cases).