### PR TITLE
fix(cli): prevent duplicated prompt rows after terminal resize

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -120,6 +120,49 @@ def _parse_reasoning_config(effort: str) -> dict | None:
     return result
 
 
+def _estimate_reflowed_height_for_narrower_width(screen, new_columns: int) -> int:
+    """Estimate how many terminal rows a rendered screen will occupy after shrink.
+
+    prompt_toolkit stores the last rendered screen as already-wrapped physical
+    rows. When the terminal narrows, each of those rows can wrap into multiple
+    new rows, which means ``renderer._cursor_pos.y`` underestimates how far the
+    cursor needs to move up before ``erase_down()``.
+
+    We can estimate shrink reflow accurately from the physical row widths stored
+    in ``screen.data_buffer``. (The inverse problem for widening is not solvable
+    from this snapshot alone, because separate wrapped rows do not retain their
+    original logical-line grouping.)
+    """
+    if screen is None or new_columns <= 0:
+        return 0
+
+    height = int(getattr(screen, "height", 0) or 0)
+    if height <= 0:
+        return 0
+
+    data_buffer = getattr(screen, "data_buffer", None)
+    total_rows = 0
+    for y in range(height):
+        row = data_buffer.get(y) if data_buffer is not None else None
+        if row:
+            row_width = max(row.keys()) + 1
+            total_rows += max(1, (row_width + new_columns - 1) // new_columns)
+        else:
+            total_rows += 1
+    return total_rows
+
+
+def _extra_rows_after_terminal_shrink(screen, new_columns: int) -> int:
+    """Return additional rows introduced when a rendered screen reflows narrower."""
+    if screen is None or new_columns <= 0:
+        return 0
+    last_height = int(getattr(screen, "height", 0) or 0)
+    if last_height <= 0:
+        return 0
+    reflowed_height = _estimate_reflowed_height_for_narrower_width(screen, new_columns)
+    return max(0, reflowed_height - last_height)
+
+
 def _get_chrome_debug_candidates(system: str) -> list[str]:
     """Return likely browser executables for local CDP auto-launch."""
     candidates: list[str] = []
@@ -8230,15 +8273,17 @@ class HermesCLI:
         )
         self._app = app  # Store reference for clarify_callback
 
-        # ── Fix ghost status-bar lines on terminal resize ──────────────
-        # When the terminal shrinks (e.g. un-maximize), the emulator reflows
-        # the previously-rendered full-width rows (status bar, input rules)
-        # into multiple narrower rows.  prompt_toolkit's _on_resize handler
-        # only cursor_up()s by the stored layout height, missing the extra
-        # rows created by reflow — leaving ghost duplicates visible.
+        # ── Fix ghost rows on terminal shrink ──────────────────────────
+        # When the terminal narrows, the emulator reflows previously-rendered
+        # rows (status bar, rules, prompt/input) into more physical lines.
+        # prompt_toolkit's default resize handler erases based on the old
+        # cursor row, so it can leave reflowed remnants behind. Those remnants
+        # look like duplicated prompt/input boxes after repeated resizes.
         #
-        # Fix: before the standard erase, inflate _cursor_pos.y so the
-        # cursor moves up far enough to cover the reflowed ghost content.
+        # We fix only the shrink case here. The last-screen snapshot stores
+        # already-wrapped physical rows, so we can estimate how many *extra*
+        # rows narrowing will create, but we cannot reliably reconstruct the
+        # inverse collapse when widening.
         _original_on_resize = app._on_resize
 
         def _resize_clear_ghosts():
@@ -8249,19 +8294,15 @@ class HermesCLI:
                 new_size = renderer.output.get_size()
                 if (
                     old_size
+                    and renderer._last_screen is not None
+                    and renderer._cursor_pos is not None
                     and new_size.columns < old_size.columns
                     and new_size.columns > 0
                 ):
