### PR TITLE
fix(discord): prevent bot-to-bot reply ping loops in Discord adapter

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -75,6 +75,30 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _discord_body_mentions_user(content: Optional[str], user_id: int) -> bool:
+    """True if the message text explicitly @'s this user (not only API message.mentions).
+
+    Discord may add users to ``message.mentions`` for reply pings without a stable
+    match to "user typed @ in the body"; gate on raw text instead.
+
+    Recognizes ``<@id>``, ``<@!id>`` (nickname mention), and plain ``@id``.
+    """
+    if not content or user_id is None:
+        return False
+    sid = str(int(user_id))
+    return f"<@{sid}>" in content or f"<@!{sid}>" in content or f"@{sid}" in content
+
+
+def _is_peer_bot_author(message: Any, bot_user: Any) -> bool:
+    """True if the message is from a bot account other than our own."""
+    if bot_user is None:
+        return False
+    author = message.author
+    return bool(getattr(author, "bot", False)) and getattr(author, "id", None) != getattr(
+        bot_user, "id", None
+    )
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available."""
     return DISCORD_AVAILABLE
@@ -589,7 +613,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not self._client.user or not _discord_body_mentions_user(
+                            message.content, self._client.user.id
+                        ):
                             return
                     # "all" falls through to handle_message
 
@@ -602,10 +628,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     "DISCORD_IGNORE_NO_MENTION", "true"
                 ).lower() in ("true", "1", "yes")
                 if _ignore_no_mention and message.mentions and not isinstance(message.channel, discord.DMChannel):
-                    _bot_mentioned = (
-                        self._client.user is not None
-                        and self._client.user in message.mentions
-                    )
+                    if _is_peer_bot_author(message, self._client.user):
+                        _bot_mentioned = self._client.user is not None and _discord_body_mentions_user(
+                            message.content, self._client.user.id
+                        )
+                    else:
+                        _bot_mentioned = (
+                            self._client.user is not None
+                            and self._client.user in message.mentions
+                        )
                     if not _bot_mentioned:
                         return  # Talking to someone else, don't interrupt
 
@@ -2250,14 +2281,29 @@ class DiscordAdapter(BasePlatformAdapter):
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._bot_participated_threads
+            peer_bot = _is_peer_bot_author(message, self._client.user)
 
-            if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions:
+            if require_mention and not is_free_channel:
+                if not self._client.user:
                     return
+                if peer_bot:
+                    if not _discord_body_mentions_user(message.content, self._client.user.id):
+                        return
+                elif not in_bot_thread:
+                    if self._client.user not in message.mentions:
+                        return
 
-            if self._client.user and self._client.user in message.mentions:
-                message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
-                message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
+            if self._client.user:
+                uid = self._client.user.id
+                strip = _discord_body_mentions_user(message.content, uid) or (
+                    not peer_bot and self._client.user in message.mentions
+                )
+                if strip:
+                    text = message.content or ""
+                    text = text.replace(f"<@{uid}>", "").strip()
+                    text = text.replace(f"<@!{uid}>", "").strip()
+                    text = text.replace(f"@{uid}", "").strip()
+                    message.content = text
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).


### PR DESCRIPTION
## Problem

When multiple Hermes bots coexist in the same Discord server (e.g. three agents sharing one server), reply pings from one bot to another incorrectly trigger responses via `message.mentions`, causing infinite response loops.

**Root cause:** Discord adds users to `message.mentions` for reply pings (when replying to someone's message), not just for explicit `<@id>` mentions typed in the message body. The existing bot-message filter checked `message.mentions`, so a bot replying to another bot's message would trigger a response even without an explicit @ mention.

## Solution

- Add `_discord_body_mentions_user()` — checks for explicit `<@id>`, `<@!id>`, or `@id` patterns in the raw message body text only
- Add `_is_peer_bot_author()` — identifies messages from bot accounts other than our own
- Update `DISCORD_ALLOW_BOTS=mentions` filter to use body text check instead of `message.mentions`
- Update `DISCORD_IGNORE_NO_MENTION` logic: peer bots require explicit body mention; humans keep existing `message.mentions` behavior
- Improve mention strip logic to handle `<@id>`, `<@!id>`, and `@id` formats

## Testing

- Three bots in same Discord channel with mutual mentions — no loops
- Human mentions all three bots — all respond exactly once
- Bot reply to another bot without explicit mention — correctly ignored
- Human in bot-participated thread — still works without explicit mention