### PR TITLE
feat(tools): add deep-memory reasoning plugin integration

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -159,6 +159,11 @@ def _discover_tools():
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
     ]
+    # Deep Memory (external package — optional)
+    try:
+        import deep_memory.hermes_integration  # noqa: F401
+    except ImportError:
+        pass
     import importlib
     for mod_name in _modules:
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2757,6 +2757,20 @@ class AIAgent:
             except Exception:
                 pass
 
+        # Deep Memory — reasoning-based insights (optional, requires deep-memory package)
+        if any(t in self.valid_tool_names for t in ("recall", "learn", "entities")):
+            try:
+                from deep_memory.hermes_integration import build_deep_memory_context
+                # Use platform user ID or session metadata to find the right entity
+                _dm_entity = getattr(self, "_deep_memory_entity_id", None)
+                _dm_block = build_deep_memory_context(_dm_entity)
+                if _dm_block:
+                    prompt_parts.append(_dm_block)
+            except ImportError:
+                pass
+            except Exception as _dm_exc:
+                logger.debug("Deep memory context injection failed: %s", _dm_exc)
+
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:
             avail_toolsets = {
@@ -9424,6 +9438,19 @@ class AIAgent:
             )
         except Exception as exc:
             logger.warning("on_session_end hook failed: %s", exc)
+
+        # Deep Memory — async post-session reasoning (fire-and-forget)
+        if any(t in self.valid_tool_names for t in ("recall", "learn", "entities")):
+            try:
+                from deep_memory.session_hook import process_session_async
+                process_session_async(
+                    session_id=self.session_id,
+                    messages=messages,
+                )
+            except ImportError:
+                pass
+            except Exception as _dm_exc:
+                logger.debug("Deep memory post-session reasoning failed: %s", _dm_exc)
 
         return result
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -48,6 +48,8 @@ _HERMES_CORE_TOOLS = [
     "text_to_speech",
     # Planning & memory
     "todo", "memory",
+    # Deep memory (reasoning-based insights — optional, requires deep-memory package)
+    "recall", "learn", "entities",
     # Session history search
     "session_search",
     # Clarifying questions


### PR DESCRIPTION
## Summary

Adds optional integration hooks for the [deep-memory](https://github.com/RichardHojunJang/deep-memory) reasoning memory plugin — a Honcho-inspired system that extracts structured insights from conversations using multi-tier reasoning (explicit → deductive → inductive → abductive).

## Changes

### model_tools.py
- Import `deep_memory.hermes_integration` in `_discover_tools()` to auto-register `recall`, `learn`, and `entities` tools with the Hermes tool registry

### toolsets.py
- Add `recall`, `learn`, `entities` to `_HERMES_CORE_TOOLS` so they appear on all platforms when the package is installed

### run_agent.py
- **System prompt injection:** When deep-memory tools are available, inject entity profiles and key insights into the system prompt (similar to existing MEMORY block)
- **Post-session hook:** Fire-and-forget async reasoning after session ends — extracts insights from the conversation and consolidates them into the deep memory store

## Design Decisions

- All imports are wrapped in `try/except ImportError` — **zero impact** when deep-memory is not installed
- Deep-memory is an external package installed via pip (`pip install -e ~/Repository/deep-memory`)
- Configuration lives in `config.yaml` under `deep_memory:` key
- Tools use the standard Hermes tool registry pattern

## Testing

- Hermes starts and runs normally without deep-memory installed
- When installed, recall/learn/entities tools appear in tool list
- System prompt includes deep memory context block when insights exist
- Post-session reasoning fires without blocking the response