### PR TITLE
fix(cron): pass fallback model chain into scheduled agents

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -615,6 +615,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Provider routing
         pr = _cfg.get("provider_routing", {})
         smart_routing = _cfg.get("smart_model_routing", {}) or {}
+        fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
 
         from hermes_cli.runtime_provider import (
             resolve_runtime_provider,
@@ -661,6 +662,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
+            fallback_model=fallback_model,
             disabled_toolsets=["cronjob", "messaging", "clarify"],
             quiet_mode=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -608,7 +608,7 @@ class TestRunJobSessionPersistence:
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
                  return_value={
-                     "api_key": "test-key",
+                     "api_key": "***",
                      "base_url": "https://example.invalid/v1",
                      "provider": "openrouter",
                      "api_mode": "chat_completions",
@@ -635,6 +635,44 @@ class TestRunJobSessionPersistence:
         assert call_args[0][0].startswith("cron_test-job_")
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
+
+    def test_run_job_passes_fallback_model_from_config(self, tmp_path):
+        job = {
+            "id": "fallback-job",
+            "name": "fallback test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+        (tmp_path / "config.yaml").write_text(
+            "fallback_model: anthropic/claude-sonnet-4.6\n",
+            encoding="utf-8",
+        )
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["fallback_model"] == "anthropic/claude-sonnet-4.6"
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
         """Empty final_response should stay empty for delivery logic (issue #2234).


### PR DESCRIPTION
## Summary
- load cron fallback configuration from `config.yaml`
- pass the fallback model/provider chain into scheduled `AIAgent` instances
- add regression coverage proving cron forwards fallback configuration into the agent constructor

## Root cause
`cron/scheduler.py` already loads `config.yaml` for model selection, reasoning config, prefill messages, provider routing, and smart model routing.

But unlike the CLI and gateway paths, it never forwarded `fallback_model` / `fallback_providers` into `AIAgent(...)`.

That meant scheduled jobs had no fallback chain even when the main config declared one.

## Fix
- read:
  - `fallback_providers`
  - fallback to `fallback_model`
- pass the resolved value as `fallback_model=` to `AIAgent(...)` in the cron scheduler

## Validation
- `python -m pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_passes_session_db_and_cron_platform tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_passes_fallback_model_from_config tests/cron/test_codex_execution_paths.py -q`
- `python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py`

These passed locally.

## Notes
I also ran the broader `tests/cron/ -q` suite locally and hit two unrelated existing failures in `TestSilentDelivery` delivery suppression assertions. Those failures are outside the fallback-model codepath touched here. The targeted scheduler + codex-path validations relevant to this change passed.

Closes #6673
