### PR TITLE
fix(matrix,mattermost): configurable E2EE passphrase, invite auth check, path traversal guard

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -59,7 +59,9 @@ _STARTUP_GRACE_SECONDS = 5
 
 # E2EE key export file for persistence across restarts.
 _KEY_EXPORT_FILE = _STORE_DIR / "exported_keys.txt"
-_KEY_EXPORT_PASSPHRASE = "hermes-matrix-e2ee-keys"
+_KEY_EXPORT_PASSPHRASE = os.environ.get(
+    "MATRIX_E2EE_KEY_PASSPHRASE", "hermes-matrix-e2ee-keys"
+)
 
 # Pending undecrypted events: cap and TTL for retry buffer.
 _MAX_PENDING_EVENTS = 100
@@ -1312,7 +1314,7 @@ class MatrixAdapter(BasePlatformAdapter):
         await self.handle_message(msg_event)
 
     async def _on_invite(self, room: Any, event: Any) -> None:
-        """Auto-join rooms when invited."""
+        """Auto-join rooms when invited (only from allowed users)."""
         import nio
 
         if not isinstance(event, nio.InviteMemberEvent):
@@ -1324,6 +1326,19 @@ class MatrixAdapter(BasePlatformAdapter):
 
         if event.membership != "invite":
             return
+
+        # Check sender against allowed users before joining.
+        allow_all = os.environ.get("MATRIX_ALLOW_ALL_USERS", "").lower() in ("1", "true", "yes")
+        if not allow_all:
+            allowed_csv = os.environ.get("MATRIX_ALLOWED_USERS", "")
+            if allowed_csv:
+                allowed = {u.strip() for u in allowed_csv.split(",") if u.strip()}
+                if event.sender not in allowed:
+                    logger.warning(
+                        "Matrix: rejecting invite to %s from unauthorized user %s",
+                        room.room_id, event.sender,
+                    )
+                    return
 
         logger.info(
             "Matrix: invited to %s by %s — joining",

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -114,6 +114,9 @@ class MattermostAdapter(BasePlatformAdapter):
     async def _api_get(self, path: str) -> Dict[str, Any]:
         """GET /api/v4/{path}."""
         import aiohttp
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return {}
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.get(url, headers=self._headers(), timeout=aiohttp.ClientTimeout(total=30)) as resp:
@@ -131,6 +134,9 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> Dict[str, Any]:
         """POST /api/v4/{path} with JSON body."""
         import aiohttp
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return {}
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.post(
@@ -151,6 +157,9 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> Dict[str, Any]:
         """PUT /api/v4/{path} with JSON body."""
         import aiohttp
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return {}
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.put(


### PR DESCRIPTION
## Summary

- **gateway/platforms/matrix.py** (HIGH-security): Make E2EE key export passphrase configurable via `MATRIX_E2EE_KEY_PASSPHRASE` env var instead of using the hardcoded `"hermes-matrix-e2ee-keys"`. Since this passphrase is publicly visible in the open-source code, anyone with read access to `~/.hermes/platforms/matrix/store/exported_keys.txt` can decrypt all historical Megolm session keys — defeating E2EE entirely.
- **gateway/platforms/matrix.py** (HIGH-security): Check `event.sender` against `MATRIX_ALLOWED_USERS` before auto-joining rooms on invite. Without this, any Matrix user on any federated server can invite the bot into arbitrary rooms, exposing its presence and metadata. Respects `MATRIX_ALLOW_ALL_USERS=true` for open deployments.
- **gateway/platforms/mattermost.py** (HIGH-security): Add `".."` path traversal guard in all three API helpers (`_api_get`, `_api_post`, `_api_put`). Values from WebSocket events (channel_id, post_id, file_id) are interpolated directly into API paths. A malicious or compromised Mattermost server could craft events with traversal payloads like `"../../users/me/tokens"` to make the bot issue authenticated requests to arbitrary API endpoints using its bearer token.

## Test plan

- [ ] Set `MATRIX_E2EE_KEY_PASSPHRASE=secret` and verify key export/import works
- [ ] Set `MATRIX_ALLOWED_USERS=@user:server` and verify invites from other users are rejected
- [ ] Verify Mattermost API calls with `../` in IDs are blocked with error log

🤖 Generated with [Claude Code](https://claude.com/claude-code)