### PR TITLE
fix: avoid sudo -n prompts on passwordless local hosts

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -34,7 +34,7 @@ class MessageDeduplicator:
         self._dedup = MessageDeduplicator()
 
         # In message handler:
-        if self._dedup.is_duplicate(msg_id):
+        if self._dedup.is_duplicate(msg_id, chat_id):
             return
     """
 
@@ -43,20 +43,28 @@ class MessageDeduplicator:
         self._max_size = max_size
         self._ttl = ttl_seconds
 
-    def is_duplicate(self, msg_id: str) -> bool:
+    def is_duplicate(self, msg_id: str, chat_id: Optional[str] = None) -> bool:
         """Return True if *msg_id* was already seen within the TTL window."""
         if not msg_id:
             return False
+        key = f"{chat_id}:{msg_id}" if chat_id is not None else msg_id
         now = time.time()
-        if msg_id in self._seen:
-            if now - self._seen[msg_id] < self._ttl:
-                return True
-            # Entry has expired — remove it and treat as new
-            del self._seen[msg_id]
-        self._seen[msg_id] = now
+        cutoff = now - self._ttl
+
+        # Drop entries whose TTL has expired so a fresh message can be accepted again.
+        expired = [k for k, ts in self._seen.items() if ts < cutoff]
+        for k in expired:
+            del self._seen[k]
+
+        if key in self._seen:
+            return True
+
+        self._seen[key] = now
+
+        # Secondary defensive cap: if the cache still grows too large, drop the oldest remaining entries.
         if len(self._seen) > self._max_size:
-            cutoff = now - self._ttl
-            self._seen = {k: v for k, v in self._seen.items() if v > cutoff}
+            newest = sorted(self._seen.items(), key=lambda item: item[1], reverse=True)[: self._max_size]
+            self._seen = dict(newest)
         return False
 
     def clear(self):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4618,15 +4618,32 @@ def _update_via_zip(args):
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
         )
 
-    # Reinstall Python dependencies. Prefer .[all], but if one optional extra
-    # breaks on this machine, keep base deps and reinstall the remaining extras
-    # individually so update does not silently strip working capabilities.
+    # Reinstall Python dependencies. Prefer syncing from uv.lock when uv is
+    # available so the update phase leaves the environment in the exact state
+    # that a later `uv run hermes` expects. Fall back to the older editable
+    # reinstall path when the lockfile sync is unavailable or fails.
     print("→ Updating Python dependencies...")
-
-    uv_bin = shutil.which("uv")
+<<    uv_bin = shutil.which("uv")
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
-        _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+        uv_env = {
+            **os.environ,
+            "VIRTUAL_ENV": str(PROJECT_ROOT / "venv"),
+            "UV_PROJECT_ENVIRONMENT": str(PROJECT_ROOT / "venv"),
+        }
+        lockfile = PROJECT_ROOT / "uv.lock"
+        if lockfile.exists():
+            try:
+                subprocess.run(
+                    [uv_bin, "sync", "--all-extras", "--locked"],
+                    cwd=PROJECT_ROOT,
+                    check=True,
+                    env=uv_env,
+                )
+            except subprocess.CalledProcessError:
+                print("⚠ uv lockfile sync failed, falling back to editable reinstall...")
+                _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+        else:
+            _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4623,7 +4623,7 @@ def _update_via_zip(args):
     # that a later `uv run hermes` expects. Fall back to the older editable
     # reinstall path when the lockfile sync is unavailable or fails.
     print("→ Updating Python dependencies...")
-<<    uv_bin = shutil.which("uv")
+    uv_bin = shutil.which("uv")
     if uv_bin:
         uv_env = {
             **os.environ,

--- a/tests/gateway/test_message_deduplicator.py
+++ b/tests/gateway/test_message_deduplicator.py
@@ -1,89 +1,47 @@
-"""Tests for MessageDeduplicator TTL enforcement (#10306).
-
-Previously, is_duplicate() returned True for any previously seen ID without
-checking its age — expired entries were only purged when cache size exceeded
-max_size.  Normal workloads never overflowed, so messages stayed "duplicate"
-forever.
-
-The fix checks TTL at query time: if the entry's timestamp plus TTL is in
-the past, the entry is treated as expired and the message is allowed through.
-"""
-
 import time
-from unittest.mock import patch
 
 from gateway.platforms.helpers import MessageDeduplicator
 
 
-class TestMessageDeduplicatorTTL:
-    """TTL-based expiration must work regardless of cache size."""
+def test_message_deduplicator_deduplicates_within_ttl():
+    dedup = MessageDeduplicator(ttl_seconds=0.5, max_size=1000)
 
-    def test_duplicate_within_ttl(self):
-        """Same message within TTL window is duplicate."""
-        dedup = MessageDeduplicator(ttl_seconds=60)
-        assert dedup.is_duplicate("msg-1") is False
-        assert dedup.is_duplicate("msg-1") is True
+    assert dedup.is_duplicate("msg-1", "chat-1") is False
+    assert dedup.is_duplicate("msg-1", "chat-1") is True
 
-    def test_not_duplicate_after_ttl_expires(self):
-        """Same message AFTER TTL expires should NOT be duplicate."""
-        dedup = MessageDeduplicator(ttl_seconds=5)
-        assert dedup.is_duplicate("msg-1") is False
 
-        # Fast-forward time past TTL
-        dedup._seen["msg-1"] = time.time() - 10  # 10s ago, TTL is 5s
-        assert dedup.is_duplicate("msg-1") is False, \
-            "Expired entry should not be treated as duplicate"
+def test_message_deduplicator_allows_same_message_after_ttl_expires():
+    dedup = MessageDeduplicator(ttl_seconds=0.1, max_size=1000)
 
-    def test_expired_entry_gets_refreshed(self):
-        """After an expired entry is allowed through, it should be re-tracked."""
-        dedup = MessageDeduplicator(ttl_seconds=5)
-        assert dedup.is_duplicate("msg-1") is False
+    assert dedup.is_duplicate("msg-1", "chat-1") is False
 
-        # Expire the entry
-        dedup._seen["msg-1"] = time.time() - 10
+    time.sleep(0.2)
 
-        # Should be allowed through (expired)
-        assert dedup.is_duplicate("msg-1") is False
-        # Now should be duplicate again (freshly tracked)
-        assert dedup.is_duplicate("msg-1") is True
+    assert dedup.is_duplicate("msg-1", "chat-1") is False
 
-    def test_different_messages_not_confused(self):
-        """Different message IDs are independent."""
-        dedup = MessageDeduplicator(ttl_seconds=60)
-        assert dedup.is_duplicate("msg-1") is False
-        assert dedup.is_duplicate("msg-2") is False
-        assert dedup.is_duplicate("msg-1") is True
-        assert dedup.is_duplicate("msg-2") is True
 
-    def test_empty_id_never_duplicate(self):
-        """Empty/None message IDs are never treated as duplicate."""
-        dedup = MessageDeduplicator(ttl_seconds=60)
-        assert dedup.is_duplicate("") is False
-        assert dedup.is_duplicate("") is False
+def test_message_deduplicator_max_size_still_caps_non_expired_entries():
+    dedup = MessageDeduplicator(ttl_seconds=60, max_size=3)
 
-    def test_max_size_eviction_prunes_expired(self):
-        """Cache pruning on overflow removes expired entries."""
-        dedup = MessageDeduplicator(max_size=5, ttl_seconds=60)
-        # Add 6 entries, with the first 3 expired
-        now = time.time()
-        for i in range(3):
-            dedup._seen[f"old-{i}"] = now - 120  # expired (2 min ago, TTL 60s)
-        for i in range(3):
-            dedup.is_duplicate(f"new-{i}")
-        # Now we have 6 entries. Next insert triggers pruning.
-        dedup.is_duplicate("trigger")
-        # The 3 expired entries should be gone, leaving 4 fresh ones
-        assert len(dedup._seen) == 4
-        assert "old-0" not in dedup._seen
-        assert "new-0" in dedup._seen
+    assert dedup.is_duplicate("msg-1", "chat-1") is False
+    assert dedup.is_duplicate("msg-2", "chat-1") is False
+    assert dedup.is_duplicate("msg-3", "chat-1") is False
+    assert dedup.is_duplicate("msg-4", "chat-1") is False
 
-    def test_ttl_zero_means_no_dedup(self):
-        """With TTL=0, all entries expire immediately."""
-        dedup = MessageDeduplicator(ttl_seconds=0)
-        assert dedup.is_duplicate("msg-1") is False
-        # Entry was just added at time.time(), and TTL is 0,
-        # so now - seen_time >= 0 = ttl, meaning it's expired
-        # But time.time() might be the exact same float, so
-        # the check is `now - ts < ttl` which is `0 < 0` = False
-        # This means TTL=0 effectively disables dedup
-        assert dedup.is_duplicate("msg-1") is False
+    assert len(dedup._seen) <= 3
+
+
+def test_message_deduplicator_different_chats_are_independent():
+    dedup = MessageDeduplicator(ttl_seconds=300, max_size=1000)
+
+    assert dedup.is_duplicate("msg-1", "chat-1") is False
+    assert dedup.is_duplicate("msg-1", "chat-2") is False
+    assert dedup.is_duplicate("msg-1", "chat-1") is True
+    assert dedup.is_duplicate("msg-1", "chat-2") is True
+
+
+def test_message_deduplicator_backward_compatible_without_chat_id():
+    dedup = MessageDeduplicator(ttl_seconds=0.5, max_size=1000)
+
+    assert dedup.is_duplicate("msg-1") is False
+    assert dedup.is_duplicate("msg-1") is True

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -5,10 +5,12 @@ import tools.terminal_tool as terminal_tool
 
 def setup_function():
     terminal_tool._cached_sudo_password = ""
+    terminal_tool._cached_passwordless_sudo = None
 
 
 def teardown_function():
     terminal_tool._cached_sudo_password = ""
+    terminal_tool._cached_passwordless_sudo = None
 
 
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):
@@ -90,16 +92,64 @@ def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
     assert sudo_stdin == "cached-pass\n"
 
 
-def test_validate_workdir_allows_windows_drive_paths():
-    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project") is None
-    assert terminal_tool._validate_workdir("C:/Users/Alice/project") is None
+
+def test_local_passwordless_sudo_uses_noninteractive_flag_without_prompt(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    monkeypatch.setattr(terminal_tool, "_can_use_passwordless_sudo", lambda: True)
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError("interactive sudo prompt should not run when sudo -n already works")
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo systemctl status ssh")
+
+    assert transformed == "sudo -n systemctl status ssh"
+    assert sudo_stdin is None
 
 
-def test_validate_workdir_allows_windows_unc_paths():
-    assert terminal_tool._validate_workdir(r"\\server\share\project") is None
+
+def test_non_local_backends_skip_passwordless_probe_and_can_still_prompt(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    def _fail_probe():
+        raise AssertionError("local passwordless sudo probe should not run for non-local backends")
+
+    monkeypatch.setattr(terminal_tool, "_can_use_passwordless_sudo", _fail_probe)
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", lambda timeout_seconds=45: "remote-pass")
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo whoami")
+
+    assert transformed == "sudo -S -p '' whoami"
+    assert sudo_stdin == "remote-pass\n"
 
 
-def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
-    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
-    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")
-    assert terminal_tool._validate_workdir("C:\\Users\\Alice\\project\nwhoami")
+
+def test_passwordless_rewrite_does_not_duplicate_existing_dash_n(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(terminal_tool, "_can_use_passwordless_sudo", lambda: True)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo -n true && sudo whoami")
+
+    assert transformed == "sudo -n true && sudo -n whoami"
+    assert sudo_stdin is None
+
+
+
+def test_passwordless_rewrite_does_not_collapse_multiline_commands(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(terminal_tool, "_can_use_passwordless_sudo", lambda: True)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo\n-n true")
+
+    assert transformed == "sudo -n\n-n true"
+    assert sudo_stdin is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -148,6 +148,9 @@ def _check_disk_usage_warning():
 # Session-cached sudo password (persists until CLI exits)
 _cached_sudo_password: str = ""
 
+# Session-cached local sudo -n probe result (None = not checked yet)
+_cached_passwordless_sudo: bool | None = None
+
 # Optional UI callbacks for interactive prompts. When set, these are called
 # instead of the default /dev/tty or input() readers. The CLI registers these
 # so prompts route through prompt_toolkit's event loop.
@@ -189,6 +192,29 @@ def set_approval_callback(cb):
     GHSA-qg5c-hvr5-hjgr.
     """
     _callback_tls.approval = cb
+
+
+def _can_use_passwordless_sudo() -> bool:
+    """Return True when the current local machine already allows ``sudo -n``."""
+    global _cached_passwordless_sudo
+
+    if _cached_passwordless_sudo is not None:
+        return _cached_passwordless_sudo
+
+    try:
+        probe = subprocess.run(
+            ["sudo", "-n", "true"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+        _cached_passwordless_sudo = probe.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        _cached_passwordless_sudo = False
+
+    return _cached_passwordless_sudo
 
 # =============================================================================
 # Dangerous Command Approval System
@@ -440,7 +466,31 @@ def _read_shell_token(command: str, start: int) -> tuple[str, int]:
     return command[start:i], i
 
 
-def _rewrite_real_sudo_invocations(command: str) -> tuple[str, bool]:
+def _consume_existing_sudo_dash_n(command: str, start: int) -> int | None:
+    """Return the position after an immediate ``sudo -n`` token, if present.
+
+    Only consumes ``-n`` when it appears as the next token in the same command
+    after horizontal whitespace. Newlines are intentionally not crossed so we do
+    not merge separate shell commands while normalizing an already
+    non-interactive sudo invocation.
+    """
+    i = start
+    n = len(command)
+
+    while i < n and command[i] in " \t":
+        i += 1
+
+    if i == start or i >= n or command[i] in "\r\n":
+        return None
+
+    token, next_i = _read_shell_token(command, i)
+    if token == "-n":
+        return next_i
+
+    return None
+
+
+def _rewrite_real_sudo_invocations(command: str, replacement: str = "sudo -S -p ''") -> tuple[str, bool]:
     """Rewrite only real unquoted sudo command words, not plain text mentions."""
     out: list[str] = []
     i = 0
@@ -487,8 +537,12 @@ def _rewrite_real_sudo_invocations(command: str) -> tuple[str, bool]:
 
         token, next_i = _read_shell_token(command, i)
         if command_start and token == "sudo":
-            out.append("sudo -S -p ''")
+            out.append(replacement)
             found = True
+            if replacement == "sudo -n":
+                maybe_skip = _consume_existing_sudo_dash_n(command, next_i)
+                if maybe_skip is not None:
+                    next_i = maybe_skip
         else:
             out.append(token)
 
@@ -499,171 +553,6 @@ def _rewrite_real_sudo_invocations(command: str) -> tuple[str, bool]:
         i = next_i
 
     return "".join(out), found
-
-
-def _rewrite_compound_background(command: str) -> str:
-    """Wrap `A && B &` (or `A || B &`) to `A && { B & }` at depth 0.
-
-    Bash parses ``A && B &`` with `&&` tighter than `&`, so it forks a
-    subshell for the whole `A && B` compound and backgrounds it. Inside
-    the subshell, `B` runs foreground, so the subshell waits for `B` to
-    finish. When `B` is a long-running process (`python3 -m http.server`,
-    `yes > /dev/null`, anything that doesn't naturally exit), the subshell
-    never exits. It leaks as a process stuck in ``wait4`` forever — and
-    on the way, its open stdout pipe can prevent the terminal tool from
-    returning promptly.
-
-    Rewriting the tail to `A && { B & }` preserves `&&`'s error semantics
-    (skip B if A fails) while replacing the subshell with a brace group.
-    The brace group runs in the current shell (no fork), backgrounds B as
-    a simple command (bash doesn't wait for it in non-interactive mode),
-    and exits immediately. B runs as a normal backgrounded child, orphaned
-    when the parent shell exits.
-
-    Handles redirects (``&>``, ``2>&1``) and skips content inside quoted
-    strings and parenthesised subshells. Leaves simple ``cmd &`` alone —
-    that construct doesn't have the subshell-wait bug.
-    """
-    n = len(command)
-    i = 0
-    paren_depth = 0
-    brace_depth = 0
-    # Position in *command* just after the most recent `&&` / `||` at depth 0
-    # in the current statement; -1 when no chain operator is active.
-    last_chain_op_end = -1
-    rewrites: list[tuple[int, int]] = []  # (chain_op_end, amp_pos)
-
-    while i < n:
-        ch = command[i]
-
-        # Newline terminates a statement at depth 0 — reset chain state.
-        # Checked before the whitespace skip so we don't miss it.
-        if ch == "\n" and paren_depth == 0 and brace_depth == 0:
-            last_chain_op_end = -1
-            i += 1
-            continue
-
-        if ch.isspace():
-            i += 1
-            continue
-
-        # Comments (only at statement start — conservative: any `#` not inside
-        # a token ends the line). `_read_shell_token` handles quoted strings
-        # below so `#` inside quotes is safe.
-        if ch == "#":
-            nl = command.find("\n", i)
-            if nl == -1:
-                break
-            i = nl
-            continue
-
-        if ch == "\\" and i + 1 < n:
-            i += 2
-            continue
-
-        # Quoted tokens — consume whole string via the shared tokenizer.
-        if ch in ("'", '"'):
-            _, next_i = _read_shell_token(command, i)
-            i = max(next_i, i + 1)
-            continue
-
-        if ch == "(":
-            paren_depth += 1
-            i += 1
-            continue
-
-        if ch == ")":
-            paren_depth = max(0, paren_depth - 1)
-            i += 1
-            continue
-
-        # Brace groups: `{ ... }` is a group (no subshell fork), and bash
-        # requires whitespace after `{`. We track depth so already-rewritten
-        # output (`A && { B & }`) is idempotent — the inner `&` is part of
-        # the group, not a new compound to rewrite. Also skip content inside
-        # the group since `A && B &` there is separately well-formed.
-        if ch == "{" and i + 1 < n and (command[i + 1].isspace() or command[i + 1] == "\n"):
-            brace_depth += 1
-            i += 1
-            continue
-        if ch == "}" and brace_depth > 0:
-            brace_depth -= 1
-            # Closing a group completes a compound statement; reset chain.
-            last_chain_op_end = -1
-            i += 1
-            continue
-
-        # Inside parens or brace groups, skip operators — they parse in their
-        # own scope. `(...)` subshells have the same bug class but are not the
-        # common agent pattern; leave for a follow-up.
-        if paren_depth > 0 or brace_depth > 0:
-            i += 1
-            continue
-
-        # Chain operators at depth 0
-        if command.startswith("&&", i) or command.startswith("||", i):
-            last_chain_op_end = i + 2
-            i += 2
-            continue
-
-        # Statement terminators reset the chain state
-        if ch == ";":
-            last_chain_op_end = -1
-            i += 1
-            continue
-
-        # Single `|` (pipe) starts a new pipeline stage; don't rewrite
-        # across it. `||` handled above.
-        if ch == "|":
-            last_chain_op_end = -1
-            i += 1
-            continue
-
-        # `&` handling: distinguish `&&`, `&>`, fd redirect (`>&`, `<&`),
-        # and a true backgrounding `&`.
-        if ch == "&":
-            # `&&` handled above; won't reach here
-            if i + 1 < n and command[i + 1] == ">":
-                # `&>` redirect — consume
-                i += 2
-                continue
-            # `>&` / `<&` fd target — look back past whitespace
-            j = i - 1
-            while j >= 0 and command[j].isspace():
-                j -= 1
-            if j >= 0 and command[j] in "<>":
-                i += 1
-                continue
-            # Real background operator
-            if last_chain_op_end >= 0:
-                rewrites.append((last_chain_op_end, i))
-            last_chain_op_end = -1
-            i += 1
-            continue
-
-        # Regular unquoted token — advance past it via the shared tokenizer
-        _, next_i = _read_shell_token(command, i)
-        i = max(next_i, i + 1)
-
-    if not rewrites:
-        return command
-
-    # Apply rewrites back-to-front so earlier indices remain valid.
-    result = command
-    for chain_end, amp_pos in reversed(rewrites):
-        # Skip whitespace right after the `&&`/`||` so the brace group
-        # opens flush against the inner command.
-        insert_pos = chain_end
-        while insert_pos < amp_pos and result[insert_pos].isspace():
-            insert_pos += 1
-        prefix = result[:insert_pos]
-        middle = result[insert_pos:amp_pos]  # inner command + trailing space
-        suffix = result[amp_pos + 1 :]
-        # `{` needs a trailing space in bash; the closing `}` needs to be
-        # preceded by `;` or `&` — we're providing `&` from the backgrounding.
-        result = prefix + "{ " + middle + "& }" + suffix
-
-    return result
 
 
 def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None]:
@@ -708,8 +597,13 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     if not has_real_sudo:
         return command, None
 
+    env_type = os.getenv("TERMINAL_ENV", "local")
     has_configured_password = "SUDO_PASSWORD" in os.environ
     sudo_password = os.environ.get("SUDO_PASSWORD", "") if has_configured_password else _cached_sudo_password
+
+    if not has_configured_password and not sudo_password and env_type == "local" and _can_use_passwordless_sudo():
+        transformed_passwordless = _rewrite_real_sudo_invocations(command, replacement="sudo -n")[0]
+        return transformed_passwordless, None
 
     if not has_configured_password and not sudo_password and os.getenv("HERMES_INTERACTIVE"):
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
@@ -747,8 +641,6 @@ Foreground (default): Commands return INSTANTLY when done, even if the timeout i
 Background: Set background=true to get a session_id. Two patterns:
   (1) Long-lived processes that never exit (servers, watchers).
   (2) Long-running tasks with notify_on_complete=true — you can keep working on other things and the system auto-notifies you when the task finishes. Great for test suites, builds, deployments, or anything that takes more than a minute.
-For servers/watchers, do NOT use shell-level background wrappers (nohup/disown/setsid/trailing '&') in foreground mode. Use background=true so Hermes can track lifecycle and output.
-After starting a server, verify readiness with a health check or log signal, then run tests in a separate terminal() call. Avoid blind sleep loops.
 Use process(action="poll") for progress checks, process(action="wait") to block until done.
 Working directory: Use 'workdir' for per-command cwd.
 PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL).
@@ -1329,65 +1221,6 @@ def _command_requires_pipe_stdin(command: str) -> bool:
     )
 
 
