### PR TITLE
fix(gateway): enforce atomic writes for voice mode persistence

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,7 +76,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_yaml_write
+from utils import atomic_json_write, atomic_yaml_write
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -605,12 +605,9 @@ class GatewayRunner:
 
     def _save_voice_modes(self) -> None:
         try:
-            self._VOICE_MODE_PATH.parent.mkdir(parents=True, exist_ok=True)
-            self._VOICE_MODE_PATH.write_text(
-                json.dumps(self._voice_mode, indent=2)
-            )
-        except OSError as e:
-            logger.warning("Failed to save voice modes: %s", e)
+            atomic_json_write(self._VOICE_MODE_PATH, self._voice_mode, indent=2)
+        except Exception as e:
+            logger.warning("Failed to save voice modes: %s", e, exc_info=True)
 
     def _set_adapter_auto_tts_disabled(self, adapter, chat_id: str, disabled: bool) -> None:
         """Update an adapter's in-memory auto-TTS suppression set if present."""

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -165,6 +165,27 @@ class TestHandleVoiceCommand:
         data = json.loads(runner._VOICE_MODE_PATH.read_text())
         assert data["123"] == "off"
 
+    def test_save_voice_modes_preserves_existing_file_on_write_failure(self, runner):
+        original = {"456": "all"}
+        runner._VOICE_MODE_PATH.write_text(json.dumps(original))
+        runner._voice_mode = {"123": "voice_only"}
+
+        with patch("utils.json.dump", side_effect=OSError("disk full")):
+            runner._save_voice_modes()
+
+        assert json.loads(runner._VOICE_MODE_PATH.read_text()) == original
+
+    @pytest.mark.asyncio
+    async def test_voice_on_succeeds_when_persistence_fails(self, runner):
+        event = _make_event("/voice on")
+
+        with patch("utils.json.dump", side_effect=OSError("disk full")):
+            result = await runner._handle_voice_command(event)
+
+        assert "enabled" in result.lower()
+        assert runner._voice_mode["123"] == "voice_only"
+        assert not runner._VOICE_MODE_PATH.exists()
+
     def test_sync_voice_mode_state_to_adapter_restores_off_chats(self, runner):
         runner._voice_mode = {"123": "off", "456": "all"}
         adapter = SimpleNamespace(_auto_tts_disabled_chats=set())


### PR DESCRIPTION
## What does this PR do?

This PR implements an **atomic persistence model** for the gateway's voice mode configuration in `gateway/run.py`. 

- **Problem:** Direct file overwriting with `Path.write_text()` is non-atomic. If the process crashes mid-write, the `gateway_voice_mode.json` file is truncated or corrupted, leading to silent loss of user `/voice` preferences.
- **Solution:** Integrated the `atomic_json_write` helper to ensure a "write-then-rename" strategy. This guarantees that a valid state file always exists on disk, and failed writes do not clobber existing valid data.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- **`gateway/run.py`**: Migrated `_save_voice_modes()` to use `atomic_json_write`. Updated logic to log persistence failures as warnings instead of crashing the live command flow.
- **`tests/gateway/test_voice_command.py`**: Added regression tests (L168, L179) to verify file integrity during simulated I/O failures and ensure in-memory state updates still occur.

## How to Test

1. Seed a valid `gateway_voice_mode.json` in the user's home directory.
2. Run `pytest tests/gateway/test_voice_command.py` to verify the new durability tests pass.
3. Manually trigger a `/voice on` command and simulate a process crash during the write phase; verify the original JSON remains intact.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes


### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A