### PR TITLE
Persist generic source metadata on sessions for observability

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -667,6 +667,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
+            source_metadata={
+                "session_family": "cron",
+                "cron_job_id": job_id,
+                "cron_job_name": job_name,
+            },
         )
         
         # Run the agent with an *inactivity*-based timeout: the job can run

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1548,6 +1548,7 @@ class BasePlatformAdapter(ABC):
         chat_topic: Optional[str] = None,
         user_id_alt: Optional[str] = None,
         chat_id_alt: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -1564,6 +1565,7 @@ class BasePlatformAdapter(ABC):
             chat_topic=chat_topic.strip() if chat_topic else None,
             user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt,
+            metadata=metadata,
         )
     
     @abstractmethod

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -433,6 +433,10 @@ class WebhookAdapter(BasePlatformAdapter):
             chat_type="webhook",
             user_id=f"webhook:{route_name}",
             user_name=route_name,
+            metadata={
+                "session_family": "webhook",
+                "webhook_route": route_name,
+            },
         )
         event = MessageEvent(
             text=prompt,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -90,6 +90,7 @@ class SessionSource:
     chat_topic: Optional[str] = None  # Channel topic/description (Discord, Slack)
     user_id_alt: Optional[str] = None  # Signal UUID (alternative to phone number)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
+    metadata: Optional[Dict[str, Any]] = None  # Stable source labels for persistence/observability
     
     @property
     def description(self) -> str:
@@ -127,10 +128,15 @@ class SessionSource:
             d["user_id_alt"] = self.user_id_alt
         if self.chat_id_alt:
             d["chat_id_alt"] = self.chat_id_alt
+        if self.metadata is not None:
+            d["metadata"] = self.metadata
         return d
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionSource":
+        metadata = data.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            metadata = None
         return cls(
             platform=Platform(data["platform"]),
             chat_id=str(data["chat_id"]),
@@ -142,6 +148,7 @@ class SessionSource:
             chat_topic=data.get("chat_topic"),
             user_id_alt=data.get("user_id_alt"),
             chat_id_alt=data.get("chat_id_alt"),
+            metadata=metadata,
         )
     
     @classmethod
@@ -755,6 +762,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "source_metadata": source.metadata,
             }
 
         # SQLite operations outside the lock
@@ -858,6 +866,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "source_metadata": old_entry.origin.metadata if old_entry.origin else None,
             }
 
         if self._db and db_end_session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
+    source_metadata TEXT,
     user_id TEXT,
     model TEXT,
     model_config TEXT,
@@ -329,6 +330,14 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add generic source metadata JSON for stable session labeling
+                # (webhook route names, cron job IDs, etc.) without prompt parsing.
+                try:
+                    cursor.execute("ALTER TABLE sessions ADD COLUMN source_metadata TEXT")
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -361,16 +370,18 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        source_metadata: Dict[str, Any] = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT OR IGNORE INTO sessions (id, source, source_metadata, user_id, model,
+                   model_config, system_prompt, parent_session_id, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
+                    json.dumps(source_metadata) if source_metadata is not None else None,
                     user_id,
                     model,
                     json.dumps(model_config) if model_config else None,
@@ -504,6 +515,7 @@ class SessionDB:
         session_id: str,
         source: str = "unknown",
         model: str = None,
+        source_metadata: Dict[str, Any] = None,
     ) -> None:
         """Ensure a session row exists, creating it with minimal metadata if absent.
 
@@ -514,9 +526,15 @@ class SessionDB:
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions
-                   (id, source, model, started_at)
-                   VALUES (?, ?, ?, ?)""",
-                (session_id, source, model, time.time()),
+                   (id, source, source_metadata, model, started_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    source,
+                    json.dumps(source_metadata) if source_metadata is not None else None,
+                    model,
+                    time.time(),
+                ),
             )
         self._execute_write(_do)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -506,6 +506,7 @@ class AIAgent:
         skip_memory: bool = False,
         session_db=None,
         parent_session_id: str = None,
