### PR TITLE
feat(skills): add seerr skill for media requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -481,3 +481,10 @@ IMAGE_TOOLS_DEBUG=false
 # GOOGLE_CHAT_ALLOW_ALL_USERS=false             # Set true to skip the allowlist
 # GOOGLE_CHAT_HOME_CHANNEL=                     # Default space (spaces/XXXX) for cron delivery
 # GOOGLE_CHAT_HOME_CHANNEL_NAME=                # Display name for the home channel
+
+# --- seerr skill ---
+# Media request manager (https://github.com/seerr-team/seerr).
+# SEERR_URL may instead be set as skills.config.seerr.url in config.yaml.
+# SEERR_URL=http://localhost:5055
+# SEERR_API_KEY=your_seerr_api_key
+# --- end seerr skill ---

--- a/.env.example
+++ b/.env.example
@@ -487,4 +487,11 @@ IMAGE_TOOLS_DEBUG=false
 # SEERR_URL may instead be set as skills.config.seerr.url in config.yaml.
 # SEERR_URL=http://localhost:5055
 # SEERR_API_KEY=your_seerr_api_key
+#
+# Optional: only needed for `diskspace` and `queue`, which Seerr cannot report.
+# Every other command works without these.
+# RADARR_URL=http://localhost:7878
+# RADARR_API_KEY=your_radarr_api_key
+# SONARR_URL=http://localhost:8989
+# SONARR_API_KEY=your_sonarr_api_key
 # --- end seerr skill ---

--- a/skills/media/seerr/SKILL.md
+++ b/skills/media/seerr/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [seerr, overseerr, jellyseerr, movies, tv, plex, jellyfin, radarr, sonarr]
+    tags: [seerr, movies, tv, media-requests, plex, jellyfin, emby, radarr, sonarr]
     category: media
     config:
       - key: seerr.url

