### PR TITLE
fix: log cron job load failures, block unredacted secrets, FIFO signal dedup

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -338,9 +338,11 @@ def load_jobs() -> List[Dict[str, Any]]:
                     save_jobs(jobs)
                     logger.warning("Auto-repaired jobs.json (had invalid control characters)")
                 return jobs
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to parse jobs.json (returning empty schedule): %s", exc)
             return []
-    except IOError:
+    except IOError as exc:
+        logger.debug("jobs.json not found or unreadable: %s", exc)
         return []
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -417,8 +417,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         try:
             from agent.redact import redact_sensitive_text
             stdout = redact_sensitive_text(stdout)
-        except Exception:
-            pass
+        except Exception as exc:
+            # Redaction failure is a security event — do NOT pass unredacted
+            # output to the LLM prompt.  Return a sanitized error instead.
+            logger.warning("Secret redaction failed for cron script output: %s", exc)
+            stdout = "[Script output redacted due to redaction engine failure]"
         return True, stdout
 
     except subprocess.TimeoutExpired:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -13,6 +13,7 @@ Requires:
 
 import asyncio
 import base64
+import collections
 import json
 import logging
 import os
@@ -181,7 +182,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Track recently sent message timestamps to prevent echo-back loops
         # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds)
-        self._recent_sent_timestamps: set = set()
+        self._recent_sent_timestamps: collections.deque = collections.deque(maxlen=50)
         self._max_recent_timestamps = 50
 
         self._phone_lock_identity: Optional[str] = None
@@ -412,7 +413,10 @@ class SignalAdapter(BasePlatformAdapter):
                     if dest == self._account_normalized:
                         # Check if this is an echo of our own outbound reply
                         if sent_ts and sent_ts in self._recent_sent_timestamps:
-                            self._recent_sent_timestamps.discard(sent_ts)
+                            try:
+                                self._recent_sent_timestamps.remove(sent_ts)
+                            except ValueError:
+                                pass
                             return
                         # Genuine user Note to Self — promote to dataMessage
                         is_note_to_self = True
@@ -658,9 +662,8 @@ class SignalAdapter(BasePlatformAdapter):
         """Record outbound message timestamp for echo-back filtering."""
         ts = rpc_result.get("timestamp") if isinstance(rpc_result, dict) else None
         if ts:
-            self._recent_sent_timestamps.add(ts)
-            if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
-                self._recent_sent_timestamps.pop()
+            self._recent_sent_timestamps.append(ts)
+            # deque(maxlen=50) auto-evicts the oldest entry (FIFO)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator."""


### PR DESCRIPTION
## Summary

- **cron/jobs.py** (CRITICAL): Add WARNING log when `jobs.json` parsing fails. Previously, a corrupted jobs file caused `load_jobs()` to silently return `[]`, making ALL scheduled cron jobs vanish with zero indication. Users would only discover this when deliveries stopped arriving. `IOError` (file not found) stays at DEBUG since it's normal on first run.
- **cron/scheduler.py** (CRITICAL-security): When the secret redaction engine fails on cron script output, replace the unredacted output with `"[Script output redacted due to redaction engine failure]"` instead of silently passing raw secrets through to the LLM prompt context. Previously, `except Exception: pass` let API keys, tokens, and credentials from script output flow directly into conversation history and platform deliveries.
- **gateway/platforms/signal.py**: Replace `set` with `collections.deque(maxlen=50)` for sent-timestamp tracking. `set.pop()` removes an **arbitrary** element (sets are unordered), so a recently sent timestamp could be evicted while old ones survive. This breaks echo-back filtering and can cause reply loops in Note to Self mode. `deque` provides proper FIFO eviction — oldest timestamps are dropped first.

## Test plan

- [ ] Corrupt `~/.hermes/cron/jobs.json` and verify WARNING appears in logs
- [ ] Mock `redact_sensitive_text` to raise and verify cron output is sanitized
- [ ] Verify Signal echo-back filtering works correctly with deque-based tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)