### PR TITLE
fix(cron): resolve tick lock path from current hermes home

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -57,9 +57,15 @@ SILENT_MARKER = "[SILENT]"
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = get_hermes_home()
 
-# File-based lock prevents concurrent ticks from gateway + daemon + systemd timer
-_LOCK_DIR = _hermes_home / "cron"
-_LOCK_FILE = _LOCK_DIR / ".tick.lock"
+
+def _get_tick_lock_file() -> Path:
+    """Return the cron tick lock path using the current HERMES_HOME.
+
+    This must be resolved dynamically instead of at import time so tests,
+    profiles, and subprocesses that override HERMES_HOME do not all contend
+    for the same stale global lock file.
+    """
+    return get_hermes_home() / "cron" / ".tick.lock"
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -824,12 +830,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     Returns:
         Number of jobs executed (0 if another tick is already running)
     """
-    _LOCK_DIR.mkdir(parents=True, exist_ok=True)
+    lock_file = _get_tick_lock_file()
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
     lock_fd = None
     try:
-        lock_fd = open(_LOCK_FILE, "w")
+        lock_fd = open(lock_file, "w")
         if fcntl:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         elif msvcrt:


### PR DESCRIPTION
## Summary
- resolve the cron tick lock file from the current `HERMES_HOME` at call time
- stop using a stale import-time lock path for `tick()`
- fix cross-profile / test-process lock contention caused by a shared global tick lock path

## Root cause
`cron/scheduler.py` cached:
- `_hermes_home = get_hermes_home()`
- `_LOCK_DIR = _hermes_home / "cron"`
- `_LOCK_FILE = _LOCK_DIR / ".tick.lock"`

at import time.

That meant later `HERMES_HOME` overrides (tests, profiles, subprocesses) still used the original lock path, so independent cron runs could contend for the same stale global lock file.

In practice, this caused the cron silent-delivery tests to intermittently skip execution with:
- `Tick skipped — another instance holds the lock`

## Fix
- add `_get_tick_lock_file()`
- resolve the lock path from `get_hermes_home()` inside `tick()` instead of using the import-time cached path

## Validation
- `python -m pytest tests/cron/test_scheduler.py::TestSilentDelivery::test_normal_response_delivers tests/cron/test_scheduler.py::TestSilentDelivery::test_silent_response_suppresses_delivery -q`
- `python -m pytest tests/cron/ -q`
- `python -m py_compile cron/scheduler.py`

All of the above passed locally.
