### PR TITLE
Emit gateway:shutdown hook on stop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1475,6 +1475,10 @@ class GatewayRunner:
     async def stop(self) -> None:
         """Stop the gateway and disconnect all adapters."""
         logger.info("Stopping gateway...")
+        try:
+            await self.hooks.emit("gateway:shutdown", {"reason": getattr(self, "_exit_reason", "clean")})
+        except Exception as e:
+            logger.warning("gateway:shutdown hook emission failed: %s", e)
         self._running = False
 
         for session_key, agent in list(self._running_agents.items()):


### PR DESCRIPTION
## Summary

- Adds a `gateway:shutdown` hook emission at the top of `GatewayRunner.stop()`, before any adapter is disconnected
- Mirrors the existing `gateway:startup` hook pattern (emitted in `start()` after adapters connect)
- Gives extensions a chance to react to shutdown events — lifecycle notifications, cleanup, etc.
- One-line minimal addition; errors are caught and logged, never fatal to the shutdown sequence

## Details

```python
try:
    await self.hooks.emit("gateway:shutdown", {"reason": getattr(self, "_exit_reason", "clean")})
except Exception as e:
    logger.warning("gateway:shutdown hook emission failed: %s", e)
```

The `reason` field passes through `_exit_reason` (set by signal handlers / watchdog) so hooks can distinguish clean shutdowns from crashes or restarts.

## Test plan

- [ ] Confirm `gateway:shutdown` fires before Telegram adapter disconnects (hook can still send messages)
- [ ] Confirm errors in hook handlers don't interrupt the shutdown sequence
- [ ] Confirm `_exit_reason` is correctly forwarded in context when set by signal handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)