+        source_metadata: Optional[Dict[str, Any]] = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
         credential_pool=None,
@@ -567,6 +568,7 @@ class AIAgent:
         self.ephemeral_system_prompt = ephemeral_system_prompt
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
         self._user_id = user_id  # Platform user identifier (gateway sessions)
+        self.source_metadata = copy.deepcopy(source_metadata) if source_metadata is not None else None
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
         # instead of going directly to stdout where patch_stdout's StdoutProxy
@@ -979,6 +981,7 @@ class AIAgent:
                     },
                     user_id=None,
                     parent_session_id=self._parent_session_id,
+                    source_metadata=self.source_metadata,
                 )
             except Exception as e:
                 # Transient SQLite lock contention (e.g. CLI and gateway writing
@@ -1922,6 +1925,7 @@ class AIAgent:
                 self.session_id,
                 source=self.platform or "cli",
                 model=self.model,
+                source_metadata=self.source_metadata,
             )
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
@@ -6056,6 +6060,7 @@ class AIAgent:
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
+                    source_metadata=self.source_metadata,
                 )
                 # Auto-number the title for the continuation session
                 if old_title:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -630,6 +630,11 @@ class TestRunJobSessionPersistence:
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
         assert kwargs["session_id"].startswith("cron_test-job_")
+        assert kwargs["source_metadata"] == {
+            "session_family": "cron",
+            "cron_job_id": "test-job",
+            "cron_job_name": "test",
+        }
         fake_db.end_session.assert_called_once()
         call_args = fake_db.end_session.call_args
         assert call_args[0][0].startswith("cron_test-job_")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -62,6 +62,23 @@ class TestSessionSourceRoundtrip:
         assert restored.chat_id == "cli"
         assert restored.chat_type == "dm"  # default value preserved
 
+    def test_roundtrip_with_metadata(self):
+        source = SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id="webhook:alerts:abc123",
+            chat_type="webhook",
+            metadata={
+                "session_family": "webhook",
+                "webhook_route": "alerts",
+            },
+        )
+        d = source.to_dict()
+        restored = SessionSource.from_dict(d)
+        assert restored.metadata == {
+            "session_family": "webhook",
+            "webhook_route": "alerts",
+        }
+
     def test_chat_id_coerced_to_string(self):
         """from_dict should handle numeric chat_id (common from Telegram)."""
         restored = SessionSource.from_dict({
@@ -781,6 +798,81 @@ class TestWhatsAppDMSessionKeyConsistency:
         key = build_session_key(source)
         # DM logic: chat_id + thread_id, user_id never included
         assert key == "agent:main:telegram:dm:99:topic-1"
+
+
+class TestSessionStoreSourceMetadata:
+    @pytest.fixture()
+    def store_with_db(self, tmp_path):
+        from hermes_state import SessionDB
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            s = SessionStore(sessions_dir=tmp_path, config=config)
+        if s._db:
+            s._db.close()
+        s._db = SessionDB(db_path=tmp_path / "state.db")
+        s._loaded = True
+        yield s
+        s._db.close()
+
+    def test_get_or_create_session_persists_source_metadata(self, store_with_db):
+        source = SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id="webhook:alerts:abc123",
+            chat_type="webhook",
+            user_id="webhook:alerts",
+            metadata={
+                "session_family": "webhook",
+                "webhook_route": "alerts",
+            },
+        )
+
+        entry = store_with_db.get_or_create_session(source)
+        session = store_with_db._db.get_session(entry.session_id)
+
+        assert session is not None
+        assert json.loads(session["source_metadata"]) == source.metadata
+
+    def test_force_new_preserves_source_metadata(self, store_with_db):
+        source = SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id="webhook:alerts:abc123",
+            chat_type="webhook",
+            user_id="webhook:alerts",
+            metadata={
+                "session_family": "webhook",
+                "webhook_route": "alerts",
+            },
+        )
+
+        first = store_with_db.get_or_create_session(source)
+        second = store_with_db.get_or_create_session(source, force_new=True)
+
+        assert second.session_id != first.session_id
+        session = store_with_db._db.get_session(second.session_id)
+        assert session is not None
+        assert json.loads(session["source_metadata"]) == source.metadata
+
+    def test_reset_session_preserves_source_metadata(self, store_with_db):
+        source = SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id="webhook:alerts:abc123",
+            chat_type="webhook",
+            user_id="webhook:alerts",
+            metadata={
+                "session_family": "webhook",
+                "webhook_route": "alerts",
+            },
+        )
+
+        entry = store_with_db.get_or_create_session(source)
+        reset_entry = store_with_db.reset_session(entry.session_key)
+
+        assert reset_entry is not None
+        assert reset_entry.session_id != entry.session_id
+        session = store_with_db._db.get_session(reset_entry.session_id)
+        assert session is not None
+        assert json.loads(session["source_metadata"]) == source.metadata
 
 
 class TestSessionStoreEntriesAttribute:

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -140,6 +140,10 @@ class TestGitHubPRWebhook:
         assert "Add webhook adapter" in event.text
         assert event.source.chat_type == "webhook"
         assert event.source.platform == Platform.WEBHOOK
