### PR TITLE
fix(codex): recover stale CLI auth sync state

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -643,32 +643,43 @@ def _read_codex_access_token() -> Optional[str]:
         if token:
             return token
 
+    tokens: Optional[Dict[str, Any]] = None
     try:
-        from hermes_cli.auth import _read_codex_tokens
+        from hermes_cli.auth import _read_codex_tokens, _sync_codex_tokens_from_cli
         data = _read_codex_tokens()
         tokens = data.get("tokens", {})
-        access_token = tokens.get("access_token")
-        if not isinstance(access_token, str) or not access_token.strip():
-            return None
-
-        # Check JWT expiry — expired tokens block the auto chain and
-        # prevent fallback to working providers (e.g. Anthropic).
-        try:
-            import base64
-            payload = access_token.split(".")[1]
-            payload += "=" * (-len(payload) % 4)
-            claims = json.loads(base64.urlsafe_b64decode(payload))
-            exp = claims.get("exp", 0)
-            if exp and time.time() > exp:
-                logger.debug("Codex access token expired (exp=%s), skipping", exp)
-                return None
-        except Exception:
-            pass  # Non-JWT token or decode error — use as-is
-
-        return access_token.strip()
+        tokens, _ = _sync_codex_tokens_from_cli(tokens if isinstance(tokens, dict) else None)
     except Exception as exc:
         logger.debug("Could not read Codex auth for auxiliary client: %s", exc)
+        try:
+            from hermes_cli.auth import _sync_codex_tokens_from_cli
+
+            tokens, _ = _sync_codex_tokens_from_cli(None)
+        except Exception:
+            tokens = None
+
+    if not isinstance(tokens, dict):
         return None
+
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        return None
+
+    # Check JWT expiry — expired tokens block the auto chain and
+    # prevent fallback to working providers (e.g. Anthropic).
+    try:
+        import base64
+        payload = access_token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            logger.debug("Codex access token expired (exp=%s), skipping", exp)
+            return None
+    except Exception:
+        pass  # Non-JWT token or decode error — use as-is
+
+    return access_token.strip()
 
 
 def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -82,6 +82,25 @@ _EXTRA_KEYS = frozenset({
     "agent_key_obtained_at", "tls",
 })
 
+_RUNTIME_STATE_FIELDS = {
+    "last_status": None,
+    "last_status_at": None,
+    "last_error_code": None,
+    "last_error_reason": None,
+    "last_error_message": None,
+    "last_error_reset_at": None,
+}
+
+_CREDENTIAL_MATERIAL_FIELDS = frozenset({
+    "access_token",
+    "refresh_token",
+    "expires_at",
+    "expires_at_ms",
+    "last_refresh",
+    "agent_key",
+    "agent_key_expires_at",
+})
+
 
 @dataclass
 class PooledCredential:
@@ -919,6 +938,11 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
         elif key in _EXTRA_KEYS:
             if existing.extra.get(key) != value:
                 extra_updates[key] = value
