### PR TITLE
fix: dead regex in quotaResetDelay, write_count race, env info lock

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -191,8 +191,12 @@ class SessionDB:
                             pass
                         raise
                 # Success — periodic best-effort checkpoint.
-                self._write_count += 1
-                if self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0:
+                # Increment inside the lock to avoid races when multiple
+                # threads call _execute_write concurrently.
+                with self._lock:
+                    self._write_count += 1
+                    needs_ckpt = self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0
+                if needs_ckpt:
                     self._try_wal_checkpoint()
                 return result
             except sqlite3.OperationalError as exc:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2310,7 +2310,7 @@ class AIAgent:
         if "reset_at" not in context:
             message = context.get("message") or ""
             if isinstance(message, str):
-                delay_match = re.search(r"quotaResetDelay[:\s\"]+(\\d+(?:\\.\\d+)?)(ms|s)", message, re.IGNORECASE)
+                delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
                 if delay_match:
                     value = float(delay_match.group(1))
                     seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -937,15 +937,17 @@ def is_persistent_env(task_id: str) -> bool:
 
 def get_active_environments_info() -> Dict[str, Any]:
     """Get information about currently active environments."""
-    info = {
-        "count": len(_active_environments),
-        "task_ids": list(_active_environments.keys()),
-        "workdirs": {},
-    }
-    
+    with _env_lock:
+        info = {
+            "count": len(_active_environments),
+            "task_ids": list(_active_environments.keys()),
+            "workdirs": {},
+        }
+        task_ids_snapshot = list(_active_environments.keys())
+
     # Calculate total disk usage (per-task to avoid double-counting)
     total_size = 0
-    for task_id in _active_environments:
+    for task_id in task_ids_snapshot:
         scratch_dir = _get_scratch_dir()
         pattern = f"hermes-*{task_id[:8]}*"
         import glob


### PR DESCRIPTION
## Summary

- **run_agent.py**: Fix double-escaped `\d` in `quotaResetDelay` regex (line 2313) — the pattern `\\d` in a raw string matches a literal backslash+d, never matching actual digits. This makes rate-limit reset time extraction dead code. The companion `sec_match` regex (line 2320) uses `\d` correctly, confirming this is a bug, not a style choice.
- **hermes_state.py**: Move `_write_count += 1` inside `self._lock` to prevent concurrent `_execute_write` callers from racing on the counter, which could skip or double WAL checkpoints.
- **tools/terminal_tool.py**: Acquire `_env_lock` in `get_active_environments_info()` before reading `_active_environments`. Without the lock, a concurrent `cleanup_vm()` call can modify the dict mid-iteration, raising `RuntimeError: dictionary changed size during iteration`.

## Test plan

- [ ] Verify `_extract_api_error_context` correctly parses `quotaResetDelay: 30000ms` from Gemini API errors
- [ ] Confirm WAL checkpoints fire at consistent intervals under concurrent writes
- [ ] Confirm `get_active_environments_info()` no longer raises under concurrent environment cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)