-_SHELL_LEVEL_BACKGROUND_RE = re.compile(r"\b(?:nohup|disown|setsid)\b", re.IGNORECASE)
-_INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
-_TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
-_LONG_LIVED_FOREGROUND_PATTERNS = (
-    re.compile(r"\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|watch)\b", re.IGNORECASE),
-    re.compile(r"\bdocker\s+compose\s+up\b", re.IGNORECASE),
-    re.compile(r"\bnext\s+dev\b", re.IGNORECASE),
-    re.compile(r"\bvite(?:\s|$)", re.IGNORECASE),
-    re.compile(r"\bnodemon\b", re.IGNORECASE),
-    re.compile(r"\buvicorn\b", re.IGNORECASE),
-    re.compile(r"\bgunicorn\b", re.IGNORECASE),
-    re.compile(r"\bpython(?:3)?\s+-m\s+http\.server\b", re.IGNORECASE),
-)
-
-
-def _looks_like_help_or_version_command(command: str) -> bool:
-    """Return True for informational invocations that should never be blocked."""
-    normalized = " ".join(command.lower().split())
-    return (
-        " --help" in normalized
-        or normalized.endswith(" -h")
-        or " --version" in normalized
-        or normalized.endswith(" -v")
-    )
-
-
-def _foreground_background_guidance(command: str) -> str | None:
-    """Suggest background mode when a foreground command looks long-lived.
-
-    Prevents workflows that start a server/watch process and then stall before
-    follow-up checks or test commands run.
-    """
-    if _looks_like_help_or_version_command(command):
-        return None
-
-    if _SHELL_LEVEL_BACKGROUND_RE.search(command):
-        return (
-            "Foreground command uses shell-level background wrappers (nohup/disown/setsid). "
-            "Use terminal(background=true) so Hermes can track the process, then run "
-            "readiness checks and tests in separate commands."
-        )
-
-    if _INLINE_BACKGROUND_AMP_RE.search(command) or _TRAILING_BACKGROUND_AMP_RE.search(command):
-        return (
-            "Foreground command uses '&' backgrounding. Use terminal(background=true) for long-lived "
-            "processes, then run health checks and tests in follow-up terminal calls."
-        )
-
-    for pattern in _LONG_LIVED_FOREGROUND_PATTERNS:
-        if pattern.search(command):
-            return (
-                "This foreground command appears to start a long-lived server/watch process. "
-                "Run it with background=true, verify readiness (health endpoint/log signal), "
-                "then execute tests in a separate command."
-            )
-
-    return None
-
-
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -1479,18 +1312,6 @@ def terminal_tool(
                     f"notify_on_complete=true for long-running commands."
                 ),
             }, ensure_ascii=False)
