### PR TITLE
fix: derive delegation api_mode from delegation model, not main model

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -703,6 +703,46 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["model"])
         self.assertIsNone(creds["provider"])
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_copilot_delegation_api_mode_uses_delegation_model(self, mock_resolve):
+        """When copilot resolves codex_responses (main model GPT-5+), delegation model
+        GPT-4.x should override to chat_completions.
+
+        Regression test for: delegation api_mode was derived from main model
+        (gpt-5.4 → codex_responses) instead of delegation model (gpt-4.1 →
+        chat_completions), causing HTTP 400 on subagent creation.
+        """
+        # Simulate: resolve_runtime_provider returns codex_responses because
+        # the main model is gpt-5.4 (GPT-5+ triggers Responses API)
+        mock_resolve.return_value = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "ghu_test_key_123",
+            "api_mode": "codex_responses",  # Wrong for gpt-4.1
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "gpt-4.1", "provider": "copilot"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        # The fix should override api_mode to chat_completions for gpt-4.1
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        self.assertEqual(creds["model"], "gpt-4.1")
+        self.assertEqual(creds["provider"], "copilot")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_copilot_delegation_api_mode_preserves_responses_for_gpt5(self, mock_resolve):
+        """When delegation model is also GPT-5+, codex_responses should be preserved."""
+        mock_resolve.return_value = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "ghu_test_key_123",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "gpt-5.4", "provider": "copilot"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        # GPT-5.4 should keep codex_responses
+        self.assertEqual(creds["api_mode"], "codex_responses")
+
 
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -801,12 +801,27 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Set the appropriate environment variable or run 'hermes auth'."
         )
 
+    api_mode = runtime.get("api_mode")
+
+    # Fix: when delegation uses copilot with a different model than the main
+    # agent, the api_mode resolved by resolve_runtime_provider is based on the
+    # main model (model.default in config).  We must re-derive it for the
+    # delegation model.  E.g. main model gpt-5.4 → codex_responses, but
+    # delegation model gpt-4.1 → chat_completions.  Without this, the
+    # subagent sends gpt-4.1 to the Responses API which returns HTTP 400.
+    if configured_model and configured_provider in ("copilot",):
+        try:
+            from hermes_cli.models import copilot_model_api_mode
+            api_mode = copilot_model_api_mode(configured_model, api_key=api_key)
+        except Exception:
+            api_mode = "chat_completions"
+
     return {
         "model": configured_model,
         "provider": runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
-        "api_mode": runtime.get("api_mode"),
+        "api_mode": api_mode,
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }


### PR DESCRIPTION
## Problem

When `delegation.provider` is `copilot` and the delegation model differs from the main model, the `api_mode` was incorrectly derived from the main model's name via `_copilot_runtime_api_mode(model_cfg, ...)`.

For example:
- Main model: `gpt-5.4` → triggers Responses API (`codex_responses`)
- Delegation model: `gpt-4.1` → needs Chat Completions (`chat_completions`)

The subagent would send `gpt-4.1` to the Responses API endpoint, resulting in:
```
HTTP 400: model gpt-4.1 is not supported via Responses API
```

## Root Cause

In `_resolve_delegation_credentials()`, the copilot credentials are resolved via `resolve_runtime_provider(requested='copilot')`, which internally calls `_copilot_runtime_api_mode(model_cfg, ...)`. This function reads `model_cfg['default']` (the **main** model name, e.g. `gpt-5.4`) to determine the API mode, not the delegation model.

## Fix

After resolving copilot credentials, re-derive the `api_mode` using `copilot_model_api_mode()` with the **delegation model** name (`configured_model`). This correctly maps:
- `gpt-4.1` → `chat_completions`
- `gpt-5.4` → `codex_responses`
- `gpt-5-mini` → `chat_completions`
- Claude models → `chat_completions` (or `anthropic_messages` via catalog)

## Affected Configurations

Any setup where:
- `model.default` is a GPT-5+ model (uses Responses API)
- `delegation.model` is a GPT-4.x or non-GPT model (needs Chat Completions)
- `delegation.provider` is `copilot`