### PR TITLE
fix(tools): allow memory tool to load without fcntl on Windows

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -105,6 +105,12 @@ class TestMemoryStoreAdd:
         assert result["success"] is True
         assert "Python 3.12 project" in result["entries"]
 
+    def test_add_entry_without_fcntl_locking(self, store, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.fcntl", None)
+        result = store.add("memory", "Portable memory note")
+        assert result["success"] is True
+        assert "Portable memory note" in store.memory_entries
+
     def test_add_to_user(self, store):
         result = store.add("user", "Name: Alice")
         assert result["success"] is True
@@ -206,6 +212,10 @@ class TestMemoryStorePersistence:
         mem_file = tmp_path / "MEMORY.md"
         mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry")
 
+        mem_file.write_text(
+            ENTRY_DELIMITER.join(["duplicate entry", "duplicate entry", "unique entry"]),
+            encoding="utf-8",
+        )
         store = MemoryStore()
         store.load_from_disk()
         assert len(store.memory_entries) == 2

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,6 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
 import json
 import logging
 import os
@@ -33,6 +32,11 @@ from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 logger = logging.getLogger(__name__)
 
@@ -145,11 +149,28 @@ class MemoryStore:
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = open(lock_path, "w")
+        flock = getattr(fcntl, "flock", None) if fcntl is not None else None
+        lock_ex = getattr(fcntl, "LOCK_EX", None) if fcntl is not None else None
+        lock_un = getattr(fcntl, "LOCK_UN", None) if fcntl is not None else None
+        lock_acquired = False
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if flock is not None and lock_ex is not None:
+                try:
+                    flock(fd, lock_ex)
+                    lock_acquired = True
+                except NotImplementedError:
+                    logger.debug(
+                        "fcntl.flock is unavailable on this platform; continuing without memory file locking."
+                    )
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            if lock_acquired and flock is not None and lock_un is not None:
+                try:
+                    flock(fd, lock_un)
+                except Exception:
+                    logger.debug(
+                        "Failed to release memory file lock for %s", lock_path, exc_info=True
+                    )
             fd.close()
 
     @staticmethod


### PR DESCRIPTION
## Summary

This fixes a small cross-platform bug in the memory tool.

`tools/memory_tool.py` imported the Unix-only `fcntl` module unconditionally and always used `fcntl.flock()` in `_file_lock()`. On Windows, that caused the memory tool to fail at import time with `ModuleNotFoundError: No module named 'fcntl'`, which also broke tests that import the module directly.

## Root cause

The memory tool assumed POSIX file locking was always available. That assumption is valid on Linux/macOS, but not on Windows.

## Fix

This PR keeps the existing POSIX locking behavior intact, but makes the import and lock path safe on platforms where `fcntl` is unavailable:

- make `fcntl` import optional
- treat file locking as a no-op when `fcntl`/`flock` is unavailable
- keep the existing `flock()` behavior on platforms that support it

This is intentionally minimal and does not change the public API or memory file format.

## Tests

Added/updated focused tests to cover the fix:

- added a regression test that verifies `MemoryStore.add()` still works when `fcntl` is unavailable
- updated the deduplication test to write the fixture file as UTF-8 explicitly so it behaves consistently on Windows

Ran:

- `python -m pytest tests/tools/test_memory_tool.py tests/tools/test_windows_compat.py tests/test_model_tools.py -q`

Result:

- `58 passed`

## Risk / impact

Low risk.

- Linux/macOS behavior is unchanged because `fcntl.flock()` is still used there
- Windows no longer crashes on import for the memory tool
- on platforms without `fcntl`, file locking degrades gracefully instead of hard failing

The only tradeoff is that platforms without `fcntl` do not get advisory locking for memory writes, but writes still use atomic replacement, so this remains a safe minimal compatibility fix.