### PR TITLE
fix(copilot): add dash-notation aliases for Claude model IDs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1255,6 +1255,13 @@ _COPILOT_MODEL_ALIASES = {
     "anthropic/claude-sonnet-4.6": "claude-sonnet-4.6",
     "anthropic/claude-sonnet-4.5": "claude-sonnet-4.5",
     "anthropic/claude-haiku-4.5": "claude-haiku-4.5",
+    # Dash-notation aliases: config.yaml defaults use dashes (claude-sonnet-4-6)
+    # but Copilot's API requires dots (claude-sonnet-4.6). Map them so users
+    # setting provider: copilot with the default model name get a clean 200.
+    "claude-opus-4-6": "claude-opus-4.6",
+    "claude-sonnet-4-6": "claude-sonnet-4.6",
+    "claude-sonnet-4-5": "claude-sonnet-4.5",
+    "claude-haiku-4-5": "claude-haiku-4.5",
 }
 
 


### PR DESCRIPTION
## Summary

Switching to `provider: copilot` with the default model name (`claude-sonnet-4-6`, dashes) produces an immediate HTTP 400 "The requested model is not supported" because Copilot's API requires dot-notation (`claude-sonnet-4.6`). There's no error message pointing at the naming mismatch — users have to figure it out by trial and error.

## What changed

| File | Change |
|------|--------|
| `hermes_cli/models.py` | Added 4 dash-notation entries to `_COPILOT_MODEL_ALIASES` |

`normalize_copilot_model_id()` already runs on every Copilot API call and resolves aliases before the request is sent. The new entries silently map `claude-{model}-4-6` → `claude-{model}-4.6` so users don't need to update their config when switching providers.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

Set `model.provider: copilot` and `model.default: claude-sonnet-4-6` (dashes) in config.yaml. Before this fix: HTTP 400. After: request succeeds with the correct model ID forwarded to Copilot.


Closes https://github.com/NousResearch/hermes-agent/issues/6879