### PR TITLE
fix(terminal): acquire _env_lock for all shared dict accesses

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -821,9 +821,12 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     # background processes (their _last_activity gets refreshed to keep them alive).
     try:
         from tools.process_registry import process_registry
-        for task_id in list(_last_activity.keys()):
+        with _env_lock:
+            activity_snapshot = list(_last_activity.keys())
+        for task_id in activity_snapshot:
             if process_registry.has_active_processes(task_id):
-                _last_activity[task_id] = current_time  # Keep sandbox alive
+                with _env_lock:
+                    _last_activity[task_id] = current_time  # Keep sandbox alive
     except ImportError:
         pass
 
@@ -937,15 +940,16 @@ def is_persistent_env(task_id: str) -> bool:
 
 def get_active_environments_info() -> Dict[str, Any]:
     """Get information about currently active environments."""
-    info = {
-        "count": len(_active_environments),
-        "task_ids": list(_active_environments.keys()),
-        "workdirs": {},
-    }
-    
+    with _env_lock:
+        info = {
+            "count": len(_active_environments),
+            "task_ids": list(_active_environments.keys()),
+            "workdirs": {},
+        }
+
     # Calculate total disk usage (per-task to avoid double-counting)
     total_size = 0
-    for task_id in _active_environments:
+    for task_id in info["task_ids"]:
         scratch_dir = _get_scratch_dir()
         pattern = f"hermes-*{task_id[:8]}*"
         import glob
@@ -962,7 +966,8 @@ def get_active_environments_info() -> Dict[str, Any]:
 
 def cleanup_all_environments():
     """Clean up ALL active environments. Use with caution."""
-    task_ids = list(_active_environments.keys())
+    with _env_lock:
+        task_ids = list(_active_environments.keys())
     cleaned = 0
     
     for task_id in task_ids:
@@ -1032,8 +1037,9 @@ def cleanup_vm(task_id: str):
 def _atexit_cleanup():
     """Stop cleanup thread and shut down all remaining sandboxes on exit."""
     _stop_cleanup_thread()
-    if _active_environments:
+    with _env_lock:
         count = len(_active_environments)
+    if count:
         logger.info("Shutting down %d remaining sandbox(es)...", count)
         cleanup_all_environments()
 


### PR DESCRIPTION
## Summary
- Acquire `_env_lock` before accessing `_active_environments` and `_last_activity` in four functions that previously read/iterated these dicts without the lock, risking `RuntimeError: dictionary changed size during iteration` when the background cleanup thread concurrently pops entries.

## Details

### `get_active_environments_info()` (line 938)
Previously iterated `_active_environments` directly without `_env_lock`. If `_cleanup_inactive_envs()` calls `.pop()` on the dict via the background cleanup thread during iteration, Python raises `RuntimeError`. Fix: snapshot `count` and `task_ids` under the lock, then iterate the snapshot for disk-usage calculation (the slow `rglob` call stays outside the lock).

### `cleanup_all_environments()` (line 963)  
Read `.keys()` without the lock. While `list()` makes the snapshot itself safe, the pattern is inconsistent with every other function in the module. Fix: acquire `_env_lock` for the snapshot.

### `_cleanup_inactive_envs()` pre-scan (line 822)
Read and wrote `_last_activity` without the lock, racing with `terminal_tool()` which updates `_last_activity` *inside* the lock (lines 1205, 1222, 1280). Fix: snapshot keys under lock, write updates under lock.

### `_atexit_cleanup()` (line 1032)
Accessed `_active_environments` directly for truthiness check and `len()`. Fix: read `len()` under lock.

## Test plan
- [ ] Verify `get_active_environments_info()` returns correct data under concurrent cleanup
- [ ] Verify `_cleanup_inactive_envs` pre-scan doesn't race with `terminal_tool` activity updates
- [ ] Run `pytest tests/ -q` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)