### PR TITLE
fix: skill symlink guard, delegate batch prefix, TTS path traversal and cleanup

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -164,11 +164,19 @@ def _build_skill_message(
             supporting.extend(entries)
 
     if not supporting and skill_dir:
+        _resolved_skill_dir = skill_dir.resolve()
         for subdir in ("references", "templates", "scripts", "assets"):
             subdir_path = skill_dir / subdir
             if subdir_path.exists():
                 for f in sorted(subdir_path.rglob("*")):
+                    if f.is_symlink():
+                        continue
                     if f.is_file():
+                        try:
+                            if not f.resolve().is_relative_to(_resolved_skill_dir):
+                                continue
+                        except (OSError, ValueError):
+                            continue
                         rel = str(f.relative_to(skill_dir))
                         supporting.append(rel)
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -201,6 +201,7 @@ def _build_child_agent(
     model: Optional[str],
     max_iterations: int,
     parent_agent,
+    task_count: int = 1,
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
@@ -256,7 +257,7 @@ def _build_child_agent(
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
     # Build progress callback to relay tool calls to parent display
-    child_progress_cb = _build_child_progress_callback(task_index, parent_agent)
+    child_progress_cb = _build_child_progress_callback(task_index, parent_agent, task_count=task_count)
 
     # Each subagent gets its own iteration budget capped at max_iterations
     # (configurable via delegation.max_iterations, default 50).  This means
@@ -593,6 +594,7 @@ def delegate_task(
                 task_index=i, goal=t["goal"], context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets, model=creds["model"],
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
+                task_count=n_tasks,
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -485,7 +485,14 @@ def text_to_speech_tool(
 
     # Determine output path
     if output_path:
-        file_path = Path(output_path).expanduser()
+        file_path = Path(output_path).expanduser().resolve()
+        # Prevent path traversal — confine output to DEFAULT_OUTPUT_DIR or CWD
+        _allowed_parents = (Path(DEFAULT_OUTPUT_DIR).resolve(), Path.cwd().resolve())
+        if not any(file_path == p or file_path.is_relative_to(p) for p in _allowed_parents):
+            return json.dumps({
+                "success": False,
+                "error": f"output_path must be under {DEFAULT_OUTPUT_DIR} or the current directory"
+            }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = Path(DEFAULT_OUTPUT_DIR)
@@ -579,10 +586,16 @@ def text_to_speech_tool(
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
         if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
+            original_file = file_str
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
+                # Clean up the original file after successful conversion
+                try:
+                    os.remove(original_file)
+                except OSError:
+                    pass
         elif provider in ("elevenlabs", "openai"):
             # These providers can output Opus natively if the path ends in .ogg
             voice_compatible = file_str.endswith(".ogg")


### PR DESCRIPTION
## Summary

- **agent/skill_commands.py**: Skip symlinks and verify resolved paths stay inside `skill_dir` when enumerating supporting files via `rglob()`. A malicious installed skill could place symlinks (e.g., `references/secrets -> ~/.ssh/`) to enumerate filenames at arbitrary paths, leaking directory listings into the agent context. Follows the same `is_symlink()` + `resolve().is_relative_to()` pattern already used in `skills_guard.py:755`.
- **tools/delegate_tool.py**: Thread `task_count` through `_build_child_agent` to `_build_child_progress_callback` so batch prefixes `[1]`, `[2]`, `[3]` are shown in parallel delegation progress. Previously `task_count` always defaulted to `1`, making the prefix always empty string — users couldn't distinguish which child was producing which output.
- **tools/tts_tool.py**: Validate `output_path` stays under `DEFAULT_OUTPUT_DIR` or CWD to prevent arbitrary file writes via path traversal (e.g., `output_path="/etc/cron.d/malicious"`). Also clean up the original MP3/WAV file after successful Opus conversion — previously orphaned files accumulated in `~/.hermes/audio_cache/` indefinitely.

## Test plan

- [ ] Verify skill with symlink in `references/` subdir doesn't enumerate files outside skill_dir
- [ ] Verify batch delegation shows `[1]`, `[2]` prefixes in progress output
- [ ] Verify `text_to_speech_tool(output_path="/etc/test.mp3")` is rejected
- [ ] Verify original MP3 is deleted after successful Opus conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)