### PR TITLE
fix(agent,cli): case-insensitive context length lookup, multimodal token estimation, /q alias

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -180,7 +180,11 @@ class ContextCompressor:
             min_protect = min(protect_tail_count, len(result) - 1)
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                content_len = len(msg.get("content") or "")
+                _raw = msg.get("content") or ""
+                content_len = (
+                    sum(len(p.get("text", "")) for p in _raw if isinstance(p, dict))
+                    if isinstance(_raw, list) else len(_raw)
+                )
                 msg_tokens = content_len // _CHARS_PER_TOKEN + 10
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
@@ -577,8 +581,12 @@ Write only the summary body. Do not include any preamble or prefix."""
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
-            content = msg.get("content") or ""
-            msg_tokens = len(content) // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
+            _raw_content = msg.get("content") or ""
+            content_len = (
+                sum(len(p.get("text", "")) for p in _raw_content if isinstance(p, dict))
+                if isinstance(_raw_content, list) else len(_raw_content)
+            )
+            msg_tokens = content_len // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
             # Include tool call arguments in estimate
             for tc in msg.get("tool_calls") or []:
                 if isinstance(tc, dict):

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -955,7 +955,7 @@ def get_model_context_length(
     for default_model, length in sorted(
         DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
     ):
-        if default_model in model_lower:
+        if default_model.lower() in model_lower:
             return length
 
     # 9. Query local server as last resort

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -141,7 +141,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",
-               cli_only=True, aliases=("exit", "q")),
+               cli_only=True, aliases=("exit",)),
 ]
 
 


### PR DESCRIPTION
## Summary
- **model_metadata**: lowercase `DEFAULT_CONTEXT_LENGTHS` keys before substring matching so HuggingFace-format entries (`Qwen/`, `deepseek-ai/`, `moonshotai/`, etc.) are found correctly instead of silently falling through to the 128K default
- **context_compressor**: handle list-type `content` (multimodal messages) in `_prune_old_tool_results` and `_find_tail_cut_by_tokens` — `len()` on a list returns element count, not character length, causing massive token underestimation for vision/image messages
- **commands**: remove duplicate `"q"` alias from `/quit` — it shadowed `/queue`'s `"q"` alias in `_build_command_lookup()`, causing `/q <prompt>` to exit the CLI instead of queuing

## Details

### Bug 1: Case-sensitive key matching in `get_model_context_length`
`DEFAULT_CONTEXT_LENGTHS` contains mixed-case keys like `"Qwen/Qwen3.5-397B-A17B"`, but the lookup does `if default_model in model_lower` where `model_lower` is lowercased. Since `"Qwen/..."` ≠ `"qwen/..."`, these 8+ entries never match. Fix: `default_model.lower() in model_lower`.

### Bug 2: `len(content)` on list-type multimodal content
When `content` is a list (e.g., `[{"type": "text", "text": "..."}, {"type": "image_url", ...}]`), `len(content)` returns the number of list elements (e.g., 2) instead of the character length. A 10,000-char multimodal message estimates as ~0 tokens, causing the compressor to over-stuff contexts.

### Bug 3: `/q` alias collision
Both `/queue` (line 74) and `/quit` (line 143) register `"q"` as an alias. Since `/quit` is defined later, it overwrites `/queue` in the lookup dict. Users typing `/q some task` exit the CLI instead of queuing work.

## Test plan
- [ ] Verify `get_model_context_length("Qwen/Qwen3.5-397B-A17B")` returns 131072 (not 128000)
- [ ] Verify `_prune_old_tool_results` correctly estimates tokens for multimodal messages
- [ ] Verify `/q <prompt>` resolves to the `queue` command, not `quit`
- [ ] Run `pytest tests/ -q` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)