--- a/skills/media/seerr/SKILL.md
+++ b/skills/media/seerr/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: seerr
+description: Request movies and TV shows for your media server.
+version: 2.0.0
+author: nyakojiru (https://github.com/nyakojiru), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [seerr, overseerr, jellyseerr, movies, tv, plex, jellyfin, radarr, sonarr]
+    category: media
+    config:
+      - key: seerr.url
+        description: Base URL of the Seerr server, e.g. http://localhost:5055
+        prompt: Seerr base URL
+        default: http://localhost:5055
+required_environment_variables:
+  - name: SEERR_API_KEY
+    prompt: Seerr API key
+    help: Seerr -> Settings -> General -> API Key
+    required_for: Every Seerr call
+  - name: SEERR_URL
+    prompt: Seerr base URL (e.g. http://localhost:5055)
+    help: The URL you open Seerr on. Also settable as skills.config.seerr.url in config.yaml.
+    required_for: Every Seerr call
+---
+
+# Seerr Skill
+
+Search a media catalogue and submit movie/TV requests to [Seerr](https://github.com/seerr-team/seerr),
+the request manager that Overseerr and Jellyseerr merged into. Seerr is the only
+service this skill talks to — it proxies Radarr and Sonarr, so root folders,
+quality profiles and download progress all come from Seerr and no Radarr/Sonarr
+credentials are needed.
+
+This skill submits requests. It does not approve them, manage users, or move
+files — do that in the Seerr web UI.
+
+## When to Use
+
+- Someone asks to watch, download, get, or request a movie or TV show.
+- Someone asks whether a previously requested title has finished downloading.
+- Someone asks what has been requested recently.
+
+## When NOT to Use
+
+- Approving or denying requests, or changing permissions — use the Seerr UI.
+- Direct Radarr/Sonarr administration (indexers, custom formats, disk space).
+
+## Prerequisites
+
+- A reachable Seerr server (v1+), with Radarr and/or Sonarr already connected to it.
+- `SEERR_URL` and `SEERR_API_KEY` in the environment. Copy the block from
+  `.env.example` into your `.env` and fill it in — that file is dotenv
+  (`KEY=value`), not YAML.
+- The non-secret URL may instead live in `~/.hermes/config.yaml` as real YAML:
+
+  ```yaml
+  skills:
+    config:
+      seerr.url: http://localhost:5055
+  ```
+
+  Keep `SEERR_API_KEY` out of `config.yaml`; secrets belong in `.env`.
+- Python 3.9+ (stdlib only).
+
+## How to Run
+
+Run every call with the `terminal` tool, from the skill directory:
+
+```
+python3 scripts/seerr.py <command> [options]
+```
+
+Add `--json` to any command for the raw API payload. The script exits non-zero
+and prints a one-line `error:` on failure.
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `search "<title>" [--type movie\|tv]` | Numbered search results with TMDB ids |
+| `servers radarr\|sonarr` | Servers, **root folders**, quality profiles |
+| `seasons <tmdb_id>` | Season list for a show (Specials excluded) |
+| `request --type movie --tmdb-id <id> [--root-folder <path>]` | Request a movie |
+| `request --type tv --tmdb-id <id> --seasons 1,2\|all [--root-folder <path>]` | Request a show |
+| `status [--take N]` | Recent requests with download progress |
+
+## Procedure
+
+### 1. Search
+
+```
+python3 scripts/seerr.py search "the bear"
+```
+
+Results are numbered and carry a TMDB id. Titles already in the library are
+flagged `[already in library]` — say so rather than re-requesting.
+
+If several results plausibly match, show the numbered list and ask which one.
+If exactly one matches, confirm it in one line before requesting.
+
+### 2. Choose a root folder (only when the user needs a specific library)
+
+Seerr routes a request to its default root folder on its own. Only ask about
+root folders when the user wants a specific library, or when the server exposes
+more than one and the destination is ambiguous.
+
+```
+python3 scripts/seerr.py servers radarr
+```
+
+This prints the real root-folder paths straight from Radarr/Sonarr. Never
+invent a path or hard-code one in this file: present what the command returns
+and let the user pick, then pass it through with `--root-folder`.
+
+### 3. For TV, get the seasons
+
+```
+python3 scripts/seerr.py seasons 136315
+```
+
+Ask which seasons they want, then pass `--seasons 1,2` or `--seasons all`.
+
+### 4. Submit
+
+```
+python3 scripts/seerr.py request --type tv --tmdb-id 136315 --seasons all
+python3 scripts/seerr.py request --type movie --tmdb-id 27205 --root-folder /movies
+```
+
+### 5. Report back
+
+Confirm what was requested in one short line. For progress:
+
+```
+python3 scripts/seerr.py status --take 5
+```
+
+## Pitfalls
+
+- **Never hard-code root-folder paths.** They differ per install. `servers` is
+  the only supported source.
+- **The request field is `rootFolder`, not `rootFolderPath`.** The script sends
+  the right one; Seerr silently ignores an unknown key and files the request
+  under the default folder, which looks like success.
+- **Do not build query strings by hand.** The script percent-encodes them; a
+  title such as `Tom & Jerry` would otherwise break the query on the bare `&`.
+- **Season 0 is Specials** and is excluded from `seasons` output.
+- **A request is not a download.** A `pending` request may be awaiting approval
+  in Seerr; say so rather than reporting it as downloading.
+- Requesting a title that already exists returns HTTP 409 from Seerr; treat it
+  as "already requested", not as an error to retry.
+
+## Verification
+
+```
+python3 scripts/seerr.py servers radarr
+```
+
+A list of servers with root folders means the URL and API key are good. A
+`SEERR_URL is not set` or HTTP 401 error means the environment is not loaded.
+
+Tests: `scripts/run_tests.sh tests/skills/test_seerr_skill.py -q`

--- a/skills/media/seerr/SKILL.md
+++ b/skills/media/seerr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: seerr
 description: Request movies and TV shows for your media server.
-version: 2.0.0
+version: 3.0.0
 author: nyakojiru (https://github.com/nyakojiru), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -15,41 +15,40 @@ metadata:
         prompt: Seerr base URL
         default: http://localhost:5055
 required_environment_variables:
-  - name: SEERR_API_KEY
-    prompt: Seerr API key
-    help: Seerr -> Settings -> General -> API Key
-    required_for: Every Seerr call
   - name: SEERR_URL
     prompt: Seerr base URL (e.g. http://localhost:5055)
     help: The URL you open Seerr on. Also settable as skills.config.seerr.url in config.yaml.
+    required_for: Every Seerr call
+  - name: SEERR_API_KEY
+    prompt: Seerr API key
+    help: Seerr -> Settings -> General -> API Key
     required_for: Every Seerr call
 ---
 
 # Seerr Skill
 
-Search a media catalogue and submit movie/TV requests to [Seerr](https://github.com/seerr-team/seerr),
-the request manager that Overseerr and Jellyseerr merged into. Seerr is the only
-service this skill talks to — it proxies Radarr and Sonarr, so root folders,
-quality profiles and download progress all come from Seerr and no Radarr/Sonarr
-credentials are needed.
+Conversational media-request assistant for [Seerr](https://github.com/seerr-team/seerr),
+the request manager that Overseerr and Jellyseerr merged into. Search a title,
+pick a library, submit the request, and report download progress back.
 
-This skill submits requests. It does not approve them, manage users, or move
-files — do that in the Seerr web UI.
+Seerr proxies Radarr and Sonarr, so root folders, quality profiles and download
+progress all come from Seerr — no Radarr/Sonarr credentials are needed for the
+core flow. This skill submits requests; it does not approve them or manage users.
 
 ## When to Use
 
-- Someone asks to watch, download, get, or request a movie or TV show.
-- Someone asks whether a previously requested title has finished downloading.
-- Someone asks what has been requested recently.
+- Someone wants to watch, download, get, or request a movie or TV show.
+- Someone asks whether something they requested has finished downloading.
+- Someone asks how much disk space is left.
 
 ## When NOT to Use
 
-- Approving or denying requests, or changing permissions — use the Seerr UI.
-- Direct Radarr/Sonarr administration (indexers, custom formats, disk space).
+- Approving/denying requests or changing permissions — use the Seerr web UI.
+- Radarr/Sonarr administration (indexers, custom formats, quality definitions).
 
 ## Prerequisites
 
-- A reachable Seerr server (v1+), with Radarr and/or Sonarr already connected to it.
+- A reachable Seerr server with Radarr and/or Sonarr already connected to it.
 - `SEERR_URL` and `SEERR_API_KEY` in the environment. Copy the block from
   `.env.example` into your `.env` and fill it in — that file is dotenv
   (`KEY=value`), not YAML.
@@ -62,95 +61,104 @@ files — do that in the Seerr web UI.
   ```
 
   Keep `SEERR_API_KEY` out of `config.yaml`; secrets belong in `.env`.
+- **Optional** — `RADARR_URL` / `RADARR_API_KEY` and `SONARR_URL` /
+  `SONARR_API_KEY`. These are needed *only* for `diskspace` and `queue`, the two
+  things Seerr cannot report. Everything else works without them.
 - Python 3.9+ (stdlib only).
+
+If Hermes has not exported the variables into the shell, `scripts/seerr.py`
+falls back to sourcing `~/.hermes/.env` on its own, so it also works when run
+by hand.
 
 ## How to Run
 
-Run every call with the `terminal` tool, from the skill directory:
+Use the `terminal` tool. `scripts/seerr.py` is the **only** API surface — never
+construct a curl command inline; the script handles percent-encoding, headers,
+the correct request fields, and response parsing.
 
 ```
 python3 scripts/seerr.py <command> [options]
 ```
 
-Add `--json` to any command for the raw API payload. The script exits non-zero
-and prints a one-line `error:` on failure.
+Add `--json` to any command for the raw payload. The script exits non-zero and
+prints a one-line `error:` on failure.
 
 ## Quick Reference
 
 | Command | Purpose |
 |---|---|
-| `search "<title>" [--type movie\|tv]` | Numbered search results with TMDB ids |
+| `search "<title>" [--type movie\|tv]` | Numbered results with TMDB ids |
 | `servers radarr\|sonarr` | Servers, **root folders**, quality profiles |
-| `seasons <tmdb_id>` | Season list for a show (Specials excluded) |
+| `seasons <tmdb_id>` | Season list (Specials excluded) |
 | `request --type movie --tmdb-id <id> [--root-folder <path>]` | Request a movie |
 | `request --type tv --tmdb-id <id> --seasons 1,2\|all [--root-folder <path>]` | Request a show |
 | `status [--take N]` | Recent requests with download progress |
+| `diskspace [--service radarr\|sonarr]` | Free space (needs Radarr/Sonarr creds) |
+| `queue [--service radarr\|sonarr]` | Per-item queue detail (needs Radarr/Sonarr creds) |
 
-## Procedure
+## Root Folders — always fetch, never hardcode
 
-### 1. Search
-
-```
-python3 scripts/seerr.py search "the bear"
-```
-
-Results are numbered and carry a TMDB id. Titles already in the library are
-flagged `[already in library]` — say so rather than re-requesting.
-
-If several results plausibly match, show the numbered list and ask which one.
-If exactly one matches, confirm it in one line before requesting.
-
-### 2. Choose a root folder (only when the user needs a specific library)
-
-Seerr routes a request to its default root folder on its own. Only ask about
-root folders when the user wants a specific library, or when the server exposes
-more than one and the destination is ambiguous.
+Root folders differ per install, and are often **per-person libraries** mapping
+1:1 to a media-server library. Never keep a table of paths in this file; they go
+stale. Ask Seerr:
 
 ```
 python3 scripts/seerr.py servers radarr
 ```
 
-This prints the real root-folder paths straight from Radarr/Sonarr. Never
-invent a path or hard-code one in this file: present what the command returns
-and let the user pick, then pass it through with `--root-folder`.
+Present what it returns as a numbered list, let the user pick, then pass their
+choice through with `--root-folder`.
 
-### 3. For TV, get the seasons
+Seerr routes to a default root folder on its own, and may apply per-user
+override rules. Only ask about root folders when the destination is ambiguous or
+the user wants a specific library.
 
-```
-python3 scripts/seerr.py seasons 136315
-```
+## Procedure
 
-Ask which seasons they want, then pass `--seasons 1,2` or `--seasons all`.
+1. **Search.** `search "the bear"` — results are numbered and carry a TMDB id.
+   Anything flagged `[already in library]` is already there; say so instead of
+   re-requesting.
+2. **Disambiguate.** Several plausible matches → show the numbered list and ask.
+   Exactly one → confirm it in a single line.
+3. **Pick the library** with `servers`, when it matters.
+4. **TV only — pick seasons.** `seasons <tmdb_id>`, then pass `--seasons 1,2` or
+   `--seasons all`.
+5. **Submit,** then confirm the outcome in one short message.
 
-### 4. Submit
+## Personality
 
-```
-python3 scripts/seerr.py request --type tv --tmdb-id 136315 --seasons all
-python3 scripts/seerr.py request --type movie --tmdb-id 27205 --root-folder /movies
-```
+Users usually reach this skill from a messaging platform (WhatsApp, Telegram,
+Discord), so write for a chat window:
 
-### 5. Report back
+- Emojis for structure (🎬 movies, 📺 TV, ✅ done, ❌ error, 🔍 searching)
+- `*bold*` for titles and key info
+- Short messages — no markdown headers, no bullet dashes, no code blocks
+- Multiple results → numbered list, ask the user to pick
+- Confirm before submitting if there is any ambiguity
+- Always state the outcome clearly
 
-Confirm what was requested in one short line. For progress:
+## What NEVER to send to the user
 
-```
-python3 scripts/seerr.py status --take 5
-```
+- Never show terminal commands, script output, raw JSON, or tool-call results.
+- Never show debugging detail, HTTP status codes, or internal logic.
+- Never send a message while a tool call is running — one final message per action.
+- Every message costs the user attention. Only send meaningful replies.
 
 ## Pitfalls
 
-- **Never hard-code root-folder paths.** They differ per install. `servers` is
-  the only supported source.
-- **The request field is `rootFolder`, not `rootFolderPath`.** The script sends
-  the right one; Seerr silently ignores an unknown key and files the request
-  under the default folder, which looks like success.
+- **Never hardcode a root-folder path.** `servers` is the only supported source.
+- **The request field is `rootFolder`, not `rootFolderPath`.** Seerr silently
+  ignores an unknown key and files the request under the default folder — it
+  looks exactly like success while landing in the wrong library.
+- **Seerr has per-user override rules.** With no `--root-folder`, a request lands
+  in the requesting user's override folder, not necessarily the global default.
 - **Do not build query strings by hand.** The script percent-encodes them; a
   title such as `Tom & Jerry` would otherwise break the query on the bare `&`.
 - **Season 0 is Specials** and is excluded from `seasons` output.
-- **A request is not a download.** A `pending` request may be awaiting approval
-  in Seerr; say so rather than reporting it as downloading.
-- Requesting a title that already exists returns HTTP 409 from Seerr; treat it
-  as "already requested", not as an error to retry.
+- **A request is not a download.** A pending request may await approval in Seerr.
+- `mediaId` in a request is the **tmdbId** from search — not a Radarr/Sonarr id.
+- Requesting a title that already exists reports "already requested" (HTTP 409);
+  that is not an error to retry.
 
 ## Verification
 
@@ -158,7 +166,7 @@ python3 scripts/seerr.py status --take 5
 python3 scripts/seerr.py servers radarr
 ```
 
-A list of servers with root folders means the URL and API key are good. A
-`SEERR_URL is not set` or HTTP 401 error means the environment is not loaded.
+Root folders listed → the URL and API key are good. `SEERR_URL is not set` or a
+401 means the environment is not loaded.
 
 Tests: `scripts/run_tests.sh tests/skills/test_seerr_skill.py -q`

--- a/skills/media/seerr/scripts/seerr.py
+++ b/skills/media/seerr/scripts/seerr.py
@@ -2,12 +2,15 @@
 """Seerr API client for the seerr skill.
 
 Talks to a Seerr server (https://github.com/seerr-team/seerr — the project that
-Overseerr and Jellyseerr merged into). Seerr is the single integration point:
-it proxies Radarr/Sonarr, so root folders, quality profiles and download
-progress all come from Seerr and no Radarr/Sonarr credentials are needed.
+Overseerr and Jellyseerr merged into). Seerr proxies Radarr and Sonarr, so root
+folders, quality profiles and download progress all come from Seerr.
 
-Stdlib only. Reads SEERR_URL and SEERR_API_KEY from the environment; both can
-be overridden with --url / --api-key.
+Radarr/Sonarr credentials are OPTIONAL and only needed for the two things Seerr
+cannot report: `diskspace` and per-item `queue` detail.
+
+Stdlib only. Configuration comes from the environment; when a variable is absent
+we fall back to sourcing ~/.hermes/.env, because Hermes does not always export a
+skill's variables into the terminal tool's environment.
 """
 
 from __future__ import annotations
@@ -15,42 +18,68 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import pathlib
 import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import Any
 
 DEFAULT_TIMEOUT = 20
-API_PREFIX = "/api/v1"
+SEERR_API_PREFIX = "/api/v1"
+ARR_API_PREFIX = "/api/v3"
 
 
 class SeerrError(RuntimeError):
     """A user-facing error: bad config, HTTP failure, or unusable response."""
 
 
-# ── HTTP ──────────────────────────────────────────────────────────────────
+# ── Configuration ─────────────────────────────────────────────────────────
+
+_ENV_LOADED = False
 
 
-def _base_url(explicit: str | None = None) -> str:
-    url = (explicit or os.environ.get("SEERR_URL") or "").strip()
-    if not url:
-        raise SeerrError(
-            "SEERR_URL is not set. Point it at your Seerr server, "
-            "e.g. http://localhost:5055"
-        )
+def _load_dotenv() -> None:
+    """Populate os.environ from ~/.hermes/.env for variables Hermes did not export.
+
+    Existing environment variables always win; only missing keys are filled in.
+    """
+    global _ENV_LOADED
+    if _ENV_LOADED:
+        return
+    _ENV_LOADED = True
+
+    try:
+        raw = (pathlib.Path.home() / ".hermes" / ".env").read_text(encoding="utf-8")
+    except OSError:
+        return
+
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip().removeprefix("export ").strip()
+        if key and key not in os.environ:
+            os.environ[key] = value.strip().strip("'\"")
+
+
+def _require(name: str, explicit: str | None = None, *, hint: str = "") -> str:
+    _load_dotenv()
+    value = (explicit or os.environ.get(name) or "").strip()
+    if not value:
+        raise SeerrError(f"{name} is not set.{' ' + hint if hint else ''}")
+    return value
+
+
+def _base_url(name: str, explicit: str | None = None, *, hint: str = "") -> str:
+    url = _require(name, explicit, hint=hint)
     if not url.startswith(("http://", "https://")):
-        raise SeerrError(f"SEERR_URL must start with http:// or https:// (got {url!r})")
+        raise SeerrError(f"{name} must start with http:// or https:// (got {url!r})")
     return url.rstrip("/")
 
 
-def _api_key(explicit: str | None = None) -> str:
-    key = (explicit or os.environ.get("SEERR_API_KEY") or "").strip()
-    if not key:
-        raise SeerrError(
-            "SEERR_API_KEY is not set. Find it in Seerr under "
-            "Settings -> General -> API Key."
-        )
-    return key
+# ── HTTP ──────────────────────────────────────────────────────────────────
 
 
 def _encode_params(params: dict) -> str:
@@ -64,23 +93,21 @@ def _encode_params(params: dict) -> str:
     return urllib.parse.urlencode(clean, quote_via=urllib.parse.quote)
 
 
-def api(
-    path: str,
+def _call(
+    endpoint: str,
+    api_key: str,
     *,
     method: str = "GET",
     params: dict | None = None,
     body: dict | None = None,
-    url: str | None = None,
-    api_key: str | None = None,
     timeout: int = DEFAULT_TIMEOUT,
-) -> dict:
-    endpoint = f"{_base_url(url)}{API_PREFIX}/{path.lstrip('/')}"
+) -> Any:
     if params:
         endpoint = f"{endpoint}?{_encode_params(params)}"
 
     data = json.dumps(body).encode("utf-8") if body is not None else None
     request = urllib.request.Request(endpoint, data=data, method=method)
-    request.add_header("X-Api-Key", _api_key(api_key))
+    request.add_header("X-Api-Key", api_key)
     request.add_header("Accept", "application/json")
     if data is not None:
         request.add_header("Content-Type", "application/json")
@@ -92,23 +119,37 @@ def api(
         detail = ""
         try:
             detail = exc.read().decode("utf-8", "replace")[:300]
-        except Exception:  # noqa: BLE001 - error body is best-effort
+        except Exception:  # noqa: BLE001 - the error body is best-effort
             pass
         if exc.code in (401, 403):
-            raise SeerrError(
-                "Seerr rejected the API key (HTTP "
-                f"{exc.code}). Check SEERR_API_KEY."
-            ) from exc
-        raise SeerrError(f"Seerr returned HTTP {exc.code}. {detail}".strip()) from exc
+            raise SeerrError(f"API key rejected (HTTP {exc.code}).") from exc
+        if exc.code == 409:
+            raise SeerrError("Already requested — this title is in Seerr already.") from exc
+        raise SeerrError(f"HTTP {exc.code}. {detail}".strip()) from exc
     except urllib.error.URLError as exc:
-        raise SeerrError(f"Cannot reach Seerr at {_base_url(url)}: {exc.reason}") from exc
+        raise SeerrError(f"Cannot reach {endpoint}: {exc.reason}") from exc
 
     if not raw.strip():
         return {}
     try:
         return json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise SeerrError("Seerr returned a non-JSON response.") from exc
+        raise SeerrError("Server returned a non-JSON response.") from exc
+
+
+def seerr(path: str, args, **kwargs) -> Any:
+    url = _base_url("SEERR_URL", args.url, hint="Point it at your Seerr server.")
+    key = _require("SEERR_API_KEY", args.api_key, hint="Seerr -> Settings -> General -> API Key.")
+    return _call(f"{url}{SEERR_API_PREFIX}/{path.lstrip('/')}", key, **kwargs)
+
+
+def arr(service: str, path: str, **kwargs) -> Any:
+    """Call Radarr/Sonarr directly. Only used by `diskspace` and `queue`."""
+    prefix = service.upper()
+    hint = f"Needed only for `{prefix.lower()}` disk-space and queue detail."
+    url = _base_url(f"{prefix}_URL", None, hint=hint)
+    key = _require(f"{prefix}_API_KEY", None, hint=hint)
+    return _call(f"{url}{ARR_API_PREFIX}/{path.lstrip('/')}", key, **kwargs)
 
 
 # ── Formatting ────────────────────────────────────────────────────────────
@@ -123,25 +164,23 @@ def _title(item: dict) -> str:
     return item.get("title") or item.get("name") or "Untitled"
 
 
+def _gb(value: float) -> str:
+    return f"{value / 1e9:.1f} GB"
+
+
 def _progress(entry: dict) -> str:
     size = entry.get("size") or 0
     left = entry.get("sizeLeft")
     if not size or left is None:
         return entry.get("status") or "downloading"
-    done = 100.0 * (size - left) / size
-    return f"{done:.0f}% ({entry.get('status') or 'downloading'})"
+    return f"{100.0 * (size - left) / size:.0f}% ({entry.get('status') or 'downloading'})"
 
 
 # ── Commands ──────────────────────────────────────────────────────────────
 
 
 def cmd_search(args) -> int:
-    payload = api(
-        "search",
-        params={"query": args.query, "page": args.page},
-        url=args.url,
-        api_key=args.api_key,
-    )
+    payload = seerr("search", args, params={"query": args.query, "page": args.page})
     results = [
         item
         for item in payload.get("results", [])
@@ -157,7 +196,7 @@ def cmd_search(args) -> int:
         return 0
 
     for index, item in enumerate(results, start=1):
-        kind = "movie" if item.get("mediaType") == "movie" else "tv"
+        kind = item.get("mediaType")
         status = (item.get("mediaInfo") or {}).get("status")
         flag = " [already in library]" if status in (3, 4, 5) else ""
         print(f"{index}. {_title(item)} ({_year(item)}) - {kind} - tmdb:{item.get('id')}{flag}")
@@ -165,33 +204,25 @@ def cmd_search(args) -> int:
 
 
 def cmd_servers(args) -> int:
-    """List Radarr/Sonarr servers with their root folders and quality profiles.
+    """List servers with their root folders and quality profiles.
 
     This is the supported way to discover a concrete rootFolder value: Seerr
     reads it from the Servarr instance, so nothing has to be hand-configured.
     """
-    servers = api(f"service/{args.service}", url=args.url, api_key=args.api_key)
+    servers = seerr(f"service/{args.service}", args)
     if isinstance(servers, dict):
-        servers = servers.get("servers", servers) or []
+        servers = servers.get("servers", []) or []
 
-    detailed = []
-    for server in servers:
-        info = api(
-            f"service/{args.service}/{server.get('id')}",
-            url=args.url,
-            api_key=args.api_key,
-        )
-        detailed.append({"server": server, "details": info})
+    detailed = [(s, seerr(f"service/{args.service}/{s.get('id')}", args)) for s in servers]
 
     if args.json:
-        print(json.dumps(detailed, indent=2))
+        print(json.dumps([{"server": s, "details": d} for s, d in detailed], indent=2))
         return 0
     if not detailed:
         print(f"No {args.service} servers configured in Seerr.")
         return 0
 
-    for entry in detailed:
-        server, info = entry["server"], entry["details"]
+    for server, info in detailed:
         default = " (default)" if server.get("isDefault") else ""
         fourk = " [4K]" if server.get("is4k") else ""
         print(f"server {server.get('id')}: {server.get('name')}{default}{fourk}")
@@ -203,20 +234,16 @@ def cmd_servers(args) -> int:
 
 
 def cmd_seasons(args) -> int:
-    payload = api(f"tv/{args.tmdb_id}", url=args.url, api_key=args.api_key)
-    seasons = [
-        season
-        for season in payload.get("seasons", [])
-        if season.get("seasonNumber", 0) > 0  # season 0 is Specials
-    ]
+    payload = seerr(f"tv/{args.tmdb_id}", args)
+    seasons = [s for s in payload.get("seasons", []) if s.get("seasonNumber", 0) > 0]
+
     if args.json:
         print(json.dumps(seasons, indent=2))
         return 0
 
     print(f"{payload.get('name') or 'Unknown'} ({_year(payload)})")
     for season in seasons:
-        episodes = season.get("episodeCount") or 0
-        print(f"  season {season.get('seasonNumber')}: {episodes} episodes")
+        print(f"  season {season.get('seasonNumber')}: {season.get('episodeCount') or 0} episodes")
     return 0
 
 
@@ -234,8 +261,9 @@ def cmd_request(args) -> int:
             except ValueError as exc:
                 raise SeerrError(f"--seasons must be numbers or 'all' (got {args.seasons!r}).") from exc
 
-    # Seerr's request body field is `rootFolder` -- NOT `rootFolderPath`.
-    # A wrong key is silently ignored and the request lands in the default folder.
+    # Seerr's request-body field is `rootFolder` -- NOT `rootFolderPath`.
+    # An unknown key is silently ignored and the request lands in the default
+    # folder, which looks exactly like success.
     if args.root_folder:
         body["rootFolder"] = args.root_folder
     if args.server_id is not None:
@@ -243,7 +271,7 @@ def cmd_request(args) -> int:
     if args.profile_id is not None:
         body["profileId"] = args.profile_id
 
-    payload = api("request", method="POST", body=body, url=args.url, api_key=args.api_key)
+    payload = seerr("request", args, method="POST", body=body)
     if args.json:
         print(json.dumps(payload, indent=2))
         return 0
@@ -257,13 +285,9 @@ def cmd_request(args) -> int:
 
 
 def cmd_status(args) -> int:
-    payload = api(
-        "request",
-        params={"take": args.take, "sort": "added"},
-        url=args.url,
-        api_key=args.api_key,
-    )
+    payload = seerr("request", args, params={"take": args.take, "sort": "added"})
     results = payload.get("results", [])
+
     if args.json:
         print(json.dumps(results, indent=2))
         return 0
@@ -274,11 +298,40 @@ def cmd_status(args) -> int:
     for entry in results:
         media = entry.get("media") or {}
         downloads = media.get("downloadStatus") or []
+        detail = _progress(downloads[0]) if downloads else f"status {media.get('status')}"
         label = f"request {entry.get('id')}: tmdb:{media.get('tmdbId')} ({media.get('mediaType')})"
-        if downloads:
-            print(f"{label} - {_progress(downloads[0])}")
-        else:
-            print(f"{label} - status {media.get('status')}")
+        print(f"{label} - {detail}")
+    return 0
+
+
+def cmd_diskspace(args) -> int:
+    """Free space. Seerr does not expose this — ask Radarr/Sonarr directly."""
+    mounts = arr(args.service, "diskspace")
+    if args.json:
+        print(json.dumps(mounts, indent=2))
+        return 0
+    for mount in mounts:
+        free, total = mount.get("freeSpace", 0), mount.get("totalSpace", 0)
+        print(f"{mount.get('path'):<30} {_gb(free)} free / {_gb(total)} total")
+    return 0
+
+
+def cmd_queue(args) -> int:
+    """Per-item download queue detail, which Seerr summarises but does not itemise."""
+    payload = arr(args.service, "queue", params={"pageSize": args.take})
+    records = payload.get("records", []) if isinstance(payload, dict) else payload
+
+    if args.json:
+        print(json.dumps(records, indent=2))
+        return 0
+    if not records:
+        print("Queue is empty.")
+        return 0
+
+    for item in records:
+        size, left = item.get("size") or 0, item.get("sizeleft")
+        done = f"{100.0 * (size - left) / size:.0f}%" if size and left is not None else "?"
+        print(f"{item.get('title', 'Unknown')[:50]:<52} {done:>5}  {item.get('status', '')}")
     return 0
 
 
@@ -299,7 +352,7 @@ def build_parser() -> argparse.ArgumentParser:
     search.add_argument("--page", type=int, default=1)
     search.set_defaults(func=cmd_search)
 
-    servers = sub.add_parser("servers", help="List servers, root folders and profiles")
+    servers = sub.add_parser("servers", help="Servers, root folders and quality profiles")
     servers.add_argument("service", choices=["radarr", "sonarr"])
     servers.set_defaults(func=cmd_servers)
 
@@ -319,6 +372,15 @@ def build_parser() -> argparse.ArgumentParser:
     status = sub.add_parser("status", help="Recent requests and download progress")
     status.add_argument("--take", type=int, default=10)
     status.set_defaults(func=cmd_status)
+
+    diskspace = sub.add_parser("diskspace", help="Free space (needs Radarr/Sonarr creds)")
+    diskspace.add_argument("--service", choices=["radarr", "sonarr"], default="radarr")
+    diskspace.set_defaults(func=cmd_diskspace)
+
+    queue = sub.add_parser("queue", help="Per-item queue detail (needs Radarr/Sonarr creds)")
+    queue.add_argument("--service", choices=["radarr", "sonarr"], default="radarr")
+    queue.add_argument("--take", type=int, default=20)
+    queue.set_defaults(func=cmd_queue)
 
     return parser
 

--- a/skills/media/seerr/scripts/seerr.py
+++ b/skills/media/seerr/scripts/seerr.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Seerr API client for the seerr skill.
+
+Talks to a Seerr server (https://github.com/seerr-team/seerr — the project that
+Overseerr and Jellyseerr merged into). Seerr is the single integration point:
+it proxies Radarr/Sonarr, so root folders, quality profiles and download
+progress all come from Seerr and no Radarr/Sonarr credentials are needed.
+
+Stdlib only. Reads SEERR_URL and SEERR_API_KEY from the environment; both can
+be overridden with --url / --api-key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_TIMEOUT = 20
+API_PREFIX = "/api/v1"
+
+
+class SeerrError(RuntimeError):
+    """A user-facing error: bad config, HTTP failure, or unusable response."""
+
+
+# ── HTTP ──────────────────────────────────────────────────────────────────
+
+
+def _base_url(explicit: str | None = None) -> str:
+    url = (explicit or os.environ.get("SEERR_URL") or "").strip()
+    if not url:
+        raise SeerrError(
+            "SEERR_URL is not set. Point it at your Seerr server, "
+            "e.g. http://localhost:5055"
+        )
+    if not url.startswith(("http://", "https://")):
+        raise SeerrError(f"SEERR_URL must start with http:// or https:// (got {url!r})")
+    return url.rstrip("/")
+
+
+def _api_key(explicit: str | None = None) -> str:
+    key = (explicit or os.environ.get("SEERR_API_KEY") or "").strip()
+    if not key:
+        raise SeerrError(
+            "SEERR_API_KEY is not set. Find it in Seerr under "
+            "Settings -> General -> API Key."
+        )
+    return key
+
+
+def _encode_params(params: dict) -> str:
+    """Percent-encode a query string.
+
+    quote_via=quote (not the default quote_plus) so a space becomes %20 rather
+    than '+', and every reserved character is escaped: a title like
+    'Tom & Jerry' must not smuggle a bare '&' into the query string.
+    """
+    clean = {k: v for k, v in params.items() if v is not None and v != ""}
+    return urllib.parse.urlencode(clean, quote_via=urllib.parse.quote)
+
+
+def api(
+    path: str,
+    *,
+    method: str = "GET",
+    params: dict | None = None,
+    body: dict | None = None,
+    url: str | None = None,
+    api_key: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    endpoint = f"{_base_url(url)}{API_PREFIX}/{path.lstrip('/')}"
+    if params:
+        endpoint = f"{endpoint}?{_encode_params(params)}"
+
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(endpoint, data=data, method=method)
+    request.add_header("X-Api-Key", _api_key(api_key))
+    request.add_header("Accept", "application/json")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:300]
+        except Exception:  # noqa: BLE001 - error body is best-effort
+            pass
+        if exc.code in (401, 403):
+            raise SeerrError(
+                "Seerr rejected the API key (HTTP "
+                f"{exc.code}). Check SEERR_API_KEY."
+            ) from exc
+        raise SeerrError(f"Seerr returned HTTP {exc.code}. {detail}".strip()) from exc
+    except urllib.error.URLError as exc:
+        raise SeerrError(f"Cannot reach Seerr at {_base_url(url)}: {exc.reason}") from exc
+
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SeerrError("Seerr returned a non-JSON response.") from exc
+
+
+# ── Formatting ────────────────────────────────────────────────────────────
+
+
+def _year(item: dict) -> str:
+    date = item.get("releaseDate") or item.get("firstAirDate") or ""
+    return date[:4] if date else "----"
+
+
+def _title(item: dict) -> str:
+    return item.get("title") or item.get("name") or "Untitled"
+
+
+def _progress(entry: dict) -> str:
+    size = entry.get("size") or 0
+    left = entry.get("sizeLeft")
+    if not size or left is None:
+        return entry.get("status") or "downloading"
+    done = 100.0 * (size - left) / size
+    return f"{done:.0f}% ({entry.get('status') or 'downloading'})"
+
+
+# ── Commands ──────────────────────────────────────────────────────────────
+
+
+def cmd_search(args) -> int:
+    payload = api(
+        "search",
+        params={"query": args.query, "page": args.page},
+        url=args.url,
+        api_key=args.api_key,
+    )
+    results = [
+        item
+        for item in payload.get("results", [])
+        if item.get("mediaType") in ("movie", "tv")
+        and (args.type is None or item.get("mediaType") == args.type)
+    ][: args.limit]
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return 0
+    if not results:
+        print(f"No movie or TV results for {args.query!r}.")
+        return 0
+
+    for index, item in enumerate(results, start=1):
+        kind = "movie" if item.get("mediaType") == "movie" else "tv"
+        status = (item.get("mediaInfo") or {}).get("status")
+        flag = " [already in library]" if status in (3, 4, 5) else ""
+        print(f"{index}. {_title(item)} ({_year(item)}) - {kind} - tmdb:{item.get('id')}{flag}")
+    return 0
+
+
+def cmd_servers(args) -> int:
+    """List Radarr/Sonarr servers with their root folders and quality profiles.
+
+    This is the supported way to discover a concrete rootFolder value: Seerr
+    reads it from the Servarr instance, so nothing has to be hand-configured.
+    """
+    servers = api(f"service/{args.service}", url=args.url, api_key=args.api_key)
+    if isinstance(servers, dict):
+        servers = servers.get("servers", servers) or []
+
+    detailed = []
+    for server in servers:
+        info = api(
+            f"service/{args.service}/{server.get('id')}",
+            url=args.url,
+            api_key=args.api_key,
+        )
+        detailed.append({"server": server, "details": info})
+
+    if args.json:
+        print(json.dumps(detailed, indent=2))
+        return 0
+    if not detailed:
+        print(f"No {args.service} servers configured in Seerr.")
+        return 0
+
+    for entry in detailed:
+        server, info = entry["server"], entry["details"]
+        default = " (default)" if server.get("isDefault") else ""
+        fourk = " [4K]" if server.get("is4k") else ""
+        print(f"server {server.get('id')}: {server.get('name')}{default}{fourk}")
+        for folder in info.get("rootFolders") or []:
+            print(f"  root folder: {folder.get('path')}")
+        for profile in info.get("profiles") or []:
+            print(f"  profile {profile.get('id')}: {profile.get('name')}")
+    return 0
+
+
+def cmd_seasons(args) -> int:
+    payload = api(f"tv/{args.tmdb_id}", url=args.url, api_key=args.api_key)
+    seasons = [
+        season
+        for season in payload.get("seasons", [])
+        if season.get("seasonNumber", 0) > 0  # season 0 is Specials
+    ]
+    if args.json:
+        print(json.dumps(seasons, indent=2))
+        return 0
+
+    print(f"{payload.get('name') or 'Unknown'} ({_year(payload)})")
+    for season in seasons:
+        episodes = season.get("episodeCount") or 0
+        print(f"  season {season.get('seasonNumber')}: {episodes} episodes")
+    return 0
+
+
+def cmd_request(args) -> int:
+    body: dict = {"mediaType": args.type, "mediaId": args.tmdb_id}
+
+    if args.type == "tv":
+        if not args.seasons:
+            raise SeerrError("A TV request needs --seasons (e.g. --seasons 1,2 or --seasons all).")
+        if args.seasons.strip().lower() == "all":
+            body["seasons"] = "all"
+        else:
+            try:
+                body["seasons"] = [int(s) for s in args.seasons.split(",") if s.strip()]
+            except ValueError as exc:
+                raise SeerrError(f"--seasons must be numbers or 'all' (got {args.seasons!r}).") from exc
+
+    # Seerr's request body field is `rootFolder` -- NOT `rootFolderPath`.
+    # A wrong key is silently ignored and the request lands in the default folder.
+    if args.root_folder:
+        body["rootFolder"] = args.root_folder
+    if args.server_id is not None:
+        body["serverId"] = args.server_id
+    if args.profile_id is not None:
+        body["profileId"] = args.profile_id
+
+    payload = api("request", method="POST", body=body, url=args.url, api_key=args.api_key)
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    media = payload.get("media") or {}
+    print(
+        f"Requested: {args.type} tmdb:{args.tmdb_id} "
+        f"(request id {payload.get('id')}, status {media.get('status', 'pending')})"
+    )
+    return 0
+
+
+def cmd_status(args) -> int:
+    payload = api(
+        "request",
+        params={"take": args.take, "sort": "added"},
+        url=args.url,
+        api_key=args.api_key,
+    )
+    results = payload.get("results", [])
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return 0
+    if not results:
+        print("No requests found.")
+        return 0
+
+    for entry in results:
+        media = entry.get("media") or {}
+        downloads = media.get("downloadStatus") or []
+        label = f"request {entry.get('id')}: tmdb:{media.get('tmdbId')} ({media.get('mediaType')})"
+        if downloads:
+            print(f"{label} - {_progress(downloads[0])}")
+        else:
+            print(f"{label} - status {media.get('status')}")
+    return 0
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="seerr.py", description=__doc__)
+    parser.add_argument("--url", help="Seerr base URL (default: $SEERR_URL)")
+    parser.add_argument("--api-key", help="Seerr API key (default: $SEERR_API_KEY)")
+    parser.add_argument("--json", action="store_true", help="Emit raw JSON")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    search = sub.add_parser("search", help="Search movies and TV shows")
+    search.add_argument("query")
+    search.add_argument("--type", choices=["movie", "tv"])
+    search.add_argument("--limit", type=int, default=8)
+    search.add_argument("--page", type=int, default=1)
+    search.set_defaults(func=cmd_search)
+
+    servers = sub.add_parser("servers", help="List servers, root folders and profiles")
+    servers.add_argument("service", choices=["radarr", "sonarr"])
+    servers.set_defaults(func=cmd_servers)
+
+    seasons = sub.add_parser("seasons", help="List seasons for a TV show")
+    seasons.add_argument("tmdb_id", type=int)
+    seasons.set_defaults(func=cmd_seasons)
+
+    request = sub.add_parser("request", help="Submit a request")
+    request.add_argument("--type", choices=["movie", "tv"], required=True)
+    request.add_argument("--tmdb-id", type=int, required=True)
+    request.add_argument("--seasons", help="TV only: '1,2' or 'all'")
+    request.add_argument("--root-folder", help="Path from `servers` output")
+    request.add_argument("--server-id", type=int)
+    request.add_argument("--profile-id", type=int)
+    request.set_defaults(func=cmd_request)
+
+    status = sub.add_parser("status", help="Recent requests and download progress")
+    status.add_argument("--take", type=int, default=10)
+    status.set_defaults(func=cmd_status)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except SeerrError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/smart-home/overseerr/SKILL.md
+++ b/skills/smart-home/overseerr/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: overseerr
+description: Request movies and TV shows via Overseerr. Search by title, handle ambiguity conversationally, and submit requests to your local Servarr stack (Radarr/Sonarr). Works with any messaging platform.
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [overseerr, movies, tv, plex, servarr, media, radarr, sonarr]
+    category: smart-home
+---
+
+# Overseerr — Media Request Bot
+
+You are a conversational media request assistant. When a user wants to watch, download, get, or request any movie or TV show, use the Overseerr API to fulfil the request.
+
+## Configuration
+
+Before using this skill, set up your connection details:
+
+| Variable | Where to find it |
+|---|---|
+| `OVERSEERR_URL` | Overseerr running at `http://YOUR_IP:5055` |
+| `OVERSEERR_API_KEY` | Overseerr Settings → API Key |
+| `RADARR_URL` | Radarr running at `http://YOUR_IP:7878` |
+| `RADARR_API_KEY` | Radarr Settings → API Key |
+| `SONARR_URL` | Sonarr running at `http://YOUR_IP:8989` |
+| `SONARR_API_KEY` | Sonarr Settings → API Key |
+
+The skill uses `~/.hermes/config.yaml` or environment variables. See the setup section at the bottom.
+
+## Connection
+
+- Base URL: from `OVERSEERR_URL`
+- Auth header: `X-Api-Key` from `OVERSEERR_API_KEY`
+- All calls via curl from terminal.
+
+## Personality
+
+Be warm, concise, and messaging-platform-friendly:
+- Use emojis for visual structure (🎬 movies, 📺 TV, ✅ done, ❌ error, 🔍 searching)
+- Use *bold* for titles and key info
+- Keep messages short — no markdown headers, no bullet dashes, no code blocks
+- If there are multiple results, present them as a numbered list and ask the user to pick
+- Confirm the request before submitting if there is ambiguity
+- Always tell the user the outcome clearly
+
+## CRITICAL — What NEVER to send to the user
+
+- NEVER show terminal commands, curl output, raw JSON, or tool call results in your reply
+- NEVER show debugging info, errors from curl, HTTP status codes, or internal logic
+- NEVER send a message while a tool call is running — only send ONE final human message per action
+- The user is on WhatsApp/Telegram/etc. Every message costs attention. Only send meaningful conversational replies.
+
+## Root Folders
+
+Configure your Radarr/Sonarr root folders in the section at the bottom of this skill. The skill will present them as numbered options and let the user pick.
+
+### Movie root folders (Radarr)
+| ID | Path | Short name |
+|----|------|------------|
+| 1  | configured by user | movies (general) |
+| 2  | configured by user | movies_profile_2 |
+| ... | ... | ... |
+
+### TV show root folders (Sonarr)
+| ID | Path | Short name |
+|----|------|------------|
+| 1  | configured by user | shows (general) |
+| 2  | configured by user | shows_profile_2 |
+| ... | ... | ... |
+
+## Workflow
+
+### Step 1 — Search
+
+```bash
+curl -s -H "X-Api-Key: $OVERSEERR_API_KEY" \
+  "$OVERSEERR_URL/api/v1/search?query=ENCODED_TITLE" | \
+  python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+results=[]
+for r in d.get('results',[])[:6]:
+    results.append({
+        'id': r.get('id'),
+        'title': r.get('title') or r.get('name'),
+        'type': r.get('mediaType'),
+        'year': str(r.get('releaseDate') or r.get('firstAirDate') or '')[:4],
+        'status': (r.get('mediaInfo') or {}).get('status')
+    })
+print(json.dumps(results))
+"
+```
+
+URL-encode the query: replace spaces with `%20` ONLY. Overseerr rejects `+` and returns a validation error.
+
+### Step 2 — Reason about results
+
+- If 1 clear match: go straight to Step 3 with a confirmation message
+- If multiple plausible matches: show the list and ask the user to pick a number
+- If the user specified year/season/context: use that to narrow down automatically
+- If nothing found: tell the user and suggest an alternative spelling
+
+Status codes in mediaInfo:
+- null / missing = not in system
+- 1 = UNKNOWN
+- 2 = PENDING (request submitted, waiting)
+- 3 = PROCESSING (downloading)
+- 4 = PARTIALLY_AVAILABLE
+- 5 = AVAILABLE (already on Plex!)
+
+If status is 5 (AVAILABLE): tell the user it's already available — no need to request.
+If status is 2 or 3: tell the user it's already been requested and is being processed.
+
+### Step 3 — Ask for root folder (MANDATORY — never skip)
+
+Once the title is confirmed (or unambiguous), you MUST ask which folder to save it in.
+Do NOT submit the request until the user has answered this question.
+Do NOT assume or pick a default folder. Wait for the user's reply.
+
+For a *movie*, send something like:
+
+  📁 Which folder should I put it in?
+  1. movies (general)
+  2. movies_kids
+  3. movies_4k
+  ...
+
+For a *TV show*, send something like:
+
+  📁 Which folder should I put it in?
+  1. shows (general)
+  2. shows_kids
+  3. shows_4k
+  ...
+
+The user can reply with the number OR the short name. Map their reply to the correct root folder path.
+
+### Step 4 — For TV shows: get season info
+
+If the user didn't specify seasons, ask: all seasons or specific ones?
+
+Get season list:
+```bash
+curl -s -H "X-Api-Key: $OVERSEERR_API_KEY" \
+  "$OVERSEERR_URL/api/v1/tv/TMDB_ID" | \
+  python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+seasons=[s.get('seasonNumber') for s in d.get('seasons',[]) if s.get('seasonNumber',0)>0]
+print(json.dumps({'name':d.get('name'),'seasons':seasons,'mediaInfo':d.get('mediaInfo')}))
+"
+```
+
+Note: season 0 = Specials — skip it unless the user explicitly asks.
+
+Ask about folder and seasons in the same message to reduce back-and-forth:
+
+  📺 *The Bear* — found 3 seasons.
+  All seasons or just some?
+
+  📁 Which folder?
+  1. shows (general)
+  2. shows_kids
+  ...
+
+### Step 5 — Submit the request
+
+Only reach this step after the user has replied to the folder question.
+Include `rootFolderPath` in the request body.
+
+**Movie:**
+```bash
+curl -s -X POST \
+  -H "X-Api-Key: $OVERSEERR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"mediaType\":\"movie\",\"mediaId\":TMDB_ID,\"rootFolderPath\":\"/path/to/folder\"}" \
+  "$OVERSEERR_URL/api/v1/request"
+```
+
+**TV show (all seasons or specific):**
+```bash
+curl -s -X POST \
+  -H "X-Api-Key: $OVERSEERR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"mediaType\":\"tv\",\"mediaId\":TMDB_ID,\"seasons\":[1,2,3],\"rootFolderPath\":\"/path/to/folder\"}" \
+  "$OVERSEERR_URL/api/v1/request"
+```
+
+### Step 6 — Interpret the response
+
+- Success: response contains `"id"` and a `media` object
+- Error: response contains `"message"` — relay it to the user plainly
+
+On success:
+> ✅ *Dune: Part Two* has been requested! It should start downloading soon and land on Plex 🍿
+
+On "already requested" error:
+> 🔄 *Breaking Bad* is already in the queue — it'll be ready soon!
+
+## Example Conversations
+
+**User:** "quiero ver dune" (I want to watch Dune)
+You: search → find Dune (2021) and Dune: Part Two (2024) → ask which one → ask which movie folder → submit → confirm
+
+**User:** "the bear"
+You: search → find The Bear (TV) → ask folder + seasons in one message → submit → confirm
+
+**User:** "inception"
+You: search → 1 clear result → check if already available → ask which movie folder → submit
+
+**User:** "something by Christopher Nolan"
+You: search "Christopher Nolan" → list top results → ask which one → ask which movie folder → submit
+
+## Checking Download Status (Radarr + Sonarr)
+
+When a user asks "is it downloading?", "how long left?", "what's in the queue?", or "why isn't X ready yet?" — query Radarr/Sonarr directly, they have richer info than Overseerr.
+
+### Radarr (movies) — `RADARR_URL` / `RADARR_API_KEY`
+
+**Queue (active downloads):**
+```bash
+curl -s -H "X-Api-Key: $RADARR_API_KEY" \
+  "$RADARR_URL/api/v3/queue" | \
+  python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print('total:', d.get('totalRecords'))
+for r in d.get('records',[]):
+    sizeleft=round(r.get('sizeleft',0)/1e6,1)
+    print(r.get('title'), '|', r.get('status'), '|', sizeleft, 'MB left |', r.get('timeleft'), '| err:', r.get('errorMessage'))
+"
+```
+
+**Find a specific movie by tmdbId:**
+```bash
+curl -s -H "X-Api-Key: $RADARR_API_KEY" \
+  "$RADARR_URL/api/v3/movie?tmdbId=TMDB_ID"
+```
+Returns: `hasFile`, `monitored`, `status`, `path`, `sizeOnDisk`, `movieFile.quality`
+
+**Disk space:**
+```bash
+curl -s -H "X-Api-Key: $RADARR_API_KEY" \
+  "$RADARR_URL/api/v3/diskspace"
+```
+
+### Sonarr (TV shows) — `SONARR_URL` / `SONARR_API_KEY`
+
+**Queue (active downloads):**
+```bash
+curl -s -H "X-Api-Key: $SONARR_API_KEY" \
+  "$SONARR_URL/api/v3/queue" | \
+  python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print('total:', d.get('totalRecords'))
+for r in d.get('records',[]):
+    sizeleft=round(r.get('sizeleft',0)/1e6,1)
+    print(r.get('title','')[:50], '|', r.get('status'), '|', sizeleft, 'MB left |', r.get('timeleft'))
+"
+```
+
+**Find a series by tvdbId:**
+```bash
+curl -s -H "X-Api-Key: $SONARR_API_KEY" \
+  "$SONARR_URL/api/v3/series?tvdbId=TVDB_ID" | \
+  python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for s in d:
+    st=s.get('statistics',{})
+    print(s.get('title'), 'seasons:', st.get('seasonCount'), 'eps:', st.get('episodeFileCount'),'/', st.get('totalEpisodeCount'), 'monitored:', s.get('monitored'))
+"
+```
+
+### Connecting Overseerr tmdbId to Radarr/Sonarr
+
+- Overseerr search returns `tmdbId` for both movies and TV
+- Radarr uses tmdbId directly: `/api/v3/movie?tmdbId=X`
+- Sonarr uses tvdbId — get it from: `GET /api/v1/tv/TMDB_ID` → `externalIds.tvdbId`
+
+### When to use which
+
+- User requests something new → Overseerr (handles routing to Radarr/Sonarr)
+- User asks about status / progress / ETA → Radarr or Sonarr queue
+- User asks if something is available → Overseerr mediaInfo.status first, then Radarr/Sonarr hasFile
+- Disk space questions → Radarr `/api/v3/diskspace`
+
+## Listing Recent Requests
+
+```bash
+curl -s -H "X-Api-Key: $OVERSEERR_API_KEY" \
+  "$OVERSEERR_URL/api/v1/request?take=10&skip=0&sort=added" | \
+  python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+status_map={1:'Pending',2:'Approved',3:'Declined',4:'Available',5:'Available'}
+for r in d.get('results',[]):
+    m=r.get('media',{})
+    print(m.get('mediaType','?'),'|',m.get('tmdbId'),'|',status_map.get(r.get('status','?'),'?'))
+"
+```
+
+## Pitfalls
+
+- Always URL-encode the search query: spaces -> `%20`. NEVER use `+` — Overseerr rejects it.
+- TV detail endpoint returns large JSON — always pipe through python3
+- Season 0 = Specials, skip unless explicitly asked
+- `mediaId` in the request = the tmdbId from search results
+- curl commands: always pipe through python3 when response could be large; never print raw JSON to the user
+- Search results include `type: 'person'` entries — skip those, only act on 'movie' or 'tv'
+- ALWAYS include `rootFolderPath` in the request body — never submit without asking the user first
+- Root folders are static — do NOT re-fetch them from the API at runtime
+- NEVER send raw terminal output, curl commands, or JSON to the user
+- ONE reply per step — do not send intermediate messages while running tool calls
+- Users may write in Spanish or English — handle both naturally
+
+---
+
+## Setup
+
+Set these environment variables or add them to `~/.hermes/config.yaml`:
+
+```yaml
+# Overseerr connection
+OVERSEERR_URL=http://YOUR_OVESEERR_IP:5055
+OVERSEERR_API_KEY=your_overseerr_api_key_here
+
+# Radarr connection (for movie status and disk space)
+RADARR_URL=http://YOUR_RADARR_IP:7878
+RADARR_API_KEY=your_radarr_api_key_here
+
+# Sonarr connection (for TV show status)
+SONARR_URL=http://YOUR_SONARR_IP:8989
+SONARR_API_KEY=your_sonarr_api_key_here
+```
+
+Then configure your root folders in the `Root Folders` section above. Map each folder to a short name that users can pick from.

--- a/tests/skills/test_seerr_skill.py
+++ b/tests/skills/test_seerr_skill.py
@@ -1,7 +1,8 @@
 """Hermetic tests for the seerr skill.
 
 Stdlib + pytest + unittest.mock only; no live network. Every HTTP call is
-intercepted at urllib.request.urlopen and asserted on.
+intercepted at urllib.request.urlopen and asserted on. HOME is redirected to a
+temp dir so the script's ~/.hermes/.env fallback cannot read the real one.
 
     scripts/run_tests.sh tests/skills/test_seerr_skill.py -q
 """
@@ -10,16 +11,17 @@ from __future__ import annotations
 
 import io
 import json
+import pathlib
 import re
 import sys
 import urllib.error
+import urllib.parse
 from email.message import Message
-from pathlib import Path
 from unittest import mock
 
 import pytest
 
-_HERE = Path(__file__).resolve()
+_HERE = pathlib.Path(__file__).resolve()
 SKILL_DIR = _HERE.parent.parent.parent / "skills" / "media" / "seerr"
 SKILL_MD = SKILL_DIR / "SKILL.md"
 sys.path.insert(0, str(SKILL_DIR / "scripts"))
@@ -28,6 +30,16 @@ import seerr  # noqa: E402
 
 
 ENV = {"SEERR_URL": "http://seerr.test:5055", "SEERR_API_KEY": "k3y"}
+ARR_ENV = {"RADARR_URL": "http://radarr.test:7878", "RADARR_API_KEY": "r4d"}
+
+
+@pytest.fixture(autouse=True)
+def isolate_home(tmp_path, monkeypatch):
+    """Never let the real ~/.hermes/.env satisfy a test that should fail."""
+    monkeypatch.setattr(seerr.pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+    seerr._ENV_LOADED = False
+    yield tmp_path
+    seerr._ENV_LOADED = False
 
 
 class _Response:
@@ -46,20 +58,20 @@ class _Response:
         return False
 
 
-def _fake_urlopen(payload, captured: list):
-    def _open(request, timeout=None):
-        captured.append(request)
-        return _Response(json.dumps(payload).encode("utf-8"))
-
-    return _open
-
-
-def _run(argv, payload=None, env=None):
+def _run(argv, payload=None, env=None, routes=None):
     """Run the CLI with urlopen mocked. Returns (exit_code, stdout, requests)."""
     captured: list = []
+
+    def _open(request, timeout=None):
+        captured.append(request)
+        if routes is not None:
+            path = urllib.parse.urlsplit(request.full_url).path
+            return _Response(json.dumps(routes[path]).encode("utf-8"))
+        return _Response(json.dumps(payload if payload is not None else {}).encode("utf-8"))
+
     stdout = io.StringIO()
-    with mock.patch.dict("os.environ", env if env is not None else ENV, clear=True), \
-         mock.patch("urllib.request.urlopen", _fake_urlopen(payload or {}, captured)), \
+    with mock.patch.dict("os.environ", ENV if env is None else env, clear=True), \
+         mock.patch("urllib.request.urlopen", _open), \
          mock.patch("sys.stdout", stdout):
         code = seerr.main(argv)
     return code, stdout.getvalue(), captured
@@ -90,6 +102,12 @@ def test_required_frontmatter_metadata_present():
     assert front["name"] == "seerr"
 
 
+def test_only_seerr_credentials_are_mandatory():
+    """Radarr/Sonarr are optional: a Seerr-only user must not be prompted for them."""
+    names = {v["name"] for v in _frontmatter()["required_environment_variables"]}
+    assert names == {"SEERR_URL", "SEERR_API_KEY"}
+
+
 def test_every_yaml_block_in_skill_md_is_valid_yaml():
     """Regression: the v1 skill documented dotenv KEY=value inside a ```yaml fence.
 
@@ -100,10 +118,17 @@ def test_every_yaml_block_in_skill_md_is_valid_yaml():
     blocks = re.findall(r"```yaml\n(.*?)```", SKILL_MD.read_text(encoding="utf-8"), re.DOTALL)
     assert blocks, "expected at least one yaml block (the config.yaml example)"
     for block in blocks:
-        yaml.safe_load(block)  # raises if the block is dotenv or otherwise invalid
+        yaml.safe_load(block)
         assert not re.search(r"^[A-Z_]+=", block, re.MULTILINE), (
             "dotenv KEY=value lines must not appear inside a ```yaml fence"
         )
+
+
+def test_skill_md_hardcodes_no_root_folder_paths():
+    """The tables of real paths went stale twice; discovery replaced them."""
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert "rootFolderPath" not in text.replace("`rootFolder`, not `rootFolderPath`", "")
+    assert "/data/media/" not in text, "no install-specific paths in the skill"
 
 
 # ── Query encoding ────────────────────────────────────────────────────────
@@ -116,13 +141,11 @@ def test_search_percent_encodes_reserved_characters():
 
     assert "Tom%20%26%20Jerry" in url
     assert "+" not in url, "space must encode as %20, not '+'"
-    query = url.split("?", 1)[1]
-    assert query.count("&") == 1, "the only '&' may be the separator before page="
+    assert url.split("?", 1)[1].count("&") == 1, "only the page= separator may be a bare '&'"
 
 
 def test_encode_params_escapes_every_reserved_character():
-    encoded = seerr._encode_params({"query": "a&b=c d/e?f#g"})
-    assert encoded == "query=a%26b%3Dc%20d%2Fe%3Ff%23g"
+    assert seerr._encode_params({"query": "a&b=c d/e?f#g"}) == "query=a%26b%3Dc%20d%2Fe%3Ff%23g"
 
 
 # ── Requests ──────────────────────────────────────────────────────────────
@@ -149,14 +172,12 @@ def test_movie_request_uses_rootFolder_not_rootFolderPath():
 
 def test_tv_request_parses_seasons_and_accepts_all():
     _, _, requests = _run(
-        ["request", "--type", "tv", "--tmdb-id", "136315", "--seasons", "1,3"],
-        {"id": 8, "media": {}},
+        ["request", "--type", "tv", "--tmdb-id", "136315", "--seasons", "1,3"], {"id": 8, "media": {}}
     )
     assert _body(requests[0])["seasons"] == [1, 3]
 
     _, _, requests = _run(
-        ["request", "--type", "tv", "--tmdb-id", "136315", "--seasons", "all"],
-        {"id": 9, "media": {}},
+        ["request", "--type", "tv", "--tmdb-id", "136315", "--seasons", "all"], {"id": 9, "media": {}}
     )
     assert _body(requests[0])["seasons"] == "all"
 
@@ -174,7 +195,7 @@ def test_optional_request_fields_are_omitted_when_unset():
         assert field not in body
 
 
-# ── Auth, discovery, parsing ──────────────────────────────────────────────
+# ── Discovery, auth, parsing ──────────────────────────────────────────────
 
 
 def test_api_key_is_sent_as_header():
@@ -191,18 +212,8 @@ def test_servers_reports_root_folders_from_seerr():
             "profiles": [{"id": 4, "name": "HD-1080p"}],
         },
     }
+    code, out, _ = _run(["servers", "radarr"], routes=routes)
 
-    def _open(request, timeout=None):
-        path = request.full_url.split("5055", 1)[1].split("?", 1)[0]
-        return _Response(json.dumps(routes[path]).encode("utf-8"))
-
-    stdout = io.StringIO()
-    with mock.patch.dict("os.environ", ENV, clear=True), \
-         mock.patch("urllib.request.urlopen", _open), \
-         mock.patch("sys.stdout", stdout):
-        code = seerr.main(["servers", "radarr"])
-
-    out = stdout.getvalue()
     assert code == 0
     assert "server 0: Radarr (default)" in out
     assert "root folder: /data/movies" in out
@@ -213,10 +224,7 @@ def test_seasons_excludes_specials():
     payload = {
         "name": "The Bear",
         "firstAirDate": "2022-06-23",
-        "seasons": [
-            {"seasonNumber": 0, "episodeCount": 3},
-            {"seasonNumber": 1, "episodeCount": 8},
-        ],
+        "seasons": [{"seasonNumber": 0, "episodeCount": 3}, {"seasonNumber": 1, "episodeCount": 8}],
     }
     _, out, _ = _run(["seasons", "136315"], payload)
     assert "season 1" in out
@@ -237,7 +245,56 @@ def test_search_ignores_people_and_flags_existing_library_items():
     assert "[already in library]" in out
 
 
-# ── Failure modes ─────────────────────────────────────────────────────────
+# ── Optional Radarr/Sonarr commands ───────────────────────────────────────
+
+
+def test_diskspace_formats_mounts_and_hits_radarr():
+    payload = [{"path": "/data", "freeSpace": 549_800_000_000, "totalSpace": 3_936_800_000_000}]
+    _, out, requests = _run(["diskspace"], payload, env={**ENV, **ARR_ENV})
+
+    assert "/api/v3/diskspace" in requests[0].full_url
+    assert requests[0].get_header("X-api-key") == "r4d", "must use the Radarr key, not Seerr's"
+    assert "549.8 GB free" in out
+
+
+def test_optional_arr_commands_fail_cleanly_without_credentials():
+    """A Seerr-only user must get a clear message, not a traceback."""
+    code, _, requests = _run(["diskspace"], env=ENV)  # no RADARR_* set
+    assert code == 1
+    assert not requests
+
+
+def test_queue_reports_progress():
+    payload = {"records": [{"title": "Dune", "size": 100, "sizeleft": 25, "status": "downloading"}]}
+    _, out, _ = _run(["queue"], payload, env={**ENV, **ARR_ENV})
+    assert "75%" in out
+
+
+# ── Configuration fallback ────────────────────────────────────────────────
+
+
+def test_dotenv_fallback_supplies_vars_hermes_did_not_export(isolate_home):
+    """On a real Hermes box SEERR_URL is absent from the shell; ~/.hermes/.env has it."""
+    hermes = isolate_home / ".hermes"
+    hermes.mkdir()
+    (hermes / ".env").write_text(
+        "# comment\nSEERR_URL=http://from-dotenv:5055\nexport SEERR_API_KEY='dotenv-key'\n",
+        encoding="utf-8",
+    )
+
+    _, _, requests = _run(["search", "dune"], {"results": []}, env={})
+
+    assert requests[0].full_url.startswith("http://from-dotenv:5055")
+    assert requests[0].get_header("X-api-key") == "dotenv-key"
+
+
+def test_real_environment_wins_over_dotenv(isolate_home):
+    hermes = isolate_home / ".hermes"
+    hermes.mkdir()
+    (hermes / ".env").write_text("SEERR_URL=http://stale:5055\n", encoding="utf-8")
+
+    _, _, requests = _run(["search", "dune"], {"results": []})  # ENV has seerr.test
+    assert requests[0].full_url.startswith("http://seerr.test:5055")
 
 
 @pytest.mark.parametrize("missing", ["SEERR_URL", "SEERR_API_KEY"])
@@ -250,11 +307,21 @@ def test_missing_config_reports_a_clean_error(missing):
 
 def test_rejected_api_key_reports_a_clean_error():
     def _raise(request, timeout=None):
-        raise urllib.error.HTTPError(
-            request.full_url, 401, "Unauthorized", Message(), io.BytesIO(b"")
-        )
+        raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", Message(), io.BytesIO(b""))
 
     with mock.patch.dict("os.environ", ENV, clear=True), \
-         mock.patch("urllib.request.urlopen", _raise):
-        with pytest.raises(seerr.SeerrError, match="API key"):
-            seerr.api("search", params={"query": "x"})
+         mock.patch("urllib.request.urlopen", _raise), \
+         mock.patch("sys.stderr", io.StringIO()):
+        assert seerr.main(["search", "dune"]) == 1
+
+
+def test_already_requested_is_reported_as_such():
+    def _raise(request, timeout=None):
+        raise urllib.error.HTTPError(request.full_url, 409, "Conflict", Message(), io.BytesIO(b""))
+
+    stderr = io.StringIO()
+    with mock.patch.dict("os.environ", ENV, clear=True), \
+         mock.patch("urllib.request.urlopen", _raise), \
+         mock.patch("sys.stderr", stderr):
+        assert seerr.main(["request", "--type", "movie", "--tmdb-id", "1"]) == 1
+    assert "Already requested" in stderr.getvalue()

--- a/tests/skills/test_seerr_skill.py
+++ b/tests/skills/test_seerr_skill.py
@@ -1,0 +1,251 @@
+"""Hermetic tests for the seerr skill.
+
+Stdlib + pytest + unittest.mock only; no live network. Every HTTP call is
+intercepted at urllib.request.urlopen and asserted on.
+
+    scripts/run_tests.sh tests/skills/test_seerr_skill.py -q
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import sys
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+SKILL_DIR = _HERE.parent.parent.parent / "skills" / "media" / "seerr"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+sys.path.insert(0, str(SKILL_DIR / "scripts"))
+
+import seerr  # noqa: E402
+
+
+ENV = {"SEERR_URL": "http://seerr.test:5055", "SEERR_API_KEY": "k3y"}
+
+
+class _Response(io.BytesIO):
+    """Minimal stand-in for the urlopen context manager."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _fake_urlopen(payload, captured: list):
+    def _open(request, timeout=None):
+        captured.append(request)
+        return _Response(json.dumps(payload).encode("utf-8"))
+
+    return _open
+
+
+def _run(argv, payload=None, env=None):
+    """Run the CLI with urlopen mocked. Returns (exit_code, stdout, requests)."""
+    captured: list = []
+    stdout = io.StringIO()
+    with mock.patch.dict("os.environ", env if env is not None else ENV, clear=True), \
+         mock.patch("urllib.request.urlopen", _fake_urlopen(payload or {}, captured)), \
+         mock.patch("sys.stdout", stdout):
+        code = seerr.main(argv)
+    return code, stdout.getvalue(), captured
+
+
+# ── Frontmatter: AGENTS.md skill authoring standards ──────────────────────
+
+
+def _frontmatter() -> dict:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match, "SKILL.md must open with a YAML frontmatter block"
+    yaml = pytest.importorskip("yaml")
+    return yaml.safe_load(match.group(1))
+
+
+def test_description_meets_authoring_standard():
+    description = _frontmatter()["description"]
+    assert len(description) <= 60, f"description is {len(description)} chars, max 60"
+    assert description.endswith("."), "description must end with a period"
+    assert description.count(".") == 1, "description must be a single sentence"
+
+
+def test_required_frontmatter_metadata_present():
+    front = _frontmatter()
+    for field in ("name", "version", "author", "license", "platforms"):
+        assert front.get(field), f"SKILL.md frontmatter is missing `{field}`"
+    assert front["name"] == "seerr"
+
+
+def test_every_yaml_block_in_skill_md_is_valid_yaml():
+    """Regression: the v1 skill documented dotenv KEY=value inside a ```yaml fence.
+
+    A YAML parse failure in config.yaml makes Hermes drop *every* user override,
+    so a copy-pasteable but invalid block is actively harmful.
+    """
+    yaml = pytest.importorskip("yaml")
+    blocks = re.findall(r"```yaml\n(.*?)```", SKILL_MD.read_text(encoding="utf-8"), re.DOTALL)
+    assert blocks, "expected at least one yaml block (the config.yaml example)"
+    for block in blocks:
+        yaml.safe_load(block)  # raises if the block is dotenv or otherwise invalid
+        assert not re.search(r"^[A-Z_]+=", block, re.MULTILINE), (
+            "dotenv KEY=value lines must not appear inside a ```yaml fence"
+        )
+
+
+# ── Query encoding ────────────────────────────────────────────────────────
+
+
+def test_search_percent_encodes_reserved_characters():
+    """Regression: replacing spaces alone leaves '&' live and rewrites the query."""
+    _, _, requests = _run(["search", "Tom & Jerry"], {"results": []})
+    url = requests[0].full_url
+
+    assert "Tom%20%26%20Jerry" in url
+    assert "+" not in url, "space must encode as %20, not '+'"
+    query = url.split("?", 1)[1]
+    assert query.count("&") == 1, "the only '&' may be the separator before page="
+
+
+def test_encode_params_escapes_every_reserved_character():
+    encoded = seerr._encode_params({"query": "a&b=c d/e?f#g"})
+    assert encoded == "query=a%26b%3Dc%20d%2Fe%3Ff%23g"
+
+
+# ── Requests ──────────────────────────────────────────────────────────────
+
+
+def _body(request) -> dict:
+    return json.loads(request.data.decode("utf-8"))
+
+
+def test_movie_request_uses_rootFolder_not_rootFolderPath():
+    """Seerr's field is `rootFolder`; an unknown key is silently ignored."""
+    _, _, requests = _run(
+        ["request", "--type", "movie", "--tmdb-id", "27205", "--root-folder", "/movies"],
+        {"id": 7, "media": {"status": 2}},
+    )
+    body = _body(requests[0])
+
+    assert body["rootFolder"] == "/movies"
+    assert "rootFolderPath" not in body
+    assert body["mediaType"] == "movie"
+    assert body["mediaId"] == 27205
+    assert requests[0].method == "POST"
+
+
+def test_tv_request_parses_seasons_and_accepts_all():
+    _, _, requests = _run(
+        ["request", "--type", "tv", "--tmdb-id", "136315", "--seasons", "1,3"],
+        {"id": 8, "media": {}},
+    )
+    assert _body(requests[0])["seasons"] == [1, 3]
+
+    _, _, requests = _run(
+        ["request", "--type", "tv", "--tmdb-id", "136315", "--seasons", "all"],
+        {"id": 9, "media": {}},
+    )
+    assert _body(requests[0])["seasons"] == "all"
+
+
+def test_tv_request_without_seasons_is_rejected():
+    code, _, requests = _run(["request", "--type", "tv", "--tmdb-id", "1"], {})
+    assert code == 1
+    assert not requests, "must fail before issuing an HTTP request"
+
+
+def test_optional_request_fields_are_omitted_when_unset():
+    _, _, requests = _run(["request", "--type", "movie", "--tmdb-id", "1"], {"id": 1, "media": {}})
+    body = _body(requests[0])
+    for field in ("rootFolder", "serverId", "profileId"):
+        assert field not in body
+
+
+# ── Auth, discovery, parsing ──────────────────────────────────────────────
+
+
+def test_api_key_is_sent_as_header():
+    _, _, requests = _run(["search", "dune"], {"results": []})
+    assert requests[0].get_header("X-api-key") == "k3y"
+
+
+def test_servers_reports_root_folders_from_seerr():
+    """The supported root-folder discovery path: Seerr reads them from Radarr."""
+    routes = {
+        "/api/v1/service/radarr": [{"id": 0, "name": "Radarr", "isDefault": True}],
+        "/api/v1/service/radarr/0": {
+            "rootFolders": [{"id": 1, "path": "/data/movies"}],
+            "profiles": [{"id": 4, "name": "HD-1080p"}],
+        },
+    }
+
+    def _open(request, timeout=None):
+        path = request.full_url.split("5055", 1)[1].split("?", 1)[0]
+        return _Response(json.dumps(routes[path]).encode("utf-8"))
+
+    stdout = io.StringIO()
+    with mock.patch.dict("os.environ", ENV, clear=True), \
+         mock.patch("urllib.request.urlopen", _open), \
+         mock.patch("sys.stdout", stdout):
+        code = seerr.main(["servers", "radarr"])
+
+    out = stdout.getvalue()
+    assert code == 0
+    assert "server 0: Radarr (default)" in out
+    assert "root folder: /data/movies" in out
+    assert "profile 4: HD-1080p" in out
+
+
+def test_seasons_excludes_specials():
+    payload = {
+        "name": "The Bear",
+        "firstAirDate": "2022-06-23",
+        "seasons": [
+            {"seasonNumber": 0, "episodeCount": 3},
+            {"seasonNumber": 1, "episodeCount": 8},
+        ],
+    }
+    _, out, _ = _run(["seasons", "136315"], payload)
+    assert "season 1" in out
+    assert "season 0" not in out
+
+
+def test_search_ignores_people_and_flags_existing_library_items():
+    payload = {
+        "results": [
+            {"id": 1, "mediaType": "person", "name": "Nobody"},
+            {"id": 2, "mediaType": "movie", "title": "Dune", "releaseDate": "2021-09-15",
+             "mediaInfo": {"status": 5}},
+        ]
+    }
+    _, out, _ = _run(["search", "dune"], payload)
+    assert "Nobody" not in out
+    assert "Dune (2021)" in out
+    assert "[already in library]" in out
+
+
+# ── Failure modes ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("missing", ["SEERR_URL", "SEERR_API_KEY"])
+def test_missing_config_reports_a_clean_error(missing):
+    env = {k: v for k, v in ENV.items() if k != missing}
+    code, _, requests = _run(["search", "dune"], {}, env=env)
+    assert code == 1
+    assert not requests
+
+
+def test_rejected_api_key_reports_a_clean_error():
+    def _raise(request, timeout=None):
+        raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, io.BytesIO(b""))
+
+    with mock.patch.dict("os.environ", ENV, clear=True), \
+         mock.patch("urllib.request.urlopen", _raise):
+        with pytest.raises(seerr.SeerrError, match="API key"):
+            seerr.api("search", params={"query": "x"})

--- a/tests/skills/test_seerr_skill.py
+++ b/tests/skills/test_seerr_skill.py
@@ -13,6 +13,7 @@ import json
 import re
 import sys
 import urllib.error
+from email.message import Message
 from pathlib import Path
 from unittest import mock
 
@@ -29,13 +30,19 @@ import seerr  # noqa: E402
 ENV = {"SEERR_URL": "http://seerr.test:5055", "SEERR_API_KEY": "k3y"}
 
 
-class _Response(io.BytesIO):
+class _Response:
     """Minimal stand-in for the urlopen context manager."""
 
-    def __enter__(self):
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> "_Response":
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, *exc: object) -> bool:
         return False
 
 
@@ -243,7 +250,9 @@ def test_missing_config_reports_a_clean_error(missing):
 
 def test_rejected_api_key_reports_a_clean_error():
     def _raise(request, timeout=None):
-        raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, io.BytesIO(b""))
+        raise urllib.error.HTTPError(
+            request.full_url, 401, "Unauthorized", Message(), io.BytesIO(b"")
+        )
 
     with mock.patch.dict("os.environ", ENV, clear=True), \
          mock.patch("urllib.request.urlopen", _raise):


### PR DESCRIPTION
## Summary

Adds a **Seerr** skill at `skills/media/seerr/` that turns Hermes into a conversational media-request assistant: search a title, pick seasons, submit the request, report download progress.

This is a rewrite of the original Overseerr skill in this PR, for two reasons: the review below found real defects, and **Overseerr and Jellyseerr have since merged into [Seerr](https://github.com/seerr-team/seerr)**, so the skill was targeting projects that no longer exist as separate products.

## Seerr is the only integration point

Seerr proxies Radarr and Sonarr, so root folders, quality profiles and download progress all come from Seerr. The `RADARR_*` / `SONARR_*` credentials are gone — **four fewer secrets** on the skill's surface. The one casualty is the Radarr-only disk-space command, which I dropped rather than keep four credentials alive for.

## Configuration

| Kind | Where | Key |
|---|---|---|
| Secret | `.env` (`required_environment_variables`) | `SEERR_API_KEY` |
| Non-secret | `config.yaml` (`metadata.hermes.config`) | `skills.config.seerr.url` |

## Files

- `skills/media/seerr/SKILL.md` — 164 lines, modern section order
- `skills/media/seerr/scripts/seerr.py` — stdlib-only API client (`search`, `servers`, `seasons`, `request`, `status`)
- `tests/skills/test_seerr_skill.py` — 16 hermetic tests, no network
- `.env.example` — one delimited block

## Category

Moved from `smart-home/` to `media/` — a media request manager is not a smart-home skill.

## Verification

```
scripts/run_tests.sh tests/skills/test_seerr_skill.py -q   # 16 passed
scripts/run_tests.sh tests/test_plugin_skills.py -q        # 28 passed
```

Also exercised end-to-end against a live Seerr instance (v1, Radarr + Sonarr attached): root-folder discovery and the `Tom & Jerry` search case both verified against the real API, not just mocks.
