### PR TITLE
fix(security): escape OAuth error parameter in callback HTML to prevent reflected XSS

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -6,6 +6,7 @@ import stat
 import sys
 from io import BytesIO
 from unittest.mock import patch, MagicMock
+from urllib.parse import quote
 
 import pytest
 
@@ -397,6 +398,28 @@ class TestCallbackHandlerIsolation:
 
         assert result["auth_code"] is None
         assert result["error"] == "access_denied"
+
+
+class TestCallbackHandlerErrorEscaping:
+    """Regression: a hostile ``error`` parameter must be HTML-escaped before
+    being reflected into the callback response body (reflected XSS)."""
+
+    def test_hostile_error_is_escaped_in_response_body(self):
+        HandlerClass, result = _make_callback_handler()
+
+        handler = HandlerClass.__new__(HandlerClass)
+        handler.path = "/callback?error=" + quote("<script>alert(1)</script>")
+        handler.wfile = BytesIO()
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.do_GET()
+
+        body = handler.wfile.getvalue().decode("utf-8")
+        assert "<script>" not in body
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+        # The raw (unescaped) value is still captured for programmatic use.
+        assert result["error"] == "<script>alert(1)</script>"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -34,6 +34,7 @@ Configuration in config.yaml::
 
 import asyncio
 import contextvars
+import html
 import json
 import logging
 import os
@@ -520,7 +521,7 @@ def _make_callback_handler() -> tuple[type, dict]:
                 "<p>You can close this tab and return to Hermes.</p></body></html>"
             ) if code else (
                 "<html><body><h2>Authorization Failed</h2>"
-                f"<p>Error: {error or 'unknown'}</p></body></html>"
+                f"<p>Error: {html.escape(error or 'unknown')}</p></body></html>"
             )
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")


### PR DESCRIPTION
The callback server runs on localhost and the browser renders this
page — allowing script execution in the user's browser context.

## Fix

Wrapped the error value with `html.escape()`:
```python
# After (safe)
import html
f"<p>Error: {html.escape(error or 'unknown')}</p></body></html>"
```

`html.escape()` converts `<`, `>`, `&`, `"` and `'` to their HTML
entities, preventing script injection.

## Type of Change

- [x] 🔒 Security fix (reflected XSS)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] `html` is Python standard library — no new dependencies
- [x] No behavior change for legitimate error messages