### PR TITLE
fix(gateway): correct /model provider picker catalogs and auth detection

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -730,7 +730,7 @@ def list_authenticated_providers(
         fetch_models_dev,
         get_provider_info as _mdev_pinfo,
     )
-    from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS
+    from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS, provider_model_ids
 
     results: List[dict] = []
     seen_slugs: set = set()
@@ -800,8 +800,9 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list
-        model_ids = curated.get(pid, [])
+        # Prefer live/provider-specific discovery when available (Codex, Nous,
+        # Copilot), then fall back to the curated static list.
+        model_ids = provider_model_ids(pid) or curated.get(pid, [])
         total = len(model_ids)
         top = model_ids[:max_models]
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -109,6 +109,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "opencode-go": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
+        extra_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
     "kilo": HermesOverlay(

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -561,6 +561,86 @@ class TestSwitchModelDirectAliasOverride:
 # CLI state update: requested_provider persistence
 # ---------------------------------------------------------------------------
 
+class TestAuthenticatedProviderListing:
+    """Provider listing should prefer live provider catalogs when available."""
+
+    def test_opencode_go_appears_when_only_opencode_go_api_key_is_set(self, monkeypatch):
+        """Provider picker should honor Hermes overlay env vars, not just models.dev env vars."""
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+        monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "agent.models_dev.fetch_models_dev",
+            lambda: {
+                "opencode-go": {
+                    "env": ["OPENCODE_API_KEY"],
+                    "name": "OpenCode Go",
+                }
+            },
+        )
+
+        providers = ms.list_authenticated_providers(current_provider="opencode-go", max_models=8)
+        opencode_go = next(p for p in providers if p["slug"] == "opencode-go")
+
+        from hermes_cli.models import _PROVIDER_MODELS
+        expected_models = list(_PROVIDER_MODELS["opencode-go"])
+
+        assert opencode_go["name"] == "OpenCode Go"
+        assert opencode_go["models"] == expected_models[:8]
+        assert opencode_go["total_models"] == len(expected_models)
+
+    def test_openai_codex_uses_live_catalog_over_static_curated_list(self, monkeypatch):
+        """Telegram/gateway /model should surface live Codex models, not stale curated ones."""
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr(
+            "hermes_cli.models.provider_model_ids",
+            lambda provider: ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"] if provider == "openai-codex" else [],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.model_switch.get_label",
+            lambda provider: "OpenAI Codex" if provider == "openai-codex" else provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.auth._load_auth_store",
+            lambda: {"providers": {}, "credential_pool": {"openai-codex": {"default": {}}}},
+        )
+
+        providers = ms.list_authenticated_providers(current_provider="openai-codex", max_models=5)
+        codex = next(p for p in providers if p["slug"] == "openai-codex")
+
+        assert codex["models"] == ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
+        assert codex["total_models"] == 3
+
+    def test_falls_back_to_curated_list_when_live_catalog_empty(self, monkeypatch):
+        """If live discovery fails, provider listing should keep the old curated fallback."""
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr("hermes_cli.models.provider_model_ids", lambda provider: [])
+        monkeypatch.setattr(
+            "hermes_cli.model_switch.get_label",
+            lambda provider: "OpenAI Codex" if provider == "openai-codex" else provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.auth._load_auth_store",
+            lambda: {"providers": {}, "credential_pool": {"openai-codex": {"default": {}}}},
+        )
+
+        providers = ms.list_authenticated_providers(current_provider="openai-codex", max_models=5)
+        codex = next(p for p in providers if p["slug"] == "openai-codex")
+
+        assert codex["models"] == [
+            "gpt-5.3-codex",
+            "gpt-5.2-codex",
+            "gpt-5.1-codex-mini",
+            "gpt-5.1-codex-max",
+        ]
+        assert codex["total_models"] == 4
+
+
 class TestCLIStateUpdate:
     """CLI /model handler should update requested_provider and explicit fields."""
 


### PR DESCRIPTION
## Summary
- use provider-specific model catalogs for Hermes-only providers in the gateway /model picker
- recognize `OPENCODE_GO_API_KEY` when deciding whether OpenCode Go should appear as an authenticated provider
- add regression coverage for both the Codex picker and OpenCode Go provider listing

## Problem
Two related Telegram `/model` picker bugs showed up in gateway mode:
- OpenAI Codex showed a stale hardcoded model list instead of the provider-specific Codex catalog
- OpenCode Go did not appear in the picker when only `OPENCODE_GO_API_KEY` was configured

## Test Plan
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_ollama_cloud_auth.py -q`
- verified the fixes live in Telegram after restarting the gateway