### PR TITLE
fix(mcp): support quoted and spaced MEDIA paths in attachment extraction

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -157,10 +157,16 @@ def _extract_attachments(msg: dict) -> List[dict]:
     # MEDIA: tags in text content
     text = _extract_message_content(msg)
     if text:
-        media_pattern = re.compile(r'MEDIA:\s*(\S+)')
+        media_pattern = re.compile(
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:[A-Za-z]:[\\/]|~/|/)[^\n]*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|pdf|txt|csv)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+        )
         for match in media_pattern.finditer(text):
-            path = match.group(1)
-            attachments.append({"type": "media", "path": path})
+            path = match.group("path").strip()
+            if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
+                path = path[1:-1].strip()
+            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+            if path:
+                attachments.append({"type": "media", "path": path})
 
     return attachments
 

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -290,6 +290,30 @@ class TestAttachmentExtraction:
         msg = {"content": "MEDIA: /a.png and MEDIA: /b.mp3"}
         assert len(_extract_attachments(msg)) == 2
 
+    def test_quoted_unix_media_path_with_spaces(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": 'Here MEDIA: "/tmp/my image.png" done'}
+        att = _extract_attachments(msg)
+        assert att == [{"type": "media", "path": "/tmp/my image.png"}]
+
+    def test_quoted_windows_media_path_with_spaces(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": 'Here MEDIA: "C:\\Users\\Simba\\Desktop\\my image.png" done'}
+        att = _extract_attachments(msg)
+        assert att == [{"type": "media", "path": "C:\\Users\\Simba\\Desktop\\my image.png"}]
+
+    def test_backticked_media_path(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": "Here MEDIA: `/tmp/out file.mp3` done"}
+        att = _extract_attachments(msg)
+        assert att == [{"type": "media", "path": "/tmp/out file.mp3"}]
+
+    def test_media_path_trims_trailing_punctuation(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": 'Here MEDIA: "/tmp/out.png", done'}
+        att = _extract_attachments(msg)
+        assert att == [{"type": "media", "path": "/tmp/out.png"}]
+
     def test_no_attachments(self):
         from mcp_serve import _extract_attachments
         assert _extract_attachments({"content": "plain text"}) == []


### PR DESCRIPTION
### Problem

`_extract_attachments()` in `mcp_serve.py` uses a single-token regex
(`MEDIA:\s*(\S+)`) to extract attachment paths. This truncates or
malforms any path that contains spaces or is wrapped in quotes/backticks:

    MEDIA: "C:\Users\\Desktop\my image.png"   → only captures `"C:\Users\\Desktop\my`
    MEDIA: '/tmp/my image.png'                      → only captures `'/tmp/my`

This breaks `attachments_fetch` for valid Hermes outputs, especially on
Windows where file paths commonly include spaces.

This is distinct from the earlier fix in `gateway/platforms/base.py`:
the gateway path extraction was already hardened there, but the MCP
bridge still had the older, narrower parser.

### What changed

Updated `mcp_serve.py` so `_extract_attachments()` no longer relies on
the single-token `MEDIA:\s*(\S+)` pattern. It now accepts:

- Quoted paths (`"..."` and `'...'`)
- Backticked paths (`` `...` ``)
- Unix absolute and tilde paths with spaces
- Windows drive-letter paths with spaces

Extracted paths are normalized by trimming wrapping quotes/backticks and
trailing punctuation before being returned.

### Why it matters

- Real behavior bug, not a refactor.
- Small and isolated to the MCP bridge.
- Improves Windows compatibility.
- Closes a consistency gap between gateway delivery parsing and MCP
  attachment parsing.

### Tests

Added regression coverage in `tests/test_mcp_serve.py`:

- Quoted Unix path with spaces: `MEDIA: "/tmp/my image.png"`
- Quoted Windows path with spaces: `MEDIA: "C:\Users\\Desktop\my image.png"`
- Backticked path: `` MEDIA: `/tmp/out file.mp3` ``
- Trailing punctuation boundary: `MEDIA: "/tmp/out.png", done`
- Existing simple-path behavior unchanged

Verification:

    python -m pytest tests/test_mcp_serve.py -q
    # Result: 44 passed, 39 skipped

### Manual verification

1. Call `_extract_attachments()` on text containing quoted `MEDIA:` paths
   with spaces and verify the full path is returned.
2. Confirm existing plain `MEDIA: /tmp/out.png` behavior still works.
3. Optionally run `hermes mcp serve` and verify `attachments_fetch`
   returns the full path for a message containing a quoted `MEDIA:` tag.

### Files changed

- `mcp_serve.py` — updated `_extract_attachments()` parser
- `tests/test_mcp_serve.py` — added regression tests

