### PR TITLE
fix(cron,mcp): allow day/month names in cron, prune output files, secure OAuth writes

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -150,7 +150,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     # Cron fields: minute hour day month weekday [year]
     parts = schedule.split()
     if len(parts) >= 5 and all(
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
+        re.match(r'^[\d\w\*\-,/]+$', p) for p in parts[:5]
     ):
         if not HAS_CRONITER:
             raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")
@@ -756,4 +756,18 @@ def save_job_output(job_id: str, output: str):
             pass
         raise
     
+    _prune_job_output(job_output_dir)
     return output_file
+
+
+_MAX_OUTPUT_FILES_PER_JOB = 100
+
+
+def _prune_job_output(job_output_dir: Path, keep: int = _MAX_OUTPUT_FILES_PER_JOB):
+    """Remove oldest output files, keeping only the most recent *keep*."""
+    try:
+        files = sorted(job_output_dir.glob("*.md"))
+        for stale in files[:-keep] if len(files) > keep else []:
+            stale.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -159,8 +159,11 @@ def _write_json(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".tmp")
     try:
-        tmp.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
-        os.chmod(tmp, 0o600)
+        # Open with 0o600 from the start — write_text uses the default umask
+        # which leaves the file world-readable between write and chmod.
+        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data, indent=2, default=str))
         tmp.rename(path)
     except OSError:
         tmp.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- **cron/jobs**: broaden cron schedule validation regex to accept standard day/month names (`MON-FRI`, `JAN`, etc.)
- **cron/jobs**: add output file pruning (keep last 100 per job) to prevent unbounded disk growth
- **mcp_oauth**: eliminate TOCTOU permission window on OAuth token files

## Details

### Cron regex rejects valid day/month names (MEDIUM)
The pre-validation regex `r'^[\d\*\-,/]+$'` only allows digits and special chars. Standard cron expressions like `0 9 * * MON-FRI` contain alphabetic day names that fail this regex, falling through to the duration/timestamp parsers and raising `"Unrecognized schedule format"`. `croniter` itself fully supports these names.

Fix: change character class to `[\d\w\*\-,/]` to allow letters. Actual validation is still done by `croniter()`.

### Cron output directory grows without bound (MEDIUM)
Every job execution writes `~/.hermes/cron/output/{job_id}/{timestamp}.md`. No cleanup exists — a 5-minute job creates ~105K files/year. `remove_job()` doesn't clean the output directory either.

Fix: add `_prune_job_output()` that keeps the newest 100 files per job, called after each save.

### MCP OAuth token TOCTOU (MEDIUM)
`_write_json()` uses `Path.write_text()` which creates files with the process umask (typically 0o644, world-readable). `os.chmod(tmp, 0o600)` runs afterward — between write and chmod, OAuth tokens (access/refresh) are readable by other users.

Fix: use `os.open(path, O_WRONLY|O_CREAT|O_TRUNC, 0o600)` + `os.fdopen()` to create the file with restricted permissions from the start (matching the pattern used in `cron/jobs.py` for job persistence).

## Test plan
- [ ] Verify `parse_schedule("0 9 * * MON-FRI")` succeeds
- [ ] Verify output files are pruned to 100 after save
- [ ] Verify OAuth token temp file has 0o600 permissions on creation
- [ ] Run `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)