-                    reflow_factor = (
-                        (old_size.columns + new_size.columns - 1)
-                        // new_size.columns
+                    extra = _extra_rows_after_terminal_shrink(
+                        renderer._last_screen,
+                        new_size.columns,
                     )
-                    last_h = (
-                        renderer._last_screen.height
-                        if renderer._last_screen
-                        else 0
-                    )
-                    extra = last_h * (reflow_factor - 1)
                     if extra > 0:
                         renderer._cursor_pos = _Pt(
                             x=renderer._cursor_pos.x,

--- a/tests/cli/test_cli_resize_reflow.py
+++ b/tests/cli/test_cli_resize_reflow.py
@@ -1,0 +1,61 @@
+"""Regression tests for TUI resize ghost-row cleanup."""
+
+from prompt_toolkit.layout.screen import Char, Screen
+
+from cli import (
+    _estimate_reflowed_height_for_narrower_width,
+    _extra_rows_after_terminal_shrink,
+)
+
+
+def _make_screen(rows: list[str]) -> Screen:
+    screen = Screen()
+    screen.height = len(rows)
+    screen.width = max((len(r) for r in rows), default=0)
+    for y, row_text in enumerate(rows):
+        for x, ch in enumerate(row_text):
+            screen.data_buffer[y][x] = Char(ch, "")
+    return screen
+
+
+class TestResizeReflowEstimation:
+    def test_counts_reflow_per_rendered_row_instead_of_global_multiplier(self):
+        screen = _make_screen([
+            "=" * 10,
+            "> short",
+            "x" * 10,
+        ])
+
+        # Narrowing from width 10 to width 5 reflows rows independently:
+        # 10 -> 2 rows, 7 -> 2 rows, 10 -> 2 rows, total = 6.
+        assert _estimate_reflowed_height_for_narrower_width(screen, 5) == 6
+        assert _extra_rows_after_terminal_shrink(screen, 5) == 3
+
+    def test_blank_rows_still_count_as_one_terminal_row(self):
+        screen = _make_screen([
+            "",
+            "abcde",
+            "",
+        ])
+
+        assert _estimate_reflowed_height_for_narrower_width(screen, 2) == 5
+        assert _extra_rows_after_terminal_shrink(screen, 2) == 2
+
+    def test_explicit_space_cells_contribute_to_row_width(self):
+        screen = _make_screen([
+            "          ",
+            "abc",
+        ])
+
+        # The first row is ten explicit spaces; it still occupies width and will
+        # wrap to two rows when the terminal narrows to five columns.
+        assert _estimate_reflowed_height_for_narrower_width(screen, 5) == 3
+        assert _extra_rows_after_terminal_shrink(screen, 5) == 1
+
+    def test_invalid_inputs_return_zero_extra_rows(self):
+        assert _estimate_reflowed_height_for_narrower_width(None, 10) == 0
+        assert _extra_rows_after_terminal_shrink(None, 10) == 0
+
+        screen = _make_screen(["abc"])
+        assert _estimate_reflowed_height_for_narrower_width(screen, 0) == 0
+        assert _extra_rows_after_terminal_shrink(screen, 0) == 0


### PR DESCRIPTION
## Summary
- replace the coarse resize reflow multiplier with row-aware shrink estimation
- prevent duplicated prompt/input rows from accumulating after repeated terminal resizes
- add a regression test for resize reflow math

## Problem
The current resize workaround in `cli.py` estimates extra reflowed rows as `last_height * (reflow_factor - 1)`. That coarse estimate can under/over-shoot when rendered rows have different widths, leaving old prompt/input rows behind after repeated shrink/expand cycles.

## Fix
Use the actual widths of the previously rendered physical rows from `renderer._last_screen.data_buffer` to estimate how many extra rows narrowing will create, then inflate `renderer._cursor_pos.y` by that exact extra-row count before prompt_toolkit erases/redraws.

## Test Plan
- `~/.hermes/Hermes-Agent/venv/bin/python -m py_compile cli.py tests/cli/test_cli_resize_reflow.py`
- `~/.hermes/Hermes-Agent/venv/bin/python -m pytest tests/cli/test_cli_resize_reflow.py tests/cli/test_cli_loading_indicator.py -q`

## Notes
- observed locally while resizing the Hermes CLI window on macOS
- fix is intentionally scoped to terminal shrink reflow, which is the case the previous workaround was targeting
