### PR TITLE
fix: prevent bot-to-bot reply ping loops in Discord + deep-memory plugin integration

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -75,6 +75,30 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _discord_body_mentions_user(content: Optional[str], user_id: int) -> bool:
+    """True if the message text explicitly @'s this user (not only API message.mentions).
+
+    Discord may add users to ``message.mentions`` for reply pings without a stable
+    match to "user typed @ in the body"; gate on raw text instead.
+
+    Recognizes ``<@id>``, ``<@!id>`` (nickname mention), and plain ``@id``.
+    """
+    if not content or user_id is None:
+        return False
+    sid = str(int(user_id))
+    return f"<@{sid}>" in content or f"<@!{sid}>" in content or f"@{sid}" in content
+
+
+def _is_peer_bot_author(message: Any, bot_user: Any) -> bool:
+    """True if the message is from a bot account other than our own."""
+    if bot_user is None:
+        return False
+    author = message.author
+    return bool(getattr(author, "bot", False)) and getattr(author, "id", None) != getattr(
+        bot_user, "id", None
+    )
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available."""
     return DISCORD_AVAILABLE
@@ -589,7 +613,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not self._client.user or not _discord_body_mentions_user(
+                            message.content, self._client.user.id
+                        ):
                             return
                     # "all" falls through to handle_message
 
@@ -602,10 +628,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     "DISCORD_IGNORE_NO_MENTION", "true"
                 ).lower() in ("true", "1", "yes")
                 if _ignore_no_mention and message.mentions and not isinstance(message.channel, discord.DMChannel):
-                    _bot_mentioned = (
-                        self._client.user is not None
-                        and self._client.user in message.mentions
-                    )
+                    if _is_peer_bot_author(message, self._client.user):
+                        _bot_mentioned = self._client.user is not None and _discord_body_mentions_user(
+                            message.content, self._client.user.id
+                        )
+                    else:
+                        _bot_mentioned = (
+                            self._client.user is not None
+                            and self._client.user in message.mentions
+                        )
                     if not _bot_mentioned:
                         return  # Talking to someone else, don't interrupt
 
@@ -2250,14 +2281,29 @@ class DiscordAdapter(BasePlatformAdapter):
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._bot_participated_threads
+            peer_bot = _is_peer_bot_author(message, self._client.user)
 
-            if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions:
+            if require_mention and not is_free_channel:
+                if not self._client.user:
                     return
+                if peer_bot:
+                    if not _discord_body_mentions_user(message.content, self._client.user.id):
+                        return
+                elif not in_bot_thread:
+                    if self._client.user not in message.mentions:
+                        return
 
-            if self._client.user and self._client.user in message.mentions:
-                message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
-                message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
+            if self._client.user:
+                uid = self._client.user.id
+                strip = _discord_body_mentions_user(message.content, uid) or (
+                    not peer_bot and self._client.user in message.mentions
+                )
+                if strip:
+                    text = message.content or ""
+                    text = text.replace(f"<@{uid}>", "").strip()
+                    text = text.replace(f"<@!{uid}>", "").strip()
+                    text = text.replace(f"@{uid}", "").strip()
+                    message.content = text
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/model_tools.py
+++ b/model_tools.py
@@ -159,6 +159,11 @@ def _discover_tools():
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
     ]
+    # Deep Memory (external package — optional)
+    try:
+        import deep_memory.hermes_integration  # noqa: F401
+    except ImportError:
+        pass
     import importlib
     for mod_name in _modules:
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2757,6 +2757,20 @@ class AIAgent:
             except Exception:
                 pass
 
+        # Deep Memory — reasoning-based insights (optional, requires deep-memory package)
+        if any(t in self.valid_tool_names for t in ("recall", "learn", "entities")):
+            try:
+                from deep_memory.hermes_integration import build_deep_memory_context
+                # Use platform user ID or session metadata to find the right entity
+                _dm_entity = getattr(self, "_deep_memory_entity_id", None)
+                _dm_block = build_deep_memory_context(_dm_entity)
+                if _dm_block:
+                    prompt_parts.append(_dm_block)
+            except ImportError:
+                pass
+            except Exception as _dm_exc:
+                logger.debug("Deep memory context injection failed: %s", _dm_exc)
+
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:
             avail_toolsets = {
@@ -9424,6 +9438,19 @@ class AIAgent:
             )
         except Exception as exc:
             logger.warning("on_session_end hook failed: %s", exc)
+
+        # Deep Memory — async post-session reasoning (fire-and-forget)
+        if any(t in self.valid_tool_names for t in ("recall", "learn", "entities")):
+            try:
+                from deep_memory.session_hook import process_session_async
+                process_session_async(
+                    session_id=self.session_id,
+                    messages=messages,
+                )
+            except ImportError:
+                pass
+            except Exception as _dm_exc:
+                logger.debug("Deep memory post-session reasoning failed: %s", _dm_exc)
 
         return result
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -48,6 +48,8 @@ _HERMES_CORE_TOOLS = [
     "text_to_speech",
     # Planning & memory
     "todo", "memory",
+    # Deep memory (reasoning-based insights — optional, requires deep-memory package)
+    "recall", "learn", "entities",
     # Session history search
     "session_search",
     # Clarifying questions


### PR DESCRIPTION
## Summary

### Discord Bot Loop Prevention
When multiple Hermes bots coexist in the same Discord server (e.g. Serin, Yerin, Herin), reply pings from one bot to another were incorrectly triggering responses, causing infinite loops.

**Root cause:** `message.mentions` includes users added via Discord reply pings, not just explicit `<@id>` mentions in message body text.

**Fix:**
- Add `_discord_body_mentions_user()` — checks for explicit `<@id>`, `<@!id>`, or `@id` in message body text only
- Add `_is_peer_bot_author()` — distinguishes peer bot messages from human messages
- Update `DISCORD_ALLOW_BOTS=mentions` filter to use body text check instead of `message.mentions`
- Update `DISCORD_IGNORE_NO_MENTION` logic with peer bot branch
- Update `_handle_message()`: peer bots require explicit body mention; humans keep existing `message.mentions` behavior
- Improve mention strip logic to handle all mention formats

### Deep-Memory Plugin Integration
Adds optional hooks for the [deep-memory](https://github.com/RichardHojunJang/deep-memory) reasoning memory plugin:
- Import `deep_memory.hermes_integration` in `_discover_tools()` (registers recall/learn/entities tools)
- Register tools in `_HERMES_CORE_TOOLS` so they appear on all platforms
- Inject deep memory context into system prompt when tools are available
- Fire-and-forget post-session reasoning hook on session end
- All imports wrapped in `try/except ImportError` — zero impact when deep-memory is not installed

## Test Plan
- [x] Three bots in same Discord channel, mutual mentions — no loops
- [x] Human mentions all three bots — all respond exactly once
- [x] Bot reply to another bot without explicit mention — correctly ignored
- [x] deep-memory tools (recall, learn, entities) load when package is installed
- [x] Hermes runs normally when deep-memory package is not installed