### PR TITLE
fix(agent): strip temperature for OAuth adaptive-thinking models in auxiliary client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -610,7 +610,11 @@ class _AnthropicCompletionsAdapter:
         self._is_oauth = is_oauth
 
     def create(self, **kwargs) -> Any:
-        from agent.anthropic_adapter import build_anthropic_kwargs, normalize_anthropic_response
+        from agent.anthropic_adapter import (
+            _supports_adaptive_thinking,
+            build_anthropic_kwargs,
+            normalize_anthropic_response,
+        )
 
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
@@ -645,6 +649,19 @@ class _AnthropicCompletionsAdapter:
             from agent.anthropic_adapter import _forbids_sampling_params
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
+
+        # Anthropic's 4.6 family models implicitly enable adaptive thinking on
+        # OAuth requests, which mandates `temperature=1` (or unset). Caller-
+        # supplied non-1 temperatures (e.g. vision_tools.py uses 0.1 for
+        # determinism) trigger HTTP 400 "Invalid request data" on these models.
+        # Strip the value so the API uses its default rather than rejecting it.
+        if (
+            self._is_oauth
+            and "temperature" in anthropic_kwargs
+            and anthropic_kwargs["temperature"] != 1
+            and _supports_adaptive_thinking(anthropic_kwargs.get("model", model))
+        ):
+            del anthropic_kwargs["temperature"]
 
         response = self._client.messages.create(**anthropic_kwargs)
         assistant_message, finish_reason = normalize_anthropic_response(response)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1130,3 +1130,114 @@ class TestAnthropicCompatImageConversion:
         }]
         result = _convert_openai_images_to_anthropic(messages)
         assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "google/gemini-3-flash-preview")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("openrouter", "google/gemini-3-flash-preview", None, None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(None, None, "")):
