### PR TITLE
fix: fall back when codex model menu cannot probe terminal

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2536,7 +2536,9 @@ def _prompt_model_selection(
     _DIM = "\033[2m"
     _RESET = "\033[0m"
 
-    # Try arrow-key menu first, fall back to number input
+    # Try arrow-key menu first, fall back to number input if the terminal
+    # cannot be probed cleanly (for example, an unknown TERM causing tput to
+    # fail inside simple_term_menu).
     try:
         from simple_term_menu import TerminalMenu
 
@@ -2581,7 +2583,7 @@ def _prompt_model_selection(
             custom = input("Enter model name: ").strip()
             return custom if custom else None
         return None
-    except (ImportError, NotImplementedError):
+    except (ImportError, NotImplementedError, OSError, subprocess.CalledProcessError):
         pass
 
     # Fallback: numbered list

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -3,6 +3,9 @@
 import json
 import time
 import base64
+import subprocess
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -12,6 +15,7 @@ from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
+    _prompt_model_selection,
     _read_codex_tokens,
     _save_codex_tokens,
     _import_codex_cli_tokens,
@@ -22,7 +26,9 @@ from hermes_cli.auth import (
 )
 
 
-def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"):
+def _setup_hermes_auth(
+    hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"
+):
     """Write Codex tokens into the Hermes auth store."""
     hermes_home.mkdir(parents=True, exist_ok=True)
     auth_store = {
@@ -46,7 +52,11 @@ def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refre
 
 def _jwt_with_exp(exp_epoch: int) -> str:
     payload = {"exp": exp_epoch}
-    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
+    encoded = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8"))
+        .rstrip(b"=")
+        .decode("utf-8")
+    )
     return f"h.{encoded}.s"
 
 
@@ -83,10 +93,14 @@ def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkey
     assert exc.value.relogin_required is True
 
 
-def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, monkeypatch):
+def test_resolve_codex_runtime_credentials_refreshes_expiring_token(
+    tmp_path, monkeypatch
+):
     hermes_home = tmp_path / "hermes"
     expiring_token = _jwt_with_exp(int(time.time()) - 10)
-    _setup_hermes_auth(hermes_home, access_token=expiring_token, refresh_token="refresh-old")
+    _setup_hermes_auth(
+        hermes_home, access_token=expiring_token, refresh_token="refresh-old"
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     called = {"count": 0}
@@ -105,7 +119,9 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
 def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
-    _setup_hermes_auth(hermes_home, access_token="access-current", refresh_token="refresh-old")
+    _setup_hermes_auth(
+        hermes_home, access_token="access-current", refresh_token="refresh-old"
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     called = {"count": 0}
@@ -116,7 +132,9 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
 
     monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
 
-    resolved = resolve_codex_runtime_credentials(force_refresh=True, refresh_if_expiring=False)
+    resolved = resolve_codex_runtime_credentials(
+        force_refresh=True, refresh_if_expiring=False
+    )
 
     assert called["count"] == 1
     assert resolved["api_key"] == "access-forced"
@@ -144,9 +162,13 @@ def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
 def test_import_codex_cli_tokens(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-cli"
     codex_home.mkdir(parents=True, exist_ok=True)
-    (codex_home / "auth.json").write_text(json.dumps({
-        "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
-    }))
+    (codex_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
+            }
+        )
+    )
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
     tokens = _import_codex_cli_tokens()
@@ -190,3 +212,23 @@ def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     assert creds["source"] == "hermes-auth-store"
     assert creds["provider"] == "openai-codex"
     assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
+
+
+def test_prompt_model_selection_falls_back_when_terminal_menu_tput_fails(monkeypatch):
+    class BrokenTerminalMenu:
+        def __init__(self, *args, **kwargs):
+            raise subprocess.CalledProcessError(3, ["tput", "lines"])
+
+    monkeypatch.setitem(
+        sys.modules,
+        "simple_term_menu",
+        types.SimpleNamespace(TerminalMenu=BrokenTerminalMenu),
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+
+    selected = _prompt_model_selection(
+        ["gpt-5.4", "gpt-5.4-mini"],
+        current_model="gpt-5.4",
+    )
+
+    assert selected == "gpt-5.4"


### PR DESCRIPTION
## Summary
- catch terminal-probing failures from `simple_term_menu` during Codex model selection so Hermes falls back to the numbered prompt instead of crashing
- add a regression test covering the `tput lines` failure path triggered by unknown terminals such as `xterm-ghostty`

## Repro
When `$TERM` is set to `xterm-ghostty` but the corresponding terminfo entry is unavailable, `hermes model` can crash during Codex model selection with:

```text
tput: unknown terminal "xterm-ghostty"
subprocess.CalledProcessError: Command '['tput', 'lines']' returned non-zero exit status 3.
```

This happens because `simple_term_menu` probes terminal dimensions via `tput`, and Hermes previously did not handle that failure.

## Verification
- `python3 -m pytest -o addopts='' tests/hermes_cli/test_auth_codex_provider.py -q`