+
+    if any(key in field_updates for key in _CREDENTIAL_MATERIAL_FIELDS):
+        for field_name, cleared_value in _RUNTIME_STATE_FIELDS.items():
+            if getattr(existing, field_name) != cleared_value:
+                field_updates.setdefault(field_name, cleared_value)
     if field_updates or extra_updates:
         if extra_updates:
             field_updates["extra"] = {**existing.extra, **extra_updates}

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1352,6 +1352,28 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         return None
 
 
+def _sync_codex_tokens_from_cli(current_tokens: Optional[Dict[str, str]] = None) -> Tuple[Optional[Dict[str, str]], bool]:
+    """Sync Hermes auth store from ~/.codex/auth.json when the token pair changed."""
+    current = dict(current_tokens or {}) if current_tokens else None
+    try:
+        cli_tokens = _import_codex_cli_tokens()
+        if not cli_tokens:
+            return current, False
+
+        cli_access = str(cli_tokens.get("access_token", "") or "").strip()
+        cli_refresh = str(cli_tokens.get("refresh_token", "") or "").strip()
+        current_access = str((current or {}).get("access_token", "") or "").strip()
+        current_refresh = str((current or {}).get("refresh_token", "") or "").strip()
+        if current_access == cli_access and current_refresh == cli_refresh:
+            return dict(cli_tokens), False
+
+        _save_codex_tokens(dict(cli_tokens))
+        return dict(cli_tokens), True
+    except Exception as exc:
+        logger.debug("Failed to sync Codex tokens from ~/.codex/auth.json: %s", exc)
+        return current, False
+
+
 def resolve_codex_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -1359,25 +1381,32 @@ def resolve_codex_runtime_credentials(
     refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> Dict[str, Any]:
     """Resolve runtime credentials from Hermes's own Codex token store."""
+    data: Optional[Dict[str, Any]] = None
+    read_error: Optional[AuthError] = None
     try:
         data = _read_codex_tokens()
     except AuthError as orig_err:
-        # Only attempt migration when there are NO tokens stored at all
-        # (code == "codex_auth_missing"), not when tokens exist but are invalid.
-        if orig_err.code != "codex_auth_missing":
-            raise
+        read_error = orig_err
 
-        # Migration: user had Codex as active provider with old storage (~/.codex/).
-        cli_tokens = _import_codex_cli_tokens()
-        if cli_tokens:
+    current_tokens = dict(data["tokens"]) if data else None
+    _synced_tokens, synced_from_cli = _sync_codex_tokens_from_cli(current_tokens)
+    if synced_from_cli:
+        if read_error and read_error.code == "codex_auth_missing":
             logger.info("Migrating Codex credentials from ~/.codex/ to Hermes auth store")
             print("⚠️  Migrating Codex credentials to Hermes's own auth store.")
             print("   This avoids conflicts with Codex CLI and VS Code.")
             print("   Run `hermes auth` to create a fully independent session.\n")
-            _save_codex_tokens(cli_tokens)
-            data = _read_codex_tokens()
+        elif read_error:
+            logger.info(
+                "Repairing Codex credentials from ~/.codex/auth.json after %s",
+                read_error.code,
+            )
         else:
-            raise
+            logger.info("Syncing updated Codex credentials from ~/.codex/auth.json into Hermes auth store")
+        data = _read_codex_tokens()
+    elif read_error:
+        raise read_error
+
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
     refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -40,6 +40,7 @@ def _clean_env(monkeypatch):
         "CONTEXT_COMPRESSION_PROVIDER", "CONTEXT_COMPRESSION_MODEL",
     ):
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("CODEX_HOME", "/var/empty/hermes-pytest-no-codex")
 
 
 @pytest.fixture
@@ -195,6 +196,37 @@ class TestReadCodexAccessToken:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         result = _read_codex_access_token()
         assert result == "plain-token-no-jwt"
