### PR TITLE
fix(skills,pairing): path traversal guard in uninstall, lock list_pending, hash paths

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -219,19 +219,20 @@ class PairingStore:
     def list_pending(self, platform: str = None) -> list:
         """List pending pairing requests, optionally filtered by platform."""
         results = []
-        platforms = [platform] if platform else self._all_platforms("pending")
-        for p in platforms:
-            self._cleanup_expired(p)
-            pending = self._load_json(self._pending_path(p))
-            for code, info in pending.items():
-                age_min = int((time.time() - info["created_at"]) / 60)
-                results.append({
-                    "platform": p,
-                    "code": code,
-                    "user_id": info["user_id"],
-                    "user_name": info.get("user_name", ""),
-                    "age_minutes": age_min,
-                })
+        with self._lock:
+            platforms = [platform] if platform else self._all_platforms("pending")
+            for p in platforms:
+                self._cleanup_expired(p)
+                pending = self._load_json(self._pending_path(p))
+                for code, info in pending.items():
+                    age_min = int((time.time() - info["created_at"]) / 60)
+                    results.append({
+                        "platform": p,
+                        "code": code,
+                        "user_id": info["user_id"],
+                        "user_name": info.get("user_name", ""),
+                        "age_minutes": age_min,
+                    })
         return results
 
     def clear_pending(self, platform: str = None) -> int:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2575,6 +2575,13 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
         return False, f"'{skill_name}' is not a hub-installed skill (may be a builtin)"
 
     install_path = SKILLS_DIR / entry["install_path"]
+    # Prevent path traversal from poisoned lock.json entries
+    try:
+        resolved = install_path.resolve()
+        if not resolved.is_relative_to(SKILLS_DIR.resolve()):
+            return False, f"Refusing to remove '{entry['install_path']}': resolves outside skills directory"
+    except (ValueError, OSError):
+        return False, f"Refusing to remove '{entry['install_path']}': path resolution failed"
     if install_path.exists():
         shutil.rmtree(install_path)
 
@@ -2588,6 +2595,8 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
+        h.update(rel_path.encode("utf-8"))
+        h.update(b"\x00")
         h.update(bundle.files[rel_path].encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 


### PR DESCRIPTION
## Summary
- **skills_hub**: prevent arbitrary directory deletion via poisoned `lock.json` entries by validating `install_path` resolves inside `SKILLS_DIR` before `shutil.rmtree`
- **skills_hub**: include file paths in `bundle_content_hash` so filename-swapping attacks change the hash
- **pairing**: wrap `list_pending()` in `self._lock` so `_cleanup_expired()` doesn't race with concurrent `generate_code()`/`approve_code()`

## Details

### Path traversal in `uninstall_skill()` (CRITICAL)
`entry["install_path"]` comes from `lock.json` on disk. If a malicious skill writes a crafted entry (e.g., `install_path: "../../"`) before being uninstalled, `SKILLS_DIR / "../../"` resolves to the parent directory and `shutil.rmtree` recursively deletes it. Compare with `install_from_quarantine()` which does validate paths.

Fix: `install_path.resolve().is_relative_to(SKILLS_DIR.resolve())` check before rmtree.

### Path-blind integrity hash
`bundle_content_hash` only hashed file contents, not filenames. An attacker could swap `SKILL.md` and `scripts/run.sh` contents without changing the hash, bypassing update-detection integrity in `check_for_skill_updates()`.

Fix: hash `rel_path + \x00 + content` for each file.

### Pairing store TOCTOU
`list_pending()` called `_cleanup_expired()` without `self._lock`. Since `_cleanup_expired()` writes to the pending JSON file, it races with `generate_code()`/`approve_code()` (which do hold the lock), potentially clobbering an approval.

Fix: wrap the entire `list_pending()` body in `self._lock`.

## Test plan
- [ ] Verify `uninstall_skill` refuses paths that resolve outside `SKILLS_DIR`
- [ ] Verify `bundle_content_hash` changes when filenames are swapped
- [ ] Verify `list_pending()` doesn't race with `approve_code()`
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)