### PR TITLE
feat(gateway): show home path and model in /status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -433,6 +433,35 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _resolve_gateway_provider(config: dict | None = None) -> str:
+    """Read provider from config.yaml, defaulting to openrouter."""
+    cfg = config if config is not None else _load_gateway_config()
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        return model_cfg.get("provider") or "openrouter"
+    return "openrouter"
+
+
+def _resolve_status_model_info(
+    *,
+    runner: "GatewayRunner",
+    session_key: str,
+    running_agent: Any = None,
+) -> tuple[str, str]:
+    """Resolve the best available model/provider pair for gateway /status."""
+    override = getattr(runner, "_session_model_overrides", {}).get(session_key, {}) or {}
+
+    model = getattr(running_agent, "model", "") if running_agent is not None else ""
+    provider = getattr(running_agent, "provider", "") if running_agent is not None else ""
+
+    if not model:
+        model = override.get("model") or _resolve_gateway_model()
+    if not provider:
+        provider = override.get("provider") or _resolve_gateway_provider()
+
+    return model or "", provider or ""
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -3379,14 +3408,16 @@ class GatewayRunner:
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
+        from hermes_constants import display_hermes_home
+
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
 
         connected_platforms = [p.value for p in self.adapters.keys()]
 
-        # Check if there's an active agent
         session_key = session_entry.session_key
-        is_running = session_key in self._running_agents
+        running_agent = self._running_agents.get(session_key)
+        is_running = running_agent is not None
 
         title = None
         if self._session_db:
@@ -3395,13 +3426,25 @@ class GatewayRunner:
             except Exception:
                 title = None
 
+        model, provider = _resolve_status_model_info(
+            runner=self,
+            session_key=session_key,
+            running_agent=running_agent,
+        )
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
             f"**Session ID:** `{session_entry.session_id}`",
+            f"**Path:** `{display_hermes_home()}`",
         ]
         if title:
             lines.append(f"**Title:** {title}")
+        if model:
+            model_line = f"**Model:** `{model}`"
+            if provider:
+                model_line += f" ({provider})"
+            lines.append(model_line)
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -49,6 +49,7 @@ def _make_runner(session_entry: SessionEntry):
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner._running_agents = {}
+    runner._session_model_overrides = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._session_db = MagicMock()
@@ -92,7 +93,7 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_status_command_includes_session_title_when_present():
+async def test_status_command_includes_path_title_and_config_model(monkeypatch):
     session_entry = SessionEntry(
         session_key=build_session_key(_make_source()),
         session_id="sess-1",
@@ -105,10 +106,49 @@ async def test_status_command_includes_session_title_when_present():
     runner = _make_runner(session_entry)
     runner._session_db.get_session_title.return_value = "My titled session"
 
+    import hermes_constants
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(hermes_constants, "display_hermes_home", lambda: "~/.hermes/profiles/tester")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "openai/gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_provider", lambda config=None: "openai")
+
     result = await runner._handle_message(_make_event("/status"))
 
     assert "**Session ID:** `sess-1`" in result
+    assert "**Path:** `~/.hermes/profiles/tester`" in result
     assert "**Title:** My titled session" in result
+    assert "**Model:** `openai/gpt-5.4` (openai)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_running_agent_model_over_config(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=321,
+    )
+    runner = _make_runner(session_entry)
+    runner._running_agents[build_session_key(_make_source())] = SimpleNamespace(
+        model="anthropic/claude-sonnet-4",
+        provider="anthropic",
+    )
+
+    import hermes_constants
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(hermes_constants, "display_hermes_home", lambda: "~/.hermes")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "openai/gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_provider", lambda config=None: "openai")
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `anthropic/claude-sonnet-4` (anthropic)" in result
+    assert "**Agent Running:** Yes ⚡" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add the active Hermes home path to gateway `/status`
- show the session's current model/provider in `/status`
- keep the existing session title display intact and cover the new output with regression tests

## Upstream context
- Title support already landed in #5942, so this PR does not try to re-solve that.
- PR #4678 partially overlaps on the model/status part, but it is still open and does not add the path line. This PR covers the missing path info while shipping the model line in the same place.

## Test Plan
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_status_command.py -q -o addopts=''`

Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.

Carried patch: patch-feat-pr6750
Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.
