### PR TITLE
fix(cron): forward model overrides on create

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -167,6 +167,9 @@ def cron_create(args):
         repeat=getattr(args, "repeat", None),
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
+        model=getattr(args, "model", None),
+        provider=getattr(args, "provider", None),
+        base_url=getattr(args, "base_url", None),
         script=getattr(args, "script", None),
     )
     if not result.get("success"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4648,6 +4648,9 @@ For more help on a command:
     cron_create.add_argument("--deliver", help="Delivery target: origin, local, telegram, discord, signal, or platform:chat_id")
     cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
     cron_create.add_argument("--skill", dest="skills", action="append", help="Attach a skill. Repeat to add multiple skills.")
+    cron_create.add_argument("--model", help="Optional per-job model override")
+    cron_create.add_argument("--provider", help="Optional per-job provider override")
+    cron_create.add_argument("--base-url", help="Optional per-job base URL override")
     cron_create.add_argument("--script", help="Path to a Python script whose stdout is injected into the prompt each run")
 
     # cron edit

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -96,6 +96,10 @@ class TestCronCommandLifecycle:
                 repeat=None,
                 skill=None,
                 skills=["blogwatcher", "find-nearby"],
+                model=None,
+                provider=None,
+                base_url=None,
+                script=None,
             )
         )
         out = capsys.readouterr().out
@@ -105,3 +109,30 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "find-nearby"]
         assert jobs[0]["name"] == "Skill combo"
+
+    def test_create_forwards_model_provider_and_base_url(self, tmp_cron_dir, capsys):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Use this exact runtime",
+                name="Pinned runtime",
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                model='{"model":"gemma4:31b","provider":"custom"}',
+                provider="custom",
+                base_url="http://localhost:11434/v1/",
+                script=None,
+            )
+        )
+
+        out = capsys.readouterr().out
+        assert "Created job" in out
+
+        jobs = list_jobs()
+        assert len(jobs) == 1
+        assert jobs[0]["model"] == '{"model":"gemma4:31b","provider":"custom"}'
+        assert jobs[0]["provider"] == "custom"
+        assert jobs[0]["base_url"] == "http://localhost:11434/v1"


### PR DESCRIPTION
## Summary
- add `--model`, `--provider`, and `--base-url` flags to `hermes cron create`
- forward those create-time overrides through the CLI wrapper into the cron job tool
- add regression coverage proving created jobs retain the requested runtime override fields

## Testing
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_cron.py -q`
- `source venv/bin/activate && python -m pytest tests/cron/test_jobs.py tests/hermes_cli/test_cron.py -q`

Closes #6709
