### PR TITLE
fix: resolve rl_cli bootstrapping NameError via import reordering

### DIFF
--- a/rl_cli.py
+++ b/rl_cli.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import fire
 import yaml
+from hermes_constants import get_hermes_home, OPENROUTER_BASE_URL
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -59,8 +60,6 @@ from tools.rl_training_tool import get_missing_keys
 # ============================================================================
 # Config Loading
 # ============================================================================
-
-from hermes_constants import get_hermes_home, OPENROUTER_BASE_URL
 
 DEFAULT_MODEL = "anthropic/claude-opus-4.5"
 DEFAULT_BASE_URL = OPENROUTER_BASE_URL

--- a/tests/test_rl_cli.py
+++ b/tests/test_rl_cli.py
@@ -1,0 +1,23 @@
+import importlib
+import sys
+import types
+
+
+def test_rl_cli_import_bootstraps_hermes_home_without_nameerror(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = object
+
+    fake_rl_tool = types.ModuleType("tools.rl_training_tool")
+    fake_rl_tool.get_missing_keys = lambda: []
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setitem(sys.modules, "tools.rl_training_tool", fake_rl_tool)
+
+    sys.modules.pop("rl_cli", None)
+    module = importlib.import_module("rl_cli")
+
+    assert module._hermes_home == home


### PR DESCRIPTION
### 1. Executive Summary
This pull request addresses a critical execution-flow defect in the Reinforcement Learning CLI (`rl_cli.py`). The defect was identified as an out-of-order namespace declaration, resulting in a fatal `NameError` during the module bootstrapping phase.

**Duplicate Check: PASS**
*Historical Audit:* No prior findings regarding `rl_cli.py` or import-order dependency crashes have been reported in the existing 70+ vulnerability log.

---

### 2. Root Cause Analysis (RCA)
The failure was traced to a synchronous execution of `get_hermes_home()` prior to its import from the `hermes_constants` module. 

* **The Trigger:** Invoking `_hermes_home = get_hermes_home()` at the top-level scope before the interpreter reached the corresponding `import` statement.
* **The Impact:** Immediate process termination upon module import, rendering the RL interface (help menus, interactive modes, and environment listing) inaccessible.

---

### 3. Technical Implementation
The intervention follows a "minimal surface area" approach to restore system stability without altering existing RL logic:

- **Namespace Correction:** Repositioned the `hermes_constants` import block to precede any functional invocations.
- **Dependency Integrity:** Maintained current environment-loading sequences to prevent unintended side effects in downstream RL components.

---

### 4. Verification & Regression Mapping

####  Regression Suite
A new isolation test (`tests/test_rl_cli.py`) has been deployed to ensure namespace integrity in future builds:
- **Mocking Strategy:** Utilizes lightweight stubs for heavy Reinforcement Learning dependencies to prevent CI/CD overhead.
- **Assertion:** Validates successful module loading and correct bootstrapping of the `HERMES_HOME` path.

####  Manual Validation
- Executed `python rl_cli.py --help` 
- **Result:** Successfully bypassed the initial `NameError`. 