+
+    def test_pool_without_selected_entry_syncs_updated_cli_token(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        codex_home = tmp_path / "codex-cli"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        codex_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {"access_token": "stale-token", "refresh_token": "stale-refresh"},
+                },
+            },
+        }))
+        (codex_home / "auth.json").write_text(json.dumps({
+            "tokens": {
+                "access_token": "cli-fresh-token",
+                "refresh_token": "cli-fresh-refresh",
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)):
+            result = _read_codex_access_token()
+
+        assert result == "cli-fresh-token"
+        auth_payload = json.loads((hermes_home / "auth.json").read_text())
+        tokens = auth_payload["providers"]["openai-codex"]["tokens"]
+        assert tokens["access_token"] == "cli-fresh-token"
+        assert tokens["refresh_token"] == "cli-fresh-refresh"
 
 
 class TestAnthropicOAuthFlag:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -388,6 +388,61 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
     assert secondary["refresh_token"] == "refresh-other"
 
 
+def test_load_pool_clears_stale_exhaustion_when_singleton_tokens_change(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "access-new",
+                        "refresh_token": "refresh-new",
+                    },
+                    "last_refresh": "2026-04-09T12:00:00Z",
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-old",
+                        "refresh_token": "refresh-old",
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 429,
+                        "last_error_reason": "device_code_exhausted",
+                        "last_error_reset_at": time.time() + 3600,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.access_token == "access-new"
+    assert entry.refresh_token == "refresh-new"
+    assert entry.last_status is None
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["access_token"] == "access-new"
+    assert persisted["refresh_token"] == "refresh-new"
+    assert persisted["last_status"] is None
+    assert persisted["last_error_code"] is None
+
+
 def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-seeded")

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -50,6 +50,11 @@ def _jwt_with_exp(exp_epoch: int) -> str:
     return f"h.{encoded}.s"
 
 
+@pytest.fixture(autouse=True)
+def _clear_codex_home(monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", "/var/empty/hermes-pytest-no-codex")
+
+
 def test_read_codex_tokens_success(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home)
@@ -120,6 +125,28 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
 
     assert called["count"] == 1
     assert resolved["api_key"] == "access-forced"
+
+
+def test_resolve_codex_runtime_credentials_syncs_updated_cli_tokens(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex-cli"
+    _setup_hermes_auth(hermes_home, access_token="access-stale", refresh_token="refresh-stale")
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": "cli-access",
+            "refresh_token": "cli-refresh",
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    resolved = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "cli-access"
+    data = _read_codex_tokens()
+    assert data["tokens"]["access_token"] == "cli-access"
+    assert data["tokens"]["refresh_token"] == "cli-refresh"
 
 
 def test_resolve_provider_explicit_codex_does_not_fallback(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a follow-up gap in Codex credential recovery after #5610.

Hermes already knew how to sync an exhausted `openai-codex` pool entry from `~/.codex/auth.json`, but recovery still broke in two common cases:

1. Hermes had a stale or partially invalid `~/.hermes/auth.json` Codex state, so `resolve_codex_runtime_credentials()` never pulled in the newer local Codex CLI token pair.
2. The credential pool was reseeded with newer tokens, but the entry kept its old transient `last_status=exhausted` runtime state and stayed unavailable.

That left gateway / auxiliary Codex flows reporting `no Codex OAuth token found` even though the local Codex CLI was healthy.

This PR makes the recovery path end-to-end:

- proactively sync newer token pairs from `~/.codex/auth.json` into the Hermes auth store
- clear stale exhaustion/error state when authoritative credential material changes during pool seeding
- let auxiliary Codex token resolution use the same CLI sync path instead of reading only the stale Hermes auth store

## Related Issue

Fixes #6651  
Follow-up to #5610

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`
  - add a shared helper to sync newer token pairs from `~/.codex/auth.json` into the Hermes auth store
  - use that helper inside `resolve_codex_runtime_credentials()` so stale / invalid Hermes Codex auth can self-repair
- `agent/credential_pool.py`
  - clear transient exhaustion/error state when seeded credential material changes (`access_token`, `refresh_token`, `last_refresh`, etc.)
- `agent/auxiliary_client.py`
  - reuse the CLI sync path before falling back to the Hermes auth store for Codex auxiliary resolution
- tests
  - add regression coverage for auth-store repair from Codex CLI tokens
  - add regression coverage for auxiliary fallback using refreshed CLI tokens
  - add regression coverage for clearing stale exhausted pool state after reseeding

## How to Test

1. Reproduce the broken state:
   - keep Hermes on `openai-codex`
   - let `~/.codex/auth.json` rotate to a newer token pair than `~/.hermes/auth.json`
   - mark the Codex pool entry exhausted or trigger an auxiliary/gateway Codex call
2. Verify Hermes recovers automatically instead of reporting `no Codex OAuth token found`
3. Run the targeted regression suite:
   - `pytest tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py tests/agent/test_auxiliary_client.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 / Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression suite used for this patch:

```bash
pytest tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py tests/agent/test_auxiliary_client.py -q
# 139 passed
```

🤖 Generated with OpenAI Codex
