### PR TITLE
fix(auth,env): prevent active_provider hijack, guard pipe FDs, lock auth reads

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -440,14 +440,18 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     if detected and detected.get("base_url"):
         # Persist the detection result keyed on the API key hash.
         key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
-        state["detected_endpoint"] = {
-            "base_url": detected["base_url"],
-            "endpoint_id": detected.get("id", ""),
-            "model": detected.get("model", ""),
-            "label": detected.get("label", ""),
-            "key_hash": key_hash,
-        }
-        _save_provider_state(auth_store, "zai", state)
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+            state = _load_provider_state(auth_store, "zai") or {}
+            state["detected_endpoint"] = {
+                "base_url": detected["base_url"],
+                "endpoint_id": detected.get("id", ""),
+                "model": detected.get("model", ""),
+                "label": detected.get("label", ""),
+                "key_hash": key_hash,
+            }
+            _save_provider_state(auth_store, "zai", state, set_active=False)
+            _save_auth_store(auth_store)
         logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
         return detected["base_url"]
 
@@ -672,13 +676,14 @@ def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Option
     return dict(state) if isinstance(state, dict) else None
 
 
-def _save_provider_state(auth_store: Dict[str, Any], provider_id: str, state: Dict[str, Any]) -> None:
+def _save_provider_state(auth_store: Dict[str, Any], provider_id: str, state: Dict[str, Any], *, set_active: bool = True) -> None:
     providers = auth_store.setdefault("providers", {})
     if not isinstance(providers, dict):
         auth_store["providers"] = {}
         providers = auth_store["providers"]
     providers[provider_id] = state
-    auth_store["active_provider"] = provider_id
+    if set_active:
+        auth_store["active_provider"] = provider_id
 
 
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
@@ -707,14 +712,16 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
 
 def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
     """Return persisted auth state for a provider, or None."""
-    auth_store = _load_auth_store()
-    return _load_provider_state(auth_store, provider_id)
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        return _load_provider_state(auth_store, provider_id)
 
 
 def get_active_provider() -> Optional[str]:
     """Return the currently active provider ID from auth store."""
-    auth_store = _load_auth_store()
-    return auth_store.get("active_provider")
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        return auth_store.get("active_provider")
 
 
 def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
@@ -1203,7 +1210,7 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
-        _save_provider_state(auth_store, "openai-codex", state)
+        _save_provider_state(auth_store, "openai-codex", state, set_active=False)
         _save_auth_store(auth_store)
 
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -150,7 +150,12 @@ class _ThreadedProcessHandle:
 
         # Pipe for stdout — drain thread in _wait_for_process reads the read end.
         read_fd, write_fd = os.pipe()
-        self._stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        try:
+            self._stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        except BaseException:
+            os.close(read_fd)
+            os.close(write_fd)
+            raise
         self._write_fd = write_fd
 
         def _worker():


### PR DESCRIPTION
## Summary
- **auth**: add `set_active` parameter to `_save_provider_state` so callers that only persist metadata (Z.AI endpoint probe, Codex token refresh) no longer silently overwrite the user's active provider
- **auth**: wrap `_resolve_zai_base_url` write path in `_auth_store_lock` to prevent TOCTOU race with concurrent token refreshes; add lock to `get_provider_auth_state` and `get_active_provider` for read-side consistency
- **base**: guard `os.pipe()` FDs with try/except in `_ThreadedProcessHandle.__init__` so both ends are closed on `fdopen` failure instead of leaking

## Details

### Bug 1: Active provider hijack via `_save_provider_state`
`_save_provider_state` unconditionally sets `auth_store["active_provider"] = provider_id`. This means:
- Z.AI endpoint detection (`_resolve_zai_base_url` → `_save_provider_state("zai", ...)`) silently switches the active provider to `"zai"` even if the user is using `"nous"`
- Codex token refresh (`_save_codex_tokens` → `_save_provider_state("openai-codex", ...)`) silently switches to `"openai-codex"` during a background refresh

Fix: add `set_active=True` keyword parameter (backward-compatible default), pass `set_active=False` from probe/refresh callers.

### Bug 2: Auth store lockless reads
`get_provider_auth_state()`, `get_active_provider()`, and `_resolve_zai_base_url()`'s write path don't acquire `_auth_store_lock`. Concurrent CLI processes or gateway threads can read a partially-written `auth.json` or clobber writes from `resolve_nous_runtime_credentials` (which does use the lock).

Fix: wrap reads and the Z.AI write path in `_auth_store_lock()`.

### Bug 3: Pipe FD leak in `_ThreadedProcessHandle`
If `os.fdopen(read_fd, ...)` raises (e.g., encoding error), `write_fd` is never closed because the `_worker` thread never starts. The `read_fd` is also leaked since `fdopen` failed before taking ownership.

Fix: wrap `fdopen` in try/except, close both FDs on failure.

## Test plan
- [ ] Verify that Z.AI endpoint detection does not change `active_provider` when user is on `"nous"`
- [ ] Verify that Codex token refresh does not change `active_provider`
- [ ] Verify `get_active_provider()` acquires lock (check via `_auth_store_lock` mock)
- [ ] Verify pipe FDs are closed on `fdopen` failure (mock `os.fdopen` to raise)
- [ ] Run `pytest tests/ -q` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)