### PR TITLE
fix(install): use npm ci to prevent lockfile mutation

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -317,14 +317,14 @@ class WhatsAppAdapter(BasePlatformAdapter):
             print(f"[{self.name}] Installing WhatsApp bridge dependencies...")
             try:
                 install_result = subprocess.run(
-                    ["npm", "install", "--silent"],
+                    ["npm", "ci", "--silent"],
                     cwd=str(bridge_dir),
                     capture_output=True,
                     text=True,
                     timeout=60,
                 )
                 if install_result.returncode != 0:
-                    print(f"[{self.name}] npm install failed: {install_result.stderr}")
+                    print(f"[{self.name}] npm ci failed: {install_result.stderr}")
                     return False
                 print(f"[{self.name}] Dependencies installed")
             except Exception as e:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -775,14 +775,14 @@ def cmd_whatsapp(args):
     if not (bridge_dir / "node_modules").exists():
         print("\n→ Installing WhatsApp bridge dependencies...")
         result = subprocess.run(
-            ["npm", "install"],
+            ["npm", "ci"],
             cwd=str(bridge_dir),
             capture_output=True,
             text=True,
             timeout=120,
         )
         if result.returncode != 0:
-            print(f"  ✗ npm install failed: {result.stderr}")
+            print(f"  ✗ npm ci failed: {result.stderr}")
             return
         print("  ✓ Dependencies installed")
     else:
@@ -3626,7 +3626,7 @@ def cmd_update(args):
             import shutil
             if shutil.which("npm"):
                 print("→ Updating Node.js dependencies...")
-                subprocess.run(["npm", "install", "--silent"], cwd=PROJECT_ROOT, check=False)
+                subprocess.run(["npm", "ci", "--silent"], cwd=PROJECT_ROOT, check=False)
         
         print()
         print("✓ Code updated!")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -372,14 +372,14 @@ def _run_post_setup(post_setup_key: str):
             _print_info("    Installing Node.js dependencies for browser tools...")
             import subprocess
             result = subprocess.run(
-                ["npm", "install", "--silent"],
+                ["npm", "ci", "--silent"],
                 capture_output=True, text=True, cwd=str(PROJECT_ROOT)
             )
             if result.returncode == 0:
                 _print_success("    Node.js dependencies installed")
             else:
                 from hermes_constants import display_hermes_home
-                _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install")
+                _print_warning(f"    npm ci failed - run manually: cd {display_hermes_home()}/hermes-agent && npm ci")
         elif not node_modules.exists():
             _print_warning("    Node.js not found - browser tools require: npm install (in hermes-agent directory)")
 
@@ -389,13 +389,13 @@ def _run_post_setup(post_setup_key: str):
             _print_info("    Installing Camofox browser server...")
             import subprocess
             result = subprocess.run(
-                ["npm", "install", "--silent"],
+                ["npm", "ci", "--silent"],
                 capture_output=True, text=True, cwd=str(PROJECT_ROOT)
             )
             if result.returncode == 0:
                 _print_success("    Camofox installed")
             else:
-                _print_warning("    npm install failed - run manually: npm install")
+                _print_warning("    npm ci failed - run manually: npm ci")
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camoufox-browser")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -881,8 +881,8 @@ install_node_deps() {
     if [ -f "$INSTALL_DIR/package.json" ]; then
         log_info "Installing Node.js dependencies (browser tools)..."
         cd "$INSTALL_DIR"
-        npm install --silent 2>/dev/null || {
-            log_warn "npm install failed (browser tools may not work)"
+        npm ci --silent 2>/dev/null || {
+            log_warn "npm ci failed (browser tools may not work)"
         }
         log_success "Node.js dependencies installed"
 
@@ -920,8 +920,8 @@ install_node_deps() {
     if [ -f "$INSTALL_DIR/scripts/whatsapp-bridge/package.json" ]; then
         log_info "Installing WhatsApp bridge dependencies..."
         cd "$INSTALL_DIR/scripts/whatsapp-bridge"
-        npm install --silent 2>/dev/null || {
-            log_warn "WhatsApp bridge npm install failed (WhatsApp may not work)"
+        npm ci --silent 2>/dev/null || {
+            log_warn "WhatsApp bridge npm ci failed (WhatsApp may not work)"
         }
         log_success "WhatsApp bridge dependencies installed"
     fi


### PR DESCRIPTION
## What does this PR do?

`scripts/install.sh` used `npm install` to install Node.js dependencies, which re-resolves semver ranges and rewrites `package-lock.json` whenever newer compatible versions are available. This leaves users with a dirty working tree after running the installer or update command.

This PR switches all `npm install` subprocess calls to `npm ci`, which installs strictly from the committed lockfile and never modifies it. The GitHub Actions workflows already used `npm ci` — this brings the rest of the codebase in line.

## Related Issue

Fixes #6716

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: browser tools and WhatsApp bridge installs
- `hermes_cli/main.py`: `/update` command Node.js dep step + WhatsApp bridge lazy-init
- `hermes_cli/tools_config.py`: agent-browser and Camofox post-setup hooks
- `gateway/platforms/whatsapp.py`: gateway-mode WhatsApp bridge lazy-install

## How to Test

1. Clone the repo fresh
2. Run `scripts/install.sh`
3. Run `git status` — `package-lock.json` should be unmodified
4. Run `hermes update` — same result

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A