### PR TITLE
fix: pass HERMES_HOME to execute_code subprocess

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -964,7 +964,8 @@ def execute_code(
         # (terminal.env_passthrough) are passed through.
         _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                               "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                              "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
+                              "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA",
+                              "HERMES_")
         _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
                               "PASSWD", "AUTH")
         try:


### PR DESCRIPTION
## Problem

When Hermes runs in Docker with `HERMES_HOME=/opt/data`, the `execute_code` tool's subprocess does not inherit the `HERMES_HOME` environment variable. This causes auxiliary tools (vision_analyze, etc.) to fail because they cannot locate `auth.json` at the correct path.

### Symptoms
- `vision_analyze` returns empty results
- `check_nous_free_tier()` returns `False` even when user is on free tier
- Auxiliary model calls fail with "Unknown model" errors

### Root Cause
The `_SAFE_ENV_PREFIXES` whitelist in `tools/code_execution_tool.py` does not include `"HERMES_"`, so the environment variable is filtered out when creating the subprocess.

```python
# Current code (line 965-967)
_SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                      "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
                      "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
# HERMES_HOME is NOT in this list!
```

## Solution

Add `"HERMES_"` to `_SAFE_ENV_PREFIXES` to allow all Hermes-related environment variables to pass through to `execute_code` subprocesses.

## Impact

- ✅ Fixes vision_analyze returning empty results in Docker environments
- ✅ Fixes any tool that relies on HERMES_HOME to locate config files
- ✅ Maintains security by only passing Hermes-prefixed vars, not secrets
- ✅ No breaking changes

## Related

Part of the HERMES_HOME profile-isolation issue family described in #5947. This PR addresses the environment variable filtering aspect, while #5947 covers hardcoded path issues.

Also related to #4140 (FAL_KEY not passed to tool execution context) — same category of environment variable propagation problem.
