### PR TITLE
fix(holographic): sanitize FTS5 queries, fix entity wildcard matching, close DB on shutdown

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -250,6 +250,11 @@ class HolographicMemoryProvider(MemoryProvider):
                 logger.debug("Holographic memory_write mirror failed: %s", e)
 
     def shutdown(self) -> None:
+        if self._store:
+            try:
+                self._store.close()
+            except Exception:
+                pass
         self._store = None
         self._retriever = None
 

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -201,7 +201,17 @@ class MemoryStore:
             if not query:
                 return []
 
-            params: list = [query, min_trust]
+            # Sanitize FTS5 query: wrap each token in double quotes to
+            # neutralize FTS5 operators (AND, OR, NOT, NEAR, *, etc.)
+            # that could cause injection or crash.
+            safe_tokens = []
+            for token in query.split():
+                token = token.replace('"', '')
+                if token:
+                    safe_tokens.append(f'"{token}"')
+            safe_query = " ".join(safe_tokens) if safe_tokens else query
+
+            params: list = [safe_query, min_trust]
             category_clause = ""
             if category is not None:
                 category_clause = "AND f.category = ?"
@@ -431,18 +441,20 @@ class MemoryStore:
 
         Returns the entity_id.
         """
-        # Exact name match
+        # Exact name match (case-insensitive via COLLATE NOCASE, not LIKE
+        # which treats % and _ as wildcards in entity names).
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id FROM entities WHERE name = ? COLLATE NOCASE", (name,)
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        # Search aliases — use INSTR for exact substring matching instead of
+        # LIKE which treats % and _ in entity names as wildcards.
         alias_row = self._conn.execute(
             """
             SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            WHERE INSTR(',' || LOWER(aliases) || ',', ',' || LOWER(?) || ',') > 0
             """,
             (name,),
         ).fetchone()


### PR DESCRIPTION
## Summary
- **FTS5 injection**: sanitize user queries passed to `MATCH` by wrapping tokens in double quotes
- **Entity wildcard**: replace `LIKE` with `= COLLATE NOCASE` for entity name matching, and `INSTR` for alias matching
- **Shutdown leak**: call `store.close()` before setting to `None` in plugin shutdown

## Details

### FTS5 query injection (HIGH)
`search_facts()` passes raw user input to `WHERE facts_fts MATCH ?`. FTS5's MATCH accepts a mini-language with operators (`AND`, `OR`, `NOT`, `NEAR()`, column filters like `content:`, prefix `*`). A query like `NOT *` crashes with a syntax error; `tags:secret` exfiltrates data across columns.

Fix: wrap each whitespace-delimited token in double quotes, stripping any embedded quotes first. This preserves word-level matching while neutralizing all FTS5 operators.

### Entity name wildcard matching (HIGH)
`_resolve_entity` uses `WHERE name LIKE ?` for case-insensitive matching. But `LIKE` treats `%` and `_` as wildcards. Entity name `"100% Complete"` matches `"1000 Complete"`, `"100X Complete"`, etc. — linking facts to wrong entities.

Fix: use `WHERE name = ? COLLATE NOCASE` for exact case-insensitive matching.

### Alias wildcard matching (HIGH)
The alias search uses `WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'` — the user-supplied name is treated as a LIKE pattern. `name = "%"` matches every entity with any alias.

Fix: use `INSTR(',' || LOWER(aliases) || ',', ',' || LOWER(?) || ',') > 0` for exact substring matching.

### Shutdown resource leak (MEDIUM)
`HolographicMemoryProvider.shutdown()` sets `self._store = None` without closing the SQLite connection, leaking the connection and WAL file until GC.

Fix: call `self._store.close()` before nulling.

## Test plan
- [ ] Verify `search_facts("NOT *")` returns empty (not crash)
- [ ] Verify entity `"100% Complete"` doesn't match `"1000 Complete"`
- [ ] Verify alias search with `%` doesn't match all entities
- [ ] Verify shutdown closes SQLite connection
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)