### PR TITLE
fix(config): strip export prefix in .env parsers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2137,6 +2137,8 @@ def load_env() -> Dict[str, str]:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith('#') and '=' in line:
+                    if line.startswith('export '):
+                        line = line[7:]
                     key, _, value = line.partition('=')
                     env_vars[key.strip()] = value.strip().strip('"\'')
     

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -220,6 +220,8 @@ def _has_any_provider_configured() -> bool:
                 line = line.strip()
                 if line.startswith("#") or "=" not in line:
                     continue
+                if line.startswith("export "):
+                    line = line[7:]
                 key, _, val = line.partition("=")
                 val = val.strip().strip("'\"")
                 if key.strip() in provider_env_vars and val:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -115,6 +115,8 @@ def load_env() -> Dict[str, str]:
         for line in f:
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:
+                if line.startswith("export "):
+                    line = line[7:]
                 key, _, value = line.partition("=")
                 env_vars[key.strip()] = value.strip().strip("\"'")
     return env_vars


### PR DESCRIPTION
## Summary
Strip the bash-compatible `export ` prefix in all three `.env` file parsers so that lines like `export API_KEY=sk-...` are correctly parsed as `API_KEY=sk-...` instead of being silently stored under the wrong key `"export API_KEY"`.

## Details

All three `.env` parsers use `line.partition("=")` to split key/value pairs, but none strip the `export ` prefix that is commonly used in bash-compatible `.env` files. This causes:

1. **`hermes_cli/config.py:load_env()`** — Core config loading. Variables with `export` prefix are stored under the wrong key and never matched by `get_env_value()`.
2. **`tools/skills_tool.py:load_env()`** — Skill environment loading. Same issue affects skill environment variable passthrough.
3. **`hermes_cli/main.py:_has_any_provider_configured()`** — Provider detection. The key lookup against `provider_env_vars` fails, causing the setup wizard to re-trigger even when valid keys exist.

Users who copy-paste from bash profiles, cloud provider docs, or tutorials that include `export` (which is extremely common) silently lose all their API keys.

## Test plan
- [ ] Verify `load_env()` correctly parses `export API_KEY=sk-123` as `{"API_KEY": "sk-123"}`
- [ ] Verify `_has_any_provider_configured()` returns `True` when `.env` has `export OPENAI_API_KEY=...`
- [ ] Verify lines without `export` still parse correctly
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)