### PR TITLE
feat(cli): add /spawn, kitty clarify overlays, and /hermes-addition

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1451,20 +1451,24 @@ def _strict_vision_backend_available(provider: str) -> bool:
     return _resolve_strict_vision_backend(provider)[0] is not None
 
 
-def _preferred_main_vision_provider() -> Optional[str]:
-    """Return the selected main provider when it is also a supported vision backend."""
-    try:
-        from hermes_cli.config import load_config
+def _read_active_provider_for_vision() -> str:
+    """Return the user's active provider for vision auto fallback.
 
-        config = load_config()
-        model_cfg = config.get("model", {})
-        if isinstance(model_cfg, dict):
-            provider = _normalize_vision_provider(model_cfg.get("provider", ""))
-            if provider in _VISION_AUTO_PROVIDER_ORDER:
-                return provider
+    Prefer config.yaml's main provider, but fall back to auth.json active_provider
+    when no main provider is configured there.
+    """
+    main_provider = _read_main_provider()
+    if main_provider and main_provider not in ("auto", ""):
+        return main_provider
+    try:
+        from hermes_cli.auth import get_active_provider
+
+        active_provider = _normalize_vision_provider(get_active_provider())
+        if active_provider and active_provider not in ("auto", ""):
+            return active_provider
     except Exception:
         pass
-    return None
+    return ""
 
 
 def get_available_vision_backends() -> List[str]:
@@ -1476,8 +1480,9 @@ def get_available_vision_backends() -> List[str]:
     available = [p for p in _VISION_AUTO_PROVIDER_ORDER
                  if _strict_vision_backend_available(p)]
     # Also check the user's active provider (may be DeepSeek, Alibaba, named
-    # custom, etc.) — resolve_provider_client handles all provider types.
-    main_provider = _read_main_provider()
+    # custom, auth-store Codex, etc.) — resolve_provider_client handles all
+    # provider types.
+    main_provider = _read_active_provider_for_vision()
     if (main_provider and main_provider not in ("auto", "")
             and main_provider not in available):
         client, _ = resolve_provider_client(main_provider, _read_main_model())
@@ -1539,7 +1544,7 @@ def resolve_vision_provider_client(
                 return _finalize(candidate, sync_client, default_model)
 
         # Fall back to the user's active provider + model.
-        main_provider = _read_main_provider()
+        main_provider = _read_active_provider_for_vision()
         main_model = _read_main_model()
         if main_provider and main_provider not in ("auto", ""):
             sync_client, resolved_model = resolve_provider_client(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -10,7 +10,7 @@ import uuid
 import os
 import re
 from dataclasses import dataclass, fields, replace
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -460,14 +460,15 @@ class CredentialPool:
         return entry
 
     def _sync_codex_entry_from_cli(self, entry: PooledCredential) -> PooledCredential:
-        """Sync an openai-codex pool entry from ~/.codex/auth.json if tokens differ.
+        """Sync the singleton openai-codex device_code entry from ~/.codex/auth.json.
 
         OpenAI OAuth refresh tokens are single-use and rotate on every refresh.
-        When the Codex CLI (or another Hermes profile) refreshes its token,
-        the pool entry's refresh_token becomes stale.  This method detects that
-        by comparing against ~/.codex/auth.json and syncing the fresh pair.
+        When the external Codex CLI refreshes its token, Hermes's singleton
+        ``device_code`` credential can become stale. Only that singleton entry is
+        allowed to mirror ~/.codex/auth.json — manually added pooled accounts must
+        remain independent and must never be overwritten by shared CLI state.
         """
-        if self.provider != "openai-codex":
+        if self.provider != "openai-codex" or entry.source != "device_code":
             return entry
         try:
             cli_tokens = _import_codex_cli_tokens()
@@ -476,20 +477,35 @@ class CredentialPool:
             cli_refresh = cli_tokens.get("refresh_token", "")
             cli_access = cli_tokens.get("access_token", "")
             if cli_refresh and cli_refresh != entry.refresh_token:
-                logger.debug("Pool entry %s: syncing tokens from ~/.codex/auth.json (refresh token changed)", entry.id)
+                logger.debug("Pool entry %s: syncing singleton device_code tokens from ~/.codex/auth.json", entry.id)
+                sync_timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+                persisted_tokens = {
+                    "access_token": cli_access,
+                    "refresh_token": cli_refresh,
+                }
+                if entry.account_id:
+                    persisted_tokens["account_id"] = entry.account_id
+                if entry.id_token:
+                    persisted_tokens["id_token"] = entry.id_token
+                auth_mod._save_codex_tokens(persisted_tokens, last_refresh=sync_timestamp)
                 updated = replace(
                     entry,
                     access_token=cli_access,
                     refresh_token=cli_refresh,
+                    label=label_from_token(cli_access, entry.label or entry.id),
+                    last_refresh=sync_timestamp,
                     last_status=None,
                     last_status_at=None,
                     last_error_code=None,
+                    last_error_reason=None,
+                    last_error_message=None,
+                    last_error_reset_at=None,
                 )
                 self._replace_entry(entry, updated)
                 self._persist()
                 return updated
         except Exception as exc:
-            logger.debug("Failed to sync from ~/.codex/auth.json: %s", exc)
+            logger.debug("Failed to sync singleton Codex entry from ~/.codex/auth.json: %s", exc)
         return entry
 
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -386,10 +386,28 @@ class CredentialPool:
                 return
 
     def _persist(self) -> None:
-        write_credential_pool(
-            self.provider,
-            [entry.to_dict() for entry in self._entries],
-        )
+        """Persist in-memory updates without resurrecting entries removed elsewhere.
+
+        Long-lived Hermes processes can hold a stale in-memory pool while another
+        process removes entries from auth.json. Blindly writing ``self._entries``
+        would reintroduce those deleted entries. Instead, merge by id onto the
+        latest on-disk pool and only persist entries that still exist there.
+        """
+        with _AUTH_STORE_MUTATION_LOCK:
+            latest_entries = self._load_latest_entries()
+            latest_by_id = {entry.id: entry for entry in latest_entries}
+            current_by_id = {entry.id: entry for entry in self._entries}
+
+            merged_entries = [
+                current_by_id.get(entry.id, latest_by_id[entry.id])
+                for entry in latest_entries
+            ]
+            merged_entries.sort(key=lambda item: item.priority)
+            write_credential_pool(
+                self.provider,
+                [entry.to_dict() for entry in merged_entries],
+            )
+            self._sync_from_latest(merged_entries)
 
     def _load_latest_entries(self) -> List[PooledCredential]:
         payloads = read_credential_pool(self.provider)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -31,6 +31,10 @@ from hermes_cli.auth import (
 
 logger = logging.getLogger(__name__)
 
+# Shared in-process lock so separate CredentialPool instances do not clobber each
+# other's auth.json updates. This matters for concurrent UI refresh/remove flows.
+_AUTH_STORE_MUTATION_LOCK = threading.Lock()
+
 
 def _load_config_safe() -> Optional[dict]:
     """Load config.yaml, returning None on any error."""
@@ -79,7 +83,7 @@ CUSTOM_POOL_PREFIX = "custom:"
 _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
-    "agent_key_obtained_at", "tls",
+    "agent_key_obtained_at", "tls", "account_id", "id_token",
 })
 
 
@@ -386,6 +390,17 @@ class CredentialPool:
             self.provider,
             [entry.to_dict() for entry in self._entries],
         )
+
+    def _load_latest_entries(self) -> List[PooledCredential]:
+        payloads = read_credential_pool(self.provider)
+        entries = [PooledCredential.from_dict(self.provider, payload) for payload in payloads]
+        entries.sort(key=lambda item: item.priority)
+        return entries
+
+    def _sync_from_latest(self, entries: List[PooledCredential]) -> None:
+        self._entries = sorted(entries, key=lambda item: item.priority)
+        if self._current_id and not any(entry.id == self._current_id for entry in self._entries):
+            self._current_id = None
 
     def _mark_exhausted(
         self,
@@ -848,15 +863,65 @@ class CredentialPool:
     def remove_index(self, index: int) -> Optional[PooledCredential]:
         if index < 1 or index > len(self._entries):
             return None
-        removed = self._entries.pop(index - 1)
-        self._entries = [
-            replace(entry, priority=new_priority)
-            for new_priority, entry in enumerate(self._entries)
-        ]
-        self._persist()
-        if self._current_id == removed.id:
-            self._current_id = None
-        return removed
+        entry_id = self._entries[index - 1].id
+        return self.remove_entry(entry_id)
+
+    def remove_entry(self, entry_id: str) -> Optional[PooledCredential]:
+        with self._lock, _AUTH_STORE_MUTATION_LOCK:
+            latest_entries = self._load_latest_entries()
+            removed = next((entry for entry in latest_entries if entry.id == entry_id), None)
+            if removed is None:
+                self._sync_from_latest(latest_entries)
+                return None
+
+            remaining = [entry for entry in latest_entries if entry.id != entry_id]
+            remaining = [
+                replace(entry, priority=new_priority)
+                for new_priority, entry in enumerate(remaining)
+            ]
+            write_credential_pool(
+                self.provider,
+                [entry.to_dict() for entry in remaining],
+            )
+            self._sync_from_latest(remaining)
+            return removed
+
+    def update_entry(self, entry_id: str, **updates: Any) -> Optional[PooledCredential]:
+        """Update one entry by id, persist it, and return the updated credential."""
+        with self._lock, _AUTH_STORE_MUTATION_LOCK:
+            latest_entries = self._load_latest_entries()
+            for idx, entry in enumerate(latest_entries):
+                if entry.id != entry_id:
+                    continue
+
+                field_names = {f.name for f in fields(entry)}
+                field_updates: Dict[str, Any] = {}
+                extra_updates = dict(entry.extra)
+                for key, value in updates.items():
+                    if key == "provider":
+                        continue
+                    if key in field_names:
+                        field_updates[key] = value
+                    elif key in _EXTRA_KEYS:
+                        extra_updates[key] = value
+                if extra_updates != entry.extra:
+                    field_updates["extra"] = extra_updates
+
+                if not field_updates:
+                    self._sync_from_latest(latest_entries)
+                    return entry
+
+                updated = replace(entry, **field_updates)
+                latest_entries[idx] = updated
+                write_credential_pool(
+                    self.provider,
+                    [item.to_dict() for item in latest_entries],
+                )
+                self._sync_from_latest(latest_entries)
+                return updated
+
+            self._sync_from_latest(latest_entries)
+        return None
 
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
@@ -884,10 +949,16 @@ class CredentialPool:
         return None, None, f'No credential matching "{raw}".'
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
-        entry = replace(entry, priority=_next_priority(self._entries))
-        self._entries.append(entry)
-        self._persist()
-        return entry
+        with self._lock, _AUTH_STORE_MUTATION_LOCK:
+            latest_entries = self._load_latest_entries()
+            updated_entry = replace(entry, priority=_next_priority(latest_entries))
+            latest_entries.append(updated_entry)
+            write_credential_pool(
+                self.provider,
+                [item.to_dict() for item in latest_entries],
+            )
+            self._sync_from_latest(latest_entries)
+            return updated_entry
 
 
 def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]) -> bool:
@@ -1029,6 +1100,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "auth_type": AUTH_TYPE_OAUTH,
                     "access_token": tokens.get("access_token", ""),
                     "refresh_token": tokens.get("refresh_token"),
+                    "account_id": tokens.get("account_id"),
+                    "id_token": tokens.get("id_token"),
                     "base_url": "https://chatgpt.com/backend-api/codex",
                     "last_refresh": state.get("last_refresh"),
                     "label": label_from_token(tokens.get("access_token", ""), "device_code"),

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -161,6 +161,15 @@ SESSION_SEARCH_GUIDANCE = (
     "asking them to repeat themselves."
 )
 
+HERMES_DOCS_LOOKUP_GUIDANCE = (
+    "When the user asks about Hermes Agent itself — commands, configuration, toolsets, "
+    "features, docs, architecture, or upstream implementation behavior — use "
+    "hermes_docs_lookup first when it is available. It searches the public Hermes "
+    "upstream docs/code on NousResearch/hermes-agent@main, which may differ from the "
+    "current local checkout or fork. Use local file/code tools only when the user "
+    "explicitly wants this checkout or you need local implementation details."
+)
+
 SKILLS_GUIDANCE = (
     "After completing a complex task (5+ tool calls), fixing a tricky error, "
     "or discovering a non-trivial workflow, save the approach as a "

--- a/cli.py
+++ b/cli.py
@@ -3750,63 +3750,48 @@ class HermesCLI:
             print(f"(x_x) Failed to save: {e}")
     
     def retry_last(self):
-        """Retry the last user message by removing the last exchange and re-sending.
-        
-        Removes the last assistant response (and any tool-call messages) and
-        the last user message, then re-sends that user message to the agent.
-        Returns the message to re-send, or None if there's nothing to retry.
-        """
+        """Retry the last visible user message by removing its trailing turn."""
         if not self.conversation_history:
             print("(._.) No messages to retry.")
             return None
-        
-        # Walk backwards to find the last user message
-        last_user_idx = None
-        for i in range(len(self.conversation_history) - 1, -1, -1):
-            if self.conversation_history[i].get("role") == "user":
-                last_user_idx = i
-                break
-        
-        if last_user_idx is None:
+
+        from run_agent import message_content_to_text, summarize_last_user_turn
+
+        summary = summarize_last_user_turn(self.conversation_history, preview_limit=60)
+        if not summary:
             print("(._.) No user message found to retry.")
             return None
-        
-        # Extract the message text and remove everything from that point forward
-        last_message = self.conversation_history[last_user_idx].get("content", "")
-        self.conversation_history = self.conversation_history[:last_user_idx]
-        
-        print(f"(^_^)b Retrying: \"{last_message[:60]}{'...' if len(last_message) > 60 else ''}\"")
+
+        last_message = summary["original_content"]
+        self.conversation_history = summary["truncated_history"]
+        preview = message_content_to_text(last_message)
+        preview = " ".join(preview.split()) or "[empty message]"
+        print(f"(^_^)b Retrying: \"{preview[:60]}{'...' if len(preview) > 60 else ''}\"")
         return last_message
-    
+
     def undo_last(self):
-        """Remove the last user/assistant exchange from conversation history.
-        
-        Walks backwards and removes all messages from the last user message
-        onward (including assistant responses, tool calls, etc.).
-        """
+        """Remove the last visible user turn from conversation history."""
         if not self.conversation_history:
             print("(._.) No messages to undo.")
             return
-        
-        # Walk backwards to find the last user message
-        last_user_idx = None
-        for i in range(len(self.conversation_history) - 1, -1, -1):
-            if self.conversation_history[i].get("role") == "user":
-                last_user_idx = i
-                break
-        
-        if last_user_idx is None:
+
+        from run_agent import (
+            format_internal_transcript_message_count,
+            summarize_last_user_turn,
+        )
+
+        summary = summarize_last_user_turn(self.conversation_history, preview_limit=60)
+        if not summary:
             print("(._.) No user message found to undo.")
             return
-        
-        # Count how many messages we're removing
-        removed_count = len(self.conversation_history) - last_user_idx
-        removed_msg = self.conversation_history[last_user_idx].get("content", "")
-        
-        # Truncate history to before the last user message
-        self.conversation_history = self.conversation_history[:last_user_idx]
-        
-        print(f"(^_^)b Undid {removed_count} message(s). Removed: \"{removed_msg[:60]}{'...' if len(removed_msg) > 60 else ''}\"")
+
+        self.conversation_history = summary["truncated_history"]
+        removed_count = int(summary["removed_count"])
+        preview = summary["preview"]
+        print(
+            f"(^_^)b Undid 1 turn ({format_internal_transcript_message_count(removed_count)}). "
+            f"Removed your last message: \"{preview}\""
+        )
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
     

--- a/cli.py
+++ b/cli.py
@@ -1479,6 +1479,8 @@ class HermesCLI:
         self.reasoning_config = _parse_reasoning_config(
             CLI_CONFIG["agent"].get("reasoning_effort", "")
         )
+        _extra_body_cfg = CLI_CONFIG["model"].get("extra_body")
+        self.extra_body_config = _extra_body_cfg if isinstance(_extra_body_cfg, dict) else None
         
         # OpenRouter provider routing preferences
         pr = CLI_CONFIG.get("provider_routing", {}) or {}
@@ -2450,6 +2452,7 @@ class HermesCLI:
                 ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
+                extra_body_config=self.extra_body_config,
                 providers_allowed=self._providers_only,
                 providers_ignored=self._providers_ignore,
                 providers_order=self._providers_order,

--- a/cli.py
+++ b/cli.py
@@ -2829,6 +2829,10 @@ class HermesCLI:
             self._last_assistant_message_text = plain
             self._publish_latest_reply_to_overlay(plain)
 
+    def _publish_latest_reply_to_overlay(self, text: str) -> None:
+        """Hook for wrapper CLIs with overlays; base Hermes has no overlay sink."""
+        return None
+
     def _show_assistant_copy_hint(self) -> None:
         if not getattr(self, "_app", None):
             return
@@ -3064,6 +3068,32 @@ class HermesCLI:
             prefix = "\n\n".join(enriched_parts)
             return f"{prefix}\n\n{user_text}" if user_text else prefix
         return user_text or "What do you see in this image?"
+
+    def _prepare_user_message_with_images(self, message, images: list, turn_route: dict):
+        if not images:
+            return message
+
+        from run_agent import (
+            build_native_multimodal_user_content,
+            message_content_to_text,
+            supports_native_multimodal_input,
+        )
+
+        runtime = (turn_route or {}).get("runtime") or {}
+        if supports_native_multimodal_input(
+            provider=runtime.get("provider"),
+            api_mode=runtime.get("api_mode"),
+            base_url=runtime.get("base_url"),
+        ):
+            return build_native_multimodal_user_content(
+                message_content_to_text(message),
+                images,
+            )
+
+        return self._preprocess_images_with_vision(
+            message if isinstance(message, str) else message_content_to_text(message),
+            images,
+        )
 
     def _show_tool_availability_warnings(self):
         """Show warnings about disabled tools due to missing API keys."""
@@ -6540,13 +6570,8 @@ class HermesCLI:
         ):
             return None
         
-        # Pre-process images through the vision tool (Gemini Flash) so the
-        # main model receives text descriptions instead of raw base64 image
-        # content — works with any model, not just vision-capable ones.
         if images:
-            message = self._preprocess_images_with_vision(
-                message if isinstance(message, str) else "", images
-            )
+            message = self._prepare_user_message_with_images(message, images, turn_route)
 
         # Expand @ context references (e.g. @file:main.py, @diff, @folder:src/)
         if isinstance(message, str) and "@" in message:

--- a/cli.py
+++ b/cli.py
@@ -2820,10 +2820,11 @@ class HermesCLI:
         return f"  ⧉ {cls._assistant_copy_shortcut_label()} copy latest reply"
 
     def _remember_assistant_message(self, text: Optional[str]) -> None:
-        """Store the latest assistant-visible message for clipboard copying."""
+        """Store and publish the latest assistant-visible message."""
         plain = _rich_text_from_ansi(text or "").plain
         if plain.strip():
             self._last_assistant_message_text = plain
+            self._publish_latest_reply_to_overlay(plain)
 
     def _show_assistant_copy_hint(self) -> None:
         if not getattr(self, "_app", None):

--- a/cli.py
+++ b/cli.py
@@ -1417,6 +1417,7 @@ class HermesCLI:
         self.api_mode = "chat_completions"
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []
+        self.codex_service_tier = None
         self.base_url = (
             base_url
             or CLI_CONFIG["model"].get("base_url", "")
@@ -1556,6 +1557,7 @@ class HermesCLI:
         self._command_status = ""
         self._attached_images: list[Path] = []
         self._image_counter = 0
+        self._last_assistant_message_text: str = ""
         self.preloaded_skills: list[str] = []
         self._startup_skills_line_shown = False
 
@@ -2437,6 +2439,7 @@ class HermesCLI:
                 base_url=runtime.get("base_url"),
                 provider=runtime.get("provider"),
                 api_mode=runtime.get("api_mode"),
+                service_tier=self.codex_service_tier,
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
@@ -2807,6 +2810,50 @@ class HermesCLI:
             return True
         self._image_counter -= 1
         return False
+
+    @staticmethod
+    def _assistant_copy_shortcut_label() -> str:
+        return "Alt+C"
+
+    @classmethod
+    def _assistant_copy_hint_text(cls) -> str:
+        return f"  ⧉ {cls._assistant_copy_shortcut_label()} copy latest reply"
+
+    def _remember_assistant_message(self, text: Optional[str]) -> None:
+        """Store the latest assistant-visible message for clipboard copying."""
+        plain = _rich_text_from_ansi(text or "").plain
+        if plain.strip():
+            self._last_assistant_message_text = plain
+
+    def _show_assistant_copy_hint(self) -> None:
+        if not getattr(self, "_app", None):
+            return
+        ChatConsole().print(f"[dim]{_escape(self._assistant_copy_hint_text())}[/]")
+
+    def _copy_latest_assistant_message(self) -> tuple[bool, str]:
+        """Copy the latest assistant reply shown in the interactive chat."""
+        latest = getattr(self, "_last_assistant_message_text", "")
+        if not latest.strip():
+            return False, "No assistant reply yet to copy."
+
+        from hermes_cli.clipboard import copy_text_to_clipboard
+
+        ok, error = copy_text_to_clipboard(latest)
+        if ok:
+            return True, "Copied latest assistant reply to the system clipboard."
+        if error:
+            return False, f"Clipboard copy failed: {error}"
+        return False, "Clipboard copy failed."
+
+    def _register_copy_shortcut(self, kb: KeyBindings) -> None:
+        """Bind Alt+C to copy the latest assistant reply."""
+
+        @kb.add('escape', 'c')
+        def handle_copy_latest_reply(event):
+            ok, message = self._copy_latest_assistant_message()
+            icon = "⧉" if ok else "⚠"
+            _cprint(f"  {_DIM}{icon} {message}{_RST}")
+            event.app.invalidate()
 
     def _handle_rollback_command(self, command: str):
         """Handle /rollback — list, diff, or restore filesystem checkpoints.
@@ -3450,11 +3497,13 @@ class HermesCLI:
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
+        self.codex_service_tier = None
 
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
             self.agent.reset_session_state()
+            self.agent.service_tier = None
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):
@@ -3525,6 +3574,7 @@ class HermesCLI:
         self.session_id = target_id
         self._resumed = True
         self._pending_title = None
+        self.codex_service_tier = None
 
         # Load conversation history (strip transcript-only metadata entries)
         restored = self._session_db.get_messages_as_conversation(target_id)
@@ -3541,6 +3591,7 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = target_id
             self.agent.reset_session_state()
+            self.agent.service_tier = None
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
@@ -4589,6 +4640,8 @@ class HermesCLI:
             self._toggle_verbose()
         elif canonical == "yolo":
             self._toggle_yolo()
+        elif canonical == "fast":
+            self._handle_fast_command(cmd_original)
         elif canonical == "reasoning":
             self._handle_reasoning_command(cmd_original)
         elif canonical == "compress":
@@ -4818,6 +4871,7 @@ class HermesCLI:
                     base_url=turn_route["runtime"].get("base_url"),
                     provider=turn_route["runtime"].get("provider"),
                     api_mode=turn_route["runtime"].get("api_mode"),
+                    service_tier=self.codex_service_tier,
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
                     max_iterations=self.max_turns,
@@ -4870,6 +4924,7 @@ class HermesCLI:
                 _cprint(f"  Prompt: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
                 ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
                 if response:
+                    self._remember_assistant_message(response)
                     try:
                         from hermes_cli.skin_engine import get_active_skin
                         _skin = get_active_skin()
@@ -4891,6 +4946,7 @@ class HermesCLI:
                         box=rich_box.HORIZONTALS,
                         padding=(1, 2),
                     ))
+                    self._show_assistant_copy_hint()
                 else:
                     _cprint("  (No response generated)")
 
@@ -4998,6 +5054,7 @@ class HermesCLI:
                 print()
 
                 if response:
+                    self._remember_assistant_message(response)
                     try:
                         from hermes_cli.skin_engine import get_active_skin
                         _skin = get_active_skin()
@@ -5013,6 +5070,7 @@ class HermesCLI:
                         box=rich_box.HORIZONTALS,
                         padding=(1, 2),
                     ))
+                    self._show_assistant_copy_hint()
                 else:
                     _cprint("  💬 /btw: (no response)")
 
@@ -5302,6 +5360,37 @@ class HermesCLI:
         else:
             os.environ["HERMES_YOLO_MODE"] = "1"
             self.console.print("  ⚡ YOLO mode [bold green]ON[/] — all commands auto-approved. Use with caution.")
+
+    def _handle_fast_command(self, cmd: str):
+        """Handle /fast — session-local Codex fast mode."""
+        from hermes_cli.fast_mode import FAST_MODE_USAGE, fast_mode_note, parse_fast_command_arg
+
+        parts = cmd.strip().split(maxsplit=1)
+        action = parse_fast_command_arg(parts[1] if len(parts) > 1 else "")
+        if action is None:
+            _cprint(f"  {_DIM}Usage: {FAST_MODE_USAGE}{_RST}")
+            return
+
+        current_enabled = self.codex_service_tier == "fast"
+        if action == "status":
+            enabled = current_enabled
+        elif action == "toggle":
+            enabled = not current_enabled
+        else:
+            enabled = action == "on"
+
+        if action != "status":
+            self.codex_service_tier = "fast" if enabled else None
+            if self.agent:
+                self.agent.service_tier = self.codex_service_tier
+
+        provider = getattr(self.agent, "provider", None) if self.agent else getattr(self, "provider", None)
+        model = getattr(self.agent, "model", None) if self.agent else getattr(self, "model", None)
+        state = "ON ✓" if enabled else "off"
+        _cprint(f"  {_GOLD}Fast mode: {state}{_RST}")
+        _cprint(f"  {_DIM}{fast_mode_note(provider=provider, model=model, enabled=enabled)}{_RST}")
+        if action != "status":
+            _cprint(f"  {_DIM}Takes effect on the next message.{_RST}")
 
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.
@@ -6732,6 +6821,8 @@ class HermesCLI:
                     response = response + "\n\n---\n_[Interrupted - processing new message]_"
 
             response_previewed = result.get("response_previewed", False) if result else False
+            if response:
+                self._remember_assistant_message(response)
 
             # Display reasoning (thinking) box if enabled and available.
             # Skip when streaming already showed reasoning live.  Use the
@@ -6792,6 +6883,8 @@ class HermesCLI:
                         padding=(1, 2),
                     ))
 
+            if response:
+                self._show_assistant_copy_hint()
 
             # Play terminal bell when agent finishes (if enabled).
             # Works over SSH — the bell propagates to the user's terminal.
@@ -7181,6 +7274,7 @@ class HermesCLI:
         
         # Key bindings for the input area
         kb = KeyBindings()
+        self._register_copy_shortcut(kb)
         
         @kb.add('enter')
         def handle_enter(event):

--- a/cli.py
+++ b/cli.py
@@ -72,6 +72,11 @@ _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧
 # User-managed env files should override stale shell exports on restart.
 from hermes_constants import get_hermes_home, display_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.kitty_overlay import (
+    DEFAULT_TIMEOUT_RESPONSE as KITTY_OVERLAY_TIMEOUT_RESPONSE,
+    kitty_overlay_available,
+    prompt_kitty_overlay_clarify,
+)
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -634,13 +639,15 @@ def _run_cleanup():
 _active_worktree: Optional[Dict[str, str]] = None
 
 
-def _git_repo_root() -> Optional[str]:
-    """Return the git repo root for CWD, or None if not in a repo."""
+def _git_repo_root(cwd: str | None = None) -> Optional[str]:
+    """Return the git repo root for ``cwd`` (or the active terminal cwd)."""
     import subprocess
+
+    target_cwd = cwd or os.getenv("TERMINAL_CWD") or os.getcwd()
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, timeout=5, cwd=target_cwd,
         )
         if result.returncode == 0:
             return result.stdout.strip()
@@ -656,6 +663,46 @@ def _path_is_within_root(path: Path, root: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _git_remote_exists(repo_root: str, remote_name: str) -> bool:
+    """Return True when ``remote_name`` exists in ``repo_root``."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", remote_name],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=repo_root,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+
+def _git_default_base_ref(repo_root: str, remote_name: str = "origin") -> str:
+    """Return the remote default branch ref, e.g. ``origin/main``."""
+    import subprocess
+
+    fallback = f"{remote_name}/main"
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", f"refs/remotes/{remote_name}/HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=repo_root,
+        )
+        if result.returncode == 0:
+            ref = result.stdout.strip()
+            if ref.startswith("refs/remotes/"):
+                return ref[len("refs/remotes/"):]
+    except Exception:
+        pass
+    return fallback
 
 
 def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
@@ -1553,6 +1600,7 @@ class HermesCLI:
         self._approval_state = None
         self._approval_deadline = 0
         self._approval_lock = threading.Lock()
+        self._background_prompt_lock = threading.Lock()
         self._secret_state = None
         self._secret_deadline = 0
         self._spinner_text: str = ""  # thinking spinner text for TUI
@@ -1665,7 +1713,60 @@ class HermesCLI:
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
+        snapshot["background_tasks"] = self._background_agent_count()
         return snapshot
+
+    def _background_agent_count(self, extra_tasks: int = 0) -> int:
+        tasks = getattr(self, "_background_tasks", None)
+        if isinstance(tasks, dict):
+            return max(0, len(tasks) + int(extra_tasks))
+        return max(0, int(extra_tasks))
+
+    def _background_status_note(self, extra_tasks: int = 0) -> str:
+        count = self._background_agent_count(extra_tasks=extra_tasks)
+        noun = "agent" if count == 1 else "agents"
+        return f"({count} background {noun} running)"
+
+    def _show_background_agent_count_note(self, extra_tasks: int = 0) -> None:
+        count = self._background_agent_count(extra_tasks=extra_tasks)
+        if count > 0:
+            _cprint(f"  {_DIM}{self._background_status_note(extra_tasks=extra_tasks)}{_RST}")
+
+    def _make_background_clarify_callback(self, task_label: str):
+        timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+
+        def _callback(question, choices):
+            prompt_lock = getattr(self, "_background_prompt_lock", None)
+            if prompt_lock is None:
+                prompt_lock = threading.Lock()
+                self._background_prompt_lock = prompt_lock
+
+            with prompt_lock:
+                if kitty_overlay_available():
+                    try:
+                        return prompt_kitty_overlay_clarify(
+                            question,
+                            choices,
+                            task_label=f"Hermes {task_label}",
+                            timeout=timeout,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Kitty overlay clarify failed for %s",
+                            task_label,
+                            exc_info=True,
+                        )
+                try:
+                    return self._clarify_callback(question, choices)
+                except Exception:
+                    logger.debug(
+                        "Inline clarify fallback failed for %s",
+                        task_label,
+                        exc_info=True,
+                    )
+                    return KITTY_OVERLAY_TIMEOUT_RESPONSE
+
+        return _callback
 
     @staticmethod
     def _status_bar_display_width(text: str) -> int:
@@ -1722,12 +1823,19 @@ class HermesCLI:
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
+            background_count = int(snapshot.get("background_tasks") or 0)
+            background_label = f"bg {background_count}" if background_count else ""
 
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
-                return self._trim_status_bar_text(text, width)
+                parts = [f"⚕ {snapshot['model_short']}"]
+                if background_label:
+                    parts.append(background_label)
+                parts.append(duration_label)
+                return self._trim_status_bar_text(" · ".join(parts), width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                if background_label:
+                    parts.append(background_label)
                 parts.append(duration_label)
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
@@ -1739,6 +1847,8 @@ class HermesCLI:
                 context_label = "ctx --"
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            if background_label:
+                parts.append(background_label)
             parts.append(duration_label)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
@@ -1760,15 +1870,24 @@ class HermesCLI:
             except Exception:
                 width = shutil.get_terminal_size((80, 24)).columns
             duration_label = snapshot["duration"]
+            background_count = int(snapshot.get("background_tasks") or 0)
+            background_label = f"bg {background_count}" if background_count else ""
 
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                ]
+                if background_label:
+                    frags.extend([
+                        ("class:status-bar-dim", " · "),
+                        ("class:status-bar-warn", background_label),
+                    ])
+                frags.extend([
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                     ("class:status-bar", " "),
-                ]
+                ])
             else:
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
@@ -1778,10 +1897,17 @@ class HermesCLI:
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
+                    ]
+                    if background_label:
+                        frags.extend([
+                            ("class:status-bar-dim", " · "),
+                            ("class:status-bar-warn", background_label),
+                        ])
+                    frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
                         ("class:status-bar", " "),
-                    ]
+                    ])
                 else:
                     if snapshot["context_length"]:
                         ctx_total = _format_context_length(snapshot["context_length"])
@@ -1800,10 +1926,17 @@ class HermesCLI:
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
+                    ]
+                    if background_label:
+                        frags.extend([
+                            ("class:status-bar-dim", " │ "),
+                            ("class:status-bar-warn", background_label),
+                        ])
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
                         ("class:status-bar", " "),
-                    ]
+                    ])
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
@@ -3813,9 +3946,12 @@ class HermesCLI:
         _cprint(f"  Task ID:         {task_id}")
         _cprint(f"  Parent session:  {parent_session_id}")
         _cprint(f"  Child session:   {new_session_id}")
-        _cprint("  You stay on the current session — results will appear here when done.\n")
+        _cprint("  You stay on the current session — results will appear here when done.")
+        self._show_background_agent_count_note(extra_tasks=1)
+        _cprint("")
 
         turn_route = self._resolve_turn_agent_config(prompt)
+        clarify_callback = self._make_background_clarify_callback(f"spawn #{task_num}")
 
         def run_spawn():
             try:
@@ -3843,6 +3979,7 @@ class HermesCLI:
                     provider_data_collection=self._provider_data_collection,
                     fallback_model=self._fallback_model,
                     pass_session_id=False,
+                    clarify_callback=clarify_callback,
                 )
                 spawn_agent._print_fn = lambda *_a, **_kw: None
 
@@ -3917,6 +4054,233 @@ class HermesCLI:
                     self._invalidate(min_interval=0)
 
         thread = threading.Thread(target=run_spawn, daemon=True, name=f"spawn-task-{task_id}")
+        self._background_tasks[task_id] = thread
+        thread.start()
+
+    def _build_hermes_addition_prompt(
+        self,
+        prompt: str,
+        *,
+        worktree_info: Dict[str, str],
+        push_remote: str,
+        base_ref: str,
+    ) -> str:
+        base_branch = base_ref.split("/", 1)[1] if "/" in base_ref else base_ref
+        worktree_path = worktree_info["path"]
+        branch_name = worktree_info["branch"]
+        repo_root = worktree_info["repo_root"]
+        instructions = textwrap.dedent(
+            f"""
+            [Hermes Addition background PR agent]
+            You are running in a background child session cloned from the parent conversation.
+
+            Isolated coding workspace:
+            - repo root: {repo_root}
+            - worktree: {worktree_path}
+            - branch: {branch_name}
+            - preferred push remote: {push_remote}
+            - base branch: {base_branch}
+
+            Required workflow:
+            1. Do repo-changing terminal and file operations only inside {worktree_path}.
+               Use terminal(..., workdir={worktree_path!r}) and file paths rooted in that worktree.
+            2. Implement the requested change, run relevant tests, and fix failures before finishing.
+            3. If you need input from the user, call the clarify tool. The parent CLI will surface it in a kitty overlay when available.
+            4. When the work is ready, commit it, push the branch to {push_remote}, and open a pull request with gh.
+               Suggested commands:
+               - git status --short
+               - git add -A
+               - git commit -m "..."
+               - git push {push_remote} HEAD
+               - gh pr create --base {base_branch} --fill
+            5. Final response must include a concise status block with:
+               - Worktree
+               - Branch
+               - Tests
+               - Commit
+               - PR
+               - Any blocker
+
+            User request:
+            {prompt}
+            """
+        ).strip()
+        return instructions
+
+    def _handle_hermes_addition_command(self, cmd: str):
+        """Handle /hermes-addition <prompt> — spawn a PR-oriented background worktree agent."""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /hermes-addition <prompt>")
+            _cprint("  Example: /hermes-addition Fix the flaky retry path and open a PR")
+            _cprint("  Creates an isolated git worktree, spawns a background child session, and aims for a PR on your fork.")
+            return
+
+        if not self.conversation_history:
+            _cprint("  No conversation to spawn from — send a message first.")
+            return
+
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start /hermes-addition: no valid credentials.")
+            return
+
+        prompt = parts[1].strip()
+        repo_root = _git_repo_root()
+        if not repo_root:
+            _cprint("  /hermes-addition requires a git repo in the active terminal cwd.")
+            return
+
+        worktree_info = _setup_worktree(repo_root=repo_root)
+        if not worktree_info:
+            _cprint("  Failed to create an isolated worktree for /hermes-addition.")
+            return
+
+        history_snapshot = list(self.conversation_history)
+        parent_session_id = self.session_id
+        now = datetime.now()
+        new_session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        current_title = self._session_db.get_session_title(parent_session_id)
+        child_title = self._session_db.get_next_title_in_lineage(current_title or "hermes-addition")
+
+        try:
+            self._session_db.clone_session(
+                source_session_id=parent_session_id,
+                new_session_id=new_session_id,
+                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                model=None,
+                model_config={
+                    "max_iterations": self.max_turns,
+                    "reasoning_config": self.reasoning_config,
+                },
+                parent_session_id=parent_session_id,
+                title=child_title,
+                messages=history_snapshot,
+            )
+        except Exception as e:
+            _cprint(f"  Failed to create /hermes-addition session: {e}")
+            return
+
+        self._background_task_counter += 1
+        task_num = self._background_task_counter
+        task_id = f"addition_{now.strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        push_remote = "fork" if _git_remote_exists(repo_root, "fork") else "origin"
+        base_ref = _git_default_base_ref(repo_root, "origin")
+        addition_prompt = self._build_hermes_addition_prompt(
+            prompt,
+            worktree_info=worktree_info,
+            push_remote=push_remote,
+            base_ref=base_ref,
+        )
+        clarify_callback = self._make_background_clarify_callback(f"hermes-addition #{task_num}")
+        _cprint(f'  🚀 Hermes Addition #{task_num} started: "{preview}"')
+        _cprint(f"  Task ID:         {task_id}")
+        _cprint(f"  Parent session:  {parent_session_id}")
+        _cprint(f"  Child session:   {new_session_id}")
+        _cprint(f"  Worktree:        {worktree_info['path']}")
+        _cprint(f"  Branch:          {worktree_info['branch']}")
+        _cprint(f"  Push remote:     {push_remote}")
+        _cprint("  Results will appear here when done.")
+        self._show_background_agent_count_note(extra_tasks=1)
+        _cprint("")
+
+        turn_route = self._resolve_turn_agent_config(prompt)
+
+        def run_addition():
+            try:
+                addition_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=self.enabled_toolsets,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=new_session_id,
+                    platform="cli",
+                    session_db=self._session_db,
+                    reasoning_config=self.reasoning_config,
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    fallback_model=self._fallback_model,
+                    pass_session_id=False,
+                    clarify_callback=clarify_callback,
+                )
+                addition_agent._print_fn = lambda *_a, **_kw: None
+
+                def _addition_thinking(text: str) -> None:
+                    if not self._agent_running:
+                        self._spinner_text = text
+                        if self._app:
+                            self._app.invalidate()
+
+                addition_agent.thinking_callback = _addition_thinking
+                result = addition_agent.run_conversation(
+                    user_message=addition_prompt,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                )
+
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                _cprint(f"  ✅ Hermes Addition #{task_num} complete")
+                _cprint(f"  Prompt: \"{preview}\"")
+                _cprint(f"  Worktree: {worktree_info['path']}")
+                _cprint(f"  Branch:   {worktree_info['branch']}")
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                if response:
+                    _chat_console = ChatConsole()
+                    _chat_console.print(Panel(
+                        _rich_text_from_ansi(response),
+                        title=f"[{_accent_hex()} bold]⚕ Hermes (hermes-addition #{task_num})[/]",
+                        title_align="left",
+                        border_style=_accent_hex(),
+                        style="#FFF8DC",
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 2),
+                    ))
+                else:
+                    _cprint("  (No response generated)")
+
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+
+            except Exception as e:
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                _cprint(f"  ❌ Hermes Addition #{task_num} failed: {e}")
+            finally:
+                self._background_tasks.pop(task_id, None)
+                if not self._agent_running:
+                    self._spinner_text = ""
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_addition, daemon=True, name=f"hermes-addition-{task_id}")
         self._background_tasks[task_id] = thread
         thread.start()
 
@@ -4812,6 +5176,8 @@ class HermesCLI:
             self._handle_branch_command(cmd_original)
         elif canonical == "spawn":
             self._handle_spawn_command(cmd_original)
+        elif canonical == "hermes-addition":
+            self._handle_hermes_addition_command(cmd_original)
         elif canonical == "save":
             self.save_conversation()
         elif canonical == "cron":
@@ -5037,20 +5403,24 @@ class HermesCLI:
             return
 
         prompt = parts[1].strip()
-        self._background_task_counter += 1
-        task_num = self._background_task_counter
-        task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
 
         # Make sure we have valid credentials
         if not self._ensure_runtime_credentials():
             _cprint("  (>_<) Cannot start background task: no valid credentials.")
             return
 
-        _cprint(f"  🔄 Background task #{task_num} started: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
+        self._background_task_counter += 1
+        task_num = self._background_task_counter
+        task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        _cprint(f'  🔄 Background task #{task_num} started: "{preview}"')
         _cprint(f"  Task ID: {task_id}")
-        _cprint("  You can continue chatting — results will appear when done.\n")
+        _cprint("  You can continue chatting — results will appear when done.")
+        self._show_background_agent_count_note(extra_tasks=1)
+        _cprint("")
 
         turn_route = self._resolve_turn_agent_config(prompt)
+        clarify_callback = self._make_background_clarify_callback(f"background #{task_num}")
 
         def run_background():
             try:
@@ -5078,6 +5448,7 @@ class HermesCLI:
                     provider_require_parameters=self._provider_require_params,
                     provider_data_collection=self._provider_data_collection,
                     fallback_model=self._fallback_model,
+                    clarify_callback=clarify_callback,
                 )
                 # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
                 bg_agent._print_fn = lambda *_a, **_kw: None

--- a/cli.py
+++ b/cli.py
@@ -3707,10 +3707,11 @@ class HermesCLI:
         except Exception:
             pass
 
-        # Create the new session with parent link
+        # Create the new session with parent link and copied transcript
         try:
-            self._session_db.create_session(
-                session_id=new_session_id,
+            self._session_db.clone_session(
+                source_session_id=parent_session_id,
+                new_session_id=new_session_id,
                 source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 model=self.model,
                 model_config={
@@ -3718,31 +3719,12 @@ class HermesCLI:
                     "reasoning_config": self.reasoning_config,
                 },
                 parent_session_id=parent_session_id,
+                title=branch_title,
+                messages=self.conversation_history,
             )
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")
             return
-
-        # Copy conversation history to the new session
-        for msg in self.conversation_history:
-            try:
-                self._session_db.append_message(
-                    session_id=new_session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                    reasoning=msg.get("reasoning"),
-                )
-            except Exception:
-                pass  # Best-effort copy
-
-        # Set title on the branch
-        try:
-            self._session_db.set_session_title(new_session_id, branch_title)
-        except Exception:
-            pass
 
         # Switch to the new session
         self.session_id = new_session_id
@@ -3774,6 +3756,177 @@ class HermesCLI:
         _cprint(f"  Original session: {parent_session_id}")
         _cprint(f"  Branch session:   {new_session_id}")
 
+    def _handle_spawn_command(self, cmd: str):
+        """Handle /spawn <prompt> — run a prompt in a child session clone."""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /spawn <prompt>")
+            _cprint("  Example: /spawn Continue this research in the background")
+            _cprint("  Clones the current session, keeps you here, and runs the prompt in the child.")
+            return
+
+        if not self.conversation_history:
+            _cprint("  No conversation to spawn from — send a message first.")
+            return
+
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start spawn task: no valid credentials.")
+            return
+
+        prompt = parts[1].strip()
+        history_snapshot = list(self.conversation_history)
+        parent_session_id = self.session_id
+        now = datetime.now()
+        new_session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+
+        current_title = self._session_db.get_session_title(parent_session_id)
+        base_title = current_title or "spawn"
+        child_title = self._session_db.get_next_title_in_lineage(base_title)
+
+        try:
+            self._session_db.clone_session(
+                source_session_id=parent_session_id,
+                new_session_id=new_session_id,
+                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                model=None,
+                model_config={
+                    "max_iterations": self.max_turns,
+                    "reasoning_config": self.reasoning_config,
+                },
+                parent_session_id=parent_session_id,
+                title=child_title,
+                messages=history_snapshot,
+            )
+        except Exception as e:
+            _cprint(f"  Failed to create spawn session: {e}")
+            return
+
+        self._background_task_counter += 1
+        task_num = self._background_task_counter
+        task_id = f"spawn_{now.strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        _cprint(f'  🪄 Spawn task #{task_num} started: "{preview}"')
+        _cprint(f"  Task ID:         {task_id}")
+        _cprint(f"  Parent session:  {parent_session_id}")
+        _cprint(f"  Child session:   {new_session_id}")
+        _cprint("  You stay on the current session — results will appear here when done.\n")
+
+        turn_route = self._resolve_turn_agent_config(prompt)
+
+        def run_spawn():
+            try:
+                spawn_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=self.enabled_toolsets,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=new_session_id,
+                    platform="cli",
+                    session_db=self._session_db,
+                    reasoning_config=self.reasoning_config,
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    fallback_model=self._fallback_model,
+                    pass_session_id=False,
+                )
+                spawn_agent._print_fn = lambda *_a, **_kw: None
+
+                def _spawn_thinking(text: str) -> None:
+                    if not self._agent_running:
+                        self._spinner_text = text
+                        if self._app:
+                            self._app.invalidate()
+
+                spawn_agent.thinking_callback = _spawn_thinking
+                result = spawn_agent.run_conversation(
+                    user_message=prompt,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                )
+
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                _cprint(f"  ✅ Spawn task #{task_num} complete")
+                _cprint(f"  Prompt: \"{preview}\"")
+                _cprint(f"  Child session: {new_session_id}")
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _skin = get_active_skin()
+                        label = _skin.get_branding("response_label", "⚕ Hermes")
+                        _resp_color = _skin.get_color("response_border", "#CD7F32")
+                        _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+                    except Exception:
+                        label = "⚕ Hermes"
+                        _resp_color = "#CD7F32"
+                        _resp_text = "#FFF8DC"
+
+                    _chat_console = ChatConsole()
+                    _chat_console.print(Panel(
+                        _rich_text_from_ansi(response),
+                        title=f"[{_resp_color} bold]{label} (spawn #{task_num})[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        style=_resp_text,
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 2),
+                    ))
+                else:
+                    _cprint("  (No response generated)")
+
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+
+            except Exception as e:
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                _cprint(f"  ❌ Spawn task #{task_num} failed: {e}")
+            finally:
+                self._background_tasks.pop(task_id, None)
+                if not self._agent_running:
+                    self._spinner_text = ""
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_spawn, daemon=True, name=f"spawn-task-{task_id}")
+        self._background_tasks[task_id] = thread
+        thread.start()
+
+    def reset_conversation(self):
+        """Reset the conversation by starting a new session."""
+        # Shut down memory provider before resetting — actual session boundary
+        if hasattr(self, 'agent') and self.agent:
+            self.agent.shutdown_memory_provider(self.conversation_history)
+        self.new_session()
+    
     def save_conversation(self):
         """Save the current conversation to a file."""
         if not self.conversation_history:
@@ -4657,6 +4810,8 @@ class HermesCLI:
             self.undo_last()
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
+        elif canonical == "spawn":
+            self._handle_spawn_command(cmd_original)
         elif canonical == "save":
             self.save_conversation()
         elif canonical == "cron":

--- a/cli.py
+++ b/cli.py
@@ -1418,6 +1418,7 @@ class HermesCLI:
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []
         self.codex_service_tier = None
+        self.context_length_override: Optional[int] = None
         self.base_url = (
             base_url
             or CLI_CONFIG["model"].get("base_url", "")
@@ -1605,6 +1606,15 @@ class HermesCLI:
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
+    def _current_context_limit(self) -> Optional[int]:
+        agent = getattr(self, "agent", None)
+        compressor = getattr(agent, "context_compressor", None) if agent else None
+        context_length = getattr(compressor, "context_length", None) if compressor else None
+        if context_length:
+            return int(context_length)
+        override = getattr(self, "context_length_override", None)
+        return int(override) if override else None
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         model_name = self.model or "unknown"
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
@@ -1619,7 +1629,7 @@ class HermesCLI:
             "model_short": model_short,
             "duration": format_duration_compact(elapsed_seconds),
             "context_tokens": 0,
-            "context_length": None,
+            "context_length": self._current_context_limit(),
             "context_percent": None,
             "session_input_tokens": 0,
             "session_output_tokens": 0,
@@ -2466,6 +2476,7 @@ class HermesCLI:
                 reasoning_callback=self._current_reasoning_callback(),
 
                 fallback_model=self._fallback_model,
+                context_length_override=self.context_length_override,
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
@@ -2510,9 +2521,7 @@ class HermesCLI:
 
         # Get context length for display before branching so it remains
         # available to the low-context warning logic in compact mode too.
-        ctx_len = None
-        if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-            ctx_len = self.agent.context_compressor.context_length
+        ctx_len = self._current_context_limit()
         
         # Auto-compact for narrow terminals — the full banner with caduceus
         # + tool list needs ~80 columns minimum to render without wrapping.
@@ -3532,10 +3541,13 @@ class HermesCLI:
         self._pending_title = None
         self._resumed = False
         self.codex_service_tier = None
+        self.context_length_override = None
 
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
+            if hasattr(self.agent, "set_context_length_override"):
+                self.agent.set_context_length_override(None)
             self.agent.reset_session_state()
             self.agent.service_tier = None
             if hasattr(self.agent, "_last_flushed_db_idx"):
@@ -3609,6 +3621,7 @@ class HermesCLI:
         self._resumed = True
         self._pending_title = None
         self.codex_service_tier = None
+        self.context_length_override = None
 
         # Load conversation history (strip transcript-only metadata entries)
         restored = self._session_db.get_messages_as_conversation(target_id)
@@ -3624,6 +3637,8 @@ class HermesCLI:
         # Sync the agent if already initialised
         if self.agent:
             self.agent.session_id = target_id
+            if hasattr(self.agent, "set_context_length_override"):
+                self.agent.set_context_length_override(None)
             self.agent.reset_session_state()
             self.agent.service_tier = None
             if hasattr(self.agent, "_last_flushed_db_idx"):
@@ -4549,9 +4564,7 @@ class HermesCLI:
                 else:
                     tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-                    ctx_len = None
-                    if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                        ctx_len = self.agent.context_compressor.context_length
+                    ctx_len = self._current_context_limit()
                     build_welcome_banner(
                         console=cc,
                         model=self.model,
@@ -4623,6 +4636,8 @@ class HermesCLI:
             self._handle_resume_command(cmd_original)
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
+        elif canonical == "context-limit":
+            self._handle_context_limit_command(cmd_original)
         elif canonical == "provider":
             self._show_model_and_providers()
         elif canonical == "prompt":
@@ -5410,6 +5425,31 @@ class HermesCLI:
         _cprint(f"  {_DIM}{fast_mode_note(provider=provider, model=model, enabled=enabled)}{_RST}")
         if action != "status":
             _cprint(f"  {_DIM}Takes effect on the next message.{_RST}")
+
+    def _handle_context_limit_command(self, cmd: str):
+        """Handle /context-limit — session-local context window override."""
+        from hermes_cli.context_limit import (
+            CONTEXT_LIMIT_USAGE,
+            cycle_context_limit,
+            parse_context_limit_value,
+        )
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) > 1:
+            target = parse_context_limit_value(parts[1])
+            if target is None:
+                _cprint(f"  {_DIM}Usage: {CONTEXT_LIMIT_USAGE}{_RST}")
+                return
+        else:
+            target = cycle_context_limit(self._current_context_limit())
+
+        self.context_length_override = target
+        applied = target
+        if self.agent and hasattr(self.agent, "set_context_length_override"):
+            applied = self.agent.set_context_length_override(target)
+
+        _cprint(f"  {_GOLD}Context limit: {applied:,} tokens{_RST}")
+        _cprint(f"  {_DIM}Session only — resets on /new or /resume.{_RST}")
 
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.
@@ -6577,9 +6617,7 @@ class HermesCLI:
         if isinstance(message, str) and "@" in message:
             try:
                 from agent.context_references import preprocess_context_references
-                from agent.model_metadata import get_model_context_length
-                _ctx_len = get_model_context_length(
-                    self.model, base_url=self.base_url or "", api_key=self.api_key or "")
+                _ctx_len = self._current_context_limit()
                 _ctx_result = preprocess_context_references(
                     message, cwd=os.getcwd(), context_length=_ctx_len)
                 if _ctx_result.expanded or _ctx_result.blocked:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1165,7 +1165,7 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset"):
+            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "spawn"):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2743,8 +2743,8 @@ class GatewayRunner:
         if _is_shared_thread and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
+        image_paths = []
         if event.media_urls:
-            image_paths = []
             for i, path in enumerate(event.media_urls):
                 # Check media_types if available; otherwise infer from message type
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
@@ -2754,10 +2754,6 @@ class GatewayRunner:
                 )
                 if is_image:
                     image_paths.append(path)
-            if image_paths:
-                message_text = await self._enrich_message_with_vision(
-                    message_text, image_paths
-                )
         
         # -----------------------------------------------------------------
         # Auto-transcribe voice/audio messages sent by the user
@@ -2912,6 +2908,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                image_paths=image_paths,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -3981,29 +3978,33 @@ class GatewayRunner:
         return await self._handle_message(retry_event)
     
     async def _handle_undo_command(self, event: MessageEvent) -> str:
-        """Handle /undo command - remove the last user/assistant exchange."""
+        """Handle /undo command - remove the last visible user turn."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         history = self.session_store.load_transcript(session_entry.session_id)
-        
-        # Find the last user message and remove everything from it onward
-        last_user_idx = None
-        for i in range(len(history) - 1, -1, -1):
-            if history[i].get("role") == "user":
-                last_user_idx = i
-                break
-        
-        if last_user_idx is None:
+
+        from run_agent import (
+            format_internal_transcript_message_count,
+            summarize_last_user_turn,
+        )
+
+        summary = summarize_last_user_turn(history, preview_limit=40)
+        if not summary:
             return "Nothing to undo."
-        
-        removed_msg = history[last_user_idx].get("content", "")
-        removed_count = len(history) - last_user_idx
-        self.session_store.rewrite_transcript(session_entry.session_id, history[:last_user_idx])
+
+        self.session_store.rewrite_transcript(
+            session_entry.session_id,
+            summary["truncated_history"],
+        )
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0
-        
-        preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
-        return f"↩️ Undid {removed_count} message(s).\nRemoved: \"{preview}\""
+
+        removed_count = int(summary["removed_count"])
+        preview = summary["preview"]
+        return (
+            f"↩️ Undid 1 turn ({format_internal_transcript_message_count(removed_count)}).\n"
+            f"Removed your last message: \"{preview}\""
+        )
     
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""
@@ -5954,6 +5955,27 @@ class GatewayRunner:
             if var in os.environ:
                 del os.environ[var]
     
+    async def _prepare_user_message_with_images(
+        self,
+        user_text,
+        image_paths: List[str],
+        turn_route: dict,
+    ):
+        if not image_paths:
+            return user_text
+
+        from run_agent import build_native_multimodal_user_content, supports_native_multimodal_input
+
+        runtime = (turn_route or {}).get("runtime") or {}
+        if supports_native_multimodal_input(
+            provider=runtime.get("provider"),
+            api_mode=runtime.get("api_mode"),
+            base_url=runtime.get("base_url"),
+        ):
+            return build_native_multimodal_user_content(user_text or "", image_paths)
+
+        return await self._enrich_message_with_vision(user_text or "", image_paths)
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,
@@ -6307,6 +6329,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        image_paths: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -6325,6 +6348,7 @@ class GatewayRunner:
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
+        image_paths = list(image_paths or [])
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -6648,7 +6672,11 @@ class GatewayRunner:
                 }
 
             pr = self._provider_routing
-            honcho_manager, honcho_config = self._get_or_create_gateway_honcho(session_key)
+            _honcho_factory = getattr(self, "_get_or_create_gateway_honcho", None)
+            if callable(_honcho_factory):
+                honcho_manager, honcho_config = _honcho_factory(session_key)
+            else:
+                honcho_manager, honcho_config = None, None
             session_entry = self.session_store.get_session(session_key) if getattr(self, "session_store", None) else None
             service_tier = getattr(session_entry, "service_tier_override", None)
             reasoning_config = self._load_reasoning_config()
@@ -6683,6 +6711,8 @@ class GatewayRunner:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            if image_paths:
+                message = asyncio.run(self._prepare_user_message_with_images(message, image_paths, turn_route))
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -6908,7 +6938,9 @@ class GatewayRunner:
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                from run_agent import prepend_text_to_message_content
+
+                message = prepend_text_to_message_content(message, _msn)
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4636,6 +4636,46 @@ class GatewayRunner:
                 exc,
             )
 
+    async def _deliver_spawn_result(
+        self,
+        adapter,
+        source: "SessionSource",
+        content: str,
+        *,
+        metadata: dict | None = None,
+        parent_session_id: str | None = None,
+    ):
+        """Persist a /spawn result to the parent transcript and deliver it with retry."""
+        self._persist_spawn_result_to_parent(parent_session_id, content)
+
+        send_with_retry = getattr(adapter, "_send_with_retry", None)
+        if callable(send_with_retry):
+            result = await send_with_retry(
+                chat_id=source.chat_id,
+                content=content,
+                metadata=metadata,
+            )
+        else:
+            result = await adapter.send(
+                chat_id=source.chat_id,
+                content=content,
+                metadata=metadata,
+            )
+
+        if not getattr(result, "success", True):
+            error_detail = getattr(result, "error", None) or "unknown send failure"
+            logger.error(
+                "Failed to deliver /spawn result for task chat=%s parent=%s: %s",
+                source.chat_id,
+                parent_session_id,
+                error_detail,
+            )
+            self._persist_spawn_result_to_parent(
+                parent_session_id,
+                f"⚠️ Spawn result delivery to chat failed after retry: {error_detail}",
+            )
+        return result
+
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str
     ) -> None:
@@ -4789,11 +4829,12 @@ class GatewayRunner:
             runtime_kwargs = _resolve_runtime_agent_kwargs()
             if not runtime_kwargs.get("api_key"):
                 error_content = f"❌ Spawn task {task_id} failed: no provider credentials configured."
-                self._persist_spawn_result_to_parent(parent_session_id, error_content)
-                await adapter.send(
-                    source.chat_id,
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
                     error_content,
                     metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
                 )
                 return
 
@@ -4855,21 +4896,14 @@ class GatewayRunner:
             if response:
                 media_files, response = adapter.extract_media(response)
                 images, text_content = adapter.extract_images(response)
-                persisted_text = header + (text_content or "(See attached media)")
-                self._persist_spawn_result_to_parent(parent_session_id, persisted_text)
-
-                if text_content:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + text_content,
-                        metadata=_thread_metadata,
-                    )
-                elif not images and not media_files:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + "(No response generated)",
-                        metadata=_thread_metadata,
-                    )
+                delivery_text = header + (text_content or "(See attached media)")
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
+                    delivery_text,
+                    metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
+                )
 
                 for image_url, alt_text in (images or []):
                     try:
@@ -4890,25 +4924,24 @@ class GatewayRunner:
                     except Exception:
                         pass
             else:
-                self._persist_spawn_result_to_parent(
-                    parent_session_id,
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
                     header + "(No response generated)",
-                )
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=header + "(No response generated)",
                     metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
                 )
 
         except Exception as e:
             logger.exception("Spawn task %s failed", task_id)
             try:
                 error_content = f"❌ Spawn task {task_id} failed: {e}"
-                self._persist_spawn_result_to_parent(parent_session_id, error_content)
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=error_content,
+                await self._deliver_spawn_result(
+                    adapter,
+                    source,
+                    error_content,
                     metadata=_thread_metadata,
+                    parent_session_id=parent_session_id,
                 )
             except Exception:
                 pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2062,6 +2062,9 @@ class GatewayRunner:
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
 
+        if canonical == "fast":
+            return await self._handle_fast_command(event)
+
         if canonical == "verbose":
             return await self._handle_verbose_command(event)
 
@@ -4819,6 +4822,36 @@ class GatewayRunner:
             except Exception:
                 pass
 
+    async def _handle_fast_command(self, event: MessageEvent) -> str:
+        """Handle /fast — session-local Codex fast mode."""
+        from hermes_cli.fast_mode import FAST_MODE_USAGE, fast_mode_note, parse_fast_command_arg
+
+        action = parse_fast_command_arg(event.get_command_args())
+        if action is None:
+            return f"⚡ Usage: `{FAST_MODE_USAGE}`"
+
+        session_entry = self.session_store.get_or_create_session(event.source)
+        current_enabled = getattr(session_entry, "service_tier_override", None) == "fast"
+
+        if action == "status":
+            enabled = current_enabled
+        elif action == "toggle":
+            enabled = not current_enabled
+        else:
+            enabled = action == "on"
+
+        if action != "status":
+            self.session_store.set_service_tier_override(
+                session_entry.session_key,
+                "fast" if enabled else None,
+            )
+
+        state = "on ✓" if enabled else "off"
+        lines = [f"⚡ **Fast mode:** {state}", f"_{fast_mode_note(enabled=enabled)}_"]
+        if action != "status":
+            lines.append("_(takes effect on next message)_")
+        return "\n".join(lines)
+
     async def _handle_reasoning_command(self, event: MessageEvent) -> str:
         """Handle /reasoning command — manage reasoning effort and display toggle.
 
@@ -6615,6 +6648,9 @@ class GatewayRunner:
                 }
 
             pr = self._provider_routing
+            honcho_manager, honcho_config = self._get_or_create_gateway_honcho(session_key)
+            session_entry = self.session_store.get_session(session_key) if getattr(self, "session_store", None) else None
+            service_tier = getattr(session_entry, "service_tier_override", None)
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             # Set up streaming consumer if enabled
@@ -6672,6 +6708,7 @@ class GatewayRunner:
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
+                    service_tier=service_tier,
                     max_iterations=max_iterations,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -6703,6 +6740,7 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
+            agent.service_tier = service_tier
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2141,6 +2141,9 @@ class GatewayRunner:
         if canonical == "branch":
             return await self._handle_branch_command(event)
 
+        if canonical == "spawn":
+            return await self._handle_spawn_command(event)
+
         if canonical == "rollback":
             return await self._handle_rollback_command(event)
 
@@ -4533,6 +4536,60 @@ class GatewayRunner:
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
         return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting — results will appear when done.'
 
+    async def _handle_spawn_command(self, event: MessageEvent) -> str:
+        """Handle /spawn <prompt> — clone the current session and run a child task."""
+        prompt = event.get_command_args().strip()
+        if not prompt:
+            return (
+                "Usage: /spawn <prompt>\n"
+                "Example: /spawn Continue this research in the background\n\n"
+                "Clones the current session, keeps you here, and runs the prompt in the child session."
+            )
+
+        if not self._session_db:
+            return "Session database not available."
+
+        source = event.source
+        current_entry = self.session_store.get_or_create_session(source)
+        history = self.session_store.load_transcript(current_entry.session_id)
+        if not history:
+            return "No conversation to spawn from — send a message first."
+
+        now = datetime.now()
+        task_id = f"spawn_{now.strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        new_session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{os.urandom(3).hex()}"
+        current_title = self._session_db.get_session_title(current_entry.session_id)
+        child_title = self._session_db.get_next_title_in_lineage(current_title or "spawn")
+
+        try:
+            self._session_db.clone_session(
+                source_session_id=current_entry.session_id,
+                new_session_id=new_session_id,
+                source=source.platform.value if source.platform else "gateway",
+                model=None,
+                parent_session_id=current_entry.session_id,
+                title=child_title,
+                messages=history,
+            )
+        except Exception as e:
+            logger.error("Failed to create spawn session: %s", e)
+            return f"Failed to create spawn session: {e}"
+
+        _task = asyncio.create_task(
+            self._run_spawn_task(prompt, source, task_id, new_session_id, history)
+        )
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        return (
+            f'🪄 Spawn task started: "{preview}"\n'
+            f"Task ID: {task_id}\n"
+            f"Parent session: {current_entry.session_id}\n"
+            f"Child session: {new_session_id}\n"
+            "You stay on the current session — results will appear here when done."
+        )
+
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str
     ) -> None:
@@ -4658,6 +4715,142 @@ class GatewayRunner:
                 await adapter.send(
                     chat_id=source.chat_id,
                     content=f"❌ Background task {task_id} failed: {e}",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
+
+    async def _run_spawn_task(
+        self,
+        prompt: str,
+        source: "SessionSource",
+        task_id: str,
+        child_session_id: str,
+        history_snapshot: list[dict],
+    ) -> None:
+        """Execute a cloned-session background task and deliver the result."""
+        from run_agent import AIAgent
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            logger.warning("No adapter for platform %s in spawn task %s", source.platform, task_id)
+            return
+
+        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+
+        try:
+            runtime_kwargs = _resolve_runtime_agent_kwargs()
+            if not runtime_kwargs.get("api_key"):
+                await adapter.send(
+                    source.chat_id,
+                    f"❌ Spawn task {task_id} failed: no provider credentials configured.",
+                    metadata=_thread_metadata,
+                )
+                return
+
+            user_config = _load_gateway_config()
+            model = _resolve_gateway_model(user_config)
+            platform_key = _platform_config_key(source.platform)
+
+            from hermes_cli.tools_config import _get_platform_tools
+            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+
+            pr = self._provider_routing
+            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            reasoning_config = self._load_reasoning_config()
+            self._reasoning_config = reasoning_config
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+
+            def run_sync():
+                agent = AIAgent(
+                    model=turn_route["model"],
+                    **turn_route["runtime"],
+                    max_iterations=max_iterations,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    enabled_toolsets=enabled_toolsets,
+                    reasoning_config=reasoning_config,
+                    providers_allowed=pr.get("only"),
+                    providers_ignored=pr.get("ignore"),
+                    providers_order=pr.get("order"),
+                    provider_sort=pr.get("sort"),
+                    provider_require_parameters=pr.get("require_parameters", False),
+                    provider_data_collection=pr.get("data_collection"),
+                    session_id=child_session_id,
+                    platform=platform_key,
+                    session_db=self._session_db,
+                    fallback_model=self._fallback_model,
+                    pass_session_id=False,
+                )
+
+                return agent.run_conversation(
+                    user_message=prompt,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                )
+
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(None, run_sync)
+
+            response = result.get("final_response", "") if result else ""
+            if not response and result and result.get("error"):
+                response = f"Error: {result['error']}"
+
+            preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+            header = (
+                f'✅ Spawn task complete\n'
+                f'Prompt: "{preview}"\n'
+                f'Child session: {child_session_id}\n\n'
+            )
+
+            if response:
+                media_files, response = adapter.extract_media(response)
+                images, text_content = adapter.extract_images(response)
+
+                if text_content:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=header + text_content,
+                        metadata=_thread_metadata,
+                    )
+                elif not images and not media_files:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=header + "(No response generated)",
+                        metadata=_thread_metadata,
+                    )
+
+                for image_url, alt_text in (images or []):
+                    try:
+                        await adapter.send_image(
+                            chat_id=source.chat_id,
+                            image_url=image_url,
+                            caption=alt_text,
+                        )
+                    except Exception:
+                        pass
+
+                for media_path in (media_files or []):
+                    try:
+                        await adapter.send_document(
+                            chat_id=source.chat_id,
+                            file_path=media_path,
+                        )
+                    except Exception:
+                        pass
+            else:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=header + "(No response generated)",
+                    metadata=_thread_metadata,
+                )
+
+        except Exception as e:
+            logger.exception("Spawn task %s failed", task_id)
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"❌ Spawn task {task_id} failed: {e}",
                     metadata=_thread_metadata,
                 )
             except Exception:
@@ -5241,38 +5434,20 @@ class GatewayRunner:
 
         parent_session_id = current_entry.session_id
 
-        # Create the new session with parent link
+        # Create the new session with parent link and copied transcript
         try:
-            self._session_db.create_session(
-                session_id=new_session_id,
+            self._session_db.clone_session(
+                source_session_id=parent_session_id,
+                new_session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 parent_session_id=parent_session_id,
+                title=branch_title,
+                messages=history,
             )
         except Exception as e:
             logger.error("Failed to create branch session: %s", e)
             return f"Failed to create branch: {e}"
-
-        # Copy conversation history to the new session
-        for msg in history:
-            try:
-                self._session_db.append_message(
-                    session_id=new_session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                    reasoning=msg.get("reasoning"),
-                )
-            except Exception:
-                pass  # Best-effort copy
-
-        # Set title
-        try:
-            self._session_db.set_session_title(new_session_id, branch_title)
-        except Exception:
-            pass
 
         # Switch the session store entry to the new session
         new_entry = self.session_store.switch_session(session_key, new_session_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1864,12 +1864,15 @@ class GatewayRunner:
             _stale_agent = self._running_agents.get(_quick_key)
             # Never evict the pending sentinel — it was just placed moments
             # ago during the async setup phase before the real agent is
-            # created.  Sentinels have no get_activity_summary(), so the
-            # idle check below would always evaluate to inf >= timeout and
-            # immediately evict them, racing with the setup path.
+            # created. Sentinels have no get_activity_summary(), so the
+            # idle check below would otherwise treat them as stale.
             _stale_idle = float("inf")  # assume idle if we can't check
             _stale_detail = ""
-            if _stale_agent and hasattr(_stale_agent, "get_activity_summary"):
+            if (
+                _stale_agent
+                and _stale_agent is not _AGENT_PENDING_SENTINEL
+                and hasattr(_stale_agent, "get_activity_summary")
+            ):
                 try:
                     _sa = _stale_agent.get_activity_summary()
                     _stale_idle = _sa.get("seconds_since_activity", float("inf"))
@@ -1880,9 +1883,11 @@ class GatewayRunner:
                     )
                 except Exception:
                     pass
-            # Evict if: agent is idle beyond timeout, OR wall-clock age is
-            # extreme (10x timeout or 2h, whichever is larger — catches
-            # cases where the agent object was garbage-collected).
+            # Evict if: agent is idle beyond timeout (only when we have a real
+            # activity tracker), OR wall-clock age is extreme (10x timeout or
+            # 2h, whichever is larger — catches leaked entries / dead objects).
+            # Do not treat the pending sentinel as idle=inf; it has no activity
+            # tracker by design and must be allowed to survive normal startup.
             _wall_ttl = max(_raw_stale_timeout * 10, 7200) if _raw_stale_timeout > 0 else float("inf")
             _should_evict = (
                 _stale_agent is not _AGENT_PENDING_SENTINEL
@@ -1980,6 +1985,11 @@ class GatewayRunner:
                 if _cmd_def_inner.name == "approve":
                     return await self._handle_approve_command(event)
                 return await self._handle_deny_command(event)
+
+            # /spawn must bypass the running-agent interrupt path so the child
+            # session can clone the latest in-memory snapshot immediately.
+            if _cmd_def_inner and _cmd_def_inner.name == "spawn":
+                return await self._handle_spawn_command(event)
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
@@ -4551,7 +4561,14 @@ class GatewayRunner:
 
         source = event.source
         current_entry = self.session_store.get_or_create_session(source)
-        history = self.session_store.load_transcript(current_entry.session_id)
+        session_key = self._session_key_for_source(source)
+        running_agent = self._running_agents.get(session_key)
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            history = list(getattr(running_agent, "_session_messages", []) or [])
+        else:
+            history = []
+        if not history:
+            history = self.session_store.load_transcript(current_entry.session_id)
         if not history:
             return "No conversation to spawn from — send a message first."
 
@@ -4576,7 +4593,14 @@ class GatewayRunner:
             return f"Failed to create spawn session: {e}"
 
         _task = asyncio.create_task(
-            self._run_spawn_task(prompt, source, task_id, new_session_id, history)
+            self._run_spawn_task(
+                prompt,
+                source,
+                task_id,
+                new_session_id,
+                history,
+                parent_session_id=current_entry.session_id,
+            )
         )
         self._background_tasks.add(_task)
         _task.add_done_callback(self._background_tasks.discard)
@@ -4589,6 +4613,28 @@ class GatewayRunner:
             f"Child session: {new_session_id}\n"
             "You stay on the current session — results will appear here when done."
         )
+
+    def _persist_spawn_result_to_parent(self, parent_session_id: str | None, content: str) -> None:
+        """Append the final /spawn result to the parent session transcript."""
+        if not parent_session_id or not content:
+            return
+        try:
+            self.session_store.append_to_transcript(
+                parent_session_id,
+                {
+                    "role": "assistant",
+                    "content": content,
+                    "timestamp": datetime.now().isoformat(),
+                    "mirror": True,
+                    "mirror_source": "spawn",
+                },
+            )
+        except Exception as exc:
+            logger.debug(
+                "Failed to persist /spawn result to parent session %s: %s",
+                parent_session_id,
+                exc,
+            )
 
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str
@@ -4727,6 +4773,7 @@ class GatewayRunner:
         task_id: str,
         child_session_id: str,
         history_snapshot: list[dict],
+        parent_session_id: str | None = None,
     ) -> None:
         """Execute a cloned-session background task and deliver the result."""
         from run_agent import AIAgent
@@ -4741,9 +4788,11 @@ class GatewayRunner:
         try:
             runtime_kwargs = _resolve_runtime_agent_kwargs()
             if not runtime_kwargs.get("api_key"):
+                error_content = f"❌ Spawn task {task_id} failed: no provider credentials configured."
+                self._persist_spawn_result_to_parent(parent_session_id, error_content)
                 await adapter.send(
                     source.chat_id,
-                    f"❌ Spawn task {task_id} failed: no provider credentials configured.",
+                    error_content,
                     metadata=_thread_metadata,
                 )
                 return
@@ -4806,6 +4855,8 @@ class GatewayRunner:
             if response:
                 media_files, response = adapter.extract_media(response)
                 images, text_content = adapter.extract_images(response)
+                persisted_text = header + (text_content or "(See attached media)")
+                self._persist_spawn_result_to_parent(parent_session_id, persisted_text)
 
                 if text_content:
                     await adapter.send(
@@ -4839,6 +4890,10 @@ class GatewayRunner:
                     except Exception:
                         pass
             else:
+                self._persist_spawn_result_to_parent(
+                    parent_session_id,
+                    header + "(No response generated)",
+                )
                 await adapter.send(
                     chat_id=source.chat_id,
                     content=header + "(No response generated)",
@@ -4848,9 +4903,11 @@ class GatewayRunner:
         except Exception as e:
             logger.exception("Spawn task %s failed", task_id)
             try:
+                error_content = f"❌ Spawn task {task_id} failed: {e}"
+                self._persist_spawn_result_to_parent(parent_session_id, error_content)
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f"❌ Spawn task {task_id} failed: {e}",
+                    content=error_content,
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -371,6 +371,9 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # Session-local runtime overrides (slash commands like /fast).
+    service_tier_override: Optional[str] = None
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -401,6 +404,7 @@ class SessionEntry:
             "last_prompt_tokens": self.last_prompt_tokens,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
+            "service_tier_override": self.service_tier_override,
             "memory_flushed": self.memory_flushed,
         }
         if self.origin:
@@ -437,6 +441,7 @@ class SessionEntry:
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
+            service_tier_override=data.get("service_tier_override"),
             memory_flushed=data.get("memory_flushed", False),
         )
 
@@ -821,6 +826,26 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def get_session(self, session_key: str) -> Optional[SessionEntry]:
+        """Return a session entry by key without creating a new session."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
+    def set_service_tier_override(self, session_key: str, service_tier: Optional[str]) -> bool:
+        """Persist a session-local service-tier override."""
+        from hermes_cli.fast_mode import normalize_service_tier
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            entry.service_tier_override = normalize_service_tier(service_tier)
+            entry.updated_at = _now()
+            self._save()
+            return True
 
     def reset_session(self, session_key: str) -> Optional[SessionEntry]:
         """Force reset a session, creating a new session ID."""

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2844,11 +2844,17 @@ def _codex_device_code_login() -> Dict[str, Any]:
         or DEFAULT_CODEX_BASE_URL
     )
 
+    token_payload = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+    }
+    for extra_key in ("account_id", "id_token"):
+        extra_value = tokens.get(extra_key)
+        if isinstance(extra_value, str) and extra_value.strip():
+            token_payload[extra_key] = extra_value.strip()
+
     return {
-        "tokens": {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-        },
+        "tokens": token_payload,
         "base_url": base_url,
         "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "auth_mode": "chatgpt",

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -234,18 +234,22 @@ def auth_add_command(args) -> None:
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
         )
-        entry = PooledCredential(
-            provider=provider,
-            id=uuid.uuid4().hex[:6],
-            label=label,
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=f"{SOURCE_MANUAL}:device_code",
-            access_token=creds["tokens"]["access_token"],
-            refresh_token=creds["tokens"].get("refresh_token"),
-            base_url=creds.get("base_url"),
-            last_refresh=creds.get("last_refresh"),
-        )
+        payload = {
+            "id": uuid.uuid4().hex[:6],
+            "label": label,
+            "auth_type": AUTH_TYPE_OAUTH,
+            "priority": 0,
+            "source": f"{SOURCE_MANUAL}:device_code",
+            "access_token": creds["tokens"]["access_token"],
+            "refresh_token": creds["tokens"].get("refresh_token"),
+            "base_url": creds.get("base_url"),
+            "last_refresh": creds.get("last_refresh"),
+        }
+        for extra_key in ("account_id", "id_token"):
+            extra_value = creds["tokens"].get(extra_key)
+            if isinstance(extra_value, str) and extra_value.strip():
+                payload[extra_key] = extra_value.strip()
+        entry = PooledCredential.from_dict(provider, payload)
         pool.add_entry(entry)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
@@ -533,6 +537,11 @@ def auth_command(args) -> None:
         return
     if action == "reset":
         auth_reset_command(args)
+        return
+    if action in {"view", "tui"}:
+        from hermes_cli.auth_tui import auth_view_command
+
+        auth_view_command(args)
         return
     # No subcommand — launch interactive mode
     _interactive_auth()

--- a/hermes_cli/auth_tui.py
+++ b/hermes_cli/auth_tui.py
@@ -1,0 +1,1101 @@
+"""Compact Codex auth TUI.
+
+Workflow
+- Scan every pooled Codex profile in one dense list.
+- Answer: which accounts are available, limited, or deactivated right now?
+- Show the short-window and long-window remaining-quota bars inline for every row.
+- Let the operator remove dead profiles from Hermes auth without leaving the view.
+
+Constraints
+- Keep rows one line tall so many profiles fit on screen.
+- Use the repo's terminal-native approach (curses) instead of adding a web UI.
+- Separate live usage fetching/pool mutation from curses rendering.
+- Support a non-interactive --smoke-test mode for validation.
+"""
+
+from __future__ import annotations
+
+import locale
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+import httpx
+
+from agent.credential_pool import (
+    PooledCredential,
+    STATUS_EXHAUSTED,
+    label_from_token,
+    load_pool,
+)
+from hermes_cli import auth as auth_mod
+
+DEFAULT_PROVIDER = "openai-codex"
+USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+WEEKLY_RESET_GAP_SECONDS = 3 * 24 * 60 * 60
+MAX_POLL_WORKERS = 8
+
+STATE_LOADING = "loading"
+STATE_AVAILABLE = "available"
+STATE_LIMITED = "limited"
+STATE_DEACTIVATED = "deactivated"
+STATE_ERROR = "error"
+
+SORT_AVAILABILITY = "availability"
+SORT_NAME = "name"
+SORT_REFRESH = "refresh"
+_SORT_LABELS = {
+    SORT_AVAILABILITY: "avail",
+    SORT_NAME: "name",
+    SORT_REFRESH: "fresh",
+}
+
+_BADGES = {
+    STATE_LOADING: "LOAD",
+    STATE_AVAILABLE: "AVAIL",
+    STATE_LIMITED: "LIMIT",
+    STATE_DEACTIVATED: "DEAD",
+    STATE_ERROR: "ERR",
+}
+
+
+@dataclass
+class CodexUsageWindow:
+    label: str
+    used_percent: float
+    reset_at_ms: Optional[int] = None
+
+    @property
+    def available_percent(self) -> float:
+        return _clamp_percent(100.0 - self.used_percent)
+
+
+@dataclass
+class CodexLiveStatus:
+    http_status: Optional[int] = None
+    email: Optional[str] = None
+    plan: Optional[str] = None
+    allowed: Optional[bool] = None
+    limit_reached: Optional[bool] = None
+    primary_window: Optional[CodexUsageWindow] = None
+    secondary_window: Optional[CodexUsageWindow] = None
+    error: Optional[str] = None
+    deactivated: bool = False
+    local_cooldown_cleared: bool = False
+
+
+@dataclass
+class CodexProfileSnapshot:
+    index: int
+    entry_id: str
+    label: str
+    display_name: str
+    auth_badge: str
+    state: str
+    state_badge: str
+    state_reason: str
+    primary_window: Optional[CodexUsageWindow]
+    secondary_window: Optional[CodexUsageWindow]
+    email: Optional[str] = None
+    plan: Optional[str] = None
+    source: str = ""
+    auth_type: str = ""
+    last_refresh: Optional[str] = None
+    local_status: Optional[str] = None
+    local_error_code: Optional[int] = None
+    http_status: Optional[int] = None
+    local_cooldown_cleared: bool = False
+    auth_reason: Optional[str] = None
+
+
+def _safe_str(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _clip(text: str, width: int) -> str:
+    if width <= 0:
+        return ""
+    if len(text) <= width:
+        return text
+    if width <= 1:
+        return text[:width]
+    return text[: width - 1] + "…"
+
+
+def _short_entry_id(entry_id: str) -> str:
+    if len(entry_id) <= 12:
+        return entry_id
+    return f"{entry_id[:6]}…{entry_id[-4:]}"
+
+
+def _footer_line(message: str, *, width: int) -> str:
+    shortcuts = "↑↓/jk move  a avail  n name  l fresh  u refresh  r remove  q quit"
+    if not message:
+        return _clip(shortcuts, width)
+    return _clip(f"{message}  |  {shortcuts}", width)
+
+
+def _clamp_percent(value: Any) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(100.0, numeric))
+
+
+def _format_percent(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    clamped = _clamp_percent(value)
+    if clamped >= 99.5:
+        return "100%"
+    return f"{int(round(clamped)):>3d}%"
+
+
+def _format_bar(value: Optional[float], width: int) -> str:
+    width = max(4, int(width))
+    if value is None:
+        return f"[{'·' * width}] n/a"
+    clamped = _clamp_percent(value)
+    filled = int(round((clamped / 100.0) * width))
+    filled = max(0, min(width, filled))
+    return f"[{'█' * filled}{'·' * (width - filled)}] {_format_percent(clamped)}"
+
+
+def _format_bar_with_reset(window: Optional[CodexUsageWindow], width: int) -> str:
+    bar = _format_bar(_window_available_percent(window), width)
+    suffix = _format_reset_compact(window.reset_at_ms if window else None)
+    return f"{bar} {suffix}" if suffix else bar
+
+
+def _window_available_percent(window: Optional[CodexUsageWindow]) -> Optional[float]:
+    if window is None:
+        return None
+    return window.available_percent
+
+
+def _window_is_exhausted(window: Optional[CodexUsageWindow]) -> bool:
+    return bool(window and window.used_percent >= 99.5)
+
+
+def _availability_metrics(snapshot: CodexProfileSnapshot) -> tuple[float, float]:
+    values = [
+        value
+        for value in (
+            _window_available_percent(snapshot.primary_window),
+            _window_available_percent(snapshot.secondary_window),
+        )
+        if value is not None
+    ]
+    if not values:
+        return 0.0, 0.0
+    return min(values), sum(values)
+
+
+def _limit_sort_rank(snapshot: CodexProfileSnapshot) -> tuple[int, float, float]:
+    primary_left = _window_available_percent(snapshot.primary_window) or 0.0
+    secondary_left = _window_available_percent(snapshot.secondary_window) or 0.0
+    primary_exhausted = _window_is_exhausted(snapshot.primary_window)
+    secondary_exhausted = _window_is_exhausted(snapshot.secondary_window)
+
+    if primary_exhausted and not secondary_exhausted:
+        return 0, -secondary_left, -primary_left
+    if secondary_exhausted and not primary_exhausted:
+        return 1, -primary_left, -secondary_left
+    if primary_exhausted and secondary_exhausted:
+        return 2, 0.0, 0.0
+    return 3, -primary_left, -secondary_left
+
+
+def _availability_sort_key(snapshot: CodexProfileSnapshot) -> tuple[Any, ...]:
+    if snapshot.auth_badge == "OK" and snapshot.state == STATE_LIMITED:
+        return (
+            _sort_bucket(snapshot),
+            *_limit_sort_rank(snapshot),
+            snapshot.display_name.lower(),
+            snapshot.index,
+        )
+    min_available, total_available = _availability_metrics(snapshot)
+    return (
+        _sort_bucket(snapshot),
+        -min_available,
+        -total_available,
+        snapshot.display_name.lower(),
+        snapshot.index,
+    )
+
+
+def _sort_bucket(snapshot: CodexProfileSnapshot) -> int:
+    if snapshot.auth_badge == "OK" and snapshot.state == STATE_AVAILABLE:
+        return 0
+    if snapshot.auth_badge == "OK" and snapshot.state == STATE_LIMITED:
+        return 1
+    if snapshot.auth_badge == "ERR" or snapshot.state == STATE_ERROR:
+        return 2
+    if snapshot.auth_badge == "LOAD" or snapshot.state == STATE_LOADING:
+        return 3
+    if snapshot.auth_badge == "DEAD" or snapshot.state == STATE_DEACTIVATED:
+        return 4
+    return 5
+
+
+def _sort_codex_profile_snapshots(
+    snapshots: list[CodexProfileSnapshot],
+    *,
+    mode: str = SORT_AVAILABILITY,
+) -> list[CodexProfileSnapshot]:
+    if mode == SORT_NAME:
+        ordered = sorted(
+            snapshots,
+            key=lambda snapshot: (
+                snapshot.display_name.lower(),
+                _sort_bucket(snapshot),
+                snapshot.index,
+            ),
+        )
+    elif mode == SORT_REFRESH:
+        ordered = sorted(
+            snapshots,
+            key=lambda snapshot: (
+                -(_parse_timestamp(snapshot.last_refresh).timestamp() if _parse_timestamp(snapshot.last_refresh) else 0.0),
+                _sort_bucket(snapshot),
+                -_availability_metrics(snapshot)[0],
+                snapshot.display_name.lower(),
+                snapshot.index,
+            ),
+        )
+    else:
+        ordered = sorted(snapshots, key=_availability_sort_key)
+    for index, snapshot in enumerate(ordered, start=1):
+        snapshot.index = index
+    return ordered
+
+
+def _boot_loading_text(frame: int) -> str:
+    spinner = "|/-\\"
+    return f"Loading {spinner[frame % len(spinner)]}"
+
+
+def _format_reset_compact(reset_at_ms: Optional[int]) -> str:
+    if not reset_at_ms:
+        return ""
+    remaining_ms = max(0, int(reset_at_ms - time.time() * 1000))
+    seconds_total = remaining_ms // 1000
+    minutes_total, seconds = divmod(seconds_total, 60)
+    hours_total, minutes = divmod(minutes_total, 60)
+    days, hours = divmod(hours_total, 24)
+    if days:
+        return f"@{days}d{hours}h"
+    if hours:
+        return f"@{hours}h{minutes}m" if minutes else f"@{hours}h"
+    if minutes:
+        return f"@{minutes}m"
+    return "@now" if seconds_total == 0 else f"@{seconds}s"
+
+
+def _format_reset(reset_at_ms: Optional[int]) -> str:
+    if not reset_at_ms:
+        return "unknown"
+    remaining_ms = max(0, int(reset_at_ms - time.time() * 1000))
+    seconds = remaining_ms // 1000
+    minutes, seconds = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
+def _parse_timestamp(timestamp: Optional[str]) -> Optional[datetime]:
+    if not timestamp:
+        return None
+    try:
+        return datetime.fromisoformat(timestamp.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _format_timestamp(timestamp: Optional[str]) -> str:
+    dt = _parse_timestamp(timestamp)
+    if dt is None:
+        return timestamp or "never"
+    return dt.strftime("%Y-%m-%d %H:%MZ")
+
+
+def _guess_display_name(entry: PooledCredential, live_email: Optional[str] = None) -> str:
+    if live_email:
+        return live_email
+    token_label = label_from_token(entry.access_token or "", entry.label or entry.id)
+    if token_label and token_label != entry.id:
+        return token_label
+    return entry.label or entry.id
+
+
+def _format_plan(data: dict[str, Any]) -> Optional[str]:
+    plan = _safe_str(data.get("plan_type"))
+    credits = data.get("credits") if isinstance(data.get("credits"), dict) else None
+    balance = None
+    if isinstance(credits, dict) and credits.get("balance") is not None:
+        try:
+            balance = float(credits.get("balance"))
+        except (TypeError, ValueError):
+            balance = None
+    if balance is not None:
+        balance_text = f"${balance:.2f}"
+        return f"{plan} ({balance_text})" if plan else balance_text
+    return plan
+
+
+def _build_window(payload: Any, *, fallback_label: str) -> Optional[CodexUsageWindow]:
+    if not isinstance(payload, dict):
+        return None
+    reset_at = payload.get("reset_at")
+    reset_at_ms = None
+    if isinstance(reset_at, (int, float)):
+        reset_at_ms = int(float(reset_at) * 1000)
+    seconds = payload.get("limit_window_seconds")
+    if isinstance(seconds, (int, float)) and float(seconds) > 0:
+        label = f"{int(round(float(seconds) / 3600.0))}h"
+    else:
+        label = fallback_label
+    return CodexUsageWindow(
+        label=label,
+        used_percent=_clamp_percent(payload.get("used_percent")),
+        reset_at_ms=reset_at_ms,
+    )
+
+
+def _resolve_secondary_label(
+    *,
+    limit_window_seconds: Any,
+    secondary_reset_at: Any,
+    primary_reset_at: Any,
+) -> str:
+    try:
+        hours = int(round(float(limit_window_seconds) / 3600.0))
+    except (TypeError, ValueError):
+        hours = 168
+
+    if hours >= 168:
+        return "Week"
+    if hours < 24:
+        return f"{hours}h"
+    if isinstance(secondary_reset_at, (int, float)) and isinstance(primary_reset_at, (int, float)):
+        if float(secondary_reset_at) - float(primary_reset_at) >= WEEKLY_RESET_GAP_SECONDS:
+            return "Week"
+    if hours == 24:
+        return "Day"
+    return f"{hours}h"
+
+
+def _build_secondary_window(payload: Any, primary_window: Optional[dict[str, Any]]) -> Optional[CodexUsageWindow]:
+    if not isinstance(payload, dict):
+        return None
+    label = _resolve_secondary_label(
+        limit_window_seconds=payload.get("limit_window_seconds"),
+        secondary_reset_at=payload.get("reset_at"),
+        primary_reset_at=(primary_window or {}).get("reset_at"),
+    )
+    reset_at = payload.get("reset_at")
+    reset_at_ms = None
+    if isinstance(reset_at, (int, float)):
+        reset_at_ms = int(float(reset_at) * 1000)
+    return CodexUsageWindow(
+        label=label,
+        used_percent=_clamp_percent(payload.get("used_percent")),
+        reset_at_ms=reset_at_ms,
+    )
+
+
+def _limit_reason(live: CodexLiveStatus) -> str:
+    hit: list[str] = []
+    for window in (live.primary_window, live.secondary_window):
+        if _window_is_exhausted(window):
+            hit.append(window.label)
+    if hit:
+        return f"{' + '.join(hit)} limit reached"
+    if live.limit_reached:
+        return "Usage limit reached"
+    return "Usage blocked"
+
+
+def _request_usage(
+    client: httpx.Client,
+    entry: PooledCredential,
+) -> httpx.Response:
+    headers = {
+        "Authorization": f"Bearer {entry.access_token}",
+        "User-Agent": "Hermes Auth View",
+        "Accept": "application/json",
+    }
+    account_id = _safe_str(getattr(entry, "account_id", None))
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    return client.get(USAGE_URL, headers=headers)
+
+
+def _fetch_codex_live_status(
+    pool,
+    entry: PooledCredential,
+    timeout_seconds: float,
+) -> tuple[PooledCredential, CodexLiveStatus]:
+    timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = _request_usage(client, entry)
+            if response.status_code in {401, 403} and entry.refresh_token:
+                try:
+                    refreshed = auth_mod.refresh_codex_oauth_pure(
+                        entry.access_token,
+                        entry.refresh_token,
+                        timeout_seconds=max(5.0, float(timeout_seconds)),
+                    )
+                    entry = (
+                        pool.update_entry(
+                            entry.id,
+                            access_token=refreshed["access_token"],
+                            refresh_token=refreshed["refresh_token"],
+                            last_refresh=refreshed.get("last_refresh"),
+                            last_status=None,
+                            last_status_at=None,
+                            last_error_code=None,
+                        )
+                        or entry
+                    )
+                    response = _request_usage(client, entry)
+                except auth_mod.AuthError as exc:
+                    return entry, CodexLiveStatus(
+                        http_status=response.status_code,
+                        error=str(exc),
+                        deactivated=True,
+                    )
+
+            if response.status_code != 200:
+                return entry, CodexLiveStatus(
+                    http_status=response.status_code,
+                    error=f"HTTP {response.status_code}",
+                    deactivated=response.status_code in {401, 403},
+                )
+
+            data = response.json() if response.content else {}
+            if not isinstance(data, dict):
+                return entry, CodexLiveStatus(
+                    http_status=200,
+                    error="Usage API returned an unexpected payload.",
+                )
+
+            rate_limit = data.get("rate_limit") if isinstance(data.get("rate_limit"), dict) else {}
+            primary_payload = rate_limit.get("primary_window") if isinstance(rate_limit, dict) else None
+            secondary_payload = rate_limit.get("secondary_window") if isinstance(rate_limit, dict) else None
+            primary_window = _build_window(primary_payload, fallback_label="5h")
+            secondary_window = _build_secondary_window(secondary_payload, primary_payload)
+
+            local_cooldown_cleared = False
+            if rate_limit.get("allowed") is True and entry.last_status == STATUS_EXHAUSTED:
+                updated = pool.update_entry(
+                    entry.id,
+                    last_status=None,
+                    last_status_at=None,
+                    last_error_code=None,
+                )
+                if updated is not None:
+                    entry = updated
+                    local_cooldown_cleared = True
+
+            live_account_id = _safe_str(data.get("account_id"))
+            if live_account_id and live_account_id != _safe_str(getattr(entry, "account_id", None)):
+                updated = pool.update_entry(entry.id, account_id=live_account_id)
+                if updated is not None:
+                    entry = updated
+
+            return entry, CodexLiveStatus(
+                http_status=200,
+                email=_safe_str(data.get("email")),
+                plan=_format_plan(data),
+                allowed=bool(rate_limit.get("allowed")) if "allowed" in rate_limit else None,
+                limit_reached=bool(rate_limit.get("limit_reached")) if "limit_reached" in rate_limit else None,
+                primary_window=primary_window,
+                secondary_window=secondary_window,
+                local_cooldown_cleared=local_cooldown_cleared,
+            )
+    except httpx.HTTPError as exc:
+        return entry, CodexLiveStatus(error=f"Network error: {exc}")
+    except Exception as exc:
+        return entry, CodexLiveStatus(error=f"Unexpected error: {exc}")
+
+
+def _snapshot_from_entry(
+    index: int,
+    entry: PooledCredential,
+    live: Optional[CodexLiveStatus] = None,
+) -> CodexProfileSnapshot:
+    live = live or CodexLiveStatus()
+    any_window_exhausted = any(
+        _window_is_exhausted(window)
+        for window in (live.primary_window, live.secondary_window)
+    )
+
+    if live.deactivated:
+        auth_badge = "DEAD"
+        auth_reason = live.error or "Token invalid or profile deactivated"
+        state = STATE_DEACTIVATED
+        state_badge = "n/a"
+        reason = auth_reason
+    elif live.error:
+        auth_badge = "ERR"
+        auth_reason = live.error
+        state = STATE_ERROR
+        state_badge = "ERR"
+        reason = live.error
+    elif live.allowed is False or live.limit_reached or any_window_exhausted:
+        auth_badge = "OK"
+        auth_reason = "Authenticated"
+        state = STATE_LIMITED
+        state_badge = _BADGES[state]
+        reason = _limit_reason(live)
+    elif live.allowed is True or live.primary_window or live.secondary_window:
+        auth_badge = "OK"
+        auth_reason = "Authenticated"
+        state = STATE_AVAILABLE
+        state_badge = _BADGES[state]
+        reason = "Available"
+        if live.local_cooldown_cleared:
+            reason = "Available (local cooldown cleared)"
+    else:
+        auth_badge = "LOAD"
+        auth_reason = "Loading..."
+        state = STATE_LOADING
+        state_badge = _BADGES[state]
+        reason = "Loading..."
+
+    display_name = _guess_display_name(entry, live.email)
+    return CodexProfileSnapshot(
+        index=index,
+        entry_id=entry.id,
+        label=entry.label,
+        display_name=display_name,
+        auth_badge=auth_badge,
+        state=state,
+        state_badge=state_badge,
+        state_reason=reason,
+        primary_window=live.primary_window,
+        secondary_window=live.secondary_window,
+        email=live.email,
+        plan=live.plan,
+        source=entry.source,
+        auth_type=entry.auth_type,
+        last_refresh=entry.last_refresh,
+        local_status=entry.last_status,
+        local_error_code=entry.last_error_code,
+        http_status=live.http_status,
+        local_cooldown_cleared=live.local_cooldown_cleared,
+        auth_reason=auth_reason,
+    )
+
+
+FetchProfileFn = Callable[[Any, PooledCredential, float], tuple[PooledCredential, CodexLiveStatus]]
+
+
+def build_codex_profile_snapshots(
+    *,
+    provider: str = DEFAULT_PROVIDER,
+    timeout_seconds: float = 10.0,
+    fetch_profile: Optional[FetchProfileFn] = None,
+) -> list[CodexProfileSnapshot]:
+    if provider != DEFAULT_PROVIDER:
+        raise SystemExit(f"Auth view currently supports only {DEFAULT_PROVIDER}.")
+    fetcher = fetch_profile or _fetch_codex_live_status
+    pool = load_pool(provider)
+    entries = list(pool.entries())
+    if not entries:
+        return []
+
+    def _poll_one(item: tuple[int, PooledCredential]) -> CodexProfileSnapshot:
+        index, entry = item
+        current_entry, live = fetcher(pool, entry, timeout_seconds)
+        return _snapshot_from_entry(index, current_entry, live)
+
+    if len(entries) == 1:
+        snapshots = [_poll_one((1, entries[0]))]
+    else:
+        max_workers = max(2, min(MAX_POLL_WORKERS, len(entries)))
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="codex-auth-view") as executor:
+            snapshots = list(executor.map(_poll_one, enumerate(entries, start=1)))
+
+    return _sort_codex_profile_snapshots(snapshots)
+
+
+def build_codex_profile_placeholders(provider: str = DEFAULT_PROVIDER) -> list[CodexProfileSnapshot]:
+    if provider != DEFAULT_PROVIDER:
+        raise SystemExit(f"Auth view currently supports only {DEFAULT_PROVIDER}.")
+    pool = load_pool(provider)
+    return [_snapshot_from_entry(index, entry) for index, entry in enumerate(pool.entries(), start=1)]
+
+
+def render_codex_auth_smoke_test(
+    *,
+    provider: str = DEFAULT_PROVIDER,
+    timeout_seconds: float = 10.0,
+) -> str:
+    snapshots = build_codex_profile_snapshots(provider=provider, timeout_seconds=timeout_seconds)
+    if not snapshots:
+        return "Codex auth view: no pooled profiles found."
+    lines = [f"Codex auth view: {len(snapshots)} profiles"]
+    for snapshot in snapshots:
+        short_label = snapshot.primary_window.label if snapshot.primary_window else "5h"
+        long_label = snapshot.secondary_window.label if snapshot.secondary_window else "Week"
+        short_pct = _format_percent(_window_available_percent(snapshot.primary_window))
+        long_pct = _format_percent(_window_available_percent(snapshot.secondary_window))
+        short_reset = _format_reset_compact(snapshot.primary_window.reset_at_ms if snapshot.primary_window else None)
+        long_reset = _format_reset_compact(snapshot.secondary_window.reset_at_ms if snapshot.secondary_window else None)
+        short_suffix = f" {short_reset}" if short_reset else ""
+        long_suffix = f" {long_reset}" if long_reset else ""
+        lines.append(
+            f"{snapshot.index:>2}. {snapshot.display_name:<30} {snapshot.auth_badge:<4} {snapshot.state_badge:<5} "
+            f"{long_label}_left={long_pct}{long_suffix} {short_label}_left={short_pct}{short_suffix}"
+        )
+    return "\n".join(lines)
+
+
+class CodexAuthTui:
+    def __init__(self, *, provider: str = DEFAULT_PROVIDER, timeout_seconds: float = 10.0):
+        if provider != DEFAULT_PROVIDER:
+            raise SystemExit(f"Auth view currently supports only {DEFAULT_PROVIDER}.")
+        self.provider = provider
+        self.timeout_seconds = timeout_seconds
+        self.sort_mode = SORT_AVAILABILITY
+        self.snapshots: list[CodexProfileSnapshot] = []
+        self.selected_index = 0
+        self.message = "Loading Codex profiles..."
+        self.loading = False
+        self._lock = threading.Lock()
+        self._refresh_generation = 0
+        self._selected_entry_id: Optional[str] = None
+        self._remove_confirm_entry_id: Optional[str] = None
+        self._remove_confirm_deadline = 0.0
+
+    def _start_refresh(self, *, initial: bool = False, show_placeholders: bool = False) -> int:
+        with self._lock:
+            self._refresh_generation += 1
+            generation = self._refresh_generation
+            if show_placeholders and (not self.snapshots or initial):
+                try:
+                    self.snapshots = build_codex_profile_placeholders(self.provider)
+                except Exception:
+                    self.snapshots = []
+            self.loading = True
+            self.message = "Refreshing Codex profiles..." if not initial else "Polling live Codex profiles..."
+            self._remove_confirm_entry_id = None
+            self._remove_confirm_deadline = 0.0
+            selected = self._selected_snapshot_unlocked()
+            self._selected_entry_id = selected.entry_id if selected else None
+            return generation
+
+    def _fetch_live_snapshots(self) -> tuple[list[CodexProfileSnapshot], str]:
+        try:
+            snapshots = build_codex_profile_snapshots(
+                provider=self.provider,
+                timeout_seconds=self.timeout_seconds,
+            )
+            message = (
+                f"Loaded {len(snapshots)} live Codex profile{'s' if len(snapshots) != 1 else ''}."
+                if snapshots
+                else "No Codex profiles found in Hermes auth."
+            )
+        except Exception as exc:
+            snapshots = []
+            message = f"Refresh failed: {exc}"
+        return snapshots, message
+
+    def _apply_sort_mode(self, snapshots: list[CodexProfileSnapshot], mode: Optional[str] = None) -> list[CodexProfileSnapshot]:
+        return _sort_codex_profile_snapshots(snapshots, mode=mode or self.sort_mode)
+
+    def _set_sort_mode(self, mode: str) -> None:
+        with self._lock:
+            if mode not in _SORT_LABELS:
+                return
+            selected = self._selected_snapshot_unlocked()
+            selected_id = selected.entry_id if selected else None
+            self.sort_mode = mode
+            self.snapshots = self._apply_sort_mode(list(self.snapshots), mode)
+            if selected_id:
+                for idx, snapshot in enumerate(self.snapshots):
+                    if snapshot.entry_id == selected_id:
+                        self.selected_index = idx
+                        break
+            self.selected_index = min(self.selected_index, max(0, len(self.snapshots) - 1))
+            selected = self._selected_snapshot_unlocked()
+            self._selected_entry_id = selected.entry_id if selected else None
+            self.message = f"Sorted by {_SORT_LABELS[self.sort_mode]}."
+
+    def _finish_refresh(self, generation: int, snapshots: list[CodexProfileSnapshot], message: str) -> None:
+        with self._lock:
+            if generation != self._refresh_generation:
+                return
+            selected_id = self._selected_entry_id
+            self.snapshots = self._apply_sort_mode(snapshots)
+            if selected_id:
+                for idx, snapshot in enumerate(self.snapshots):
+                    if snapshot.entry_id == selected_id:
+                        self.selected_index = idx
+                        break
+                else:
+                    self.selected_index = min(self.selected_index, max(0, len(self.snapshots) - 1))
+            else:
+                self.selected_index = min(self.selected_index, max(0, len(self.snapshots) - 1))
+            self.loading = False
+            self.message = message
+            selected = self._selected_snapshot_unlocked()
+            self._selected_entry_id = selected.entry_id if selected else None
+
+    def _refresh_async(self) -> None:
+        generation = self._start_refresh(show_placeholders=not self.snapshots)
+        thread = threading.Thread(target=self._refresh_worker, args=(generation,), daemon=True)
+        thread.start()
+
+    def _refresh_blocking(self, *, initial: bool = False) -> None:
+        generation = self._start_refresh(initial=initial, show_placeholders=False)
+        snapshots, message = self._fetch_live_snapshots()
+        self._finish_refresh(generation, snapshots, message)
+
+    def _refresh_worker(self, generation: int) -> None:
+        snapshots, message = self._fetch_live_snapshots()
+        self._finish_refresh(generation, snapshots, message)
+
+    def _selected_snapshot_unlocked(self) -> Optional[CodexProfileSnapshot]:
+        if not self.snapshots:
+            return None
+        self.selected_index = max(0, min(self.selected_index, len(self.snapshots) - 1))
+        return self.snapshots[self.selected_index]
+
+    def _selected_snapshot(self) -> Optional[CodexProfileSnapshot]:
+        with self._lock:
+            return self._selected_snapshot_unlocked()
+
+    def _status_counts(self) -> dict[str, int]:
+        counts = {
+            "auth_ok": 0,
+            "dead": 0,
+            "avail": 0,
+            "limit": 0,
+            "err": 0,
+            "load": 0,
+        }
+        with self._lock:
+            snapshots = list(self.snapshots)
+        for snapshot in snapshots:
+            if snapshot.auth_badge == "OK":
+                counts["auth_ok"] += 1
+            elif snapshot.auth_badge == "DEAD":
+                counts["dead"] += 1
+            elif snapshot.auth_badge == "ERR":
+                counts["err"] += 1
+            elif snapshot.auth_badge == "LOAD":
+                counts["load"] += 1
+
+            if snapshot.state == STATE_AVAILABLE:
+                counts["avail"] += 1
+            elif snapshot.state == STATE_LIMITED:
+                counts["limit"] += 1
+        return counts
+
+    def _remove_selected(self) -> None:
+        with self._lock:
+            snapshot = self._selected_snapshot_unlocked()
+            if snapshot is None:
+                self.message = "No profile selected."
+                return
+            now = time.time()
+            short_id = _short_entry_id(snapshot.entry_id)
+            if self._remove_confirm_entry_id != snapshot.entry_id or now > self._remove_confirm_deadline:
+                self._remove_confirm_entry_id = snapshot.entry_id
+                self._remove_confirm_deadline = now + 5.0
+                self.message = f"Press r again to remove [{short_id}] {snapshot.display_name}."
+                return
+            selected_entry_id = snapshot.entry_id
+            self._remove_confirm_entry_id = None
+            self._remove_confirm_deadline = 0.0
+
+        pool = load_pool(self.provider)
+        removed = pool.remove_entry(selected_entry_id)
+        if removed is None:
+            with self._lock:
+                self.message = "Selected profile was already removed."
+            self._refresh_async()
+            return
+        with self._lock:
+            if removed is None:
+                self.message = "Failed to remove selected profile."
+            else:
+                removed_label = snapshot.display_name if snapshot else removed.label
+                self.message = f"Removed [{_short_entry_id(removed.id)}] {removed_label} from Hermes auth."
+        self._refresh_async()
+
+    def _clear_expired_confirmation(self) -> None:
+        with self._lock:
+            if self._remove_confirm_entry_id and time.time() > self._remove_confirm_deadline:
+                self._remove_confirm_entry_id = None
+                self._remove_confirm_deadline = 0.0
+
+    def _layout_sizes(self, width: int) -> tuple[int, int]:
+        if width >= 120:
+            return 34, 12
+        if width >= 100:
+            return 28, 9
+        if width >= 84:
+            return 20, 7
+        return 14, 5
+
+    def _label_pair(self) -> tuple[str, str]:
+        short_label = "5h"
+        long_label = "Week"
+        with self._lock:
+            snapshots = list(self.snapshots)
+        for snapshot in snapshots:
+            if snapshot.primary_window:
+                short_label = snapshot.primary_window.label
+                break
+        for snapshot in snapshots:
+            if snapshot.secondary_window:
+                long_label = snapshot.secondary_window.label
+                break
+        return short_label, long_label
+
+    def _render_row(self, snapshot: CodexProfileSnapshot, width: int, *, selected: bool = False) -> str:
+        account_width, bar_width = self._layout_sizes(width)
+        account = _clip(snapshot.display_name, account_width)
+        week = _format_bar_with_reset(snapshot.secondary_window, bar_width)
+        hour = _format_bar_with_reset(snapshot.primary_window, bar_width)
+        prefix = ">" if selected else " "
+        return _clip(
+            f"{prefix} {snapshot.auth_badge:<4} {snapshot.state_badge:<5} {account:<{account_width}} {week} {hour}",
+            width - 1,
+        )
+
+    def _detail_lines(self, width: int) -> list[str]:
+        snapshot = self._selected_snapshot()
+        if snapshot is None:
+            return ["No Codex profiles found.", "Add one with: hermes auth add openai-codex --type oauth", ""]
+        line1 = (
+            f"Selected: {snapshot.display_name} [{_short_entry_id(snapshot.entry_id)}] | Auth: {snapshot.auth_badge} | "
+            f"Quota: {snapshot.state_badge} | Plan: {snapshot.plan or 'unknown'} | Source: {snapshot.source}"
+        )
+        primary = snapshot.primary_window
+        secondary = snapshot.secondary_window
+        short_label = primary.label if primary else "5h"
+        long_label = secondary.label if secondary else "Week"
+        line2 = (
+            f"{long_label} left: {_format_bar(_window_available_percent(secondary), 10)} "
+            f"back {_format_reset(secondary.reset_at_ms if secondary else None)} | "
+            f"{short_label} left: {_format_bar(_window_available_percent(primary), 10)} "
+            f"back {_format_reset(primary.reset_at_ms if primary else None)}"
+        )
+        local_bits = []
+        if snapshot.local_status:
+            local_bits.append(snapshot.local_status)
+        if snapshot.local_error_code:
+            local_bits.append(str(snapshot.local_error_code))
+        local_text = " ".join(local_bits) if local_bits else "clear"
+        if snapshot.local_cooldown_cleared:
+            local_text = "clear (auto-cleared)"
+        line3 = (
+            f"Hermes local: {local_text} | Last refresh: {_format_timestamp(snapshot.last_refresh)} | "
+            f"Auth: {snapshot.auth_reason or 'n/a'} | Quota: {snapshot.state_reason}"
+        )
+        return [_clip(line1, width - 1), _clip(line2, width - 1), _clip(line3, width - 1)]
+
+    def _draw_boot_loading(self, stdscr, frame: int = 0) -> None:
+        import curses
+
+        stdscr.erase()
+        max_y, max_x = stdscr.getmaxyx()
+        line = _boot_loading_text(frame)
+        y = max(0, max_y // 2)
+        x = max(0, (max_x - len(line)) // 2)
+        attr = curses.A_BOLD if curses.has_colors() else curses.A_NORMAL
+        if curses.has_colors():
+            attr |= curses.color_pair(4)
+        stdscr.addnstr(y, x, _clip(line, max_x - x - 1), max_x - x - 1, attr)
+        stdscr.refresh()
+
+    def _run_curses(self, stdscr) -> None:
+        import curses
+
+        locale.setlocale(locale.LC_ALL, "")
+        curses.curs_set(0)
+        stdscr.timeout(100)
+        if curses.has_colors():
+            curses.start_color()
+            curses.use_default_colors()
+            curses.init_pair(1, curses.COLOR_GREEN, -1)
+            curses.init_pair(2, curses.COLOR_YELLOW, -1)
+            curses.init_pair(3, curses.COLOR_RED, -1)
+            curses.init_pair(4, curses.COLOR_CYAN, -1)
+            curses.init_pair(5, curses.COLOR_MAGENTA, -1)
+            dim_color = 8 if getattr(curses, "COLORS", 0) > 8 else curses.COLOR_WHITE
+            curses.init_pair(6, dim_color, -1)
+
+        generation = self._start_refresh(initial=True, show_placeholders=False)
+        thread = threading.Thread(target=self._refresh_worker, args=(generation,), daemon=True)
+        thread.start()
+        boot_frame = 0
+        while True:
+            self._draw_boot_loading(stdscr, boot_frame)
+            with self._lock:
+                loading = self.loading
+            if not loading:
+                break
+            boot_frame += 1
+            key = stdscr.getch()
+            if key in {ord('q'), 27}:
+                return
+
+        scroll_offset = 0
+        while True:
+            self._clear_expired_confirmation()
+            stdscr.erase()
+            max_y, max_x = stdscr.getmaxyx()
+            if max_y < 10 or max_x < 72:
+                stdscr.addnstr(0, 0, "Terminal too small for auth view (need at least 72x10).", max_x - 1)
+                stdscr.refresh()
+                key = stdscr.getch()
+                if key in {ord('q'), 27}:
+                    return
+                continue
+
+            with self._lock:
+                snapshots = list(self.snapshots)
+                selected_index = self.selected_index
+                loading = self.loading
+                message = self.message
+                sort_mode = self.sort_mode
+
+            counts = self._status_counts()
+            short_label, long_label = self._label_pair()
+            header = (
+                f"Codex auth view  sort={_SORT_LABELS.get(sort_mode, sort_mode)}  total={len(snapshots)}  "
+                f"ok={counts['auth_ok']}  dead={counts['dead']}  avail={counts['avail']}  limit={counts['limit']}"
+            )
+            if loading:
+                spinner = "|/-\\"[int(time.time() * 8) % 4]
+                header += f"  refreshing {spinner}"
+            header_attr = curses.A_BOLD
+            if curses.has_colors():
+                header_attr |= curses.color_pair(4)
+            stdscr.addnstr(0, 0, _clip(header, max_x - 1), max_x - 1, header_attr)
+
+            account_width, bar_width = self._layout_sizes(max_x)
+            column_width = bar_width + 14
+            week_heading = _clip(f" {long_label} left / back", column_width)
+            hour_heading = _clip(f" {short_label} left / back", column_width)
+            col_header = _clip(
+                f"  {'auth':<4} {'quota':<5} {'account':<{account_width}} {week_heading:<{column_width}} {hour_heading:<{column_width}}",
+                max_x - 1,
+            )
+            dim_attr = curses.color_pair(6) if curses.has_colors() else curses.A_DIM
+            stdscr.addnstr(1, 0, col_header, max_x - 1, dim_attr)
+
+            body_top = 2
+            body_bottom = max_y - 5
+            visible_rows = max(1, body_bottom - body_top + 1)
+            if selected_index < scroll_offset:
+                scroll_offset = selected_index
+            elif selected_index >= scroll_offset + visible_rows:
+                scroll_offset = selected_index - visible_rows + 1
+            scroll_offset = max(0, scroll_offset)
+
+            if not snapshots:
+                stdscr.addnstr(body_top, 0, _clip("  No pooled Codex profiles found.", max_x - 1), max_x - 1)
+            else:
+                for row_idx in range(visible_rows):
+                    snapshot_idx = scroll_offset + row_idx
+                    if snapshot_idx >= len(snapshots):
+                        break
+                    snapshot = snapshots[snapshot_idx]
+                    is_selected = snapshot_idx == selected_index
+                    row_text = self._render_row(snapshot, max_x, selected=is_selected)
+                    attr = curses.A_NORMAL
+                    if snapshot.state == STATE_AVAILABLE and curses.has_colors():
+                        attr |= curses.color_pair(1)
+                    elif snapshot.state == STATE_LIMITED and curses.has_colors():
+                        attr |= curses.color_pair(2)
+                    elif snapshot.state == STATE_DEACTIVATED and curses.has_colors():
+                        attr |= curses.color_pair(3)
+                    elif snapshot.state == STATE_ERROR and curses.has_colors():
+                        attr |= curses.color_pair(5)
+                    elif snapshot.state == STATE_LOADING and curses.has_colors():
+                        attr |= curses.color_pair(6)
+                    if is_selected:
+                        attr |= curses.A_BOLD
+                    stdscr.addnstr(body_top + row_idx, 0, row_text, max_x - 1, attr)
+
+            detail_lines = self._detail_lines(max_x)
+            for offset, line in enumerate(detail_lines, start=max_y - 4):
+                stdscr.addnstr(offset, 0, line, max_x - 1)
+
+            stdscr.addnstr(max_y - 1, 0, _footer_line(message, width=max_x - 1), max_x - 1, dim_attr)
+            stdscr.refresh()
+
+            key = stdscr.getch()
+            if key == -1:
+                continue
+            if key in {ord('q'), 27}:
+                return
+            if key in {curses.KEY_UP, ord('k')}:
+                with self._lock:
+                    if self.snapshots:
+                        self.selected_index = max(0, self.selected_index - 1)
+                        self._selected_entry_id = self._selected_snapshot_unlocked().entry_id
+                continue
+            if key in {curses.KEY_DOWN, ord('j')}:
+                with self._lock:
+                    if self.snapshots:
+                        self.selected_index = min(len(self.snapshots) - 1, self.selected_index + 1)
+                        self._selected_entry_id = self._selected_snapshot_unlocked().entry_id
+                continue
+            if key == ord('a'):
+                self._set_sort_mode(SORT_AVAILABILITY)
+                continue
+            if key == ord('n'):
+                self._set_sort_mode(SORT_NAME)
+                continue
+            if key == ord('l'):
+                self._set_sort_mode(SORT_REFRESH)
+                continue
+            if key == ord('u'):
+                self._refresh_async()
+                continue
+            if key == ord('r'):
+                self._remove_selected()
+                continue
+
+    def run(self) -> None:
+        import curses
+
+        curses.wrapper(self._run_curses)
+
+
+def auth_view_command(args) -> None:
+    provider = getattr(args, "provider", DEFAULT_PROVIDER) or DEFAULT_PROVIDER
+    timeout_seconds = float(getattr(args, "timeout", 10.0) or 10.0)
+    smoke_test = bool(getattr(args, "smoke_test", False))
+
+    if smoke_test:
+        print(render_codex_auth_smoke_test(provider=provider, timeout_seconds=timeout_seconds))
+        return
+
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        raise SystemExit("`hermes auth view` requires an interactive terminal. Use `--smoke-test` for CI/non-interactive checks.")
+
+    CodexAuthTui(provider=provider, timeout_seconds=timeout_seconds).run()

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -130,6 +130,23 @@ def get_available_skills() -> Dict[str, List[str]]:
 _UPDATE_CHECK_CACHE_SECONDS = 6 * 3600
 
 
+def _git_stdout(repo_dir: Path, *args: str, timeout: float = 5) -> Optional[str]:
+    """Return stripped stdout for a successful git command, else ``None``."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
 def check_for_updates() -> Optional[int]:
     """Check how many commits behind origin/main the local repo is.
 
@@ -147,12 +164,16 @@ def check_for_updates() -> Optional[int]:
     if not (repo_dir / ".git").exists():
         return None
 
+    current_head = _git_stdout(repo_dir, "rev-parse", "HEAD")
+
     # Read cache
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
-            if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
+            cache_is_fresh = now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+            cache_matches_head = not current_head or cached.get("head") == current_head
+            if cache_is_fresh and cache_matches_head:
                 return cached.get("behind")
     except Exception:
         pass
@@ -183,7 +204,9 @@ def check_for_updates() -> Optional[int]:
 
     # Write cache
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind}))
+        cache_file.write_text(
+            json.dumps({"ts": now, "behind": behind, "head": current_head})
+        )
     except Exception:
         pass
 

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -1,20 +1,24 @@
-"""Clipboard image extraction for macOS, Windows, Linux, and WSL2.
+"""Clipboard image extraction and text copy helpers for macOS, Windows, Linux, and WSL2.
 
-Provides a single function `save_clipboard_image(dest)` that checks the
-system clipboard for image data, saves it to *dest* as PNG, and returns
-True on success.  No external Python dependencies — uses only OS-level
-CLI tools that ship with the platform (or are commonly installed).
+Provides:
+- `save_clipboard_image(dest)` to extract clipboard image data to *dest*
+- `has_clipboard_image()` to cheaply detect clipboard image content
+- `copy_text_to_clipboard(text)` to copy plain text to the system clipboard
+
+No external Python dependencies — uses only OS-level CLI tools that ship
+with the platform (or are commonly installed).
 
 Platform support:
-  macOS   — osascript (always available), pngpaste (if installed)
+  macOS   — osascript/pngpaste for images, pbcopy for text
   Windows — PowerShell via .NET System.Windows.Forms.Clipboard
-  WSL2    — powershell.exe via .NET System.Windows.Forms.Clipboard
-  Linux   — wl-paste (Wayland), xclip (X11)
+  WSL2    — powershell.exe/.NET for images, clip.exe for text
+  Linux   — wl-paste/wl-copy (Wayland), xclip (X11)
 """
 
 import base64
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -52,6 +56,77 @@ def has_clipboard_image() -> bool:
     if os.environ.get("WAYLAND_DISPLAY"):
         return _wayland_has_image()
     return _xclip_has_image()
+
+
+def copy_text_to_clipboard(text: str) -> tuple[bool, str | None]:
+    """Copy plain text to the system clipboard.
+
+    Returns (True, None) on success, or (False, error_message) on failure.
+    """
+    command, missing_error = _text_copy_command()
+    if not command:
+        return False, missing_error
+
+    run_kwargs = {
+        "input": text,
+        "text": True,
+        "timeout": 3,
+        "check": False,
+    }
+    if command[0] in {"wl-copy", "xclip", "xsel"}:
+        # These Linux clipboard tools may keep a background process alive to
+        # serve clipboard requests. Capturing pipes can make subprocess.run()
+        # wait on that background child until timeout.
+        run_kwargs["stdout"] = subprocess.DEVNULL
+        run_kwargs["stderr"] = subprocess.DEVNULL
+    else:
+        run_kwargs["capture_output"] = True
+
+    try:
+        result = subprocess.run(command, **run_kwargs)
+    except FileNotFoundError:
+        return False, f"Clipboard copy backend not installed: {command[0]}"
+    except Exception as e:
+        logger.debug("Clipboard text copy failed: %s", e)
+        return False, str(e)
+
+    if result.returncode == 0:
+        return True, None
+
+    detail = (result.stderr or result.stdout or "").strip()
+    if not detail:
+        detail = f"{command[0]} exited with status {result.returncode}"
+    return False, detail
+
+
+def _text_copy_command() -> tuple[list[str] | None, str | None]:
+    """Return a text clipboard command and a fallback error if unavailable."""
+    if sys.platform == "darwin":
+        return ["pbcopy"], None
+
+    if _is_wsl():
+        if shutil.which("clip.exe"):
+            return ["clip.exe"], None
+        if shutil.which("powershell.exe"):
+            return [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Set-Clipboard",
+            ], None
+        return None, "No clipboard copy backend found in WSL. Install/use clip.exe or powershell.exe."
+
+    if os.environ.get("WAYLAND_DISPLAY") and shutil.which("wl-copy"):
+        return ["wl-copy"], None
+
+    if shutil.which("xclip"):
+        return ["xclip", "-selection", "clipboard"], None
+
+    if shutil.which("xsel"):
+        return ["xsel", "--clipboard", "--input"], None
+
+    return None, "No clipboard copy backend found. Install wl-copy (Wayland) or xclip/xsel (X11)."
 
 
 # ── macOS ────────────────────────────────────────────────────────────────

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -19,6 +19,8 @@ from typing import Any
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
 from prompt_toolkit.completion import Completer, Completion
 
+from hermes_cli.fast_mode import FAST_MODE_SUBCOMMANDS
+
 
 # ---------------------------------------------------------------------------
 # CommandDef dataclass
@@ -87,6 +89,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("model", "Switch model for this session", "Configuration", args_hint="[model] [--global]"),
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
+    CommandDef("fast", "Toggle Codex fast mode", "Configuration",
+               args_hint="[on|off|status]", subcommands=FAST_MODE_SUBCOMMANDS),
     CommandDef("prompt", "View/set custom system prompt", "Configuration",
                cli_only=True, args_hint="[text]", subcommands=("clear",)),
     CommandDef("personality", "Set a predefined personality", "Configuration",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -87,6 +87,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration", args_hint="[model] [--global]"),
+    CommandDef("context-limit", "Set or toggle the current session context window", "Configuration",
+               cli_only=True, args_hint="[tokens]"),
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
     CommandDef("fast", "Toggle Codex fast mode", "Configuration",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -63,6 +63,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("fork",), args_hint="[name]"),
     CommandDef("spawn", "Spawn a background child session from the current context", "Session",
                args_hint="<prompt>"),
+    CommandDef("hermes-addition", "Spawn a background worktree agent that prepares a PR on your fork", "Session",
+               cli_only=True, args_hint="<prompt>"),
     CommandDef("compress", "Manually compress conversation context", "Session"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -61,6 +61,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",
                aliases=("fork",), args_hint="[name]"),
+    CommandDef("spawn", "Spawn a background child session from the current context", "Session",
+               args_hint="<prompt>"),
     CommandDef("compress", "Manually compress conversation context", "Session"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),

--- a/hermes_cli/context_limit.py
+++ b/hermes_cli/context_limit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+
+CONTEXT_LIMIT_PRESETS: tuple[int, int] = (272_000, 1_000_000)
+CONTEXT_LIMIT_USAGE = "/context-limit [tokens]"
+
+_SUFFIX_MULTIPLIERS = {
+    "": 1,
+    "k": 1_000,
+    "m": 1_000_000,
+}
+
+
+def parse_context_limit_value(raw: str) -> int | None:
+    """Parse token counts like 500000, 272k, 1m, or 500,000."""
+    cleaned = (raw or "").strip().lower().replace(",", "").replace("_", "")
+    if not cleaned:
+        return None
+
+    match = re.fullmatch(r"(\d+)([km]?)", cleaned)
+    if not match:
+        return None
+
+    value = int(match.group(1)) * _SUFFIX_MULTIPLIERS[match.group(2)]
+    return value if value > 0 else None
+
+
+def cycle_context_limit(current: int | None) -> int:
+    """Toggle between the preferred session presets."""
+    low, high = CONTEXT_LIMIT_PRESETS
+    return high if current == low else low

--- a/hermes_cli/fast_mode.py
+++ b/hermes_cli/fast_mode.py
@@ -1,0 +1,67 @@
+"""Shared helpers for Hermes /fast mode."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+FAST_MODE_USAGE = "/fast [on|off|status]"
+FAST_MODE_SUBCOMMANDS = ("on", "off", "status")
+
+
+def parse_fast_command_arg(raw: str | None) -> str | None:
+    """Parse a /fast argument into toggle/on/off/status.
+
+    Returns:
+        "toggle", "on", "off", "status", or None for invalid input.
+    """
+    if raw is None:
+        return "toggle"
+    value = raw.strip().lower()
+    if not value:
+        return "toggle"
+    if value in {"on", "off", "status"}:
+        return value
+    return None
+
+
+def normalize_service_tier(value: str | None) -> Optional[str]:
+    """Normalize service-tier state to Hermes' internal values."""
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized or normalized in {"off", "none", "default", "standard"}:
+        return None
+    if normalized in {"fast", "priority"}:
+        return "fast"
+    if normalized == "flex":
+        return "flex"
+    return None
+
+
+def responses_api_service_tier(value: str | None) -> Optional[str]:
+    """Map Hermes service-tier state to OpenAI/Codex Responses payload values."""
+    normalized = normalize_service_tier(value)
+    if normalized == "fast":
+        return "priority"
+    if normalized == "flex":
+        return "flex"
+    return None
+
+
+def fast_mode_note(
+    provider: str | None = None,
+    model: str | None = None,
+    enabled: bool = True,
+) -> str:
+    """Return a short applicability note for user-facing status output."""
+    if not enabled:
+        return "Fast mode is off — Hermes will not send service_tier=priority until you turn it on."
+
+    provider_norm = (provider or "").strip().lower()
+    model_norm = (model or "").strip().lower().split("/")[-1]
+    if provider_norm == "openai-codex" and model_norm == "gpt-5.4":
+        return "Hermes will send service_tier=priority on the next Codex turn."
+    if provider_norm == "openai-codex":
+        return "Hermes sends service_tier=priority on Codex turns; non-gpt-5.4 models may ignore it."
+    return "Hermes sends service_tier=priority on OpenAI Codex gpt-5.4 turns; other providers/models ignore it."

--- a/hermes_cli/kitty_overlay.py
+++ b/hermes_cli/kitty_overlay.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+DEFAULT_TIMEOUT_RESPONSE = (
+    "The user did not provide a response within the time limit. "
+    "Use your best judgement to make the choice and proceed."
+)
+
+
+def kitty_overlay_available(env: Mapping[str, str] | None = None) -> bool:
+    env_map = env or os.environ
+    return bool(
+        env_map.get("KITTY_LISTEN_ON")
+        and env_map.get("KITTY_WINDOW_ID")
+        and shutil.which("kitten")
+    )
+
+
+
+def build_overlay_launch_command(
+    *,
+    listen_on: str,
+    window_id: str,
+    python_executable: str,
+    script_path: str,
+    spec_path: str,
+) -> list[str]:
+    return [
+        "kitten",
+        "@",
+        "--to",
+        listen_on,
+        "launch",
+        "--match",
+        f"window_id:{window_id}",
+        "--type=overlay",
+        "--cwd",
+        "current",
+        python_executable,
+        script_path,
+        "--spec",
+        spec_path,
+    ]
+
+
+
+def _wait_for_overlay_response(response_path: Path, timeout: int) -> str:
+    deadline = time.monotonic() + max(1, timeout) + 5
+    while time.monotonic() < deadline:
+        if response_path.exists():
+            try:
+                payload = json.loads(response_path.read_text(encoding="utf-8"))
+            except Exception:
+                return DEFAULT_TIMEOUT_RESPONSE
+            response = str(payload.get("response") or "").strip()
+            return response or DEFAULT_TIMEOUT_RESPONSE
+        time.sleep(0.2)
+    return DEFAULT_TIMEOUT_RESPONSE
+
+
+
+def prompt_kitty_overlay_clarify(
+    question: str,
+    choices: Sequence[str] | None,
+    *,
+    task_label: str = "background task",
+    timeout: int = 120,
+    env: Mapping[str, str] | None = None,
+    python_executable: str | None = None,
+) -> str:
+    env_map = dict(env or os.environ)
+    if not kitty_overlay_available(env_map):
+        raise RuntimeError("Kitty overlay remote-control environment is not available.")
+
+    listen_on = str(env_map["KITTY_LISTEN_ON"])
+    window_id = str(env_map["KITTY_WINDOW_ID"])
+    python_exec = python_executable or sys.executable or shutil.which("python3") or "python3"
+    script_path = str(Path(__file__).with_name("kitty_overlay_prompt.py"))
+
+    with tempfile.TemporaryDirectory(prefix="hermes-kitty-overlay-") as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        spec_path = tmpdir_path / "spec.json"
+        response_path = tmpdir_path / "response.json"
+        spec = {
+            "task_label": task_label,
+            "question": question,
+            "choices": list(choices or []),
+            "timeout": int(timeout),
+            "response_path": str(response_path),
+        }
+        spec_path.write_text(json.dumps(spec, ensure_ascii=False), encoding="utf-8")
+
+        command = build_overlay_launch_command(
+            listen_on=listen_on,
+            window_id=window_id,
+            python_executable=python_exec,
+            script_path=script_path,
+            spec_path=str(spec_path),
+        )
+        result = subprocess.run(command, capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "kitty overlay launch failed").strip()
+            raise RuntimeError(detail)
+
+        return _wait_for_overlay_response(response_path, int(timeout))

--- a/hermes_cli/kitty_overlay_prompt.py
+++ b/hermes_cli/kitty_overlay_prompt.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import select
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_TIMEOUT_RESPONSE = (
+    "The user did not provide a response within the time limit. "
+    "Use your best judgement to make the choice and proceed."
+)
+
+
+
+def _read_line_with_timeout(timeout: float) -> str | None:
+    remaining = max(0.0, timeout)
+    ready, _, _ = select.select([sys.stdin], [], [], remaining)
+    if not ready:
+        return None
+    line = sys.stdin.readline()
+    if not line:
+        return None
+    return line.rstrip("\r\n")
+
+
+
+def _write_response(path: Path, response: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"response": response}, ensure_ascii=False), encoding="utf-8")
+
+
+
+def _resolve_choice_response(raw: str, choices: list[str], timeout_deadline: float) -> str:
+    cleaned = (raw or "").strip()
+    if not cleaned:
+        return DEFAULT_TIMEOUT_RESPONSE
+
+    other_index = len(choices) + 1
+    if cleaned.isdigit():
+        numeric = int(cleaned)
+        if 1 <= numeric <= len(choices):
+            return choices[numeric - 1]
+        if numeric == other_index:
+            print()
+            print("Type your answer and press Enter:")
+            follow_up = _read_line_with_timeout(timeout_deadline - time.monotonic())
+            cleaned_follow_up = (follow_up or "").strip()
+            return cleaned_follow_up or DEFAULT_TIMEOUT_RESPONSE
+    return cleaned
+
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Hermes kitty overlay clarify prompt")
+    parser.add_argument("--spec", required=True, help="Path to the prompt spec JSON file")
+    args = parser.parse_args(argv)
+
+    spec_path = Path(args.spec)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    task_label = str(spec.get("task_label") or "Hermes background task")
+    question = str(spec.get("question") or "")
+    choices = [str(choice).strip() for choice in (spec.get("choices") or []) if str(choice).strip()]
+    timeout = int(spec.get("timeout") or 120)
+    response_path = Path(spec["response_path"])
+    deadline = time.monotonic() + max(1, timeout)
+
+    print(f"{task_label} needs your input")
+    print("=" * max(24, len(task_label) + 18))
+    print()
+    print(question)
+    print()
+
+    if choices:
+        for index, choice in enumerate(choices, 1):
+            print(f"  {index}. {choice}")
+        print(f"  {len(choices) + 1}. Other (type your answer)")
+        print()
+        print(f"Respond within {timeout}s. Type a number or free-form answer, then press Enter:")
+        raw = _read_line_with_timeout(deadline - time.monotonic())
+        response = DEFAULT_TIMEOUT_RESPONSE if raw is None else _resolve_choice_response(raw, choices, deadline)
+    else:
+        print(f"Respond within {timeout}s and press Enter:")
+        raw = _read_line_with_timeout(deadline - time.monotonic())
+        response = (raw or "").strip() or DEFAULT_TIMEOUT_RESPONSE
+
+    _write_response(response_path, response)
+    print()
+    print("Thanks — closing overlay.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4195,6 +4195,7 @@ Examples:
     hermes logout                 Clear stored authentication
     hermes auth add <provider>    Add a pooled credential
     hermes auth list              List pooled credentials
+    hermes auth view              Open compact Codex auth TUI
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
     hermes auth reset <provider>  Clear exhaustion status for a provider
     hermes model                  Select default model
@@ -4587,12 +4588,24 @@ For more help on a command:
     auth_add.add_argument("--timeout", type=float, help="OAuth/network timeout in seconds")
     auth_add.add_argument("--insecure", action="store_true", help="Disable TLS verification for OAuth login")
     auth_add.add_argument("--ca-bundle", help="Custom CA bundle for OAuth login")
-    auth_list = auth_subparsers.add_parser("list", help="List pooled credentials")
+    auth_list=auth_subparsers.add_parser("list", help="List pooled credentials")
     auth_list.add_argument("provider", nargs="?", help="Optional provider filter")
-    auth_remove = auth_subparsers.add_parser("remove", help="Remove a pooled credential by index, id, or label")
+    auth_view=auth_subparsers.add_parser(
+        "view",
+        aliases=["tui"],
+        help="Open a compact Codex auth TUI with live usage bars",
+    )
+    auth_view.add_argument(
+        "--provider",
+        default="openai-codex",
+        help="Auth provider to inspect (currently only openai-codex is supported)",
+    )
+    auth_view.add_argument("--timeout", type=float, default=10.0, help="Per-profile usage request timeout in seconds")
+    auth_view.add_argument("--smoke-test", action="store_true", help="Print a non-interactive snapshot instead of launching curses")
+    auth_remove=auth_subparsers.add_parser("remove", help="Remove a pooled credential by index, id, or label")
     auth_remove.add_argument("provider", help="Provider id")
     auth_remove.add_argument("target", help="Credential index, entry id, or exact label")
-    auth_reset = auth_subparsers.add_parser("reset", help="Clear exhaustion status for all credentials for a provider")
+    auth_reset=auth_subparsers.add_parser("reset", help="Clear exhaustion status for all credentials for a provider")
     auth_reset.add_argument("provider", help="Provider id")
     auth_parser.set_defaults(func=cmd_auth)
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -68,6 +68,7 @@ def _prompt(question: str, default: str = None, password: bool = False) -> str:
 # These map to keys in toolsets.py TOOLSETS dict.
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
+    ("docs",            "📚 Hermes Public Docs",        "hermes_docs_lookup (public upstream docs/code)"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),
@@ -91,6 +92,10 @@ CONFIGURABLE_TOOLSETS = [
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
 _DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl"}
+
+# New built-in toolsets that should default to enabled for existing configs
+# until the user has seen/saved them explicitly once.
+_NEW_DEFAULT_ON_BUILTIN_TOOLSETS = {"docs"}
 
 
 def _get_effective_configurable_toolsets():
@@ -510,6 +515,12 @@ def _get_platform_tools(
 
     if has_explicit_config:
         enabled_toolsets = {ts for ts in toolset_names if ts in configurable_keys}
+
+        known_builtin_map = config.get("known_builtin_toolsets", {})
+        known_builtin_for_platform = set(known_builtin_map.get(platform, []))
+        for ts in _NEW_DEFAULT_ON_BUILTIN_TOOLSETS:
+            if ts in configurable_keys and ts not in toolset_names and ts not in known_builtin_for_platform:
+                enabled_toolsets.add(ts)
     else:
         # No explicit config — fall back to resolving composite toolset names
         # (e.g. "hermes-cli") to individual tool names and reverse-mapping.
@@ -612,6 +623,13 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
 
     # Merge preserved entries with new enabled toolsets
     config["platform_toolsets"][platform] = sorted(enabled_toolset_keys | preserved_entries)
+
+    # Track which built-in configurable toolsets are "known" for this platform
+    # so newly introduced default-on built-ins (e.g. docs lookup) can auto-enable
+    # once, then respect later user disables after the next save.
+    builtin_configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    config.setdefault("known_builtin_toolsets", {})
+    config["known_builtin_toolsets"][platform] = sorted(builtin_configurable_keys)
 
     # Track which plugin toolsets are "known" for this platform so we can
     # distinguish "new plugin, default enabled" from "user disabled it".

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,7 +23,7 @@ import threading
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -381,6 +381,68 @@ class SessionDB:
             )
         self._execute_write(_do)
         return session_id
+
+    def clone_session(
+        self,
+        source_session_id: str,
+        new_session_id: str,
+        *,
+        source: str,
+        title: str | None = None,
+        model: str = None,
+        model_config: Dict[str, Any] = None,
+        system_prompt: str = None,
+        user_id: str = None,
+        parent_session_id: str | None = None,
+        messages: Iterable[Dict[str, Any]] | None = None,
+    ) -> str:
+        """Clone a session's transcript into a new child session.
+
+        Creates the child session record, copies the provided messages (or loads
+        them from ``source_session_id`` when omitted), preserves the parent
+        linkage, and optionally sets a title. It does not end or switch the
+        source session.
+        """
+        parent_id = parent_session_id or source_session_id
+        self.create_session(
+            session_id=new_session_id,
+            source=source,
+            model=model,
+            model_config=model_config,
+            system_prompt=system_prompt,
+            user_id=user_id,
+            parent_session_id=parent_id,
+        )
+
+        source_messages = (
+            list(messages)
+            if messages is not None
+            else self.get_messages_as_conversation(source_session_id)
+        )
+        for msg in source_messages:
+            try:
+                self.append_message(
+                    session_id=new_session_id,
+                    role=msg.get("role", "user"),
+                    content=msg.get("content"),
+                    tool_name=msg.get("tool_name") or msg.get("name"),
+                    tool_calls=msg.get("tool_calls"),
+                    tool_call_id=msg.get("tool_call_id"),
+                    finish_reason=msg.get("finish_reason"),
+                    reasoning=msg.get("reasoning"),
+                    reasoning_details=msg.get("reasoning_details"),
+                    codex_reasoning_items=msg.get("codex_reasoning_items"),
+                )
+            except Exception:
+                pass  # Best-effort copy
+
+        if title:
+            try:
+                self.set_session_title(new_session_id, title)
+            except Exception:
+                pass
+
+        return new_session_id
 
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended."""

--- a/model_tools.py
+++ b/model_tools.py
@@ -140,6 +140,7 @@ def _discover_tools():
         "tools.terminal_tool",
         "tools.file_tools",
         "tools.vision_tools",
+        "tools.native_image_tool",
         "tools.mixture_of_agents_tool",
         "tools.image_generation_tool",
         "tools.skills_tool",
@@ -235,6 +236,7 @@ def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    excluded_tool_names: Optional[List[str] | set[str] | tuple[str, ...]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -245,6 +247,10 @@ def get_tool_definitions(
         enabled_toolsets: Only include tools from these toolsets.
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
+        excluded_tool_names: Tool names to remove after toolset resolution,
+            regardless of which toolsets are enabled. Useful for runtime-aware
+            capability filtering (for example, hiding vision_analyze when the
+            active model already accepts native image input).
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -292,6 +298,10 @@ def get_tool_definitions(
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
+    excluded_tool_names = {str(name) for name in (excluded_tool_names or []) if str(name)}
+    if excluded_tool_names:
+        tools_to_include.difference_update(excluded_tool_names)
+
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()
     # all check the tool registry for plugin-provided toolsets.  No bypass
@@ -300,6 +310,11 @@ def get_tool_definitions(
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    if excluded_tool_names:
+        filtered_tools = [
+            tool for tool in filtered_tools
+            if tool.get("function", {}).get("name") not in excluded_tool_names
+        ]
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
@@ -340,6 +355,20 @@ def get_tool_definitions(
                     }
                     break
 
+    if "read_file" in available_tool_names and "vision_analyze" not in available_tool_names:
+        for i, td in enumerate(filtered_tools):
+            if td.get("function", {}).get("name") == "read_file":
+                desc = td["function"].get("description", "")
+                desc = desc.replace(
+                    " NOTE: Cannot read images or binary files — use vision_analyze for images.",
+                    " NOTE: Cannot read images or binary files.",
+                )
+                filtered_tools[i] = {
+                    "type": "function",
+                    "function": {**td["function"], "description": desc},
+                }
+                break
+
     if not quiet_mode:
         if filtered_tools:
             tool_names = [t["function"]["name"] for t in filtered_tools]
@@ -361,7 +390,7 @@ def get_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "attach_image"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -146,6 +146,7 @@ def _discover_tools():
         "tools.skills_tool",
         "tools.skill_manager_tool",
         "tools.browser_tool",
+        "tools.hermes_docs_lookup_tool",
         "tools.cronjob_tools",
         "tools.rl_training_tool",
         "tools.tts_tool",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@askjo/camoufox-browser": "^1.0.0",
         "agent-browser": "^0.13.0"
       },
       "engines": {
@@ -37,6 +38,26 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
+    },
+    "node_modules/@askjo/camoufox-browser": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@askjo/camoufox-browser/-/camoufox-browser-1.0.12.tgz",
+      "integrity": "sha512-MxRvjK6SkX6zJSNleoO32g9iwhJAcXpaAgj4pik7y2SrYXqcHllpG7FfLkKE7d5bnBt7pO82rdarVYu6xtW2RA==",
+      "deprecated": "Renamed to @askjo/camofox-browser",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "camoufox-js": "^0.8.5",
+        "dotenv": "^17.2.3",
+        "express": "^4.18.2",
+        "playwright": "^1.50.0",
+        "playwright-core": "^1.58.0",
+        "playwright-extra": "^4.3.6",
+        "puppeteer-extra-plugin-stealth": "^2.11.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -105,10 +126,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -263,6 +311,28 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -357,6 +427,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
@@ -522,6 +607,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/basic-ftp": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
@@ -531,10 +628,133 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -550,6 +770,39 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer": {
@@ -590,6 +843,188 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camoufox-js": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/camoufox-js/-/camoufox-js-0.8.5.tgz",
+      "integrity": "sha512-20ihPbspAcOVSUTX9Drxxp0C116DON1n8OVA1eUDglWZiHwiHwFVFOMrIEBwAHMZpU11mIEH/kawJtstRIrDPA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "better-sqlite3": "^12.2.0",
+        "commander": "^14.0.0",
+        "fingerprint-generator": "^2.1.66",
+        "glob": "^13.0.0",
+        "impit": "^0.7.0",
+        "language-tags": "^2.0.1",
+        "maxmind": "^5.0.0",
+        "progress": "^2.0.3",
+        "ua-parser-js": "^2.0.2",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "camoufox-js": "dist/__main__.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "playwright-core": "*"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/lru-cache": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.1.tgz",
+      "integrity": "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001786",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
+      "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -644,6 +1079,12 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -732,6 +1173,22 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
+      "license": "MIT",
+      "dependencies": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -775,11 +1232,53 @@
         "node": ">= 14"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -924,6 +1423,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -945,6 +1477,54 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dom-serializer": {
@@ -1000,6 +1580,47 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -1092,11 +1713,32 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
@@ -1132,6 +1774,36 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1140,6 +1812,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -1193,6 +1871,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1219,6 +1906,76 @@
       "dependencies": {
         "bare-events": "^2.7.0"
       }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -1296,6 +2053,80 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fingerprint-generator": {
+      "version": "2.1.82",
+      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.82.tgz",
+      "integrity": "sha512-5Z/yCKW324pMyMarpIKe/QPdkrFWKNJv3ktdU+fXHri80+HAwNE6QhMvEvsMkK9Q8DeCXZlpPHV77UBa1nFb4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "generative-bayesian-network": "^2.1.82",
+        "header-generator": "^2.1.82",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1310,6 +2141,73 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/geckodriver": {
@@ -1333,6 +2231,16 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/generative-bayesian-network": {
+      "version": "2.1.82",
+      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.82.tgz",
+      "integrity": "sha512-DH4NrmQheoMaJErdVv2IzaqkbOYSDQZmiZTV6UPDJYRDK2EyPpIQ88XRcYdPeFrUjS1N0Jj25H3HUywoJ1dbow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.9",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1340,6 +2248,30 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-port": {
@@ -1352,6 +2284,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -1383,6 +2328,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -1404,6 +2355,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1423,6 +2386,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/header-generator": {
+      "version": "2.1.82",
+      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.82.tgz",
+      "integrity": "sha512-4NjPB0+bAKjPoponSmTOkK58IEF2W22sOJA5O48k/MxbCZgOm+jrU4WVR53Z2I6xFgIPkVrQmKtt1LAbWtfqXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "browserslist": "^4.21.1",
+        "generative-bayesian-network": "^2.1.82",
+        "ow": "^0.28.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/htmlfy": {
@@ -1460,6 +2462,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -1526,6 +2548,153 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
     },
+    "node_modules/impit": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit/-/impit-0.7.6.tgz",
+      "integrity": "sha512-AkS6Gv63+E6GMvBrcRhMmOREKpq5oJ0J5m3xwfkHiEs97UIsbpEqFmW3sFw/sdyOTDGRF5q4EjaLxtb922Ta8g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "impit-darwin-arm64": "0.7.6",
+        "impit-darwin-x64": "0.7.6",
+        "impit-linux-arm64-gnu": "0.7.6",
+        "impit-linux-arm64-musl": "0.7.6",
+        "impit-linux-x64-gnu": "0.7.6",
+        "impit-linux-x64-musl": "0.7.6",
+        "impit-win32-arm64-msvc": "0.7.6",
+        "impit-win32-x64-msvc": "0.7.6"
+      }
+    },
+    "node_modules/impit-darwin-arm64": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.7.6.tgz",
+      "integrity": "sha512-M7NQXkttyzqilWfzVkNCp7hApT69m0etyJkVpHze4bR5z1kJnHhdsb8BSdDv2dzvZL4u1JyqZNxq+qoMn84eUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-darwin-x64": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.7.6.tgz",
+      "integrity": "sha512-kikTesWirAwJp9JPxzGLoGVc+heBlEabWS5AhTkQedACU153vmuL90OBQikVr3ul2N0LPImvnuB+51wV0zDE6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-gnu": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.7.6.tgz",
+      "integrity": "sha512-H6GHjVr/0lG9VEJr6IHF8YLq+YkSIOF4k7Dfue2ygzUAj1+jZ5ZwnouhG/XrZHYW6EWsZmEAjjRfWE56Q0wDRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-musl": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.7.6.tgz",
+      "integrity": "sha512-1sCB/UBVXLZTpGJsXRdNNSvhN9xmmQcYLMWAAB4Itb7w684RHX1pLoCb6ichv7bfAf6tgaupcFIFZNBp3ghmQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-gnu": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.7.6.tgz",
+      "integrity": "sha512-yYhlRnZ4fhKt8kuGe0JK2WSHc8TkR6BEH0wn+guevmu8EOn9Xu43OuRvkeOyVAkRqvFnlZtMyySUo/GuSLz9Gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-musl": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.7.6.tgz",
+      "integrity": "sha512-sdGWyu+PCLmaOXy7Mzo4WP61ZLl5qpZ1L+VeXW+Ycazgu0e7ox0NZLdiLRunIrEzD+h0S+e4CyzNwaiP3yIolg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-arm64-msvc": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.7.6.tgz",
+      "integrity": "sha512-sM5deBqo0EuXg5GACBUMKEua9jIau/i34bwNlfrf/Amnw1n0GB4/RkuUh+sKiUcbNAntrRq+YhCq8qDP8IW19w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-x64-msvc": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.7.6.tgz",
+      "integrity": "sha512-ry63ADGLCB/PU/vNB1VioRt2V+klDJ34frJUXUZBEv1kA96HEAg9AxUk+604o+UHS3ttGH2rkLmrbwHOdAct5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -1536,10 +2705,27 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -1551,10 +2737,43 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1571,6 +2790,38 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -1599,6 +2850,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -1621,6 +2881,18 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jszip": {
@@ -1663,6 +2935,45 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-2.1.0.tgz",
+      "integrity": "sha512-D4CgpyCt+61f6z2jHjJS1OmZPviAWM57iJ9OKdFFWSNgS7Udj9QVWqyGs/cveVNF57XpZmhSvMdVIV5mjLA7Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lazystream": {
@@ -1749,6 +3060,13 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.zip": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
@@ -1780,6 +3098,115 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/maxmind": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-5.0.6.tgz",
+      "integrity": "sha512-5bvd/u+kIaTqaGM+xkXjatzQw1dQfSmlLggr2W1EKMyMxSgx2woZyusLpNpZ4DdPmL+1bbJWeo4LXsi6bC0Iew==",
+      "license": "MIT",
+      "dependencies": {
+        "mmdb-lib": "3.0.2",
+        "tiny-lru": "13.0.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -1793,6 +3220,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -1810,6 +3246,44 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
+    "node_modules/mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-object/node_modules/for-in": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/mmdb-lib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-3.0.2.tgz",
+      "integrity": "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/modern-tar": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.4.tgz",
@@ -1825,6 +3299,21 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -1833,6 +3322,24 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "license": "MIT"
     },
     "node_modules/node-simctl": {
       "version": "7.7.5",
@@ -1877,6 +3384,30 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1884,6 +3415,25 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/ow": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.2.tgz",
+      "integrity": "sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.2.0",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "vali-date": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -1979,6 +3529,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
@@ -1992,6 +3551,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -2019,22 +3587,145 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright-extra": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
+      "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "playwright-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/process": {
@@ -2059,6 +3750,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/proxy-agent": {
@@ -2105,11 +3809,242 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/puppeteer-extra-plugin": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
+      "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=9.11.2"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-stealth": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
+      "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-preferences": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
+      "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-preferences": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
+      "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/readable-stream": {
       "version": "4.7.0",
@@ -2250,6 +4185,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2261,6 +4205,45 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/serialize-error": {
       "version": "12.0.0",
@@ -2289,6 +4272,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -2300,6 +4298,48 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2334,6 +4374,78 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2344,6 +4456,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/smart-buffer": {
@@ -2426,6 +4583,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/streamx": {
@@ -2544,6 +4710,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
@@ -2628,11 +4803,41 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tiny-lru": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-13.0.0.tgz",
+      "integrity": "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-fest": {
       "version": "4.26.0",
@@ -2644,6 +4849,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
+      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/undici": {
@@ -2660,6 +4929,54 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/urlpattern-polyfill": {
       "version": "10.1.0",
@@ -2682,6 +4999,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -2693,6 +5019,24 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/wait-port": {
@@ -2971,6 +5315,28 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -127,6 +127,10 @@ class HonchoMemoryProvider(MemoryProvider):
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
         self._sync_thread: Optional[threading.Thread] = None
+        self._init_thread: Optional[threading.Thread] = None
+        self._init_lock = threading.Lock()
+        self._pending_sync_turns: list[tuple[str, str]] = []
+        self._pending_sync_lock = threading.Lock()
 
         # B1: recall_mode — set during initialize from config
         self._recall_mode = "hybrid"  # "context", "tools", or "hybrid"
@@ -257,13 +261,61 @@ class HonchoMemoryProvider(MemoryProvider):
                 return
 
             # ----- Eager init (context or hybrid mode) -----
-            self._do_session_init(cfg, session_id, **kwargs)
+            # Honcho can be slow or unavailable, and its SDK defaults to 60s
+            # request timeouts. Run startup in the background so the first
+            # Hermes prompt doesn't appear stuck on "Initializing agent...".
+            with self._init_lock:
+                if self._session_initialized:
+                    return
+                if self._init_thread and self._init_thread.is_alive():
+                    return
+
+                def _run_init() -> None:
+                    try:
+                        self._do_session_init(cfg, session_id, **kwargs)
+                    except Exception as e:
+                        logger.warning("Honcho init failed: %s", e)
+                        self._manager = None
+                    finally:
+                        self._flush_pending_sync_turns()
+
+                self._init_thread = threading.Thread(
+                    target=_run_init,
+                    daemon=True,
+                    name="honcho-init",
+                )
+                self._init_thread.start()
 
         except ImportError:
             logger.debug("honcho-ai package not installed — plugin inactive")
         except Exception as e:
             logger.warning("Honcho init failed: %s", e)
             self._manager = None
+
+    def _flush_pending_sync_turns(self) -> None:
+        """Flush turns queued while background Honcho init was still running."""
+        with self._pending_sync_lock:
+            pending = list(self._pending_sync_turns)
+            self._pending_sync_turns.clear()
+
+        if not pending or not self._manager or not self._session_key:
+            return
+
+        for user_content, assistant_content in pending:
+            try:
+                self._sync_turn_now(user_content, assistant_content)
+            except Exception as e:
+                logger.debug("Honcho delayed sync_turn failed: %s", e)
+
+    def _sync_turn_now(self, user_content: str, assistant_content: str) -> None:
+        """Write a turn to Honcho immediately using the active session."""
+        session = self._manager.get_or_create(self._session_key)
+        msg_limit = self._config.message_max_chars if self._config else 25000
+        for chunk in self._chunk_message(user_content, msg_limit):
+            session.add_message("user", chunk)
+        for chunk in self._chunk_message(assistant_content, msg_limit):
+            session.add_message("assistant", chunk)
+        self._manager._flush_session(session)
 
     def _do_session_init(self, cfg, session_id: str, **kwargs) -> None:
         """Shared session initialization logic for both eager and lazy paths."""
@@ -571,18 +623,14 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._cron_skipped:
             return
         if not self._manager or not self._session_key:
+            if self._init_thread and self._init_thread.is_alive():
+                with self._pending_sync_lock:
+                    self._pending_sync_turns.append((user_content, assistant_content))
             return
-
-        msg_limit = self._config.message_max_chars if self._config else 25000
 
         def _sync():
             try:
-                session = self._manager.get_or_create(self._session_key)
-                for chunk in self._chunk_message(user_content, msg_limit):
-                    session.add_message("user", chunk)
-                for chunk in self._chunk_message(assistant_content, msg_limit):
-                    session.add_message("assistant", chunk)
-                self._manager._flush_session(session)
+                self._sync_turn_now(user_content, assistant_content)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)
 
@@ -647,6 +695,8 @@ class HonchoMemoryProvider(MemoryProvider):
                 return tool_error("Honcho session could not be initialized.")
 
         if not self._manager or not self._session_key:
+            if self._init_thread and self._init_thread.is_alive():
+                return tool_error("Honcho is still initializing in the background.")
             return tool_error("Honcho is not active for this session.")
 
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -73,6 +73,7 @@ from tools.browser_tool import cleanup_browser
 
 
 from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli.fast_mode import normalize_service_tier, responses_api_service_tier
 
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block
@@ -490,6 +491,7 @@ class AIAgent:
         tool_gen_callback: callable = None,
         status_callback: callable = None,
         max_tokens: int = None,
+        service_tier: str = None,
         reasoning_config: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
@@ -559,6 +561,7 @@ class AIAgent:
         self.ephemeral_system_prompt = ephemeral_system_prompt
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
         self._user_id = user_id  # Platform user identifier (gateway sessions)
+        self.service_tier = normalize_service_tier(service_tier)
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
         # instead of going directly to stdout where patch_stdout's StdoutProxy
@@ -3272,6 +3275,7 @@ class AIAgent:
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
             "tool_choice", "parallel_tool_calls", "prompt_cache_key",
+            "service_tier",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -3303,6 +3307,12 @@ class AIAgent:
             val = api_kwargs.get(passthrough_key)
             if val is not None:
                 normalized[passthrough_key] = val
+
+        service_tier = api_kwargs.get("service_tier")
+        if service_tier is not None:
+            if not isinstance(service_tier, str) or service_tier not in {"priority", "flex"}:
+                raise ValueError("Codex Responses 'service_tier' must be 'priority' or 'flex' when set.")
+            normalized["service_tier"] = service_tier
 
         if allow_stream:
             stream = api_kwargs.get("stream")
@@ -5371,6 +5381,15 @@ class AIAgent:
 
             if not is_github_responses:
                 kwargs["prompt_cache_key"] = self.session_id
+
+            api_service_tier = responses_api_service_tier(self.service_tier)
+            if api_service_tier and not is_github_responses:
+                base_url_lower = (self.base_url or "").lower()
+                if (
+                    self._is_direct_openai_url(self.base_url)
+                    or "chatgpt.com/backend-api/codex" in base_url_lower
+                ):
+                    kwargs["service_tier"] = api_service_tier
 
             if reasoning_enabled:
                 if is_github_responses:

--- a/run_agent.py
+++ b/run_agent.py
@@ -624,7 +624,8 @@ class AIAgent:
         self.stream_delta_callback = stream_delta_callback
         self.status_callback = status_callback
         self.tool_gen_callback = tool_gen_callback
-
+        self._last_reported_tool = None  # Track for "new tool" mode
+        self._credential_pool_401_refresh_attempted_ids = set()
         
         # Tool execution state — allows _vprint during tool execution
         # even when stream consumers are registered (no tokens streaming then)
@@ -4183,8 +4184,50 @@ class AIAgent:
             return False, True
 
         if status_code == 401:
+            pool_provider = getattr(pool, "provider", "")
+            current_entry_getter = getattr(pool, "current", None)
+            current_entry = current_entry_getter() if callable(current_entry_getter) else None
+            current_id = getattr(current_entry, "id", None)
+            refreshed_401_ids = getattr(self, "_credential_pool_401_refresh_attempted_ids", None)
+            if not isinstance(refreshed_401_ids, set):
+                refreshed_401_ids = set()
+                self._credential_pool_401_refresh_attempted_ids = refreshed_401_ids
+
+            if current_id and current_id in refreshed_401_ids:
+                if pool_provider == "openai-codex":
+                    self._emit_status("🔁 Codex auth still failing after refresh — switching accounts...")
+                elif pool_provider == "anthropic":
+                    self._emit_status("🔁 Anthropic auth still failing after refresh — switching credentials...")
+                elif pool_provider == "nous":
+                    self._emit_status("🔁 Nous auth still failing after refresh — switching credentials...")
+                else:
+                    self._emit_status("🔁 Provider auth still failing after refresh — switching credentials...")
+
+                next_entry = pool.mark_exhausted_and_rotate(status_code=401)
+                if next_entry is not None:
+                    logger.info(
+                        "Credential 401 persisted after refresh — rotated from pool entry %s to %s",
+                        current_id or "?",
+                        getattr(next_entry, "id", "?"),
+                    )
+                    refreshed_401_ids.discard(current_id)
+                    self._swap_credential(next_entry)
+                    return True, False
+                return False, has_retried_429
+
+            if pool_provider == "openai-codex":
+                self._emit_status("🔐 Refreshing Codex auth after 401...")
+            elif pool_provider == "anthropic":
+                self._emit_status("🔐 Refreshing Anthropic credentials after 401...")
+            elif pool_provider == "nous":
+                self._emit_status("🔐 Refreshing Nous credentials after 401...")
+            else:
+                self._emit_status("🔐 Refreshing provider credentials after 401...")
             refreshed = pool.try_refresh_current()
             if refreshed is not None:
+                refreshed_id = getattr(refreshed, "id", None) or current_id
+                if refreshed_id:
+                    refreshed_401_ids.add(refreshed_id)
                 logger.info(f"Credential 401 — refreshed pool entry {getattr(refreshed, 'id', '?')}")
                 self._swap_credential(refreshed)
                 return True, has_retried_429
@@ -4193,6 +4236,8 @@ class AIAgent:
             next_entry = pool.mark_exhausted_and_rotate(status_code=401, error_context=error_context)
             if next_entry is not None:
                 logger.info(f"Credential 401 (refresh failed) — rotated to pool entry {getattr(next_entry, 'id', '?')}")
+                if current_id:
+                    refreshed_401_ids.discard(current_id)
                 self._swap_credential(next_entry)
                 return True, False
 
@@ -7414,11 +7459,12 @@ class AIAgent:
             max_retries = 3
             primary_recovery_attempted = False
             max_compression_attempts = 3
-            codex_auth_retry_attempted=False
-            anthropic_auth_retry_attempted=False
-            nous_auth_retry_attempted=False
+            codex_auth_retry_attempted = False
+            anthropic_auth_retry_attempted = False
+            nous_auth_retry_attempted = False
             thinking_sig_retry_attempted = False
             has_retried_429 = False
+            self._credential_pool_401_refresh_attempted_ids.clear()
             restart_with_compressed_messages = False
             restart_with_length_continuation = False
 
@@ -7966,6 +8012,7 @@ class AIAgent:
                     if (
                         self.api_mode == "codex_responses"
                         and self.provider == "openai-codex"
+                        and self._credential_pool is None
                         and status_code == 401
                         and not codex_auth_retry_attempted
                     ):
@@ -7976,6 +8023,7 @@ class AIAgent:
                     if (
                         self.api_mode == "chat_completions"
                         and self.provider == "nous"
+                        and self._credential_pool is None
                         and status_code == 401
                         and not nous_auth_retry_attempted
                     ):
@@ -7985,6 +8033,7 @@ class AIAgent:
                             continue
                     if (
                         self.api_mode == "anthropic_messages"
+                        and self._credential_pool is None
                         and status_code == 401
                         and hasattr(self, '_anthropic_api_key')
                         and not anthropic_auth_retry_attempted

--- a/run_agent.py
+++ b/run_agent.py
@@ -240,7 +240,7 @@ from agent.memory_manager import build_memory_context_block
 from agent.retry_utils import jittered_backoff
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
-    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, HERMES_DOCS_LOOKUP_GUIDANCE, SKILLS_GUIDANCE,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
@@ -2916,6 +2916,8 @@ class AIAgent:
             tool_guidance.append(MEMORY_GUIDANCE)
         if "session_search" in self.valid_tool_names:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
+        if "hermes_docs_lookup" in self.valid_tool_names:
+            tool_guidance.append(HERMES_DOCS_LOOKUP_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
         if tool_guidance:

--- a/run_agent.py
+++ b/run_agent.py
@@ -493,6 +493,7 @@ class AIAgent:
         max_tokens: int = None,
         service_tier: str = None,
         reasoning_config: Dict[str, Any] = None,
+        extra_body_config: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
         user_id: str = None,
@@ -538,6 +539,8 @@ class AIAgent:
             max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
             reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
                 If None, defaults to {"enabled": True, "effort": "medium"} for OpenRouter. Set to disable/customize reasoning.
+            extra_body_config (Dict): Extra OpenAI-compatible request fields to merge into `extra_body` for each call.
+                Useful for local routes that need flags like chat_template_kwargs.enable_thinking=false.
             prefill_messages (List[Dict]): Messages to prepend to conversation history as prefilled context.
                 Useful for injecting a few-shot example or priming the model's response style.
                 Example: [{"role": "user", "content": "Hi!"}, {"role": "assistant", "content": "Hello!"}]
@@ -656,6 +659,7 @@ class AIAgent:
         # Model response configuration
         self.max_tokens = max_tokens  # None = use model default
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
+        self.extra_body_config = copy.deepcopy(extra_body_config or {})
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         
         # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
@@ -5658,7 +5662,7 @@ class AIAgent:
             except Exception:
                 pass  # fail open — let OpenRouter pick its default
 
-        extra_body = {}
+        extra_body = copy.deepcopy(self.extra_body_config or {})
 
         _is_openrouter = self._is_openrouter_url()
         _is_github_models = (

--- a/run_agent.py
+++ b/run_agent.py
@@ -27,7 +27,7 @@ import copy
 import hashlib
 import json
 import logging
-logger = logging.getLogger(__name__)
+import mimetypes
 import os
 import random
 import re
@@ -38,12 +38,172 @@ import threading
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
-from openai import OpenAI
-import fire
 from datetime import datetime
 from pathlib import Path
+from openai import OpenAI
+import fire
+
+logger = logging.getLogger(__name__)
+
+
+def supports_native_multimodal_input(*, provider: Any = None, api_mode: Any = None, base_url: Any = None) -> bool:
+    """True when the active runtime should receive native image input.
+
+    Today this is intentionally narrow: Codex/OpenAI-style Responses routes,
+    excluding GitHub/Copilot's Responses endpoint.
+    """
+    normalized_mode = str(api_mode or "").strip().lower()
+    if normalized_mode != "codex_responses":
+        return False
+
+    provider_name = str(provider or "").strip().lower()
+    base = str(base_url or "").strip().lower()
+    if provider_name == "copilot":
+        return False
+    if "models.github.ai" in base or "api.githubcopilot.com" in base:
+        return False
+    return True
+
+
+def message_content_to_text(content: Any) -> str:
+    """Best-effort text rendering for logs, memory hooks, and previews."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            if part:
+                parts.append(part)
+            continue
+        if not isinstance(part, dict):
+            continue
+        ptype = str(part.get("type", "") or "")
+        if ptype in {"text", "input_text"}:
+            text = str(part.get("text", "") or "")
+            if text:
+                parts.append(text)
+        elif ptype in {"image_url", "input_image"}:
+            parts.append("[image]")
+
+    return " ".join(p for p in parts if p).strip()
+
+
+def summarize_last_user_turn(messages: List[Dict[str, Any]], *, preview_limit: int = 60) -> Optional[Dict[str, Any]]:
+    """Return metadata for the last visible user turn in a transcript/history.
+
+    Hermes stores full internal agent loops (assistant tool-call messages, tool
+    results, intermediate assistant messages) after each user turn.  Commands
+    like /undo operate on the whole trailing slice, but the UX should still talk
+    in terms of one visible user turn.
+    """
+    if not isinstance(messages, list) or not messages:
+        return None
+
+    last_user_idx = None
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "user":
+            continue
+        if msg.get("_native_image_attachment"):
+            continue
+        last_user_idx = i
+        break
+
+    if last_user_idx is None:
+        return None
+
+    removed = messages[last_user_idx:]
+    preview_text = message_content_to_text(messages[last_user_idx].get("content", ""))
+    preview_text = " ".join(preview_text.split()) or "[empty message]"
+    if len(preview_text) > preview_limit:
+        preview_text = preview_text[:preview_limit] + "..."
+
+    return {
+        "start_idx": last_user_idx,
+        "removed_count": len(removed),
+        "removed_messages": removed,
+        "truncated_history": messages[:last_user_idx],
+        "preview": preview_text,
+        "original_content": messages[last_user_idx].get("content", ""),
+    }
+
+
+def format_internal_transcript_message_count(count: int) -> str:
+    noun = "message" if count == 1 else "messages"
+    return f"{count} internal transcript {noun}"
+
+
+def _content_text_part_type(content: Any) -> str:
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and str(part.get("type", "")).startswith("input_"):
+                return "input_text"
+    return "text"
+
+
+def prepend_text_to_message_content(content: Any, text: str) -> Any:
+    text = str(text or "").strip()
+    if not text:
+        return content
+    if isinstance(content, list):
+        return [{"type": _content_text_part_type(content), "text": text}, *content]
+    base = message_content_to_text(content)
+    return f"{text}\n\n{base}" if base else text
+
+
+def append_text_to_message_content(content: Any, text: str) -> Any:
+    text = str(text or "").strip()
+    if not text:
+        return content
+    if isinstance(content, list):
+        return [*content, {"type": _content_text_part_type(content), "text": text}]
+    base = message_content_to_text(content)
+    return f"{base}\n\n{text}" if base else text
+
+
+def _coerce_image_reference_to_data_url(image_ref: Any) -> str:
+    raw = str(image_ref or "").strip()
+    if not raw or raw.startswith("data:") or re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", raw):
+        return raw
+
+    path = Path(os.path.expanduser(raw))
+    if not path.exists() or not path.is_file():
+        return raw
+
+    from tools.vision_tools import _image_to_base64_data_url
+
+    return _image_to_base64_data_url(path)
+
+
+def build_native_multimodal_user_content(text: str, image_paths: List[Any]) -> List[Dict[str, Any]]:
+    content: List[Dict[str, Any]] = []
+    if isinstance(text, str) and text:
+        content.append({"type": "text", "text": text})
+    for image_path in image_paths or []:
+        image_url = _coerce_image_reference_to_data_url(image_path)
+        if image_url:
+            content.append({"type": "image_url", "image_url": {"url": image_url}})
+    return content
+
+
+_NATIVE_IMAGE_EXTENSIONS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".svg", ".ico"
+}
+_NATIVE_IMAGE_ATTACH_PROMPT = (
+    "[Internal: Inspect the attached image and continue the current task. "
+    "Treat it as fresh visual context from a previous tool step.]"
+)
+
 
 from hermes_constants import get_hermes_home
+
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -212,7 +372,7 @@ class IterationBudget:
 
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.
-_NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
+_NEVER_PARALLEL_TOOLS = frozenset({"clarify", "attach_image"})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
@@ -884,16 +1044,13 @@ class AIAgent:
                       " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain))
 
         # Get available tools with filtering
-        self.tools = get_tool_definitions(
-            enabled_toolsets=enabled_toolsets,
-            disabled_toolsets=disabled_toolsets,
-            quiet_mode=self.quiet_mode,
-        )
+        self.tools = []
+        self.valid_tool_names = set()
+        self._pending_native_images: list[dict[str, str]] = []
+        self.refresh_tool_surface(quiet_mode=self.quiet_mode, invalidate_prompt=False)
         
         # Show tool configuration and store valid tool names for validation
-        self.valid_tool_names = set()
         if self.tools:
-            self.valid_tool_names = {tool["function"]["name"] for tool in self.tools}
             tool_names = sorted(self.valid_tool_names)
             if not self.quiet_mode:
                 print(f"🛠️  Loaded {len(self.tools)} tools: {', '.join(tool_names)}")
@@ -1387,8 +1544,7 @@ class AIAgent:
                 new_context_length * self.context_compressor.threshold_percent
             )
 
-        # ── Invalidate cached system prompt so it rebuilds next turn ──
-        self._cached_system_prompt = None
+        self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
 
         # ── Update _primary_runtime so the change persists across turns ──
         _cc = self.context_compressor if hasattr(self, "context_compressor") and self.context_compressor else None
@@ -3008,6 +3164,108 @@ class AIAgent:
 
         return None
 
+    def _runtime_excluded_tool_names(self) -> set[str]:
+        """Tool names to hide for the current runtime's native capabilities."""
+        excluded: set[str] = set()
+        if supports_native_multimodal_input(
+            provider=self.provider,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        ):
+            excluded.add("vision_analyze")
+        else:
+            excluded.add("attach_image")
+        return excluded
+
+    @staticmethod
+    def _native_image_attachment_prompt(entries: List[Dict[str, str]]) -> str:
+        notes = [str(entry.get("note") or "").strip() for entry in entries if str(entry.get("note") or "").strip()]
+        if not notes:
+            return _NATIVE_IMAGE_ATTACH_PROMPT
+        lines = [_NATIVE_IMAGE_ATTACH_PROMPT, "Notes:"]
+        lines.extend(f"- {note}" for note in notes[:6])
+        return "\n".join(lines)
+
+    def _queue_native_image_attachment(self, image_path: str, *, note: str | None = None) -> Dict[str, Any]:
+        if not supports_native_multimodal_input(
+            provider=self.provider,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        ):
+            return {
+                "success": False,
+                "error": "Current runtime does not support native image input.",
+            }
+
+        raw_path = str(image_path or "").strip()
+        if not raw_path:
+            return {"success": False, "error": "Image path is required."}
+
+        resolved = Path(os.path.expanduser(raw_path))
+        if not resolved.exists() or not resolved.is_file():
+            return {"success": False, "error": f"Image file not found: {raw_path}"}
+
+        mime_type, _ = mimetypes.guess_type(str(resolved))
+        is_image = bool(mime_type and mime_type.startswith("image/")) or resolved.suffix.lower() in _NATIVE_IMAGE_EXTENSIONS
+        if not is_image:
+            return {"success": False, "error": f"File is not a supported image: {resolved.name}"}
+
+        entry = {"path": str(resolved), "note": str(note or "").strip()}
+        self._pending_native_images.append(entry)
+        return {
+            "success": True,
+            "queued": len(self._pending_native_images),
+            "image_path": str(resolved),
+            "note": entry["note"] or None,
+        }
+
+    def _flush_pending_native_images(self, messages: List[Dict[str, Any]]) -> bool:
+        if not self._pending_native_images:
+            return False
+        if not supports_native_multimodal_input(
+            provider=self.provider,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        ):
+            logger.debug("Pending native images exist but current runtime is not native-multimodal; leaving queue untouched")
+            return False
+
+        entries = list(self._pending_native_images)
+        self._pending_native_images.clear()
+        message = {
+            "role": "user",
+            "content": build_native_multimodal_user_content(
+                self._native_image_attachment_prompt(entries),
+                [entry["path"] for entry in entries],
+            ),
+            "_native_image_attachment": True,
+        }
+        messages.append(message)
+        return True
+
+    def refresh_tool_surface(
+        self,
+        *,
+        quiet_mode: Optional[bool] = None,
+        invalidate_prompt: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Rebuild the current tool surface, applying runtime-aware exclusions."""
+        quiet = self.quiet_mode if quiet_mode is None else quiet_mode
+        previous_names = set(getattr(self, "valid_tool_names", set()) or set())
+        tools = get_tool_definitions(
+            enabled_toolsets=self.enabled_toolsets,
+            disabled_toolsets=self.disabled_toolsets,
+            quiet_mode=quiet,
+            excluded_tool_names=self._runtime_excluded_tool_names(),
+        )
+        self.tools = tools
+        self.valid_tool_names = {
+            tool["function"]["name"] for tool in tools or []
+        }
+        if invalidate_prompt and previous_names != self.valid_tool_names:
+            self._invalidate_system_prompt()
+        return self.tools
+
     def _invalidate_system_prompt(self):
         """
         Invalidate the cached system prompt, forcing a rebuild on the next turn.
@@ -3112,7 +3370,8 @@ class AIAgent:
 
             if role in {"user", "assistant"}:
                 content = msg.get("content", "")
-                content_text = str(content) if content is not None else ""
+                normalized_content = self._normalize_codex_content(content)
+                content_text = message_content_to_text(normalized_content)
 
                 if role == "assistant":
                     # Replay encrypted reasoning items from previous turns
@@ -3125,8 +3384,8 @@ class AIAgent:
                                 items.append(ri)
                                 has_codex_reasoning = True
 
-                    if content_text.strip():
-                        items.append({"role": "assistant", "content": content_text})
+                    if (isinstance(normalized_content, list) and normalized_content) or content_text.strip():
+                        items.append({"role": "assistant", "content": normalized_content})
                     elif has_codex_reasoning:
                         # The Responses API requires a following item after each
                         # reasoning item (otherwise: missing_following_item error).
@@ -3178,7 +3437,7 @@ class AIAgent:
                             })
                     continue
 
-                items.append({"role": role, "content": content_text})
+                items.append({"role": role, "content": normalized_content})
                 continue
 
             if role == "tool":
@@ -3269,6 +3528,11 @@ class AIAgent:
             role = item.get("role")
             if role in {"user", "assistant"}:
                 content = item.get("content", "")
+                if isinstance(content, list):
+                    normalized_content = self._normalize_codex_content(content)
+                    normalized.append({"role": role, "content": normalized_content})
+                    continue
+
                 if content is None:
                     content = ""
                 if not isinstance(content, str):
@@ -5092,6 +5356,8 @@ class AIAgent:
                     fb_context_length * self.context_compressor.threshold_percent
                 )
 
+            self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
+
             self._emit_status(
                 f"🔄 Primary model failed — switching to fallback: "
                 f"{fb_model} via {fb_provider}"
@@ -5157,6 +5423,8 @@ class AIAgent:
             cc.provider = rt["compressor_provider"]
             cc.context_length = rt["compressor_context_length"]
             cc.threshold_tokens = rt["compressor_threshold_tokens"]
+
+            self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
 
             # ── Reset fallback chain for the new turn ──
             self._fallback_activated = False
@@ -5265,6 +5533,38 @@ class AIAgent:
             if isinstance(part, dict) and part.get("type") in {"image_url", "input_image"}:
                 return True
         return False
+
+    @staticmethod
+    def _normalize_codex_content(content: Any) -> Any:
+        from agent.auxiliary_client import _convert_content_for_responses
+
+        if isinstance(content, list):
+            normalized_parts: List[Dict[str, Any]] = []
+            for part in content:
+                if isinstance(part, str):
+                    if part:
+                        normalized_parts.append({"type": "text", "text": part})
+                    continue
+                if not isinstance(part, dict):
+                    continue
+                normalized_part = dict(part)
+                ptype = str(normalized_part.get("type", "") or "")
+                if ptype == "image_url":
+                    image_data = normalized_part.get("image_url", {})
+                    if isinstance(image_data, dict):
+                        url = _coerce_image_reference_to_data_url(image_data.get("url"))
+                        normalized_part["image_url"] = {**image_data, "url": url}
+                    else:
+                        normalized_part["image_url"] = {"url": _coerce_image_reference_to_data_url(image_data)}
+                elif ptype == "input_image":
+                    normalized_part["image_url"] = _coerce_image_reference_to_data_url(
+                        normalized_part.get("image_url")
+                    )
+                normalized_parts.append(normalized_part)
+
+            return _convert_content_for_responses(normalized_parts)
+
+        return content if isinstance(content, str) else (str(content) if content is not None else "")
 
     @staticmethod
     def _materialize_data_url_for_vision(image_url: str) -> tuple[str, Optional[Path]]:
@@ -6292,6 +6592,14 @@ class AIAgent:
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
             )
+        elif function_name == "attach_image":
+            return json.dumps(
+                self._queue_native_image_attachment(
+                    function_args.get("path", ""),
+                    note=function_args.get("note"),
+                ),
+                ensure_ascii=False,
+            )
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -6524,6 +6832,8 @@ class AIAgent:
                 tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
                 print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
 
+        self._flush_pending_native_images(messages)
+
     def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
@@ -6692,6 +7002,17 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif function_name == "attach_image":
+                function_result = json.dumps(
+                    self._queue_native_image_attachment(
+                        function_args.get("path", ""),
+                        note=function_args.get("note"),
+                    ),
+                    ensure_ascii=False,
+                )
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('attach_image', function_args, tool_duration, result=function_result)}")
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.
@@ -6858,6 +7179,8 @@ class AIAgent:
                 remaining = self.max_iterations - api_call_count
                 tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
                 print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
+
+        self._flush_pending_native_images(messages)
 
     def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
         """Return a budget pressure string, or None if not yet needed.
@@ -7156,7 +7479,8 @@ class AIAgent:
         self.iteration_budget = IterationBudget(self.max_iterations)
 
         # Log conversation turn start for debugging/observability
-        _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
+        _user_message_text = message_content_to_text(user_message)
+        _msg_preview = (_user_message_text[:80] + "...") if len(_user_message_text) > 80 else _user_message_text
         _msg_preview = _msg_preview.replace("\n", " ")
         logger.info(
             "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
@@ -7192,6 +7516,7 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+        original_user_message_text = message_content_to_text(original_user_message)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
@@ -7212,7 +7537,9 @@ class AIAgent:
         self._persist_user_message_idx = current_turn_user_idx
         
         if not self.quiet_mode:
-            self._safe_print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
+            self._safe_print(
+                f"💬 Starting conversation: '{_user_message_text[:60]}{'...' if len(_user_message_text) > 60 else ''}'"
+            )
         
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.
@@ -7379,8 +7706,7 @@ class AIAgent:
         _ext_prefetch_cache = ""
         if self._memory_manager:
             try:
-                _query = original_user_message if isinstance(original_user_message, str) else ""
-                _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
+                _ext_prefetch_cache = self._memory_manager.prefetch_all(original_user_message_text) or ""
             except Exception:
                 pass
 
@@ -7460,8 +7786,10 @@ class AIAgent:
                         _injections.append(_plugin_user_context)
                     if _injections:
                         _base = api_msg.get("content", "")
-                        if isinstance(_base, str):
-                            api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                        api_msg["content"] = append_text_to_message_content(
+                            _base,
+                            "\n\n".join(_injections),
+                        )
 
                 # For ALL assistant messages, pass reasoning back to the API
                 # This ensures multi-turn reasoning context is preserved
@@ -7478,8 +7806,9 @@ class AIAgent:
                 # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
                 if "finish_reason" in api_msg:
                     api_msg.pop("finish_reason")
-                # Strip internal thinking-prefill marker
+                # Strip internal-only markers
                 api_msg.pop("_thinking_prefill", None)
+                api_msg.pop("_native_image_attachment", None)
                 # Strip Codex Responses API fields (call_id, response_item_id) for
                 # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
                 # Uses new dicts so the internal messages list retains the fields
@@ -9461,10 +9790,10 @@ class AIAgent:
         # External memory provider: sync the completed turn + queue next prefetch.
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
-        if self._memory_manager and final_response and original_user_message:
+        if self._memory_manager and final_response and original_user_message_text:
             try:
-                self._memory_manager.sync_all(original_user_message, final_response)
-                self._memory_manager.queue_prefetch_all(original_user_message)
+                self._memory_manager.sync_all(original_user_message_text, final_response)
+                self._memory_manager.queue_prefetch_all(original_user_message_text)
             except Exception:
                 pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1516,6 +1516,84 @@ class AIAgent:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 
+    def _api_max_retries(self) -> int:
+        """Return the configured outer API retry budget for a conversation turn."""
+        raw_value = os.getenv("HERMES_API_MAX_RETRIES", "20")
+        try:
+            parsed = int(raw_value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid HERMES_API_MAX_RETRIES=%r; falling back to 20",
+                raw_value,
+            )
+            return 20
+        return max(1, parsed)
+
+    def _infer_api_error_status_code(self, api_error: Exception) -> Optional[int]:
+        """Best-effort HTTP-style status classification for SDK/runtime errors."""
+        for candidate in (
+            getattr(api_error, "status_code", None),
+            getattr(getattr(api_error, "response", None), "status_code", None),
+        ):
+            if isinstance(candidate, int):
+                return candidate
+
+        fragments: list[str] = []
+        for value in (
+            str(api_error),
+            getattr(api_error, "body", None),
+            getattr(getattr(api_error, "response", None), "text", None),
+        ):
+            if not value:
+                continue
+            if isinstance(value, dict):
+                try:
+                    fragments.append(json.dumps(value, ensure_ascii=False, sort_keys=True))
+                except Exception:
+                    fragments.append(str(value))
+            else:
+                fragments.append(str(value))
+
+        haystack = " ".join(fragments).lower()
+        if not haystack:
+            return None
+
+        if any(marker in haystack for marker in (
+            "error code: 401",
+            "http 401",
+            "status code: 401",
+        )):
+            return 401
+        if any(marker in haystack for marker in (
+            "error code: 402",
+            "http 402",
+            "status code: 402",
+            "payment required",
+            "insufficient credits",
+            "credits exhausted",
+            "out of credits",
+        )):
+            return 402
+        if any(marker in haystack for marker in (
+            "error code: 429",
+            "http 429",
+            "status code: 429",
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "usage limit",
+            "quota",
+        )):
+            return 429
+        if any(marker in haystack for marker in (
+            "unauthorized",
+            "invalid api key",
+            "invalid_api_key",
+            "authentication failed",
+        )):
+            return 401
+        return None
+
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any reasoning/thinking blocks.
@@ -4165,6 +4243,8 @@ class AIAgent:
         if pool is None or status_code is None:
             return False, has_retried_429
 
+        pool_provider = getattr(pool, "provider", "")
+
         if status_code == 402:
             next_entry = pool.mark_exhausted_and_rotate(status_code=402, error_context=error_context)
             if next_entry is not None:
@@ -4174,6 +4254,17 @@ class AIAgent:
             return False, has_retried_429
 
         if status_code == 429:
+            if pool_provider == "openai-codex":
+                next_entry = pool.mark_exhausted_and_rotate(status_code=429)
+                if next_entry is not None:
+                    self._emit_status("🔁 Codex profile hit a limit — switching accounts...")
+                    logger.info(
+                        "Codex credential 429/quota — rotated immediately to pool entry %s",
+                        getattr(next_entry, "id", "?"),
+                    )
+                    self._swap_credential(next_entry)
+                    return True, False
+                return False, False
             if not has_retried_429:
                 return False, True
             next_entry = pool.mark_exhausted_and_rotate(status_code=429, error_context=error_context)
@@ -4184,7 +4275,6 @@ class AIAgent:
             return False, True
 
         if status_code == 401:
-            pool_provider = getattr(pool, "provider", "")
             current_entry_getter = getattr(pool, "current", None)
             current_entry = current_entry_getter() if callable(current_entry_getter) else None
             current_id = getattr(current_entry, "id", None)
@@ -7456,7 +7546,7 @@ class AIAgent:
             
             api_start_time = time.time()
             retry_count = 0
-            max_retries = 3
+            max_retries = self._api_max_retries()
             primary_recovery_attempted = False
             max_compression_attempts = 3
             codex_auth_retry_attempted = False
@@ -8000,7 +8090,7 @@ class AIAgent:
                         # Surrogates weren't in messages — might be in system
                         # prompt or prefill.  Fall through to normal error path.
 
-                    status_code = getattr(api_error, "status_code", None)
+                    status_code = self._infer_api_error_status_code(api_error)
                     error_context = self._extract_api_error_context(api_error)
                     recovered_with_pool, has_retried_429 = self._recover_with_credential_pool(
                         status_code=status_code,
@@ -8009,6 +8099,33 @@ class AIAgent:
                     )
                     if recovered_with_pool:
                         continue
+                    pool = self._credential_pool
+                    pool_provider = getattr(pool, "provider", "")
+                    if (
+                        pool is not None
+                        and pool_provider == "openai-codex"
+                        and status_code in {402, 429}
+                        and not pool.has_available()
+                    ):
+                        _final_summary = self._summarize_api_error(api_error)
+                        self._emit_status("⚠️ All Codex profiles are exhausted — trying fallback...")
+                        if self._try_activate_fallback():
+                            retry_count = 0
+                            continue
+                        self._vprint(
+                            f"{self.log_prefix}❌ All Codex profiles are exhausted. Giving up without backoff.",
+                            force=True,
+                        )
+                        self._vprint(f"{self.log_prefix}   💀 Final error: {_final_summary}", force=True)
+                        self._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": f"All Codex profiles are exhausted: {_final_summary}",
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _final_summary,
+                        }
                     if (
                         self.api_mode == "codex_responses"
                         and self.provider == "openai-codex"
@@ -8135,7 +8252,7 @@ class AIAgent:
                     # Check for 413 payload-too-large BEFORE generic 4xx handler.
                     # A 413 is a payload-size error — the correct response is to
                     # compress history and retry, not abort immediately.
-                    status_code = getattr(api_error, "status_code", None)
+                    status_code = self._infer_api_error_status_code(api_error)
 
                     # ── Anthropic Sonnet long-context tier gate ───────────
                     # Anthropic returns HTTP 429 "Extra usage is required for

--- a/run_agent.py
+++ b/run_agent.py
@@ -4245,8 +4245,16 @@ class AIAgent:
 
         pool_provider = getattr(pool, "provider", "")
 
+        def _rotate_with_optional_error_context(code: int):
+            try:
+                return pool.mark_exhausted_and_rotate(status_code=code, error_context=error_context)
+            except TypeError as exc:
+                if "error_context" not in str(exc):
+                    raise
+                return pool.mark_exhausted_and_rotate(status_code=code)
+
         if status_code == 402:
-            next_entry = pool.mark_exhausted_and_rotate(status_code=402, error_context=error_context)
+            next_entry = _rotate_with_optional_error_context(402)
             if next_entry is not None:
                 logger.info(f"Credential 402 (billing) — rotated to pool entry {getattr(next_entry, 'id', '?')}")
                 self._swap_credential(next_entry)
@@ -4267,7 +4275,7 @@ class AIAgent:
                 return False, False
             if not has_retried_429:
                 return False, True
-            next_entry = pool.mark_exhausted_and_rotate(status_code=429, error_context=error_context)
+            next_entry = _rotate_with_optional_error_context(429)
             if next_entry is not None:
                 logger.info(f"Credential 429 (rate limit) — rotated to pool entry {getattr(next_entry, 'id', '?')}")
                 self._swap_credential(next_entry)

--- a/run_agent.py
+++ b/run_agent.py
@@ -667,6 +667,7 @@ class AIAgent:
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
+        context_length_override: int | None = None,
         persist_session: bool = True,
     ):
         """
@@ -709,10 +710,12 @@ class AIAgent:
             skip_context_files (bool): If True, skip auto-injection of SOUL.md, AGENTS.md, and .cursorrules
                 into the system prompt. Use this for batch processing and data generation to avoid
                 polluting trajectories with user-specific persona or project instructions.
+            context_length_override (int | None): Optional session-local context window override.
         """
         _install_safe_stdio()
 
         self.model = model
+        self.context_length_override = int(context_length_override) if context_length_override else None
         self.max_iterations = max_iterations
         # Shared iteration budget — parent creates, children inherit.
         # Consumed by every LLM turn across parent + all subagents.
@@ -1316,7 +1319,14 @@ class AIAgent:
                                     except (TypeError, ValueError):
                                         pass
                         break
-        
+
+        self._config_context_length = _config_context_length
+        _effective_context_length = (
+            self.context_length_override
+            if self.context_length_override is not None
+            else self._config_context_length
+        )
+
         self.context_compressor = ContextCompressor(
             model=self.model,
             threshold_percent=compression_threshold,
@@ -1327,7 +1337,7 @@ class AIAgent:
             quiet_mode=self.quiet_mode,
             base_url=self.base_url,
             api_key=getattr(self, "api_key", ""),
-            config_context_length=_config_context_length,
+            config_context_length=_effective_context_length,
             provider=self.provider,
         )
         self.compression_enabled = compression_enabled
@@ -1456,6 +1466,48 @@ class AIAgent:
             self.context_compressor._context_probe_persistable = False
             # Iterative summary from previous session must not bleed into new one (#2635)
             self.context_compressor._previous_summary = None
+
+    def _effective_config_context_length(self) -> int | None:
+        if self.context_length_override is not None:
+            return self.context_length_override
+        return getattr(self, "_config_context_length", None)
+
+    def _refresh_context_compressor_context_length(self) -> int | None:
+        if not hasattr(self, "context_compressor") or not self.context_compressor:
+            return None
+
+        from agent.model_metadata import get_model_context_length
+
+        new_context_length = get_model_context_length(
+            self.model,
+            base_url=self.base_url,
+            api_key=getattr(self, "api_key", ""),
+            config_context_length=self._effective_config_context_length(),
+            provider=self.provider,
+        )
+        self.context_compressor.model = self.model
+        self.context_compressor.base_url = self.base_url
+        self.context_compressor.api_key = getattr(self, "api_key", "")
+        self.context_compressor.provider = self.provider
+        self.context_compressor.context_length = new_context_length
+        self.context_compressor.threshold_tokens = int(
+            new_context_length * self.context_compressor.threshold_percent
+        )
+        return new_context_length
+
+    def set_context_length_override(self, context_length: int | None) -> int:
+        self.context_length_override = int(context_length) if context_length else None
+        refreshed = self._refresh_context_compressor_context_length()
+        if hasattr(self, "_primary_runtime") and isinstance(self._primary_runtime, dict) and refreshed:
+            self._primary_runtime.update({
+                "compressor_model": self.context_compressor.model,
+                "compressor_base_url": self.context_compressor.base_url,
+                "compressor_api_key": getattr(self.context_compressor, "api_key", ""),
+                "compressor_provider": self.context_compressor.provider,
+                "compressor_context_length": refreshed,
+                "compressor_threshold_tokens": self.context_compressor.threshold_tokens,
+            })
+        return refreshed or 0
     
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
@@ -1527,22 +1579,7 @@ class AIAgent:
         )
 
         # ── Update context compressor ──
-        if hasattr(self, "context_compressor") and self.context_compressor:
-            from agent.model_metadata import get_model_context_length
-            new_context_length = get_model_context_length(
-                self.model,
-                base_url=self.base_url,
-                api_key=self.api_key,
-                provider=self.provider,
-            )
-            self.context_compressor.model = self.model
-            self.context_compressor.base_url = self.base_url
-            self.context_compressor.api_key = self.api_key
-            self.context_compressor.provider = self.provider
-            self.context_compressor.context_length = new_context_length
-            self.context_compressor.threshold_tokens = int(
-                new_context_length * self.context_compressor.threshold_percent
-            )
+        new_context_length = self._refresh_context_compressor_context_length()
 
         self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
 
@@ -5341,20 +5378,7 @@ class AIAgent:
             # Without this, compression decisions use the primary model's
             # context window (e.g. 200K) instead of the fallback's (e.g. 32K),
             # causing oversized sessions to overflow the fallback.
-            if hasattr(self, 'context_compressor') and self.context_compressor:
-                from agent.model_metadata import get_model_context_length
-                fb_context_length = get_model_context_length(
-                    self.model, base_url=self.base_url,
-                    api_key=self.api_key, provider=self.provider,
-                )
-                self.context_compressor.model = self.model
-                self.context_compressor.base_url = self.base_url
-                self.context_compressor.api_key = self.api_key
-                self.context_compressor.provider = self.provider
-                self.context_compressor.context_length = fb_context_length
-                self.context_compressor.threshold_tokens = int(
-                    fb_context_length * self.context_compressor.threshold_percent
-                )
+            self._refresh_context_compressor_context_length()
 
             self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -767,6 +767,21 @@ class TestAuxiliaryPoolAwareness:
         assert client is not None
         assert provider == "custom:local"
 
+    def test_vision_auto_uses_auth_store_active_provider_when_config_missing(self, monkeypatch):
+        """Vision auto should consult auth.json active_provider when config.yaml has no provider."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._read_main_provider", return_value=""), \
+             patch("agent.auxiliary_client._read_main_model", return_value="gpt-5-codex"), \
+             patch("hermes_cli.auth.get_active_provider", return_value="openai-codex"), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(MagicMock(), "gpt-5-codex")) as mock_resolve:
+            provider, client, model = resolve_vision_provider_client()
+        assert client is not None
+        assert provider == "openai-codex"
+        mock_resolve.assert_called_once_with("openai-codex", "gpt-5-codex")
+
     def test_vision_direct_endpoint_override(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         monkeypatch.setenv("AUXILIARY_VISION_BASE_URL", "http://localhost:4567/v1")

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -352,6 +352,104 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
     assert secondary["refresh_token"] == "refresh-other"
 
 
+def test_update_entry_persists_extra_metadata_and_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-old",
+                        "refresh_token": "refresh-old",
+                        "last_status": "exhausted",
+                        "last_status_at": 1711230000.0,
+                        "last_error_code": 429,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    updated = pool.update_entry(
+        "cred-1",
+        access_token="access-new",
+        account_id="acct-123",
+        last_status=None,
+        last_status_at=None,
+        last_error_code=None,
+    )
+
+    assert updated is not None
+    assert updated.access_token == "access-new"
+    assert updated.account_id == "acct-123"
+    assert updated.last_status is None
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = payload["credential_pool"]["openai-codex"][0]
+    assert entry["access_token"] == "access-new"
+    assert entry["account_id"] == "acct-123"
+    assert entry["last_status"] is None
+    assert entry["last_status_at"] is None
+    assert entry["last_error_code"] is None
+
+
+def test_update_entry_uses_latest_store_and_does_not_revive_removed_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-1",
+                        "refresh_token": "refresh-1",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "device_code",
+                        "access_token": "access-2",
+                        "refresh_token": "refresh-2",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    stale_pool = load_pool("openai-codex")
+    fresh_pool = load_pool("openai-codex")
+
+    removed = fresh_pool.remove_entry("cred-2")
+    assert removed is not None
+    updated = stale_pool.update_entry("cred-1", access_token="access-new")
+    assert updated is not None
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    assert [entry["id"] for entry in entries] == ["cred-1"]
+    assert entries[0]["access_token"] == "access-new"
+
+
 def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-seeded")

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -553,6 +553,58 @@ def test_update_entry_uses_latest_store_and_does_not_revive_removed_entry(tmp_pa
     assert entries[0]["access_token"] == "access-new"
 
 
+def test_mark_exhausted_does_not_restore_entry_removed_by_fresh_pool(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "access-1",
+                        "refresh_token": "refresh-1",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "access-2",
+                        "refresh_token": "refresh-2",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    stale_pool = load_pool("openai-codex")
+    fresh_pool = load_pool("openai-codex")
+
+    removed = fresh_pool.remove_entry("cred-2")
+    assert removed is not None
+
+    selected = stale_pool.select()
+    assert selected is not None
+    assert selected.id == "cred-1"
+
+    next_entry = stale_pool.mark_exhausted_and_rotate(status_code=429)
+    assert next_entry is None
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    assert [entry["id"] for entry in entries] == ["cred-1"]
+    assert entries[0]["last_status"] == "exhausted"
+
+
 def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-seeded")

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -261,7 +261,7 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
                         "auth_type": "api_key",
                         "priority": 0,
                         "source": "manual",
-                        "access_token": "sk-ant-api-primary",
+                        "access_token": "sk-ant-1",
                     },
                     {
                         "id": "cred-2",
@@ -269,7 +269,7 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
                         "auth_type": "api_key",
                         "priority": 1,
                         "source": "manual",
-                        "access_token": "sk-ant-api-secondary",
+                        "access_token": "sk-ant-2",
                     },
                 ]
             },
@@ -290,6 +290,109 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     persisted = auth_payload["credential_pool"]["anthropic"][0]
     assert persisted["last_status"] == "exhausted"
     assert persisted["last_error_code"] == 402
+
+
+def test_exhausted_manual_codex_entry_does_not_sync_from_cli_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "manual-1",
+                        "label": "manual-account",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "access-manual",
+                        "refresh_token": "refresh-manual",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 401,
+                    }
+                ]
+            },
+            "providers": {},
+        },
+    )
+
+    monkeypatch.setattr(
+        "agent.credential_pool._import_codex_cli_tokens",
+        lambda: {
+            "access_token": "access-cli",
+            "refresh_token": "refresh-cli",
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+
+    assert pool.select() is None
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = auth_payload["credential_pool"]["openai-codex"][0]
+    assert entry["access_token"] == "access-manual"
+    assert entry["refresh_token"] == "refresh-manual"
+    assert entry["last_status"] == "exhausted"
+
+
+def test_exhausted_device_code_codex_entry_syncs_cli_tokens_to_provider_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "device-1",
+                        "label": "device-code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-old",
+                        "refresh_token": "refresh-old",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 401,
+                        "account_id": "acct-existing",
+                    }
+                ]
+            },
+            "providers": {},
+        },
+    )
+
+    monkeypatch.setattr(
+        "agent.credential_pool._import_codex_cli_tokens",
+        lambda: {
+            "access_token": "access-cli",
+            "refresh_token": "refresh-cli",
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.id == "device-1"
+    assert entry.access_token == "access-cli"
+    assert entry.refresh_token == "refresh-cli"
+    assert entry.last_status is None
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    pool_entry = auth_payload["credential_pool"]["openai-codex"][0]
+    assert pool_entry["access_token"] == "access-cli"
+    assert pool_entry["refresh_token"] == "refresh-cli"
+    assert pool_entry["last_status"] is None
+    assert auth_payload["providers"]["openai-codex"]["tokens"]["access_token"] == "access-cli"
+    assert auth_payload["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-cli"
+    assert auth_payload["providers"]["openai-codex"]["tokens"]["account_id"] == "acct-existing"
 
 
 def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):

--- a/tests/cli/test_background_agent_commands.py
+++ b/tests/cli/test_background_agent_commands.py
@@ -1,0 +1,167 @@
+import os
+import threading
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli import HermesCLI
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    os.environ["HERMES_HOME"] = str(tmp_path / ".hermes")
+    os.makedirs(tmp_path / ".hermes", exist_ok=True)
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / ".hermes" / "test_sessions.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def cli_instance(session_db):
+    cli = MagicMock()
+    cli._session_db = session_db
+    cli.session_id = "20260409_010000_abc123"
+    cli.model = "anthropic/claude-sonnet-4.6"
+    cli.max_turns = 90
+    cli.reasoning_config = {"enabled": True, "effort": "medium"}
+    cli.session_start = datetime.now()
+    cli._pending_title = None
+    cli._resumed = False
+    cli.agent = None
+    cli.conversation_history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+        {"role": "user", "content": "Please implement the feature."},
+        {"role": "assistant", "content": "Working on it."},
+    ]
+    cli.enabled_toolsets = ["terminal", "file"]
+    cli._providers_only = None
+    cli._providers_ignore = None
+    cli._providers_order = None
+    cli._provider_sort = None
+    cli._provider_require_params = False
+    cli._provider_data_collection = None
+    cli._fallback_model = None
+    cli._agent_running = False
+    cli._spinner_text = ""
+    cli._app = None
+    cli.bell_on_complete = False
+    cli._background_tasks = {}
+    cli._background_task_counter = 0
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+    cli._resolve_turn_agent_config = MagicMock(return_value={"model": cli.model, "runtime": {}})
+    cli._make_background_clarify_callback = MagicMock(return_value="CALLBACK")
+    cli._remember_assistant_message = MagicMock()
+    cli._show_assistant_copy_hint = MagicMock()
+    cli._invalidate = MagicMock()
+
+    session_db.create_session(
+        session_id=cli.session_id,
+        source="cli",
+        model=cli.model,
+    )
+    session_db.set_session_title(cli.session_id, "Hermes Addition Session")
+    return cli
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, daemon=None, name=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self.daemon = daemon
+        self.name = name
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+def test_make_background_clarify_callback_uses_kitty_overlay():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._background_prompt_lock = threading.Lock()
+    cli._clarify_callback = MagicMock(return_value="fallback")
+
+    with patch("cli.kitty_overlay_available", return_value=True), \
+         patch("cli.prompt_kitty_overlay_clarify", return_value="overlay answer") as overlay_prompt:
+        callback = HermesCLI._make_background_clarify_callback(cli, "spawn #1")
+        result = callback("Which branch should I use?", ["main", "dev"])
+
+    assert result == "overlay answer"
+    cli._clarify_callback.assert_not_called()
+    overlay_prompt.assert_called_once()
+
+
+def test_make_background_clarify_callback_falls_back_to_inline_prompt():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._background_prompt_lock = threading.Lock()
+    cli._clarify_callback = MagicMock(return_value="fallback")
+
+    with patch("cli.kitty_overlay_available", return_value=False):
+        callback = HermesCLI._make_background_clarify_callback(cli, "spawn #1")
+        result = callback("Which branch should I use?", ["main", "dev"])
+
+    assert result == "fallback"
+    cli._clarify_callback.assert_called_once_with("Which branch should I use?", ["main", "dev"])
+
+
+def test_spawn_passes_background_clarify_callback_to_child_agent(cli_instance):
+    with patch("cli.threading.Thread", _ImmediateThread), \
+         patch("cli.AIAgent") as MockAgent, \
+         patch("cli.ChatConsole") as MockChatConsole:
+        MockAgent.return_value.run_conversation.return_value = {"final_response": ""}
+        MockChatConsole.return_value.print = MagicMock()
+
+        HermesCLI._handle_spawn_command(cli_instance, "/spawn Continue in the background")
+
+    assert MockAgent.call_args.kwargs["clarify_callback"] == "CALLBACK"
+    cli_instance._make_background_clarify_callback.assert_called_once()
+
+
+def test_background_passes_background_clarify_callback_to_child_agent(cli_instance):
+    with patch("cli.threading.Thread", _ImmediateThread), \
+         patch("cli.AIAgent") as MockAgent, \
+         patch("cli.ChatConsole") as MockChatConsole:
+        MockAgent.return_value.run_conversation.return_value = {"final_response": ""}
+        MockChatConsole.return_value.print = MagicMock()
+
+        HermesCLI._handle_background_command(cli_instance, "/background Implement the feature")
+
+    assert MockAgent.call_args.kwargs["clarify_callback"] == "CALLBACK"
+    cli_instance._make_background_clarify_callback.assert_called_once()
+
+
+def test_hermes_addition_registered():
+    from hermes_cli.commands import COMMAND_REGISTRY
+
+    assert any(command.name == "hermes-addition" for command in COMMAND_REGISTRY)
+
+
+def test_hermes_addition_creates_worktree_and_injects_pr_workflow(cli_instance):
+    cli_instance._build_hermes_addition_prompt = HermesCLI._build_hermes_addition_prompt.__get__(cli_instance, HermesCLI)
+
+    with patch("cli._git_repo_root", return_value="/repo"), \
+         patch("cli._setup_worktree", return_value={
+            "path": "/repo/.worktrees/hermes-1234",
+            "branch": "hermes/hermes-1234",
+            "repo_root": "/repo",
+         }), \
+         patch("cli._git_remote_exists", return_value=True), \
+         patch("cli._git_default_base_ref", return_value="origin/main"), \
+         patch("cli.threading.Thread", _ImmediateThread), \
+         patch("cli.AIAgent") as MockAgent, \
+         patch("cli.ChatConsole") as MockChatConsole:
+        MockAgent.return_value.run_conversation.return_value = {"final_response": ""}
+        MockChatConsole.return_value.print = MagicMock()
+
+        HermesCLI._handle_hermes_addition_command(cli_instance, "/hermes-addition Fix the flaky retry path")
+
+    user_message = MockAgent.return_value.run_conversation.call_args.kwargs["user_message"]
+    assert "/repo/.worktrees/hermes-1234" in user_message
+    assert "hermes/hermes-1234" in user_message
+    assert "gh pr create" in user_message
+    assert "fork" in user_message
+    assert MockAgent.call_args.kwargs["clarify_callback"] == "CALLBACK"

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -176,8 +176,98 @@ class TestBranchCommandCLI:
         assert result.name == "branch"
 
 
+def _find_child_sessions(session_db, parent_session_id):
+    cursor = session_db._conn.execute(
+        "SELECT id FROM sessions WHERE parent_session_id = ? ORDER BY started_at",
+        (parent_session_id,),
+    )
+    return [row["id"] for row in cursor.fetchall()]
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, daemon=None, name=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self.daemon = daemon
+        self.name = name
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+class TestSpawnCommandCLI:
+    """Test the /spawn command logic for the CLI."""
+
+    def _configure_spawn_cli(self, cli_instance):
+        cli_instance._background_task_counter = 0
+        cli_instance._background_tasks = {}
+        cli_instance.enabled_toolsets = ["terminal", "file"]
+        cli_instance._providers_only = None
+        cli_instance._providers_ignore = None
+        cli_instance._providers_order = None
+        cli_instance._provider_sort = None
+        cli_instance._provider_require_params = False
+        cli_instance._provider_data_collection = None
+        cli_instance._fallback_model = None
+        cli_instance._agent_running = False
+        cli_instance._spinner_text = ""
+        cli_instance._app = None
+        cli_instance.bell_on_complete = False
+        cli_instance._ensure_runtime_credentials = MagicMock(return_value=True)
+        cli_instance._resolve_turn_agent_config = MagicMock(
+            return_value={"model": cli_instance.model, "runtime": {}}
+        )
+
+    def test_spawn_creates_child_session_without_switching(self, cli_instance, session_db):
+        from cli import HermesCLI
+
+        self._configure_spawn_cli(cli_instance)
+        original_id = cli_instance.session_id
+
+        with patch("cli.threading.Thread", _ImmediateThread), \
+             patch("cli.AIAgent") as MockAgent, \
+             patch("cli.ChatConsole") as MockChatConsole:
+            MockAgent.return_value.run_conversation.return_value = {"final_response": ""}
+            MockChatConsole.return_value.print = MagicMock()
+            HermesCLI._handle_spawn_command(cli_instance, "/spawn Continue in the background")
+
+        child_sessions = _find_child_sessions(session_db, original_id)
+        assert len(child_sessions) == 1
+        child_id = child_sessions[0]
+        assert cli_instance.session_id == original_id
+        assert child_id != original_id
+        assert session_db.get_session(original_id)["end_reason"] is None
+        assert session_db.get_session(child_id)["parent_session_id"] == original_id
+        assert len(session_db.get_messages_as_conversation(child_id)) == 4
+
+    def test_spawn_runs_child_with_pass_session_id_disabled(self, cli_instance, session_db):
+        from cli import HermesCLI
+
+        self._configure_spawn_cli(cli_instance)
+        original_id = cli_instance.session_id
+
+        with patch("cli.threading.Thread", _ImmediateThread), \
+             patch("cli.AIAgent") as MockAgent, \
+             patch("cli.ChatConsole") as MockChatConsole:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": ""}
+            MockAgent.return_value = mock_agent
+            MockChatConsole.return_value.print = MagicMock()
+
+            HermesCLI._handle_spawn_command(cli_instance, "/spawn Continue in the background")
+
+        child_id = _find_child_sessions(session_db, original_id)[0]
+        kwargs = MockAgent.call_args.kwargs
+        assert kwargs["session_id"] == child_id
+        assert kwargs["pass_session_id"] is False
+        mock_agent.run_conversation.assert_called_once()
+        assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == cli_instance.conversation_history
+
+
 class TestBranchCommandDef:
-    """Test the CommandDef registration for /branch."""
+    """Test the CommandDef registration for /branch and /spawn."""
 
     def test_branch_in_registry(self):
         """The branch command should be in the command registry."""
@@ -196,3 +286,13 @@ class TestBranchCommandDef:
         from hermes_cli.commands import COMMAND_REGISTRY
         branch = next(c for c in COMMAND_REGISTRY if c.name == "branch")
         assert branch.category == "Session"
+
+    def test_spawn_in_registry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        names = [c.name for c in COMMAND_REGISTRY]
+        assert "spawn" in names
+
+    def test_spawn_in_session_category(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        spawn = next(c for c in COMMAND_REGISTRY if c.name == "spawn")
+        assert spawn.category == "Session"

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -28,6 +28,7 @@ class _FakeAgent:
         self.session_id = session_id
         self.session_start = session_start
         self.model = "anthropic/claude-opus-4.6"
+        self.service_tier = None
         self._last_flushed_db_idx = 7
         self._todo_store = TodoStore()
         self._todo_store.write(
@@ -137,6 +138,8 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     cli = _prepare_cli_with_active_session(tmp_path)
     old_session_id = cli.session_id
     old_session_start = cli.session_start
+    cli.codex_service_tier = "fast"
+    cli.agent.service_tier = "fast"
 
     cli.process_command("/new")
 
@@ -154,10 +157,26 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     assert cli.agent.session_id == cli.session_id
     assert cli.agent._last_flushed_db_idx == 0
     assert cli.agent._todo_store.read() == []
+    assert cli.codex_service_tier is None
+    assert cli.agent.service_tier is None
     assert cli.session_start > old_session_start
     assert cli.agent.session_start == cli.session_start
     cli.agent.flush_memories.assert_called_once_with([{"role": "user", "content": "hello"}])
     cli.agent._invalidate_system_prompt.assert_called_once()
+
+
+def test_resume_command_clears_fast_mode(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+    resumed_session_id = "previous_session_123"
+    cli._session_db.create_session(session_id=resumed_session_id, source="cli", model=cli.model)
+    cli.codex_service_tier = "fast"
+    cli.agent.service_tier = "fast"
+
+    cli._handle_resume_command(f"/resume {resumed_session_id}")
+
+    assert cli.session_id == resumed_session_id
+    assert cli.codex_service_tier is None
+    assert cli.agent.service_tier is None
 
 
 def test_reset_command_is_alias_for_new_session(tmp_path):

--- a/tests/cli/test_cli_retry.py
+++ b/tests/cli/test_cli_retry.py
@@ -1,4 +1,4 @@
-"""Regression tests for CLI /retry history replacement semantics."""
+"""Regression tests for CLI /retry and /undo history replacement semantics."""
 
 from tests.cli.test_cli_init import _make_cli
 
@@ -47,3 +47,42 @@ def test_process_command_retry_requeues_original_message_not_retry_command():
 
     assert queued == ["retry me"]
     assert cli.conversation_history == []
+
+
+def test_undo_last_reports_one_turn_and_internal_transcript_count(capsys):
+    cli = _make_cli()
+    cli.conversation_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "one"},
+        {"role": "user", "content": "fix /undo"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "search_files", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"success": true}'},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "[Internal: inspect the attached image and continue.]"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "_native_image_attachment": True,
+        },
+        {"role": "assistant", "content": "intermediate note"},
+        {"role": "assistant", "content": "final answer"},
+    ]
+
+    cli.undo_last()
+
+    out = capsys.readouterr().out
+    assert cli.conversation_history == [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "one"},
+    ]
+    assert "Undid 1 turn" in out
+    assert "6 internal transcript messages" in out
+    assert 'Removed your last message: "fix /undo"' in out
+    assert "Undid 5 message(s)" not in out

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -11,6 +11,7 @@ def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
+    cli_obj._background_tasks = {}
     return cli_obj
 
 
@@ -78,6 +79,22 @@ class TestCLIStatusBar:
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+
+    def test_build_status_bar_text_includes_background_agent_count(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._background_tasks = {"bg1": MagicMock(), "bg2": MagicMock()}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "bg 2" in text
 
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -28,7 +28,7 @@ class TestHermesApiServerToolset:
         expected = [
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
-            "vision_analyze", "image_generate",
+            "vision_analyze", "attach_image", "image_generate",
             "execute_code", "delegate_task",
             "todo", "memory", "session_search", "cronjob",
         ]

--- a/tests/gateway/test_branch_command.py
+++ b/tests/gateway/test_branch_command.py
@@ -1,0 +1,98 @@
+"""Tests for gateway /branch command regression coverage."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    os.environ["HERMES_HOME"] = str(tmp_path / ".hermes")
+    os.makedirs(tmp_path / ".hermes", exist_ok=True)
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / ".hermes" / "test_sessions.db")
+    yield db
+    db.close()
+
+
+def _make_event(text="/branch", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(session_db):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = session_db
+    runner._running_agents = {}
+    runner.config = {"model": {"default": "anthropic/claude-sonnet-4.6"}}
+
+    current_session_id = "20260408_091500_parent"
+    session_db.create_session(
+        session_id=current_session_id,
+        source="telegram",
+        model="anthropic/claude-sonnet-4.6",
+    )
+    session_db.set_session_title(current_session_id, "Gateway Session")
+
+    history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+        {"role": "user", "content": "Explore option B"},
+        {"role": "assistant", "content": "Sure"},
+    ]
+    for msg in history:
+        session_db.append_message(
+            session_id=current_session_id,
+            role=msg["role"],
+            content=msg["content"],
+        )
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = SimpleNamespace(session_id=current_session_id)
+    mock_store.load_transcript.return_value = history
+    mock_store.switch_session.side_effect = lambda session_key, target_session_id: SimpleNamespace(session_id=target_session_id)
+    runner.session_store = mock_store
+    runner._session_key_for_source = MagicMock(return_value="telegram:67890")
+    runner._evict_cached_agent = MagicMock()
+    return runner, current_session_id, history
+
+
+def _find_child_sessions(session_db, parent_session_id):
+    cursor = session_db._conn.execute(
+        "SELECT id FROM sessions WHERE parent_session_id = ? ORDER BY started_at",
+        (parent_session_id,),
+    )
+    return [row["id"] for row in cursor.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_gateway_branch_clones_history_and_switches_session(session_db):
+    runner, parent_id, history = _make_runner(session_db)
+
+    event = _make_event(text="/branch branch idea")
+    result = await runner._handle_branch_command(event)
+
+    child_sessions = _find_child_sessions(session_db, parent_id)
+    assert len(child_sessions) == 1
+    child_id = child_sessions[0]
+    assert len(session_db.get_messages_as_conversation(child_id)) == len(history)
+    assert session_db.get_session(child_id)["parent_session_id"] == parent_id
+    runner.session_store.switch_session.assert_called_once_with("telegram:67890", child_id)
+    runner._evict_cached_agent.assert_called_once_with("telegram:67890")
+    assert "Branched to **branch idea**" in result
+    assert parent_id in result
+    assert child_id in result

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -1,0 +1,155 @@
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, SessionStore
+
+
+def _make_event(text="/fast", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(tmp_path):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner.session_store = SessionStore(tmp_path / "sessions", GatewayConfig())
+    return runner
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+        self.service_tier = kwargs.get("service_tier")
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_api_calls = 1
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "none"
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "tools": [],
+        }
+
+
+class TestGatewayFastCommand:
+    @pytest.mark.asyncio
+    async def test_help_output_lists_fast(self, tmp_path):
+        runner = _make_runner(tmp_path)
+
+        result = await runner._handle_help_command(_make_event("/help"))
+
+        assert "/fast [on|off|status]" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_fast_command_sets_session_override(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        event = _make_event("/fast on")
+
+        result = await runner._handle_fast_command(event)
+        entry = runner.session_store.get_or_create_session(event.source)
+
+        assert "takes effect on next message" in result
+        assert entry.service_tier_override == "fast"
+
+    def test_force_new_session_clears_fast_override(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        source = _make_event("/fast on").source
+
+        entry = runner.session_store.get_or_create_session(source)
+        runner.session_store.set_service_tier_override(entry.session_key, "fast")
+
+        fresh_entry = runner.session_store.get_or_create_session(source, force_new=True)
+
+        assert fresh_entry.session_id != entry.session_id
+        assert fresh_entry.service_tier_override is None
+
+    def test_switch_session_clears_fast_override(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        source = _make_event("/fast on").source
+
+        entry = runner.session_store.get_or_create_session(source)
+        runner.session_store.set_service_tier_override(entry.session_key, "fast")
+
+        switched_entry = runner.session_store.switch_session(entry.session_key, "older_session_abc")
+
+        assert switched_entry is not None
+        assert switched_entry.session_id == "older_session_abc"
+        assert switched_entry.service_tier_override is None
+
+    def test_run_agent_passes_service_tier_from_session(self, tmp_path, monkeypatch):
+        runner = _make_runner(tmp_path)
+        event = _make_event("/fast on", platform=Platform.LOCAL, chat_id="cli")
+        entry = runner.session_store.get_or_create_session(event.source)
+        runner.session_store.set_service_tier_override(entry.session_key, "fast")
+
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "test-key",
+            },
+        )
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=event.source,
+                session_id=entry.session_id,
+                session_key=entry.session_key,
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["service_tier"] == "fast"

--- a/tests/gateway/test_gateway_multimodal.py
+++ b/tests/gateway/test_gateway_multimodal.py
@@ -1,0 +1,63 @@
+import sys
+import types
+
+import pytest
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_prepare_user_message_with_images_uses_native_multimodal_for_codex(tmp_path):
+    runner = object.__new__(GatewayRunner)
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await runner._prepare_user_message_with_images(
+        "Describe this",
+        [str(img)],
+        {
+            "runtime": {
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            }
+        },
+    )
+
+    assert isinstance(result, list)
+    assert result[0]["type"] == "text"
+    assert result[1]["type"] == "image_url"
+    assert result[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_prepare_user_message_with_images_uses_vision_fallback_for_text_only_route(tmp_path):
+    runner = object.__new__(GatewayRunner)
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    async def _fake_enrich(message_text, image_paths):
+        assert message_text == "Describe this"
+        assert image_paths == [str(img)]
+        return "fallback text"
+
+    runner._enrich_message_with_vision = _fake_enrich
+
+    result = await runner._prepare_user_message_with_images(
+        "Describe this",
+        [str(img)],
+        {
+            "runtime": {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        },
+    )
+
+    assert result == "fallback text"

--- a/tests/gateway/test_spawn_command.py
+++ b/tests/gateway/test_spawn_command.py
@@ -1,0 +1,180 @@
+"""Tests for /spawn gateway slash command."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    os.environ["HERMES_HOME"] = str(tmp_path / ".hermes")
+    os.makedirs(tmp_path / ".hermes", exist_ok=True)
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / ".hermes" / "test_sessions.db")
+    yield db
+    db.close()
+
+
+def _make_event(text="/spawn", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(session_db):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = session_db
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    runner.config = {"model": {"default": "anthropic/claude-sonnet-4.6"}}
+
+    current_session_id = "20260408_090000_parent"
+    session_db.create_session(
+        session_id=current_session_id,
+        source="telegram",
+        model="anthropic/claude-sonnet-4.6",
+    )
+    session_db.set_session_title(current_session_id, "Main Session")
+
+    history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+        {"role": "user", "content": "Investigate the bug"},
+        {"role": "assistant", "content": "On it"},
+    ]
+    for msg in history:
+        session_db.append_message(
+            session_id=current_session_id,
+            role=msg["role"],
+            content=msg["content"],
+        )
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = SimpleNamespace(session_id=current_session_id)
+    mock_store.load_transcript.return_value = history
+    runner.session_store = mock_store
+
+    from gateway.hooks import HookRegistry
+
+    runner.hooks = HookRegistry()
+    return runner, current_session_id, history
+
+
+def _find_child_sessions(session_db, parent_session_id):
+    cursor = session_db._conn.execute(
+        "SELECT id FROM sessions WHERE parent_session_id = ? ORDER BY started_at",
+        (parent_session_id,),
+    )
+    return [row["id"] for row in cursor.fetchall()]
+
+
+class TestHandleSpawnCommand:
+    @pytest.mark.asyncio
+    async def test_no_prompt_shows_usage(self, session_db):
+        runner, _, _ = _make_runner(session_db)
+        event = _make_event(text="/spawn")
+        result = await runner._handle_spawn_command(event)
+        assert "Usage:" in result
+        assert "/spawn" in result
+
+    @pytest.mark.asyncio
+    async def test_spawn_clones_child_session_without_switching(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            created_tasks.append(mock_task)
+            return mock_task
+
+        with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            event = _make_event(text="/spawn Continue in the background")
+            result = await runner._handle_spawn_command(event)
+
+        child_sessions = _find_child_sessions(session_db, parent_id)
+        assert len(child_sessions) == 1
+        child_id = child_sessions[0]
+        child = session_db.get_session(child_id)
+        assert child["parent_session_id"] == parent_id
+        assert len(session_db.get_messages_as_conversation(child_id)) == len(history)
+        runner.session_store.switch_session.assert_not_called()
+        assert "Spawn task started" in result
+        assert parent_id in result
+        assert child_id in result
+        assert len(created_tasks) == 1
+
+
+class TestRunSpawnTask:
+    @pytest.mark.asyncio
+    async def test_spawn_task_uses_child_session_and_disables_pass_session_id(self, session_db):
+        runner, _, history = _make_runner(session_db)
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "Spawned result", "messages": []}
+            MockAgent.return_value = mock_agent
+
+            await runner._run_spawn_task(
+                prompt="continue",
+                source=source,
+                task_id="spawn_test",
+                child_session_id="20260408_090001_child",
+                history_snapshot=history,
+            )
+
+        kwargs = MockAgent.call_args.kwargs
+        assert kwargs["session_id"] == "20260408_090001_child"
+        assert kwargs["pass_session_id"] is False
+        mock_agent.run_conversation.assert_called_once_with(
+            user_message="continue",
+            conversation_history=history,
+            task_id="spawn_test",
+        )
+        sent_content = mock_adapter.send.call_args.kwargs["content"]
+        assert "Spawn task complete" in sent_content
+        assert "20260408_090001_child" in sent_content
+
+
+class TestSpawnCommandRegistration:
+    def test_spawn_is_known_gateway_command(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+
+        assert "spawn" in GATEWAY_KNOWN_COMMANDS
+
+    def test_spawn_in_cli_commands(self):
+        from hermes_cli.commands import COMMANDS
+
+        assert "/spawn" in COMMANDS

--- a/tests/gateway/test_spawn_command.py
+++ b/tests/gateway/test_spawn_command.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource, build_session_key
 
 
@@ -235,7 +235,8 @@ class TestRunSpawnTask:
     async def test_spawn_task_uses_child_session_and_disables_pass_session_id(self, session_db):
         runner, _, history = _make_runner(session_db)
         mock_adapter = AsyncMock()
-        mock_adapter.send = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True))
         mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
         mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
@@ -269,7 +270,7 @@ class TestRunSpawnTask:
             conversation_history=history,
             task_id="spawn_test",
         )
-        sent_content = mock_adapter.send.call_args.kwargs["content"]
+        sent_content = mock_adapter._send_with_retry.call_args.kwargs["content"]
         assert "Spawn task complete" in sent_content
         assert "20260408_090001_child" in sent_content
 
@@ -278,7 +279,8 @@ class TestRunSpawnTask:
         runner, parent_id, history = _make_runner(session_db)
         runner.session_store.append_to_transcript = MagicMock()
         mock_adapter = AsyncMock()
-        mock_adapter.send = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True))
         mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
         mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
@@ -310,6 +312,45 @@ class TestRunSpawnTask:
         assert args[0] == parent_id
         assert "Spawn task complete" in args[1]["content"]
         assert "Spawned result" in args[1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_spawn_task_sends_text_callback_even_when_response_is_media_only(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+        runner.session_store.append_to_transcript = MagicMock()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter.send_document = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter.extract_media = MagicMock(return_value=([("/tmp/result.txt", False)], ""))
+        mock_adapter.extract_images = MagicMock(return_value=([], ""))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "MEDIA:/tmp/result.txt", "messages": []}
+            MockAgent.return_value = mock_agent
+
+            await runner._run_spawn_task(
+                prompt="continue",
+                source=source,
+                task_id="spawn_test",
+                child_session_id="20260408_090001_child",
+                history_snapshot=history,
+                parent_session_id=parent_id,
+            )
+
+        sent_content = mock_adapter._send_with_retry.call_args.kwargs["content"]
+        assert "Spawn task complete" in sent_content
+        assert "(See attached media)" in sent_content
+        mock_adapter.send_document.assert_awaited_once()
 
 
 class TestSpawnCommandRegistration:

--- a/tests/gateway/test_spawn_command.py
+++ b/tests/gateway/test_spawn_command.py
@@ -1,14 +1,15 @@
 """Tests for /spawn gateway slash command."""
 
+import asyncio
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
-from gateway.session import SessionSource
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
 
 
 @pytest.fixture
@@ -43,8 +44,12 @@ def _make_runner(session_db):
     runner._provider_routing = {}
     runner._fallback_model = None
     runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
     runner._background_tasks = set()
     runner.config = {"model": {"default": "anthropic/claude-sonnet-4.6"}}
+    runner._session_key_for_source = MagicMock(side_effect=build_session_key)
+    runner._is_user_authorized = MagicMock(return_value=True)
 
     current_session_id = "20260408_090000_parent"
     session_db.create_session(
@@ -123,6 +128,107 @@ class TestHandleSpawnCommand:
         assert child_id in result
         assert len(created_tasks) == 1
 
+    @pytest.mark.asyncio
+    async def test_spawn_prefers_running_agent_snapshot_over_transcript(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+
+        running_history = history + [
+            {"role": "user", "content": "Latest in-memory prompt"},
+            {"role": "assistant", "content": "Latest in-memory answer"},
+        ]
+        session_key = build_session_key(_make_event().source)
+        runner._running_agents[session_key] = SimpleNamespace(_session_messages=running_history)
+        runner.session_store.load_transcript.return_value = history
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            return mock_task
+
+        with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            event = _make_event(text="/spawn Continue in the background")
+            result = await runner._handle_spawn_command(event)
+
+        child_sessions = _find_child_sessions(session_db, parent_id)
+        assert len(child_sessions) == 1
+        child_id = child_sessions[0]
+        assert session_db.get_messages_as_conversation(child_id) == running_history
+        runner.session_store.load_transcript.assert_not_called()
+        assert child_id in result
+
+    @pytest.mark.asyncio
+    async def test_spawn_bypasses_running_agent_guard(self, session_db):
+        runner, _, _ = _make_runner(session_db)
+        event = _make_event(text="/spawn Continue in the background")
+        session_key = build_session_key(event.source)
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+        runner.adapters[Platform.TELEGRAM] = SimpleNamespace(
+            _pending_messages={},
+            get_pending_message=MagicMock(return_value=None),
+        )
+        runner._handle_spawn_command = AsyncMock(return_value="spawn handled")
+
+        result = await runner._handle_message(event)
+
+        assert result == "spawn handled"
+        runner._handle_spawn_command.assert_awaited_once_with(event)
+        running_agent.interrupt.assert_not_called()
+        assert runner.adapters[Platform.TELEGRAM]._pending_messages == {}
+
+    @pytest.mark.asyncio
+    async def test_spawn_bypasses_adapter_active_session_guard(self):
+        source = _make_event().source
+        session_key = build_session_key(source)
+        handler_called_with = []
+
+        async def fake_handler(event):
+            handler_called_with.append(event)
+            return "spawn handled"
+
+        class _ConcreteAdapter(BasePlatformAdapter):
+            platform = Platform.TELEGRAM
+
+            async def connect(self):
+                return None
+
+            async def disconnect(self):
+                return None
+
+            async def send(self, chat_id, content, **kwargs):
+                return None
+
+            async def get_chat_info(self, chat_id):
+                return {}
+
+        adapter = _ConcreteAdapter(
+            PlatformConfig(enabled=True, token="***"),
+            Platform.TELEGRAM,
+        )
+        adapter.set_message_handler(fake_handler)
+
+        sent = []
+
+        async def fake_send_with_retry(chat_id, content, reply_to=None, metadata=None):
+            sent.append(content)
+
+        adapter._send_with_retry = fake_send_with_retry
+        interrupt_event = asyncio.Event()
+        adapter._active_sessions[session_key] = interrupt_event
+
+        event = MessageEvent(
+            text="/spawn Continue in the background",
+            source=source,
+            message_id="m1",
+            message_type=MessageType.COMMAND,
+        )
+        await adapter.handle_message(event)
+
+        assert handler_called_with == [event]
+        assert sent == ["spawn handled"]
+        assert not interrupt_event.is_set()
+        assert session_key not in adapter._pending_messages
+
 
 class TestRunSpawnTask:
     @pytest.mark.asyncio
@@ -166,6 +272,44 @@ class TestRunSpawnTask:
         sent_content = mock_adapter.send.call_args.kwargs["content"]
         assert "Spawn task complete" in sent_content
         assert "20260408_090001_child" in sent_content
+
+    @pytest.mark.asyncio
+    async def test_spawn_task_persists_result_to_parent_session_context(self, session_db):
+        runner, parent_id, history = _make_runner(session_db)
+        runner.session_store.append_to_transcript = MagicMock()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Spawned result"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Spawned result"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "Spawned result", "messages": []}
+            MockAgent.return_value = mock_agent
+
+            await runner._run_spawn_task(
+                prompt="continue",
+                source=source,
+                task_id="spawn_test",
+                child_session_id="20260408_090001_child",
+                history_snapshot=history,
+                parent_session_id=parent_id,
+            )
+
+        runner.session_store.append_to_transcript.assert_called_once()
+        args = runner.session_store.append_to_transcript.call_args.args
+        assert args[0] == parent_id
+        assert "Spawn task complete" in args[1]["content"]
+        assert "Spawned result" in args[1]["content"]
 
 
 class TestSpawnCommandRegistration:

--- a/tests/gateway/test_undo_command.py
+++ b/tests/gateway/test_undo_command.py
@@ -1,0 +1,68 @@
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_event(text="/undo"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        user_name="tester",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+@pytest.mark.asyncio
+async def test_handle_undo_command_reports_one_turn_and_internal_transcript_count():
+    runner = object.__new__(GatewayRunner)
+    entry = SimpleNamespace(session_id="sess-1", last_prompt_tokens=42)
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "one"},
+        {"role": "user", "content": "fix /undo"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "search_files", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"success": true}'},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "[Internal: inspect the attached image and continue.]"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "_native_image_attachment": True,
+        },
+        {"role": "assistant", "content": "intermediate note"},
+        {"role": "assistant", "content": "final answer"},
+    ]
+
+    store = MagicMock()
+    store.get_or_create_session.return_value = entry
+    store.load_transcript.return_value = history
+    runner.session_store = store
+
+    result = await runner._handle_undo_command(_make_event())
+
+    store.rewrite_transcript.assert_called_once_with("sess-1", history[:2])
+    assert entry.last_prompt_tokens == 0
+    assert "Undid 1 turn" in result
+    assert "6 internal transcript messages" in result
+    assert 'Removed your last message: "fix /undo"' in result
+    assert "Undid 5 message(s)" not in result

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -184,6 +184,41 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+def test_auth_add_codex_oauth_preserves_optional_account_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("codex-meta@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "refresh-token",
+                "account_id": "acct-42",
+                "id_token": "id-token-42",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-03-23T10:00:00Z",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = payload["credential_pool"]["openai-codex"][0]
+    assert entry["label"] == "codex-meta@example.com"
+    assert entry["account_id"] == "acct-42"
+    assert entry["id_token"] == "id-token-42"
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources

--- a/tests/hermes_cli/test_auth_tui.py
+++ b/tests/hermes_cli/test_auth_tui.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import replace
+from types import SimpleNamespace
+
+from agent.credential_pool import PooledCredential, STATUS_EXHAUSTED
+from hermes_cli.auth_tui import (
+    CodexAuthTui,
+    CodexLiveStatus,
+    CodexProfileSnapshot,
+    CodexUsageWindow,
+    SORT_AVAILABILITY,
+    SORT_NAME,
+    SORT_REFRESH,
+    STATE_AVAILABLE,
+    STATE_DEACTIVATED,
+    STATE_LIMITED,
+    _boot_loading_text,
+    _footer_line,
+    auth_view_command,
+    build_codex_profile_snapshots,
+    render_codex_auth_smoke_test,
+)
+
+
+
+class _FakePool:
+    def __init__(self, entries: list[PooledCredential]):
+        self._entries = list(entries)
+
+    def entries(self) -> list[PooledCredential]:
+        return list(self._entries)
+
+    def update_entry(self, entry_id: str, **updates):
+        for idx, entry in enumerate(self._entries):
+            if entry.id != entry_id:
+                continue
+            extra = dict(entry.extra)
+            field_updates = {}
+            for key, value in updates.items():
+                if hasattr(entry, key):
+                    field_updates[key] = value
+                else:
+                    extra[key] = value
+            updated = replace(entry, extra=extra, **field_updates)
+            self._entries[idx] = updated
+            return updated
+        return None
+
+    def remove_entry(self, entry_id: str):
+        for idx, entry in enumerate(self._entries):
+            if entry.id != entry_id:
+                continue
+            return self._entries.pop(idx)
+        return None
+
+
+def test_build_codex_profile_snapshots_classifies_states(monkeypatch):
+    available_entry = PooledCredential(
+        provider="openai-codex",
+        id="cred-1",
+        label="available@example.com",
+        auth_type="oauth",
+        priority=0,
+        source="manual:device_code",
+        access_token="token-1",
+        refresh_token="refresh-1",
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=1711230000.0,
+        last_error_code=429,
+    )
+    primary_exhausted_entry = PooledCredential(
+        provider="openai-codex",
+        id="cred-2",
+        label="hour-capped@example.com",
+        auth_type="oauth",
+        priority=1,
+        source="manual:device_code",
+        access_token="token-2",
+        refresh_token="refresh-2",
+    )
+    dead_entry = PooledCredential(
+        provider="openai-codex",
+        id="cred-3",
+        label="dead@example.com",
+        auth_type="oauth",
+        priority=2,
+        source="manual:device_code",
+        access_token="token-3",
+        refresh_token="refresh-3",
+    )
+    pool = _FakePool([available_entry, primary_exhausted_entry, dead_entry])
+    monkeypatch.setattr("hermes_cli.auth_tui.load_pool", lambda provider: pool)
+
+    def _fake_fetch(pool_obj, entry, timeout_seconds):
+        assert timeout_seconds == 7.5
+        if entry.id == "cred-1":
+            updated = pool_obj.update_entry(
+                entry.id,
+                last_status=None,
+                last_status_at=None,
+                last_error_code=None,
+            )
+            return updated, CodexLiveStatus(
+                http_status=200,
+                email="available@example.com",
+                plan="plus",
+                allowed=True,
+                limit_reached=False,
+                primary_window=CodexUsageWindow(label="5h", used_percent=18, reset_at_ms=1700000000000),
+                secondary_window=CodexUsageWindow(label="Week", used_percent=6, reset_at_ms=1700600000000),
+                local_cooldown_cleared=True,
+            )
+        if entry.id == "cred-2":
+            return entry, CodexLiveStatus(
+                http_status=200,
+                email="hour-capped@example.com",
+                plan="team",
+                allowed=True,
+                limit_reached=False,
+                primary_window=CodexUsageWindow(label="5h", used_percent=100, reset_at_ms=1700000000000),
+                secondary_window=CodexUsageWindow(label="Week", used_percent=12, reset_at_ms=1700600000000),
+            )
+        return entry, CodexLiveStatus(http_status=401, error="HTTP 401", deactivated=True)
+
+    snapshots = build_codex_profile_snapshots(
+        provider="openai-codex",
+        timeout_seconds=7.5,
+        fetch_profile=_fake_fetch,
+    )
+
+    assert len(snapshots) == 3
+    assert snapshots[0].auth_badge == "OK"
+    assert snapshots[0].state == STATE_AVAILABLE
+    assert snapshots[0].local_cooldown_cleared is True
+    assert snapshots[0].local_status is None
+    assert snapshots[0].primary_window is not None
+    assert snapshots[0].primary_window.label == "5h"
+    assert snapshots[1].auth_badge == "OK"
+    assert snapshots[1].state == STATE_LIMITED
+    assert snapshots[1].state_reason == "5h limit reached"
+    assert snapshots[2].auth_badge == "DEAD"
+    assert snapshots[2].state == STATE_DEACTIVATED
+    assert snapshots[2].state_reason == "HTTP 401"
+
+
+def test_build_codex_profile_snapshots_polls_in_parallel(monkeypatch):
+    entries = [
+        PooledCredential(
+            provider="openai-codex",
+            id=f"cred-{idx}",
+            label=f"user{idx}@example.com",
+            auth_type="oauth",
+            priority=idx,
+            source="manual:device_code",
+            access_token=f"token-{idx}",
+            refresh_token=f"refresh-{idx}",
+        )
+        for idx in range(4)
+    ]
+    pool = _FakePool(entries)
+    monkeypatch.setattr("hermes_cli.auth_tui.load_pool", lambda provider: pool)
+
+    thread_ids = set()
+    thread_lock = threading.Lock()
+
+    def _fake_fetch(pool_obj, entry, timeout_seconds):
+        with thread_lock:
+            thread_ids.add(threading.get_ident())
+        time.sleep(0.2)
+        return entry, CodexLiveStatus(
+            http_status=200,
+            email=entry.label,
+            allowed=True,
+            limit_reached=False,
+            primary_window=CodexUsageWindow(label="5h", used_percent=10),
+            secondary_window=CodexUsageWindow(label="Week", used_percent=10),
+        )
+
+    snapshots = build_codex_profile_snapshots(
+        provider="openai-codex",
+        timeout_seconds=7.5,
+        fetch_profile=_fake_fetch,
+    )
+
+    assert len(snapshots) == 4
+    assert len(thread_ids) >= 2
+
+
+def test_build_codex_profile_snapshots_sorts_by_availability(monkeypatch):
+    entries = [
+        PooledCredential(
+            provider="openai-codex",
+            id="dead",
+            label="dead@example.com",
+            auth_type="oauth",
+            priority=0,
+            source="manual:device_code",
+            access_token="token-dead",
+            refresh_token="refresh-dead",
+        ),
+        PooledCredential(
+            provider="openai-codex",
+            id="limited-hour",
+            label="limited-hour@example.com",
+            auth_type="oauth",
+            priority=1,
+            source="manual:device_code",
+            access_token="token-limited-hour",
+            refresh_token="refresh-limited-hour",
+        ),
+        PooledCredential(
+            provider="openai-codex",
+            id="limited-week",
+            label="limited-week@example.com",
+            auth_type="oauth",
+            priority=2,
+            source="manual:device_code",
+            access_token="token-limited-week",
+            refresh_token="refresh-limited-week",
+        ),
+        PooledCredential(
+            provider="openai-codex",
+            id="avail-low",
+            label="avail-low@example.com",
+            auth_type="oauth",
+            priority=3,
+            source="manual:device_code",
+            access_token="token-avail-low",
+            refresh_token="refresh-avail-low",
+        ),
+        PooledCredential(
+            provider="openai-codex",
+            id="avail-high",
+            label="avail-high@example.com",
+            auth_type="oauth",
+            priority=4,
+            source="manual:device_code",
+            access_token="token-avail-high",
+            refresh_token="refresh-avail-high",
+        ),
+    ]
+    pool = _FakePool(entries)
+    monkeypatch.setattr("hermes_cli.auth_tui.load_pool", lambda provider: pool)
+
+    def _fake_fetch(pool_obj, entry, timeout_seconds):
+        if entry.id == "avail-high":
+            return entry, CodexLiveStatus(
+                http_status=200,
+                email="avail-high@example.com",
+                allowed=True,
+                limit_reached=False,
+                primary_window=CodexUsageWindow(label="5h", used_percent=5),
+                secondary_window=CodexUsageWindow(label="Week", used_percent=10),
+            )
+        if entry.id == "avail-low":
+            return entry, CodexLiveStatus(
+                http_status=200,
+                email="avail-low@example.com",
+                allowed=True,
+                limit_reached=False,
+                primary_window=CodexUsageWindow(label="5h", used_percent=55),
+                secondary_window=CodexUsageWindow(label="Week", used_percent=15),
+            )
+        if entry.id == "limited-hour":
+            return entry, CodexLiveStatus(
+                http_status=200,
+                email="limited-hour@example.com",
+                allowed=True,
+                limit_reached=False,
+                primary_window=CodexUsageWindow(label="5h", used_percent=100),
+                secondary_window=CodexUsageWindow(label="Week", used_percent=5),
+            )
+        if entry.id == "limited-week":
+            return entry, CodexLiveStatus(
+                http_status=200,
+                email="limited-week@example.com",
+                allowed=True,
+                limit_reached=False,
+                primary_window=CodexUsageWindow(label="5h", used_percent=5),
+                secondary_window=CodexUsageWindow(label="Week", used_percent=100),
+            )
+        return entry, CodexLiveStatus(http_status=401, error="HTTP 401", deactivated=True)
+
+    snapshots = build_codex_profile_snapshots(
+        provider="openai-codex",
+        timeout_seconds=7.5,
+        fetch_profile=_fake_fetch,
+    )
+
+    assert [snapshot.display_name for snapshot in snapshots] == [
+        "avail-high@example.com",
+        "avail-low@example.com",
+        "limited-hour@example.com",
+        "limited-week@example.com",
+        "dead@example.com",
+    ]
+    assert [snapshot.index for snapshot in snapshots] == [1, 2, 3, 4, 5]
+
+
+def test_render_codex_auth_smoke_test(monkeypatch):
+    monkeypatch.setattr("hermes_cli.auth_tui.time.time", lambda: 0)
+    snapshots = [
+        CodexProfileSnapshot(
+            index=1,
+            entry_id="cred-1",
+            label="available@example.com",
+            display_name="available@example.com",
+            auth_badge="OK",
+            state=STATE_AVAILABLE,
+            state_badge="AVAIL",
+            state_reason="Available",
+            primary_window=CodexUsageWindow(label="5h", used_percent=18, reset_at_ms=5 * 60 * 60 * 1000),
+            secondary_window=CodexUsageWindow(label="Week", used_percent=6, reset_at_ms=(6 * 24 + 23) * 60 * 60 * 1000),
+        ),
+        CodexProfileSnapshot(
+            index=2,
+            entry_id="cred-2",
+            label="dead@example.com",
+            display_name="dead@example.com",
+            auth_badge="DEAD",
+            state=STATE_DEACTIVATED,
+            state_badge="n/a",
+            state_reason="HTTP 401",
+            primary_window=None,
+            secondary_window=None,
+        ),
+    ]
+    monkeypatch.setattr("hermes_cli.auth_tui.build_codex_profile_snapshots", lambda **kwargs: snapshots)
+
+    output = render_codex_auth_smoke_test()
+
+    assert "Codex auth view: 2 profiles" in output
+    assert "available@example.com" in output
+    assert "OK   AVAIL" in output
+    assert "Week_left= 94% @6d23h" in output
+    assert "5h_left= 82% @5h" in output
+    assert "DEAD n/a" in output
+
+
+def test_boot_loading_text_is_compact_spinner_message():
+    assert _boot_loading_text(0) == "Loading |"
+    assert _boot_loading_text(1) == "Loading /"
+
+
+def test_footer_line_prioritizes_message_visibility():
+    line = _footer_line(
+        "Press r again to remove [dup-b] duplicate@example.com.",
+        width=72,
+    )
+
+    assert line.startswith("Press r again to remove")
+    assert "duplicate@example.com" in line
+
+
+def test_refresh_blocking_fetches_live_before_showing_rows(monkeypatch):
+    tui = CodexAuthTui(provider="openai-codex", timeout_seconds=3.0)
+    snapshots = [
+        CodexProfileSnapshot(
+            index=1,
+            entry_id="cred-1",
+            label="live@example.com",
+            display_name="live@example.com",
+            auth_badge="OK",
+            state=STATE_AVAILABLE,
+            state_badge="AVAIL",
+            state_reason="Available",
+            primary_window=CodexUsageWindow(label="5h", used_percent=18),
+            secondary_window=CodexUsageWindow(label="Week", used_percent=6),
+        )
+    ]
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_tui.build_codex_profile_placeholders",
+        lambda provider: (_ for _ in ()).throw(AssertionError("no placeholders on initial load")),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth_tui.build_codex_profile_snapshots",
+        lambda provider, timeout_seconds: snapshots,
+    )
+
+    tui._refresh_blocking(initial=True)
+
+    assert tui.loading is False
+    assert tui.snapshots == snapshots
+    assert tui.message == "Loaded 1 live Codex profile."
+
+
+def test_set_sort_mode_reorders_rows_and_preserves_selection():
+    tui = CodexAuthTui(provider="openai-codex", timeout_seconds=3.0)
+    tui.snapshots = [
+        CodexProfileSnapshot(
+            index=1,
+            entry_id="b",
+            label="beta@example.com",
+            display_name="beta@example.com",
+            auth_badge="OK",
+            state=STATE_AVAILABLE,
+            state_badge="AVAIL",
+            state_reason="Available",
+            primary_window=CodexUsageWindow(label="5h", used_percent=10),
+            secondary_window=CodexUsageWindow(label="Week", used_percent=10),
+            last_refresh="2026-04-03T05:00:00Z",
+        ),
+        CodexProfileSnapshot(
+            index=2,
+            entry_id="a",
+            label="alpha@example.com",
+            display_name="alpha@example.com",
+            auth_badge="OK",
+            state=STATE_AVAILABLE,
+            state_badge="AVAIL",
+            state_reason="Available",
+            primary_window=CodexUsageWindow(label="5h", used_percent=10),
+            secondary_window=CodexUsageWindow(label="Week", used_percent=10),
+            last_refresh="2026-04-03T07:00:00Z",
+        ),
+    ]
+    tui.selected_index = 1
+    tui._selected_entry_id = "a"
+
+    tui._set_sort_mode(SORT_NAME)
+    assert tui.sort_mode == SORT_NAME
+    assert [snapshot.display_name for snapshot in tui.snapshots] == [
+        "alpha@example.com",
+        "beta@example.com",
+    ]
+    assert tui.selected_index == 0
+
+    tui._set_sort_mode(SORT_REFRESH)
+    assert tui.sort_mode == SORT_REFRESH
+    assert tui.snapshots[0].entry_id == "a"
+    assert tui.selected_index == 0
+
+    tui._set_sort_mode(SORT_AVAILABILITY)
+    assert tui.sort_mode == SORT_AVAILABILITY
+
+
+def test_remove_selected_removes_exact_duplicate_entry(monkeypatch):
+    duplicate_a = PooledCredential(
+        provider="openai-codex",
+        id="dup-a",
+        label="duplicate@example.com",
+        auth_type="oauth",
+        priority=0,
+        source="manual:device_code",
+        access_token="token-a",
+        refresh_token="refresh-a",
+    )
+    duplicate_b = PooledCredential(
+        provider="openai-codex",
+        id="dup-b",
+        label="duplicate@example.com",
+        auth_type="oauth",
+        priority=1,
+        source="manual:device_code",
+        access_token="token-b",
+        refresh_token="refresh-b",
+    )
+    pool = _FakePool([duplicate_a, duplicate_b])
+    monkeypatch.setattr("hermes_cli.auth_tui.load_pool", lambda provider: pool)
+
+    tui = CodexAuthTui(provider="openai-codex", timeout_seconds=3.0)
+    tui.snapshots = [
+        CodexProfileSnapshot(
+            index=1,
+            entry_id="dup-a",
+            label="duplicate@example.com",
+            display_name="duplicate@example.com",
+            auth_badge="OK",
+            state=STATE_AVAILABLE,
+            state_badge="AVAIL",
+            state_reason="Available",
+            primary_window=None,
+            secondary_window=None,
+        ),
+        CodexProfileSnapshot(
+            index=2,
+            entry_id="dup-b",
+            label="duplicate@example.com",
+            display_name="duplicate@example.com",
+            auth_badge="OK",
+            state=STATE_AVAILABLE,
+            state_badge="AVAIL",
+            state_reason="Available",
+            primary_window=None,
+            secondary_window=None,
+        ),
+    ]
+    tui.selected_index = 1
+    tui._selected_entry_id = "dup-b"
+    monkeypatch.setattr(tui, "_refresh_async", lambda: None)
+
+    tui._remove_selected()
+    assert "Press r again" in tui.message
+    assert "dup-b" in tui.message
+    assert [entry.id for entry in pool.entries()] == ["dup-a", "dup-b"]
+
+    tui._remove_selected()
+    assert [entry.id for entry in pool.entries()] == ["dup-a"]
+    assert "Removed" in tui.message
+    assert "dup-b" in tui.message
+
+
+def test_render_row_marks_selection_without_inverting_bars(monkeypatch):
+    monkeypatch.setattr("hermes_cli.auth_tui.time.time", lambda: 0)
+    tui = CodexAuthTui(provider="openai-codex", timeout_seconds=3.0)
+    snapshot = CodexProfileSnapshot(
+        index=1,
+        entry_id="cred-1",
+        label="live@example.com",
+        display_name="live@example.com",
+        auth_badge="OK",
+        state=STATE_AVAILABLE,
+        state_badge="AVAIL",
+        state_reason="Available",
+        primary_window=CodexUsageWindow(label="5h", used_percent=18, reset_at_ms=5 * 60 * 60 * 1000),
+        secondary_window=CodexUsageWindow(label="Week", used_percent=6, reset_at_ms=(6 * 24 + 23) * 60 * 60 * 1000),
+    )
+
+    plain = tui._render_row(snapshot, 120, selected=False)
+    selected = tui._render_row(snapshot, 120, selected=True)
+
+    assert plain.startswith("  OK")
+    assert selected.startswith("> OK")
+    assert "Week" not in selected
+    assert selected.index("@6d23h") < selected.index("@5h")
+    assert "[████████" in selected
+
+
+def test_auth_view_command_smoke_test(capsys, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth_tui.render_codex_auth_smoke_test",
+        lambda **kwargs: "smoke ok",
+    )
+
+    auth_view_command(SimpleNamespace(provider="openai-codex", timeout=3.0, smoke_test=True))
+
+    out = capsys.readouterr().out
+    assert out.strip() == "smoke ok"

--- a/tests/hermes_cli/test_context_limit.py
+++ b/tests/hermes_cli/test_context_limit.py
@@ -1,0 +1,28 @@
+from hermes_cli.context_limit import (
+    CONTEXT_LIMIT_PRESETS,
+    cycle_context_limit,
+    parse_context_limit_value,
+)
+
+
+def test_parse_context_limit_accepts_plain_integer():
+    assert parse_context_limit_value("500000") == 500_000
+
+
+def test_parse_context_limit_accepts_suffixes_and_separators():
+    assert parse_context_limit_value("272k") == 272_000
+    assert parse_context_limit_value("1m") == 1_000_000
+    assert parse_context_limit_value("500,000") == 500_000
+
+
+def test_parse_context_limit_rejects_invalid_values():
+    assert parse_context_limit_value("") is None
+    assert parse_context_limit_value("turbo") is None
+    assert parse_context_limit_value("0") is None
+
+
+def test_cycle_context_limit_switches_between_presets():
+    low, high = CONTEXT_LIMIT_PRESETS
+    assert cycle_context_limit(low) == high
+    assert cycle_context_limit(high) == low
+    assert cycle_context_limit(500_000) == low

--- a/tests/hermes_cli/test_fast_mode.py
+++ b/tests/hermes_cli/test_fast_mode.py
@@ -1,0 +1,36 @@
+from hermes_cli.fast_mode import (
+    FAST_MODE_USAGE,
+    fast_mode_note,
+    normalize_service_tier,
+    parse_fast_command_arg,
+    responses_api_service_tier,
+)
+
+
+class TestFastModeHelpers:
+    def test_parse_fast_command_args(self):
+        assert parse_fast_command_arg("") == "toggle"
+        assert parse_fast_command_arg(None) == "toggle"
+        assert parse_fast_command_arg("on") == "on"
+        assert parse_fast_command_arg("off") == "off"
+        assert parse_fast_command_arg("status") == "status"
+        assert parse_fast_command_arg("weird") is None
+
+    def test_normalize_service_tier(self):
+        assert normalize_service_tier(None) is None
+        assert normalize_service_tier("priority") == "fast"
+        assert normalize_service_tier("fast") == "fast"
+        assert normalize_service_tier("flex") == "flex"
+        assert normalize_service_tier("off") is None
+
+    def test_responses_api_mapping(self):
+        assert responses_api_service_tier("fast") == "priority"
+        assert responses_api_service_tier("priority") == "priority"
+        assert responses_api_service_tier("flex") == "flex"
+        assert responses_api_service_tier(None) is None
+
+    def test_fast_mode_note(self):
+        assert "service_tier=priority" in fast_mode_note()
+        assert "next Codex turn" in fast_mode_note("openai-codex", "gpt-5.4")
+        assert "will not send" in fast_mode_note(enabled=False)
+        assert FAST_MODE_USAGE.startswith("/fast")

--- a/tests/hermes_cli/test_kitty_overlay.py
+++ b/tests/hermes_cli/test_kitty_overlay.py
@@ -1,0 +1,33 @@
+from hermes_cli.kitty_overlay import build_overlay_launch_command, kitty_overlay_available
+
+
+def test_kitty_overlay_available_requires_socket_and_window(monkeypatch):
+    monkeypatch.setenv("KITTY_LISTEN_ON", "unix:/tmp/kitty-rc.sock")
+    monkeypatch.setenv("KITTY_WINDOW_ID", "42")
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/kitten" if cmd == "kitten" else None)
+
+    assert kitty_overlay_available() is True
+
+
+def test_kitty_overlay_available_is_false_without_socket(monkeypatch):
+    monkeypatch.delenv("KITTY_LISTEN_ON", raising=False)
+    monkeypatch.setenv("KITTY_WINDOW_ID", "42")
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/kitten" if cmd == "kitten" else None)
+
+    assert kitty_overlay_available() is False
+
+
+def test_build_overlay_launch_command_targets_current_window():
+    cmd = build_overlay_launch_command(
+        listen_on="unix:/tmp/kitty-rc.sock",
+        window_id="42",
+        python_executable="/usr/bin/python3",
+        script_path="/opt/hermes/kitty_overlay_prompt.py",
+        spec_path="/tmp/spec.json",
+    )
+
+    assert cmd[:5] == ["kitten", "@", "--to", "unix:/tmp/kitty-rc.sock", "launch"]
+    assert "--match" in cmd
+    assert "window_id:42" in cmd
+    assert "--type=overlay" in cmd
+    assert cmd[-4:] == ["/usr/bin/python3", "/opt/hermes/kitty_overlay_prompt.py", "--spec", "/tmp/spec.json"]

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -72,6 +72,27 @@ def test_get_platform_tools_keeps_enabled_mcp_servers_with_explicit_builtin_sele
     assert "web-search-prime" in enabled
 
 
+def test_get_platform_tools_auto_enables_new_default_on_builtin_toolset_once():
+    config = {
+        "platform_toolsets": {"cli": ["web", "memory"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert "docs" in enabled
+
+
+def test_get_platform_tools_respects_saved_disable_of_new_builtin_toolset():
+    config = {
+        "platform_toolsets": {"cli": ["web", "memory"]},
+        "known_builtin_toolsets": {"cli": ["web", "docs", "memory"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert "docs" not in enabled
+
+
 def test_get_platform_tools_no_mcp_sentinel_excludes_all_mcp_servers():
     """The 'no_mcp' sentinel in platform_toolsets excludes all MCP servers."""
     config = {
@@ -165,6 +186,7 @@ def test_save_platform_tools_handles_empty_existing_config():
     saved_toolsets = config["platform_toolsets"]["telegram"]
     assert "web" in saved_toolsets
     assert "terminal" in saved_toolsets
+    assert "docs" in config["known_builtin_toolsets"]["telegram"]
 
 
 def test_save_platform_tools_handles_invalid_existing_config():

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -1,6 +1,7 @@
 """Tests for the update check mechanism in hermes_cli.banner."""
 
 import json
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -25,14 +26,18 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "head": "abc123"}))
+
+    mock_head = subprocess.CompletedProcess(
+        ["git", "rev-parse", "HEAD"], 0, stdout="abc123\n", stderr=""
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with patch("hermes_cli.banner.subprocess.run", return_value=mock_head) as mock_run:
         result = check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    assert mock_run.call_count == 1
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
@@ -47,14 +52,46 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     cache_file = tmp_path / ".update_check"
     cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
 
-    mock_result = MagicMock(returncode=0, stdout="5\n")
+    mock_run_results = [
+        subprocess.CompletedProcess(["git", "rev-parse", "HEAD"], 0, stdout="abc123\n", stderr=""),
+        subprocess.CompletedProcess(["git", "fetch", "origin", "--quiet"], 0, stdout="", stderr=""),
+        subprocess.CompletedProcess(["git", "rev-list", "--count", "HEAD..origin/main"], 0, stdout="5\n", stderr=""),
+    ]
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+    with patch("hermes_cli.banner.subprocess.run", side_effect=mock_run_results) as mock_run:
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # git rev-parse + git fetch + git rev-list
+
+
+def test_check_for_updates_ignores_fresh_cache_when_head_changes(tmp_path):
+    """Fresh cache should be refreshed after a manual git update changes HEAD."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 47, "head": "oldsha"}))
+
+    mock_run_results = [
+        subprocess.CompletedProcess(["git", "rev-parse", "HEAD"], 0, stdout="newsha\n", stderr=""),
+        subprocess.CompletedProcess(["git", "fetch", "origin", "--quiet"], 0, stdout="", stderr=""),
+        subprocess.CompletedProcess(["git", "rev-list", "--count", "HEAD..origin/main"], 0, stdout="0\n", stderr=""),
+    ]
+
+    with patch("hermes_cli.banner.os.getenv", return_value=str(tmp_path)):
+        with patch("hermes_cli.banner.subprocess.run", side_effect=mock_run_results) as mock_run:
+            result = check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 3
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 0
+    assert cached["head"] == "newsha"
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1,5 +1,7 @@
 """Tests for plugins/memory/honcho/session.py — HonchoSession and helpers."""
 
+import threading
+import time
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -361,3 +363,90 @@ class TestDialecticInputGuard:
         # The query passed to chat() should be truncated
         actual_query = mock_peer.chat.call_args[0][0]
         assert len(actual_query) <= 100
+
+
+# ---------------------------------------------------------------------------
+# Provider initialization
+# ---------------------------------------------------------------------------
+
+
+class TestHonchoProviderInit:
+    def test_initialize_hybrid_returns_without_waiting_for_honcho(self, monkeypatch):
+        provider = HonchoMemoryProvider()
+        cfg = SimpleNamespace(
+            enabled=True,
+            api_key="test-key",
+            base_url=None,
+            recall_mode="hybrid",
+            raw={},
+        )
+        started = threading.Event()
+        release = threading.Event()
+
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda: cfg,
+        )
+
+        def fake_do_session_init(_cfg, _session_id, **_kwargs):
+            started.set()
+            release.wait(timeout=1.0)
+
+        provider._do_session_init = fake_do_session_init
+
+        start = time.perf_counter()
+        provider.initialize("session-1")
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.2
+        assert started.wait(timeout=0.2)
+        assert provider._init_thread is not None
+        assert provider._init_thread.is_alive()
+
+        release.set()
+        provider._init_thread.join(timeout=1.0)
+
+    def test_sync_turn_queues_while_background_init_is_running(self):
+        provider = HonchoMemoryProvider()
+        provider._init_thread = MagicMock()
+        provider._init_thread.is_alive.return_value = True
+
+        provider.sync_turn("hello", "world")
+
+        assert provider._pending_sync_turns == [("hello", "world")]
+
+    def test_background_init_flushes_queued_turns(self, monkeypatch):
+        provider = HonchoMemoryProvider()
+        cfg = SimpleNamespace(
+            enabled=True,
+            api_key="test-key",
+            base_url=None,
+            recall_mode="hybrid",
+            raw={},
+            message_max_chars=25000,
+        )
+        session = MagicMock()
+        manager = MagicMock()
+        manager.get_or_create.return_value = session
+
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda: cfg,
+        )
+
+        def fake_do_session_init(_cfg, _session_id, **_kwargs):
+            provider._config = cfg
+            provider._manager = manager
+            provider._session_key = "session-1"
+            provider._session_initialized = True
+
+        provider._do_session_init = fake_do_session_init
+        provider._pending_sync_turns.append(("hello", "world"))
+
+        provider.initialize("session-1")
+        provider._init_thread.join(timeout=1.0)
+
+        session.add_message.assert_any_call("user", "hello")
+        session.add_message.assert_any_call("assistant", "world")
+        manager._flush_session.assert_called_once_with(session)
+        assert provider._pending_sync_turns == []

--- a/tests/run_agent/test_context_limit_override.py
+++ b/tests/run_agent/test_context_limit_override.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _build_agent(*, context_length_override: int = 272_000) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            model="test/model",
+            base_url="https://example.invalid/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            context_length_override=context_length_override,
+        )
+    agent.client = MagicMock()
+    return agent
+
+
+def test_set_context_length_override_updates_live_compressor_and_runtime():
+    agent = _build_agent()
+
+    new_context = agent.set_context_length_override(1_000_000)
+
+    assert new_context == 1_000_000
+    assert agent.context_length_override == 1_000_000
+    assert agent.context_compressor.context_length == 1_000_000
+    assert agent.context_compressor.threshold_tokens == int(
+        1_000_000 * agent.context_compressor.threshold_percent
+    )
+    assert agent._primary_runtime["compressor_context_length"] == 1_000_000
+
+
+def test_switch_model_preserves_context_length_override():
+    agent = _build_agent(context_length_override=500_000)
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+    ):
+        agent.switch_model(
+            new_model="gpt-5",
+            new_provider="openai-codex",
+            api_key="test-key-1234567890",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+        )
+
+    assert agent.context_length_override == 500_000
+    assert agent.context_compressor.context_length == 500_000
+    assert agent._primary_runtime["compressor_context_length"] == 500_000

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -493,6 +493,27 @@ class TestChatMessagesToResponsesInput:
         reasoning_items = [i for i in items if i.get("type") == "reasoning"]
         assert len(reasoning_items) == 0
 
+    def test_user_multimodal_content_becomes_responses_parts(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUFB"}},
+            ],
+        }]
+
+        items = agent._chat_messages_to_responses_input(messages)
+
+        assert items == [{
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "What is in this image?"},
+                {"type": "input_image", "image_url": "data:image/png;base64,QUFB"},
+            ],
+        }]
+
 
 # ── Response normalization tests ─────────────────────────────────────────────
 
@@ -843,6 +864,23 @@ class TestCodexReasoningPreflight:
         reasoning_items = [i for i in items if isinstance(i, dict) and i.get("type") == "reasoning"]
         assert len(reasoning_items) == 1
         assert reasoning_items[0]["encrypted_content"] == "enc123"
+
+    def test_multimodal_content_list_passes_preflight(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        raw_input = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe it"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                ],
+            }
+        ]
+
+        normalized = agent._preflight_codex_input_items(raw_input)
+
+        assert normalized == raw_input
 
 
 # ── Reasoning effort consistency tests ───────────────────────────────────────

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -374,6 +374,42 @@ class TestBuildApiKwargsCodex:
         assert "name" in tools[0]
         assert "function" not in tools[0]
 
+    def test_fast_service_tier_maps_to_priority(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        agent.service_tier = "fast"
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs["service_tier"] == "priority"
+
+    def test_non_openai_responses_route_omits_service_tier(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "custom", api_mode="codex_responses",
+                            base_url="https://example.invalid/v1")
+        agent.service_tier = "fast"
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "service_tier" not in kwargs
+
+    def test_openai_codex_provider_on_openrouter_omits_service_tier(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://openrouter.ai/api/v1")
+        agent.service_tier = "fast"
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "service_tier" not in kwargs
+
+    def test_preflight_accepts_priority_service_tier(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        normalized = agent._preflight_codex_api_kwargs(
+            {
+                "model": "gpt-5.4",
+                "instructions": "be helpful",
+                "input": [{"role": "user", "content": "hi"}],
+                "tools": [],
+                "store": False,
+                "service_tier": "priority",
+            }
+        )
+        assert normalized["service_tier"] == "priority"
+
 
 # ── Message conversion tests ────────────────────────────────────────────────
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -713,6 +713,28 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
 
+    def test_hermes_docs_lookup_guidance_when_tool_loaded(self):
+        from agent.prompt_builder import HERMES_DOCS_LOOKUP_GUIDANCE
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "hermes_docs_lookup"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-k...7890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        prompt = agent._build_system_prompt()
+        assert HERMES_DOCS_LOOKUP_GUIDANCE in prompt
+
     def test_includes_datetime(self, agent):
         prompt = agent._build_system_prompt()
         # Should contain current date info like "Conversation started:"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2228,6 +2228,47 @@ class TestCredentialPoolRecovery:
         assert captured["status_code"] == 429
         assert captured["error_context"]["reason"] == "device_code_exhausted"
 
+    def test_recover_with_pool_rotates_after_same_credential_401s_twice(self, agent):
+        """A pooled credential should only get one refresh attempt per request."""
+        current = SimpleNamespace(label="primary", id="abc")
+        refreshed_entry = SimpleNamespace(label="refreshed-primary", id="abc")
+        next_entry = SimpleNamespace(label="secondary", id="def")
+
+        pool = MagicMock()
+        pool.provider = "openai-codex"
+        pool.current.return_value = current
+        pool.try_refresh_current.return_value = refreshed_entry
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+        agent._emit_status = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        assert agent._credential_pool_401_refresh_attempted_ids == {"abc"}
+        agent._swap_credential.assert_called_once_with(refreshed_entry)
+        pool.try_refresh_current.assert_called_once()
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        assert agent._swap_credential.call_count == 2
+        assert agent._swap_credential.call_args_list[1].args == (next_entry,)
+        pool.try_refresh_current.assert_called_once()
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=401)
+        assert agent._credential_pool_401_refresh_attempted_ids == set()
+
 
 class TestMaxTokensParam:
     """Verify _max_tokens_param returns the correct key for each provider."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -806,6 +806,14 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["extra_body"]["provider"]["only"] == ["Anthropic"]
 
+    def test_custom_extra_body_forwarded_for_local_openai_routes(self, agent):
+        agent.base_url = "http://127.0.0.1:30121/v1"
+        agent.extra_body_config = {"chat_template_kwargs": {"enable_thinking": False}}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+        assert "reasoning" not in kwargs["extra_body"]
+
     def test_reasoning_config_default_openrouter(self, agent):
         """Default reasoning config for OpenRouter should be medium."""
         agent.base_url = "https://openrouter.ai/api/v1"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -512,6 +512,111 @@ class TestInit:
             )
 
 
+class TestNativeMultimodalToolFiltering:
+    @staticmethod
+    def _fake_tool_loader(**kwargs):
+        names = ["web_search", "vision_analyze", "attach_image"]
+        excluded = set(kwargs.get("excluded_tool_names") or set())
+        return _make_tool_defs(*[name for name in names if name not in excluded])
+
+    def test_codex_runtime_excludes_vision_tool_on_init(self):
+        with (
+            patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                provider="openai-codex",
+                api_mode="codex_responses",
+                base_url="https://chatgpt.com/backend-api/codex",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent.valid_tool_names == {"web_search", "attach_image"}
+        assert "vision_analyze" not in agent.valid_tool_names
+
+    def test_switch_model_refreshes_runtime_filtered_tool_surface(self, agent):
+        with (
+            patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader),
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        ):
+            agent.refresh_tool_surface(invalidate_prompt=False)
+            assert agent.valid_tool_names == {"web_search", "vision_analyze"}
+
+            agent.switch_model(
+                new_model="gpt-5",
+                new_provider="openai-codex",
+                api_key="test-key-1234567890",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_mode="codex_responses",
+            )
+
+        assert agent.valid_tool_names == {"web_search", "attach_image"}
+
+    def test_fallback_restore_refreshes_runtime_filtered_tool_surface(self, agent):
+        with patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader):
+            agent.refresh_tool_surface(invalidate_prompt=False)
+            assert agent.valid_tool_names == {"web_search", "vision_analyze"}
+
+        agent._fallback_activated = False
+        agent._fallback_chain = [{"provider": "openai-codex", "model": "gpt-5"}]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://chatgpt.com/backend-api/codex"
+        mock_client.api_key = "test-key-1234567890"
+
+        with (
+            patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader),
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.valid_tool_names == {"web_search", "attach_image"}
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.valid_tool_names == {"web_search", "vision_analyze"}
+
+
+class TestNativeImageQueue:
+    def test_flush_pending_native_images_appends_internal_multimodal_user_message(self, agent, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        agent.provider = "openai-codex"
+        agent.api_mode = "codex_responses"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+
+        result = agent._queue_native_image_attachment(str(img), note="inspect this screenshot")
+        assert result["success"] is True
+        assert result["queued"] == 1
+
+        messages = [{"role": "user", "content": "do the task"}]
+        assert agent._flush_pending_native_images(messages) is True
+        assert len(messages) == 2
+        queued_message = messages[-1]
+        assert queued_message["role"] == "user"
+        assert queued_message["_native_image_attachment"] is True
+        assert queued_message["content"][0]["type"] == "text"
+        assert "inspect this screenshot" in queued_message["content"][0]["text"]
+        assert queued_message["content"][1]["type"] == "image_url"
+        assert queued_message["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert agent._pending_native_images == []
+
+    def test_queue_native_image_attachment_rejects_text_only_runtime(self, agent, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        agent.provider = "openrouter"
+        agent.api_mode = "chat_completions"
+        agent.base_url = "https://openrouter.ai/api/v1"
+
+        result = agent._queue_native_image_attachment(str(img))
+        assert result["success"] is False
+        assert "does not support native image input" in result["error"]
+        assert agent._pending_native_images == []
+
+
 class TestInterrupt:
     def test_interrupt_sets_flag(self, agent):
         with patch("run_agent._set_interrupt"):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1924,6 +1924,155 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "rate limited" in result["error"]
 
+    def test_api_errors_retry_twenty_times_by_default(self, agent):
+        """Main API loop should keep retrying long enough for auth/pool recovery paths."""
+        self._setup_agent(agent)
+        calls = {"api": 0}
+
+        class _RateLimitError(RuntimeError):
+            def __init__(self):
+                super().__init__("rate limited")
+                self.status_code = 429
+
+        def _fake_api_call(api_kwargs):
+            calls["api"] += 1
+            raise _RateLimitError()
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch("run_agent.time", self._make_fast_time_mock()),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert calls["api"] == 20
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "rate limited" in result["error"]
+
+    def test_402_pool_rotation_still_recovers_with_default_retry_budget(self, agent):
+        """Hermes credential-pool auth should still rotate/retry successfully on 402."""
+        self._setup_agent(agent)
+        calls = {"api": 0}
+        next_entry = SimpleNamespace(label="secondary")
+
+        class _PaymentRequiredError(RuntimeError):
+            def __init__(self):
+                super().__init__("Error code: 402 - credits exhausted")
+                self.status_code = 402
+
+        class _Pool:
+            def mark_exhausted_and_rotate(self, *, status_code):
+                assert status_code == 402
+                return next_entry
+
+        def _fake_api_call(api_kwargs):
+            calls["api"] += 1
+            if calls["api"] == 1:
+                raise _PaymentRequiredError()
+            return _mock_response(
+                content="Recovered after pool rotation",
+                finish_reason="stop",
+            )
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert calls["api"] == 2
+        agent._swap_credential.assert_called_once_with(next_entry)
+        assert result.get("completed") is True
+        assert result.get("final_response") == "Recovered after pool rotation"
+
+    def test_codex_pool_quota_text_rotates_without_backoff(self, agent):
+        """Codex profile limits should rotate immediately even when the SDK omits status_code."""
+        self._setup_agent(agent)
+        agent.provider = "openai-codex"
+        calls = {"api": 0}
+        next_entry = SimpleNamespace(label="secondary", id="cred-2")
+
+        class _QuotaError(RuntimeError):
+            pass
+
+        def _fake_api_call(api_kwargs):
+            calls["api"] += 1
+            if calls["api"] == 1:
+                raise _QuotaError("usage limit reached for current codex profile")
+            return _mock_response(
+                content="Recovered via secondary Codex profile",
+                finish_reason="stop",
+            )
+
+        pool = MagicMock()
+        pool.provider = "openai-codex"
+        pool.has_available.return_value = True
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+        agent._emit_status = MagicMock()
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch("run_agent.time.sleep") as mock_sleep,
+        ):
+            result = agent.run_conversation("hello")
+
+        assert calls["api"] == 2
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429)
+        agent._swap_credential.assert_called_once_with(next_entry)
+        mock_sleep.assert_not_called()
+        assert result.get("completed") is True
+        assert result.get("final_response") == "Recovered via secondary Codex profile"
+
+    def test_codex_pool_exhaustion_fails_fast_without_backoff(self, agent):
+        """Once every Codex profile is exhausted, fail immediately instead of exponential waiting."""
+        self._setup_agent(agent)
+        agent.provider = "openai-codex"
+        calls = {"api": 0}
+
+        class _QuotaError(RuntimeError):
+            pass
+
+        def _fake_api_call(api_kwargs):
+            calls["api"] += 1
+            raise _QuotaError("usage limit reached for current codex profile")
+
+        pool = MagicMock()
+        pool.provider = "openai-codex"
+        pool.has_available.return_value = False
+        pool.mark_exhausted_and_rotate.return_value = None
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+        agent._emit_status = MagicMock()
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch("run_agent.time.sleep") as mock_sleep,
+        ):
+            result = agent.run_conversation("hello")
+
+        assert calls["api"] == 1
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429)
+        mock_sleep.assert_not_called()
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "All Codex profiles are exhausted" in result.get("final_response", "")
+
 
 # ---------------------------------------------------------------------------
 # Flush sentinel leak
@@ -2115,9 +2264,29 @@ class TestCredentialPoolRecovery:
         assert retry_same is False
         agent._swap_credential.assert_called_once_with(next_entry)
 
+    def test_recover_with_codex_pool_rotates_immediately_on_first_429(self, agent):
+        next_entry = SimpleNamespace(label="secondary")
+        pool = MagicMock()
+        pool.provider = "openai-codex"
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+        agent._emit_status = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429)
+        agent._swap_credential.assert_called_once_with(next_entry)
+
 
     def test_recover_with_pool_refreshes_on_401(self, agent):
-        """401 with successful refresh should swap to refreshed credential."""
+
         refreshed_entry = SimpleNamespace(label="refreshed-primary", id="abc")
 
         class _Pool:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -24,7 +25,15 @@ def _patch_agent_bootstrap(monkeypatch):
                     "description": "Run shell commands.",
                     "parameters": {"type": "object", "properties": {}},
                 },
-            }
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "attach_image",
+                    "description": "Attach a local image for native multimodal inspection.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
         ],
     )
     monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
@@ -434,6 +443,73 @@ def test_run_conversation_codex_empty_output_no_output_text_retries(monkeypatch)
     assert calls["api"] >= 2
     assert result["completed"] is True
     assert result["final_response"] == "Recovered"
+
+
+def test_run_conversation_codex_multimodal_user_content(monkeypatch, tmp_path):
+    agent = _build_agent(monkeypatch)
+    image_path = tmp_path / "screenshot.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    seen = {}
+
+    def _fake_api_call(api_kwargs):
+        seen["api_kwargs"] = api_kwargs
+        return _codex_message_response("looks good")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation([
+        {"type": "text", "text": "What is in this screenshot?"},
+        {"type": "image_url", "image_url": {"url": str(image_path)}},
+    ])
+
+    assert result["completed"] is True
+    assert result["final_response"] == "looks good"
+    assert seen["api_kwargs"]["input"][0]["role"] == "user"
+    assert seen["api_kwargs"]["input"][0]["content"][0]["type"] == "input_text"
+    assert seen["api_kwargs"]["input"][0]["content"][1]["type"] == "input_image"
+    assert seen["api_kwargs"]["input"][0]["content"][1]["image_url"].startswith("data:image/png;base64,")
+
+
+def test_run_conversation_codex_attach_image_tool_queues_native_image_for_next_step(monkeypatch, tmp_path):
+    agent = _build_agent(monkeypatch)
+    image_path = tmp_path / "screenshot.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    seen_calls = []
+
+    attach_response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="function_call",
+                id="fc_attach_1",
+                call_id="call_attach_1",
+                name="attach_image",
+                arguments=json.dumps({"path": str(image_path), "note": "inspect this screenshot"}),
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+    responses = [attach_response, _codex_message_response("looks good")]
+
+    def _fake_api_call(api_kwargs):
+        seen_calls.append(api_kwargs)
+        return responses[len(seen_calls) - 1]
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("Inspect the screenshot you just created")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "looks good"
+    assert len(seen_calls) == 2
+    second_input = seen_calls[1]["input"]
+    assert second_input[-1]["role"] == "user"
+    assert second_input[-1]["content"][0]["type"] == "input_text"
+    assert "inspect this screenshot" in second_input[-1]["content"][0]["text"]
+    assert second_input[-1]["content"][1]["type"] == "input_image"
+    assert second_input[-1]["content"][1]["image_url"].startswith("data:image/png;base64,")
 
 
 def test_run_conversation_codex_refreshes_after_401_and_retries(monkeypatch):

--- a/tests/test_cli_context_limit_command.py
+++ b/tests/test_cli_context_limit_command.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+class _FakeAgent:
+    def __init__(self, context_length: int):
+        self.context_compressor = SimpleNamespace(context_length=context_length)
+        self.calls = []
+
+    def set_context_length_override(self, value):
+        self.calls.append(value)
+        self.context_compressor.context_length = value
+        return value
+
+
+def _make_cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = None
+    cli.model = "gpt-5.4"
+    cli.provider = "openai-codex"
+    cli.context_length_override = None
+    return cli
+
+
+class TestCliContextLimitCommand:
+    def test_process_command_routes_context_limit(self):
+        cli = _make_cli()
+        cli._handle_context_limit_command = MagicMock()
+
+        result = cli.process_command("/context-limit 500000")
+
+        assert result is True
+        cli._handle_context_limit_command.assert_called_once_with("/context-limit 500000")
+
+    def test_handle_context_limit_toggles_live_agent(self):
+        cli = _make_cli()
+        cli.agent = _FakeAgent(272_000)
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_context_limit_command("/context-limit")
+
+        assert cli.context_length_override == 1_000_000
+        assert cli.agent.calls == [1_000_000]
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        assert "1,000,000" in printed
+
+    def test_handle_context_limit_sets_explicit_value(self):
+        cli = _make_cli()
+        cli.agent = _FakeAgent(272_000)
+
+        with patch("cli._cprint"):
+            cli._handle_context_limit_command("/context-limit 500000")
+
+        assert cli.context_length_override == 500_000
+        assert cli.agent.calls == [500_000]
+
+    def test_handle_context_limit_invalid_arg_shows_usage(self):
+        cli = _make_cli()
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_context_limit_command("/context-limit turbo")
+
+        assert cli.context_length_override is None
+        assert any("Usage: /context-limit" in call.args[0] for call in mock_cprint.call_args_list)

--- a/tests/test_cli_fast_command.py
+++ b/tests/test_cli_fast_command.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.codex_service_tier = None
+    cli.agent = None
+    cli.model = "gpt-5.4"
+    cli.provider = "openai-codex"
+    return cli
+
+
+class TestCliFastCommand:
+    def test_process_command_routes_fast(self):
+        cli = _make_cli()
+        cli._handle_fast_command = MagicMock()
+
+        result = cli.process_command("/fast on")
+
+        assert result is True
+        cli._handle_fast_command.assert_called_once_with("/fast on")
+
+    def test_handle_fast_on_updates_live_agent(self):
+        cli = _make_cli()
+        cli.agent = SimpleNamespace(service_tier=None, provider="openai-codex", model="gpt-5.4")
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_fast_command("/fast on")
+
+        assert cli.codex_service_tier == "fast"
+        assert cli.agent.service_tier == "fast"
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        assert "Fast mode" in printed
+        assert "service_tier=priority" in printed
+
+    def test_handle_fast_status_does_not_mutate(self):
+        cli = _make_cli()
+        cli.codex_service_tier = "fast"
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_fast_command("/fast status")
+
+        assert cli.codex_service_tier == "fast"
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        assert "ON" in printed
+
+    def test_handle_fast_invalid_arg_shows_usage(self):
+        cli = _make_cli()
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_fast_command("/fast turbo")
+
+        assert cli.codex_service_tier is None
+        assert any("Usage: /fast" in call.args[0] for call in mock_cprint.call_args_list)

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -8,6 +8,7 @@ import pytest
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
@@ -137,3 +138,50 @@ class TestBackwardCompat:
     def test_tool_to_toolset_map(self):
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
+
+    def test_attach_image_registered_in_vision_toolset(self):
+        assert get_toolset_for_tool("attach_image") == "vision"
+
+
+class TestGetToolDefinitionsRuntimeFiltering:
+    def test_excluded_tool_names_remove_tool_and_strip_stale_read_file_hint(self):
+        read_file_tool = {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": (
+                    "Read a text file. NOTE: Cannot read images or binary files — "
+                    "use vision_analyze for images."
+                ),
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        vision_tool = {
+            "type": "function",
+            "function": {
+                "name": "vision_analyze",
+                "description": "Analyze images using AI vision.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        def _resolve(toolset_name):
+            return {
+                "file": ["read_file"],
+                "vision": ["vision_analyze"],
+            }[toolset_name]
+
+        with (
+            patch("model_tools.validate_toolset", return_value=True),
+            patch("model_tools.resolve_toolset", side_effect=_resolve),
+            patch("model_tools.registry.get_definitions", return_value=[read_file_tool, vision_tool]),
+        ):
+            tools = get_tool_definitions(
+                enabled_toolsets=["file", "vision"],
+                quiet_mode=True,
+                excluded_tool_names={"vision_analyze"},
+            )
+
+        tool_names = [tool["function"]["name"] for tool in tools]
+        assert tool_names == ["read_file"]
+        assert "vision_analyze" not in tools[0]["function"]["description"]

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -30,6 +30,10 @@ class TestResolveToolset:
         tools = resolve_toolset("web")
         assert set(tools) == {"web_search", "web_extract"}
 
+    def test_docs_toolset(self):
+        tools = resolve_toolset("docs")
+        assert set(tools) == {"hermes_docs_lookup"}
+
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
         assert "terminal" in tools

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -752,7 +752,101 @@ class TestHasClipboardImage:
 
 
 # ═════════════════════════════════════════════════════════════════════════
-# Level 2: _preprocess_images_with_vision — image → text via vision tool
+# Level 2: Text clipboard copy helpers
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestCopyTextToClipboard:
+    def test_macos_uses_pbcopy(self):
+        import hermes_cli.clipboard as cb
+
+        with patch("hermes_cli.clipboard.sys.platform", "darwin"):
+            with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stderr="")
+                ok, error = cb.copy_text_to_clipboard("hello world")
+
+        assert ok is True
+        assert error is None
+        mock_run.assert_called_once_with(
+            ["pbcopy"],
+            input="hello world",
+            text=True,
+            capture_output=True,
+            timeout=3,
+            check=False,
+        )
+
+    def test_linux_x11_uses_xclip_when_available(self):
+        import hermes_cli.clipboard as cb
+
+        with patch("hermes_cli.clipboard.sys.platform", "linux"):
+            with patch("hermes_cli.clipboard._is_wsl", return_value=False):
+                with patch.dict(os.environ, {}, clear=True):
+                    with patch("hermes_cli.clipboard.shutil.which", side_effect=lambda cmd: "/usr/bin/xclip" if cmd == "xclip" else None):
+                        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+                            mock_run.return_value = MagicMock(returncode=0, stderr="")
+                            ok, error = cb.copy_text_to_clipboard("copied text")
+
+        assert ok is True
+        assert error is None
+        mock_run.assert_called_once_with(
+            ["xclip", "-selection", "clipboard"],
+            input="copied text",
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+            check=False,
+        )
+
+    def test_linux_without_copy_backend_returns_helpful_error(self):
+        import hermes_cli.clipboard as cb
+
+        with patch("hermes_cli.clipboard.sys.platform", "linux"):
+            with patch("hermes_cli.clipboard._is_wsl", return_value=False):
+                with patch.dict(os.environ, {}, clear=True):
+                    with patch("hermes_cli.clipboard.shutil.which", return_value=None):
+                        ok, error = cb.copy_text_to_clipboard("hello")
+
+        assert ok is False
+        assert error is not None
+        assert "clipboard" in error.lower()
+        assert "wl-copy" in error or "xclip" in error
+
+
+class TestCopyLatestAssistantMessage:
+    @pytest.fixture
+    def cli(self):
+        from cli import HermesCLI
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj._last_assistant_message_text = ""
+        return cli_obj
+
+    def test_no_reply_returns_message(self, cli):
+        assert cli._copy_latest_assistant_message() == (False, "No assistant reply yet to copy.")
+
+    def test_success_copies_latest_reply(self, cli):
+        cli._last_assistant_message_text = "latest reply"
+
+        with patch("hermes_cli.clipboard.copy_text_to_clipboard", return_value=(True, None)) as mock_copy:
+            assert cli._copy_latest_assistant_message() == (
+                True,
+                "Copied latest assistant reply to the system clipboard.",
+            )
+
+        mock_copy.assert_called_once_with("latest reply")
+
+    def test_backend_error_is_returned(self, cli):
+        cli._last_assistant_message_text = "latest reply"
+
+        with patch("hermes_cli.clipboard.copy_text_to_clipboard", return_value=(False, "xclip missing")):
+            assert cli._copy_latest_assistant_message() == (
+                False,
+                "Clipboard copy failed: xclip missing",
+            )
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Level 3: _preprocess_images_with_vision — image → text via vision tool
 # ═════════════════════════════════════════════════════════════════════════
 
 class TestPreprocessImagesWithVision:
@@ -862,6 +956,55 @@ class TestPreprocessImagesWithVision:
             result = cli._preprocess_images_with_vision("check this", [img])
         assert isinstance(result, str)
         assert str(img) in result  # path still included for retry
+
+
+class TestPrepareUserMessageWithImages:
+    @pytest.fixture
+    def cli(self):
+        from cli import HermesCLI
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        return cli_obj
+
+    def test_codex_route_uses_native_multimodal(self, cli, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        result = cli._prepare_user_message_with_images(
+            "Describe this",
+            [img],
+            {
+                "runtime": {
+                    "provider": "openai-codex",
+                    "api_mode": "codex_responses",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                }
+            },
+        )
+
+        assert isinstance(result, list)
+        assert result[0]["type"] == "text"
+        assert result[1]["type"] == "image_url"
+        assert result[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_text_only_route_uses_vision_fallback(self, cli, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        with patch.object(cli, "_preprocess_images_with_vision", return_value="fallback text") as mock_pre:
+            result = cli._prepare_user_message_with_images(
+                "Describe this",
+                [img],
+                {
+                    "runtime": {
+                        "provider": "openrouter",
+                        "api_mode": "chat_completions",
+                        "base_url": "https://openrouter.ai/api/v1",
+                    }
+                },
+            )
+
+        assert result == "fallback text"
+        mock_pre.assert_called_once_with("Describe this", [img])
 
 
 # ═════════════════════════════════════════════════════════════════════════

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -844,6 +844,10 @@ class TestCopyLatestAssistantMessage:
                 "Clipboard copy failed: xclip missing",
             )
 
+    def test_remember_assistant_message_noops_without_overlay_sink(self, cli):
+        cli._remember_assistant_message("hello from hermes")
+        assert cli._last_assistant_message_text == "hello from hermes"
+
 
 # ═════════════════════════════════════════════════════════════════════════
 # Level 3: _preprocess_images_with_vision — image → text via vision tool

--- a/tests/tools/test_hermes_docs_lookup_tool.py
+++ b/tests/tools/test_hermes_docs_lookup_tool.py
@@ -1,0 +1,134 @@
+"""Tests for tools/hermes_docs_lookup_tool.py — public-upstream retrieval and ranking."""
+
+import json
+from textwrap import dedent
+from unittest.mock import patch
+
+from tools.hermes_docs_lookup_tool import hermes_docs_lookup_tool
+
+
+PUBLIC_TREE = [
+    {"path": "website/docs/user-guide/features/plugins.md", "type": "blob"},
+    {"path": "website/docs/user-guide/features/skins.md", "type": "blob"},
+    {"path": "website/docs/user-guide/features/personality.md", "type": "blob"},
+    {"path": "website/docs/user-guide/features/memory-providers.md", "type": "blob"},
+    {"path": "hermes_cli/plugins.py", "type": "blob"},
+    {"path": "model_tools.py", "type": "blob"},
+    {"path": "RELEASE_v0.4.0.md", "type": "blob"},
+]
+
+PUBLIC_CONTENT = {
+    "website/docs/user-guide/features/plugins.md": dedent(
+        """
+        ---
+        title: Plugins
+        ---
+        # Plugins
+
+        Hermes has a plugin system for adding custom tools, hooks, and integrations without modifying core code.
+
+        ## Quick overview
+        Drop a directory into ~/.hermes/plugins/ with a plugin.yaml and Python code.
+        """
+    ).strip(),
+    "website/docs/user-guide/features/skins.md": dedent(
+        """
+        # Skins & Themes
+
+        Skins control the visual presentation of the Hermes CLI.
+        Personality changes tone and wording.
+        """
+    ).strip(),
+    "website/docs/user-guide/features/personality.md": dedent(
+        """
+        # Personality & SOUL.md
+
+        Personality controls how Hermes sounds, while skins control the visual presentation.
+        """
+    ).strip(),
+    "website/docs/user-guide/features/memory-providers.md": dedent(
+        """
+        # Memory Providers
+
+        Hermes Agent ships with 8 external memory provider plugins.
+        """
+    ).strip(),
+    "hermes_cli/plugins.py": dedent(
+        '''
+        class PluginManager:
+            """Central manager that discovers, loads, and invokes plugins."""
+
+        def discover_plugins():
+            pass
+        '''
+    ).strip(),
+    "model_tools.py": dedent(
+        """
+        # Plugin tool discovery (user/project/pip plugins)
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+        """
+    ).strip(),
+    "RELEASE_v0.4.0.md": dedent(
+        """
+        # Release v0.4.0
+
+        - hermes plugins install/remove/list commands
+        - Slash command registration for plugins
+        """
+    ).strip(),
+}
+
+
+def _mock_fetch_text(path: str, *, prefer_cache: bool = True) -> str:
+    return PUBLIC_CONTENT[path]
+
+
+class TestHermesDocsLookupTool:
+    def test_prefers_public_docs_page_over_code_and_release_notes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("tools.hermes_docs_lookup_tool._fetch_upstream_tree", return_value=PUBLIC_TREE),
+            patch("tools.hermes_docs_lookup_tool._fetch_upstream_text", side_effect=_mock_fetch_text),
+        ):
+            data = json.loads(hermes_docs_lookup_tool("how do plugins work", scope="docs_and_code", limit=3))
+
+        assert data["success"] is True
+        assert data["corpus"] == "public_hermes_main"
+        assert data["results"][0]["path"] == "website/docs/user-guide/features/plugins.md"
+        assert data["results"][0]["source_kind"] == "public_docs"
+        assert data["results"][0]["heading"] == "Plugins"
+        assert "plugin system" in data["results"][0]["snippet"].lower()
+        assert data["results"][0]["url"].startswith("https://hermes-agent.nousresearch.com/docs/")
+
+    def test_returns_public_code_result_for_symbol_query_when_scope_includes_code(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("tools.hermes_docs_lookup_tool._fetch_upstream_tree", return_value=PUBLIC_TREE),
+            patch("tools.hermes_docs_lookup_tool._fetch_upstream_text", side_effect=_mock_fetch_text),
+        ):
+            data = json.loads(hermes_docs_lookup_tool("discover_plugins", scope="docs_and_code", limit=5))
+
+        assert data["success"] is True
+        assert any(
+            r["path"] == "hermes_cli/plugins.py" and r["source_kind"] == "public_code"
+            for r in data["results"]
+        )
+
+    def test_handles_concept_query_that_maps_to_multiple_docs_pages(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("tools.hermes_docs_lookup_tool._fetch_upstream_tree", return_value=PUBLIC_TREE),
+            patch("tools.hermes_docs_lookup_tool._fetch_upstream_text", side_effect=_mock_fetch_text),
+        ):
+            data = json.loads(hermes_docs_lookup_tool("difference between personality and skin", limit=5))
+
+        assert data["success"] is True
+        top_paths = [r["path"] for r in data["results"][:3]]
+        assert "website/docs/user-guide/features/skins.md" in top_paths
+        assert "website/docs/user-guide/features/personality.md" in top_paths
+
+    def test_invalid_scope_returns_error_json(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        data = json.loads(hermes_docs_lookup_tool("plugins", scope="nope"))
+        assert "error" in data

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -13,8 +13,10 @@ import pytest
 from tools.vision_tools import (
     _validate_image_url,
     _handle_vision_analyze,
+    _detect_image_mime_type,
     _determine_mime_type,
     _image_to_base64_data_url,
+    _rasterize_svg_to_png,
     vision_analyze_tool,
     check_vision_requirements,
     get_debug_session_info,
@@ -151,6 +153,91 @@ class TestImageToBase64DataUrl:
     def test_file_not_found_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             _image_to_base64_data_url(tmp_path / "nonexistent.png")
+
+
+# ---------------------------------------------------------------------------
+# SVG rasterization
+# ---------------------------------------------------------------------------
+
+
+class TestSvgRasterization:
+    def test_detects_svg_content_even_when_extension_is_not_svg(self, tmp_path):
+        svg = tmp_path / "downloaded-image.jpg"
+        svg.write_text("<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12'></svg>", encoding="utf-8")
+
+        assert _detect_image_mime_type(svg) == "image/svg+xml"
+
+    def test_rasterize_svg_to_png_uses_headless_chrome_fallback(self, tmp_path):
+        svg = tmp_path / "diagram.svg"
+        svg.write_text("<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12'></svg>", encoding="utf-8")
+
+        def fake_run(cmd, check, stdout, stderr):
+            out_flag = next(part for part in cmd if part.startswith("--screenshot="))
+            out_path = Path(out_flag.split("=", 1)[1])
+            out_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+            return MagicMock()
+
+        with (
+            patch.dict("sys.modules", {"cairosvg": None}),
+            patch("tools.vision_tools.shutil.which", side_effect=lambda name: "/usr/bin/google-chrome" if name == "google-chrome" else None),
+            patch("tools.vision_tools.subprocess.run", side_effect=fake_run) as mock_run,
+        ):
+            png = _rasterize_svg_to_png(svg)
+
+        assert png.suffix == ".png"
+        assert png.exists()
+        assert png.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+        assert mock_run.called
+
+    @pytest.mark.asyncio
+    async def test_local_svg_is_rasterized_to_png_before_llm_call(self, tmp_path):
+        svg = tmp_path / "diagram.svg"
+        svg.write_text("<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12'></svg>", encoding="utf-8")
+        rasterized = tmp_path / "diagram.rasterized.png"
+        rasterized.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Rendered SVG"
+        mock_response.choices = [mock_choice]
+
+        def fake_data_url(path, mime_type=None):
+            assert path == rasterized
+            assert mime_type == "image/png"
+            return "data:image/png;base64,abc"
+
+        with (
+            patch("tools.vision_tools._rasterize_svg_to_png", return_value=rasterized),
+            patch("tools.vision_tools._image_to_base64_data_url", side_effect=fake_data_url),
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response),
+        ):
+            result = json.loads(await vision_analyze_tool(str(svg), "describe this", "test/model"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Rendered SVG"
+
+    @pytest.mark.asyncio
+    async def test_local_svg_keeps_source_but_cleans_up_rasterized_png(self, tmp_path):
+        svg = tmp_path / "diagram.svg"
+        svg.write_text("<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12'></svg>", encoding="utf-8")
+        rasterized = tmp_path / "diagram.rasterized.png"
+        rasterized.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Rendered SVG"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("tools.vision_tools._rasterize_svg_to_png", return_value=rasterized),
+            patch("tools.vision_tools._image_to_base64_data_url", return_value="data:image/png;base64,abc"),
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response),
+        ):
+            result = json.loads(await vision_analyze_tool(str(svg), "describe this", "test/model"))
+
+        assert result["success"] is True
+        assert svg.exists(), "local source SVG should not be deleted"
+        assert not rasterized.exists(), "temporary rasterized PNG should be cleaned up"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hermes_docs_lookup_tool.py
+++ b/tools/hermes_docs_lookup_tool.py
@@ -1,0 +1,799 @@
+"""Public Hermes docs/code lookup tool.
+
+Searches the public upstream Hermes repository (NousResearch/hermes-agent@main)
+with docs-first ranking so the agent can answer Hermes product questions without
+being biased toward the current local checkout/fork.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, List
+
+import requests
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+PUBLIC_REPO = "NousResearch/hermes-agent"
+PUBLIC_BRANCH = "main"
+PUBLIC_TREE_URL = f"https://api.github.com/repos/{PUBLIC_REPO}/git/trees/{PUBLIC_BRANCH}?recursive=1"
+PUBLIC_RAW_BASE_URL = f"https://raw.githubusercontent.com/{PUBLIC_REPO}/{PUBLIC_BRANCH}/"
+PUBLIC_BLOB_BASE_URL = f"https://github.com/{PUBLIC_REPO}/blob/{PUBLIC_BRANCH}/"
+PUBLIC_DOCS_BASE_URL = "https://hermes-agent.nousresearch.com/docs/"
+
+TREE_TTL_SECONDS = 60 * 60
+CONTENT_TTL_SECONDS = 60 * 60 * 24
+DEFAULT_LIMIT = 5
+MAX_LIMIT = 10
+MAX_CANDIDATE_FILES = 18
+MIN_CANDIDATE_FILES = 8
+
+VALID_SCOPES = {"docs", "code", "docs_and_code"}
+
+STOPWORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "between", "by", "can", "config", "configuration",
+    "difference", "do", "does", "for", "from", "get", "how", "i", "in", "is", "it", "kind", "kinds",
+    "of", "on", "or", "our", "should", "that", "the", "their", "them", "these", "this", "to", "up",
+    "use", "using", "what", "when", "which", "why", "with", "would", "you", "your",
+}
+
+TOKEN_SYNONYMS = {
+    "plugin": {"plugins"},
+    "plugins": {"plugin"},
+    "skin": {"skins", "theme", "themes"},
+    "skins": {"skin", "theme", "themes"},
+    "theme": {"themes", "skin", "skins"},
+    "themes": {"theme", "skin", "skins"},
+    "personality": {"soul"},
+    "memory": {"memories"},
+    "provider": {"providers"},
+    "providers": {"provider"},
+    "tool": {"tools", "toolset", "toolsets"},
+    "tools": {"tool", "toolset", "toolsets"},
+    "toolset": {"toolsets", "tools"},
+    "toolsets": {"toolset", "tools"},
+    "command": {"commands", "cli"},
+    "commands": {"command", "cli"},
+    "docs": {"documentation"},
+    "documentation": {"docs"},
+    "lookup": {"search"},
+    "search": {"lookup"},
+}
+
+CURATED_FALLBACK_PATHS = [
+    "website/docs/getting-started/quickstart.md",
+    "website/docs/user-guide/configuration.md",
+    "website/docs/user-guide/features/overview.md",
+    "website/docs/reference/cli-commands.md",
+    "website/docs/reference/slash-commands.md",
+    "website/docs/reference/tools-reference.md",
+    "website/docs/developer-guide/architecture.md",
+    "README.md",
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "run_agent.py",
+    "cli.py",
+    "model_tools.py",
+    "toolsets.py",
+]
+
+_SESSION = requests.Session()
+_SESSION.headers.update({"User-Agent": "HermesAgent/hermes_docs_lookup"})
+
+_TREE_MEMORY_CACHE: dict[str, Any] = {"tree": None, "fetched_at": 0.0}
+_CONTENT_MEMORY_CACHE: dict[str, tuple[float, str]] = {}
+
+_ROOT_DOCS = {"README.md", "AGENTS.md", "CONTRIBUTING.md"}
+_CODE_ROOTS = (
+    "agent/",
+    "gateway/",
+    "hermes_cli/",
+    "tools/",
+)
+_CODE_ROOT_FILES = {"run_agent.py", "cli.py", "model_tools.py", "toolsets.py"}
+
+
+def _cache_dir() -> Path:
+    path = get_hermes_home() / "cache" / "hermes_docs_lookup"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _tree_cache_path() -> Path:
+    return _cache_dir() / "public_tree.json"
+
+
+def _content_cache_path(path: str) -> Path:
+    digest = hashlib.sha1(path.encode("utf-8")).hexdigest()
+    return _cache_dir() / "content" / f"{digest}.json"
+
+
+def _load_cache_payload(path: Path) -> dict[str, Any] | None:
+    try:
+        if path.exists():
+            return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug("Failed to load cache payload %s: %s", path, exc)
+    return None
+
+
+def _save_cache_payload(path: Path, payload: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_json_write(path, payload, indent=None, separators=(",", ":"))
+    except Exception as exc:
+        logger.debug("Failed to save cache payload %s: %s", path, exc)
+
+
+def _cache_is_fresh(payload: dict[str, Any] | None, ttl_seconds: int) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(fetched_at, (int, float)):
+        return False
+    return (time.time() - float(fetched_at)) < ttl_seconds
+
+
+def _http_get_json(url: str, timeout: int = 20) -> Any:
+    response = _SESSION.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def _http_get_text(url: str, timeout: int = 20) -> str:
+    response = _SESSION.get(url, timeout=timeout)
+    response.raise_for_status()
+    response.encoding = response.encoding or "utf-8"
+    return response.text
+
+
+def _fetch_upstream_tree(*, prefer_cache: bool = True) -> list[dict[str, Any]]:
+    if prefer_cache and _TREE_MEMORY_CACHE.get("tree") and (time.time() - _TREE_MEMORY_CACHE.get("fetched_at", 0.0)) < TREE_TTL_SECONDS:
+        return list(_TREE_MEMORY_CACHE["tree"])
+
+    disk_payload = _load_cache_payload(_tree_cache_path()) if prefer_cache else None
+    if prefer_cache and _cache_is_fresh(disk_payload, TREE_TTL_SECONDS):
+        tree = disk_payload.get("tree") or []
+        _TREE_MEMORY_CACHE["tree"] = list(tree)
+        _TREE_MEMORY_CACHE["fetched_at"] = float(disk_payload.get("fetched_at", time.time()))
+        return list(tree)
+
+    try:
+        data = _http_get_json(PUBLIC_TREE_URL)
+        tree = data.get("tree") or []
+        payload = {"fetched_at": time.time(), "tree": tree}
+        _TREE_MEMORY_CACHE["tree"] = list(tree)
+        _TREE_MEMORY_CACHE["fetched_at"] = float(payload["fetched_at"])
+        _save_cache_payload(_tree_cache_path(), payload)
+        return list(tree)
+    except Exception as exc:
+        logger.debug("Failed to fetch public Hermes tree: %s", exc)
+
+    if isinstance(disk_payload, dict):
+        tree = disk_payload.get("tree") or []
+        if tree:
+            return list(tree)
+    return []
+
+
+def _fetch_upstream_text(path: str, *, prefer_cache: bool = True) -> str:
+    if prefer_cache:
+        mem_entry = _CONTENT_MEMORY_CACHE.get(path)
+        if mem_entry and (time.time() - mem_entry[0]) < CONTENT_TTL_SECONDS:
+            return mem_entry[1]
+
+    cache_path = _content_cache_path(path)
+    disk_payload = _load_cache_payload(cache_path) if prefer_cache else None
+    if prefer_cache and _cache_is_fresh(disk_payload, CONTENT_TTL_SECONDS):
+        text = str(disk_payload.get("text") or "")
+        _CONTENT_MEMORY_CACHE[path] = (float(disk_payload.get("fetched_at", time.time())), text)
+        return text
+
+    url = f"{PUBLIC_RAW_BASE_URL}{path}"
+    try:
+        text = _http_get_text(url)
+        payload = {"fetched_at": time.time(), "path": path, "text": text}
+        _CONTENT_MEMORY_CACHE[path] = (float(payload["fetched_at"]), text)
+        _save_cache_payload(cache_path, payload)
+        return text
+    except Exception as exc:
+        logger.debug("Failed to fetch upstream text for %s: %s", path, exc)
+
+    if isinstance(disk_payload, dict) and isinstance(disk_payload.get("text"), str):
+        return str(disk_payload["text"])
+    raise
+
+
+def _local_checkout_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _iter_local_paths(scope: str) -> list[dict[str, Any]]:
+    root = _local_checkout_root()
+    paths: list[dict[str, Any]] = []
+
+    def _add_if_exists(rel: str) -> None:
+        if (root / rel).exists():
+            paths.append({"path": rel, "type": "blob"})
+
+    if scope in {"docs", "docs_and_code"}:
+        docs_root = root / "website" / "docs"
+        if docs_root.exists():
+            for file_path in docs_root.rglob("*.md"):
+                paths.append({"path": str(file_path.relative_to(root)), "type": "blob"})
+            for file_path in docs_root.rglob("*.mdx"):
+                paths.append({"path": str(file_path.relative_to(root)), "type": "blob"})
+        for rel in sorted(_ROOT_DOCS):
+            _add_if_exists(rel)
+        for file_path in sorted(root.glob("RELEASE_*.md")):
+            paths.append({"path": str(file_path.relative_to(root)), "type": "blob"})
+
+    if scope in {"code", "docs_and_code"}:
+        for rel in sorted(_CODE_ROOT_FILES):
+            _add_if_exists(rel)
+        for subdir in _CODE_ROOTS:
+            base = root / subdir
+            if base.exists():
+                for file_path in base.rglob("*.py"):
+                    paths.append({"path": str(file_path.relative_to(root)), "type": "blob"})
+
+    return paths
+
+
+def _fetch_local_text(path: str, *, prefer_cache: bool = True) -> str:
+    del prefer_cache
+    return (_local_checkout_root() / path).read_text(encoding="utf-8")
+
+
+def _is_docs_path(path: str) -> bool:
+    return path.startswith("website/docs/") and path.endswith((".md", ".mdx"))
+
+
+def _is_root_doc_path(path: str) -> bool:
+    return path in _ROOT_DOCS or bool(re.fullmatch(r"RELEASE_[^/]+\.md", path))
+
+
+def _is_code_path(path: str) -> bool:
+    if not path.endswith(".py"):
+        return False
+    return path in _CODE_ROOT_FILES or any(path.startswith(prefix) for prefix in _CODE_ROOTS)
+
+
+def _path_allowed_for_scope(path: str, scope: str) -> bool:
+    if scope == "docs":
+        return _is_docs_path(path) or _is_root_doc_path(path)
+    if scope == "code":
+        return _is_code_path(path)
+    if scope == "docs_and_code":
+        return _is_docs_path(path) or _is_root_doc_path(path) or _is_code_path(path)
+    return False
+
+
+def _source_kind_for_path(path: str, corpus: str) -> str:
+    if corpus == "public_hermes_main":
+        if _is_docs_path(path):
+            return "public_docs"
+        if _is_root_doc_path(path):
+            return "public_root_docs"
+        return "public_code"
+
+    if _is_docs_path(path):
+        return "local_checkout_fallback_docs"
+    if _is_root_doc_path(path):
+        return "local_checkout_fallback_root_docs"
+    return "local_checkout_fallback_code"
+
+
+def _normalize_token(token: str) -> set[str]:
+    token = token.strip().lower()
+    if not token:
+        return set()
+
+    variants = {token}
+    if len(token) > 4 and token.endswith("ies"):
+        variants.add(token[:-3] + "y")
+    if len(token) > 3 and token.endswith("es"):
+        variants.add(token[:-2])
+    if len(token) > 3 and token.endswith("s") and not token.endswith("ss"):
+        variants.add(token[:-1])
+    if len(token) > 5 and token.endswith("ing"):
+        variants.add(token[:-3])
+    if len(token) > 4 and token.endswith("ed"):
+        variants.add(token[:-2])
+    variants |= TOKEN_SYNONYMS.get(token, set())
+    return {v for v in variants if v and v not in STOPWORDS}
+
+
+def _tokenize(text: str) -> set[str]:
+    raw_tokens = re.findall(r"[a-zA-Z0-9_]+", text.lower())
+    tokens: set[str] = set()
+    for raw in raw_tokens:
+        tokens |= _normalize_token(raw)
+        if "_" in raw:
+            for part in raw.split("_"):
+                tokens |= _normalize_token(part)
+    return tokens
+
+
+def _query_terms(query: str) -> set[str]:
+    tokens = _tokenize(query)
+    if not tokens:
+        stripped = re.findall(r"[a-zA-Z0-9_]+", query.lower())
+        return {tok for tok in stripped if tok}
+    return tokens
+
+
+def _docs_page_url(path: str, heading: str | None = None) -> str:
+    rel = path.removeprefix("website/docs/")
+    rel = re.sub(r"\.(md|mdx)$", "", rel)
+    url = f"{PUBLIC_DOCS_BASE_URL}{rel}"
+    if heading:
+        anchor = _slugify_heading(heading)
+        if anchor:
+            url = f"{url}#{anchor}"
+    return url
+
+
+def _github_blob_url(path: str, start_line: int | None = None, end_line: int | None = None) -> str:
+    url = f"{PUBLIC_BLOB_BASE_URL}{path}"
+    if start_line and end_line and end_line >= start_line:
+        if end_line == start_line:
+            return f"{url}#L{start_line}"
+        return f"{url}#L{start_line}-L{end_line}"
+    if start_line:
+        return f"{url}#L{start_line}"
+    return url
+
+
+def _slugify_heading(heading: str) -> str:
+    slug = heading.strip().lower()
+    slug = re.sub(r"[`*_]+", "", slug)
+    slug = re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = re.sub(r"\s+", "-", slug)
+    slug = re.sub(r"-+", "-", slug)
+    return slug.strip("-")
+
+
+def _path_priority(path: str) -> int:
+    if _is_docs_path(path):
+        return 0
+    if _is_root_doc_path(path):
+        return 1
+    return 2
+
+
+def _looks_like_symbol_query(query: str) -> bool:
+    return bool(re.search(r"[_./:]", query)) or bool(re.search(r"[a-z][A-Z]", query))
+
+
+def _path_score(path: str, query_terms: set[str], query: str) -> float:
+    path_tokens = _tokenize(path.replace("/", " ").replace("-", " ").replace(".", " "))
+    filename = Path(path).stem.lower()
+    score = 0.0
+    matched_terms = 0
+    path_lower = path.lower()
+    symbol_query = _looks_like_symbol_query(query)
+    for term in query_terms:
+        if term in path_tokens:
+            score += 4.0
+            matched_terms += 1
+        elif term in path_lower:
+            score += 1.5
+        if term == filename:
+            score += 5.0
+    score += float(matched_terms * matched_terms)
+
+    if _is_docs_path(path):
+        score += 3.0
+        if "/user-guide/" in path_lower or "/reference/" in path_lower:
+            score += 1.5
+        if "/developer-guide/" in path_lower and not symbol_query and not ({"developer", "implementation", "internal", "internals", "runtime", "source", "code"} & query_terms):
+            score -= 2.5
+    elif _is_root_doc_path(path):
+        score += 1.5
+    else:
+        score += 0.5
+        if symbol_query and (query.lower() in path_lower or filename == query.lower()):
+            score += 8.0
+    return score
+
+
+@dataclass
+class Chunk:
+    path: str
+    source_kind: str
+    title: str
+    heading: str
+    start_line: int
+    end_line: int
+    text: str
+    url: str
+    path_score: float
+
+
+def _strip_frontmatter(lines: list[str]) -> tuple[list[str], int, str | None]:
+    if not lines or lines[0].strip() != "---":
+        return lines, 0, None
+
+    title: str | None = None
+    for idx in range(1, len(lines)):
+        line = lines[idx]
+        if line.strip() == "---":
+            body = lines[idx + 1 :]
+            for meta_line in lines[1:idx]:
+                match = re.match(r"title\s*:\s*[\"']?(.*?)[\"']?\s*$", meta_line.strip())
+                if match and match.group(1).strip():
+                    title = match.group(1).strip()
+                    break
+            return body, idx + 1, title
+    return lines, 0, None
+
+
+def _markdown_chunks(path: str, source_kind: str, raw_text: str, path_score: float) -> list[Chunk]:
+    lines = raw_text.splitlines()
+    body_lines, offset, frontmatter_title = _strip_frontmatter(lines)
+    if not body_lines:
+        return []
+
+    page_title = frontmatter_title or Path(path).stem.replace("-", " ").title()
+    chunks: list[Chunk] = []
+    current_heading = page_title
+    current_start = 1 + offset
+    current_buffer: list[str] = []
+
+    def _flush(end_line_exclusive: int) -> None:
+        if not current_buffer:
+            return
+        text = "\n".join(current_buffer).strip()
+        if not text:
+            return
+        url = _docs_page_url(path, None if current_heading == page_title else current_heading)
+        chunks.append(
+            Chunk(
+                path=path,
+                source_kind=source_kind,
+                title=page_title,
+                heading=current_heading,
+                start_line=current_start,
+                end_line=max(current_start, end_line_exclusive - 1),
+                text=text,
+                url=url,
+                path_score=path_score,
+            )
+        )
+
+    for idx, line in enumerate(body_lines, start=1 + offset):
+        heading_match = re.match(r"^(#{1,6})\s+(.*)$", line.strip())
+        if heading_match:
+            _flush(idx)
+            current_heading = heading_match.group(2).strip() or page_title
+            current_start = idx
+            current_buffer = [line]
+        else:
+            current_buffer.append(line)
+
+    _flush(len(body_lines) + offset + 1)
+    return chunks
+
+
+def _code_chunks(path: str, source_kind: str, raw_text: str, path_score: float) -> list[Chunk]:
+    lines = raw_text.splitlines()
+    if not lines:
+        return []
+
+    chunks: list[Chunk] = []
+    title = Path(path).name
+    symbol_pattern = re.compile(r"^(class|def)\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+    # Module header chunk
+    header_end = min(len(lines), 40)
+    header_text = "\n".join(lines[:header_end]).strip()
+    if header_text:
+        chunks.append(
+            Chunk(
+                path=path,
+                source_kind=source_kind,
+                title=title,
+                heading=f"module {title}",
+                start_line=1,
+                end_line=header_end,
+                text=header_text,
+                url=_github_blob_url(path, 1, header_end),
+                path_score=path_score,
+            )
+        )
+
+    symbol_lines: list[tuple[int, str]] = []
+    for idx, line in enumerate(lines, start=1):
+        match = symbol_pattern.match(line)
+        if match:
+            symbol_lines.append((idx, match.group(2)))
+
+    for pos, (start_line, symbol_name) in enumerate(symbol_lines):
+        next_start = symbol_lines[pos + 1][0] if pos + 1 < len(symbol_lines) else len(lines) + 1
+        end_line = min(len(lines), next_start - 1)
+        text = "\n".join(lines[start_line - 1 : end_line]).strip()
+        if not text:
+            continue
+        chunks.append(
+            Chunk(
+                path=path,
+                source_kind=source_kind,
+                title=title,
+                heading=symbol_name,
+                start_line=start_line,
+                end_line=end_line,
+                text=text,
+                url=_github_blob_url(path, start_line, end_line),
+                path_score=path_score,
+            )
+        )
+
+    return chunks
+
+
+def _chunks_for_document(path: str, source_kind: str, text: str, path_score: float) -> list[Chunk]:
+    if path.endswith((".md", ".mdx")):
+        return _markdown_chunks(path, source_kind, text, path_score)
+    return _code_chunks(path, source_kind, text, path_score)
+
+
+def _combined_text_tokens(chunk: Chunk) -> set[str]:
+    return _tokenize(f"{chunk.path} {chunk.title} {chunk.heading} {chunk.text}")
+
+
+def _chunk_score(chunk: Chunk, query_terms: set[str], query: str) -> float:
+    title_tokens = _tokenize(chunk.title)
+    heading_tokens = _tokenize(chunk.heading)
+    body_tokens = _tokenize(chunk.text)
+    combined_tokens = title_tokens | heading_tokens | body_tokens
+    symbol_query = _looks_like_symbol_query(query)
+
+    score = chunk.path_score
+    for term in query_terms:
+        if term in title_tokens:
+            score += 7.0
+        if term in heading_tokens:
+            score += 9.0
+        if term in body_tokens:
+            score += 2.0
+        if term in combined_tokens:
+            score += 0.5
+
+    query_words = [w for w in re.findall(r"[a-zA-Z0-9_]+", query.lower()) if w not in STOPWORDS]
+    phrase = " ".join(query_words).strip()
+    haystack = re.sub(r"\s+", " ", f"{chunk.heading} {chunk.text}".lower())
+    if phrase and phrase in haystack:
+        score += 10.0
+
+    if symbol_query:
+        if query.lower() in chunk.heading.lower():
+            score += 12.0
+        if query.lower() in chunk.path.lower():
+            score += 10.0
+        if chunk.source_kind.endswith("code"):
+            score += 4.0
+
+    if chunk.source_kind == "public_docs":
+        score += 4.0
+    elif chunk.source_kind == "public_root_docs":
+        score += 2.0
+
+    return score
+
+
+def _snippet_from_chunk(chunk: Chunk, query_terms: set[str], max_chars: int = 320) -> str:
+    text = re.sub(r"\s+", " ", chunk.text).strip()
+    if len(text) <= max_chars:
+        return text
+
+    lower = text.lower()
+    best_index = -1
+    for term in sorted(query_terms, key=len, reverse=True):
+        best_index = lower.find(term.lower())
+        if best_index != -1:
+            break
+
+    if best_index == -1:
+        return text[: max_chars - 1].rstrip() + "…"
+
+    start = max(0, best_index - max_chars // 3)
+    end = min(len(text), start + max_chars)
+    snippet = text[start:end].strip()
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(text):
+        snippet = snippet.rstrip() + "…"
+    return snippet
+
+
+def _fallback_candidates(tree: list[dict[str, Any]], scope: str) -> list[str]:
+    allowed = {entry.get("path") for entry in tree if isinstance(entry, dict) and _path_allowed_for_scope(str(entry.get("path", "")), scope)}
+    return [path for path in CURATED_FALLBACK_PATHS if path in allowed and _path_allowed_for_scope(path, scope)]
+
+
+def _candidate_paths(tree: list[dict[str, Any]], query_terms: set[str], scope: str, query: str) -> list[tuple[str, float]]:
+    scored: list[tuple[str, float]] = []
+    for entry in tree:
+        if not isinstance(entry, dict) or entry.get("type") != "blob":
+            continue
+        path = str(entry.get("path") or "")
+        if not path or not _path_allowed_for_scope(path, scope):
+            continue
+        score = _path_score(path, query_terms, query)
+        scored.append((path, score))
+
+    scored.sort(key=lambda item: (-item[1], _path_priority(item[0]), item[0]))
+    nonzero = [item for item in scored if item[1] > 0][:MAX_CANDIDATE_FILES]
+    if len(nonzero) >= MIN_CANDIDATE_FILES:
+        return nonzero
+
+    seen = {path for path, _ in nonzero}
+    results = list(nonzero)
+    for path in _fallback_candidates(tree, scope):
+        if path not in seen:
+            results.append((path, _path_score(path, query_terms, query)))
+            seen.add(path)
+        if len(results) >= MIN_CANDIDATE_FILES:
+            break
+
+    if len(results) < MIN_CANDIDATE_FILES:
+        for path, score in scored:
+            if path in seen:
+                continue
+            results.append((path, score))
+            seen.add(path)
+            if len(results) >= MIN_CANDIDATE_FILES:
+                break
+
+    return results[:MAX_CANDIDATE_FILES]
+
+
+def _search_tree(
+    query: str,
+    scope: str,
+    limit: int,
+    tree: list[dict[str, Any]],
+    fetch_text: Callable[..., str],
+    corpus: str,
+) -> list[dict[str, Any]]:
+    query_terms = _query_terms(query)
+    candidates = _candidate_paths(tree, query_terms, scope, query)
+    scored_chunks: list[tuple[float, Chunk]] = []
+
+    for path, path_score in candidates:
+        try:
+            text = fetch_text(path, prefer_cache=True)
+        except Exception as exc:
+            logger.debug("Skipping candidate %s: %s", path, exc)
+            continue
+
+        source_kind = _source_kind_for_path(path, corpus)
+        for chunk in _chunks_for_document(path, source_kind, text, path_score):
+            score = _chunk_score(chunk, query_terms, query)
+            if score <= 0:
+                continue
+            scored_chunks.append((score, chunk))
+
+    scored_chunks.sort(key=lambda item: (-item[0], _path_priority(item[1].path), item[1].path, item[1].start_line))
+
+    results: list[dict[str, Any]] = []
+    seen_sections: set[tuple[str, str, int]] = set()
+    for score, chunk in scored_chunks:
+        section_key = (chunk.path, chunk.heading, chunk.start_line)
+        if section_key in seen_sections:
+            continue
+        seen_sections.add(section_key)
+        results.append(
+            {
+                "path": chunk.path,
+                "source_kind": chunk.source_kind,
+                "title": chunk.title,
+                "heading": chunk.heading,
+                "start_line": chunk.start_line,
+                "end_line": chunk.end_line,
+                "score": round(score, 2),
+                "snippet": _snippet_from_chunk(chunk, query_terms),
+                "url": chunk.url,
+            }
+        )
+        if len(results) >= limit:
+            break
+
+    return results
+
+
+def hermes_docs_lookup_tool(query: str, scope: str = "docs", limit: int = DEFAULT_LIMIT) -> str:
+    """Search public Hermes upstream docs/code and return cited results as JSON."""
+    query = (query or "").strip()
+    if not query:
+        return json.dumps({"error": "query is required"}, ensure_ascii=False)
+
+    scope = (scope or "docs").strip().lower()
+    if scope not in VALID_SCOPES:
+        return json.dumps({"error": f"Invalid scope '{scope}'. Expected one of: {', '.join(sorted(VALID_SCOPES))}"}, ensure_ascii=False)
+
+    try:
+        limit_int = int(limit)
+    except (TypeError, ValueError):
+        limit_int = DEFAULT_LIMIT
+    limit_int = max(1, min(MAX_LIMIT, limit_int))
+
+    corpus = "public_hermes_main"
+    tree = _fetch_upstream_tree(prefer_cache=True)
+    fetch_text = _fetch_upstream_text
+
+    if not tree:
+        corpus = "local_checkout_fallback"
+        tree = _iter_local_paths(scope)
+        fetch_text = _fetch_local_text
+
+    results = _search_tree(query, scope, limit_int, tree, fetch_text, corpus)
+    payload: dict[str, Any] = {
+        "success": True,
+        "query": query,
+        "scope": scope,
+        "corpus": corpus,
+        "repo": f"{PUBLIC_REPO}@{PUBLIC_BRANCH}",
+        "results": results,
+    }
+    if corpus != "public_hermes_main":
+        payload["warning"] = "Public upstream docs/code were unavailable; results are from the local checkout fallback and may differ from public Hermes."
+
+    return json.dumps(payload, ensure_ascii=False)
+
+
+HERMES_DOCS_LOOKUP_SCHEMA = {
+    "name": "hermes_docs_lookup",
+    "description": (
+        "Search public Hermes upstream documentation and selected upstream source files from "
+        "NousResearch/hermes-agent main. Use this first for Hermes Agent questions about "
+        "commands, config, features, docs, architecture, or upstream code behavior instead of "
+        "searching the local checkout. Returns cited sections with URLs and source kinds."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to look up in public Hermes docs/code.",
+            },
+            "scope": {
+                "type": "string",
+                "enum": ["docs", "code", "docs_and_code"],
+                "description": "docs = public docs/root docs; code = selected public upstream source; docs_and_code = both.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of cited matches to return (1-10).",
+                "minimum": 1,
+                "maximum": 10,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+registry.register(
+    name="hermes_docs_lookup",
+    toolset="docs",
+    schema=HERMES_DOCS_LOOKUP_SCHEMA,
+    handler=lambda args, **kw: hermes_docs_lookup_tool(
+        args.get("query", ""),
+        scope=args.get("scope", "docs"),
+        limit=args.get("limit", DEFAULT_LIMIT),
+    ),
+    emoji="📚",
+    max_result_size_chars=50_000,
+)

--- a/tools/native_image_tool.py
+++ b/tools/native_image_tool.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Native image attachment tool schema.
+
+This tool does not analyze images itself. Instead, it tells the agent loop to
+queue a local image file for native multimodal input on the next model call.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tools.registry import registry
+
+
+def check_attach_image_requirements() -> bool:
+    return True
+
+
+ATTACH_IMAGE_SCHEMA = {
+    "name": "attach_image",
+    "description": (
+        "Attach a local image file so the current model can inspect it natively on the next step. "
+        "Use this instead of vision analysis when the active runtime already supports native multimodal input. "
+        "Pass a filesystem path to an image and an optional note describing what to inspect."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Absolute or relative filesystem path to a local image file.",
+            },
+            "note": {
+                "type": "string",
+                "description": "Optional short note describing what to inspect in the image.",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+def _attach_image_stub(args, **kwargs) -> str:
+    return json.dumps({"error": "attach_image must be handled by the agent loop"})
+
+
+registry.register(
+    name="attach_image",
+    toolset="vision",
+    schema=ATTACH_IMAGE_SCHEMA,
+    handler=_attach_image_stub,
+    check_fn=check_attach_image_requirements,
+    emoji="📎",
+)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -32,6 +32,10 @@ import base64
 import json
 import logging
 import os
+import re
+import shutil
+import subprocess
+import tempfile
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
@@ -102,7 +106,7 @@ def _validate_image_url(url: str) -> bool:
 def _detect_image_mime_type(image_path: Path) -> Optional[str]:
     """Return a MIME type when the file looks like a supported image."""
     with image_path.open("rb") as f:
-        header = f.read(64)
+        header = f.read(256)
 
     if header.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"
@@ -114,10 +118,15 @@ def _detect_image_mime_type(image_path: Path) -> Optional[str]:
         return "image/bmp"
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
-    if image_path.suffix.lower() == ".svg":
+
+    # SVGs are text-based and often arrive from remote URLs with a generic or wrong
+    # extension (for example our temp downloads use .jpg). Detect by content, not just suffix.
+    try:
         head = image_path.read_text(encoding="utf-8", errors="ignore")[:4096].lower()
-        if "<svg" in head:
-            return "image/svg+xml"
+    except OSError:
+        return None
+    if "<svg" in head:
+        return "image/svg+xml"
     return None
 
 
@@ -235,6 +244,93 @@ def _determine_mime_type(image_path: Path) -> str:
     return mime_types.get(extension, 'image/jpeg')
 
 
+def _estimate_svg_window_size(svg_path: Path) -> tuple[int, int]:
+    """Best-effort viewport sizing for headless-browser SVG rasterization."""
+    try:
+        head = svg_path.read_text(encoding="utf-8", errors="ignore")[:4096]
+    except OSError:
+        return (1600, 1200)
+
+    def _clamp(value: float, default: int) -> int:
+        try:
+            value = int(round(float(value)))
+        except (TypeError, ValueError):
+            return default
+        return max(64, min(value, 4096))
+
+    viewbox = re.search(
+        r"viewBox=['\"]\s*[-+0-9.eE]+\s+[-+0-9.eE]+\s+([-+0-9.eE]+)\s+([-+0-9.eE]+)\s*['\"]",
+        head,
+        flags=re.IGNORECASE,
+    )
+    if viewbox:
+        return (_clamp(viewbox.group(1), 1600), _clamp(viewbox.group(2), 1200))
+
+    width = re.search(r"\bwidth=['\"]\s*([-+0-9.eE]+)", head, flags=re.IGNORECASE)
+    height = re.search(r"\bheight=['\"]\s*([-+0-9.eE]+)", head, flags=re.IGNORECASE)
+    if width and height:
+        return (_clamp(width.group(1), 1600), _clamp(height.group(1), 1200))
+
+    return (1600, 1200)
+
+
+def _rasterize_svg_to_png(svg_path: Path) -> Path:
+    """Convert SVG input into a PNG that multimodal providers can accept."""
+    tmp = tempfile.NamedTemporaryFile(prefix=f"{svg_path.stem}_", suffix=".png", delete=False)
+    output_path = Path(tmp.name)
+    tmp.close()
+
+    try:
+        try:
+            import cairosvg  # type: ignore
+        except Exception:
+            cairosvg = None
+
+        if cairosvg is not None:
+            cairosvg.svg2png(url=str(svg_path), write_to=str(output_path))
+            if output_path.exists() and output_path.stat().st_size > 0:
+                return output_path
+            raise RuntimeError("cairosvg did not produce a PNG output file")
+
+        browser = next(
+            (
+                path
+                for path in (
+                    shutil.which("google-chrome"),
+                    shutil.which("chromium"),
+                    shutil.which("chromium-browser"),
+                    shutil.which("chrome"),
+                )
+                if path
+            ),
+            None,
+        )
+        if browser:
+            width, height = _estimate_svg_window_size(svg_path)
+            cmd = [
+                browser,
+                "--headless",
+                "--disable-gpu",
+                "--hide-scrollbars",
+                f"--window-size={width},{height}",
+                f"--screenshot={output_path}",
+                svg_path.resolve().as_uri(),
+            ]
+            subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if output_path.exists() and output_path.stat().st_size > 0:
+                return output_path
+            raise RuntimeError("headless browser did not produce a PNG output file")
+
+        raise RuntimeError(
+            "SVG vision input needs rasterization, but no supported rasterizer was found. "
+            "Install cairosvg or a Chromium browser such as google-chrome/chromium."
+        )
+    except Exception:
+        if output_path.exists():
+            output_path.unlink(missing_ok=True)
+        raise
+
+
 def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None) -> str:
     """
     Convert an image file to a base64-encoded data URL.
@@ -271,7 +367,8 @@ async def vision_analyze_tool(
     
     This tool accepts either an HTTP/HTTPS URL or a local file path. For URLs,
     it downloads the image first. In both cases, the image is converted to base64
-    and processed using Gemini 3 Flash Preview via OpenRouter API.
+    and processed using Gemini 3 Flash Preview via OpenRouter API. SVG inputs are
+    rasterized to PNG first because upstream multimodal providers reject raw SVG payloads.
     
     The user_prompt parameter is expected to be pre-formatted by the calling
     function (typically model_tools.py) to include both full description
@@ -296,7 +393,8 @@ async def vision_analyze_tool(
     Note:
         - For URLs, temporary images are stored in ./temp_vision_images/ and cleaned up
         - For local file paths, the file is used directly and NOT deleted
-        - Supports common image formats (JPEG, PNG, GIF, WebP, etc.)
+        - Temporary rasterized PNGs created from SVG input are cleaned up automatically
+        - Supports common image formats (JPEG, PNG, GIF, WebP, SVG, etc.)
     """
     debug_call_data = {
         "parameters": {
@@ -312,9 +410,7 @@ async def vision_analyze_tool(
     }
     
     temp_image_path = None
-    # Track whether we should clean up the file after processing.
-    # Local files (e.g. from the image cache) should NOT be deleted.
-    should_cleanup = True
+    cleanup_paths: list[Path] = []
     detected_mime_type = None
     
     try:
@@ -331,7 +427,6 @@ async def vision_analyze_tool(
             # Local file path (e.g. from platform image cache) -- skip download
             logger.info("Using local image file: %s", image_url)
             temp_image_path = local_path
-            should_cleanup = False  # Don't delete cached/local files
         elif _validate_image_url(image_url):
             # Remote URL -- download to a temporary location
             blocked = check_website_access(image_url)
@@ -341,7 +436,7 @@ async def vision_analyze_tool(
             temp_dir = Path("./temp_vision_images")
             temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.jpg"
             await _download_image(image_url, temp_image_path)
-            should_cleanup = True
+            cleanup_paths.append(temp_image_path)
         else:
             raise ValueError(
                 "Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path."
@@ -355,6 +450,13 @@ async def vision_analyze_tool(
         detected_mime_type = _detect_image_mime_type(temp_image_path)
         if not detected_mime_type:
             raise ValueError("Only real image files are supported for vision analysis.")
+
+        if detected_mime_type == "image/svg+xml":
+            logger.info("Rasterizing SVG for vision compatibility...")
+            rasterized_path = _rasterize_svg_to_png(temp_image_path)
+            cleanup_paths.append(rasterized_path)
+            temp_image_path = rasterized_path
+            detected_mime_type = "image/png"
         
         # Convert image to base64 data URL
         logger.info("Converting image to base64...")
@@ -483,15 +585,16 @@ async def vision_analyze_tool(
         return json.dumps(result, indent=2, ensure_ascii=False)
     
     finally:
-        # Clean up temporary image file (but NOT local/cached files)
-        if should_cleanup and temp_image_path and temp_image_path.exists():
-            try:
-                temp_image_path.unlink()
-                logger.debug("Cleaned up temporary image file")
-            except Exception as cleanup_error:
-                logger.warning(
-                    "Could not delete temporary file: %s", cleanup_error, exc_info=True
-                )
+        # Clean up any temporary downloaded or rasterized files.
+        for cleanup_path in dict.fromkeys(path for path in cleanup_paths if path):
+            if cleanup_path.exists():
+                try:
+                    cleanup_path.unlink()
+                    logger.debug("Cleaned up temporary image file")
+                except Exception as cleanup_error:
+                    logger.warning(
+                        "Could not delete temporary file: %s", cleanup_error, exc_info=True
+                    )
 
 
 def check_vision_requirements() -> bool:

--- a/toolsets.py
+++ b/toolsets.py
@@ -29,8 +29,8 @@ from typing import List, Dict, Any, Set, Optional
 # Shared tool list for CLI and all messaging platform toolsets.
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
-    # Web
-    "web_search", "web_extract",
+    # Web + docs lookup
+    "web_search", "web_extract", "hermes_docs_lookup",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -76,6 +76,12 @@ TOOLSETS = {
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
+        "includes": []
+    },
+
+    "docs": {
+        "description": "Public Hermes upstream docs/code lookup with cited results",
+        "tools": ["hermes_docs_lookup"],
         "includes": []
     },
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -36,7 +36,7 @@ _HERMES_CORE_TOOLS = [
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "attach_image", "image_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -80,8 +80,8 @@ TOOLSETS = {
     },
     
     "vision": {
-        "description": "Image analysis and vision tools",
-        "tools": ["vision_analyze"],
+        "description": "Image analysis and native multimodal image attachment tools",
+        "tools": ["vision_analyze", "attach_image"],
         "includes": []
     },
     
@@ -252,7 +252,7 @@ TOOLSETS = {
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation
-            "vision_analyze", "image_generate",
+            "vision_analyze", "attach_image", "image_generate",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation


### PR DESCRIPTION
Summary:
- transplant the /spawn background child-session flow onto this branch
- add kitty-contained clarify overlays for background child agents, with inline fallback
- add a /hermes-addition command that creates an isolated worktree and steers the child toward push+PR workflow
- surface background agent counts in the CLI status bar and launch notices

Tests:
- /home/main/.hermes/hermes-agent/.venv/bin/python -m pytest -q tests/cli/test_branch_command.py tests/cli/test_background_agent_commands.py tests/cli/test_cli_background_tui_refresh.py tests/cli/test_cli_status_bar.py tests/gateway/test_spawn_command.py tests/gateway/test_session_race_guard.py tests/hermes_cli/test_kitty_overlay.py -o addopts=''