### PR TITLE
fix(browser): redact CDP URLs in logs, clean temp files on timeout

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -948,6 +948,11 @@ def _run_browser_command(
             proc.wait()
             logger.warning("browser '%s' timed out after %ds (task=%s, socket_dir=%s)",
                            command, timeout, task_id, task_socket_dir)
+            for p in (stdout_path, stderr_path):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
             return {"success": False, "error": f"Command timed out after {timeout} seconds"}
 
         with open(stdout_path, "r") as f:
@@ -970,9 +975,13 @@ def _run_browser_command(
         
         # Log empty output as warning — common sign of broken agent-browser
         if not stdout.strip() and returncode == 0:
+            safe_cmd = " ".join(
+                "ws://[REDACTED]" if p.startswith(("ws://", "wss://")) else p
+                for p in cmd_parts[:4]
+            ) + "..."
             logger.warning("browser '%s' returned empty stdout with rc=0. "
                            "cmd=%s stderr=%s",
-                           command, " ".join(cmd_parts[:4]) + "...",
+                           command, safe_cmd,
                            (stderr or "")[:200])
 
         stdout_text = stdout.strip()


### PR DESCRIPTION
## Summary
- **browser_tool**: redact websocket CDP URLs in log messages — they embed Browserbase API keys and session IDs as query parameters
- **browser_tool**: clean up stdout/stderr temp files before returning on command timeout

## Details

### CDP URL credential leak in logs
`cmd_parts[:4]` is logged at WARNING level when agent-browser returns empty output. In CDP/cloud mode, `cmd_parts` contains `["npx", "agent-browser", "--cdp", "wss://connect.browserbase.com?apiKey=KEY&sessionId=SID"]` — the full Browserbase API key is written to persistent log files.

Fix: replace ws:// and wss:// URLs with `ws://[REDACTED]` before logging.

### Temp file leak on timeout
When `subprocess.TimeoutExpired` fires, the early `return` on line 951 skips the cleanup block at lines 959-964. Two temp files (`_stdout_{command}` and `_stderr_{command}`) remain on disk per timeout. Under repeated timeouts these accumulate.

Fix: clean up temp files before the early return.

## Test plan
- [ ] Verify CDP URLs are not visible in WARNING-level logs
- [ ] Verify temp files are cleaned up after command timeout
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)