### PR TITLE
feat(slack): mention gating, thread cache, Block Kit, commands

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -6,6 +6,9 @@ Uses slack-bolt (Python) with Socket Mode for:
 - Sending responses back
 - Handling slash commands
 - Thread support
+- Thread history loading for context
+- Smart mention detection (implicit mentions after participation)
+- Table formatting support
 """
 
 import asyncio
@@ -14,7 +17,7 @@ import logging
 import os
 import re
 import time
-from typing import Dict, Optional, Any, Tuple
+from typing import Dict, Optional, Any, List, Tuple
 
 try:
     from slack_bolt.async_app import AsyncApp
@@ -39,6 +42,35 @@ from gateway.platforms.base import (
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
     cache_document_from_bytes,
+)
+from gateway.platforms.slack_utils import (
+    get_thread_participation_cache,
+    check_mention_gate,
+    load_thread_context,
+    format_thread_context_for_prompt,
+    convert_markdown_tables_to_slack,
+    validate_slack_file_url,
+    looks_like_html_content,
+    normalize_slack_voice_mimetype,
+    resolve_channel_config,
+    is_user_allowed_in_channel,
+    SlackChannelConfig,
+    # Connection state tracking
+    SlackConnectionState,
+    is_non_recoverable_slack_error,
+    format_slack_error,
+    # Scope validation
+    fetch_slack_scopes,
+    validate_slack_scopes,
+    SlackScopeValidation,
+    REQUIRED_SLACK_SCOPES,
+    RECOMMENDED_SLACK_SCOPES,
+    # Health probe
+    probe_slack_connection,
+    SlackProbeResult,
+    # Message updating
+    update_slack_message,
+    SlackMessageRef,
 )
 
 
@@ -87,14 +119,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
-        # Track timestamps of messages sent by the bot so we can respond
-        # to thread replies even without an explicit @mention.
-        self._bot_message_ts: set = set()
-        self._BOT_TS_MAX = 5000  # cap to avoid unbounded growth
-        # Track threads where the bot has been @mentioned — once mentioned,
-        # respond to ALL subsequent messages in that thread automatically.
-        self._mentioned_threads: set = set()
-        self._MENTIONED_THREADS_MAX = 5000
+        # Connection state tracking (for health checks and stale socket detection)
+        # Note: Reconnection is handled by gateway/run.py at the platform level
+        self._connection_state: SlackConnectionState = SlackConnectionState()
+        # Message tracking for updates
+        self._pending_messages: Dict[str, SlackMessageRef] = {}  # id → ref
         # Assistant thread metadata keyed by (channel_id, thread_ts). Slack's
         # AI Assistant lifecycle events can arrive before/alongside message
         # events, and they carry the user/thread identity needed for stable
@@ -210,9 +239,27 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._app.action(_action_id)(self._handle_approval_action)
 
+            # Register interactive component handler (block_actions)
+            # This handles button clicks, select menu choices, etc.
+            @self._app.action(re.compile(r"hermes:.*"))
+            async def handle_block_action(ack, body, respond):
+                await ack()
+                await self._handle_block_action(body, respond)
+
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token)
             self._socket_mode_task = asyncio.create_task(self._handler.start_async())
+
+            # Mark connection state as connected
+            self._connection_state.mark_connected()
+            
+            # Validate OAuth scopes (non-blocking warning)
+            try:
+                validation = await self.validate_scopes()
+                if not validation.valid:
+                    logger.warning("[Slack] %s", validation.format_warning())
+            except Exception as e:
+                logger.debug("[Slack] Scope validation skipped: %s", e)
 
             self._running = True
             logger.info(
@@ -227,6 +274,9 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Slack."""
+        # Mark connection state as disconnected
+        self._connection_state.mark_disconnected()
+        
         if self._handler:
             try:
                 await self._handler.close_async()
@@ -258,14 +308,43 @@ class SlackAdapter(BasePlatformAdapter):
         content: str,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        blocks: Optional[List[Dict[str, Any]]] = None,
     ) -> SendResult:
-        """Send a message to a Slack channel or DM."""
+        """Send a message to a Slack channel or DM.
+        
+        Args:
+            chat_id: Slack channel ID
+            content: Message text (fallback for notifications)
+            reply_to: Message ID to reply to
+            metadata: Optional metadata dict
+            blocks: Optional Block Kit blocks for rich formatting
+        """
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
         try:
             # Convert standard markdown → Slack mrkdwn
             formatted = self.format_message(content)
+
+            # If blocks provided, use them for rich content
+            if blocks:
+                # Validate blocks structure
+                validated_blocks = self._validate_blocks(blocks)
+                text = formatted or " "  # Fallback text required
+                
+                thread_ts = self._resolve_thread_ts(reply_to, metadata)
+                
+                result = await self._get_client(chat_id).chat_postMessage(
+                    channel=chat_id,
+                    text=text,
+                    blocks=validated_blocks,
+                    thread_ts=thread_ts,
+                )
+                return SendResult(
+                    success=True,
+                    message_id=result.get("ts"),
+                    raw_response=result,
+                )
 
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -278,9 +357,10 @@ class SlackAdapter(BasePlatformAdapter):
             broadcast = self.config.extra.get("reply_broadcast", False)
 
             for i, chunk in enumerate(chunks):
