### PR TITLE
fix(gateway): evict cached agents across fresh session boundaries

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2329,6 +2329,7 @@ class GatewayRunner:
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        self._evict_cached_agent_for_new_session(session_key, session_entry)
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
@@ -5168,6 +5169,10 @@ class GatewayRunner:
         if session_key in self._running_agents:
             del self._running_agents[session_key]
 
+        # Switching to a different stored session must not reuse the cached
+        # agent from the previous session_key occupant.
+        self._evict_cached_agent(session_key)
+
         # Switch the session entry to point at the old session
         new_entry = self.session_store.switch_session(session_key, target_id)
         if not new_entry:
@@ -6285,10 +6290,34 @@ class GatewayRunner:
 
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc)."""
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache is None:
+            return
         _lock = getattr(self, "_agent_cache_lock", None)
         if _lock:
             with _lock:
-                self._agent_cache.pop(session_key, None)
+                _cache.pop(session_key, None)
+        else:
+            _cache.pop(session_key, None)
+
+    def _evict_cached_agent_for_new_session(self, session_key: str, session_entry) -> None:
+        """Drop any cached agent when a fresh session entry replaces an old one.
+
+        The gateway cache is keyed by session_key (chat/thread identity), not by
+        session_id. When a DM auto-resets due to inactivity, or when a brand-new
+        session is created for an existing session_key, reusing the cached agent
+        would keep the previous session_id and frozen system prompt alive.
+        That can make a fresh conversation inherit stale identity/context.
+        """
+        if not session_entry:
+            return
+
+        is_new_session = (
+            session_entry.created_at == session_entry.updated_at
+            or getattr(session_entry, "was_auto_reset", False)
+        )
+        if is_new_session:
+            self._evict_cached_agent(session_key)
 
     async def _run_agent(
         self,

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -99,6 +99,95 @@ class TestAgentConfigSignature:
         assert sig1 == sig2
 
 
+class TestNewSessionCacheEviction:
+    """Fresh sessions must not reuse a cached agent from the previous session."""
+
+    def test_evicts_for_brand_new_session_entry(self):
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        runner = _make_runner()
+        session_key = "telegram:12345"
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = ("agent", "sig")
+
+        entry = SimpleNamespace(
+            created_at=datetime(2026, 4, 9, 18, 0, 0),
+            updated_at=datetime(2026, 4, 9, 18, 0, 0),
+            was_auto_reset=False,
+        )
+
+        runner._evict_cached_agent_for_new_session(session_key, entry)
+
+        with runner._agent_cache_lock:
+            assert session_key not in runner._agent_cache
+
+    def test_evicts_for_auto_reset_session_entry(self):
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        runner = _make_runner()
+        session_key = "telegram:12345"
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = ("agent", "sig")
+
+        entry = SimpleNamespace(
+            created_at=datetime(2026, 4, 9, 17, 0, 0),
+            updated_at=datetime(2026, 4, 9, 17, 5, 0),
+            was_auto_reset=True,
+        )
+
+        runner._evict_cached_agent_for_new_session(session_key, entry)
+
+        with runner._agent_cache_lock:
+            assert session_key not in runner._agent_cache
+
+    def test_keeps_cached_agent_for_continuing_session(self):
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        runner = _make_runner()
+        session_key = "telegram:12345"
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = ("agent", "sig")
+
+        entry = SimpleNamespace(
+            created_at=datetime(2026, 4, 9, 17, 0, 0),
+            updated_at=datetime(2026, 4, 9, 18, 0, 0),
+            was_auto_reset=False,
+        )
+
+        runner._evict_cached_agent_for_new_session(session_key, entry)
+
+        with runner._agent_cache_lock:
+            assert session_key in runner._agent_cache
+
+    def test_new_session_same_session_key_drops_stale_cached_identity(self):
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        runner = _make_runner()
+        session_key = "feishu:oc_123"
+        stale_agent = SimpleNamespace(
+            session_id="old-session",
+            _cached_system_prompt="You are Hermes Agent, an intelligent AI assistant created by Nous Research.",
+        )
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = (stale_agent, "sig")
+
+        fresh_entry = SimpleNamespace(
+            created_at=datetime(2026, 4, 9, 18, 0, 0),
+            updated_at=datetime(2026, 4, 9, 18, 0, 0),
+            was_auto_reset=False,
+            session_id="new-session",
+        )
+
+        runner._evict_cached_agent_for_new_session(session_key, fresh_entry)
+
+        with runner._agent_cache_lock:
+            assert session_key not in runner._agent_cache
+
+
 class TestAgentCacheLifecycle:
     """End-to-end cache behavior with real AIAgent construction."""
 

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -201,6 +201,33 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_evicts_cached_agent(self, tmp_path):
+        """Switching sessions must evict the cached agent for that session key."""
+        from hermes_state import SessionDB
+        from gateway.run import GatewayRunner
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session", "telegram")
+        db.set_session_title("old_session", "Old Work")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Old Work")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        real_key = _session_key_for_event(event)
+        runner._agent_cache = {real_key: ("cached-agent", "sig")}
+        runner._agent_cache_lock = None
+        runner._evict_cached_agent = GatewayRunner._evict_cached_agent.__get__(runner, GatewayRunner)
+
+        await runner._handle_resume_command(event)
+
+        assert real_key not in runner._agent_cache
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_flushes_memories(self, tmp_path):
         """Resume should flush memories from the current session before switching."""
         from hermes_state import SessionDB


### PR DESCRIPTION
## Summary
- evict cached gateway agents when a fresh session is created for an existing session key
- evict cached gateway agents before `/resume` switches to a different stored session
- add regression coverage for stale cached identity/system-prompt reuse across new-session boundaries

## Root cause
The gateway caches `AIAgent` instances by `session_key` (chat/thread identity), not by `session_id`.

That cached agent carries a frozen `_cached_system_prompt` and its prior `session_id`. When a fresh session is created for the same `session_key` — including auto-reset/new-session boundaries or a `/resume` switch — the gateway could reuse the previous cached agent instead of rebuilding from the new session boundary.

In the Feishu case from #6731, that can make a fresh conversation inherit stale identity/context instead of rebuilding from `SOUL.md`.

## Fix
- add `_evict_cached_agent_for_new_session()` and call it immediately after `get_or_create_session()` in the gateway message handler
- evict cached agent on `/resume` before switching the session entry
- make `_evict_cached_agent()` work in lightweight runners/tests even when no cache lock is configured

## Validation
- `python -m pytest tests/gateway/test_agent_cache.py tests/gateway/test_resume_command.py -q`
- `python -m pytest tests/gateway/test_session_model_reset.py tests/gateway/test_session_boundary_hooks.py tests/gateway/test_agent_cache.py tests/gateway/test_resume_command.py -q`
- `python -m pytest tests/gateway/test_feishu.py -q`
- `python -m pytest tests/run_agent/test_run_agent.py -q`
- `python -m py_compile gateway/run.py tests/gateway/test_agent_cache.py tests/gateway/test_resume_command.py`

All of the above passed locally.

## Notes
I also ran the broader `tests/gateway/ -q` suite locally. It had one unrelated existing failure in `tests/gateway/test_run_progress_topics.py` due to a tool-progress emoji expectation mismatch (`💻` vs `⚙️`) and not in the session caching / Feishu / SOUL.md path touched here.

Closes #6731
