### PR TITLE
fix: flush_memories history destruction, OpenClaw overwrite, set dedup, chat_id guard

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -662,7 +662,7 @@ def switch_model(
         )
 
     # --- OpenCode api_mode override ---
-    if target_provider in {"opencode-zen", "opencode-go", "opencode", "opencode-go"}:
+    if target_provider in {"opencode-zen", "opencode-go", "opencode"}:
         api_mode = opencode_model_api_mode(target_provider, new_model)
 
     # --- Determine api_mode if not already set ---

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2628,7 +2628,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
             target_root=hermes_home.resolve(),
             execute=True,
             workspace_target=None,
-            overwrite=True,
+            overwrite=False,
             migrate_secrets=True,
             output_dir=None,
             selected_options=selected,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5914,7 +5914,8 @@ class AIAgent:
                     break
 
             if not memory_tool_def:
-                messages.pop()  # remove flush msg
+                # No memory tool available — skip the flush API call.
+                # Do NOT pop the sentinel here; the finally block handles cleanup.
                 return
 
             # Use auxiliary client for the flush call when available --

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -444,11 +444,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             send_parse_mode = ParseMode.MARKDOWN_V2
 
         bot = Bot(token=token)
-        int_chat_id = int(chat_id)
+        try:
+            int_chat_id = int(chat_id)
+        except (ValueError, TypeError):
+            return _error(f"Invalid Telegram chat_id (expected numeric): {chat_id!r}")
         media_files = media_files or []
         thread_kwargs = {}
         if thread_id is not None:
-            thread_kwargs["message_thread_id"] = int(thread_id)
+            try:
+                thread_kwargs["message_thread_id"] = int(thread_id)
+            except (ValueError, TypeError):
+                return _error(f"Invalid Telegram thread_id (expected numeric): {thread_id!r}")
 
         last_msg = None
         warnings = []


### PR DESCRIPTION
## Summary

- **run_agent.py** (HIGH): Fix a latent bug in `flush_memories` where `messages.pop()` removes the sentinel before the `finally` block runs. When `memory_tool_def` is None (no memory tool registered), the `finally` while-loop fails to find the sentinel and keeps popping until the entire `messages` list is empty — destroying all conversation history. Fix: let the `finally` block handle cleanup as designed.
- **hermes_cli/setup.py**: The comment on line 2624 says "no overwrite" but code passes `overwrite=True`. This silently overwrites existing Hermes configuration with stale OpenClaw data when setup wizard is run again. Fix: align code with comment (`overwrite=False`).
- **hermes_cli/model_switch.py**: Remove duplicate `"opencode-go"` entry from set literal on line 665 (copy-paste error).
- **tools/send_message_tool.py**: Wrap `int(chat_id)` and `int(thread_id)` in try/except to prevent unhandled `ValueError` when Telegram channel name resolution returns non-numeric values (e.g., `"@channelname"` format).

## Test plan

- [ ] Verify `flush_memories` with no memory tool registered does not corrupt `messages` list
- [ ] Verify OpenClaw migration preserves existing Hermes config files
- [ ] Verify `switch_model` with all three OpenCode provider variants
- [ ] Verify `_send_telegram` with non-numeric chat_id returns clean error

🤖 Generated with [Claude Code](https://claude.com/claude-code)