### PR TITLE
Fix Windows gateway shutdown escalation when SIGKILL is unavailable

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -185,6 +185,16 @@ def kill_gateway_processes(force: bool = False, exclude_pids: set | None = None)
     return killed
 
 
+def _force_kill_pid(pid: int) -> str:
+    """Force-terminate a gateway PID using platform-safe signaling."""
+    if is_windows():
+        os.kill(pid, signal.SIGTERM)
+        return "SIGTERM"
+
+    os.kill(pid, signal.SIGKILL)
+    return "SIGKILL"
+
+
 def stop_profile_gateway() -> bool:
     """Stop only the gateway for the current profile (HERMES_HOME-scoped).
 
@@ -1201,8 +1211,8 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
         if not force_sent and time.monotonic() >= force_deadline:
             # Grace period expired — force-kill the specific PID.
             try:
-                os.kill(pid, signal.SIGKILL)
-                print(f"⚠ Gateway PID {pid} did not exit gracefully; sent SIGKILL")
+                kill_signal = _force_kill_pid(pid)
+                print(f"⚠ Gateway PID {pid} did not exit gracefully; sent {kill_signal}")
             except (ProcessLookupError, PermissionError):
                 return  # Already gone or we can't touch it.
             force_sent = True

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -204,7 +204,7 @@ class TestWaitForGatewayExit:
         assert poll_count == 3
 
     def test_force_kills_after_grace_period(self, monkeypatch):
-        """When the process doesn't exit, SIGKILL the saved PID."""
+        """When the process doesn't exit, use the platform force-kill signal."""
         import time as _time
 
         # Simulate monotonic time advancing past force_after
@@ -230,10 +230,11 @@ class TestWaitForGatewayExit:
         monkeypatch.setattr("os.kill", mock_kill)
 
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=5.0)
-        assert (42, signal.SIGKILL) in kills
+        expected_signal = signal.SIGTERM if gateway.is_windows() else signal.SIGKILL
+        assert (42, expected_signal) in kills
 
     def test_handles_process_already_gone_on_kill(self, monkeypatch):
-        """ProcessLookupError during SIGKILL is not fatal."""
+        """ProcessLookupError during force-kill is not fatal."""
         import time as _time
 
         call_num = 0
@@ -252,3 +253,15 @@ class TestWaitForGatewayExit:
 
         # Should not raise — ProcessLookupError means it's already gone.
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=2.0)
+
+
+def test_force_kill_pid_uses_sigterm_on_windows(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+
+    used = gateway._force_kill_pid(123)
+
+    assert used == "SIGTERM"
+    assert calls == [(123, signal.SIGTERM)]


### PR DESCRIPTION
### PR Description

#### Problem
`hermes_cli/gateway.py` → `_wait_for_gateway_exit()` unconditionally references `signal.SIGKILL` when escalating a forced termination after the grace period expires. `signal.SIGKILL` is **not defined on Windows**, so any restart/stop flow that reaches the escalation path crashes with:
`AttributeError: module 'signal' has no attribute 'SIGKILL'`

This is meaningfully distinct from the previously fixed WMIC discovery issue: that older bug prevented **finding** gateway processes at all, while this one occurs **later** in the forced-termination path after a PID is already known.

#### Fix
New helper `_force_kill_pid(pid)` centralizes the platform-safe forced-termination logic:
- **Unix** → `os.kill(pid, signal.SIGKILL)` (unchanged behavior)
- **Windows** → `os.kill(pid, signal.SIGTERM)` (supported fallback)

`_wait_for_gateway_exit()` now calls `_force_kill_pid()` instead of touching `signal.SIGKILL` directly, and prints the actual signal name used.

#### Tests
| Test | Purpose |
| :--- | :--- |
| **Updated** `test…force_kills_after_grace_period` | Asserts the platform-appropriate signal instead of always expecting SIGKILL |
| **New** `test_force_kill_pid_uses_sigterm_on_windows` | Directly covers the Windows-specific regression |

**Verification command:**
```bash
python -m pytest tests/hermes_cli/test_gateway.py -q -k \
  "force_kills_after_grace_period or handles_process_already_gone_on_kill or force_kill_pid_uses_sigterm_on_windows or returns_when_process_exits_gracefully or returns_immediately_when_no_pid"
  
  Result: 5 passed ✅