### PR TITLE
fix(install): use npm ci for reproducible installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -881,8 +881,8 @@ install_node_deps() {
     if [ -f "$INSTALL_DIR/package.json" ]; then
         log_info "Installing Node.js dependencies (browser tools)..."
         cd "$INSTALL_DIR"
-        npm install --silent 2>/dev/null || {
-            log_warn "npm install failed (browser tools may not work)"
+        npm ci --silent 2>/dev/null || {
+            log_warn "npm ci failed (browser tools may not work)"
         }
         log_success "Node.js dependencies installed"
 
@@ -920,8 +920,8 @@ install_node_deps() {
     if [ -f "$INSTALL_DIR/scripts/whatsapp-bridge/package.json" ]; then
         log_info "Installing WhatsApp bridge dependencies..."
         cd "$INSTALL_DIR/scripts/whatsapp-bridge"
-        npm install --silent 2>/dev/null || {
-            log_warn "WhatsApp bridge npm install failed (WhatsApp may not work)"
+        npm ci --silent 2>/dev/null || {
+            log_warn "WhatsApp bridge npm ci failed (WhatsApp may not work)"
         }
         log_success "WhatsApp bridge dependencies installed"
     fi

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_install_script_uses_npm_ci_for_reproducible_node_installs():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "install.sh"
+    content = script.read_text()
+
+    assert content.count('npm ci --silent 2>/dev/null || {') == 2
+    assert 'npm install --silent 2>/dev/null || {' not in content


### PR DESCRIPTION
## Summary
- switch installer Node dependency steps from `npm install` to `npm ci`
- apply the same reproducible install behavior to the WhatsApp bridge
- add a regression test covering both installer call sites

## Testing
- `uv run pytest tests/test_install_script.py -q`

Closes #6716
