### PR TITLE
feat(cli): braille animations, tool progress widget, session stats

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1374,7 +1374,12 @@ class HermesCLI:
         self._reasoning_stream_started = False  # True once live reasoning starts streaming
         self._reasoning_preview_buf = ""  # Coalesce tiny reasoning chunks for [thinking] output
         self._pending_edit_snapshots = {}
-        
+
+        # Tool progress tracking
+        from hermes_cli.tool_progress_widget import ToolProgressTracker
+        self._tool_tracker = ToolProgressTracker()
+        self._turn_start_time: float = 0.0
+
         # Configuration - priority: CLI args > env vars > config file
         # Model comes from: CLI arg or config.yaml (single source of truth).
         # LLM_MODEL/OPENAI_MODEL env vars are NOT checked — config.yaml is
@@ -1740,6 +1745,14 @@ class HermesCLI:
             return []
         try:
             snapshot = self._get_status_bar_snapshot()
+
+            # Animated icon when agent is running — breathe animation
+            if self._agent_running:
+                import time as _time
+                from hermes_cli.braille_animations import get_frame
+                _agent_icon = f" {get_frame('breathe', int(_time.monotonic() * 1000))} "
+            else:
+                _agent_icon = " ⚕ "
             # Use prompt_toolkit's own terminal width when running inside the
             # TUI — shutil.get_terminal_size() can return stale or fallback
             # values (especially on SSH) that differ from what prompt_toolkit
@@ -1754,7 +1767,7 @@ class HermesCLI:
 
             if width < 52:
                 frags = [
-                    ("class:status-bar", " ⚕ "),
+                    ("class:status-bar", _agent_icon),
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
@@ -1765,7 +1778,7 @@ class HermesCLI:
                 percent_label = f"{percent}%" if percent is not None else "--"
                 if width < 76:
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        ("class:status-bar", _agent_icon),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
@@ -1783,7 +1796,7 @@ class HermesCLI:
 
                     bar_style = self._status_bar_context_style(percent)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        ("class:status-bar", _agent_icon),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
@@ -2245,8 +2258,22 @@ class HermesCLI:
         return "Processing command..."
 
     def _command_spinner_frame(self) -> str:
-        """Return the current spinner frame for slow slash commands."""
+        """Return the current spinner frame for slow slash commands.
+
+        If the active skin specifies a braille animation, use that instead
+        of the default 10-frame braille dots.
+        """
         import time as _time
+
+        try:
+            from hermes_cli.skin_engine import get_active_skin
+            anim_name = get_active_skin().get_spinner_animation()
+            if anim_name:
+                from hermes_cli.braille_animations import get_frame
+                elapsed_ms = int(_time.monotonic() * 1000)
+                return get_frame(anim_name, elapsed_ms)
+        except Exception:
+            pass
 
         frame_idx = int(_time.monotonic() * 10) % len(_COMMAND_SPINNER_FRAMES)
         return _COMMAND_SPINNER_FRAMES[frame_idx]
@@ -5650,9 +5677,17 @@ class HermesCLI:
 
         Updates the TUI spinner widget so the user can see what the agent
         is doing during tool execution (fills the gap between thinking
-        spinner and next response).  Also plays audio cue in voice mode.
+        spinner and next response).  Also plays audio cue in voice mode
+        and updates the tool progress tracker.
         """
-        # Only act on tool.started; ignore tool.completed, reasoning.available, etc.
+        # Track tool activity for the progress widget (respects tool_progress config)
+        if self.tool_progress_mode != "off" and function_name and not function_name.startswith("_"):
+            if event_type == "tool.started":
+                self._tool_tracker.on_tool_start(function_name, preview or function_name)
+            elif event_type == "tool.completed":
+                self._tool_tracker.on_tool_complete(function_name)
+
+        # Only update spinner text on tool.started
         if event_type != "tool.started":
             return
         if function_name and not function_name.startswith("_"):
@@ -7018,6 +7053,7 @@ class HermesCLI:
         approval_widget,
         clarify_widget,
         spinner_widget,
+        tool_progress_widget=None,
         spacer,
         status_bar,
         input_rule_top,
@@ -7033,13 +7069,17 @@ class HermesCLI:
         this method.  Override this only when you need full control over widget
         ordering.
         """
-        return [
+        children = [
             Window(height=0),
             sudo_widget,
             secret_widget,
             approval_widget,
             clarify_widget,
             spinner_widget,
+        ]
+        if tool_progress_widget is not None:
+            children.append(tool_progress_widget)
+        children.extend([
             spacer,
             *self._get_extra_tui_widgets(),
             status_bar,
@@ -7049,7 +7089,8 @@ class HermesCLI:
             input_rule_bot,
             voice_status_bar,
             completions_menu,
-        ]
+        ])
+        return children
 
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
@@ -7833,6 +7874,31 @@ class HermesCLI:
             height=get_spinner_height,
         )
 
