### PR TITLE
fix(agent): deduplicate streaming tool names, guard Anthropic interrupt, cap data URL size

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4537,7 +4537,8 @@ class AIAgent:
                             entry["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:
-                                entry["function"]["name"] += tc_delta.function.name
+                                if not entry["function"]["name"]:
+                                    entry["function"]["name"] = tc_delta.function.name
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)
@@ -4642,7 +4643,11 @@ class AIAgent:
                                     _fire_first_delta()
                                     self._fire_reasoning_delta(thinking_text)
 
-                # Return the native Anthropic Message for downstream processing
+                # Return the native Anthropic Message for downstream processing.
+                # If the stream was interrupted, don't call get_final_message()
+                # — it may hang draining the stream or return a corrupt message.
+                if self._interrupt_requested:
+                    return None
                 return stream.get_final_message()
 
         def _call():
@@ -5173,9 +5178,15 @@ class AIAgent:
                 return True
         return False
 
+    # 20 MB base64 ≈ 15 MB decoded image – generous but prevents OOM.
+    _MAX_DATA_URL_BASE64_BYTES = 20 * 1024 * 1024
+
     @staticmethod
     def _materialize_data_url_for_vision(image_url: str) -> tuple[str, Optional[Path]]:
         header, _, data = str(image_url or "").partition(",")
+        if len(data) > AgentRunner._MAX_DATA_URL_BASE64_BYTES:
+            logger.warning("data-URL payload too large (%d bytes), skipping", len(data))
+            return "", None
         mime = "image/jpeg"
         if header.startswith("data:"):
             mime_part = header[len("data:"):].split(";", 1)[0].strip()


### PR DESCRIPTION
## Summary
- **streaming**: change tool-call function name accumulation from `+=` to a conditional one-shot write — some providers re-send the complete name in every delta, doubling it
- **anthropic**: return `None` instead of calling `get_final_message()` on an interrupted stream to prevent hangs or corrupt tool_use data
- **vision**: add 20 MB cap on base64 data URL payloads before `base64.b64decode()` to prevent OOM

## Details

### Tool name doubling (line 4540)
The streaming tool-call accumulator uses `entry["function"]["name"] += tc_delta.function.name` to build tool names. OpenAI sends names in a single delta, but Ollama/vLLM re-send the full name in subsequent deltas for the same index. This produces `"read_fileread_file"` — an unknown tool that silently fails dispatch.

Fix: `if not entry["function"]["name"]: entry["function"]["name"] = tc_delta.function.name` — write once, ignore re-sends. (Arguments still use `+=` since they are legitimately streamed in fragments.)

### Anthropic interrupt guard (line 4646)
When `self._interrupt_requested` breaks out of the Anthropic streaming loop, `stream.get_final_message()` is called on a partially-consumed stream. The SDK may hang trying to drain remaining events, or return a Message with incomplete tool_use blocks (partial JSON in `input`). The caller raises `InterruptedError` anyway, so the return value is unused.

Fix: check `self._interrupt_requested` and `return None` before calling `get_final_message()`.

### Data URL OOM (line 5179)
`_materialize_data_url_for_vision` decodes arbitrary-size base64 data URLs with no size check. A 100MB+ payload creates ~275MB of memory pressure. Gateway users sharing the same process can trivially OOM it.

Fix: add `_MAX_DATA_URL_BASE64_BYTES = 20 * 1024 * 1024` (20MB base64 ≈ 15MB decoded) guard.

## Test plan
- [ ] Verify Ollama streaming produces correct tool names (not doubled)
- [ ] Verify Anthropic interrupt doesn't hang on `get_final_message()`
- [ ] Verify oversized data URLs return `("", None)` instead of OOMing
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)