### PR TITLE
fix: async email send, HA domain/service validation, session root resolution

### DIFF
--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -241,16 +241,23 @@ def _handle_get_state(args: dict, **kw) -> str:
 
 def _handle_call_service(args: dict, **kw) -> str:
     """Handler for ha_call_service tool."""
-    domain = args.get("domain", "")
-    service = args.get("service", "")
+    domain = args.get("domain", "").strip().lower()
+    service = args.get("service", "").strip().lower()
     if not domain or not service:
         return tool_error("Missing required parameters: domain and service")
 
+    # Validate domain/service format to prevent URL path injection
+    _SERVICE_NAME_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+    if not _SERVICE_NAME_RE.match(domain):
+        return tool_error(f"Invalid domain format: {domain}")
+    if not _SERVICE_NAME_RE.match(service):
+        return tool_error(f"Invalid service format: {service}")
+
     if domain in _BLOCKED_DOMAINS:
-        return json.dumps({
-            "error": f"Service domain '{domain}' is blocked for security. "
+        return tool_error(
+            f"Service domain '{domain}' is blocked for security. "
             f"Blocked domains: {', '.join(sorted(_BLOCKED_DOMAINS))}"
-        })
+        )
 
     entity_id = args.get("entity_id")
     if entity_id and not _ENTITY_ID_RE.match(entity_id):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -646,6 +646,7 @@ async def _send_signal(extra, chat_id, message):
 
 async def _send_email(extra, chat_id, message):
     """Send via SMTP (one-shot, no persistent connection needed)."""
+    import asyncio
     import smtplib
     from email.mime.text import MIMEText
 
@@ -657,7 +658,7 @@ async def _send_email(extra, chat_id, message):
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
 
-    try:
+    def _send_sync():
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
@@ -668,6 +669,9 @@ async def _send_email(extra, chat_id, message):
         server.login(address, password)
         server.send_message(msg)
         server.quit()
+
+    try:
+        await asyncio.to_thread(_send_sync)
         return {"success": True, "platform": "email", "chat_id": chat_id}
     except Exception as e:
         return _error(f"Email send failed: {e}")

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -207,8 +207,11 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
                     visited.add(sid)
                     s = db.get_session(sid)
                     parent = s.get("parent_session_id") if s else None
+                    prev_sid = sid
                     sid = parent if parent else None
-                current_root = max(visited, key=len) if visited else current_session_id
+                # The root is the last valid session ID in the chain,
+                # not the longest string (max by len was incorrect).
+                current_root = prev_sid if visited else current_session_id
             except Exception:
                 current_root = current_session_id
 


### PR DESCRIPTION
## Summary

- **tools/send_message_tool.py**: Wrap synchronous `smtplib` calls in `asyncio.to_thread()`. `_send_email` was declared `async def` but used blocking `smtplib.SMTP` — the only `_send_*` function not using async I/O. This blocks the entire event loop for 1–30 seconds during SMTP transactions, stalling all other platform message processing in the gateway.
- **tools/homeassistant_tool.py**: Add `^[a-z_][a-z0-9_]*$` regex validation for `domain` and `service` parameters to prevent URL path injection (e.g., `domain="../../api/config"` would traverse to `{hass_url}/api/config/`). Normalize inputs to lowercase before blocklist check so `"SHELL_COMMAND"` is also blocked. Fix inconsistent error format: blocked-domain error used raw `json.dumps({"error":...})` instead of `tool_error()`.
- **tools/session_search_tool.py**: Fix root session resolution that used `max(visited, key=len)` — selecting the session ID with the longest string rather than the actual root of the parent chain. This could cause the current session to not be excluded from search results (data leakage).

## Test plan

- [ ] Verify email sending no longer blocks the event loop (other platform messages process during SMTP)
- [ ] Verify HA `domain="../../api/config"` is rejected with "Invalid domain format"
- [ ] Verify HA `domain="SHELL_COMMAND"` is blocked (case-insensitive)
- [ ] Verify session search excludes current session lineage correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)