### PR TITLE
nix: add tirith to runtime deps

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -14,7 +14,7 @@
       };
 
       runtimeDeps = with pkgs; [
-        nodejs_20 ripgrep git openssh ffmpeg
+        nodejs_20 ripgrep git openssh ffmpeg tirith
       ];
 
       runtimePath = pkgs.lib.makeBinPath runtimeDeps;


### PR DESCRIPTION
## What does this PR do?

tirith is enabled by default in HA but not included in the nix deps

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- added tirith to the runtimeDeps section of the agent nix pkg in `nix/packages.nix`


## How to Test

launch hermes agent from scratch with no config
before:
<img width="1136" height="117" alt="image" src="https://github.com/user-attachments/assets/f633797f-31cb-41d2-93fe-2c5b362d6866" />

after:
<img width="725" height="98" alt="image" src="https://github.com/user-attachments/assets/dcf9b1b5-82f7-478e-ac02-e53e40048522" />
