### PR TITLE
fix(cli): prefer auth.py env vars over models.dev in provider detection

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -733,6 +733,7 @@ def list_authenticated_providers(
         fetch_models_dev,
         get_provider_info as _mdev_pinfo,
     )
+    from hermes_cli.auth import PROVIDER_REGISTRY
     from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS
 
     results: List[dict] = []
@@ -753,9 +754,16 @@ def list_authenticated_providers(
         if not isinstance(pdata, dict):
             continue
 
-        env_vars = pdata.get("env", [])
-        if not isinstance(env_vars, list):
-            continue
+        # Prefer auth.py PROVIDER_REGISTRY for env var names — it's our
+        # source of truth.  models.dev can have wrong mappings (e.g.
+        # minimax-cn → MINIMAX_API_KEY instead of MINIMAX_CN_API_KEY).
+        pconfig = PROVIDER_REGISTRY.get(hermes_id)
+        if pconfig and pconfig.api_key_env_vars:
+            env_vars = list(pconfig.api_key_env_vars)
+        else:
+            env_vars = pdata.get("env", [])
+            if not isinstance(env_vars, list):
+                continue
 
         # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)


### PR DESCRIPTION
## Summary

`list_authenticated_providers()` in `model_switch.py` was using env var names from the external `models.dev` registry to detect whether a provider has credentials. This registry has incorrect mappings for **5 providers**:

| Provider | auth.py (correct) | models.dev (wrong) |
|----------|-------------------|--------------------|
| minimax-cn | `MINIMAX_CN_API_KEY` | `MINIMAX_API_KEY` |
| zai | `GLM_API_KEY` / `ZAI_API_KEY` / `Z_AI_API_KEY` | `ZHIPU_API_KEY` |
| opencode-zen | `OPENCODE_ZEN_API_KEY` | `OPENCODE_API_KEY` |
| opencode-go | `OPENCODE_GO_API_KEY` | `OPENCODE_API_KEY` |
| kilocode | `KILOCODE_API_KEY` | `KILO_API_KEY` |

The fix: check `PROVIDER_REGISTRY` from `auth.py` first (our source of truth for env var names), falling back to `models.dev` only for providers not in our registry.

## Test plan
- E2E verified: all 5 previously-broken providers now detected when their correct env var is set
- Regression check: providers that already worked (anthropic, etc.) still detected
- Full `hermes_cli/` suite: 1512 passed (4 pre-existing env_loader failures from test pollution, confirmed on unmodified main)

Fixes #6620. Based on @devorun's investigation in PR #6625.