### PR TITLE
fix(packaging): flatten all extra for Docker builds

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3324,12 +3324,14 @@ def _invalidate_update_cache():
 
 
 def _load_installable_optional_extras() -> list[str]:
-    """Return the optional extras referenced by the ``all`` group.
+    """Return the optional extras covered by the ``all`` install flow.
 
-    Only extras that ``[all]`` actually pulls in are retried individually.
-    Extras outside ``[all]`` (e.g. ``rl``, ``yc-bench``) are intentionally
-    excluded — they have heavy or platform-specific deps that most users
-    never installed.
+    ``[all]`` is intentionally flattened in ``pyproject.toml`` to avoid pip
+    recursing through self-referential ``hermes-agent[extra]`` requirements.
+    The fallback installer still needs the names of the extras to retry
+    individually, so we derive them from the optional-dependency table while
+    preserving explicit exclusions such as ``matrix``, ``rl``, and
+    ``yc-bench``.
     """
     try:
         import tomllib
@@ -3342,15 +3344,66 @@ def _load_installable_optional_extras() -> list[str]:
     if not isinstance(optional_deps, dict):
         return []
 
-    # Parse the [all] group to find which extras it references.
-    # Entries look like "hermes-agent[matrix]" or "package-name[extra]".
     all_refs = optional_deps.get("all", [])
+    if not isinstance(all_refs, list):
+        return []
+
+    excluded = {"all", "matrix", "rl", "yc-bench"}
+
+    project_name = project.get("name", "")
+    canonical_project_name = str(project_name).strip().lower().replace("_", "-")
+
+    # Backward compatibility: older packaging represented [all] as
+    # self-references like "hermes-agent[mcp]". Honor only that form, not
+    # third-party package extras such as "discord.py[voice]".
     referenced: list[str] = []
+    seen: set[str] = set()
     for ref in all_refs:
-        if "[" in ref and "]" in ref:
-            name = ref.split("[", 1)[1].split("]", 1)[0]
-            if name in optional_deps:
+        if not isinstance(ref, str):
+            continue
+
+        prefix, separator, suffix = ref.partition("[")
+        if separator and "]" in suffix and prefix.strip().lower().replace("_", "-") == canonical_project_name:
+            name = suffix.split("]", 1)[0]
+            if name in optional_deps and name not in excluded and name not in seen:
                 referenced.append(name)
+                seen.add(name)
+
+    if referenced:
+        return referenced
+
+    def _requirement_name(requirement: str) -> str:
+        requirement = requirement.strip()
+        if not requirement:
+            return ""
+
+        head = requirement.split(";", 1)[0].strip()
+        if "@" in head:
+            head = head.split("@", 1)[0].strip()
+
+        for separator in ("<", ">", "=", "!", "~", " "):
+            if separator in head:
+                head = head.split(separator, 1)[0].strip()
+
+        return head.split("[", 1)[0].strip().lower().replace("_", "-")
+
+    all_requirement_names = {
+        _requirement_name(ref)
+        for ref in all_refs
+        if isinstance(ref, str) and _requirement_name(ref)
+    }
+
+    for name, deps in optional_deps.items():
+        if name in excluded or not isinstance(deps, list) or not deps:
+            continue
+
+        dep_names = {
+            _requirement_name(dep)
+            for dep in deps
+            if isinstance(dep, str) and _requirement_name(dep)
+        }
+        if dep_names and dep_names.issubset(all_requirement_names):
+            referenced.append(name)
 
     return referenced
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,28 +74,35 @@ rl = [
 ]
 yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; python_version >= '3.12'"]
 all = [
-  "hermes-agent[modal]",
-  "hermes-agent[daytona]",
-  "hermes-agent[messaging]",
+  "modal>=1.0.0,<2",
+  "daytona>=0.148.0,<1",
+  "python-telegram-bot[webhooks]>=22.6,<23",
+  "discord.py[voice]>=2.7.1,<3",
+  "aiohttp>=3.13.3,<4",
+  "slack-bolt>=1.18.0,<2",
+  "slack-sdk>=3.27.0,<4",
   # matrix excluded: python-olm (required by matrix-nio[e2e]) is upstream-broken
   # on modern macOS (archived libolm, C++ errors with Clang 21+). Including it
   # here causes the entire [all] install to fail, dropping all other extras.
   # Users who need Matrix can install manually: pip install 'hermes-agent[matrix]'
-  "hermes-agent[cron]",
-  "hermes-agent[cli]",
-  "hermes-agent[dev]",
-  "hermes-agent[tts-premium]",
-  "hermes-agent[slack]",
-  "hermes-agent[pty]",
-  "hermes-agent[honcho]",
-  "hermes-agent[mcp]",
-  "hermes-agent[homeassistant]",
-  "hermes-agent[sms]",
-  "hermes-agent[acp]",
-  "hermes-agent[voice]",
-  "hermes-agent[dingtalk]",
-  "hermes-agent[feishu]",
-  "hermes-agent[mistral]",
+  "croniter>=6.0.0,<7",
+  "simple-term-menu>=1.0,<2",
+  "debugpy>=1.8.0,<2",
+  "pytest>=9.0.2,<10",
+  "pytest-asyncio>=1.3.0,<2",
+  "pytest-xdist>=3.0,<4",
+  "mcp>=1.2.0,<2",
+  "elevenlabs>=1.0,<2",
+  "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
+  "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
+  "honcho-ai>=2.0.1,<3",
+  "agent-client-protocol>=0.9.0,<1.0",
+  "faster-whisper>=1.0.0,<2",
+  "sounddevice>=0.4.6,<1",
+  "numpy>=1.24.0,<3",
+  "dingtalk-stream>=0.1.0,<1",
+  "lark-oapi>=1.5.3,<2",
+  "mistralai>=2.3.0,<3",
 ]
 
 [project.scripts]

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -403,6 +403,93 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     assert ".[all]" in install_cmds[0]
 
 
+def test_load_installable_optional_extras_uses_flattened_all_pyproject(monkeypatch, tmp_path):
+    """Flattened [all] should still map back to the intended per-extra retries."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "hermes-agent"
+
+[project.optional-dependencies]
+modal = ["modal>=1"]
+messaging = ["aiohttp>=3", "slack-sdk>=3"]
+matrix = ["matrix-nio>=0.24"]
+rl = ["atroposlib @ git+https://example.com/atropos.git"]
+yc-bench = ["yc-bench @ git+https://example.com/yc-bench.git"]
+all = ["modal>=1", "aiohttp>=3", "slack-sdk>=3"]
+""".strip()
+    )
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+
+    assert hermes_main._load_installable_optional_extras() == ["modal", "messaging"]
+
+
+def test_load_installable_optional_extras_supports_legacy_self_references(monkeypatch, tmp_path):
+    """Older self-referential [all] metadata should still be understood."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "hermes-agent"
+
+[project.optional-dependencies]
+mcp = ["mcp>=1.2"]
+matrix = ["matrix-nio>=0.24"]
+all = ["hermes-agent[matrix]", "hermes-agent[mcp]", "hermes-agent[mcp]"]
+""".strip()
+    )
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+
+    assert hermes_main._load_installable_optional_extras() == ["mcp"]
+
+
+def test_load_installable_optional_extras_skips_flattened_extras_not_covered_by_all(monkeypatch, tmp_path):
+    """Flattened [all] should not accidentally pull in unrelated future extras."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "hermes-agent"
+
+[project.optional-dependencies]
+messaging = ["aiohttp>=3", "slack-sdk>=3"]
+homeassistant = ["aiohttp>=3.9"]
+future = ["unrelated-lib>=1"]
+all = ["aiohttp>=3.13.3", "slack-sdk>=3.27.0"]
+""".strip()
+    )
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+
+    assert hermes_main._load_installable_optional_extras() == ["messaging", "homeassistant"]
+
+
+def test_repo_pyproject_flattened_all_still_maps_to_expected_retry_extras():
+    """The real pyproject should keep update fallback aligned with the old [all] intent."""
+    expected = [
+        "modal",
+        "daytona",
+        "dev",
+        "messaging",
+        "cron",
+        "slack",
+        "cli",
+        "tts-premium",
+        "voice",
+        "pty",
+        "honcho",
+        "mcp",
+        "homeassistant",
+        "sms",
+        "acp",
+        "mistral",
+        "dingtalk",
+        "feishu",
+    ]
+
+    assert hermes_main._load_installable_optional_extras() == expected
+
+
 # ---------------------------------------------------------------------------
 # ff-only fallback to reset --hard on diverged history
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker build failure on `main` where `pip install -e ".[all]"` can blow up with `resolution-too-deep`.

The root cause was that the `all` extra was self-referential (`hermes-agent[modal]`, `hermes-agent[messaging]`, etc.), which makes pip recursively resolve the package against itself. This PR flattens `all` into concrete third-party requirements, then updates the update fallback helper so `hermes update` still knows which extras to retry individually if `.[all]` fails on a given machine.

## Related Issue

Fixes #6352

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Flattened `[project.optional-dependencies].all` in `pyproject.toml` so it no longer depends on `hermes-agent[...]` extras recursively
- Kept the intentional exclusions unchanged: `matrix`, `rl`, and `yc-bench` are still outside `.[all]`
- Updated `_load_installable_optional_extras()` in `hermes_cli/main.py` to:
  - support the new flattened `all` representation
  - keep backward compatibility with the old self-referential form
  - avoid misclassifying third-party extras like `discord.py[voice]` as Hermes extras
- Added regression tests in `tests/hermes_cli/test_update_autostash.py` for:
  - flattened `all`
  - legacy self-referential `all`
  - ignoring unrelated future extras
  - the real repo `pyproject.toml` mapping still matching the intended retry extras

## How to Test

1. Reproduce the failure on current `main` with `docker build .` or `pip install -e ".[all]"` and observe pip hitting `resolution-too-deep`
2. Check out this branch and run:
   - `pytest tests/hermes_cli/test_update_autostash.py tests/test_project_metadata.py tests/test_packaging_metadata.py -q`
3. Build the Docker image again:
   - `docker build .`
   - the editable `.[all]` install should complete without self-referential `hermes-agent[...]` metadata

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Docker on x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Original failure from Docker build:

```text
error: resolution-too-deep
× Dependency resolution exceeded maximum depth
╰─> Pip cannot resolve the current dependencies as the dependency graph is too complex for pip to solve efficiently.
```

Validation on this branch:

```text
31 passed in 1.82s
```

And `docker build .` completed successfully locally after this change.