+        assert event.source.metadata == {
+            "session_family": "webhook",
+            "webhook_route": "github-pr",
+        }
         assert "github-pr" in event.source.chat_id
         assert event.message_id == "gh-delivery-001"
 

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -16,6 +16,7 @@ Bug scenario (pre-fix):
   8. Fallback wrote only user/assistant pair — summary lost
 """
 
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -33,7 +34,7 @@ class TestFlushAfterCompression:
     even when conversation_history (from the original session) is longer than
     the compressed messages list."""
 
-    def _make_agent(self, session_db):
+    def _make_agent(self, session_db, **kwargs):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             from run_agent import AIAgent
             agent = AIAgent(
@@ -43,6 +44,7 @@ class TestFlushAfterCompression:
                 session_id="original-session",
                 skip_context_files=True,
                 skip_memory=True,
+                **kwargs,
             )
         return agent
 
@@ -130,6 +132,41 @@ class TestFlushAfterCompression:
                 "Expected 0 messages with stale conversation_history "
                 "(this test verifies the bug condition exists)"
             )
+
+    def test_compression_continuation_preserves_source_metadata(self):
+        """Compression-created continuation sessions should keep source metadata."""
+        from hermes_state import SessionDB
+
+        source_metadata = {
+            "session_family": "cron",
+            "cron_job_id": "job-123",
+            "cron_job_name": "Nightly Report",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(db, source_metadata=source_metadata)
+            old_session_id = agent.session_id
+
+            with patch.object(agent, "flush_memories"), patch.object(
+                agent, "_build_system_prompt", return_value="compressed system prompt"
+            ), patch.object(
+                agent.context_compressor,
+                "compress",
+                return_value=[{"role": "assistant", "content": "summary"}],
+            ):
+                agent._compress_context(
+                    [{"role": "user", "content": "hello"}],
+                    "system prompt",
+                )
+
+            assert agent.session_id != old_session_id
+            new_session = db.get_session(agent.session_id)
+            assert new_session is not None
+            assert new_session["parent_session_id"] == old_session_id
+            assert json.loads(new_session["source_metadata"]) == source_metadata
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import json
 import time
 import pytest
 from pathlib import Path
@@ -37,6 +38,23 @@ class TestSessionLifecycle:
 
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
+
+    def test_create_session_persists_source_metadata(self, db):
+        db.create_session(
+            session_id="s1",
+            source="webhook",
+            source_metadata={
+                "session_family": "webhook",
+                "webhook_route": "github-pr",
+            },
+        )
+
+        session = db.get_session("s1")
+        assert session is not None
+        assert json.loads(session["source_metadata"]) == {
+            "session_family": "webhook",
+            "webhook_route": "github-pr",
+        }
 
     def test_end_session(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -935,7 +953,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -943,8 +961,14 @@ class TestSchemaInit:
         columns = {row[1] for row in cursor.fetchall()}
         assert "title" in columns
 
+    def test_source_metadata_column_exists(self, db):
+        """Verify the source_metadata column was created in the sessions table."""
+        cursor = db._conn.execute("PRAGMA table_info(sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "source_metadata" in columns
+
     def test_migration_from_v2(self, tmp_path):
-        """Simulate a v2 database and verify migration adds title column."""
+        """Simulate a v2 database and verify migration reaches the latest schema."""
         import sqlite3
 
         db_path = tmp_path / "migrate_test.db"
@@ -991,22 +1015,111 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to v7
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
-        # Verify title column exists and is NULL for existing sessions
+        # Verify new columns exist and are NULL for existing sessions
         session = migrated_db.get_session("existing")
         assert session is not None
         assert session["title"] is None
+        assert session["source_metadata"] is None
 
         # Verify we can set title on migrated session
         assert migrated_db.set_session_title("existing", "Migrated Title") is True
         session = migrated_db.get_session("existing")
         assert session["title"] == "Migrated Title"
+
+        migrated_db.close()
+
+    def test_migration_from_v6_adds_source_metadata(self, tmp_path):
+        """Simulate a v6 database and verify migration adds source_metadata."""
+        import sqlite3
+
+        db_path = tmp_path / "migrate_v6.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (6);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT,
+                title TEXT
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("existing-v6", "cron", 1000.0),
+        )
+        conn.commit()
+        conn.close()
+
+        migrated_db = SessionDB(db_path=db_path)
+
+        cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
+        assert cursor.fetchone()[0] == 7
+
+        session = migrated_db.get_session("existing-v6")
+        assert session is not None
+        assert "source_metadata" in session
+        assert session["source_metadata"] is None
+
+        migrated_db.create_session(
+            session_id="new-v7",
+            source="cron",
+            source_metadata={
+                "session_family": "cron",
+                "cron_job_id": "job-123",
+            },
+        )
+        new_session = migrated_db.get_session("new-v7")
+        assert json.loads(new_session["source_metadata"]) == {
+            "session_family": "cron",
+            "cron_job_id": "job-123",
+        }
 
         migrated_db.close()
 


### PR DESCRIPTION
## Summary

Adds a generic `source_metadata` JSON field to persisted session rows and populates it for webhook and cron sessions.

This gives downstream analytics and observability tooling a stable way to label sessions by webhook route or cron job identity without inferring that data from prompt text or session IDs.

## What Changed

- Added `source_metadata TEXT` to the `sessions` table with a schema bump and additive migration.
- Extended `SessionDB.create_session(...)` to accept and persist `source_metadata`.
- Extended `AIAgent` session creation to accept `source_metadata` and preserve it across compression continuations.
- Extended `gateway.session.SessionSource` with optional `metadata` and passed it through gateway session creation and reset paths.
- Populated webhook session metadata as:
  - `{"session_family":"webhook","webhook_route":"<route_name>"}`
- Populated cron session metadata as:
  - `{"session_family":"cron","cron_job_id": job["id"], "cron_job_name": job["name"]}`

## Non-Goals

This PR does not add any Grafana, Prometheus, Alloy, exporter, dashboard, or alerting code. It only persists generic source metadata in an upstream-safe way.

## Validation

Focused tests passed for:
- session metadata persistence
- v6 to v7 schema migration
- webhook metadata propagation
- cron metadata wiring
- gateway reset/new-session preservation
- compression continuation preservation

I also ran the full test suite in this checkout. It is not currently green due to unrelated existing failures outside this change.
