### PR TITLE
fix(agent): generalize intermediate ack detection to all api_modes

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1548,15 +1548,32 @@ class AIAgent:
         content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
         return content
 
-    def _looks_like_codex_intermediate_ack(
+    def _looks_like_intermediate_ack(
         self,
         user_message: str,
         assistant_content: str,
         messages: List[Dict[str, Any]],
     ) -> bool:
-        """Detect a planning/ack message that should continue instead of ending the turn."""
-        if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
-            return False
+        """Detect a planning/ack message that should continue instead of ending the turn.
+
+        Many models (GLM, Codex, smaller open-source LLMs) sometimes respond
+        with a planning message ("I'll look into the codebase...") instead of
+        actually calling tools.  This detector catches those and injects a
+        continuation prompt so the model proceeds with tool calls.
+
+        Two modes:
+        1. First-turn ack: no tool results yet, model says "I'll look into..."
+           -> broad detection (workspace + action markers).
+        2. Mid-task ack: tools already used this turn, model suddenly produces
+           a short planning message instead of continuing with tool calls
+           -> stricter detection (must have future-tense intent + action verb,
+           and the response must be short -- a genuine final answer is usually
+           longer than a planning blurb).
+        """
+        has_tool_results = any(
+            isinstance(msg, dict) and msg.get("role") == "tool"
+            for msg in messages
+        )
 
         assistant_text = self._strip_think_blocks(assistant_content or "").strip().lower()
         if not assistant_text:
@@ -1565,9 +1582,15 @@ class AIAgent:
             return False
 
         has_future_ack = bool(
-            re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+            re.search(r"\b(i[\'\'\u2019]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
         )
-        if not has_future_ack:
+
+        # Chinese planning patterns (common with GLM and other Chinese LLMs)
+        has_cn_future_ack = bool(
+            re.search(r"(现在|接下来|马上|然后).{0,10}(分析|写入|处理|执行|开始|继续|导出|生成|创建)", assistant_text)
+        )
+
+        if not has_future_ack and not has_cn_future_ack:
             return False
 
         action_markers = (
@@ -1590,6 +1613,10 @@ class AIAgent:
             "walkthrough",
             "report back",
             "summarize",
+            "write",
+            "create",
+            "export",
+            "process",
         )
         workspace_markers = (
             "directory",
@@ -1607,18 +1634,32 @@ class AIAgent:
             "path",
         )
 
-        user_text = (user_message or "").strip().lower()
-        user_targets_workspace = (
-            any(marker in user_text for marker in workspace_markers)
-            or "~/" in user_text
-            or "/" in user_text
-        )
         assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
-        assistant_targets_workspace = any(
-            marker in assistant_text for marker in workspace_markers
-        )
-        return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
-    
+
+        if not has_tool_results:
+            # First-turn mode: original broad detection
+            user_text = (user_message or "").strip().lower()
+            user_targets_workspace = (
+                any(marker in user_text for marker in workspace_markers)
+                or "~/" in user_text
+                or "/" in user_text
+            )
+            assistant_targets_workspace = any(
+                marker in assistant_text for marker in workspace_markers
+            )
+            return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
+
+        # Mid-task mode: tools already used, model produced a short planning
+        # blurb instead of continuing.  Be stricter to avoid catching genuine
+        # final answers -- require the response to be short (< 400 chars) and
+        # contain a clear future-tense action intent.
+        if len(assistant_text) > 400:
+            return False
+        # Chinese ack alone is sufficient (it already implies action intent)
+        if has_cn_future_ack:
+            return True
+        return has_future_ack and assistant_mentions_action
+
     
     def _extract_reasoning(self, assistant_message) -> Optional[str]:
         """
@@ -7198,7 +7239,7 @@ class AIAgent:
         api_call_count = 0
         final_response = None
         interrupted = False
-        codex_ack_continuations = 0
+        ack_continuations = 0
         length_continue_retries = 0
         truncated_response_prefix = ""
         compression_attempts = 0
@@ -7305,6 +7346,11 @@ class AIAgent:
                     if reasoning_text:
                         # Add reasoning_content for API compatibility (Moonshot AI, Novita, OpenRouter)
                         api_msg["reasoning_content"] = reasoning_text
+                    elif msg.get("tool_calls"):
+                        # Kimi API requires reasoning_content field for tool call messages
+                        # when thinking is enabled. Ensure the field exists even if empty.
+                        if "reasoning_content" not in api_msg:
+                            api_msg["reasoning_content"] = ""
 
                 # Remove 'reasoning' field - it's for trajectory storage only
                 # We've copied it to 'reasoning_content' for the API above
@@ -9064,16 +9110,15 @@ class AIAgent:
                     self._thinking_prefill_retries = 0
 
                     if (
-                        self.api_mode == "codex_responses"
-                        and self.valid_tool_names
-                        and codex_ack_continuations < 2
-                        and self._looks_like_codex_intermediate_ack(
+                        self.valid_tool_names
+                        and ack_continuations < 2
+                        and self._looks_like_intermediate_ack(
                             user_message=user_message,
                             assistant_content=final_response,
                             messages=messages,
                         )
                     ):
-                        codex_ack_continuations += 1
+                        ack_continuations += 1
                         interim_msg = self._build_assistant_message(assistant_message, "incomplete")
                         messages.append(interim_msg)
 
@@ -9089,7 +9134,7 @@ class AIAgent:
                         self._save_session_log(messages)
                         continue
 
-                    codex_ack_continuations = 0
+                    ack_continuations = 0
 
                     if truncated_response_prefix:
                         final_response = truncated_response_prefix + final_response


### PR DESCRIPTION
## Summary

The `_looks_like_codex_intermediate_ack` method was gated behind `api_mode == "codex_responses"`, preventing it from catching planning-only responses on `chat_completions` providers (GLM, Kimi, MiniMax, etc.).

These models exhibit the same pattern as Codex: they return a short planning message ("I'll analyze the files...") with `finish_reason=stop` instead of actually calling tools, causing the agent loop to terminate mid-task.

## Changes

- **Remove the `codex_responses` api_mode gate** so all providers benefit from intermediate ack detection
- **Rename** `_looks_like_codex_intermediate_ack` → `_looks_like_intermediate_ack` (no longer Codex-specific)
- **Rename** `codex_ack_continuations` → `ack_continuations`
- **Add mid-task detection mode**: when tool results already exist in the conversation, use stricter heuristics (< 400 chars + future-tense action intent) to avoid false positives on genuine final answers
- **Add Chinese planning pattern detection** for GLM-family models (e.g. `现在...分析`, `接下来...写入`, `马上...执行`)
- **Add action markers**: `write`, `create`, `export`, `process`

## Root Cause

The original method was introduced in `ce175d73` ("Fix Codex Responses continuation and schema parity") specifically for OpenAI Codex, which has a known tendency to produce planning messages instead of tool calls. The `api_mode == "codex_responses"` gate was a conservative scope restriction — at the time, only Codex exhibited this behavior.

Since then, multiple `chat_completions` providers have been added (z-ai/GLM-5, kimi-coding, minimax, etc.) that exhibit the same pattern. The gate prevented these models from benefiting from the existing protection.

## How to Test

1. Use a `chat_completions` provider (e.g., `z-ai/glm-5`) with tools enabled
2. Give the agent a multi-step task (e.g., "analyze the files in this directory and write a summary")
3. Previously: the agent would stop after the model returned "I'll analyze the files now..." without calling tools
4. Now: the agent detects the planning message and injects a continuation prompt

## Platforms Tested

- macOS (darwin/bash)

## Test Results

All 669 `tests/run_agent/` tests pass. The 2 existing `intermediate_ack` / `looks_like` tests also pass.
