### PR TITLE
docs(feishu): add permission scopes, event subscription, and publish steps

### DIFF
--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -42,6 +42,40 @@ Set it to `false` only if you explicitly want one shared conversation per chat.
 Keep the App Secret private. Anyone with it can impersonate your app.
 :::
 
+### Configure Permissions
+
+In the Feishu developer console, go to **Permission Management** and add the following scopes. You can bulk-import them in the permissions page.
+
+**Required permissions:**
+
+| Scope | Purpose |
+|-------|---------|
+| `im:message` | Receive and read messages |
+| `im:message:send_as_bot` | Send messages as the bot |
+| `im:resource` | Access images, files, and audio sent by users |
+| `im:chat` | Access chat/group metadata |
+| `im:chat:readonly` | Read chat list and membership |
+
+**Recommended permissions (for full functionality):**
+
+| Scope | Purpose |
+|-------|---------|
+| `im:message.reactions:readonly` | Receive emoji reaction events |
+| `admin:app.info:readonly` | Auto-detect bot identity for @mention gating |
+| `contact:user.id:readonly` | Resolve user IDs for allowlist matching |
+
+### Configure Events
+
+In **Events and Callbacks**:
+
+1. Set the connection mode to **Long Connection (WebSocket)** (recommended) or configure a webhook URL
+2. In the **Event Configuration** section, subscribe to:
+   - `im.message.receive_v1` — required for receiving messages
+
+### Publish the App
+
+After configuring permissions and events, go to **Version Management** and publish a new version of the app. The permissions won't take effect until a version is published and approved (for enterprise apps, this may require admin approval).
+
 ## Step 2: Choose a Connection Mode
 
 ### Recommended: WebSocket mode


### PR DESCRIPTION
The Feishu setup guide was missing the specific permission scopes to configure in the developer console and the event subscription needed for the bot to receive messages. Users had to reference external documentation to complete the setup.

Adds to Step 1:
- **Permissions table** — required scopes (`im:message`, `im:message:send_as_bot`, `im:resource`, `im:chat`) and recommended scopes (`im:message.reactions:readonly`, `admin:app.info:readonly`, `contact:user.id:readonly`)
- **Event subscription step** — subscribe to `im.message.receive_v1`
- **Publish reminder** — permissions require a published app version

34 lines added to `website/docs/user-guide/messaging/feishu.md`. Based on user feedback and cross-referenced with the Feishu adapter source (`gateway/platforms/feishu.py`).