### PR TITLE
feat: add Exa MCP server toolset configuration and examples

### DIFF
--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -236,7 +236,7 @@ Look up customer ACME Corp and summarize recent invoice activity.
 
 This is the sort of place where a strict whitelist is far better than an exclude list.
 
-### Pattern 4: Exa web search and content retrieval
+### Pattern 4: Exa search and content retrieval
 
 ```yaml
 mcp_servers:

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -236,7 +236,53 @@ Look up customer ACME Corp and summarize recent invoice activity.
 
 This is the sort of place where a strict whitelist is far better than an exclude list.
 
-### Pattern 4: documentation / knowledge servers
+### Pattern 4: Exa web search and content retrieval
+
+```yaml
+mcp_servers:
+  exa:
+    command: "npx"
+    args: ["-y", "exa-mcp-server"]
+    env:
+      EXA_API_KEY: "***"
+```
+
+This gives Hermes three tools:
+
+| Tool | Description |
+|------|-------------|
+| `web_search_exa` | Web search with category filtering (company, research paper, news, etc.) |
+| `web_search_advanced_exa` | Advanced search with domain, date, text filters, summaries, and highlights |
+| `web_fetch_exa` | Fetch full page content from a URL |
+
+`web_search_exa` and `web_fetch_exa` are enabled by default. To also enable advanced search:
+
+```yaml
+mcp_servers:
+  exa:
+    command: "npx"
+    args: ["-y", "exa-mcp-server"]
+    env:
+      EXA_API_KEY: "***"
+    tools:
+      include: [web_search_exa, web_search_advanced_exa, web_fetch_exa]
+```
+
+Good prompts:
+
+```text
+Search for recent research papers about transformer architectures and summarize the key findings.
+```
+
+```text
+Find companies working on autonomous vehicles and extract their homepages.
+```
+
+```text
+Fetch the full content of https://example.com/blog/post and summarize it.
+```
+
+### Pattern 5: documentation / knowledge servers
 
 Some MCP servers expose prompts or resources that are more like shared knowledge assets than direct actions.
 

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -236,53 +236,7 @@ Look up customer ACME Corp and summarize recent invoice activity.
 
 This is the sort of place where a strict whitelist is far better than an exclude list.
 
-### Pattern 4: Exa search and content retrieval
-
-```yaml
-mcp_servers:
-  exa:
-    command: "npx"
-    args: ["-y", "exa-mcp-server"]
-    env:
-      EXA_API_KEY: "***"
-```
-
-This gives Hermes three tools:
-
-| Tool | Description |
-|------|-------------|
-| `web_search_exa` | Web search with category filtering (company, research paper, news, etc.) |
-| `web_search_advanced_exa` | Advanced search with domain, date, text filters, summaries, and highlights |
-| `web_fetch_exa` | Fetch full page content from a URL |
-
-`web_search_exa` and `web_fetch_exa` are enabled by default. To also enable advanced search:
-
-```yaml
-mcp_servers:
-  exa:
-    command: "npx"
-    args: ["-y", "exa-mcp-server"]
-    env:
-      EXA_API_KEY: "***"
-    tools:
-      include: [web_search_exa, web_search_advanced_exa, web_fetch_exa]
-```
-
-Good prompts:
-
-```text
-Search for recent research papers about transformer architectures and summarize the key findings.
-```
-
-```text
-Find companies working on autonomous vehicles and extract their homepages.
-```
-
-```text
-Fetch the full content of https://example.com/blog/post and summarize it.
-```
-
-### Pattern 5: documentation / knowledge servers
+### Pattern 4: documentation / knowledge servers
 
 Some MCP servers expose prompts or resources that are more like shared knowledge assets than direct actions.
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -359,7 +359,7 @@ Use it like:
 Look up the last 10 failed payments and summarize common failure reasons.
 ```
 
-### Exa web search with advanced filtering
+### Exa search with advanced filtering
 
 ```yaml
 mcp_servers:
@@ -382,7 +382,7 @@ The Exa MCP server exposes three tools:
 
 | Tool | Default | Description |
 |------|---------|-------------|
-| `web_search_exa` | enabled | Neural web search with category filtering |
+| `web_search_exa` | enabled | Web search with category filtering |
 | `web_search_advanced_exa` | off | Advanced search with domain, date, text filters, summaries, and highlights |
 | `web_fetch_exa` | enabled | Fetch full page content from a URL |
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -359,6 +359,33 @@ Use it like:
 Look up the last 10 failed payments and summarize common failure reasons.
 ```
 
+### Exa web search with advanced filtering
+
+```yaml
+mcp_servers:
+  exa:
+    command: "npx"
+    args: ["-y", "exa-mcp-server"]
+    env:
+      EXA_API_KEY: "***"
+    tools:
+      include: [web_search_exa, web_search_advanced_exa, web_fetch_exa]
+```
+
+Use it like:
+
+```text
+Search for recent AI research papers about reasoning models and summarize the top results.
+```
+
+The Exa MCP server exposes three tools:
+
+| Tool | Default | Description |
+|------|---------|-------------|
+| `web_search_exa` | enabled | Neural web search with category filtering |
+| `web_search_advanced_exa` | off | Advanced search with domain, date, text filters, summaries, and highlights |
+| `web_fetch_exa` | enabled | Fetch full page content from a URL |
+
 ### Filesystem server for a single project root
 
 ```yaml


### PR DESCRIPTION
## Summary

Adds Exa MCP server configuration examples to the hermes-agent docs.

### Changes

- **`mcp.md`**: Adds Exa as an MCP server example with config for all 3 non-deprecated tools (`web_search_exa`, `web_search_advanced_exa`, `web_fetch_exa`). Placed alongside existing branded examples (Stripe, GitHub).
- **`use-mcp-with-hermes.md`**: No Exa-specific pattern added here — keeps the generic patterns list clean (filesystem, GitHub, internal API, docs/knowledge servers).

No deprecated tools or features mentioned.