### PR TITLE
fix(security): hardcode OSV endpoint to prevent malware scan bypass via env var

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -1,5 +1,6 @@
 """Tests for OSV malware check on MCP extension packages."""
 
+import importlib
 import json
 import pytest
 from unittest.mock import patch, MagicMock
@@ -170,6 +171,38 @@ class TestCheckPackageForMalware:
             call_data = json.loads(mock_url.call_args[0][0].data)
             assert call_data["package"]["ecosystem"] == "PyPI"
             assert call_data["package"]["name"] == "mcp-server-fetch"
+
+
+class TestEndpointHardcoded:
+    """Regression: the OSV endpoint must be hardcoded — an OSV_ENDPOINT env
+    var must not be able to redirect the malware scan to an attacker-controlled
+    server (scan bypass)."""
+
+    def test_env_var_cannot_override_endpoint(self, monkeypatch):
+        import tools.osv_check as osv_mod
+
+        monkeypatch.setenv("OSV_ENDPOINT", "https://attacker.example.com/v1/query")
+        # Reload so the module-level endpoint constant is re-evaluated with
+        # the hostile env var present.
+        importlib.reload(osv_mod)
+        try:
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps({"vulns": []}).encode()
+            mock_response.__enter__ = lambda s: s
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with patch(
+                "tools.osv_check.urllib.request.urlopen",
+                return_value=mock_response,
+            ) as mock_urlopen:
+                osv_mod._query_osv("react", "npm")
+
+            req = mock_urlopen.call_args[0][0]
+            assert req.full_url == "https://api.osv.dev/v1/query"
+        finally:
+            # Restore module state with a clean environment.
+            monkeypatch.delenv("OSV_ENDPOINT", raising=False)
+            importlib.reload(osv_mod)
 
 
 class TestLiveOsvQuery:

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -19,7 +19,7 @@ from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-_OSV_ENDPOINT = os.getenv("OSV_ENDPOINT", "https://api.osv.dev/v1/query")
+_OSV_ENDPOINT = "https://api.osv.dev/v1/query"
 _TIMEOUT = 10  # seconds
 
 


### PR DESCRIPTION
## What does this PR do?

`tools/osv_check.py` read the OSV API endpoint from an environment variable:
```python
# Before (vulnerable)
_OSV_ENDPOINT = os.getenv("OSV_ENDPOINT", "https://api.osv.dev/v1/query")
```

An attacker with control over the environment (CI pipeline, compromised
`.env` file, container environment injection) could set `OSV_ENDPOINT`
to a fake server that always returns empty results — silently bypassing
the entire malware scan for all MCP extension packages.

This defeats the purpose of the OSV security check entirely.

## Fix

Hardcoded the endpoint to the official OSV API URL:
```python
# After (safe)
_OSV_ENDPOINT = "https://api.osv.dev/v1/query"
```

The OSV endpoint is a security control — it should not be
user-configurable via environment variables.

## Type of Change

- [x] 🔒 Security fix (security control bypass)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] No behavior change for legitimate usage
- [x] `os` import preserved — still used by `_infer_ecosystem()`