### PR TITLE
fix(cron): recover recurring jobs with missing next_run_at

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -249,6 +249,28 @@ def _recoverable_oneshot_run_at(
     return None
 
 
+def _recoverable_recurring_next_run(schedule: Dict[str, Any], now: datetime) -> Optional[str]:
+    """Return the next future run for a broken recurring job.
+
+    If a recurring job loses `next_run_at`, repair it by computing the next
+    future occurrence from now. Do not immediately replay missed work.
+    """
+    kind = schedule.get("kind")
+    if kind == "interval":
+        minutes = schedule.get("minutes")
+        if not minutes:
+            return None
+        return (now + timedelta(minutes=minutes)).isoformat()
+
+    if kind == "cron":
+        expr = schedule.get("expr")
+        if not expr or not HAS_CRONITER:
+            return None
+        return croniter(expr, now).get_next(datetime).isoformat()
+
+    return None
+
+
 def _compute_grace_seconds(schedule: dict) -> int:
     """Compute how late a job can be and still catch up instead of fast-forwarding.
 
@@ -672,19 +694,25 @@ def get_due_jobs() -> List[Dict[str, Any]]:
 
         next_run = job.get("next_run_at")
         if not next_run:
+            schedule = job.get("schedule", {})
             recovered_next = _recoverable_oneshot_run_at(
-                job.get("schedule", {}),
+                schedule,
                 now,
                 last_run_at=job.get("last_run_at"),
             )
+            recovery_kind = "one-shot"
+            if not recovered_next:
+                recovered_next = _recoverable_recurring_next_run(schedule, now)
+                recovery_kind = schedule.get("kind", "job")
             if not recovered_next:
                 continue
 
             job["next_run_at"] = recovered_next
             next_run = recovered_next
             logger.info(
-                "Job '%s' had no next_run_at; recovering one-shot run at %s",
+                "Job '%s' had no next_run_at; recovering %s run at %s",
                 job.get("name", job["id"]),
+                recovery_kind,
                 recovered_next,
             )
             for rj in raw_jobs:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -565,6 +565,64 @@ class TestGetDueJobs:
         assert get_due_jobs() == []
         assert get_job("oneshot-stale")["next_run_at"] is None
 
+    def test_broken_interval_job_without_next_run_is_recovered_to_future(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "interval-recover",
+                "name": "Recover interval",
+                "prompt": "Word of the day",
+                "schedule": {"kind": "interval", "minutes": 30, "display": "every 30m"},
+                "schedule_display": "every 30m",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T04:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        assert get_due_jobs() == []
+        assert get_job("interval-recover")["next_run_at"] == "2026-03-18T05:00:00+00:00"
+
+    def test_broken_cron_job_without_next_run_is_recovered_to_future(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "cron-recover",
+                "name": "Recover cron",
+                "prompt": "Word of the day",
+                "schedule": {"kind": "cron", "expr": "0 5 * * *", "display": "0 5 * * *"},
+                "schedule_display": "0 5 * * *",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T04:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        assert get_due_jobs() == []
+        assert get_job("cron-recover")["next_run_at"] == "2026-03-18T05:00:00+00:00"
+
 
 class TestSaveJobOutput:
     def test_creates_output_file(self, tmp_cron_dir):


### PR DESCRIPTION
## Summary
Recurring cron jobs can become permanently inert if `next_run_at` is missing from `jobs.json`.

Today `get_due_jobs()` only recovers broken one-shot jobs. For recurring `cron` / `interval` jobs with `enabled=true` and `state=scheduled`, a missing `next_run_at` causes the scheduler to silently skip them forever.

This patch adds safe self-healing for recurring jobs by recomputing the next future run from `now` and persisting it back to storage.

## Behavior change
- broken one-shot jobs keep the existing recovery behavior
- broken recurring jobs now recover to their next future occurrence
- recurring jobs are not fired immediately as catch-up work
- at-most-once semantics for recurring jobs stay intact

## Why this is safe
The scheduler already prefers fast-forwarding recurring jobs over replaying missed runs. This applies the same philosophy when `next_run_at` is absent instead of stale.

## Tests
- added regression test for interval jobs with `next_run_at=None`
- added regression test for cron jobs with `next_run_at=None`
- existing cron job tests still pass

## Verification
`uv run pytest tests/cron/test_jobs.py -q`
