### PR TITLE
fix(security): enforce user authorization on Slack approval button clicks

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1229,7 +1229,14 @@ class SlackAdapter(BasePlatformAdapter):
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
         user_name = body.get("user", {}).get("name", "unknown")
-
+        user_id = body.get("user", {}).get("id", "")
+        # Only allow authorized users to click approval buttons
+        if self._allowed_user_ids and user_id not in self._allowed_user_ids:
+            logger.warning(
+                "[Slack] Unauthorized approval button click by user %s — ignoring",
+                user_name,
+            )
+            return
         # Map action_id to approval choice
         choice_map = {
             "hermes_approve_once": "once",

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1397,7 +1397,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 except (ValueError, IndexError):
                     await query.answer(text="Invalid approval data.")
                     return
-
+                # Only allow authorized users to click approval buttons
+                user_id = str(getattr(query.from_user, "id", ""))
+                if self._allowed_user_ids and user_id not in self._allowed_user_ids:
+                    await query.answer(text="⛔ You are not authorized to approve commands.")
+                    return
                 session_key = self._approval_state.pop(approval_id, None)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")


### PR DESCRIPTION
## What does this PR do?

The Slack approval button handler `_handle_approval_action` had no
authorization check — any member of the Slack workspace could click
"Allow Once", "Allow Session", or "Always Allow" to approve dangerous
commands:
```python
# Before (vulnerable)
user_name = body.get("user", {}).get("name", "unknown")
# No check — approval proceeds for any user
```

An unauthorized workspace member could approve arbitrary dangerous
commands that the agent was waiting on, bypassing the intended
security boundary.

## Fix

Added a user ID check against `self._allowed_user_ids` before
processing the approval:
```python
user_id = body.get("user", {}).get("id", "")
if self._allowed_user_ids and user_id not in self._allowed_user_ids:
    logger.warning(
        "[Slack] Unauthorized approval button click by user %s — ignoring",
        user_name,
    )
    return
```

When no allowlist is configured (`_allowed_user_ids` is empty), the
behavior is unchanged — consistent with the existing open-access design
for unconfigured deployments.

## Type of Change

- [x] 🔒 Security fix (broken access control)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing `_allowed_user_ids` pattern in Slack adapter
- [x] No behavior change when no allowlist is configured