+        # --- Tool progress widget: multi-lane tool activity display ---
+
+        from hermes_cli.tool_progress_widget import build_progress_fragments
+
+        def get_tool_progress_fragments():
+            if not cli_ref._tool_tracker.has_activity():
+                return []
+            try:
+                cols = shutil.get_terminal_size((80, 24)).columns
+            except Exception:
+                cols = 80
+            return build_progress_fragments(cli_ref._tool_tracker, cols)
+
+        def get_tool_progress_height():
+            lanes = cli_ref._tool_tracker.get_active_lanes()
+            return len(lanes) + 4 if lanes else 0  # header + border lines + lanes + footer
+
+        tool_progress_widget = ConditionalContainer(
+            Window(
+                content=FormattedTextControl(get_tool_progress_fragments),
+                height=get_tool_progress_height,
+            ),
+            filter=Condition(lambda: cli_ref._tool_tracker.has_activity()),
+        )
+
         spacer = Window(
             content=FormattedTextControl(get_hint_text),
             height=get_hint_height,
@@ -8101,6 +8167,7 @@ class HermesCLI:
                     approval_widget=approval_widget,
                     clarify_widget=clarify_widget,
                     spinner_widget=spinner_widget,
+                    tool_progress_widget=tool_progress_widget,
                     spacer=spacer,
                     status_bar=status_bar,
                     input_rule_top=input_rule_top,
@@ -8227,9 +8294,26 @@ class HermesCLI:
                 if not self._app:
                     _time.sleep(0.1)
                     continue
-                if self._command_running:
-                    self._invalidate(min_interval=0.1)
-                    _time.sleep(0.1)
+                if self._command_running or self._agent_running:
+                    # Adapt tick rate to skin animation interval if present
+                    tick = 0.1
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        skin = get_active_skin()
+                        anim_name = skin.get_spinner_animation()
+                        if anim_name:
+                            # Skin can override interval; fall back to animation default
+                            override_ms = skin.get_spinner_animation_interval()
+                            if override_ms > 0:
+                                tick = override_ms / 1000.0
+                            else:
+                                from hermes_cli.braille_animations import get_animation
+                                tick = get_animation(anim_name)["interval_ms"] / 1000.0
+                            tick = max(tick, 0.05)  # floor at 50ms
+                    except Exception:
+                        pass
+                    self._invalidate(min_interval=tick)
+                    _time.sleep(tick)
                 else:
                     now = _time.monotonic()
                     if now - last_idle_refresh >= 1.0:
@@ -8358,6 +8442,7 @@ class HermesCLI:
 
                     # Regular chat - run agent
                     self._agent_running = True
+                    self._turn_start_time = time.monotonic()
                     app.invalidate()  # Refresh status line
 
                     try:
@@ -8366,6 +8451,17 @@ class HermesCLI:
                         self._agent_running = False
                         self._spinner_text = ""
 
+                        # Post-turn stats (guarded so it can't suppress the real exception)
+                        try:
+                            if self.tool_progress_mode != "off" and self._turn_start_time:
+                                from hermes_cli.session_stats import format_turn_summary
+                                duration = time.monotonic() - self._turn_start_time
+                                summary = self._tool_tracker.get_turn_summary()
+                                if sum(summary.values()) > 0:
+                                    _cprint(f"\033[2m{format_turn_summary(duration, summary)}\033[0m")
+                            self._tool_tracker.on_turn_end()
+                        except Exception:
+                            pass
                         app.invalidate()  # Refresh status line
 
                         # Continuous voice: auto-restart recording after agent responds.

--- a/hermes_cli/braille_animations.py
+++ b/hermes_cli/braille_animations.py
@@ -1,0 +1,248 @@
+"""Braille-based terminal animations — pure frame data, zero dependencies.
+
+Ported from the unicode-animations npm package (by Gunnar Gray, Perplexity).
+Each animation is a dict with:
+  - "frames": tuple[str, ...]  — each frame is a string of braille characters
+  - "interval_ms": int         — recommended millisecond interval between frames
+
+All animations use Unicode braille characters (U+2800..U+28FF) so they
+render correctly in any modern terminal.
+
+Usage:
+    from hermes_cli.braille_animations import get_frame, get_animation_names
+
+    # Time-based frame selection (for render loops):
+    frame = get_frame("breathe", elapsed_ms=1200)
+
+    # Direct access:
+    anim = ANIMATIONS["dna"]
+    frames, interval = anim["frames"], anim["interval_ms"]
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Tuple
+
+# ── Braille grid conversion ─────────────────────────────────────────
+#
+# Each braille character is a 2-column × 4-row dot grid.
+# Base codepoint U+2800, with dots mapped via:
+#
+#   col 0   col 1
+#   ─────   ─────
+#   0x01    0x08    row 0
+#   0x02    0x10    row 1
+#   0x04    0x20    row 2
+#   0x40    0x80    row 3
+
+BRAILLE_BASE = 0x2800
+
+BRAILLE_DOT_MAP = [
+    [0x01, 0x08],
+    [0x02, 0x10],
+    [0x04, 0x20],
+    [0x40, 0x80],
+]
+
+
+def grid_to_braille(grid: List[List[bool]]) -> str:
+    """Convert a 2D boolean grid to a string of braille characters.
+
+    Each braille character encodes a 4-row × 2-column region of the grid.
+    The grid can have arbitrary dimensions; partial cells are handled.
+    """
+    rows = len(grid)
+    if rows == 0:
+        return ""
+    cols = len(grid[0])
+    char_count = math.ceil(cols / 2)
+    result = []
+    for c in range(char_count):
+        code = BRAILLE_BASE
+        for r in range(min(4, rows)):
+            for d in range(2):
+                col = c * 2 + d
+                if col < cols and grid[r][col]:
+                    code |= BRAILLE_DOT_MAP[r][d]
+        result.append(chr(code))
+    return "".join(result)
+
+
+def make_grid(rows: int, cols: int) -> List[List[bool]]:
+    """Create a rows×cols boolean grid initialized to False."""
+    return [[False] * cols for _ in range(rows)]
+
+
+# ── Animation definitions ────────────────────────────────────────────
+#
+# Frames are stored as tuples (immutable, zero-copy on repeated access).
+# Three animations have hardcoded frames; the remaining 15 use frames
+# extracted from the upstream snapshot tests (ground truth).
+
+ANIMATIONS: Dict[str, dict] = {
+    # ── Classic braille ──────────────────────────────────────────────
+    "braille": {
+        "frames": (
+            "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+        ),
+        "interval_ms": 80,
+    },
+    "braillewave": {
+        "frames": (
+            "⠁⠂⠄⡀", "⠂⠄⡀⢀", "⠄⡀⢀⠠", "⡀⢀⠠⠐",
+            "⢀⠠⠐⠈", "⠠⠐⠈⠁", "⠐⠈⠁⠂", "⠈⠁⠂⠄",
+        ),
+        "interval_ms": 100,
+    },
+    "dna": {
+        "frames": (
+            "⠋⠉⠙⠚", "⠉⠙⠚⠒", "⠙⠚⠒⠂", "⠚⠒⠂⠂",
+            "⠒⠂⠂⠒", "⠂⠂⠒⠲", "⠂⠒⠲⠴", "⠒⠲⠴⠤",
+            "⠲⠴⠤⠄", "⠴⠤⠄⠋", "⠤⠄⠋⠉", "⠄⠋⠉⠙",
+        ),
+        "interval_ms": 80,
+    },
+    # ── Grid-based animations ────────────────────────────────────────
+    "scan": {
+        "frames": (
+            "⠀⠀⠀⠀", "⡇⠀⠀⠀", "⣿⠀⠀⠀", "⢸⡇⠀⠀",
+            "⠀⣿⠀⠀", "⠀⢸⡇⠀", "⠀⠀⣿⠀", "⠀⠀⢸⡇",
+            "⠀⠀⠀⣿", "⠀⠀⠀⢸",
+        ),
+        "interval_ms": 70,
+    },
+    "rain": {
+        "frames": (
+            "⢁⠂⠔⠈", "⠂⠌⡠⠐", "⠄⡐⢀⠡", "⡈⠠⠀⢂",
+            "⠐⢀⠁⠄", "⠠⠁⠊⡀", "⢁⠂⠔⠈", "⠂⠌⡠⠐",
+            "⠄⡐⢀⠡", "⡈⠠⠀⢂", "⠐⢀⠁⠄", "⠠⠁⠊⡀",
+        ),
+        "interval_ms": 100,
+    },
+    "scanline": {
+        "frames": (
+            "⠉⠉⠉", "⠓⠓⠓", "⠦⠦⠦", "⣄⣄⣄", "⠦⠦⠦", "⠓⠓⠓",
+        ),
+        "interval_ms": 120,
+    },
+    "pulse": {
+        "frames": (
+            "⠀⠶⠀", "⠰⣿⠆", "⢾⣉⡷", "⣏⠀⣹", "⡁⠀⢈",
+        ),
+        "interval_ms": 180,
+    },
+    "snake": {
+        "frames": (
+            "⣁⡀", "⣉⠀", "⡉⠁", "⠉⠉", "⠈⠙", "⠀⠛",
+            "⠐⠚", "⠒⠒", "⠖⠂", "⠶⠀", "⠦⠄", "⠤⠤",
+            "⠠⢤", "⠀⣤", "⢀⣠", "⣀⣀",
+        ),
+        "interval_ms": 80,
+    },
+    "sparkle": {
+        "frames": (
+            "⡡⠊⢔⠡", "⠊⡰⡡⡘", "⢔⢅⠈⢢",
+            "⡁⢂⠆⡍", "⢔⠨⢑⢐", "⠨⡑⡠⠊",
+        ),
+        "interval_ms": 150,
+    },
+    "cascade": {
+        "frames": (
+            "⠀⠀⠀⠀", "⠀⠀⠀⠀", "⠁⠀⠀⠀", "⠋⠀⠀⠀",
+            "⠞⠁⠀⠀", "⡴⠋⠀⠀", "⣠⠞⠁⠀", "⢀⡴⠋⠀",
+            "⠀⣠⠞⠁", "⠀⢀⡴⠋", "⠀⠀⣠⠞", "⠀⠀⢀⡴",
+            "⠀⠀⠀⣠", "⠀⠀⠀⢀",
+        ),
+        "interval_ms": 60,
+    },
+    "columns": {
+        "frames": (
+            "⡀⠀⠀", "⡄⠀⠀", "⡆⠀⠀", "⡇⠀⠀",
+            "⣇⠀⠀", "⣧⠀⠀", "⣷⠀⠀", "⣿⠀⠀",
+            "⣿⡀⠀", "⣿⡄⠀", "⣿⡆⠀", "⣿⡇⠀",
+            "⣿⣇⠀", "⣿⣧⠀", "⣿⣷⠀", "⣿⣿⠀",
+            "⣿⣿⡀", "⣿⣿⡄", "⣿⣿⡆", "⣿⣿⡇",
+            "⣿⣿⣇", "⣿⣿⣧", "⣿⣿⣷", "⣿⣿⣿",
+            "⣿⣿⣿", "⠀⠀⠀",
+        ),
+        "interval_ms": 60,
+    },
+    "orbit": {
+        "frames": (
+            "⠃", "⠉", "⠘", "⠰", "⢠", "⣀", "⡄", "⠆",
+        ),
+        "interval_ms": 100,
+    },
+    "breathe": {
+        "frames": (
+            "⠀", "⠂", "⠌", "⡑", "⢕", "⢝", "⣫", "⣟", "⣿",
+            "⣟", "⣫", "⢝", "⢕", "⡑", "⠌", "⠂", "⠀",
+        ),
+        "interval_ms": 100,
+    },
+    "waverows": {
+        "frames": (
+            "⠖⠉⠉⠑", "⡠⠖⠉⠉", "⣠⡠⠖⠉", "⣄⣠⡠⠖",
+            "⠢⣄⣠⡠", "⠙⠢⣄⣠", "⠉⠙⠢⣄", "⠊⠉⠙⠢",
+            "⠜⠊⠉⠙", "⡤⠜⠊⠉", "⣀⡤⠜⠊", "⢤⣀⡤⠜",
+            "⠣⢤⣀⡤", "⠑⠣⢤⣀", "⠉⠑⠣⢤", "⠋⠉⠑⠣",
+        ),
+        "interval_ms": 90,
+    },
+    "checkerboard": {
+        "frames": (
+            "⢕⢕⢕", "⡪⡪⡪", "⢊⠔⡡", "⡡⢊⠔",
+        ),
+        "interval_ms": 250,
+    },
+    "helix": {
+        "frames": (
+            "⢌⣉⢎⣉", "⣉⡱⣉⡱", "⣉⢎⣉⢎", "⡱⣉⡱⣉",
+            "⢎⣉⢎⣉", "⣉⡱⣉⡱", "⣉⢎⣉⢎", "⡱⣉⡱⣉",
+            "⢎⣉⢎⣉", "⣉⡱⣉⡱", "⣉⢎⣉⢎", "⡱⣉⡱⣉",
+            "⢎⣉⢎⣉", "⣉⡱⣉⡱", "⣉⢎⣉⢎", "⡱⣉⡱⣉",
+        ),
+        "interval_ms": 80,
+    },
+    "fillsweep": {
+        "frames": (
+            "⣀⣀", "⣤⣤", "⣶⣶", "⣿⣿", "⣿⣿",
+            "⣿⣿", "⣶⣶", "⣤⣤", "⣀⣀", "⠀⠀", "⠀⠀",
+        ),
+        "interval_ms": 100,
+    },
+    "diagswipe": {
+        "frames": (
+            "⠁⠀", "⠋⠀", "⠟⠁", "⡿⠋", "⣿⠟", "⣿⡿",
+            "⣿⣿", "⣿⣿", "⣾⣿", "⣴⣿", "⣠⣾", "⢀⣴",
+            "⠀⣠", "⠀⢀", "⠀⠀", "⠀⠀",
+        ),
+        "interval_ms": 60,
+    },
+}
+
+
+# ── Public API ───────────────────────────────────────────────────────
+
+
+def get_animation_names() -> Tuple[str, ...]:
+    """Return sorted tuple of available animation names."""
+    return tuple(sorted(ANIMATIONS.keys()))
+
+
+def get_animation(name: str) -> dict:
+    """Get animation dict by name. Raises KeyError if not found."""
+    return ANIMATIONS[name]
+
+
+def get_frame(name: str, elapsed_ms: int) -> str:
+    """Get the current frame for an animation based on elapsed time.
+
+    Automatically wraps based on the animation's interval and frame count.
+    """
+    anim = ANIMATIONS[name]
+    frames = anim["frames"]
+    interval = anim["interval_ms"]
+    idx = (elapsed_ms // interval) % len(frames)
+    return frames[idx]

--- a/hermes_cli/session_stats.py
+++ b/hermes_cli/session_stats.py
@@ -1,0 +1,38 @@
+"""Post-turn session statistics — a one-line summary after each agent response.
+
+Prints a compact summary of turn duration and tool call breakdown.
+
+Example output::
+
+    12.3s · 5 tool calls — terminal(3) write_file(2)
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def format_turn_summary(
+    duration_seconds: float,
+    tool_counts: Dict[str, int],
+) -> str:
+    """Format a compact turn summary line.
+
+    Returns a string like ``12.3s · 5 tool calls — terminal(3) write_file(2)``.
+    """
+    # Duration
+    if duration_seconds < 60:
+        dur = f"{duration_seconds:.1f}s"
+    else:
+        mins = int(duration_seconds // 60)
+        secs = duration_seconds % 60
+        dur = f"{mins}m{secs:.0f}s"
+
+    total = sum(tool_counts.values())
+    if total == 0:
+        return f"  {dur} · no tool calls"
+
+    sorted_tools = sorted(tool_counts.items(), key=lambda x: -x[1])
+    breakdown = " ".join(f"{name}({count})" for name, count in sorted_tools)
+
+    return f"  {dur} · {total} tool calls — {breakdown}"

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -47,6 +47,12 @@ All fields are optional. Missing values inherit from the ``default`` skin.
       wings:                              # Optional left/right spinner decorations
         - ["⟪⚔", "⚔⟫"]                  # Each entry is [left, right] pair
         - ["⟪▲", "▲⟫"]
+      animation: breathe                    # Braille animation name (from braille_animations)
+                                            # Valid: braille, braillewave, dna, scan, rain,
+                                            #   scanline, pulse, snake, sparkle, cascade,
+                                            #   columns, orbit, breathe, waverows,
+                                            #   checkerboard, helix, fillsweep, diagswipe
+      animation_interval_ms: 120            # Override default interval (optional)
 
     # Branding: text strings used throughout the CLI
     branding:
@@ -143,6 +149,19 @@ class SkinConfig:
         """Get a branding value with fallback."""
         return self.branding.get(key, fallback)
 
+    def get_spinner_animation(self) -> str:
+        """Get the braille animation name for the command spinner, or empty string.
+
+        When set, the CLI uses animated braille frames from
+        ``hermes_cli.braille_animations`` instead of the default spinner.
+        Valid values: any key in ``braille_animations.ANIMATIONS``.
+        """
+        return str(self.spinner.get("animation", ""))
+
+    def get_spinner_animation_interval(self) -> int:
+        """Get the animation interval override in ms, or 0 for default."""
+        return int(self.spinner.get("animation_interval_ms", 0))
+
 
 # =============================================================================
 # Built-in skin definitions
@@ -215,6 +234,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
                 ["⟪╸", "╺⟫"],
                 ["⟪⛨", "⛨⟫"],
             ],
+            "animation": "dna",
         },
         "branding": {
             "agent_name": "Ares Agent",
@@ -342,6 +362,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
                 ["⟪∿", "∿⟫"],
                 ["⟪◌", "◌⟫"],
             ],