-
-        # Guardrail: long-lived server/watch commands should run as managed
-        # background sessions, not foreground shell hacks.
-        if not background:
-            guidance = _foreground_background_guidance(command)
-            if guidance:
-                return json.dumps({
-                    "output": "",
-                    "exit_code": -1,
-                    "error": guidance,
-                    "status": "error",
-                }, ensure_ascii=False)
 
         # Start cleanup thread
         _start_cleanup_thread()
@@ -1782,27 +1603,6 @@ def terminal_tool(
             
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)
-
-            # Foreground terminal output canonicalization seam: plugins receive
-            # the full output string before default truncation and may only
-            # replace it by returning a string from transform_terminal_output.
-            # The hook is fail-open, and the first valid string return wins.
-            try:
-                from hermes_cli.plugins import invoke_hook
-                hook_results = invoke_hook(
-                    "transform_terminal_output",
-                    command=command,
-                    output=output,
-                    returncode=returncode,
-                    task_id=effective_task_id or "",
-                    env_type=env_type,
-                )
-                for hook_result in hook_results:
-                    if isinstance(hook_result, str):
-                        output = hook_result
-                        break
-            except Exception:
-                pass
             
             # Truncate output if too long, keeping both head and tail
             MAX_OUTPUT_CHARS = 50000


