### PR TITLE
fix(gateway,cli): sanitize error messages, validate webhook args, use reopen_session API

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2413,11 +2413,7 @@ class HermesCLI:
                 )
             # Re-open the session (clear ended_at so it's active again)
             try:
-                self._session_db._conn.execute(
-                    "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
-                    (self.session_id,),
-                )
-                self._session_db._conn.commit()
+                self._session_db.reopen_session(self.session_id)
             except Exception:
                 pass
         

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -577,13 +577,34 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error="Missing repo or pr_number"
             )
 
+        # --- Input validation (prevent CLI argument injection) ---
+        # pr_number must be a positive integer.
+        try:
+            pr_int = int(pr_number)
+            if pr_int <= 0:
+                raise ValueError("non-positive")
+        except (ValueError, TypeError):
+            logger.error(
+                "[webhook] invalid pr_number: %r", pr_number
+            )
+            return SendResult(
+                success=False, error="Invalid pr_number"
+            )
+
+        # repo must match owner/name (alphanumeric, hyphens, underscores, dots).
+        if not re.fullmatch(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo):
+            logger.error("[webhook] invalid repo format: %r", repo)
+            return SendResult(
+                success=False, error="Invalid repo format"
+            )
+
         try:
             result = subprocess.run(
                 [
                     "gh",
                     "pr",
                     "comment",
-                    str(pr_number),
+                    str(pr_int),
                     "--repo",
                     repo,
                     "--body",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3129,8 +3129,8 @@ class GatewayRunner:
             except Exception:
                 pass
             logger.exception("Agent error in session %s", session_key)
-            error_type = type(e).__name__
-            error_detail = str(e)[:300] if str(e) else "no details available"
+            # Log full details server-side only; never expose raw exception
+            # types or messages to end users (info-leakage risk).
             status_hint = ""
             status_code = getattr(e, "status_code", None)
             _hist_len = len(history) if 'history' in locals() else 0
@@ -3170,9 +3170,7 @@ class GatewayRunner:
                 elif status_code == 400:
                     status_hint = " The request was rejected by the API."
             return (
-                f"Sorry, I encountered an error ({error_type}).\n"
-                f"{error_detail}\n"
-                f"{status_hint}"
+                f"Sorry, I encountered an unexpected error.{status_hint}\n"
                 "Try again or use /reset to start a fresh session."
             )
         finally:


### PR DESCRIPTION
## Summary
- **gateway/run.py**: stop exposing raw `type(e).__name__` and `str(e)[:300]` to end users on chat platforms — internal exception details can leak API URLs, file paths, and partial credentials
- **gateway/platforms/webhook.py**: validate `pr_number` (must be positive int) and `repo` (must match `owner/name` format) before passing to `subprocess.run` for `gh pr comment`
- **cli.py**: use the proper `reopen_session()` API instead of bypassing `_execute_write()` with raw `_conn.execute()`

## Details

### Error message information leakage (gateway/run.py)
The agent error handler sent `type(e).__name__` (Python exception class names) and `str(e)[:300]` (raw error text) directly to users over Telegram/Discord/Slack. Exception messages from LLM providers often contain API endpoint URLs, partial keys in auth errors, and internal file paths. Fix: return a generic message; keep curated status hints for known HTTP codes (401, 429, etc.); full details stay in server logs.

### Webhook CLI argument injection (webhook.py)
`repo` and `pr_number` from `deliver_extra` are rendered from the webhook payload via template substitution. An attacker controlling the payload can inject `--help` or arbitrary repo names into the `gh pr comment` subprocess. Fix: validate `pr_number` is a positive integer (use `int()` + range check), validate `repo` matches `[A-Za-z0-9._-]+/[A-Za-z0-9._-]+` (standard GitHub format).

### Session reopen bypasses write lock (cli.py)
`_init_agent()` directly calls `self._session_db._conn.execute()` + `._conn.commit()` to reopen sessions, bypassing both the threading lock and `BEGIN IMMEDIATE` transaction wrapper. The proper `reopen_session()` method (which uses `_execute_write()`) already exists but wasn't used here.

## Test plan
- [ ] Verify error messages to users no longer contain exception class names or raw error text
- [ ] Verify webhook rejects `pr_number: "--help"` and `repo: "../../evil"`
- [ ] Verify session reopen uses the proper API
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)