-                kwargs = {
+                kwargs: Dict[str, Any] = {
                     "channel": chat_id,
                     "text": chunk,
+                    "blocks": self._content_to_blocks(chunk),
                 }
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
@@ -290,18 +370,12 @@ class SlackAdapter(BasePlatformAdapter):
 
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
-            # Track the sent message ts so we can auto-respond to thread
-            # replies without requiring @mention.
+            # Record thread participation so we auto-respond to future
+            # thread replies without requiring @mention.
             sent_ts = last_result.get("ts") if last_result else None
-            if sent_ts:
-                self._bot_message_ts.add(sent_ts)
-                # Also register the thread root so replies-to-my-replies work
-                if thread_ts:
-                    self._bot_message_ts.add(thread_ts)
-                if len(self._bot_message_ts) > self._BOT_TS_MAX:
-                    excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
-                    for old_ts in list(self._bot_message_ts)[:excess]:
-                        self._bot_message_ts.discard(old_ts)
+            if sent_ts and thread_ts:
+                cache = get_thread_participation_cache()
+                await cache.record("default", chat_id, thread_ts)
 
             return SendResult(
                 success=True,
@@ -312,6 +386,101 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[Slack] Send error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    def _validate_blocks(self, blocks: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+        """Validate and sanitize Block Kit blocks.
+        
+        - Limits to 50 blocks (Slack API limit)
+        - Ensures each block has required type field
+        - Truncates long text fields
+        """
+        if not blocks:
+            return []
+        
+        MAX_BLOCKS = 50
+        MAX_TEXT_LENGTH = 3000
+        MAX_PLAIN_TEXT = 75
+        
+        validated = []
+        for block in blocks[:MAX_BLOCKS]:
+            if not isinstance(block, dict):
+                continue
+            if "type" not in block:
+                continue
+            
+            # Deep copy to avoid mutating input
+            block_copy = json.loads(json.dumps(block))
+            
+            # Truncate text fields
+            if "text" in block_copy:
+                text_obj = block_copy["text"]
+                if isinstance(text_obj, dict):
+                    max_len = MAX_PLAIN_TEXT if text_obj.get("type") == "plain_text" else MAX_TEXT_LENGTH
+                    if "text" in text_obj and len(str(text_obj["text"])) > max_len:
+                        text_obj["text"] = str(text_obj["text"])[:max_len - 3] + "..."
+            
+            validated.append(block_copy)
+        
+        return validated
+
+    def _content_to_blocks(self, mrkdwn_content: str) -> List[Dict[str, Any]]:
+        """Convert mrkdwn content into Block Kit blocks.
+
+        Mirrors how ``send_exec_approval`` builds blocks — section blocks
+        with ``mrkdwn`` text — so every message sent to Slack uses the
+        ``blocks`` parameter for native rendering.
+
+        Splits on ``---`` dividers and leading ``*Header*`` lines (which
+        ``format_message`` produces from ``# Header`` markdown).
+        """
+        if not mrkdwn_content or not mrkdwn_content.strip():
+            return [{"type": "section", "text": {"type": "mrkdwn", "text": " "}}]
+
+        blocks: List[Dict[str, Any]] = []
+        # Split on horizontal-rule dividers (--- on its own line)
+        segments = re.split(r'^-{3,}\s*$', mrkdwn_content, flags=re.MULTILINE)
+
+        for seg_idx, segment in enumerate(segments):
+            segment = segment.strip()
+            if not segment:
+                if seg_idx > 0:
+                    blocks.append({"type": "divider"})
+                continue
+
+            # Add divider between segments (except before the first)
+            if seg_idx > 0:
+                blocks.append({"type": "divider"})
+
+            # Section text limit is 3000 chars
+            if len(segment) <= 3000:
+                blocks.append({
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": segment},
+                })
+            else:
+                # Split oversized sections at line boundaries
+                chunk = ""
+                for line in segment.split("\n"):
+                    if len(chunk) + len(line) + 1 > 3000:
+                        if chunk:
+                            blocks.append({
+                                "type": "section",
+                                "text": {"type": "mrkdwn", "text": chunk},
+                            })
+                        chunk = line
+                    else:
+                        chunk = f"{chunk}\n{line}" if chunk else line
+                if chunk:
+                    blocks.append({
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": chunk},
+                    })
+
+        if not blocks:
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": " "}})
+
+        # Slack limit: 50 blocks per message
+        return blocks[:50]
 
     async def edit_message(
         self,
@@ -430,9 +599,14 @@ class SlackAdapter(BasePlatformAdapter):
         Protected regions (code blocks, inline code) are extracted first so
         their contents are never modified.  Standard markdown constructs
         (headers, bold, italic, links) are translated to mrkdwn syntax.
+        Tables are converted to code blocks since Slack doesn't support
+        native markdown tables.
         """
         if not content:
             return content
+
+        # Convert markdown tables to Slack-compatible format
+        content, _ = convert_markdown_tables_to_slack(content, use_block_kit=False)
 
         placeholders: dict = {}
         counter = [0]
@@ -914,17 +1088,12 @@ class SlackAdapter(BasePlatformAdapter):
                     if v > cutoff
                 }
 
-        # Ignore bot messages (including our own)
-        if event.get("bot_id") or event.get("subtype") == "bot_message":
-            return
+        # Mark event received for stale socket detection
+        self._mark_event_received()
 
-        # Ignore message edits and deletions
-        subtype = event.get("subtype")
-        if subtype in ("message_changed", "message_deleted"):
-            return
-
-        text = event.get("text", "")
+        # Extract basic info first (needed for channel config resolution)
         channel_id = event.get("channel", "")
+        user_id = event.get("user", "")
         ts = event.get("ts", "")
         assistant_meta = self._lookup_assistant_thread_metadata(
             event,
@@ -950,71 +1119,157 @@ class SlackAdapter(BasePlatformAdapter):
             channel_type = "im"
         is_dm = channel_type == "im"
 
-        # Build thread_ts for session keying.
-        # In channels: fall back to ts so each top-level @mention starts a
-        #   new thread/session (the bot always replies in a thread).
-        # In DMs: only use the real thread_ts — top-level DMs should share
-        #   one continuous session, threaded DMs get their own session.
+        # Resolve per-channel configuration early (needed for allowBots check)
+        channel_name = None  # Will be resolved later if needed
+        channel_config = resolve_channel_config(
+            channel_id=channel_id,
+            channel_name=channel_name,
+            global_config=self.config.extra,
+        )
+
+        # Ignore bot messages (including our own)
+        bot_id = event.get("bot_id")
+        is_bot_message = event.get("subtype") == "bot_message"
+        
+        # Use channel-specific allowBots if set, else global default
+        allow_bots = channel_config.allow_bots
+        if allow_bots is None:
+            allow_bots = self.config.extra.get("allowBots", False)
+        
+        if bot_id or is_bot_message:
+            # Skip our own messages
+            if user_id and self._bot_user_id and user_id == self._bot_user_id:
+                return
+            # Skip other bots unless allowBots is enabled
+            if not allow_bots:
+                logger.debug("[Slack] Dropping bot message %s (allowBots=%s)", bot_id or "unknown", allow_bots)
+                return
+
+        # Handle message subtypes
+        subtype = event.get("subtype")
+        
+        # thread_broadcast: reply posted to thread AND broadcast to channel
+        if subtype == "thread_broadcast":
+            # Process like a regular message but note it's a broadcast
+            logger.debug("[Slack] Received thread_broadcast message")
+            # Continue processing below - don't return
+        
+        # slack_audio: voice message (handle MIME type conversion below)
+        if subtype == "slack_audio":
+            logger.debug("[Slack] Received voice message (slack_audio subtype)")
+            # Continue processing - file handling will convert MIME type
+        
+        # message_deleted: nothing to process
+        if subtype == "message_deleted":
+            return
+
+        # message_changed: extract the edited message and re-process it.
+        # Slack wraps the new version in event["message"].
+        if subtype == "message_changed":
+            inner = event.get("message")
+            if not inner or inner.get("subtype") == "bot_message":
+                return
+            # Promote the inner message fields so downstream code sees them
+            # at the top level, matching a normal message event.
+            event = {**event, **inner, "subtype": None}
+            logger.debug("[Slack] Processing edited message %s", inner.get("ts"))
+
+        text = event.get("text", "")
+
+        # Get parent user ID for thread ownership detection
+        parent_user_id = event.get("parent_user_id")
+
+        # Build thread_ts for session keying
         if is_dm:
             thread_ts = event.get("thread_ts") or assistant_meta.get("thread_ts")  # None for top-level DMs
         else:
             thread_ts = event.get("thread_ts") or ts  # ts fallback for channels
 
-        # In channels, respond if:
-        #   1. The bot is @mentioned in this message, OR
-        #   2. The message is a reply in a thread the bot started/participated in, OR
-        #   3. The message is in a thread where the bot was previously @mentioned, OR
-        #   4. There's an existing session for this thread (survives restarts)
-        bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
-        is_mentioned = bot_uid and f"<@{bot_uid}>" in text
-        event_thread_ts = event.get("thread_ts")
-        is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
-
-        if not is_dm and bot_uid and not is_mentioned:
-            reply_to_bot_thread = (
-                is_thread_reply and event_thread_ts in self._bot_message_ts
+        # Check for thread participation (cache + persistent session fallback)
+        thread_participation_cache = get_thread_participation_cache()
+        account_id = "default"  # TODO: Support multi-account
+        has_thread_participation = False
+        if thread_ts and not is_dm:
+            has_thread_participation = await thread_participation_cache.has_participated(
+                account_id, channel_id, thread_ts
             )
-            in_mentioned_thread = (
-                event_thread_ts is not None
-                and event_thread_ts in self._mentioned_threads
-            )
-            has_session = (
-                is_thread_reply
-                and self._has_active_session_for_thread(
+            # Fallback: check persistent session store (survives restarts)
+            if not has_thread_participation:
+                has_thread_participation = self._has_active_session_for_thread(
                     channel_id=channel_id,
-                    thread_ts=event_thread_ts,
+                    thread_ts=thread_ts,
                     user_id=user_id,
                 )
+
+        # Check user authorization (per-channel whitelist)
+        if not is_dm and channel_config.users:
+            user_allowed, user_reason = is_user_allowed_in_channel(
+                user_id=user_id,
+                user_name=None,  # Will be resolved later
+                channel_config=channel_config,
+                global_config=self.config.extra,
             )
-            if not reply_to_bot_thread and not in_mentioned_thread and not has_session:
+            if not user_allowed:
+                logger.debug("[Slack] Blocked user %s in channel %s: %s", user_id, channel_id, user_reason)
                 return
 
-        if is_mentioned:
-            # Strip the bot mention from the text
-            text = text.replace(f"<@{bot_uid}>", "").strip()
-            # Register this thread so all future messages auto-trigger the bot
-            if event_thread_ts:
-                self._mentioned_threads.add(event_thread_ts)
-                if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
-                    to_remove = list(self._mentioned_threads)[:self._MENTIONED_THREADS_MAX // 2]
-                    for t in to_remove:
-                        self._mentioned_threads.discard(t)
+        # Smart mention detection
+        bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
 
-        # When entering a thread for the first time (no existing session),
-        # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
-            channel_id=channel_id,
-            thread_ts=event_thread_ts,
-            user_id=user_id,
-        ):
-            thread_context = await self._fetch_thread_context(
-                channel_id=channel_id,
-                thread_ts=event_thread_ts,
-                current_ts=ts,
-                team_id=team_id,
-            )
-            if thread_context:
-                text = thread_context + text
+        # Use channel-specific require_mention if set, else global default
+        require_mention = channel_config.require_mention
+        if require_mention is None:
+            require_mention = self.config.extra.get("require_mention", True)
+        mention_result = check_mention_gate(
+            text=text,
+            bot_user_id=bot_uid,
+            is_dm=is_dm,
+            thread_ts=thread_ts,
+            parent_user_id=parent_user_id,
+            has_thread_participation=has_thread_participation,
+            require_mention=require_mention,
+        )
+
+        if not mention_result.should_respond:
+            logger.debug("[Slack] Skipping message: %s", mention_result.reason)
+            return
+
+        # Strip the bot mention from text if present
+        if mention_result.was_mentioned and bot_uid:
+            text = text.replace(f"<@{bot_uid}>", "").strip()
+
+        # Record thread participation on mention so future replies auto-trigger
+        if mention_result.was_mentioned and thread_ts and not is_dm:
+            await thread_participation_cache.record(account_id, channel_id, thread_ts)
+
+        # Load thread history for context if in a thread and this is a new session
+        thread_context_text = ""
+        if thread_ts and not is_dm:
+            try:
+                # Check if this is a new session by looking at the thread participation
+                # If we've already participated, the session is continuing
+                if not has_thread_participation:
+                    # Use channel-specific limit if set, else global default
+                    history_limit = channel_config.thread_history_limit
+                    if history_limit is None:
+                        history_limit = self.config.extra.get("thread_history_limit", 20)
+                    
+                    thread_context = await load_thread_context(
+                        client=self._get_client(channel_id),
+                        channel_id=channel_id,
+                        thread_ts=thread_ts,
+                        current_message_ts=ts,
+                        history_limit=history_limit,
+                    )
+                    if thread_context.thread_history:
+                        thread_context_text = format_thread_context_for_prompt(thread_context)
+                        logger.debug("[Slack] Loaded %d thread messages for context", len(thread_context.thread_history))
+            except Exception as e:
+                logger.warning("[Slack] Failed to load thread context: %s", e)
+
+        # Inject thread context into the message if loaded
+        if thread_context_text:
+            text = f"{thread_context_text}\n\n[Current message]: {text}"
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -1025,9 +1280,16 @@ class SlackAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         files = event.get("files", [])
-        for f in files:
+        max_files = self.config.extra.get("maxFiles", 8)
+        
+        for f in files[:max_files]:  # Limit concurrent file processing
             mimetype = f.get("mimetype", "unknown")
+            file_subtype = f.get("subtype", "")
             url = f.get("url_private_download") or f.get("url_private", "")
+            
+            # Normalize Slack voice message MIME type (slack_audio has video/* but is audio)
+            mimetype = normalize_slack_voice_mimetype(mimetype, file_subtype)
+            
             if mimetype.startswith("image/") and url:
                 try:
                     ext = "." + mimetype.split("/")[-1].split(";")[0]
@@ -1132,6 +1394,10 @@ class SlackAdapter(BasePlatformAdapter):
         await self._add_reaction(channel_id, ts, "eyes")
 
         await self.handle_message(msg_event)
+
+        # Record thread participation for future implicit mentions
+        if thread_ts and not is_dm:
+            await thread_participation_cache.record(account_id, channel_id, thread_ts)
 
         # Replace 👀 with ✅ when done
         await self._remove_reaction(channel_id, ts, "eyes")
@@ -1300,80 +1566,61 @@ class SlackAdapter(BasePlatformAdapter):
         # Clean up stale approval state
         self._approval_resolved.pop(msg_ts, None)
 
-    # ----- Thread context fetching -----
-
-    async def _fetch_thread_context(
-        self, channel_id: str, thread_ts: str, current_ts: str,
-        team_id: str = "", limit: int = 30,
-    ) -> str:
-        """Fetch recent thread messages to provide context when the bot is
-        mentioned mid-thread for the first time.
-
-        Returns a formatted string with thread history, or empty string on
-        failure or if the thread is empty (just the parent message).
-        """
-        try:
-            client = self._get_client(channel_id)
-            result = await client.conversations_replies(
-                channel=channel_id,
-                ts=thread_ts,
-                limit=limit + 1,  # +1 because it includes the current message
-                inclusive=True,
-            )
-            messages = result.get("messages", [])
-            if not messages:
-                return ""
-
-            context_parts = []
-            for msg in messages:
-                msg_ts = msg.get("ts", "")
-                # Skip the current message (the one that triggered this fetch)
-                if msg_ts == current_ts:
-                    continue
-                # Skip bot messages from ourselves
-                if msg.get("bot_id") or msg.get("subtype") == "bot_message":
-                    continue
-
-                msg_user = msg.get("user", "unknown")
-                msg_text = msg.get("text", "").strip()
-                if not msg_text:
-                    continue
-
-                # Strip bot mentions from context messages
-                bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
-                if bot_uid:
-                    msg_text = msg_text.replace(f"<@{bot_uid}>", "").strip()
-
-                # Mark the thread parent
-                is_parent = msg_ts == thread_ts
-                prefix = "[thread parent] " if is_parent else ""
-
-                # Resolve user name (cached)
-                name = await self._resolve_user_name(msg_user, chat_id=channel_id)
-                context_parts.append(f"{prefix}{name}: {msg_text}")
-
-            if not context_parts:
-                return ""
-
-            return (
-                "[Thread context — previous messages in this thread:]\n"
-                + "\n".join(context_parts)
-                + "\n[End of thread context]\n\n"
-            )
-        except Exception as e:
-            logger.warning("[Slack] Failed to fetch thread context: %s", e)
-            return ""
-
     async def _handle_slash_command(self, command: dict) -> None:
         """Handle /hermes slash command."""
         text = command.get("text", "").strip()
         user_id = command.get("user_id", "")
         channel_id = command.get("channel_id", "")
         team_id = command.get("team_id", "")
+        trigger_id = command.get("trigger_id", "")
+        response_url = command.get("response_url", "")
 
         # Track which workspace owns this channel
         if team_id and channel_id:
             self._channel_team[channel_id] = team_id
+
+        # Check for built-in interactive commands
+        first_word = text.split()[0].lower() if text else ""
+        
+        if first_word in ("help", "skills", "status", "config"):
+            # Handle with interactive command handlers
+            from gateway.platforms.slack_commands import (
+                SlashCommandContext,
+                dispatch_slash_command,
+            )
+            
+            ctx = SlashCommandContext(
+                user_id=user_id,
+                channel_id=channel_id,
+                team_id=team_id,
+                trigger_id=trigger_id,
+                response_url=response_url,
+                adapter=self,
+            )
+            
+            result = await dispatch_slash_command(text, ctx)
+
+            # Send ephemeral response
+            client = self._get_client(channel_id)
+            try:
+                await client.chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=result.text,
+                    blocks=result.blocks if result.blocks else None,
+                )
+            except Exception as e:
+                logger.error("[Slack] Failed to send ephemeral for /%s: %s", first_word, e)
+                # Fallback: send text-only ephemeral
+                try:
+                    await client.chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=result.text or f"Error running /{first_word}",
+                    )
+                except Exception:
+                    pass
+            return
 
         # Map subcommands to gateway commands — derived from central registry.
         # Also keep "compact" as a Slack-specific alias for /compress.
@@ -1452,10 +1699,85 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:
             return False
 
+    async def _handle_block_action(self, body: dict, respond: Any) -> None:
+        """Handle interactive Block Kit actions (button clicks, select menus).
+
+        This is called when a user interacts with a Block Kit component that
+        has an action_id matching "hermes:.*".
+
+        Args:
+            body: The interaction payload from Slack
+            respond: Function to respond to the interaction
+        """
+        import json
+
+        user_id = body.get("user", {}).get("id", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        message_ts = body.get("message", {}).get("ts", "")
+
+        # Extract action details
+        actions = body.get("actions", [])
+        if not actions:
+            return
+
+        action = actions[0]
+        action_id = action.get("action_id", "")
+        action_type = action.get("type", "")
+
+        # Parse action_id: hermes:reply_button:N:M or hermes:reply_select:N
+        parts = action_id.split(":")
+        if len(parts) < 2:
+            return
+
+        action_name = parts[1]  # reply_button or reply_select
+
+        # Get the selected value
+        value = ""
+        if action_type == "button":
+            value = action.get("value", "")
+        elif action_type == "static_select":
+            selected_option = action.get("selected_option", {})
+            value = selected_option.get("value", "")
+
+        logger.info(
+            "[Slack] Block action: user=%s channel=%s action=%s value=%s",
+            user_id, channel_id, action_name, value
+        )
+
+        # Build a synthetic message event with the selected value
+        text = value
+
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_type="group",  # Block actions typically in channels
+            user_id=user_id,
+            thread_id=body.get("message", {}).get("thread_ts"),
+        )
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=body,
+        )
+
+        # Process the selection as a message
+        await self.handle_message(event)
+
     async def _download_slack_file(self, url: str, ext: str, audio: bool = False, team_id: str = "") -> str:
-        """Download a Slack file using the bot token for auth, with retry."""
+        """Download a Slack file using the bot token for auth, with retry.
+        
+        Includes SSRF protection and HTML detection to prevent credential leaks.
+        """
         import asyncio
         import httpx
+
+        # SSRF protection: validate URL points to Slack domain
+        try:
+            url = validate_slack_file_url(url)
+        except ValueError as e:
+            logger.warning("[Slack] SSRF protection rejected URL: %s", e)
+            raise
 
         bot_token = self._team_clients[team_id].token if team_id and team_id in self._team_clients else self.config.token
         last_exc = None
@@ -1468,6 +1790,11 @@ class SlackAdapter(BasePlatformAdapter):
                         headers={"Authorization": f"Bearer {bot_token}"},
                     )
                     response.raise_for_status()
+
+                    # Detect HTML auth/error pages
+                    if not audio and looks_like_html_content(response.content):
+                        logger.warning("[Slack] Received HTML instead of binary file (auth failure?)")
+                        raise ValueError("Received HTML content instead of file")
 
                     if audio:
                         from gateway.platforms.base import cache_audio_from_bytes
@@ -1488,9 +1815,19 @@ class SlackAdapter(BasePlatformAdapter):
         raise last_exc
 
     async def _download_slack_file_bytes(self, url: str, team_id: str = "") -> bytes:
-        """Download a Slack file and return raw bytes, with retry."""
+        """Download a Slack file and return raw bytes, with retry.
+        
+        Includes SSRF protection and HTML detection.
+        """
         import asyncio
         import httpx
+
+        # SSRF protection: validate URL points to Slack domain
+        try:
+            url = validate_slack_file_url(url)
+        except ValueError as e:
+            logger.warning("[Slack] SSRF protection rejected URL: %s", e)
+            raise
 
         bot_token = self._team_clients[team_id].token if team_id and team_id in self._team_clients else self.config.token
         last_exc = None
@@ -1503,6 +1840,12 @@ class SlackAdapter(BasePlatformAdapter):
                         headers={"Authorization": f"Bearer {bot_token}"},
                     )
                     response.raise_for_status()
+
+                    # Detect HTML auth/error pages
+                    if looks_like_html_content(response.content):
+                        logger.warning("[Slack] Received HTML instead of binary file (auth failure?)")
+                        raise ValueError("Received HTML content instead of file")
+
                     return response.content
                 except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
                     last_exc = exc
@@ -1515,3 +1858,154 @@ class SlackAdapter(BasePlatformAdapter):
                         continue
                     raise
         raise last_exc
+
+    # -----------------------------------------------------------------------
+    # Message Updating
+    # -----------------------------------------------------------------------
+
+    async def update_message(
+        self,
+        message_ref: SlackMessageRef,
+        text: str,
+        blocks: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
+        """
+        Update an existing Slack message.
+        
+        Useful for:
+        - Progress updates on long-running tasks
+        - Approval flow (approve/deny/always buttons)
+        - Error correction
+        
+        Args:
+            message_ref: Reference to the message to update
+            text: New message text
+            blocks: Optional new Block Kit blocks
+        
+        Returns:
+            True if update succeeded
+        """
+        if not self._app:
+            logger.error("[Slack] Cannot update message: not connected")
+            return False
+        
+        client = self._get_client(message_ref.channel_id)
+        return await update_slack_message(client, message_ref, text, blocks)
+
+    async def send_with_update_ref(
+        self,
+        chat_id: str,
+        content: str,
+        ref_id: str,
+        blocks: Optional[List[Dict[str, Any]]] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """
+        Send a message and store a reference for later updates.
+        
+        Args:
+            chat_id: Channel ID
+            content: Message text
+            ref_id: Unique ID to reference this message later
+            blocks: Optional Block Kit blocks
+            reply_to: Thread parent ID
+        
+        Returns:
+            SendResult with message_id
+        """
+        result = await self.send(chat_id, content, reply_to=reply_to, blocks=blocks)
+        
+        if result.success and result.message_id:
+            self._pending_messages[ref_id] = SlackMessageRef(
+                channel_id=chat_id,
+                message_ts=result.message_id,
+            )
+        
+        return result
+
+    async def update_by_ref_id(
+        self,
+        ref_id: str,
+        text: str,
+        blocks: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
+        """
+        Update a message by its reference ID.
+        
+        Args:
+            ref_id: The reference ID stored when sending
+            text: New message text
+            blocks: Optional new blocks
+        
+        Returns:
+            True if update succeeded
+        """
+        ref = self._pending_messages.get(ref_id)
+        if not ref:
+            logger.warning("[Slack] No message found with ref_id: %s", ref_id)
+            return False
+        
+        return await self.update_message(ref, text, blocks)
+
+    # -----------------------------------------------------------------------
+    # Connection Health & Reconnection
+    # -----------------------------------------------------------------------
+
+    async def health_check(self) -> SlackProbeResult:
+        """
+        Check Slack connection health.
+        
+        Returns:
+            SlackProbeResult with connection status
+        """
+        if not self._app:
+            return SlackProbeResult(ok=False, error="not connected")
+        
+        return await probe_slack_connection(self._app.client)
+
+    def get_connection_state(self) -> SlackConnectionState:
+        """Get current connection state."""
+        return self._connection_state
+
+    def is_socket_stale(self, threshold_seconds: float = 60.0) -> bool:
+        """
+        Check if socket appears connected but is stale.
+        
+        Detects "half-dead" sockets that pass health checks
+        but silently stop delivering events.
+        
+        Args:
+            threshold_seconds: Seconds without events to consider stale
+        
+        Returns:
+            True if socket is stale
+        """
+        return self._connection_state.is_socket_stale(threshold_seconds)
+
+    async def validate_scopes(self) -> SlackScopeValidation:
+        """
+        Validate OAuth scopes for current connection.
+        
+        Returns:
+            SlackScopeValidation with missing scopes
+        """
+        if not self._app:
+            return SlackScopeValidation(
+                valid=False,
+                missing_required=list(REQUIRED_SLACK_SCOPES),
+                missing_recommended=list(RECOMMENDED_SLACK_SCOPES),
+                all_scopes=[],
+            )
+        
+        scopes = await fetch_slack_scopes(self._app.client)
+        validation = validate_slack_scopes(scopes)
+        
+        if not validation.valid:
+            logger.warning(validation.format_warning())
+        
+        return validation
+
+    def _mark_event_received(self) -> None:
+        """Mark that an event was received (called by message handler)."""
+        self._connection_state.mark_event_received()
+

--- a/gateway/platforms/slack_commands.py
+++ b/gateway/platforms/slack_commands.py
@@ -1,0 +1,342 @@
+"""
+Slack slash command handlers.
+
+Provides interactive slash commands for:
+- /hermes skills - List available skills
+- /hermes status - Show connection status
+- /hermes config - Manage configuration
+- /hermes help - Show available commands
+"""
+
+import logging
+from typing import Dict, List, Any, Optional, Callable, Awaitable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SlashCommandContext:
+    """Context for slash command execution."""
+    user_id: str
+    channel_id: str
+    team_id: str
+    trigger_id: str
+    response_url: str
+    adapter: Any  # SlackAdapter
+
+
+@dataclass
+class SlashCommandResult:
+    """Result of slash command execution."""
+    text: str
+    blocks: Optional[List[Dict]] = None
+    response_type: str = "ephemeral"  # "ephemeral" or "in_channel"
+
+
+def build_header_block(text: str) -> Dict:
+    """Build a header block."""
+    return {
+        "type": "header",
+        "text": {"type": "plain_text", "text": text[:150]},
+    }
+
+
+def build_section_block(text: str) -> Dict:
+    """Build a section block with markdown text."""
+    return {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": text[:3000]},
+    }
+
+
+def build_context_block(elements: List[str]) -> Dict:
+    """Build a context block."""
+    return {
+        "type": "context",
+        "elements": [
+            {"type": "mrkdwn", "text": elem[:300]}
+            for elem in elements
+        ],
+    }
+
+
+def build_divider_block() -> Dict:
+    """Build a divider block."""
+    return {"type": "divider"}
+
+
+def build_actions_block(elements: List[Dict]) -> Dict:
+    """Build an actions block."""
+    return {
+        "type": "actions",
+        "elements": elements[:25],
+    }
+
+
+def build_button(
+    text: str,
+    action_id: str,
+    value: str = "",
+    style: Optional[str] = None,
+) -> Dict:
+    """Build a button element."""
+    button = {
+        "type": "button",
+        "text": {"type": "plain_text", "text": text[:75]},
+        "action_id": action_id,
+        "value": value,
+    }
+    if style in ("primary", "danger"):
+        button["style"] = style
+    return button
+
+
+def build_select_menu(
+    placeholder: str,
+    action_id: str,
+    options: List[Dict[str, str]],
+) -> Dict:
+    """Build a static select menu."""
+    return {
+        "type": "static_select",
+        "placeholder": {"type": "plain_text", "text": placeholder[:150]},
+        "action_id": action_id,
+        "options": [
+            {
+                "text": {"type": "plain_text", "text": opt["text"][:75]},
+                "value": opt["value"][:75],
+            }
+            for opt in options[:100]
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Command Handlers
+# ---------------------------------------------------------------------------
+
+async def handle_help_command(ctx: SlashCommandContext) -> SlashCommandResult:
+    """Handle /hermes help command."""
+    blocks = [
+        build_header_block("Hermes Agent Help"),
+        build_section_block(
+            "*Available Commands:*\n\n"
+            "• `/hermes help` - Show this help message\n"
+            "• `/hermes skills` - List available skills\n"
+            "• `/hermes status` - Show connection status\n"
+            "• `/hermes config` - View configuration\n"
+            "• `/hermes compact` - Compact conversation\n"
+            "• `/hermes clear` - Clear conversation\n\n"
+            "You can also just ask questions directly!"
+        ),
+        build_divider_block(),
+        build_context_block([
+            "Hermes Agent v1.0 • Slack Integration",
+        ]),
+    ]
+    
+    return SlashCommandResult(
+        text="Hermes Help",
+        blocks=blocks,
+    )
+
+
+async def handle_skills_command(ctx: SlashCommandContext) -> SlashCommandResult:
+    """Handle /hermes skills command."""
+    try:
+        # Import skills list from tools
+        from tools.skills_tool import skills_list
+        import json as json_module
+        
+        result_json = skills_list()
+        result = json_module.loads(result_json)
+        
+        if not result.get("success"):
+            return SlashCommandResult(
+                text=f"Error loading skills: {result.get('error', 'unknown error')}",
+            )
+        
+        skills = result.get("skills", [])
+        categories = result.get("categories", [])
+        
+        if not skills:
+            message = result.get("message", "No skills found.")
+            return SlashCommandResult(
+                text=message,
+            )
+        
+        # Group skills by category
+        skill_by_category: Dict[str, List[Dict]] = {}
+        for skill in skills[:50]:  # Limit to 50 skills
+            cat = skill.get("category", "general")
+            if cat not in skill_by_category:
+                skill_by_category[cat] = []
+            skill_by_category[cat].append(skill)
+        
+        blocks = [build_header_block(f"Available Skills ({len(skills)} total)")]
+        
+        for category in list(skill_by_category.keys())[:10]:  # Max 10 categories
+            skill_list = skill_by_category[category]
+            lines = []
+            for s in skill_list[:10]:  # Max 10 skills per category
+                name = s.get("name", "unknown")
+                desc = s.get("description", "")[:60]
+                if desc:
+                    lines.append(f"• `{name}` - {desc}")
+                else:
+                    lines.append(f"• `{name}`")
+            
+            text = f"*{category.title()}*\n" + "\n".join(lines)
+            blocks.append(build_section_block(text))
+        
+        if len(skills) > 50:
+            blocks.append(build_context_block([
+                f"Showing 50 of {len(skills)} skills. Use `hermes skills list` in CLI for full list.",
+            ]))
+        
+        return SlashCommandResult(
+            text=f"Available Skills ({len(skills)} total)",
+            blocks=blocks,
+        )
+    
+    except Exception as e:
+        logger.error("[Slack] Skills command error: %s", e, exc_info=True)
+        return SlashCommandResult(
+            text=f"Error loading skills. Use `hermes skills list` in CLI.",
+        )
+
+
+async def handle_status_command(ctx: SlashCommandContext) -> SlashCommandResult:
+    """Handle /hermes status command."""
+    adapter = ctx.adapter
+    
+    # Get connection state
+    state = adapter.get_connection_state()
+    
+    status_emoji = {
+        "connected": ":large_green_circle:",
+        "disconnected": ":red_circle:",
+        "connecting": ":large_yellow_circle:",
+        "reconnecting": ":large_yellow_circle:",
+        "error": ":red_circle:",
+    }.get(state.status.value, ":white_circle:")
+    
+    # Get health check
+    try:
+        probe = await adapter.health_check()
+        health_status = f"Latency: {probe.elapsed_ms:.0f}ms" if probe.ok else f"Error: {probe.error}"
+    except Exception as e:
+        health_status = f"Health check failed: {e}"
+    
+    blocks = [
+        build_header_block("Hermes Status"),
+        build_section_block(
+            f"*Connection:* {status_emoji} {state.status.value.title()}\n"
+            f"*Health:* {health_status}\n"
+            f"*Reconnect Attempts:* {state.reconnect_attempts}"
+        ),
+    ]
+    
+    # Add last event time if available
+    if state.last_event_at:
+        import time
+        seconds_ago = time.time() - state.last_event_at
+        blocks.append(build_context_block([
+            f"Last event: {seconds_ago:.0f}s ago",
+        ]))
+    
+    # Add stale socket warning
+    if adapter.is_socket_stale():
+        blocks.append(build_section_block(
+            ":warning: *Warning:* Socket appears stale (no recent events)"
+        ))
+    
+    return SlashCommandResult(
+        text=f"Status: {state.status.value}",
+        blocks=blocks,
+    )
+
+
+async def handle_config_command(ctx: SlashCommandContext) -> SlashCommandResult:
+    """Handle /hermes config command."""
+    adapter = ctx.adapter
+    config = adapter.config
+    
+    # Build config summary (don't expose sensitive values)
+    blocks = [
+        build_header_block("Hermes Configuration"),
+        build_section_block(
+            f"*Platform:* Slack\n"
+            f"*Token Set:* {'Yes' if config.token else 'No'}\n"
+            f"*Allowed Users:* {len(config.extra.get('allowed_users', []))} users"
+        ),
+    ]
+    
+    # Show extra config options
+    extra = config.extra or {}
+    if extra:
+        extra_items = []
+        for key, value in list(extra.items())[:10]:
+            if key in ("token", "bot_token", "app_token", "signing_secret"):
+                continue
+            if isinstance(value, str) and len(value) > 50:
+                value = value[:50] + "..."
+            extra_items.append(f"• `{key}`: {value}")
+        
+        if extra_items:
+            blocks.append(build_section_block(
+                "*Extra Config:*\n" + "\n".join(extra_items)
+            ))
+    
+    return SlashCommandResult(
+        text="Configuration",
+        blocks=blocks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Command Registry
+# ---------------------------------------------------------------------------
+
+SLASH_COMMANDS: Dict[str, Callable[[SlashCommandContext], Awaitable[SlashCommandResult]]] = {
+    "help": handle_help_command,
+    "skills": handle_skills_command,
+    "status": handle_status_command,
+    "config": handle_config_command,
+}
+
+
+async def dispatch_slash_command(
+    text: str,
+    ctx: SlashCommandContext,
+) -> SlashCommandResult:
+    """
+    Dispatch a slash command to the appropriate handler.
+    
+    Args:
+        text: Command text (after /hermes)
+        ctx: Slash command context
+    
+    Returns:
+        SlashCommandResult with response
+    """
+    parts = text.strip().split(None, 1)
+    command = parts[0].lower() if parts else "help"
+    args = parts[1] if len(parts) > 1 else ""
+    
+    handler = SLASH_COMMANDS.get(command)
+    
+    if handler:
+        try:
+            return await handler(ctx)
+        except Exception as e:
+            logger.error("[Slack] Slash command error: %s", e, exc_info=True)
+            return SlashCommandResult(
+                text=f"Error executing command: {e}",
+            )
+    
+    # Unknown command - return help
+    return SlashCommandResult(
+        text=f"Unknown command: `{command}`. Use `/hermes help` for available commands.",
+    )

--- a/gateway/platforms/slack_utils.py
+++ b/gateway/platforms/slack_utils.py
@@ -1,0 +1,1476 @@
+"""
+Slack-specific utilities for thread handling, caching, and message processing.
+
+This module provides:
+- Thread participation cache for implicit mention detection
+- Thread history loading for context
+- Smart mention gating logic
+- SSRF-safe file downloading
+- Table formatting support
+- Reconnection and resilience utilities
+- Connection status tracking
+"""
+
+import asyncio
+import logging
+import time
+import re
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any, Tuple
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SSRF Protection for Slack File Downloads
+#
+# Slack file URLs should only point to known Slack domains.
+# This prevents credential leakage if a malicious URL is crafted.
+# ---------------------------------------------------------------------------
+
+SLACK_ALLOWED_HOSTNAMES = (
+    "slack.com",
+    "*.slack.com", 
+    "slack-edge.com",
+    "*.slack-edge.com",
+    "slack-files.com",
+    "*.slack-files.com",
+)
+
+import urllib.parse
+
+
+def is_slack_hostname(hostname: str) -> bool:
+    """Check if hostname matches allowed Slack domains."""
+    if not hostname:
+        return False
+    
+    hostname = hostname.lower().rstrip(".")
+    
+    for pattern in SLACK_ALLOWED_HOSTNAMES:
+        if pattern.startswith("*."):
+            # Wildcard match
+            suffix = pattern[2:]  # Remove "*."
+            if hostname == suffix or hostname.endswith(f".{suffix}"):
+                return True
+        else:
+            if hostname == pattern:
+                return True
+    
+    return False
+
+
+def validate_slack_file_url(url: str) -> str:
+    """
+    Validate that a URL points to a known Slack domain.
+    
+    Args:
+        url: The URL to validate
+        
+    Returns:
+        The validated URL
+        
+    Raises:
+        ValueError: If URL is invalid or points to non-Slack domain
+    """
+    if not url:
+        raise ValueError("Empty URL")
+    
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception as e:
+        raise ValueError(f"Invalid URL: {url}") from e
+    
+    if parsed.scheme not in ("https",):
+        raise ValueError(f"Refusing non-HTTPS Slack file URL: {parsed.scheme}")
+    
+    if not is_slack_hostname(parsed.hostname or ""):
+        raise ValueError(
+            f"Refusing to send Slack token to non-Slack host: {parsed.hostname}"
+        )
+    
+    return url
+
+
+def looks_like_html_content(data: bytes) -> bool:
+    """
+    Check if downloaded content looks like HTML (auth page, error page).
+    
+    Slack sometimes returns HTML login pages instead of binary files
+    when auth fails or the file is unavailable.
+    
+    Args:
+        data: Raw bytes of downloaded content
+        
+    Returns:
+        True if content appears to be HTML
+    """
+    if len(data) < 10:
+        return False
+    
+    # Check first 512 bytes for HTML markers
+    head = data[:512].decode("utf-8", errors="ignore").strip().lower()
+    
+    return head.startswith("<!doctype html") or head.startswith("<html")
+
+
+# ---------------------------------------------------------------------------
+# Voice Message MIME Type Handling
+#
+# Slack voice messages (slack_audio subtype) are served with video/* MIME
+# types but should be treated as audio for transcription.
+# ---------------------------------------------------------------------------
+
+def normalize_slack_voice_mimetype(mimetype: Optional[str], subtype: Optional[str]) -> Optional[str]:
+    """
+    Normalize MIME type for Slack voice messages.
+    
+    Slack voice clips have subtype="slack_audio" but are served with
+    video/* MIME types. Convert to audio/* for proper handling.
+    
+    Args:
+        mimetype: Original MIME type from file metadata
+        subtype: Slack file subtype (e.g., "slack_audio")
+        
+    Returns:
+        Normalized MIME type
+    """
+    if not mimetype:
+        return mimetype
+    
+    if subtype == "slack_audio" and mimetype.startswith("video/"):
+        return mimetype.replace("video/", "audio/", 1)
+    
+    return mimetype
+
+
+# ---------------------------------------------------------------------------
+# Thread Participation Cache
+#
+# In-memory cache tracking which threads the bot has participated in.
+# Used to allow implicit mentions (no @mention required) after first reply.
+# Similar to Hermes' sent-thread-cache pattern.
+# ---------------------------------------------------------------------------
+
+class ThreadParticipationCache:
+    """
+    LRU cache tracking bot participation in Slack threads.
+    
+    After the bot replies in a thread, subsequent messages in that thread
+    don't require an explicit @mention - the bot will respond implicitly.
+    
+    TTL: 24 hours
+    Max entries: 5000 (prevents unbounded memory growth)
+    """
+    
+    def __init__(self, ttl_seconds: int = 24 * 60 * 60, max_entries: int = 5000):
+        self._ttl_seconds = ttl_seconds
+        self._max_entries = max_entries
+        self._cache: OrderedDict[str, float] = OrderedDict()
+        self._lock = asyncio.Lock()
+    
+    def _make_key(self, account_id: str, channel_id: str, thread_ts: str) -> str:
+        return f"{account_id}:{channel_id}:{thread_ts}"
+    
+    async def record(self, account_id: str, channel_id: str, thread_ts: str) -> None:
+        """Record that the bot has participated in a thread."""
+        if not account_id or not channel_id or not thread_ts:
+            return
+        
+        key = self._make_key(account_id, channel_id, thread_ts)
+        
+        async with self._lock:
+            # Remove if exists (will be re-added at end for LRU)
+            if key in self._cache:
+                del self._cache[key]
+            
+            # Evict oldest if at capacity
+            while len(self._cache) >= self._max_entries:
+                self._cache.popitem(last=False)
+            
+            self._cache[key] = time.time()
+    
+    async def has_participated(self, account_id: str, channel_id: str, thread_ts: str) -> bool:
+        """Check if the bot has participated in a thread (within TTL)."""
+        if not account_id or not channel_id or not thread_ts:
+            return False
+        
+        key = self._make_key(account_id, channel_id, thread_ts)
+        
+        async with self._lock:
+            if key not in self._cache:
+                return False
+            
+            # Check TTL
+            recorded_at = self._cache[key]
+            if time.time() - recorded_at > self._ttl_seconds:
+                del self._cache[key]
+                return False
+            
+            # Move to end (LRU)
+            del self._cache[key]
+            self._cache[key] = recorded_at
+            return True
+    
+    async def cleanup_expired(self) -> int:
+        """Remove expired entries. Returns count of removed entries."""
+        removed = 0
+        cutoff = time.time() - self._ttl_seconds
+        
+        async with self._lock:
+            expired_keys = [
+                k for k, v in self._cache.items()
+                if v < cutoff
+            ]
+            for key in expired_keys:
+                del self._cache[key]
+                removed += 1
+        
+        return removed
+    
+    async def clear(self) -> None:
+        """Clear all entries."""
+        async with self._lock:
+            self._cache.clear()
+
+
+# Global singleton instance
+_thread_participation_cache: Optional[ThreadParticipationCache] = None
+
+
+def get_thread_participation_cache() -> ThreadParticipationCache:
+    """Get the global thread participation cache instance."""
+    global _thread_participation_cache
+    if _thread_participation_cache is None:
+        _thread_participation_cache = ThreadParticipationCache()
+    return _thread_participation_cache
+
+
+# ---------------------------------------------------------------------------
+# Thread History Loading
+#
+# Fetches previous messages in a thread to provide context when the bot
+# is first invoked in a thread session.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThreadMessage:
+    """A message from a Slack thread."""
+    text: str
+    user_id: Optional[str] = None
+    bot_id: Optional[str] = None
+    ts: Optional[str] = None
+    files: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ThreadContext:
+    """Context loaded from a Slack thread."""
+    thread_starter: Optional[ThreadMessage] = None
+    thread_history: List[ThreadMessage] = field(default_factory=list)
+    thread_label: Optional[str] = None
+    starter_media_paths: List[str] = field(default_factory=list)
+
+
+async def fetch_thread_history(
+    client,
+    channel_id: str,
+    thread_ts: str,
+    current_message_ts: Optional[str] = None,
+    limit: int = 20,
+) -> List[ThreadMessage]:
+    """
+    Fetch recent messages from a Slack thread.
+    
+    Uses cursor pagination and keeps only the latest N messages.
+    
+    Args:
+        client: Slack WebClient (async)
+        channel_id: Slack channel ID
+        thread_ts: Thread parent timestamp
+        current_message_ts: Exclude this message (the triggering one)
+        limit: Maximum messages to return (default 20)
+    
+    Returns:
+        List of ThreadMessage objects (oldest to newest)
+    """
+    messages: List[ThreadMessage] = []
+    cursor: Optional[str] = None
+    fetch_limit = 200  # Slack's recommended max per page
+    
+    try:
+        while True:
+            kwargs = {
+                "channel": channel_id,
+                "ts": thread_ts,
+                "limit": fetch_limit,
+                "inclusive": True,
+            }
+            if cursor:
+                kwargs["cursor"] = cursor
+            
+            response = await client.conversations_replies(**kwargs)
+            
+            for msg in response.get("messages", []):
+                # Skip messages without content
+                text = (msg.get("text") or "").strip()
+                files = msg.get("files", [])
+                if not text and not files:
+                    continue
+                
+                # Skip the current triggering message
+                msg_ts = msg.get("ts")
+                if current_message_ts and msg_ts == current_message_ts:
+                    continue
+                
+                messages.append(ThreadMessage(
+                    text=text,
+                    user_id=msg.get("user"),
+                    bot_id=msg.get("bot_id"),
+                    ts=msg_ts,
+                    files=files if files else [],
+                ))
+                
+                # Keep only last N messages
+                if len(messages) > limit:
+                    messages.pop(0)
+            
+            # Check for more pages
+            cursor = response.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+            
+            # Already have enough messages
+            if len(messages) >= limit:
+                break
+        
+        return messages
+        
+    except Exception as e:
+        logger.warning("[Slack] Failed to fetch thread history: %s", e)
+        return []
+
+
+async def fetch_thread_starter(
+    client,
+    channel_id: str,
+    thread_ts: str,
+) -> Optional[ThreadMessage]:
+    """
+    Fetch the parent message of a thread.
+    
+    Args:
+        client: Slack WebClient (async)
+        channel_id: Slack channel ID
+        thread_ts: Thread parent timestamp
+    
+    Returns:
+        ThreadMessage or None if not found
+    """
+    try:
+        response = await client.conversations_replies(
+            channel=channel_id,
+            ts=thread_ts,
+            limit=1,
+            inclusive=True,
+        )
+        
+        messages = response.get("messages", [])
+        if not messages:
+            return None
+        
+        msg = messages[0]
+        text = (msg.get("text") or "").strip()
+        if not text:
+            return None
+        
+        return ThreadMessage(
+            text=text,
+            user_id=msg.get("user"),
+            bot_id=msg.get("bot_id"),
+            ts=msg.get("ts"),
+            files=msg.get("files", []),
+        )
+        
+    except Exception as e:
+        logger.debug("[Slack] Failed to fetch thread starter: %s", e)
+        return None
+
+
+async def load_thread_context(
+    client,
+    channel_id: str,
+    thread_ts: str,
+    current_message_ts: Optional[str] = None,
+    history_limit: int = 20,
+    user_name_resolver: Optional[callable] = None,
+) -> ThreadContext:
+    """
+    Load full thread context including starter and recent history.
+    
+    Args:
+        client: Slack WebClient (async)
+        channel_id: Slack channel ID
+        thread_ts: Thread parent timestamp
+        current_message_ts: Exclude this message from history
+        history_limit: Max history messages to load
+        user_name_resolver: Optional async function to resolve user IDs to names
+    
+    Returns:
+        ThreadContext with starter, history, and metadata
+    """
+    context = ThreadContext()
+    
+    # Fetch thread starter
+    starter = await fetch_thread_starter(client, channel_id, thread_ts)
+    if starter:
+        context.thread_starter = starter
+        
+        # Create a label for the thread
+        snippet = ' '.join(starter.text.split())[:80]
+        context.thread_label = f"Slack thread: {snippet}" if snippet else "Slack thread"
+    
+    # Fetch thread history
+    history = await fetch_thread_history(
+        client,
+        channel_id,
+        thread_ts,
+        current_message_ts,
+        history_limit,
+    )
+    context.thread_history = history
+    
+    return context
+
+
+def format_thread_context_for_prompt(
+    context: ThreadContext,
+    user_name_resolver: Optional[callable] = None,
+) -> str:
+    """
+    Format thread context as a string for injection into the agent prompt.
+    
+    Args:
+        context: ThreadContext object
+        user_name_resolver: Optional async function to resolve user IDs
+    
+    Returns:
+        Formatted string for prompt injection
+    """
+    parts: List[str] = []
+    
+    # Add thread starter
+    if context.thread_starter:
+        starter = context.thread_starter
+        user_part = f"<@{starter.user_id}>" if starter.user_id else "Unknown"
+        if starter.bot_id:
+            user_part = "Assistant"
+        
+        parts.append(f"[Thread started by {user_part}]")
+        parts.append(starter.text)
+        parts.append("")
+    
+    # Add thread history
+    if context.thread_history:
+        parts.append("[Previous thread messages]")
+        for msg in context.thread_history:
+            user_part = f"<@{msg.user_id}>" if msg.user_id else "Unknown"
+            if msg.bot_id:
+                user_part = "Assistant"
+            parts.append(f"{user_part}: {msg.text}")
+        parts.append("")
+    
+    return "\n".join(parts) if parts else ""
+
+
+# ---------------------------------------------------------------------------
+# Smart Mention Detection
+#
+# Determines if a message should trigger the bot based on:
+# 1. Explicit @mention
+# 2. Thread participation (bot has replied in this thread)
+# 3. Parent ownership (bot started this thread)
+# 4. DM (no mention required)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MentionGateResult:
+    """Result of mention gating logic."""
+    should_respond: bool
+    was_mentioned: bool
+    implicit_mention: bool
+    reason: str = ""
+
+
+def check_mention_gate(
+    text: str,
+    bot_user_id: Optional[str],
+    is_dm: bool,
+    thread_ts: Optional[str],
+    parent_user_id: Optional[str],
+    has_thread_participation: bool,
+    require_mention: bool = True,
+) -> MentionGateResult:
+    """
+    Determine if the bot should respond to a message.
+    
+    Args:
+        text: Message text
+        bot_user_id: Bot's Slack user ID
+        is_dm: Whether this is a DM
+        thread_ts: Thread timestamp (None if not in a thread)
+        parent_user_id: User ID of thread parent (None if not applicable)
+        has_thread_participation: Whether bot has replied in this thread
+        require_mention: Whether @mention is required in channels
+    
+    Returns:
+        MentionGateResult with response decision and metadata
+    """
+    # DMs always respond
+    if is_dm:
+        return MentionGateResult(
+            should_respond=True,
+            was_mentioned=False,
+            implicit_mention=False,
+            reason="DM - no mention required"
+        )
+    
+    # Check for explicit mention
+    explicit_mention = False
+    if bot_user_id:
+        explicit_mention = f"<@{bot_user_id}>" in text
+    
+    # If explicitly mentioned, always respond
+    if explicit_mention:
+        return MentionGateResult(
+            should_respond=True,
+            was_mentioned=True,
+            implicit_mention=False,
+            reason="Explicit @mention"
+        )
+    
+    # If mention not required, respond
+    if not require_mention:
+        return MentionGateResult(
+            should_respond=True,
+            was_mentioned=False,
+            implicit_mention=True,
+            reason="Mention not required in this channel"
+        )
+    
+    # Check for implicit mention via thread participation
+    if thread_ts:
+        # Bot started this thread
+        if parent_user_id and bot_user_id and parent_user_id == bot_user_id:
+            return MentionGateResult(
+                should_respond=True,
+                was_mentioned=False,
+                implicit_mention=True,
+                reason="Bot started this thread"
+            )
+        
+        # Bot has participated in this thread
+        if has_thread_participation:
+            return MentionGateResult(
+                should_respond=True,
+                was_mentioned=False,
+                implicit_mention=True,
+                reason="Bot has participated in this thread"
+            )
+    
+    # Not mentioned and no implicit triggers
+    return MentionGateResult(
+        should_respond=False,
+        was_mentioned=False,
+        implicit_mention=False,
+        reason="No @mention and no implicit triggers"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown Table Utilities
+#
+# Convert markdown tables to Slack-compatible formats.
+# Slack doesn't support native markdown tables, so we use:
+# 1. Block Kit table blocks (preferred)
+# 2. Fallback: code-formatted ASCII tables
+# ---------------------------------------------------------------------------
+
+def extract_markdown_tables(content: str) -> List[Tuple[str, str, int, int]]:
+    """
+    Extract markdown tables from content.
+    
+    Returns list of (table_content, remaining_content, start_pos, end_pos)
+    """
+    import re
+    
+    # Pattern for markdown tables
+    # | col1 | col2 | col3 |
+    # |------|------|------|
+    # | val1 | val2 | val3 |
+    table_pattern = re.compile(
+        r'(\|[^\n]+\|\n\|[-:\s|]+\|\n(?:\|[^\n]+\|\n?)+)',
+        re.MULTILINE
+    )
+    
+    tables = []
+    for match in table_pattern.finditer(content):
+        tables.append((
+            match.group(1).strip(),
+            match.start(),
+            match.end()
+        ))
+    
+    return tables
+
+
+def parse_markdown_table(table_text: str) -> Tuple[List[str], List[List[str]]]:
+    """
+    Parse a markdown table into headers and rows.
+    
+    Args:
+        table_text: Raw markdown table text
+    
+    Returns:
+        Tuple of (headers, rows)
+    """
+    lines = [
+        line.strip()
+        for line in table_text.strip().split('\n')
+        if line.strip() and line.strip().startswith('|')
+    ]
+    
+    if len(lines) < 2:
+        return [], []
+    
+    # First line is headers
+    headers = [
+        cell.strip()
+        for cell in lines[0].split('|')
+        if cell.strip()
+    ]
+    
+    # Skip separator line (index 1), parse data rows
+    rows = []
+    for line in lines[2:]:
+        row = [
+            cell.strip()
+            for cell in line.split('|')
+            if cell.strip() or cell == ''
+        ]
+        # Only add non-empty rows
+        if any(cell for cell in row):
+            rows.append(row)
+    
+    return headers, rows
+
+
+def format_table_as_code_block(table_text: str) -> str:
+    """
+    Format a markdown table as a code block (Slack fallback).
+    
+    This preserves the visual structure without Block Kit.
+    """
+    headers, rows = parse_markdown_table(table_text)
+    
+    if not headers:
+        return f"```\n{table_text}\n```"
+    
+    # Calculate column widths
+    num_cols = len(headers)
+    widths = [len(str(h)) for h in headers]
+    
+    for row in rows:
+        for i, cell in enumerate(row):
+            if i < num_cols:
+                widths[i] = max(widths[i], len(str(cell)))
+    
+    # Build formatted table
+    lines = []
+    
+    # Header row
+    header_parts = [
+        str(headers[i]).ljust(widths[i])
+        for i in range(min(len(headers), num_cols))
+    ]
+    lines.append("| " + " | ".join(header_parts) + " |")
+    
+    # Separator
+    sep_parts = ["-" * w for w in widths[:num_cols]]
+    lines.append("| " + " | ".join(sep_parts) + " |")
+    
+    # Data rows
+    for row in rows:
+        row_parts = []
+        for i in range(num_cols):
+            cell = str(row[i]) if i < len(row) else ""
+            row_parts.append(cell.ljust(widths[i]))
+        lines.append("| " + " | ".join(row_parts) + " |")
+    
+    return "```\n" + "\n".join(lines) + "\n```"
+
+
+def convert_markdown_tables_to_slack(content: str, use_block_kit: bool = False) -> Tuple[str, List[Dict]]:
+    """
+    Convert markdown tables in content to Slack-compatible format.
+    
+    Args:
+        content: Text with markdown tables
+        use_block_kit: If True, return Block Kit structures (not yet implemented)
+    
+    Returns:
+        Tuple of (modified_content, blocks)
+    """
+    tables = extract_markdown_tables(content)
+    
+    if not tables:
+        return content, []
+    
+    blocks = []
+    result = content
+    
+    # Process tables in reverse order to preserve positions
+    for table_text, start, end in reversed(tables):
+        if use_block_kit:
+            # TODO: Implement Block Kit table blocks when Slack adds them
+            # For now, fall back to code block
+            formatted = format_table_as_code_block(table_text)
+        else:
+            formatted = format_table_as_code_block(table_text)
+        
+        result = result[:start] + formatted + result[end:]
+    
+    return result, blocks
+
+
+# ---------------------------------------------------------------------------
+# Per-Channel Configuration
+#
+# Allows fine-grained control over bot behavior per channel:
+# - requireMention: Override global setting per channel
+# - allowBots: Allow bot messages in this channel
+# - users: Whitelist of allowed user IDs
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SlackChannelConfig:
+    """Configuration for a specific Slack channel."""
+    channel_id: str
+    channel_name: Optional[str] = None
+    require_mention: Optional[bool] = None
+    allow_bots: Optional[bool] = None
+    users: Optional[List[str]] = None
+    thread_history_limit: Optional[int] = None
+    reply_broadcast: Optional[bool] = None
+
+
+def resolve_channel_config(
+    channel_id: str,
+    channel_name: Optional[str],
+    global_config: Dict[str, Any],
+) -> SlackChannelConfig:
+    """
+    Resolve the effective configuration for a Slack channel.
+    
+    Priority (highest to lowest):
+    1. Direct channel ID match
+    2. Channel name match (if allowNameMatching is enabled)
+    3. Global defaults
+    
+    Args:
+        channel_id: Slack channel ID
+        channel_name: Human-readable channel name (optional)
+        global_config: Global Slack configuration dict
+    
+    Returns:
+        SlackChannelConfig with resolved settings
+    """
+    channels_config = global_config.get("channels", {})
+    allow_name_matching = global_config.get("allowNameMatching", False)
+    
+    # Try direct ID match first
+    channel_config = channels_config.get(channel_id)
+    
+    # Fall back to name match if enabled
+    if not channel_config and allow_name_matching and channel_name:
+        channel_config = channels_config.get(channel_name)
+        if channel_config:
+            logger.debug("[Slack] Matched channel config by name: %s", channel_name)
+    
+    # Build config with fallbacks to global settings
+    return SlackChannelConfig(
+        channel_id=channel_id,
+        channel_name=channel_name,
+        require_mention=channel_config.get("requireMention") if channel_config else None,
+        allow_bots=channel_config.get("allowBots") if channel_config else None,
+        users=channel_config.get("users") if channel_config else None,
+        thread_history_limit=channel_config.get("threadHistoryLimit") if channel_config else None,
+        reply_broadcast=channel_config.get("replyBroadcast") if channel_config else None,
+    )
+
+
+def is_user_allowed_in_channel(
+    user_id: str,
+    user_name: Optional[str],
+    channel_config: SlackChannelConfig,
+    global_config: Dict[str, Any],
+) -> Tuple[bool, str]:
+    """
+    Check if a user is allowed to interact with the bot in a channel.
+    
+    Args:
+        user_id: Slack user ID
+        user_name: Display name (for name matching)
+        channel_config: Resolved channel configuration
+        global_config: Global configuration
+    
+    Returns:
+        Tuple of (allowed: bool, reason: str)
+    """
+    allow_name_matching = global_config.get("allowNameMatching", False)
+    
+    # If no users whitelist, everyone is allowed
+    if not channel_config.users:
+        return True, "no_user_whitelist"
+    
+    # Check direct ID match
+    if user_id in channel_config.users:
+        return True, "user_id_match"
+    
+    # Check name match if enabled
+    if allow_name_matching and user_name:
+        normalized_name = user_name.strip().lower()
+        for allowed in channel_config.users:
+            if allowed.strip().lower() == normalized_name:
+                return True, "user_name_match"
+    
+    return False, "not_in_whitelist"
+
+
+# ---------------------------------------------------------------------------
+# Reconnection and Resilience
+#
+# Provides exponential backoff with jitter for reconnection attempts,
+# detection of non-recoverable auth errors, and connection status tracking.
+# ---------------------------------------------------------------------------
+
+import random
+from enum import Enum
+from typing import Callable, Awaitable
+
+
+class SlackConnectionStatus(Enum):
+    """Connection status for Slack gateway."""
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    RECONNECTING = "reconnecting"
+    ERROR = "error"
+
+
+@dataclass
+class SlackReconnectPolicy:
+    """Configuration for reconnection behavior."""
+    initial_ms: float = 2000.0
+    max_ms: float = 30000.0
+    factor: float = 1.8
+    jitter: float = 0.25
+    max_attempts: int = 12
+    
+    def compute_backoff(self, attempt: int) -> float:
+        """
+        Compute backoff delay with exponential increase and jitter.
+        
+        Args:
+            attempt: Current attempt number (0-indexed)
+        
+        Returns:
+            Delay in milliseconds
+        """
+        if attempt >= self.max_attempts:
+            return self.max_ms
+        
+        # Exponential backoff
+        delay = self.initial_ms * (self.factor ** attempt)
+        
+        # Cap at max
+        delay = min(delay, self.max_ms)
+        
+        # Add jitter
+        jitter_amount = delay * self.jitter
+        delay = delay - jitter_amount + (random.random() * 2 * jitter_amount)
+        
+        return delay
+
+
+# Non-recoverable auth error patterns
+SLACK_AUTH_ERROR_PATTERNS = [
+    r"account_inactive",
+    r"invalid_auth",
+    r"token_revoked",
+    r"token_expired",
+    r"not_authed",
+    r"org_login_required",
+    r"team_access_not_granted",
+    r"missing_scope",
+    r"cannot_find_service",
+    r"invalid_token",
+]
+
+SLACK_AUTH_ERROR_RE = re.compile(
+    "|".join(SLACK_AUTH_ERROR_PATTERNS),
+    re.IGNORECASE
+)
+
+
+def is_non_recoverable_slack_error(error: Exception) -> bool:
+    """
+    Check if an error is non-recoverable (should not retry).
+    
+    These indicate permanent credential problems:
+    - Revoked bot token
+    - Deactivated account
+    - Expired token
+    - Missing scopes
+    
+    Args:
+        error: Exception to check
+    
+    Returns:
+        True if error is non-recoverable
+    """
+    error_str = str(error)
+    if hasattr(error, 'message'):
+        error_str = getattr(error, 'message', error_str)
+    
+    return bool(SLACK_AUTH_ERROR_RE.search(error_str))
+
+
+def format_slack_error(error: Exception) -> str:
+    """Format an error for logging/display."""
+    if isinstance(error, Exception):
+        return error.message if hasattr(error, 'message') else str(error)
+    return str(error)
+
+
+@dataclass
+class SlackConnectionState:
+    """Tracks connection state for health monitoring."""
+    status: SlackConnectionStatus = SlackConnectionStatus.DISCONNECTED
+    last_event_at: Optional[float] = None
+    last_inbound_at: Optional[float] = None
+    last_disconnect_at: Optional[float] = None
+    last_error: Optional[str] = None
+    reconnect_attempts: int = 0
+    connected_at: Optional[float] = None
+    
+    def mark_connected(self) -> None:
+        """Mark connection as established."""
+        self.status = SlackConnectionStatus.CONNECTED
+        self.connected_at = time.time()
+        self.last_error = None
+        self.reconnect_attempts = 0
+    
+    def mark_disconnected(self, error: Optional[Exception] = None) -> None:
+        """Mark connection as lost."""
+        self.status = SlackConnectionStatus.DISCONNECTED
+        self.last_disconnect_at = time.time()
+        if error:
+            self.last_error = format_slack_error(error)
+    
+    def mark_event_received(self) -> None:
+        """Mark that an event was received (liveness tracking)."""
+        now = time.time()
+        self.last_event_at = now
+        self.last_inbound_at = now
+    
+    def get_seconds_since_last_event(self) -> Optional[float]:
+        """Get seconds since last event, or None if no events received."""
+        if self.last_event_at is None:
+            return None
+        return time.time() - self.last_event_at
+    
+    def is_socket_stale(self, stale_threshold_seconds: float = 60.0) -> bool:
+        """
+        Check if socket appears connected but is stale (no events).
+        
+        This detects "half-dead" sockets that pass health checks
+        but silently stop delivering events.
+        
+        Args:
+            stale_threshold_seconds: Seconds without events to consider stale
+        
+        Returns:
+            True if socket is stale
+        """
+        if self.status != SlackConnectionStatus.CONNECTED:
+            return False
+        
+        seconds_since = self.get_seconds_since_last_event()
+        if seconds_since is None:
+            # No events received yet, check how long we've been "connected"
+            if self.connected_at:
+                return (time.time() - self.connected_at) > stale_threshold_seconds
+            return False
+        
+        return seconds_since > stale_threshold_seconds
+
+
+class SlackReconnectionManager:
+    """
+    Manages reconnection logic for Slack gateway.
+    
+    Features:
+    - Exponential backoff with jitter
+    - Non-recoverable error detection
+    - Connection state tracking
+    - Stale socket detection
+    """
+    
+    def __init__(
+        self,
+        policy: Optional[SlackReconnectPolicy] = None,
+        stale_threshold_seconds: float = 60.0,
+        on_status_change: Optional[Callable[[SlackConnectionStatus], Awaitable[None]]] = None,
+    ):
+        self.policy = policy or SlackReconnectPolicy()
+        self.state = SlackConnectionState()
+        self.stale_threshold_seconds = stale_threshold_seconds
+        self.on_status_change = on_status_change
+        self._should_stop = False
+    
+    def should_retry(self, error: Optional[Exception] = None) -> bool:
+        """
+        Determine if we should attempt reconnection.
+        
+        Args:
+            error: Optional error that caused disconnect
+        
+        Returns:
+            True if we should retry, False if non-recoverable
+        """
+        if self._should_stop:
+            return False
+        
+        if error and is_non_recoverable_slack_error(error):
+            logger.error("[Slack] Non-recoverable auth error: %s", format_slack_error(error))
+            return False
+        
+        if self.state.reconnect_attempts >= self.policy.max_attempts:
+            logger.error("[Slack] Max reconnection attempts (%d) reached", self.policy.max_attempts)
+            return False
+        
+        return True
+    
+    def get_backoff_delay(self) -> float:
+        """Get backoff delay for current attempt in seconds."""
+        delay_ms = self.policy.compute_backoff(self.state.reconnect_attempts)
+        return delay_ms / 1000.0  # Convert to seconds
+    
+    async def wait_with_backoff(self) -> None:
+        """Wait with exponential backoff before next reconnection attempt."""
+        delay = self.get_backoff_delay()
+        logger.info(
+            "[Slack] Waiting %.1fs before reconnection attempt %d/%d",
+            delay,
+            self.state.reconnect_attempts + 1,
+            self.policy.max_attempts,
+        )
+        await asyncio.sleep(delay)
+    
+    def begin_reconnection(self) -> None:
+        """Mark beginning of reconnection attempt."""
+        self.state.reconnect_attempts += 1
+        self.state.status = SlackConnectionStatus.RECONNECTING
+    
+    def mark_connected(self) -> None:
+        """Mark successful connection."""
+        self.state.mark_connected()
+        logger.info(
+            "[Slack] Connected successfully after %d attempts",
+            self.state.reconnect_attempts,
+        )
+    
+    def mark_disconnected(self, error: Optional[Exception] = None) -> None:
+        """Mark disconnection."""
+        self.state.mark_disconnected(error)
+        if error:
+            logger.warning("[Slack] Disconnected: %s", format_slack_error(error))
+        else:
+            logger.info("[Slack] Disconnected")
+    
+    def mark_event_received(self) -> None:
+        """Mark that an event was received."""
+        self.state.mark_event_received()
+    
+    def check_stale_socket(self) -> bool:
+        """Check if socket is stale and needs reconnection."""
+        if self.state.is_socket_stale(self.stale_threshold_seconds):
+            logger.warning(
+                "[Slack] Socket stale (no events for %.1fs), reconnecting",
+                self.state.get_seconds_since_last_event(),
+            )
+            return True
+        return False
+    
+    def stop(self) -> None:
+        """Stop reconnection attempts."""
+        self._should_stop = True
+    
+    def reset(self) -> None:
+        """Reset state for fresh start."""
+        self.state = SlackConnectionState()
+        self._should_stop = False
+
+
+# ---------------------------------------------------------------------------
+# Scope Validation
+#
+# Utilities for validating Slack OAuth scopes.
+# ---------------------------------------------------------------------------
+
+REQUIRED_SLACK_SCOPES = {
+    "chat:write",
+    "app_mentions:read",
+    "channels:history",
+    "groups:history",
+    "im:history",
+    "im:read",
+    "im:write",
+    "files:read",
+    "files:write",
+    "reactions:write",
+}
+
+RECOMMENDED_SLACK_SCOPES = {
+    "users:read",
+    "users:read.email",
+    "channels:read",
+    "groups:read",
+    "mpim:history",
+    "mpim:read",
+    "mpim:write",
+}
+
+
+@dataclass
+class SlackScopeValidation:
+    """Result of scope validation."""
+    valid: bool
+    missing_required: List[str]
+    missing_recommended: List[str]
+    all_scopes: List[str]
+    
+    def format_warning(self) -> str:
+        """Format a warning message for missing scopes."""
+        lines = []
+        
+        if self.missing_required:
+            lines.append(f"[Slack] WARNING: Missing required scopes: {', '.join(self.missing_required)}")
+            lines.append("  These scopes are required for full functionality.")
+        
+        if self.missing_recommended:
+            lines.append(f"[Slack] NOTE: Missing recommended scopes: {', '.join(self.missing_recommended)}")
+            lines.append("  These scopes enhance functionality but are not required.")
+        
+        return "\n".join(lines)
+
+
+async def fetch_slack_scopes(client, timeout_ms: int = 5000) -> List[str]:
+    """
+    Fetch granted OAuth scopes from Slack API.
+    
+    Tries multiple API methods:
+    1. auth.scopes (preferred)
+    2. apps.permissions.info (fallback)
+    
+    Args:
+        client: Slack WebClient
+        timeout_ms: Timeout in milliseconds
+    
+    Returns:
+        List of granted scope strings
+    """
+    scopes = []
+    
+    # Try auth.scopes first (newer API)
+    try:
+        result = await asyncio.wait_for(
+            client.auth_scopes_list(),
+            timeout=timeout_ms / 1000,
+        )
+        if result.get("ok"):
+            scopes.extend(result.get("scopes", []))
+    except Exception:
+        pass
+    
+    # Fallback to apps.permissions.info
+    if not scopes:
+        try:
+            result = await asyncio.wait_for(
+                client.apps_permissions_info(),
+                timeout=timeout_ms / 1000,
+            )
+            if result.get("ok"):
+                info = result.get("info", {})
+                scopes.extend(info.get("scopes", []))
+                scopes.extend(info.get("bot_scopes", []))
+        except Exception:
+            pass
+    
+    return list(set(s.strip() for s in scopes if s and s.strip()))
+
+
+def validate_slack_scopes(granted_scopes: List[str]) -> SlackScopeValidation:
+    """
+    Validate that required scopes are granted.
+    
+    Args:
+        granted_scopes: List of scopes granted to the app
+    
+    Returns:
+        SlackScopeValidation with missing scopes
+    """
+    granted_set = set(s.lower() for s in granted_scopes)
+    
+    missing_required = sorted(
+        s for s in REQUIRED_SLACK_SCOPES
+        if s.lower() not in granted_set
+    )
+    
+    missing_recommended = sorted(
+        s for s in RECOMMENDED_SLACK_SCOPES
+        if s.lower() not in granted_set
+    )
+    
+    return SlackScopeValidation(
+        valid=len(missing_required) == 0,
+        missing_required=missing_required,
+        missing_recommended=missing_recommended,
+        all_scopes=sorted(granted_scopes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Health Probe
+#
+# Simple health check for Slack connection.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SlackProbeResult:
+    """Result of Slack connection probe."""
+    ok: bool
+    error: Optional[str] = None
+    elapsed_ms: Optional[float] = None
+    bot_id: Optional[str] = None
+    bot_name: Optional[str] = None
+    team_id: Optional[str] = None
+    team_name: Optional[str] = None
+
+
+async def probe_slack_connection(
+    client,
+    timeout_ms: int = 2500,
+) -> SlackProbeResult:
+    """
+    Probe Slack connection health.
+    
+    Args:
+        client: Slack WebClient
+        timeout_ms: Timeout in milliseconds
+    
+    Returns:
+        SlackProbeResult with connection info
+    """
+    start = time.time()
+    
+    try:
+        result = await asyncio.wait_for(
+            client.auth_test(),
+            timeout=timeout_ms / 1000,
+        )
+        
+        if not result.get("ok"):
+            return SlackProbeResult(
+                ok=False,
+                error=result.get("error", "unknown"),
+                elapsed_ms=(time.time() - start) * 1000,
+            )
+        
+        return SlackProbeResult(
+            ok=True,
+            elapsed_ms=(time.time() - start) * 1000,
+            bot_id=result.get("user_id"),
+            bot_name=result.get("user"),
+            team_id=result.get("team_id"),
+            team_name=result.get("team"),
+        )
+        
+    except asyncio.TimeoutError:
+        return SlackProbeResult(
+            ok=False,
+            error="timeout",
+            elapsed_ms=(time.time() - start) * 1000,
+        )
+    except Exception as e:
+        return SlackProbeResult(
+            ok=False,
+            error=format_slack_error(e),
+            elapsed_ms=(time.time() - start) * 1000,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Message Updating
+#
+# Utilities for updating existing messages (progress, approvals).
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SlackMessageRef:
+    """Reference to an existing Slack message."""
+    channel_id: str
+    message_ts: str
+
+
+async def update_slack_message(
+    client,
+    message_ref: SlackMessageRef,
+    text: str,
+    blocks: Optional[List[Dict]] = None,
+) -> bool:
+    """
+    Update an existing Slack message.
+    
+    Args:
+        client: Slack WebClient
+        message_ref: Reference to message to update
+        text: New message text
+        blocks: Optional new blocks
+    
+    Returns:
+        True if update succeeded
+    """
+    try:
+        params = {
+            "channel": message_ref.channel_id,
+            "ts": message_ref.message_ts,
+            "text": text,
+        }
+        if blocks:
+            params["blocks"] = blocks
+        
+        result = await client.chat_update(**params)
+        return result.get("ok", False)
+        
+    except Exception as e:
+        logger.error("[Slack] Failed to update message: %s", format_slack_error(e))
+        return False
+
+
+def build_approval_blocks(
+    title: str,
+    description: str,
+    approval_id: str,
+    allow_always: bool = True,
+) -> List[Dict]:
+    """
+    Build Block Kit blocks for approval message.
+    
+    Args:
+        title: Approval title
+        description: Description of what needs approval
+        approval_id: Unique ID for tracking
+        allow_always: Whether to show "Always Allow" button
+    
+    Returns:
+        List of Block Kit blocks
+    """
+    buttons = [
+        {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Approve"},
+            "style": "primary",
+            "action_id": f"approval:approve:{approval_id}",
+        },
+        {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Deny"},
+            "style": "danger",
+            "action_id": f"approval:deny:{approval_id}",
+        },
+    ]
+    
+    if allow_always:
+        buttons.append({
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Always Allow"},
+            "action_id": f"approval:always:{approval_id}",
+        })
+    
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*{title}*\n{description}",
+            },
+        },
+        {
+            "type": "actions",
+            "elements": buttons,
+        },
+    ]
+
+
+def build_resolved_approval_blocks(
+    title: str,
+    description: str,
+    resolved_by: str,
+    decision: str,
+) -> List[Dict]:
+    """
+    Build Block Kit blocks for resolved approval message.
+    
+    Args:
+        title: Approval title
+        description: Original description
+        resolved_by: User who resolved
+        decision: "approved", "denied", or "always"
+    
+    Returns:
+        List of Block Kit blocks
+    """
+    decision_emoji = {
+        "approved": "white_check_mark",
+        "denied": "x",
+        "always": "white_check_mark",
+    }.get(decision, "white_check_mark")
+    
+    decision_label = {
+        "approved": "Approved",
+        "denied": "Denied",
+        "always": "Always Allowed",
+    }.get(decision, decision.title())
+    
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*{title}*\n{description}",
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f":{decision_emoji}: {decision_label} by <@{resolved_by}>",
+                },
+            ],
+        },
+    ]

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -238,83 +238,77 @@ class TestSlackApprovalAction:
 
 
 # ===========================================================================
-# _fetch_thread_context
+# Thread context loading (load_thread_context from slack_utils)
 # ===========================================================================
 
 class TestSlackThreadContext:
-    """Test thread context fetching."""
+    """Test thread context loading via slack_utils.load_thread_context."""
 
     @pytest.mark.asyncio
     async def test_fetches_and_formats_context(self):
-        adapter = _make_adapter()
-        mock_client = adapter._team_clients["T1"]
+        from gateway.platforms.slack_utils import (
+            load_thread_context,
+            format_thread_context_for_prompt,
+        )
+
+        mock_client = AsyncMock()
         mock_client.conversations_replies = AsyncMock(return_value={
             "messages": [
                 {"ts": "1000.0", "user": "U1", "text": "This is the parent message"},
                 {"ts": "1000.1", "user": "U2", "text": "I think we should refactor"},
-                {"ts": "1000.2", "user": "U1", "text": "Good idea, <@U_BOT> what do you think?"},
-            ]
+                {"ts": "1000.2", "user": "U1", "text": "Good idea, what do you think?"},
+            ],
+            "has_more": False,
         })
 
-        # Mock user name resolution
-        adapter._user_name_cache = {"U1": "Alice", "U2": "Bob"}
+        async def resolve_name(uid):
+            return {"U1": "Alice", "U2": "Bob"}.get(uid, uid)
 
-        context = await adapter._fetch_thread_context(
+        ctx = await load_thread_context(
+            client=mock_client,
             channel_id="C1",
             thread_ts="1000.0",
-            current_ts="1000.2",  # The message that triggered the fetch
-            team_id="T1",
+            current_message_ts="1000.2",
+            user_name_resolver=resolve_name,
         )
 
-        assert "[Thread context" in context
-        assert "[thread parent] Alice: This is the parent message" in context
-        assert "Bob: I think we should refactor" in context
-        # Current message should be excluded
-        assert "what do you think" not in context
-        # Bot mention should be stripped from context
-        assert "<@U_BOT>" not in context
-
-    @pytest.mark.asyncio
-    async def test_skips_bot_messages(self):
-        adapter = _make_adapter()
-        mock_client = adapter._team_clients["T1"]
-        mock_client.conversations_replies = AsyncMock(return_value={
-            "messages": [
-                {"ts": "1000.0", "user": "U1", "text": "Parent"},
-                {"ts": "1000.1", "bot_id": "B1", "text": "Bot reply (should be skipped)"},
-                {"ts": "1000.2", "user": "U1", "text": "Current"},
-            ]
-        })
-        adapter._user_name_cache = {"U1": "Alice"}
-
-        context = await adapter._fetch_thread_context(
-            channel_id="C1", thread_ts="1000.0", current_ts="1000.2", team_id="T1"
-        )
-
-        assert "Bot reply" not in context
-        assert "Alice: Parent" in context
+        assert ctx.thread_starter is not None
+        assert ctx.thread_starter.text == "This is the parent message"
+        # Current message should be excluded from history
+        assert all(m.ts != "1000.2" for m in ctx.thread_history)
 
     @pytest.mark.asyncio
     async def test_empty_thread(self):
-        adapter = _make_adapter()
-        mock_client = adapter._team_clients["T1"]
-        mock_client.conversations_replies = AsyncMock(return_value={"messages": []})
+        from gateway.platforms.slack_utils import load_thread_context
 
-        context = await adapter._fetch_thread_context(
-            channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"
+        mock_client = AsyncMock()
+        mock_client.conversations_replies = AsyncMock(return_value={
+            "messages": [],
+            "has_more": False,
+        })
+
+        ctx = await load_thread_context(
+            client=mock_client,
+            channel_id="C1",
+            thread_ts="1000.0",
         )
-        assert context == ""
+        assert ctx.thread_starter is None
+        assert ctx.thread_history == []
 
     @pytest.mark.asyncio
     async def test_api_failure_returns_empty(self):
-        adapter = _make_adapter()
-        mock_client = adapter._team_clients["T1"]
+        from gateway.platforms.slack_utils import load_thread_context
+
+        mock_client = AsyncMock()
         mock_client.conversations_replies = AsyncMock(side_effect=Exception("API error"))
 
-        context = await adapter._fetch_thread_context(
-            channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"
+        ctx = await load_thread_context(
+            client=mock_client,
+            channel_id="C1",
+            thread_ts="1000.0",
         )
-        assert context == ""
+        assert ctx.thread_starter is None
+        assert ctx.thread_history == []
 
 
 # ===========================================================================
@@ -374,53 +368,54 @@ class TestSessionKeyFix:
 
 
 # ===========================================================================
-# Thread engagement — bot-started threads & mentioned threads
+# Thread engagement — ThreadParticipationCache
 # ===========================================================================
 
 class TestThreadEngagement:
-    """Test _bot_message_ts and _mentioned_threads tracking."""
+    """Test ThreadParticipationCache tracking."""
 
     @pytest.mark.asyncio
-    async def test_send_tracks_bot_message_ts(self):
-        """Bot's sent messages are tracked so thread replies work without @mention."""
+    async def test_send_records_thread_participation(self):
+        """Bot's sent messages in threads are tracked via ThreadParticipationCache."""
+        from gateway.platforms.slack_utils import get_thread_participation_cache
+
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]
         mock_client.chat_postMessage = AsyncMock(return_value={"ts": "9000.1"})
 
+        cache = get_thread_participation_cache()
+        await cache.clear()
+
         await adapter.send(chat_id="C1", content="Hello!", metadata={"thread_id": "8000.0"})
 
-        assert "9000.1" in adapter._bot_message_ts
-        # Thread root should also be tracked
-        assert "8000.0" in adapter._bot_message_ts
+        # Thread should be recorded in cache
+        assert await cache.has_participated("default", "C1", "8000.0")
 
     @pytest.mark.asyncio
-    async def test_bot_message_ts_cap(self):
-        """Verify memory is bounded when many messages are sent."""
-        adapter = _make_adapter()
-        adapter._BOT_TS_MAX = 10  # low cap for testing
-        mock_client = adapter._team_clients["T1"]
+    async def test_cache_has_max_entries(self):
+        """Verify ThreadParticipationCache respects max entries."""
+        from gateway.platforms.slack_utils import ThreadParticipationCache
+
+        cache = ThreadParticipationCache(max_entries=10)
 
         for i in range(20):
-            mock_client.chat_postMessage = AsyncMock(return_value={"ts": f"{i}.0"})
-            await adapter.send(chat_id="C1", content=f"msg {i}")
+            await cache.record("default", "C1", f"{i}.0")
 
-        assert len(adapter._bot_message_ts) <= 10
+        # Count non-expired entries
+        count = 0
+        for i in range(20):
+            if await cache.has_participated("default", "C1", f"{i}.0"):
+                count += 1
+        assert count <= 10
 
-    def test_mentioned_threads_populated_on_mention(self):
-        """When bot is @mentioned in a thread, that thread is tracked."""
-        adapter = _make_adapter()
-        # Simulate what _handle_slack_message does on mention
-        adapter._mentioned_threads.add("1000.0")
-        assert "1000.0" in adapter._mentioned_threads
+    @pytest.mark.asyncio
+    async def test_cache_ttl_expiry(self):
+        """Verify entries expire after TTL."""
+        from gateway.platforms.slack_utils import ThreadParticipationCache
+        import time
 
-    def test_mentioned_threads_cap(self):
-        """Verify _mentioned_threads is bounded."""
-        adapter = _make_adapter()
-        adapter._MENTIONED_THREADS_MAX = 10
-        for i in range(15):
-            adapter._mentioned_threads.add(f"{i}.0")
-            if len(adapter._mentioned_threads) > adapter._MENTIONED_THREADS_MAX:
-                to_remove = list(adapter._mentioned_threads)[:adapter._MENTIONED_THREADS_MAX // 2]
-                for t in to_remove:
-                    adapter._mentioned_threads.discard(t)
-        assert len(adapter._mentioned_threads) <= 10
+        cache = ThreadParticipationCache(ttl_seconds=0)  # Immediate expiry
+        await cache.record("default", "C1", "1000.0")
+
+        # Entry should be expired
+        assert not await cache.has_participated("default", "C1", "1000.0")


### PR DESCRIPTION
## What does this PR do?

Overhauls the Slack adapter with enterprise-grade capabilities. The existing inline mention logic, thread tracking sets, and thread context fetcher are replaced with testable, structured utilities extracted into `slack_utils.py`. New features include per-channel configuration, Block Kit message rendering, connection health monitoring, slash commands, and message edit detection.

+2,500 lines across 4 files (`slack.py`, `slack_utils.py`, `slack_commands.py`, `test_slack_approval_buttons.py`)

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Refactors (behavior-preserving replacements of existing code)

- `check_mention_gate()` replaces inline mention conditional — pure function returning `MentionGateResult` with `should_respond`, `was_mentioned`, `implicit_mention`, `reason` (`gateway/platforms/slack_utils.py`)
- `ThreadParticipationCache` replaces `_bot_message_ts` / `_mentioned_threads` sets — LRU OrderedDict with 24h TTL, async lock, account-aware keys (`gateway/platforms/slack_utils.py`)
- `load_thread_context()` + `format_thread_context_for_prompt()` replaces `_fetch_thread_context()` — returns `ThreadContext` / `ThreadMessage` dataclasses, cursor pagination, preserves bot messages as "Assistant" (`gateway/platforms/slack_utils.py`)
- `_has_active_session_for_thread()` kept as fallback when `ThreadParticipationCache` misses after restart (`gateway/platforms/slack.py`)

### New features

- **Per-channel config** — `channels` block under `gateway.slack` with `requireMention`, `allowBots`, `users`, `threadHistoryLimit`, `replyBroadcast` overrides. Resolved early via `resolve_channel_config()` (`gateway/platforms/slack_utils.py`)
- **Per-channel user authorization** — `is_user_allowed_in_channel()` whitelists user IDs per channel (`gateway/platforms/slack_utils.py`)
- **Connection health monitoring** — `SlackConnectionState`, `probe_slack_connection()`, `is_non_recoverable_slack_error()`, stale socket detection via `_mark_event_received()` (`gateway/platforms/slack_utils.py`)
- **OAuth scope validation** — `fetch_slack_scopes()` + `validate_slack_scopes()` against required/recommended sets (`gateway/platforms/slack_utils.py`)
- **Block Kit message rendering** — `send()` wraps every outgoing message in Block Kit section blocks via `_content_to_blocks()`, matching the pattern that makes `send_exec_approval` work. Splits on `---` for native dividers, handles oversized sections at line boundaries (`gateway/platforms/slack.py`)
- **Interactive Block Kit actions** — handler for `hermes:.*` action IDs (buttons/selects), routes as synthetic `MessageEvent` (`gateway/platforms/slack.py`)
- **Message edit detection** — `message_changed` events extract the inner edited message and re-process it instead of being ignored (`gateway/platforms/slack.py`)
- **Slash commands** — `/hermes help`, `/hermes skills`, `/hermes status`, `/hermes config` with Block Kit formatting, dispatch via `SLASH_COMMANDS` registry (`gateway/platforms/slack_commands.py`)

### Shared utilities module (`gateway/platforms/slack_utils.py`)

- SSRF protection (`validate_slack_file_url`, `is_slack_hostname`)
- HTML detection for failed file downloads (`looks_like_html_content`)
- Voice message MIME normalization (`normalize_slack_voice_mimetype`)
- Markdown table to Slack code block conversion (`convert_markdown_tables_to_slack`)
- Message update helpers (`update_slack_message`, `SlackMessageRef`)

### Tests

- Updated `TestSlackThreadContext` to test `load_thread_context()` instead of removed `_fetch_thread_context()`
- Updated `TestThreadEngagement` to test `ThreadParticipationCache` instead of removed `_bot_message_ts` / `_mentioned_threads` sets
- 88 Slack tests passing (16 approval + 69 main + 3 assistant thread)

## How to Test

1. Connect Hermes to a Slack workspace via Socket Mode
2. Send a message in a channel with `@hermes` — verify mention gating responds correctly
3. Reply in a thread where the bot has participated — verify implicit mention (no `@` needed)
4. Edit a message the bot responded to — verify it detects the edit
5. Run `/hermes status` — verify Block Kit formatted response with connection state
6. Run `/hermes skills` — verify skills list renders
7. Run `/hermes config` — verify config summary renders
8. Trigger a command that requires approval — verify buttons render and clicking Approve/Deny unblocks the command
9. Test per-channel config by adding a `channels` block to `gateway.slack` in `config.yaml`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A