### PR TITLE
Fix Discord startup timeout during slash sync

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -544,13 +544,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
 
+                # Mark the adapter ready as soon as the bot session is usable.
+                # Slash-command sync can take longer on first install when the
+                # guild has many commands to create/update, and startup should
+                # not be treated as failed just because command registration is
+                # still in flight.
+                adapter_self._ready_event.set()
+
                 # Sync slash commands with Discord
                 try:
                     synced = await adapter_self._client.tree.sync()
                     logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
                 except Exception as e:  # pragma: no cover - defensive logging
                     logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
-                adapter_self._ready_event.set()
 
             @self._client.event
             async def on_message(message: DiscordMessage):


### PR DESCRIPTION
  ## What does this PR do?

  This PR fixes a Discord gateway startup bug where Hermes could incorrectly report a connection timeout even after the
  bot had already connected successfully.

  The root cause was that `DiscordAdapter.connect()` waited for `_ready_event`, but `_ready_event` was only set after
  `tree.sync()` finished inside `on_ready()`. On first install or servers with many slash commands, Discord command sync
  can take longer than the 30 second startup timeout, causing Hermes to treat startup as failed even though the Discord
  session was already usable.

  This change marks the adapter as ready as soon as the bot session is connected and username resolution is complete.
  Slash command sync still runs, but it no longer blocks startup success.

  ## Related Issue

  Fixes #

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Updated [gateway/platforms/discord.py](../blob/main/gateway/platforms/discord.py)
  - Moved `_ready_event.set()` to happen before `tree.sync()`
  - Kept slash command sync behavior unchanged, but made it non-blocking for startup readiness
  - Added a comment explaining why readiness should not depend on slash command sync completion

  ## How to Test

  1. Configure Hermes with a valid Discord bot token and start the gateway with `hermes gateway run`
  2. Use a bot/server setup where slash command sync is slow enough to approach or exceed the previous 30 second startup
  window
  3. Confirm Hermes reports Discord as connected instead of failing startup with `Timeout waiting for connection to
  Discord`

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`,
  `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a
  duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu 24.04

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/
  NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Relevant log output after the fix:

  ```text
  [Discord] Connected as ...
  ✓ discord connected
  Gateway running with 1 platform(s)
  [Discord] Synced 99 slash command(s)