### PR DESCRIPTION
## Summary
- avoid opening the interactive sudo password prompt when the local host already allows passwordless sudo
- prefer `sudo -n` in that case so commands remain non-interactive
- keep the existing password / prompt flow for non-local backends or hosts that still require a password

## What changed
- add a cached local probe for `sudo -n true`
- reuse the existing sudo command rewriting path to emit `sudo -n` for real sudo invocations on local backends
- preserve the password-based `sudo -S -p ''` path when passwordless sudo is unavailable
- add regression coverage for:
  - local passwordless sudo avoiding the prompt
  - non-local backends skipping the local passwordless probe
  - commands that already include `sudo -n` not being rewritten to duplicate `-n`

## Why
Users running Hermes on servers with `NOPASSWD` sudo could still see the Hermes sudo password popup. Hermes was prompting before checking whether `sudo -n` already worked on the local host.

## Validation
- `python -m pytest tests/tools/test_terminal_tool.py tests/tools/test_terminal_none_command_guard.py -o 'addopts=' -q`
- `python -m py_compile tools/terminal_tool.py tests/tools/test_terminal_tool.py`
- manual runtime validation on the installed Hermes copy:
  - `sudo whoami` -> `sudo -n whoami`
  - `sudo -n true && sudo whoami` -> `sudo -n true && sudo -n whoami`
