### PR TITLE
fix(gateway): make --replace startup path Windows-safe

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
 
+_IS_WINDOWS = sys.platform == "win32"
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -7476,6 +7478,65 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker stopped")
 
 
+def _force_kill_signal():
+    """Return the strongest portable termination signal for this platform."""
+    return signal.SIGTERM if _IS_WINDOWS else signal.SIGKILL
+
+
+def _replace_existing_gateway(existing_pid: int) -> bool:
+    """Stop a stale gateway instance before starting a replacement."""
+    from gateway.status import remove_pid_file
+
+    logger.info(
+        "Replacing existing gateway instance (PID %d) with --replace.",
+        existing_pid,
+    )
+    try:
+        os.kill(existing_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass  # Already gone
+    except PermissionError:
+        logger.error(
+            "Permission denied killing PID %d. Cannot replace.",
+            existing_pid,
+        )
+        return False
+
+    # Wait up to 10 seconds for the old process to exit.
+    for _ in range(20):
+        try:
+            os.kill(existing_pid, 0)
+            time.sleep(0.5)
+        except (ProcessLookupError, PermissionError):
+            break  # Process is gone
+    else:
+        force_signal = _force_kill_signal()
+        logger.warning(
+            "Old gateway (PID %d) did not exit after SIGTERM, sending %s.",
+            existing_pid,
+            force_signal.name,
+        )
+        try:
+            os.kill(existing_pid, force_signal)
+            time.sleep(0.5)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    remove_pid_file()
+    # Also release all scoped locks left by the old process.
+    # Stopped (Ctrl+Z) processes don't release locks on exit,
+    # leaving stale lock files that block the new gateway from starting.
+    try:
+        from gateway.status import release_all_scoped_locks
+        _released = release_all_scoped_locks()
+        if _released:
+            logger.info("Released %d stale scoped lock(s) from old gateway.", _released)
+    except Exception:
+        pass
+
+    return True
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -7495,54 +7556,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # The PID file is scoped to HERMES_HOME, so future multi-profile
     # setups (each profile using a distinct HERMES_HOME) will naturally
     # allow concurrent instances without tripping this guard.
-    import time as _time
-    from gateway.status import get_running_pid, remove_pid_file
+    from gateway.status import get_running_pid
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
-            logger.info(
-                "Replacing existing gateway instance (PID %d) with --replace.",
-                existing_pid,
-            )
-            try:
-                os.kill(existing_pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass  # Already gone
-            except PermissionError:
-                logger.error(
-                    "Permission denied killing PID %d. Cannot replace.",
-                    existing_pid,
-                )
+            if not _replace_existing_gateway(existing_pid):
                 return False
-            # Wait up to 10 seconds for the old process to exit
-            for _ in range(20):
-                try:
-                    os.kill(existing_pid, 0)
-                    _time.sleep(0.5)
-                except (ProcessLookupError, PermissionError):
-                    break  # Process is gone
-            else:
-                # Still alive after 10s — force kill
-                logger.warning(
-                    "Old gateway (PID %d) did not exit after SIGTERM, sending SIGKILL.",
-                    existing_pid,
-                )
-                try:
-                    os.kill(existing_pid, signal.SIGKILL)
-                    _time.sleep(0.5)
-                except (ProcessLookupError, PermissionError):
-                    pass
-            remove_pid_file()
-            # Also release all scoped locks left by the old process.
-            # Stopped (Ctrl+Z) processes don't release locks on exit,
-            # leaving stale lock files that block the new gateway from starting.
-            try:
-                from gateway.status import release_all_scoped_locks
-                _released = release_all_scoped_locks()
-                if _released:
-                    logger.info("Released %d stale scoped lock(s) from old gateway.", _released)
-            except Exception:
-                pass
         else:
             hermes_home = str(get_hermes_home())
             logger.error(

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
+
 import pytest
 
+import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.run import GatewayRunner
@@ -87,3 +90,44 @@ async def test_runner_allows_cron_only_mode_when_no_platforms_are_enabled(monkey
     assert runner.adapters == {}
     state = read_runtime_status()
     assert state["gateway_state"] == "running"
+
+
+def test_replace_existing_gateway_uses_sigterm_on_windows(monkeypatch):
+    calls = []
+    removed = []
+    fake_sigterm = SimpleNamespace(name="SIGTERM")
+
+    monkeypatch.setattr(gateway_run, "_IS_WINDOWS", True)
+    monkeypatch.setattr(gateway_run, "signal", SimpleNamespace(SIGTERM=fake_sigterm))
+    monkeypatch.setattr(gateway_run.time, "sleep", lambda _: None)
+    monkeypatch.setattr(gateway_run.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: removed.append(True))
+    monkeypatch.setattr("gateway.status.release_all_scoped_locks", lambda: 0)
+
+    assert gateway_run._replace_existing_gateway(42) is True
+    assert calls[0] == (42, fake_sigterm)
+    assert calls[-1] == (42, fake_sigterm)
+    assert removed == [True]
+
+
+def test_replace_existing_gateway_uses_sigkill_off_windows(monkeypatch):
+    calls = []
+    removed = []
+    fake_sigterm = SimpleNamespace(name="SIGTERM")
+    fake_sigkill = SimpleNamespace(name="SIGKILL")
+
+    monkeypatch.setattr(gateway_run, "_IS_WINDOWS", False)
+    monkeypatch.setattr(
+        gateway_run,
+        "signal",
+        SimpleNamespace(SIGTERM=fake_sigterm, SIGKILL=fake_sigkill),
+    )
+    monkeypatch.setattr(gateway_run.time, "sleep", lambda _: None)
+    monkeypatch.setattr(gateway_run.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: removed.append(True))
+    monkeypatch.setattr("gateway.status.release_all_scoped_locks", lambda: 0)
+
+    assert gateway_run._replace_existing_gateway(99) is True
+    assert calls[0] == (99, fake_sigterm)
+    assert calls[-1] == (99, fake_sigkill)
+    assert removed == [True]


### PR DESCRIPTION
This PR fixes a Windows-specific crash in the gateway startup replacement path.

When `hermes gateway run --replace` has to force-stop an older gateway process,
`gateway/run.py` unconditionally referenced `signal.SIGKILL`. That works on Unix
but crashes on Windows with:

    AttributeError: module 'signal' has no attribute 'SIGKILL'

This is meaningfully distinct from the previously fixed `hermes_cli/gateway.py`
SIGKILL issue. That earlier bug was in the CLI stop/restart waiting path; this
one is in the gateway runtime startup replacement path in `gateway/run.py`, with
different execution flow and user impact.

### What changed

- Added `_IS_WINDOWS` platform detection.
- Added `_force_kill_signal()` to choose `SIGTERM` on Windows and `SIGKILL`
  elsewhere.
- Extracted stale-process replacement logic into `_replace_existing_gateway()`.
- Updated `start_gateway(..., replace=True)` to call that helper instead of
  open-coding the kill/wait/cleanup sequence.
- Updated the warning log to report the actual signal being used.

### Why it matters

`--replace` is exactly the recovery path users and services rely on when a
previous gateway instance is stuck. On Windows, that recovery path currently
fails with an `AttributeError`.

### Tests

- Added a regression test proving the Windows replacement path uses `SIGTERM`
  and does not rely on `SIGKILL`.
- Added a regression test proving non-Windows behavior still uses `SIGKILL`.

```bash
python -m pytest tests/gateway/test_runner_startup_failures.py -q
# Result: 4 passed