+            with pytest.raises(Exception, match="insufficient credits"):
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+
+
+class TestAnthropicAdapterTemperatureStripping:
+    """Verify _AnthropicCompletionsAdapter.create strips temperature for OAuth
+    requests targeting Anthropic 4.6 models that implicitly enable adaptive
+    thinking (which mandates temperature=1 or unset).
+    """
+
+    def _make_adapter(self, is_oauth: bool):
+        from agent.auxiliary_client import _AnthropicCompletionsAdapter
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="text", text="ok")]
+        mock_response.stop_reason = "end_turn"
+        mock_response.usage = MagicMock(
+            input_tokens=10, output_tokens=2, total_tokens=12
+        )
+        real_client = MagicMock()
+        real_client.messages.create.return_value = mock_response
+        adapter = _AnthropicCompletionsAdapter(
+            real_client=real_client,
+            model="claude-opus-4-6",
+            is_oauth=is_oauth,
+        )
+        return adapter, real_client
+
+    def _call(self, adapter, *, model, temperature):
+        adapter.create(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=100,
+            temperature=temperature,
+        )
+
+    def test_oauth_opus_46_strips_non_one_temperature(self):
+        """OAuth + Opus 4.6 + temperature=0.1 → temperature must be stripped."""
+        adapter, real_client = self._make_adapter(is_oauth=True)
+        self._call(adapter, model="claude-opus-4-6", temperature=0.1)
+        sent = real_client.messages.create.call_args.kwargs
+        assert "temperature" not in sent, (
+            f"temperature should be stripped but got {sent.get('temperature')}"
+        )
+
+    def test_oauth_sonnet_46_strips_non_one_temperature(self):
+        """OAuth + Sonnet 4.6 + temperature=0.5 → temperature must be stripped.
+
+        Both 4.6 models match _supports_adaptive_thinking; Sonnet 4.6 may not
+        currently exhibit the implicit adaptive-thinking behavior server-side
+        but is covered defensively against future Anthropic changes.
+        """
+        adapter, real_client = self._make_adapter(is_oauth=True)
+        self._call(adapter, model="claude-sonnet-4-6", temperature=0.5)
+        sent = real_client.messages.create.call_args.kwargs
+        assert "temperature" not in sent
+
+    def test_oauth_temperature_one_is_preserved(self):
+        """OAuth + Opus 4.6 + temperature=1 → temperature must be preserved
+        (1 is the only value compatible with adaptive thinking)."""
+        adapter, real_client = self._make_adapter(is_oauth=True)
+        self._call(adapter, model="claude-opus-4-6", temperature=1)
+        sent = real_client.messages.create.call_args.kwargs
+        assert sent.get("temperature") == 1
+
+    def test_oauth_haiku_45_keeps_temperature(self):
+        """OAuth + Haiku 4.5 + temperature=0.1 → preserved (Haiku does not
+        support adaptive thinking and accepts arbitrary temperatures)."""
+        adapter, real_client = self._make_adapter(is_oauth=True)
+        self._call(adapter, model="claude-haiku-4-5", temperature=0.1)
+        sent = real_client.messages.create.call_args.kwargs
+        assert sent.get("temperature") == 0.1
+
+    def test_non_oauth_opus_46_keeps_temperature(self):
+        """Non-OAuth (API key) + Opus 4.6 + temperature=0.1 → preserved.
+        The implicit adaptive thinking only kicks in on OAuth requests."""
+        adapter, real_client = self._make_adapter(is_oauth=False)
+        self._call(adapter, model="claude-opus-4-6", temperature=0.1)
+        sent = real_client.messages.create.call_args.kwargs
+        assert sent.get("temperature") == 0.1
+
+    def test_oauth_opus_46_no_temperature_unchanged(self):
+        """OAuth + Opus 4.6 + no temperature → kwargs untouched (no key added,
+        no spurious deletion)."""
+        from agent.auxiliary_client import _AnthropicCompletionsAdapter
+        real_client = MagicMock()
+        real_client.messages.create.return_value = MagicMock(
+            content=[MagicMock(type="text", text="ok")],
+            stop_reason="end_turn",
+            usage=MagicMock(input_tokens=1, output_tokens=1, total_tokens=2),
+        )
+        adapter = _AnthropicCompletionsAdapter(
+            real_client=real_client,
+            model="claude-opus-4-6",
+            is_oauth=True,
+        )
+        adapter.create(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=100,
+        )
+        sent = real_client.messages.create.call_args.kwargs
+        assert "temperature" not in sent


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where the auxiliary client (vision analysis, compression, summarization) fails with HTTP 400 \`Invalid request data\` on **every** Anthropic Claude Opus 4.6 request when using OAuth authentication (Claude Code subscription tokens).

**Root cause**: As of early April 2026, Anthropic's 4.6-family models implicitly enable adaptive thinking for OAuth requests. Adaptive thinking mandates \`temperature=1\` (or unset). Hermes's \`_AnthropicCompletionsAdapter.create()\` in \`agent/auxiliary_client.py\` accepts a caller-supplied temperature and forwards it to \`messages.create()\` unchanged. Vision analysis hardcodes \`temperature=0.1\` for determinism (\`tools/vision_tools.py\` line ~407), so every OAuth Opus 4.6 vision call fails.

The error returned is the generic \`{\"type\": \"invalid_request_error\", \"message\": \"Invalid request data\"}\`. The explicit form (which Anthropic returns when thinking is set explicitly rather than implicitly) is more illuminating: \`\\\`temperature\\\` may only be set to 1 when thinking is enabled or in adaptive mode.\`

**The fix**: In \`_AnthropicCompletionsAdapter.create()\`, after temperature is injected into \`anthropic_kwargs\`, strip it when:

- the client is OAuth (\`self._is_oauth\`)
- \`temperature\` is set and not 1
- the target model matches \`_supports_adaptive_thinking()\` (the existing helper at \`agent/anthropic_adapter.py\` line 88, currently used inside \`build_anthropic_kwargs\` for the same temperature-must-be-1 invariant)

This mirrors Hermes's existing pattern at \`agent/anthropic_adapter.py:1345\`, which already sets \`temperature=1\` when thinking is **explicitly** configured. This PR extends the same protection to the **implicit** adaptive-thinking path that the auxiliary client triggers post-April-2026 Anthropic server changes.

The model gate is intentionally broad — it covers both Opus 4.6 (known broken today) and Sonnet 4.6 (advertises the same adaptive thinking capability and likely to follow Opus). Stripping rather than coercing to 1 lets Anthropic apply its current default, avoiding a magic number that may need to change in future.

## Related Issue

Not currently filed as a standalone issue. Related to but distinct from #6475 (which tracks the broader \`out of extra usage\` Anthropic OAuth content validation problem). This PR addresses a separate issue that surfaced in the same time window: the temperature constraint on Opus 4.6 OAuth requests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`agent/auxiliary_client.py\`: Extended the lazy import inside \`_AnthropicCompletionsAdapter.create()\` to include \`_supports_adaptive_thinking\`. Added a 9-line guard after the existing temperature injection that strips temperature when the OAuth + 4.6 + non-1 condition holds.
- \`tests/agent/test_auxiliary_client.py\`: Added \`TestAnthropicAdapterTemperatureStripping\` with 6 unit test cases.

Diff: **+118 / -1 lines** across 2 files.

## How to Test

### Reproduction (without this patch)

\`\`\`bash
source venv/bin/activate
python -c \"
import asyncio, sys
from agent.auxiliary_client import async_call_llm

PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=='

async def main():
    msgs = [{'role': 'user', 'content': [
        {'type': 'text', 'text': 'What color? One word.'},
        {'type': 'image_url', 'image_url': {'url': f'data:image/png;base64,{PNG}'}},
    ]}]
    try:
        resp = await async_call_llm(
            task='vision', provider='anthropic',
            model='anthropic/claude-opus-4-6',
            messages=msgs, temperature=0.1, max_tokens=50, timeout=60,
        )
        print('SUCCESS')
    except Exception as e:
        print(f'FAIL: {type(e).__name__}: {e}')

asyncio.run(main())
\"
\`\`\`

**Pre-patch**: \`FAIL: BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'Invalid request data'}, ...}\`

**Post-patch**: \`SUCCESS\` (model returns a one-word color description)

Requires a valid Claude Code OAuth token in \`~/.claude/.credentials.json\`.

### Unit tests

\`\`\`bash
source venv/bin/activate
python -m pytest tests/agent/test_auxiliary_client.py::TestAnthropicAdapterTemperatureStripping -v
\`\`\`

All 6 cases pass:
- \`test_oauth_opus_46_strips_non_one_temperature\`: temperature=0.1 stripped ✓
- \`test_oauth_sonnet_46_strips_non_one_temperature\`: defensive coverage for Sonnet 4.6 ✓
- \`test_oauth_temperature_one_is_preserved\`: temperature=1 left alone ✓
- \`test_oauth_haiku_45_keeps_temperature\`: Haiku 4.5 (non-adaptive) keeps temperature ✓
- \`test_non_oauth_opus_46_keeps_temperature\`: API-key (non-OAuth) Opus keeps temperature ✓
- \`test_oauth_opus_46_no_temperature_unchanged\`: missing temperature → no spurious mutation ✓

### Empirical verification matrix

Tested live against \`api.anthropic.com\` with a real Claude Code OAuth token, vision request with a 1×1 PNG, \`temperature=0.1\`:

| Model | Pre-patch | Post-patch |
|---|---|---|
| \`claude-haiku-4-5\` | ✅ SUCCESS | ✅ SUCCESS |
| \`claude-sonnet-4-6\` | ✅ SUCCESS | ✅ SUCCESS |
| \`claude-opus-4-6\` | ❌ 400 \`Invalid request data\` | ✅ SUCCESS |

### Empirical confirmation that Opus 4.6 OAuth requires temperature=1

Direct \`anthropic\` SDK calls bypassing Hermes (raw \`messages.create\` with the same OAuth token, system prompt, and image):

| Variant | Result |
|---|---|
| Opus 4.6, no temperature | ✅ SUCCESS |
| Opus 4.6, temperature=0.1 | ❌ 400 \`Invalid request data\` |
| Opus 4.6, temperature=1 | ✅ SUCCESS |
| Opus 4.6, temperature=0.1, \`thinking={\"type\": \"adaptive\"}\` | ❌ 400 with explicit error: \`temperature may only be set to 1 when thinking is enabled or in adaptive mode\` |
| Opus 4.6, temperature=1, \`thinking={\"type\": \"adaptive\"}\` | ✅ SUCCESS |

The explicit-thinking variant returns the descriptive error. Without explicit \`thinking\`, Anthropic returns the generic \`Invalid request data\` because the implicit adaptive-thinking is internal to their server and not advertised in the request.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(agent): strip temperature for OAuth adaptive-thinking models in auxiliary client\`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (1 source file + 1 test file, 2 hunks total)
- [x] I've run \`pytest tests/agent/test_auxiliary_client.py\` — 103/104 pass. The single failure (\`TestGetTextAuxiliaryClient::test_codex_fallback_when_nothing_else\`) is **pre-existing on main** and unrelated to this change (verified by running on a clean checkout: same test fails identically).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux, Python 3.11.15, hermes-agent main @ 268ee6bd

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the inline comment in \`auxiliary_client.py\` documents the API quirk)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A (no config changes)
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A (no architecture changes)
- [x] I've considered cross-platform impact — N/A (pure Python, no OS-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes for the maintainer

- The implicit adaptive-thinking behavior on Opus 4.6 OAuth is **not documented** in Anthropic's public API docs. I discovered it empirically by binary-searching the request shape against the 400 error. The inline comment in \`auxiliary_client.py\` captures this context for future maintainers.
- This is a recent regression (post-April 2026 Anthropic server-side change), not a long-standing bug. Users on older hermes-agent versions plus older Anthropic backends may not have observed it.
- The same logic could be defensively added inside \`build_anthropic_kwargs\` itself, but the auxiliary client is the only call site that supplies a non-1 temperature on this code path. \`run_agent.py\`'s main agent loop passes temperature only via \`reasoning_config\`, which already routes through the existing \`_supports_adaptive_thinking\` branch at \`anthropic_adapter.py:1337-1345\`. Keeping the fix at the actual call site is the smaller, more local change.