### PR TITLE
fix(agent): limit .hermes.md parent walk to git repos, skip images in token estimate

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -976,9 +976,30 @@ def estimate_tokens_rough(text: str) -> int:
     return len(text) // 4
 
 
+_IMAGE_TOKEN_ESTIMATE = 2000  # Approximate tokens for a high-detail image
+
+
+def _message_chars_for_estimate(msg: Dict[str, Any]) -> int:
+    """Count characters in a message, using a fixed estimate for image blocks."""
+    content = msg.get("content") if isinstance(msg, dict) else None
+    if isinstance(content, list):
+        chars = 0
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in ("image_url", "input_image"):
+                chars += _IMAGE_TOKEN_ESTIMATE * 4  # Convert tokens→chars
+            else:
+                chars += len(str(part))
+        # Add non-content keys (role, name, tool_calls, etc.)
+        for k, v in msg.items():
+            if k != "content":
+                chars += len(str(k)) + len(str(v))
+        return chars
+    return len(str(msg))
+
+
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only)."""
-    total_chars = sum(len(str(msg)) for msg in messages)
+    total_chars = sum(_message_chars_for_estimate(msg) for msg in messages)
     return total_chars // 4
 
 
@@ -999,7 +1020,7 @@ def estimate_request_tokens_rough(
     if system_prompt:
         total_chars += len(system_prompt)
     if messages:
-        total_chars += sum(len(str(msg)) for msg in messages)
+        total_chars += sum(_message_chars_for_estimate(msg) for msg in messages)
     if tools:
         total_chars += len(str(tools))
     return total_chars // 4

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -99,12 +99,15 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     stop_at = _find_git_root(cwd)
     current = cwd.resolve()
 
-    for directory in [current, *current.parents]:
+    # When there is no git root, only check cwd itself – walking parents
+    # could pick up a .hermes.md planted in /tmp, /home, etc.
+    search_dirs = [current, *current.parents] if stop_at else [current]
+
+    for directory in search_dirs:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
             if candidate.is_file():
                 return candidate
-        # Stop walking at the git root (or filesystem root).
         if stop_at and directory == stop_at:
             break
     return None


### PR DESCRIPTION
## Summary
- **prompt_builder**: restrict `_find_hermes_md` parent-directory walk to sessions inside a git repo — prevents cross-user prompt injection on shared systems
- **model_metadata**: skip image content blocks in token estimation, using a fixed ~2000 token estimate per image instead of stringifying entire base64 data URLs

## Details

### `.hermes.md` walks to filesystem root (prompt injection)
`_find_hermes_md()` walks parent directories looking for `.hermes.md`/`HERMES.md`. The walk stops at the git root, but when there's no git repo (`_find_git_root()` returns `None`), the guard `if stop_at and directory == stop_at: break` never fires, and the loop walks all the way to `/`.

On shared systems (CI runners, multi-tenant servers), a `.hermes.md` at `/tmp/`, `/home/`, or `/` would be loaded into the system prompt of any agent session that isn't inside a git repo.

Fix: when no git root exists, only check `cwd` — don't walk parents.

### Token estimate counts base64 image data (premature compression)
`estimate_messages_tokens_rough` does `sum(len(str(msg)) for msg in messages)`, which stringifies entire message dicts including base64 data URLs. A 500KB screenshot produces ~683K base64 chars → ~170K phantom tokens. This triggers premature context compression (threshold ~150K for 200K context), discarding conversation history after a single image.

The same bug affects `estimate_request_tokens_rough` via the same `len(str(msg))` pattern.

Fix: add `_message_chars_for_estimate()` helper that detects `image_url`/`input_image` content blocks and uses a fixed 2000-token estimate (matching high-detail vision costs) instead of stringifying the base64 payload.

## Test plan
- [ ] Verify `_find_hermes_md` stops at cwd when outside a git repo
- [ ] Verify `_find_hermes_md` still walks parents up to git root inside a repo
- [ ] Verify `estimate_messages_tokens_rough` returns ~2000 tokens per image (not ~170K)
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)