### PR TITLE
feat: per-chat secrets injection (chat_secrets config)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -272,8 +272,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         delivery_content = (
             f"Cronjob Response: {task_name}\n"
             f"-------------\n\n"
-            f"{content}\n\n"
-            f"Note: The agent cannot see this message, and therefore cannot respond to it."
+            f"{content}"
         )
     else:
         delivery_content = content

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5932,19 +5932,67 @@ class GatewayRunner:
         return True
 
     def _set_session_env(self, context: SessionContext) -> None:
-        """Set environment variables for the current session."""
-        os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
-        os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
+        """Set environment variables for the current session.
+
+        In addition to the standard HERMES_SESSION_* vars, this injects
+        per-chat secrets from the ``chat_secrets`` config section.  Keys in
+        that section are ``"platform:chat_id"`` strings and values are dicts
+        of env-var name → value.  The matching is tried in order:
+
+        1. ``"platform:chat_id"``   (e.g. ``"telegram:-1001234567890"``)
+        2. ``"platform:*"``         (wildcard — all chats on that platform)
+        """
+        platform_value = context.source.platform.value
+        chat_id = context.source.chat_id
+
+        os.environ["HERMES_SESSION_PLATFORM"] = platform_value
+        os.environ["HERMES_SESSION_CHAT_ID"] = chat_id
         if context.source.chat_name:
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
         if context.source.thread_id:
             os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
-    
+
+        # ── Per-chat secrets injection ──────────────────────────────────
+        self._chat_secret_keys: list[str] = []  # track for cleanup
+        try:
+            raw_cfg = _load_gateway_config()
+            secrets_map = raw_cfg.get("chat_secrets") or {}
+            if not secrets_map:
+                return
+
+            chat_key = f"{platform_value}:{chat_id}"
+            wildcard_key = f"{platform_value}:*"
+
+            env_vars: dict[str, str] = {}
+            # Wildcard first, then specific overrides on top
+            if wildcard_key in secrets_map and isinstance(secrets_map[wildcard_key], dict):
+                env_vars.update(secrets_map[wildcard_key])
+            if chat_key in secrets_map and isinstance(secrets_map[chat_key], dict):
+                env_vars.update(secrets_map[chat_key])
+
+            for key, value in env_vars.items():
+                os.environ[key] = str(value)
+                self._chat_secret_keys.append(key)
+
+            if self._chat_secret_keys:
+                logger.debug(
+                    "Injected %d chat secret(s) for %s",
+                    len(self._chat_secret_keys), chat_key,
+                )
+        except Exception as e:
+            logger.warning("Failed to inject chat_secrets: %s", e)
+
     def _clear_session_env(self) -> None:
-        """Clear session environment variables."""
+        """Clear session environment variables and per-chat secrets."""
         for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
             if var in os.environ:
                 del os.environ[var]
+
+        # Clean up per-chat secrets
+        for key in getattr(self, "_chat_secret_keys", []):
+            if key in os.environ:
+                del os.environ[key]
+        self._chat_secret_keys = []
     
     async def _enrich_message_with_vision(
         self,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -555,10 +555,21 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
-        # Wrap delivered cron responses with a header (task name) and footer
-        # ("The agent cannot see this message").  Set to false for clean output.
+        # Wrap delivered cron responses with a header showing the task name.
+        # Set to false for clean output without the header.
         "wrap_response": True,
     },
+
+    # Per-chat secrets — inject environment variables based on chat ID.
+    # Keys are "platform:chat_id" strings, values are dicts of env vars.
+    # Example:
+    #   chat_secrets:
+    #     "telegram:-1001111111111":
+    #       GITHUB_TOKEN: ghp_token_for_repo_A
+    #     "telegram:-1002222222222":
+    #       GITHUB_TOKEN: ghp_token_for_repo_B
+    # Secrets are set as env vars at session start and cleared after.
+    "chat_secrets": {},
 
     # Logging — controls file logging to ~/.hermes/logs/.
     # agent.log captures INFO+ (all agent activity); errors.log captures WARNING+.
@@ -1397,6 +1408,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "memory", "gateway",
+    "chat_secrets",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -201,7 +201,7 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response: daily-report" in sent_content
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
-        assert "The agent cannot see this message" in sent_content
+        assert "The agent cannot see" not in sent_content
 
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 from gateway.config import Platform
 from gateway.run import GatewayRunner
@@ -43,3 +44,121 @@ def test_clear_session_env_removes_thread_id(monkeypatch):
     assert os.getenv("HERMES_SESSION_CHAT_ID") is None
     assert os.getenv("HERMES_SESSION_CHAT_NAME") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None