+            "animation": "braillewave",
         },
         "branding": {
             "agent_name": "Poseidon Agent",
@@ -406,6 +427,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
                 ["⟪◌", "◌⟫"],
                 ["⟪⬤", "⬤⟫"],
             ],
+            "animation": "breathe",
         },
         "branding": {
             "agent_name": "Sisyphus Agent",
@@ -471,6 +493,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
                 ["⟪◌", "◌⟫"],
                 ["⟪◇", "◇⟫"],
             ],
+            "animation": "cascade",
         },
         "branding": {
             "agent_name": "Charizard Agent",

--- a/hermes_cli/tool_progress_widget.py
+++ b/hermes_cli/tool_progress_widget.py
@@ -1,0 +1,188 @@
+"""Multi-lane tool progress widget for the prompt_toolkit TUI.
+
+Inspired by SubQ Code's research-progress component. Shows parallel
+tool/agent activity as distinct lanes with animated spinners,
+completion checkmarks, and tool call counts.
+
+Integrates with the existing TUI via ConditionalContainer in cli.py
+and is driven by the _on_tool_progress / _on_tool_complete callbacks.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+# Lane states
+LANE_WAITING = "waiting"
+LANE_ACTIVE = "active"
+LANE_DONE = "done"
+LANE_ERROR = "error"
+
+from hermes_cli.braille_animations import ANIMATIONS as _ANIMATIONS
+
+SPINNER_FRAMES = _ANIMATIONS["braille"]["frames"]
+_SPINNER_INTERVAL_MS = _ANIMATIONS["braille"]["interval_ms"]
+
+STATUS_ICONS = {
+    LANE_WAITING: "◌",
+    LANE_DONE: "✓",
+    LANE_ERROR: "✗",
+}
+
+LANE_NAME_WIDTH = 14
+PAD_X = 2
+THROTTLE_MS = 50
+
+
+@dataclass
+class LaneState:
+    name: str
+    status: str = LANE_WAITING
+    action: str = "Waiting..."
+    tool_calls: int = 0
+
+
+class ToolProgressTracker:
+    """Thread-safe tracker for tool execution state.
+
+    Usage from cli.py::
+
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        tracker.on_tool_complete("terminal")
+        tracker.on_turn_end()  # clears all lanes
+    """
+
+    def __init__(self) -> None:
+        self._lanes: Dict[str, LaneState] = {}
+        self._lock = threading.Lock()
+        self._turn_tool_counts: Dict[str, int] = {}
+        self._invalidate_cb: Optional[Callable[[], None]] = None
+        self._last_invalidate: float = 0.0
+
+    def set_invalidate_callback(self, cb: Callable[[], None]) -> None:
+        self._invalidate_cb = cb
+
+    def on_tool_start(self, tool_name: str, preview: str = "") -> None:
+        with self._lock:
+            if tool_name not in self._lanes:
+                self._lanes[tool_name] = LaneState(
+                    name=tool_name,
+                    status=LANE_ACTIVE,
+                    action=preview or f"Running {tool_name}...",
+                )
+            else:
+                lane = self._lanes[tool_name]
+                lane.status = LANE_ACTIVE
+                lane.action = preview or f"Running {tool_name}..."
+
+            self._lanes[tool_name].tool_calls += 1
+            self._turn_tool_counts[tool_name] = (
+                self._turn_tool_counts.get(tool_name, 0) + 1
+            )
+        self._throttled_invalidate()
+
+    def on_tool_complete(self, tool_name: str, success: bool = True) -> None:
+        with self._lock:
+            if tool_name in self._lanes:
+                lane = self._lanes[tool_name]
+                lane.status = LANE_DONE if success else LANE_ERROR
+                lane.action = "Done" if success else "Failed"
+        self._throttled_invalidate()
+
+    def on_turn_end(self) -> None:
+        """Reset all lanes at end of agent turn."""
+        with self._lock:
+            self._lanes.clear()
+            self._turn_tool_counts.clear()
+        self._throttled_invalidate()
+
+    def get_active_lanes(self) -> List[LaneState]:
+        with self._lock:
+            return list(self._lanes.values())
+
+    def get_turn_summary(self) -> Dict[str, int]:
+        """Return {tool_name: call_count} for session stats."""
+        with self._lock:
+            return dict(self._turn_tool_counts)
+
+    def has_activity(self) -> bool:
+        with self._lock:
+            return len(self._lanes) > 0
+
+    def _throttled_invalidate(self) -> None:
+        cb = None
+        with self._lock:
+            now = time.monotonic() * 1000
+            if now - self._last_invalidate >= THROTTLE_MS and self._invalidate_cb:
+                self._last_invalidate = now
+                cb = self._invalidate_cb
+        if cb:
+            cb()
+
+
+def build_progress_fragments(
+    tracker: ToolProgressTracker,
+    width: int,
+) -> List[Tuple[str, str]]:
+    """Build prompt_toolkit (style, text) fragments for the progress widget.
+
+    Returns an empty list when there are no active lanes.
+    """
+    lanes = tracker.get_active_lanes()
+    if not lanes:
+        return []
+
+    fragments: List[Tuple[str, str]] = []
+    inner = width - PAD_X * 2
+    pad = " " * PAD_X
+    border = "─" * max(inner, 1)
+
+    # Header
+    fragments.append(("class:hint", f"{pad}{border}\n"))
+    fragments.append(("class:status-bar-strong", f"{pad}Tool Activity"))
+    fragments.append(("class:hint", f" ({len(lanes)} tools)\n"))
+    fragments.append(("class:hint", f"{pad}{border}\n"))
+
+    for lane in lanes:
+        # Status icon
+        if lane.status == LANE_ACTIVE:
+            frame_idx = int(time.monotonic() * 1000) // _SPINNER_INTERVAL_MS % len(SPINNER_FRAMES)
+            icon = SPINNER_FRAMES[frame_idx]
+            icon_style = "class:status-bar-strong"
+        elif lane.status == LANE_DONE:
+            icon = STATUS_ICONS[LANE_DONE]
+            icon_style = "class:status-bar-good"
+        elif lane.status == LANE_ERROR:
+            icon = STATUS_ICONS[LANE_ERROR]
+            icon_style = "class:status-bar-bad"
+        else:
+            icon = STATUS_ICONS[LANE_WAITING]
+            icon_style = "class:hint"
+
+        # Lane name
+        name = lane.name[:LANE_NAME_WIDTH].ljust(LANE_NAME_WIDTH)
+        name_style = "class:hint" if lane.status == LANE_DONE else "class:status-bar"
+
+        # Action text
+        action_max = max(10, inner - LANE_NAME_WIDTH - 12)
+        action = lane.action[:action_max]
+        action_style = "class:hint"
+
+        # Counter
+        counter = f"{lane.tool_calls}x" if lane.tool_calls > 0 else ""
+        counter = counter.rjust(6)
+
+        action_pad = max(0, action_max - len(action))
+        fragments.append((icon_style, f"{pad}{icon} "))
+        fragments.append((name_style, name))
+        fragments.append((action_style, action))
+        fragments.append(("", " " * action_pad))
+        fragments.append(("class:hint", f" {counter}\n"))
+
+    fragments.append(("class:hint", f"{pad}{border}\n"))
+
+    return fragments

--- a/tests/test_braille_animations.py
+++ b/tests/test_braille_animations.py
@@ -1,0 +1,115 @@
+"""Tests for hermes_cli.braille_animations — ported unicode-animations frame data."""
+
+import pytest
+
+from hermes_cli.braille_animations import (
+    ANIMATIONS,
+    grid_to_braille,
+    make_grid,
+    get_animation,
+    get_animation_names,
+    get_frame,
+)
+
+
+class TestAnimationData:
+    def test_all_18_animations_present(self):
+        assert len(ANIMATIONS) == 18
+
+    def test_animation_names_sorted(self):
+        names = get_animation_names()
+        assert names == tuple(sorted(names))
+        assert len(names) == 18
+
+    def test_each_animation_has_required_keys(self):
+        for name, anim in ANIMATIONS.items():
+            assert "frames" in anim, f"{name} missing 'frames'"
+            assert "interval_ms" in anim, f"{name} missing 'interval_ms'"
+            assert isinstance(anim["frames"], tuple), f"{name} frames should be tuple"
+            assert len(anim["frames"]) > 0, f"{name} has no frames"
+            assert anim["interval_ms"] > 0, f"{name} has non-positive interval"
+
+    def test_frames_are_strings(self):
+        for name, anim in ANIMATIONS.items():
+            for i, frame in enumerate(anim["frames"]):
+                assert isinstance(frame, str), f"{name} frame {i} is not a string"
+
+    def test_known_animation_frame_counts(self):
+        assert len(ANIMATIONS["braille"]["frames"]) == 10
+        assert len(ANIMATIONS["breathe"]["frames"]) == 17
+        assert len(ANIMATIONS["columns"]["frames"]) == 26
+        assert len(ANIMATIONS["orbit"]["frames"]) == 8
+        assert len(ANIMATIONS["dna"]["frames"]) == 12
+
+    def test_braille_is_classic_spinner(self):
+        frames = ANIMATIONS["braille"]["frames"]
+        assert frames[0] == "⠋"
+        assert frames[-1] == "⠏"
+
+
+class TestGetAnimation:
+    def test_valid_name(self):
+        anim = get_animation("breathe")
+        assert anim["interval_ms"] == 100
+        assert len(anim["frames"]) == 17
+
+    def test_invalid_name_raises(self):
+        with pytest.raises(KeyError):
+            get_animation("nonexistent")
+
+
+class TestGetFrame:
+    def test_returns_first_frame_at_zero(self):
+        frame = get_frame("braille", 0)
+        assert frame == "⠋"
+
+    def test_wraps_around(self):
+        anim = ANIMATIONS["braille"]
+        total_ms = anim["interval_ms"] * len(anim["frames"])
+        frame_at_0 = get_frame("braille", 0)
+        frame_at_wrap = get_frame("braille", total_ms)
+        assert frame_at_0 == frame_at_wrap
+
+    def test_advances_with_time(self):
+        frame_0 = get_frame("braille", 0)
+        frame_1 = get_frame("braille", 80)
+        assert frame_0 != frame_1
+
+    def test_invalid_name_raises(self):
+        with pytest.raises(KeyError):
+            get_frame("nonexistent", 0)
+
+
+class TestGridToBraille:
+    def test_empty_grid(self):
+        assert grid_to_braille([]) == ""
+
+    def test_single_cell_all_false(self):
+        grid = make_grid(4, 2)
+        result = grid_to_braille(grid)
+        assert result == "⠀"  # U+2800 (braille blank)
+
+    def test_single_cell_all_true(self):
+        grid = make_grid(4, 2)
+        for r in range(4):
+            for c in range(2):
+                grid[r][c] = True
+        result = grid_to_braille(grid)
+        assert result == "⣿"  # U+28FF (all dots)
+
+    def test_top_left_dot(self):
+        grid = make_grid(4, 2)
+        grid[0][0] = True
+        result = grid_to_braille(grid)
+        assert result == "⠁"  # U+2801 (dot 1)
+
+
+class TestMakeGrid:
+    def test_dimensions(self):
+        grid = make_grid(4, 6)
+        assert len(grid) == 4
+        assert all(len(row) == 6 for row in grid)
+
+    def test_all_false(self):
+        grid = make_grid(4, 2)
+        assert all(not cell for row in grid for cell in row)

--- a/tests/test_tool_progress_widget.py
+++ b/tests/test_tool_progress_widget.py
@@ -1,0 +1,141 @@
+"""Tests for hermes_cli.tool_progress_widget — multi-lane tool progress tracker."""
+
+import threading
+
+import pytest
+
+from hermes_cli.tool_progress_widget import (
+    LANE_ACTIVE,
+    LANE_DONE,
+    LANE_ERROR,
+    LANE_WAITING,
+    ToolProgressTracker,
+    build_progress_fragments,
+)
+
+
+class TestToolProgressTracker:
+    def test_initial_state(self):
+        tracker = ToolProgressTracker()
+        assert not tracker.has_activity()
+        assert tracker.get_active_lanes() == []
+        assert tracker.get_turn_summary() == {}
+
+    def test_tool_start_creates_lane(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        assert tracker.has_activity()
+        lanes = tracker.get_active_lanes()
+        assert len(lanes) == 1
+        assert lanes[0].name == "terminal"
+        assert lanes[0].status == LANE_ACTIVE
+        assert lanes[0].tool_calls == 1
+
+    def test_tool_complete_marks_done(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        tracker.on_tool_complete("terminal")
+        lanes = tracker.get_active_lanes()
+        assert lanes[0].status == LANE_DONE
+
+    def test_tool_complete_error(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        tracker.on_tool_complete("terminal", success=False)
+        lanes = tracker.get_active_lanes()
+        assert lanes[0].status == LANE_ERROR
+
+    def test_multiple_calls_increment_count(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        tracker.on_tool_complete("terminal")
+        tracker.on_tool_start("terminal", "ls -la")
+        assert tracker.get_active_lanes()[0].tool_calls == 2
+
+    def test_multiple_tools(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        tracker.on_tool_start("write_file", "test.py")
+        assert len(tracker.get_active_lanes()) == 2
+
+    def test_turn_end_clears_all(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        tracker.on_tool_start("write_file", "test.py")
+        tracker.on_turn_end()
+        assert not tracker.has_activity()
+        assert tracker.get_turn_summary() == {}
+
+    def test_turn_summary(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        tracker.on_tool_start("terminal", "ls")
+        tracker.on_tool_start("write_file", "test.py")
+        summary = tracker.get_turn_summary()
+        assert summary == {"terminal": 2, "write_file": 1}
+
+    def test_thread_safety(self):
+        tracker = ToolProgressTracker()
+        errors = []
+
+        def start_tools():
+            try:
+                for i in range(50):
+                    tracker.on_tool_start(f"tool_{i % 5}", f"action_{i}")
+            except Exception as e:
+                errors.append(e)
+
+        def complete_tools():
+            try:
+                for i in range(50):
+                    tracker.on_tool_complete(f"tool_{i % 5}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=start_tools),
+            threading.Thread(target=complete_tools),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+
+    def test_invalidate_callback(self):
+        tracker = ToolProgressTracker()
+        calls = []
+        tracker.set_invalidate_callback(lambda: calls.append(1))
+        tracker.on_tool_start("terminal", "whoami")
+        assert len(calls) >= 1
+
+
+class TestBuildProgressFragments:
+    def test_empty_when_no_activity(self):
+        tracker = ToolProgressTracker()
+        frags = build_progress_fragments(tracker, 80)
+        assert frags == []
+
+    def test_returns_fragments_with_activity(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        frags = build_progress_fragments(tracker, 80)
+        assert len(frags) > 0
+        # Should contain style/text tuples
+        for style, text in frags:
+            assert isinstance(style, str)
+            assert isinstance(text, str)
+
+    def test_contains_tool_name(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        frags = build_progress_fragments(tracker, 80)
+        all_text = "".join(text for _, text in frags)
+        assert "terminal" in all_text
+
+    def test_narrow_width_does_not_crash(self):
+        tracker = ToolProgressTracker()
+        tracker.on_tool_start("terminal", "whoami")
+        frags = build_progress_fragments(tracker, 30)
+        assert len(frags) > 0


### PR DESCRIPTION
## Summary

Ports the 18 braille animations from [unicode-animations](https://www.npmjs.com/package/unicode-animations) into the skin engine and adds two new TUI components—a multi-lane tool progress widget and post-turn session stats.

- **Skin-driven braille animations.** Skins can now set `spinner.animation: breathe` (or any of 18 patterns) to replace the default braille dots with richer visual feedback. Four built-in skins ship with animations: ares (dna), poseidon (braillewave), sisyphus (breathe), charizard (cascade). User skins in `~/.hermes/skins/` get the same capability via YAML.
- **Tool progress widget.** Multi-lane display during agent turns showing parallel tool activity—per-lane braille spinners, completion checkmarks, error markers, and call counts. Respects `display.tool_progress` config.
- **Session stats.** Post-turn summary line: `12.3s · 5 tool calls — terminal(3) write_file(2)`. Dimmed, unobtrusive, gated behind the same tool progress config.
- **Animated status bar icon.** The `⚕` in the status bar breathes while the agent is running—visual heartbeat that the agent is alive.
- **Skin interval override.** `spinner.animation_interval_ms` lets skin authors tune animation speed independently of the animation's default timing.

Zero new dependencies. All animation frames are pure Unicode data—no runtime cost beyond frame selection.

## Changes

| File | What |
|------|------|
| `hermes_cli/braille_animations.py` | **New** — 18 animations ported as pre-computed frame tuples, `grid_to_braille` utility, `get_frame` convenience API |
| `hermes_cli/tool_progress_widget.py` | **New** — `ToolProgressTracker` (thread-safe, throttled invalidation) + `build_progress_fragments` for prompt_toolkit |
| `hermes_cli/session_stats.py` | **New** — `format_turn_summary` post-turn formatter |
| `hermes_cli/skin_engine.py` | Add `get_spinner_animation()`, `get_spinner_animation_interval()`, animation keys on 4 built-in skins |
| `cli.py` | Skin-aware `_command_spinner_frame`, adaptive `spinner_loop` tick rate, tool progress widget in TUI layout, animated status bar icon, post-turn stats in agent turn finally block |
| `tests/test_braille_animations.py` | **New** — 18 tests (frame data, grid conversion, timing) |
| `tests/test_tool_progress_widget.py` | **New** — 14 tests (state machine, thread safety, fragment rendering) |

## Credit

Animation frame data ported from [unicode-animations](https://github.com/gunnargray-dev/unicode-animations) by **Gunnar Gray** (Perplexity). MIT license. The `grid_to_braille` encoding and all 18 frame sequences originate from that package—this PR is a Python port of the pre-computed frames, not a reimplementation of the generators.

Spotted via [@vikingmute's tweet](https://x.com/vikingmute/status/2041841995006849465) highlighting the package for agent loading effects.

## Test Plan

- [x] 32 new tests pass (`pytest tests/test_braille_animations.py tests/test_tool_progress_widget.py`)
- [x] 36 existing skin engine + banner tests pass (backwards compat)
- [x] Skins without `animation` key behave identically to before
- [x] `display.tool_progress: "off"` suppresses both widget and stats
- [ ] Manual: `/skin ares` → verify dna spinner, `/skin poseidon` → braillewave
- [ ] Manual: multi-tool prompt → verify progress panel appears and clears
- [ ] Manual: narrow terminal (<52 cols) → graceful degradation