### PR TITLE
fix(docker): enable unbuffered stdout for live logs (salvage #6258)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:13.4
 
+# Disable Python stdout buffering to ensure logs are printed immediately
+ENV PYTHONUNBUFFERED=1
+
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Cherry-pick of #6258 by @MustafaKara7 onto current main.

Adds `ENV PYTHONUNBUFFERED=1` to the Dockerfile so Python stdout is unbuffered inside the container. This allows `docker logs -f` to show live output instead of buffering until container stop.

Fixes #6197

## Credit

Original PR: #6258 by @MustafaKara7