+
+
+def _make_context(platform=Platform.TELEGRAM, chat_id="-1001", chat_name="Group"):
+    source = SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_name=chat_name,
+        chat_type="group",
+    )
+    return SessionContext(source=source, connected_platforms=[], home_channels={})
+
+
+def test_chat_secrets_injected_for_matching_chat(monkeypatch):
+    """chat_secrets config injects env vars matching platform:chat_id."""
+    runner = object.__new__(GatewayRunner)
+    context = _make_context(chat_id="-1001111")
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+
+    secrets_config = {
+        "chat_secrets": {
+            "telegram:-1001111": {"GITHUB_TOKEN": "ghp_convent_token"},
+            "telegram:-1002222": {"GITHUB_TOKEN": "ghp_other_token"},
+        }
+    }
+
+    with patch("gateway.run._load_gateway_config", return_value=secrets_config):
+        runner._set_session_env(context)
+
+    assert os.getenv("GITHUB_TOKEN") == "ghp_convent_token"
+
+    # Cleanup should remove the injected secret
+    runner._clear_session_env()
+    assert os.getenv("GITHUB_TOKEN") is None
+
+
+def test_chat_secrets_no_match_leaves_env_clean(monkeypatch):
+    """When no chat_secrets match, no extra env vars are set."""
+    runner = object.__new__(GatewayRunner)
+    context = _make_context(chat_id="-9999999")
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    secrets_config = {
+        "chat_secrets": {
+            "telegram:-1001111": {"GITHUB_TOKEN": "ghp_convent_token"},
+        }
+    }
+
+    with patch("gateway.run._load_gateway_config", return_value=secrets_config):
+        runner._set_session_env(context)
+
+    assert os.getenv("GITHUB_TOKEN") is None
+
+
+def test_chat_secrets_wildcard_platform(monkeypatch):
+    """platform:* wildcard matches any chat on that platform."""
+    runner = object.__new__(GatewayRunner)
+    context = _make_context(chat_id="-9999999")
+
+    monkeypatch.delenv("DEFAULT_ORG", raising=False)
+
+    secrets_config = {
+        "chat_secrets": {
+            "telegram:*": {"DEFAULT_ORG": "etherea"},
+        }
+    }
+
+    with patch("gateway.run._load_gateway_config", return_value=secrets_config):
+        runner._set_session_env(context)
+
+    assert os.getenv("DEFAULT_ORG") == "etherea"
+
+    runner._clear_session_env()
+    assert os.getenv("DEFAULT_ORG") is None
+
+
+def test_chat_secrets_specific_overrides_wildcard(monkeypatch):
+    """Specific chat_id entry overrides wildcard for the same key."""
+    runner = object.__new__(GatewayRunner)
+    context = _make_context(chat_id="-1001111")
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("SHARED_VAR", raising=False)
+
+    secrets_config = {
+        "chat_secrets": {
+            "telegram:*": {"GITHUB_TOKEN": "ghp_default", "SHARED_VAR": "from_wildcard"},
+            "telegram:-1001111": {"GITHUB_TOKEN": "ghp_specific"},
+        }
+    }
+
+    with patch("gateway.run._load_gateway_config", return_value=secrets_config):
+        runner._set_session_env(context)
+
+    # Specific overrides wildcard
+    assert os.getenv("GITHUB_TOKEN") == "ghp_specific"
+    # Wildcard-only key still present
+    assert os.getenv("SHARED_VAR") == "from_wildcard"
+
+    runner._clear_session_env()
+    assert os.getenv("GITHUB_TOKEN") is None
+    assert os.getenv("SHARED_VAR") is None
+
+
+def test_chat_secrets_empty_config_is_noop(monkeypatch):
+    """Empty chat_secrets doesn't break anything."""
+    runner = object.__new__(GatewayRunner)
+    context = _make_context()
+
+    with patch("gateway.run._load_gateway_config", return_value={"chat_secrets": {}}):
+        runner._set_session_env(context)
+
+    # Should still set standard vars
+    assert os.getenv("HERMES_SESSION_PLATFORM") == "telegram"
+    runner._clear_session_env()


### PR DESCRIPTION
## Summary

Two changes:

### 1. Per-chat secrets injection (chat_secrets config)

Adds a new `chat_secrets` section to config.yaml that maps `platform:chat_id` keys to environment variables. At session start, matching secrets are injected into `os.environ` and cleaned up after the agent finishes.

This enables scoping GitHub tokens (or any secret) to specific chats.

**Features:**
- Exact match: `telegram:-1001234567890`
- Platform wildcard: `telegram:*`
- Specific entries override wildcard for the same key
- Secrets are cleaned from env after each session

### 2. Remove cron delivery footer

Removes the misleading 'The agent cannot see this message' note from cron deliveries.

## Files changed

- `hermes_cli/config.py` - add chat_secrets to DEFAULT_CONFIG and _KNOWN_ROOT_KEYS
- `gateway/run.py` - inject/cleanup per-chat secrets in _set_session_env/_clear_session_env
- `tests/gateway/test_session_env.py` - 5 new tests
- `cron/scheduler.py` - remove footer note
- `tests/cron/test_scheduler.py` - update assertion
