### PR TITLE
fix(whatsapp): use lsof for port cleanup on macOS

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -53,6 +53,19 @@ def _kill_port_process(port: int) -> None:
                             )
                         except subprocess.SubprocessError:
                             pass
+        elif sys.platform == "darwin":
+            # macOS fuser only works with files, not port/tcp syntax.
+            # Use lsof to find and kill processes holding the port.
+            result = subprocess.run(
+                ["lsof", "-ti", f"tcp:{port}"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                for pid in result.stdout.strip().splitlines():
+                    try:
+                        os.kill(int(pid), 15)  # SIGTERM
+                    except (ValueError, OSError):
+                        pass
         else:
             result = subprocess.run(
                 ["fuser", f"{port}/tcp"],


### PR DESCRIPTION
## Summary

- **`_kill_port_process()` silently fails on macOS**, causing the WhatsApp bridge to crash with `EADDRINUSE` on every gateway restart
- macOS ships `fuser` but it only accepts file paths — not the `port/tcp` syntax used on Linux — so the stale bridge process is never killed
- Adds a `sys.platform == "darwin"` branch using `lsof -ti tcp:<port>` + `os.kill(pid, SIGTERM)` to match the existing Linux `fuser -k` behavior

## Problem

When the gateway restarts on macOS, the old Node bridge process may still hold the WhatsApp bridge port (default 3000). The existing cleanup function calls `fuser 3000/tcp` which silently fails on macOS:

```
$ fuser 3000/tcp
/usr/bin/fuser: '3000/tcp' does not exist
```

The new bridge instance then crashes immediately:

```
Error: listen EADDRINUSE: address already in use 127.0.0.1:3000
```

Since launchd `KeepAlive` restarts the gateway on failure, this creates an infinite restart loop.

## Fix

```python
elif sys.platform == "darwin":
    result = subprocess.run(
        ["lsof", "-ti", f"tcp:{port}"],
        capture_output=True, text=True, timeout=5,
    )
    if result.returncode == 0:
        for pid in result.stdout.strip().splitlines():
            try:
                os.kill(int(pid), 15)  # SIGTERM
            except (ValueError, OSError):
                pass
```

## Test plan

- [x] Verify on macOS: start gateway, kill it ungracefully (`kill -9`), restart — bridge should recover without manual intervention
- [x] Verify on Linux: existing `fuser` path is unchanged
- [x] Verify on Windows: existing `netstat`/`taskkill` path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)