### PR TITLE
feat: add generalized ACP LLM external provider support

### DIFF
--- a/agent/claude_code_client.py
+++ b/agent/claude_code_client.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shlex
+import subprocess
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+ACP_MARKER_BASE_URL = "acp://claude-code"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+
+def _resolve_command() -> str:
+    return os.getenv("CLAUDE_CODE_ACP_COMMAND", "").strip() or "claude"
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("CLAUDE_CODE_ACP_ARGS", "").strip()
+    if not raw:
+        return ["--print", "--output-format", "stream-json", "--verbose", "--dangerously-skip-permissions", "--no-session-persistence"]
+    return shlex.split(raw)
+
+
+class _CCChatCompletions:
+    def __init__(self, client: "ClaudeCodeClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _CCChatNamespace:
+    def __init__(self, client: "ClaudeCodeClient"):
+        self.completions = _CCChatCompletions(client)
+
+
+class ClaudeCodeClient:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-code-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = command or _resolve_command()
+        self._args = list(args or _resolve_args())
+        self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _CCChatNamespace(self)
+        self.is_closed = False
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        **_: Any,
+    ) -> Any:
+        prompt = _messages_to_prompt(messages or [])
+        text = self._run_prompt(prompt, timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS))
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        msg = SimpleNamespace(
+            content=text,
+            tool_calls=[],
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        return SimpleNamespace(choices=[choice], usage=usage, model=model or "claude-code-acp")
+
+    def _run_prompt(self, prompt: str, *, timeout_seconds: float) -> str:
+        try:
+            proc = subprocess.Popen(
+                [self._command] + self._args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+                cwd=self._cwd,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude Code command '{self._command}'. "
+                "Install Claude Code CLI or set CLAUDE_CODE_ACP_COMMAND."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("Claude Code process did not expose stdin/stdout pipes.")
+
+        inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+
+        def _reader() -> None:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    inbox.put(json.loads(line))
+                except Exception:
+                    pass
+
+        threading.Thread(target=_reader, daemon=True).start()
+        proc.stdin.write(prompt)
+        proc.stdin.close()
+
+        parts: list[str] = []
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            if proc.poll() is not None and inbox.empty():
+                break
+            try:
+                evt = inbox.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            evt_type = evt.get("type")
+            if evt_type == "assistant":
+                for block in (evt.get("message") or {}).get("content") or []:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if text:
+                            parts.append(text)
+            elif evt_type == "result":
+                result = evt.get("result", "")
+                if result and not parts:
+                    parts.append(result)
+                break
+
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+        if not parts:
+            stderr_out = (proc.stderr.read() or "").strip()
+            raise RuntimeError(
+                f"Claude Code returned no content. stderr: {stderr_out[:500]}"
+            )
+        return "".join(parts)
+
+
+def _messages_to_prompt(messages: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for m in messages:
+        role = str(m.get("role") or "user").strip().lower()
+        content = m.get("content") or ""
+        if isinstance(content, list):
+            texts = [
+                b.get("text", "") for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            content = "\n".join(texts)
+        label = {"system": "System", "user": "User", "assistant": "Assistant"}.get(
+            role, role.title()
+        )
+        if str(content).strip():
+            parts.append(f"{label}:\n{content}")
+    parts.append("Continue from the latest user message.")
+    return "\n\n".join(parts)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -88,7 +88,7 @@ class ProviderConfig:
     """Describes a known inference provider."""
     id: str
     name: str
-    auth_type: str  # "oauth_device_code", "oauth_external", or "api_key"
+    auth_type: str  # "oauth_device_code", "oauth_external", "api_key", or "acp"
     portal_base_url: str = ""
     inference_base_url: str = ""
     client_id: str = ""
@@ -242,6 +242,20 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://router.huggingface.co/v1",
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
+    ),
+    "llm-acp": ProviderConfig(
+        id="llm-acp",
+        name="ACP LLM",
+        auth_type="acp",
+        inference_base_url="acp://llm",
+        base_url_env_var="ACP_LLM_BASE_URL",
+    ),
+    "claude-agent-acp": ProviderConfig(
+        id="claude-agent-acp",
+        name="Claude Agent ACP",
+        auth_type="acp",
+        inference_base_url="acp://claude-agent",
+        base_url_env_var="CLAUDE_AGENT_ACP_BASE_URL",
     ),
 }
 
@@ -825,6 +839,8 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "acp-llm": "llm-acp", "llmacp": "llm-acp",
+        "claude-acp": "claude-agent-acp", "claude-agent": "claude-agent-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
@@ -2335,6 +2351,57 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     return {
         "provider": provider_id,
         "api_key": "copilot-acp",
+        "base_url": base_url.rstrip("/"),
+        "command": resolved_command or command,
+        "args": args,
+        "source": "process",
+    }
+
+
+def resolve_acp_provider_credentials(provider_id: str) -> Dict[str, Any]:
+    """Resolve runtime details for generic ACP subprocess providers (auth_type='acp')."""
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    if not pconfig or pconfig.auth_type != "acp":
+        raise AuthError(
+            f"Provider '{provider_id}' is not an ACP provider.",
+            provider=provider_id,
+            code="invalid_provider",
+        )
+
+    base_url = ""
+    if pconfig.base_url_env_var:
+        base_url = os.getenv(pconfig.base_url_env_var, "").strip()
+    if not base_url:
+        base_url = pconfig.inference_base_url
+
+    if provider_id == "claude-agent-acp":
+        command = os.getenv("CLAUDE_AGENT_ACP_COMMAND", "").strip() or "claude-agent-acp"
+        raw_args = os.getenv("CLAUDE_AGENT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--stdio"]
+    else:
+        command = os.getenv("ACP_LLM_COMMAND", "").strip()
+        if not command:
+            raise AuthError(
+                "ACP_LLM_COMMAND is required for the 'llm-acp' provider. "
+                "Set it to the command that starts your ACP-compatible LLM server.",
+                provider=provider_id,
+                code="missing_command",
+            )
+        raw_args = os.getenv("ACP_LLM_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--stdio"]
+
+    resolved_command = shutil.which(command) if command else None
+    if not resolved_command and not base_url.startswith("acp+tcp://"):
+        raise AuthError(
+            f"Could not find ACP command '{command}'. "
+            "Install it or set the appropriate environment variable.",
+            provider=provider_id,
+            code="missing_command",
+        )
+
+    return {
+        "provider": provider_id,
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -257,6 +257,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="acp://claude-agent",
         base_url_env_var="CLAUDE_AGENT_ACP_BASE_URL",
     ),
+    "claude-code-acp": ProviderConfig(
+        id="claude-code-acp",
+        name="Claude Code ACP",
+        auth_type="acp",
+        inference_base_url="acp://claude-code",
+        base_url_env_var="CLAUDE_CODE_ACP_BASE_URL",
+    ),
 }
 
 
@@ -841,6 +848,7 @@ def resolve_provider(
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "acp-llm": "llm-acp", "llmacp": "llm-acp",
         "claude-acp": "claude-agent-acp", "claude-agent": "claude-agent-acp",
+        "claude-code-acp": "claude-code-acp", "cc-acp": "claude-code-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
@@ -2374,7 +2382,13 @@ def resolve_acp_provider_credentials(provider_id: str) -> Dict[str, Any]:
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    if provider_id == "claude-agent-acp":
+    if provider_id == "claude-code-acp":
+        command = os.getenv("CLAUDE_CODE_ACP_COMMAND", "").strip() or "claude"
+        raw_args = os.getenv("CLAUDE_CODE_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else [
+            "--print", "--output-format", "stream-json", "--verbose", "--dangerously-skip-permissions", "--no-session-persistence"
+        ]
+    elif provider_id == "claude-agent-acp":
         command = os.getenv("CLAUDE_AGENT_ACP_COMMAND", "").strip() or "claude-agent-acp"
         raw_args = os.getenv("CLAUDE_AGENT_ACP_ARGS", "").strip()
         args = shlex.split(raw_args) if raw_args else ["--stdio"]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -933,6 +933,8 @@ def select_provider_and_model(args=None):
         "kilocode": "Kilo Code",
         "alibaba": "Alibaba Cloud (DashScope)",
         "huggingface": "Hugging Face",
+        "llm-acp": "ACP LLM",
+        "claude-agent-acp": "Claude Agent ACP",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active) if active else "none"
@@ -955,6 +957,8 @@ def select_provider_and_model(args=None):
 
     extended_providers = [
         ("copilot-acp", "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
+        ("claude-agent-acp", "Claude Agent ACP (spawns `claude-agent-acp --stdio`)"),
+        ("llm-acp", "ACP LLM (generic ACP subprocess — any ACP-compatible LLM server)"),
         ("gemini", "Google AI Studio (Gemini models — OpenAI-compatible endpoint)"),
         ("zai", "Z.AI / GLM (Zhipu AI direct API)"),
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
@@ -1049,6 +1053,10 @@ def select_provider_and_model(args=None):
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-agent-acp":
+        _model_flow_claude_agent_acp(config, current_model)
+    elif selected_provider == "llm-acp":
+        _model_flow_llm_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -2158,6 +2166,118 @@ def _model_flow_copilot_acp(config, current_model=""):
     deactivate_provider()
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_claude_agent_acp(config, current_model=""):
+    import os
+    import getpass
+    from hermes_cli.auth import PROVIDER_REGISTRY, deactivate_provider
+    from hermes_cli.config import load_config, save_config
+
+    del config
+    provider_id = "claude-agent-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    env_cmd = os.getenv("CLAUDE_AGENT_ACP_COMMAND", "").strip()
+    default_cmd = env_cmd or "claude-agent-acp"
+    print("  Claude Agent ACP connects Hermes to a Claude Code ACP subprocess.")
+    print("  Install: https://github.com/agentclientprotocol/claude-agent-acp")
+    print(f"  Current command: {default_cmd}")
+    print()
+
+    try:
+        cmd = input(f"  Command [{default_cmd}]: ").strip() or default_cmd
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    if not cmd:
+        print("  Cancelled.")
+        return
+
+    try:
+        model_name = input("  Model name (or Enter to skip): ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    from hermes_cli.config import save_env_value
+    save_env_value("CLAUDE_AGENT_ACP_COMMAND", cmd)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = pconfig.inference_base_url
+    model["api_mode"] = "chat_completions"
+    if model_name:
+        model["default"] = model_name
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"  Configured: {provider_id} via {cmd}")
+
+
+def _model_flow_llm_acp(config, current_model=""):
+    import os
+    import getpass
+    from hermes_cli.auth import PROVIDER_REGISTRY, deactivate_provider
+    from hermes_cli.config import load_config, save_config
+
+    del config
+    provider_id = "llm-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    env_cmd = os.getenv("ACP_LLM_COMMAND", "").strip()
+    env_url = os.getenv("ACP_LLM_BASE_URL", "").strip()
+    print("  ACP LLM connects Hermes to any ACP-compatible LLM subprocess.")
+    print(f"  Current command: {env_cmd or '(not set)'}")
+    print(f"  Current base URL: {env_url or pconfig.inference_base_url}")
+    print()
+
+    try:
+        cmd = input("  Command (required, e.g. my-acp-llm): ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    if not cmd:
+        print("  Cancelled — command is required.")
+        return
+
+    try:
+        base_url = input(f"  Base URL [{env_url or pconfig.inference_base_url}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    if not base_url:
+        base_url = env_url or pconfig.inference_base_url
+
+    try:
+        model_name = input("  Model name (or Enter to skip): ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    from hermes_cli.config import save_env_value
+    save_env_value("ACP_LLM_COMMAND", cmd)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = base_url
+    model["api_mode"] = "chat_completions"
+    if model_name:
+        model["default"] = model_name
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"  Configured: {provider_id} via {cmd}")
 
 
 def _model_flow_kimi(config, current_model=""):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -935,6 +935,7 @@ def select_provider_and_model(args=None):
         "huggingface": "Hugging Face",
         "llm-acp": "ACP LLM",
         "claude-agent-acp": "Claude Agent ACP",
+        "claude-code-acp": "Claude Code ACP",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active) if active else "none"
@@ -957,6 +958,7 @@ def select_provider_and_model(args=None):
 
     extended_providers = [
         ("copilot-acp", "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
+        ("claude-code-acp", "Claude Code ACP (uses local `claude` CLI as backend)"),
         ("claude-agent-acp", "Claude Agent ACP (spawns `claude-agent-acp --stdio`)"),
         ("llm-acp", "ACP LLM (generic ACP subprocess — any ACP-compatible LLM server)"),
         ("gemini", "Google AI Studio (Gemini models — OpenAI-compatible endpoint)"),
@@ -1053,6 +1055,8 @@ def select_provider_and_model(args=None):
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-code-acp":
+        _model_flow_claude_code_acp(config, current_model)
     elif selected_provider == "claude-agent-acp":
         _model_flow_claude_agent_acp(config, current_model)
     elif selected_provider == "llm-acp":
@@ -2166,6 +2170,52 @@ def _model_flow_copilot_acp(config, current_model=""):
     deactivate_provider()
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_claude_code_acp(config, current_model=""):
+    import os
+    from hermes_cli.auth import PROVIDER_REGISTRY, deactivate_provider
+    from hermes_cli.config import load_config, save_config, save_env_value
+
+    del config
+    provider_id = "claude-code-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    env_cmd = os.getenv("CLAUDE_CODE_ACP_COMMAND", "").strip()
+    default_cmd = env_cmd or "claude"
+    print("  Claude Code ACP uses your local `claude` CLI as the Hermes backend.")
+    print("  Each Hermes turn spawns `claude --print --output-format stream-json`.")
+    print(f"  Current command: {default_cmd}")
+    print()
+
+    try:
+        cmd = input(f"  Command [{default_cmd}]: ").strip() or default_cmd
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    try:
+        model_name = input("  Model name (or Enter to skip): ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    save_env_value("CLAUDE_CODE_ACP_COMMAND", cmd)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = pconfig.inference_base_url
+    model["api_mode"] = "chat_completions"
+    if model_name:
+        model["default"] = model_name
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"  Configured: {provider_id} via {cmd}")
 
 
 def _model_flow_claude_agent_acp(config, current_model=""):

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -728,7 +728,7 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    if provider in ("llm-acp", "claude-agent-acp"):
+    if provider in ("llm-acp", "claude-agent-acp", "claude-code-acp"):
         creds = resolve_acp_provider_credentials(provider)
         return {
             "provider": provider,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -23,6 +23,7 @@ from hermes_cli.auth import (
     resolve_qwen_runtime_credentials,
     resolve_api_key_provider_credentials,
     resolve_external_process_provider_credentials,
+    resolve_acp_provider_credentials,
     has_usable_secret,
 )
 from hermes_cli.config import load_config
@@ -718,6 +719,19 @@ def resolve_runtime_provider(
         creds = resolve_external_process_provider_credentials(provider)
         return {
             "provider": "copilot-acp",
+            "api_mode": "chat_completions",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
+    if provider in ("llm-acp", "claude-agent-acp"):
+        creds = resolve_acp_provider_credentials(provider)
+        return {
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/run_agent.py
+++ b/run_agent.py
@@ -3632,6 +3632,17 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
+        if self.provider == "claude-code-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://claude-code"):
+            from agent.claude_code_client import ClaudeCodeClient
+
+            client = ClaudeCodeClient(**client_kwargs)
+            logger.info(
+                "Claude Code ACP client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
         client = OpenAI(**client_kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",


### PR DESCRIPTION
## Summary

- Adds a generalized `llm-acp` provider for any ACP-protocol LLM subprocess (configured via `ACP_LLM_COMMAND` env var)
- Adds a dedicated `claude-agent-acp` provider for https://github.com/agentclientprotocol/claude-agent-acp (defaults to `claude-agent-acp --stdio`)
- Both providers use `auth_type="acp"` in `PROVIDER_REGISTRY` and follow the existing `copilot-acp` pattern throughout auth.py, runtime_provider.py, and main.py

## Changes

- `hermes_cli/auth.py`: new ProviderConfig entries for `llm-acp` and `claude-agent-acp`; new `resolve_acp_provider_credentials()` function; aliases in `resolve_provider()`
- `hermes_cli/runtime_provider.py`: new branch dispatching to `resolve_acp_provider_credentials()` for both providers
- `hermes_cli/main.py`: new setup wizard flows `_model_flow_claude_agent_acp()` and `_model_flow_llm_acp()`; both providers added to `extended_providers` list

## Test plan

- [ ] Set `ACP_LLM_COMMAND=<binary>` and run `hermes` -- provider selection should show `ACP LLM` option
- [ ] Run `hermes` and select `Claude Agent ACP` -- should default to `claude-agent-acp --stdio` if installed
- [ ] Missing `ACP_LLM_COMMAND` should raise AuthError with clear message
- [ ] Unknown command (not on PATH) should raise AuthError with clear message

Generated with Claude Code