### PR TITLE
fix(ci): don't fail supply chain scan when PR comment can't be posted on fork PRs

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -183,7 +183,7 @@ jobs:
           ---
           *Automated scan triggered by [supply-chain-audit](/.github/workflows/supply-chain-audit.yml). If this is a false positive, a maintainer can approve after manual review.*"
 
-          gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" || echo "::warning::Could not post PR comment (expected for fork PRs — GITHUB_TOKEN is read-only)"
 
       - name: Fail on critical findings
         if: steps.scan.outputs.critical == 'true'


### PR DESCRIPTION
The GITHUB_TOKEN for fork PRs is read-only — `gh pr comment` fails with `Resource not accessible by integration`. This causes every fork PR to show a red X on the supply chain scan even when no findings are detected. The scan itself still runs and the 'Fail on critical findings' step still exits 1 on real issues. Only the comment posting is gracefully skipped. 1 line changed. Closes #6679