### PR TITLE
fix: autodetect Camofox in /browser connect

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -31,9 +31,28 @@ from typing import List, Dict, Any, Optional
 logger = logging.getLogger(__name__)
 
 
+def _normalize_browser_connect_endpoint(endpoint: str) -> str:
+    """Normalize user-supplied browser connect endpoints for local host:port inputs."""
+    raw = (endpoint or "").strip().rstrip("/")
+    if not raw:
+        return raw
+
+    lowered = raw.lower()
+    if lowered.startswith(("http://", "https://", "ws://", "wss://")):
+        return raw
+
+    host, sep, port = raw.rpartition(":")
+    if sep and host.lower() in {"localhost", "127.0.0.1", "0.0.0.0"} and port.isdigit():
+        return f"http://{raw}"
+    if raw.startswith("[::1]:") and raw[len("[::1]:"):].isdigit():
+        return f"http://{raw}"
+
+    return raw
+
+
 def _detect_browser_connect_backend(endpoint: str) -> tuple[str, str]:
     """Classify a /browser connect endpoint as CDP or Camofox."""
-    raw = (endpoint or "").strip().rstrip("/")
+    raw = _normalize_browser_connect_endpoint(endpoint)
     if not raw:
         return "unknown", raw
 
@@ -5064,6 +5083,7 @@ class HermesCLI:
             connect_parts = cmd.strip().split(None, 2)
             cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
             detected_mode, normalized_endpoint = _detect_browser_connect_backend(cdp_url)
+            cdp_url = normalized_endpoint or cdp_url
 
             try:
                 from tools.browser_tool import cleanup_all_browsers

--- a/cli.py
+++ b/cli.py
@@ -30,6 +30,45 @@ from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _detect_browser_connect_backend(endpoint: str) -> tuple[str, str]:
+    """Classify a /browser connect endpoint as CDP or Camofox."""
+    raw = (endpoint or "").strip().rstrip("/")
+    if not raw:
+        return "unknown", raw
+
+    lowered = raw.lower()
+    if "/devtools/browser/" in lowered:
+        return "cdp", raw
+
+    discovery_url = raw
+    if lowered.startswith(("ws://", "wss://")):
+        if raw.count(":") == 2 and raw.rstrip("/").rsplit(":", 1)[-1].isdigit() and "/" not in raw.split(":", 2)[-1]:
+            discovery_url = ("http://" if lowered.startswith("ws://") else "https://") + raw.split("://", 1)[1]
+        else:
+            return "cdp", raw
+
+    try:
+        import requests as _requests
+        version_url = discovery_url if discovery_url.lower().endswith("/json/version") else discovery_url + "/json/version"
+        response = _requests.get(version_url, timeout=5)
+        response.raise_for_status()
+        payload = response.json()
+        if str(payload.get("webSocketDebuggerUrl") or "").strip():
+            return "cdp", raw
+    except Exception:
+        pass
+
+    try:
+        import requests as _requests
+        health = _requests.get(raw + "/health", timeout=5)
+        if health.status_code == 200:
+            return "camofox", raw
+    except Exception:
+        pass
+
+    return "unknown", raw
+
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
@@ -5010,7 +5049,7 @@ class HermesCLI:
             return False
 
     def _handle_browser_command(self, cmd: str):
-        """Handle /browser connect|disconnect|status — manage live Chrome CDP connection."""
+        """Handle /browser connect|disconnect|status — manage browser backend overrides."""
         import platform as _plat
 
         parts = cmd.strip().split(None, 1)
@@ -5018,13 +5057,14 @@ class HermesCLI:
 
         _DEFAULT_CDP = "http://localhost:9222"
         current = os.environ.get("BROWSER_CDP_URL", "").strip()
+        current_mode = os.environ.get("BROWSER_CONNECT_MODE", "").strip().lower()
+        current_camofox = os.environ.get("CAMOFOX_URL", "").strip().rstrip("/")
 
         if sub.startswith("connect"):
-            # Optionally accept a custom CDP URL: /browser connect ws://host:port
-            connect_parts = cmd.strip().split(None, 2)  # ["/browser", "connect", "ws://..."]
+            connect_parts = cmd.strip().split(None, 2)
             cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
+            detected_mode, normalized_endpoint = _detect_browser_connect_backend(cdp_url)
 
-            # Clear any existing browser sessions so the next tool call uses the new backend
             try:
                 from tools.browser_tool import cleanup_all_browsers
                 cleanup_all_browsers()
@@ -5033,14 +5073,40 @@ class HermesCLI:
 
             print()
 
-            # Extract port for connectivity checks
+            if detected_mode == "camofox":
+                previous_camofox = os.environ.get("CAMOFOX_URL", "").strip().rstrip("/")
+                if previous_camofox and previous_camofox != normalized_endpoint:
+                    os.environ["BROWSER_PREV_CAMOFOX_URL"] = previous_camofox
+                else:
+                    os.environ.pop("BROWSER_PREV_CAMOFOX_URL", None)
+
+                os.environ.pop("BROWSER_CDP_URL", None)
+                os.environ["CAMOFOX_URL"] = normalized_endpoint
+                os.environ["BROWSER_CONNECT_MODE"] = "camofox"
+
+                print(f"   ✓ Camofox detected at {normalized_endpoint}")
+                print()
+                print("🌐 Browser connected to Camofox")
+                print(f"   Endpoint: {normalized_endpoint}")
+                print()
+
+                if hasattr(self, '_pending_input'):
+                    self._pending_input.put(
+                        "[System note: The user has connected your browser tools to a live Camofox browser backend. "
+                        "Your browser tools now route through Camofox instead of the default browser backend. "
+                        "Camofox may preserve cookies or sessions depending on its server-side profile configuration. "
+                        "Please await the user's instruction before attempting to operate the browser.]"
+                    )
+                return
+
+            os.environ.pop("BROWSER_CONNECT_MODE", None)
+
             _port = 9222
             try:
                 _port = int(cdp_url.rsplit(":", 1)[-1].split("/")[0])
             except (ValueError, IndexError):
                 pass
 
-            # Check if Chrome is already listening on the debug port
             import socket
             _already_open = False
             try:
@@ -5055,11 +5121,9 @@ class HermesCLI:
             if _already_open:
                 print(f"   ✓ Chrome is already listening on port {_port}")
             elif cdp_url == _DEFAULT_CDP:
-                # Try to auto-launch Chrome with remote debugging
                 print("   Chrome isn't running with remote debugging — attempting to launch...")
                 _launched = self._try_launch_chrome_debug(_port, _plat.system())
                 if _launched:
-                    # Wait for the port to come up
                     import time as _time
                     for _wait in range(10):
                         try:
@@ -5078,7 +5142,6 @@ class HermesCLI:
                         print("     You may need to close existing Chrome windows first and retry")
                 else:
                     print("   ⚠ Could not auto-launch Chrome")
-                    # Show manual instructions as fallback
                     sys_name = _plat.system()
                     if sys_name == "Darwin":
                         chrome_cmd = 'open -a "Google Chrome" --args --remote-debugging-port=9222'
@@ -5096,7 +5159,6 @@ class HermesCLI:
             print(f"   Endpoint: {cdp_url}")
             print()
 
-            # Inject context message so the model knows
             if hasattr(self, '_pending_input'):
                 self._pending_input.put(
                     "[System note: The user has connected your browser tools to their live Chrome browser "
@@ -5109,31 +5171,43 @@ class HermesCLI:
                 )
 
         elif sub == "disconnect":
-            if current:
+            if current or current_mode == "camofox":
+                was_camofox = current_mode == "camofox"
                 os.environ.pop("BROWSER_CDP_URL", None)
+                os.environ.pop("BROWSER_CONNECT_MODE", None)
+                previous_camofox = os.environ.pop("BROWSER_PREV_CAMOFOX_URL", "").strip().rstrip("/")
+                if was_camofox:
+                    if previous_camofox:
+                        os.environ["CAMOFOX_URL"] = previous_camofox
+                    else:
+                        os.environ.pop("CAMOFOX_URL", None)
                 try:
                     from tools.browser_tool import cleanup_all_browsers
                     cleanup_all_browsers()
                 except Exception:
                     pass
                 print()
-                print("🌐 Browser disconnected from live Chrome")
+                print("🌐 Browser disconnected from Camofox" if was_camofox else "🌐 Browser disconnected from live Chrome")
                 print("   Browser tools reverted to default mode (local headless or cloud provider)")
                 print()
 
                 if hasattr(self, '_pending_input'):
                     self._pending_input.put(
-                        "[System note: The user has disconnected the browser tools from their live Chrome. "
+                        "[System note: The user has disconnected the browser tools from their explicit browser backend override. "
                         "Browser tools are back to default mode (headless local browser or cloud provider).]"
                     )
             else:
                 print()
-                print("Browser is not connected to live Chrome (already using default mode)")
+                print("Browser is not connected to an explicit browser override (already using default mode)")
                 print()
 
         elif sub == "status":
             print()
-            if current:
+            if current_camofox:
+                print("🌐 Browser: connected to Camofox" if current_mode == "camofox" else "🌐 Browser: Camofox (configured)")
+                print(f"   Endpoint: {current_camofox}")
+                print("   Status: ✓ configured")
+            elif current:
                 print("🌐 Browser: connected to live Chrome via CDP")
                 print(f"   Endpoint: {current}")
 
@@ -5163,7 +5237,7 @@ class HermesCLI:
                 else:
                     print("🌐 Browser: local headless Chromium (agent-browser)")
             print()
-            print("   /browser connect      — connect to your live Chrome")
+            print("   /browser connect      — connect to Chrome or Camofox")
             print("   /browser disconnect   — revert to default")
             print()
 
@@ -5171,7 +5245,7 @@ class HermesCLI:
             print()
             print("Usage: /browser connect|disconnect|status")
             print()
-            print("   connect      Connect browser tools to your live Chrome session")
+            print("   connect      Connect browser tools to Chrome CDP or Camofox")
             print("   disconnect   Revert to default browser backend")
             print("   status       Show current browser mode")
             print()

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -1,7 +1,13 @@
-"""Shared helpers for attaching Hermes to a local Chromium-family CDP port."""
+"""Shared helpers for attaching Hermes to a local browser backend.
+
+Covers Chromium-family CDP launch/discovery and Camofox autodetection used
+by both the classic CLI ``/browser connect`` path and TUI/Desktop
+``browser.manage``.
+"""
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import platform
@@ -11,6 +17,7 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass, field
+from urllib.parse import urlparse
 
 from hermes_constants import get_hermes_home
 
@@ -19,6 +26,157 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BROWSER_CDP_PORT = 9222
 DEFAULT_BROWSER_CDP_URL = f"http://127.0.0.1:{DEFAULT_BROWSER_CDP_PORT}"
+
+# In-process /browser connect override. Camofox snapshots must survive a
+# connect to the already-configured URL so disconnect can restore it.
+BROWSER_CONNECT_MODE_ENV = "BROWSER_CONNECT_MODE"
+BROWSER_PREV_CAMOFOX_URL_ENV = "BROWSER_PREV_CAMOFOX_URL"
+BROWSER_PREV_CAMOFOX_SET_ENV = "BROWSER_PREV_CAMOFOX_SET"
+
+
+def normalize_browser_connect_endpoint(endpoint: str) -> str:
+    """Normalize user-supplied ``/browser connect`` endpoints.
+
+    Schemeless ``host:port`` inputs become ``http://host:port``. Trailing
+    slashes are stripped so later ``/json/version`` and ``/health`` probes
+    do not double up path separators.
+    """
+    raw = (endpoint or "").strip().rstrip("/")
+    if not raw:
+        return raw
+    if "://" in raw:
+        return raw
+    return f"http://{raw}"
+
+
+def _http_json(url: str, timeout: float) -> dict | None:
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            if not (200 <= getattr(resp, "status", 200) < 300):
+                return None
+            payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def detect_browser_connect_backend(
+    endpoint: str, *, timeout: float = 2.0
+) -> tuple[str, str]:
+    """Classify a ``/browser connect`` target as ``cdp``, ``camofox``, or ``unknown``.
+
+    CDP is probed first (``/json/version`` ``webSocketDebuggerUrl``) so a
+    Chromium-family browser is never mistaken for Camofox. Camofox is the
+    fallback when that probe fails and ``/health`` returns HTTP 200.
+    """
+    raw = normalize_browser_connect_endpoint(endpoint)
+    if not raw:
+        return "unknown", raw
+
+    parsed = urlparse(raw)
+    if parsed.path.startswith("/devtools/browser/"):
+        return "cdp", raw
+
+    discovery_url = raw
+    if parsed.scheme in {"ws", "wss"}:
+        # Bare ``ws://host:port`` can still be a discovery root. A concrete
+        # DevTools websocket already returned above.
+        if parsed.path and parsed.path != "/":
+            return "cdp", raw
+        discovery_url = raw.replace("wss://", "https://", 1).replace("ws://", "http://", 1)
+
+    version_url = (
+        discovery_url
+        if discovery_url.lower().endswith("/json/version")
+        else f"{discovery_url.rstrip('/')}/json/version"
+    )
+    version = _http_json(version_url, timeout)
+    if str((version or {}).get("webSocketDebuggerUrl") or "").strip():
+        return "cdp", raw
+
+    health_root = discovery_url
+    if health_root.lower().endswith("/json/version"):
+        health_root = health_root[: -len("/json/version")]
+    # Require a JSON object so a generic HTTP 200 (or a CDP probe stub that
+    # only exposes ``status``) is not treated as Camofox.
+    health = _http_json(f"{health_root.rstrip('/')}/health", timeout)
+    if health is not None:
+        return "camofox", raw
+
+    return "unknown", raw
+
+
+def _snapshot_camofox_url() -> None:
+    """Remember the exact current ``CAMOFOX_URL`` env state, including identity."""
+    if "CAMOFOX_URL" in os.environ:
+        os.environ[BROWSER_PREV_CAMOFOX_URL_ENV] = os.environ["CAMOFOX_URL"]
+        os.environ[BROWSER_PREV_CAMOFOX_SET_ENV] = "1"
+        return
+    os.environ.pop(BROWSER_PREV_CAMOFOX_URL_ENV, None)
+    os.environ.pop(BROWSER_PREV_CAMOFOX_SET_ENV, None)
+
+
+def _restore_camofox_url() -> None:
+    """Restore the snapshotted ``CAMOFOX_URL``, or unset it when none existed."""
+    was_set = os.environ.pop(BROWSER_PREV_CAMOFOX_SET_ENV, "")
+    previous = os.environ.pop(BROWSER_PREV_CAMOFOX_URL_ENV, "")
+    if was_set:
+        os.environ["CAMOFOX_URL"] = previous
+        return
+    os.environ.pop("CAMOFOX_URL", None)
+
+
+def apply_browser_backend_override(*, mode: str, url: str) -> None:
+    """Publish a reversible ``/browser connect`` backend override.
+
+    Camofox connects always snapshot the prior ``CAMOFOX_URL`` — even when
+    the new URL is identical — so disconnect can restore that exact state.
+    CDP connects leave ``CAMOFOX_URL`` in place; ``BROWSER_CDP_URL`` already
+    suppresses Camofox routing.
+    """
+    normalized = (url or "").strip().rstrip("/")
+    if mode == "camofox":
+        _snapshot_camofox_url()
+        os.environ["CAMOFOX_URL"] = normalized
+        os.environ[BROWSER_CONNECT_MODE_ENV] = "camofox"
+        os.environ.pop("BROWSER_CDP_URL", None)
+        return
+
+    os.environ["BROWSER_CDP_URL"] = url
+    os.environ[BROWSER_CONNECT_MODE_ENV] = "cdp"
+
+
+def restore_browser_backend_override() -> str:
+    """Clear the connect override and restore any snapshotted Camofox env.
+
+    Returns the mode that was active (``cdp``, ``camofox``, or ``""``).
+    """
+    mode = os.environ.pop(BROWSER_CONNECT_MODE_ENV, "").strip().lower()
+    os.environ.pop("BROWSER_CDP_URL", None)
+    if mode == "camofox" or BROWSER_PREV_CAMOFOX_SET_ENV in os.environ:
+        _restore_camofox_url()
+    else:
+        os.environ.pop(BROWSER_PREV_CAMOFOX_URL_ENV, None)
+        os.environ.pop(BROWSER_PREV_CAMOFOX_SET_ENV, None)
+    return mode
+
+
+def get_browser_connect_override() -> tuple[str, str]:
+    """Return ``(mode, url)`` for the active in-process connect override.
+
+    Does no network I/O. An empty mode means no ``/browser connect`` override
+    is active (configured ``CAMOFOX_URL`` / ``browser.cdp_url`` may still apply).
+    """
+    mode = os.environ.get(BROWSER_CONNECT_MODE_ENV, "").strip().lower()
+    if mode == "camofox":
+        return "camofox", os.environ.get("CAMOFOX_URL", "").strip().rstrip("/")
+    cdp = os.environ.get("BROWSER_CDP_URL", "").strip()
+    if cdp or mode == "cdp":
+        return "cdp", cdp
+    return "", ""
+
 
 _DARWIN_APPS = (
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -31,12 +31,16 @@ from hermes_constants import display_hermes_home, is_termux as _is_termux_enviro
 from agent.turn_context import extract_api_content_sidecar
 from hermes_cli.browser_connect import (
     DEFAULT_BROWSER_CDP_URL,
+    apply_browser_backend_override,
+    detect_browser_connect_backend,
     discover_local_cdp_url,
     find_free_debug_port,
+    get_browser_connect_override,
     is_browser_debug_ready,
     launch_chrome_debug,
     local_port_in_use,
     manual_chrome_debug_command,
+    restore_browser_backend_override,
 )
 
 
@@ -2305,14 +2309,16 @@ class CLICommandsMixin:
         )
 
     def _handle_browser_command(self, cmd: str):
-        """Handle /browser connect|disconnect|status — manage live Chromium-family CDP connection."""
+        """Handle /browser connect|disconnect|status — manage live browser backend overrides."""
         import platform as _plat
 
         parts = cmd.strip().split(None, 1)
         sub = parts[1].lower().strip() if len(parts) > 1 else "status"
 
         _DEFAULT_CDP = DEFAULT_BROWSER_CDP_URL
-        current = os.environ.get("BROWSER_CDP_URL", "").strip()
+        current_mode, current_override = get_browser_connect_override()
+        current = current_override if current_mode == "cdp" else os.environ.get("BROWSER_CDP_URL", "").strip()
+        current_camofox = os.environ.get("CAMOFOX_URL", "").strip().rstrip("/")
 
         if sub == "use" or sub.startswith("use "):
             # /browser use [off] — toggle Browser Use mode (browser.backend),
@@ -2388,6 +2394,30 @@ class CLICommandsMixin:
                     fragment="",
                 ).geturl()
 
+            detected_mode, detected_url = detect_browser_connect_backend(parsed_cdp.geturl())
+            if detected_mode == "camofox":
+                try:
+                    from tools.browser_tool import cleanup_all_browsers
+                    cleanup_all_browsers()
+                except Exception:
+                    pass
+                apply_browser_backend_override(mode="camofox", url=detected_url)
+                print()
+                print(f"   ✓ Camofox detected at {detected_url}")
+                print()
+                print("🌐 Browser connected to Camofox")
+                print(f"   Endpoint: {detected_url}")
+                print()
+                if hasattr(self, "_pending_input"):
+                    self._pending_input.put(
+                        "[System note: The user invoked /browser connect and connected your browser tools to "
+                        "a live Camofox browser backend. Your browser tools now route through Camofox instead "
+                        "of the default browser backend. Camofox may preserve cookies or sessions depending on "
+                        "its server-side profile configuration. Please await the user's instruction before "
+                        "attempting to operate the browser.]"
+                    )
+                return
+
             # Clear any existing browser sessions so the next tool call uses the new backend
             try:
                 from tools.browser_tool import cleanup_all_browsers
@@ -2461,7 +2491,7 @@ class CLICommandsMixin:
                 print()
                 return
 
-            os.environ["BROWSER_CDP_URL"] = cdp_url
+            apply_browser_backend_override(mode="cdp", url=cdp_url)
             # Eagerly start the CDP supervisor so pending_dialogs + frame_tree
             # show up in the next browser_snapshot.  No-op if already started.
             try:
@@ -2490,8 +2520,9 @@ class CLICommandsMixin:
                 )
 
         elif sub == "disconnect":
-            if current:
-                os.environ.pop("BROWSER_CDP_URL", None)
+            if current_mode:
+                was_camofox = current_mode == "camofox"
+                restore_browser_backend_override()
                 try:
                     from tools.browser_tool import cleanup_all_browsers, _stop_cdp_supervisor
                     _stop_cdp_supervisor("default")
@@ -2499,18 +2530,18 @@ class CLICommandsMixin:
                 except Exception:
                     pass
                 print()
-                print("🌐 Browser disconnected from live Chromium-family browser")
+                print("🌐 Browser disconnected from Camofox" if was_camofox else "🌐 Browser disconnected from live Chromium-family browser")
                 print("   Browser tools reverted to default mode (local headless or cloud provider)")
                 print()
 
                 if hasattr(self, '_pending_input'):
                     self._pending_input.put(
-                        "[System note: The user has disconnected the browser tools from their live Chromium-family browser. "
+                        "[System note: The user has disconnected the browser tools from their explicit browser backend override. "
                         "Browser tools are back to default mode (headless local browser or cloud provider).]"
                     )
             else:
                 print()
-                print("Browser is not connected to a live Chromium-family browser (already using default mode)")
+                print("Browser is not connected to an explicit browser override (already using default mode)")
                 print()
 
         elif sub == "status":
@@ -2520,14 +2551,22 @@ class CLICommandsMixin:
                 _bu_mode = is_browser_use_cli_mode()
             except Exception:
                 _bu_mode = False
-            if _bu_mode:
+            if current_mode == "camofox":
+                print("🌐 Browser: connected to Camofox")
+                print(f"   Endpoint: {current_override}")
+                print("   Status: ✓ configured")
+            elif _bu_mode:
                 print("🌐 Browser: Browser Use mode (browser_exec via the Browser Use CLI 3.0)")
                 print("   Local Chrome via CDP, or Browser Use cloud browsers")
                 print()
                 print("   /browser use off      — revert to the built-in browser tools")
                 print()
                 return
-            if current:
+            elif current_camofox and not current:
+                print("🌐 Browser: Camofox (configured)")
+                print(f"   Endpoint: {current_camofox}")
+                print("   Status: ✓ configured")
+            elif current:
                 print("🌐 Browser: connected to live Chromium-family browser via CDP")
                 print(f"   Endpoint: {current}")
 
@@ -2570,7 +2609,7 @@ class CLICommandsMixin:
                     else:
                         print("🌐 Browser: local headless Chromium (agent-browser)")
             print()
-            print("   /browser connect      — connect to your live Chromium-family browser")
+            print("   /browser connect      — connect to Chrome/CDP or Camofox")
             print("   /browser disconnect   — revert to default")
             print()
 
@@ -2578,7 +2617,7 @@ class CLICommandsMixin:
             print()
             print("Usage: /browser connect|disconnect|status|use")
             print()
-            print("   connect      Connect browser tools to your live Chromium-family browser session")
+            print("   connect      Connect browser tools to Chrome CDP or a Camofox server")
             print("   disconnect   Revert to default browser backend")
             print("   status       Show current browser mode")
             print("   use [off]    Switch to Browser Use mode (CLI 3.0) / back to built-in tools")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -118,7 +118,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
                aliases=("reload_mcp",)),
-    CommandDef("browser", "Connect browser tools to your live Chrome via CDP", "Tools & Skills",
+    CommandDef("browser", "Connect browser tools to Chrome CDP or Camofox", "Tools & Skills",
                cli_only=True, args_hint="[connect|disconnect|status]",
                subcommands=("connect", "disconnect", "status")),
     CommandDef("plugins", "List installed plugins and their status",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -348,7 +348,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("reload_mcp",)),
     CommandDef("reload-skills", "Re-scan ~/.hermes/skills/ for newly installed or removed skills",
                "Tools & Skills", aliases=("reload_skills",)),
-    CommandDef("browser", "Connect browser tools to your live Chromium-family browser via CDP, or switch to Browser Use mode", "Tools & Skills",
+    CommandDef("browser", "Connect browser tools to a live Chromium-family browser via CDP, a Camofox server, or switch to Browser Use mode", "Tools & Skills",
                cli_only=True, args_hint="[connect|disconnect|status|use]",
                subcommands=("connect", "disconnect", "status", "use")),
     CommandDef("plugins", "List installed plugins and their status",

--- a/tests/cli/test_browser_connect_detection.py
+++ b/tests/cli/test_browser_connect_detection.py
@@ -2,7 +2,7 @@ import os
 import queue
 from unittest.mock import patch
 
-from cli import HermesCLI
+from cli import HermesCLI, _normalize_browser_connect_endpoint
 
 
 class _FakeResponse:
@@ -24,6 +24,10 @@ def _bare_cli():
     return cli
 
 
+def test_normalize_browser_connect_endpoint_adds_http_for_schemeless_localhost():
+    assert _normalize_browser_connect_endpoint("localhost:9377") == "http://localhost:9377"
+
+
 @patch("tools.browser_tool.cleanup_all_browsers")
 def test_browser_connect_autodetects_camofox_on_9377(mock_cleanup, monkeypatch, capsys):
     cli = _bare_cli()
@@ -40,7 +44,7 @@ def test_browser_connect_autodetects_camofox_on_9377(mock_cleanup, monkeypatch, 
         raise AssertionError(f"unexpected URL {url}")
 
     with patch("requests.get", side_effect=fake_get):
-        cli._handle_browser_command("/browser connect http://localhost:9377")
+        cli._handle_browser_command("/browser connect localhost:9377")
 
     out = capsys.readouterr().out
     assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"

--- a/tests/cli/test_browser_connect_detection.py
+++ b/tests/cli/test_browser_connect_detection.py
@@ -1,0 +1,81 @@
+import os
+import queue
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json_data
+
+
+def _bare_cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_input = queue.Queue()
+    return cli
+
+
+@patch("tools.browser_tool.cleanup_all_browsers")
+def test_browser_connect_autodetects_camofox_on_9377(mock_cleanup, monkeypatch, capsys):
+    cli = _bare_cli()
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv("CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_CONNECT_MODE", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_URL", raising=False)
+
+    def fake_get(url, timeout=10):
+        if url == "http://localhost:9377/json/version":
+            return _FakeResponse(status_code=404)
+        if url == "http://localhost:9377/health":
+            return _FakeResponse(status_code=200, json_data={"ok": True})
+        raise AssertionError(f"unexpected URL {url}")
+
+    with patch("requests.get", side_effect=fake_get):
+        cli._handle_browser_command("/browser connect http://localhost:9377")
+
+    out = capsys.readouterr().out
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert os.environ.get("BROWSER_CONNECT_MODE") == "camofox"
+    assert not os.environ.get("BROWSER_CDP_URL")
+    assert "connected to Camofox" in out
+    assert "Endpoint: http://localhost:9377" in out
+
+
+@patch("tools.browser_tool.cleanup_all_browsers")
+def test_browser_status_reports_camofox_when_connected(mock_cleanup, monkeypatch, capsys):
+    cli = _bare_cli()
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setenv("BROWSER_CONNECT_MODE", "camofox")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+    cli._handle_browser_command("/browser status")
+
+    out = capsys.readouterr().out
+    assert "Browser: connected to Camofox" in out
+    assert "Endpoint: http://localhost:9377" in out
+
+
+@patch("tools.browser_tool.cleanup_all_browsers")
+def test_browser_disconnect_restores_previous_camofox_url(mock_cleanup, monkeypatch, capsys):
+    cli = _bare_cli()
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setenv("BROWSER_CONNECT_MODE", "camofox")
+    monkeypatch.setenv("BROWSER_PREV_CAMOFOX_URL", "http://localhost:9999")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+    cli._handle_browser_command("/browser disconnect")
+
+    out = capsys.readouterr().out
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9999"
+    assert not os.environ.get("BROWSER_CONNECT_MODE")
+    assert not os.environ.get("BROWSER_PREV_CAMOFOX_URL")
+    assert "Browser disconnected from Camofox" in out

--- a/tests/cli/test_browser_connect_detection.py
+++ b/tests/cli/test_browser_connect_detection.py
@@ -1,0 +1,112 @@
+"""CLI /browser connect Camofox autodetection."""
+
+from __future__ import annotations
+
+import json
+import os
+from queue import Queue
+from unittest.mock import patch
+
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+
+class _BareCLI(CLICommandsMixin):
+    """Mixin-only stand-in so tests don't import the full cli.py module."""
+
+
+class _FakeResponse:
+    def __init__(self, status=200, body=b""):
+        self.status = status
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _bare_cli():
+    cli = _BareCLI()
+    cli._pending_input = Queue()
+    return cli
+
+
+def _camofox_urlopen(url, timeout=2.0):
+    if url.endswith("/json/version"):
+        raise OSError("not cdp")
+    if url.endswith("/health"):
+        return _FakeResponse(body=json.dumps({"ok": True}).encode())
+    raise AssertionError(f"unexpected probe {url}")
+
+
+def test_browser_connect_autodetects_camofox_on_9377(monkeypatch, capsys):
+    cli = _bare_cli()
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv("CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_CONNECT_MODE", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_SET", raising=False)
+
+    with patch("urllib.request.urlopen", side_effect=_camofox_urlopen):
+        cli._handle_browser_command("/browser connect localhost:9377")
+
+    out = capsys.readouterr().out
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert os.environ.get("BROWSER_CONNECT_MODE") == "camofox"
+    assert not os.environ.get("BROWSER_CDP_URL")
+    assert "connected to Camofox" in out
+    assert "Endpoint: http://localhost:9377" in out
+
+
+def test_browser_status_reports_camofox_when_connected(monkeypatch, capsys):
+    cli = _bare_cli()
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setenv("BROWSER_CONNECT_MODE", "camofox")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+    cli._handle_browser_command("/browser status")
+
+    out = capsys.readouterr().out
+    assert "Browser: connected to Camofox" in out
+    assert "Endpoint: http://localhost:9377" in out
+
+
+def test_browser_disconnect_restores_previous_camofox_url(monkeypatch, capsys):
+    cli = _bare_cli()
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setenv("BROWSER_CONNECT_MODE", "camofox")
+    monkeypatch.setenv("BROWSER_PREV_CAMOFOX_URL", "http://localhost:9999")
+    monkeypatch.setenv("BROWSER_PREV_CAMOFOX_SET", "1")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+    cli._handle_browser_command("/browser disconnect")
+
+    out = capsys.readouterr().out
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9999"
+    assert not os.environ.get("BROWSER_CONNECT_MODE")
+    assert not os.environ.get("BROWSER_PREV_CAMOFOX_URL")
+    assert "Browser disconnected from Camofox" in out
+
+
+def test_browser_connect_disconnect_preserves_identical_camofox_url(monkeypatch, capsys):
+    """Connecting to the already configured Camofox URL must not clear it."""
+    cli = _bare_cli()
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv("BROWSER_CONNECT_MODE", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_SET", raising=False)
+
+    with patch("urllib.request.urlopen", side_effect=_camofox_urlopen):
+        cli._handle_browser_command("/browser connect http://localhost:9377")
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert os.environ.get("BROWSER_CONNECT_MODE") == "camofox"
+
+    cli._handle_browser_command("/browser disconnect")
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert not os.environ.get("BROWSER_CONNECT_MODE")
+    assert "Browser disconnected from Camofox" in capsys.readouterr().out

--- a/tests/hermes_cli/test_browser_connect_detection.py
+++ b/tests/hermes_cli/test_browser_connect_detection.py
@@ -1,0 +1,142 @@
+"""Shared /browser connect Camofox detection and reversible backend state."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from hermes_cli.browser_connect import (
+    BROWSER_CONNECT_MODE_ENV,
+    BROWSER_PREV_CAMOFOX_SET_ENV,
+    BROWSER_PREV_CAMOFOX_URL_ENV,
+    apply_browser_backend_override,
+    detect_browser_connect_backend,
+    get_browser_connect_override,
+    normalize_browser_connect_endpoint,
+    restore_browser_backend_override,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status=200, body=b""):
+        self.status = status
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _json_body(payload: dict) -> bytes:
+    return json.dumps(payload).encode("utf-8")
+
+
+def test_normalize_browser_connect_endpoint_adds_http_for_schemeless_localhost():
+    assert normalize_browser_connect_endpoint("localhost:9377") == "http://localhost:9377"
+    assert normalize_browser_connect_endpoint("http://localhost:9377/") == "http://localhost:9377"
+
+
+def test_detect_browser_connect_backend_prefers_cdp_version(monkeypatch):
+    def fake_urlopen(url, timeout=2.0):
+        if url.endswith("/json/version"):
+            return _FakeResponse(
+                body=_json_body({"webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/abc"})
+            )
+        raise AssertionError(f"unexpected probe {url}")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    mode, endpoint = detect_browser_connect_backend("http://127.0.0.1:9222")
+    assert mode == "cdp"
+    assert endpoint == "http://127.0.0.1:9222"
+
+
+def test_detect_browser_connect_backend_falls_back_to_camofox_health(monkeypatch):
+    def fake_urlopen(url, timeout=2.0):
+        if url.endswith("/json/version"):
+            raise OSError("not cdp")
+        if url.endswith("/health"):
+            return _FakeResponse(body=_json_body({"ok": True}))
+        raise AssertionError(f"unexpected probe {url}")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    mode, endpoint = detect_browser_connect_backend("localhost:9377")
+    assert mode == "camofox"
+    assert endpoint == "http://localhost:9377"
+
+
+def test_detect_status_only_http_200_is_not_camofox(monkeypatch):
+    """A probe stub that only exposes HTTP 200 (no JSON body) is unknown."""
+
+    class _StatusOnly:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: _StatusOnly())
+    mode, _endpoint = detect_browser_connect_backend("http://127.0.0.1:9222")
+    assert mode == "unknown"
+
+
+def test_detect_devtools_websocket_is_cdp_without_probe(monkeypatch):
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not probe")),
+    )
+    mode, endpoint = detect_browser_connect_backend(
+        "ws://127.0.0.1:9222/devtools/browser/abc"
+    )
+    assert mode == "cdp"
+    assert endpoint.endswith("/devtools/browser/abc")
+
+
+def test_apply_and_restore_preserves_identical_camofox_url(monkeypatch):
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv(BROWSER_CONNECT_MODE_ENV, raising=False)
+    monkeypatch.delenv(BROWSER_PREV_CAMOFOX_URL_ENV, raising=False)
+    monkeypatch.delenv(BROWSER_PREV_CAMOFOX_SET_ENV, raising=False)
+
+    apply_browser_backend_override(mode="camofox", url="http://localhost:9377")
+
+    assert get_browser_connect_override() == ("camofox", "http://localhost:9377")
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert os.environ.get(BROWSER_PREV_CAMOFOX_SET_ENV) == "1"
+    assert os.environ.get(BROWSER_PREV_CAMOFOX_URL_ENV) == "http://localhost:9377"
+
+    assert restore_browser_backend_override() == "camofox"
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert get_browser_connect_override() == ("", "")
+    assert BROWSER_PREV_CAMOFOX_SET_ENV not in os.environ
+
+
+def test_apply_and_restore_restores_previous_different_camofox_url(monkeypatch):
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9999")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv(BROWSER_CONNECT_MODE_ENV, raising=False)
+
+    apply_browser_backend_override(mode="camofox", url="http://localhost:9377")
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+
+    restore_browser_backend_override()
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9999"
+
+
+def test_apply_and_restore_clears_camofox_when_none_was_configured(monkeypatch):
+    monkeypatch.delenv("CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv(BROWSER_CONNECT_MODE_ENV, raising=False)
+
+    apply_browser_backend_override(mode="camofox", url="http://localhost:9377")
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+
+    restore_browser_backend_override()
+    assert "CAMOFOX_URL" not in os.environ

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15580,6 +15580,106 @@ def test_browser_manage_disconnect_drops_env_and_cleans(monkeypatch):
     assert cleanup_count["n"] == 2
 
 
+def _camofox_urlopen(url, timeout=2.0):
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self):
+            if str(url).endswith("/health"):
+                return json.dumps({"ok": True}).encode()
+            raise OSError("not cdp")
+
+    if str(url).endswith("/json/version"):
+        raise OSError("not cdp")
+    return _Resp()
+
+
+def test_browser_manage_connect_autodetects_camofox(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv("CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_CONNECT_MODE", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_SET", raising=False)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", _camofox_urlopen)
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": "localhost:9377"},
+            }
+        )
+
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == "http://localhost:9377"
+    assert resp["result"]["backend"] == "camofox"
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert os.environ.get("BROWSER_CONNECT_MODE") == "camofox"
+    assert "BROWSER_CDP_URL" not in os.environ
+
+
+def test_browser_manage_status_reports_camofox_override(monkeypatch):
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setenv("BROWSER_CONNECT_MODE", "camofox")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
+    )
+
+    assert resp["result"] == {
+        "connected": True,
+        "url": "http://localhost:9377",
+        "backend": "camofox",
+    }
+
+
+def test_browser_manage_connect_disconnect_preserves_identical_camofox_url(monkeypatch):
+    """Connecting to the already configured Camofox URL must restore it."""
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.delenv("BROWSER_CONNECT_MODE", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_URL", raising=False)
+    monkeypatch.delenv("BROWSER_PREV_CAMOFOX_SET", raising=False)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", _camofox_urlopen)
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        connect = server.handle_request(
+            {
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": "http://localhost:9377"},
+            }
+        )
+        assert connect["result"]["backend"] == "camofox"
+        assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+
+        disconnect = server.handle_request(
+            {"id": "2", "method": "browser.manage", "params": {"action": "disconnect"}}
+        )
+
+    assert disconnect["result"] == {"connected": False}
+    assert os.environ.get("CAMOFOX_URL") == "http://localhost:9377"
+    assert "BROWSER_CONNECT_MODE" not in os.environ
+
+
 # ── config.get indicator normalization ───────────────────────────────
 
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1401,6 +1401,11 @@ def _(rid, params: dict) -> dict:
     action = params.get("action", "status")
 
     if action == "status":
+        from hermes_cli.browser_connect import get_browser_connect_override
+
+        mode, override_url = get_browser_connect_override()
+        if mode == "camofox":
+            return _ok(rid, {"connected": True, "url": override_url, "backend": "camofox"})
         url = _resolve_browser_cdp_url()
         return _ok(rid, {"connected": bool(url), "url": url})
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15136,7 +15136,11 @@ def _failure_messages(url: str, port: int, system: str) -> list[str]:
 def _browser_connect(rid, params: dict) -> dict:
     import platform
 
-    from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
+    from hermes_cli.browser_connect import (
+        DEFAULT_BROWSER_CDP_URL,
+        apply_browser_backend_override,
+        detect_browser_connect_backend,
+    )
     from tools.browser_tool import cleanup_all_browsers
     from urllib.parse import urlparse
 
@@ -15175,6 +15179,24 @@ def _browser_connect(rid, params: dict) -> dict:
         url = DEFAULT_BROWSER_CDP_URL
         parsed = urlparse(url)
         port = parsed.port or 9222
+
+    detected_mode, detected_url = detect_browser_connect_backend(url)
+    if detected_mode == "camofox":
+        try:
+            cleanup_all_browsers()
+            apply_browser_backend_override(mode="camofox", url=detected_url)
+            cleanup_all_browsers()
+        except Exception as e:
+            return _err(rid, 5031, str(e))
+        announce(f"Camofox detected at {detected_url}")
+        payload: dict[str, object] = {
+            "connected": True,
+            "url": detected_url,
+            "backend": "camofox",
+        }
+        if messages:
+            payload["messages"] = messages
+        return _ok(rid, payload)
 
     try:
         # ws[s]://.../devtools/browser/<id> endpoints (hosted CDP
@@ -15265,7 +15287,7 @@ def _browser_connect(rid, params: dict) -> dict:
         # then again AFTER so the default task's cached supervisor
         # is drained against the new URL.
         cleanup_all_browsers()
-        os.environ["BROWSER_CDP_URL"] = normalized
+        apply_browser_backend_override(mode="cdp", url=normalized)
         cleanup_all_browsers()
     except Exception as e:
         return _err(rid, 5031, str(e))
@@ -15287,8 +15309,10 @@ def _browser_disconnect(rid) -> dict:
         except Exception:
             pass
 
+    from hermes_cli.browser_connect import restore_browser_backend_override
+
     reap()
-    os.environ.pop("BROWSER_CDP_URL", None)
+    restore_browser_backend_override()
     reap()
     return _ok(rid, {"connected": False})
 

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -46,7 +46,7 @@ Hermes includes full browser automation with multiple backend options for naviga
 
 - **Browserbase** — Managed cloud browsers with anti-bot tooling, CAPTCHA solving, and residential proxies
 - **Browser Use** — Alternative cloud browser provider
-- **Local Chrome via CDP** — Connect to your running Chrome instance using `/browser connect`
+- **Local Chrome via CDP / Camofox** — Connect `/browser connect` to your running Chrome instance or a Camofox server
 - **Local Chromium** — Headless local browser via the `agent-browser` CLI
 
 See [Browser Automation](/docs/user-guide/features/browser) for setup and usage.

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -55,6 +55,7 @@ Hermes includes full browser automation with multiple backend options for naviga
 - **Browserbase** — Managed cloud browsers with anti-bot tooling, CAPTCHA solving, and residential proxies
 - **Browser Use** — Alternative cloud browser provider
 - **Local Chromium-family CDP** — Connect to your running Chrome, Brave, Chromium, or Edge browser using `/browser connect`
+- **Camofox** — Connect to a local Camofox server with `/browser connect http://localhost:9377` (auto-detected) or `CAMOFOX_URL`
 - **Local Chromium** — Headless local browser via the `agent-browser` CLI
 
 See [Browser Automation](/user-guide/features/browser) for setup and usage.

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -126,18 +126,21 @@ The Camofox server must also be configured with `CAMOFOX_PROFILE_DIR` on the ser
 
 When Camofox runs in headed mode (with a visible browser window), it exposes a VNC port in its health check response. Hermes automatically discovers this and includes the VNC URL in navigation responses, so the agent can share a link for you to watch the browser live.
 
-### Local Chrome via CDP (`/browser connect`)
+### Local Chrome via CDP or Camofox (`/browser connect`)
 
-Instead of a cloud provider, you can attach Hermes browser tools to your own running Chrome instance via the Chrome DevTools Protocol (CDP). This is useful when you want to see what the agent is doing in real-time, interact with pages that require your own cookies/sessions, or avoid cloud browser costs.
+Instead of a cloud provider, you can attach Hermes browser tools to your own running Chrome instance via the Chrome DevTools Protocol (CDP), or point `/browser connect` at a Camofox server endpoint. This is useful when you want to see what the agent is doing in real-time, interact with pages that require your own cookies/sessions, or use a local anti-detection backend without changing config first.
 
 In the CLI, use:
 
 ```
-/browser connect              # Connect to Chrome at ws://localhost:9222
-/browser connect ws://host:port  # Connect to a specific CDP endpoint
+/browser connect                   # Connect to Chrome at ws://localhost:9222
+/browser connect ws://host:port    # Connect to a specific CDP endpoint
+/browser connect http://localhost:9377  # Auto-detect and connect to Camofox
 /browser status               # Check current connection
 /browser disconnect            # Detach and return to cloud/local mode
 ```
+
+If the target looks like Chrome CDP, Hermes resolves `/json/version` and uses the DevTools websocket. If the target exposes a Camofox `/health` endpoint instead, Hermes switches the browser tools to the Camofox backend automatically.
 
 If Chrome isn't already running with remote debugging, Hermes will attempt to auto-launch it with `--remote-debugging-port=9222`.
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -237,7 +237,7 @@ The rewrite only applies to page navigation URLs with loopback hosts (`localhost
 
 Or configure via `hermes tools` → Browser Automation → Camofox.
 
-When `CAMOFOX_URL` is set, all browser tools automatically route through Camofox instead of Browserbase or agent-browser.
+When `CAMOFOX_URL` is set, all browser tools automatically route through Camofox instead of Browserbase or agent-browser. You can also attach at runtime with `/browser connect http://localhost:9377` (or `localhost:9377`) — Hermes detects the Camofox health endpoint and switches backends without requiring the env var to be pre-set.
 
 #### Persistent browser sessions
 
@@ -370,9 +370,12 @@ In the CLI, use:
 ```
 /browser connect                 # Auto-launch/connect to a local Chromium-family browser at http://127.0.0.1:9222
 /browser connect ws://host:port  # Connect to a specific CDP endpoint
+/browser connect localhost:9377  # Auto-detect a Camofox server and switch to that backend
 /browser status                  # Check current connection
 /browser disconnect              # Detach and return to cloud/local mode
 ```
+
+`/browser connect` probes `/json/version` first (CDP) and falls back to `/health` (Camofox). The same detection runs in the classic CLI and in TUI/Desktop `browser.manage`. Disconnect restores the previous `CAMOFOX_URL` exactly, including when you reconnect to the already configured Camofox URL.
 
 If a browser isn't already running with remote debugging, Hermes will attempt to auto-launch a supported Chromium-family browser with `--remote-debugging-port=9222`. Detection includes Brave, Google Chrome, Chromium, and Microsoft Edge, with common Linux install paths such as `/opt/brave-bin/brave` and `/snap/bin/brave`.
 


### PR DESCRIPTION
## Summary
- auto-detect whether `/browser connect` targets Chrome CDP or a Camofox server
- probe `/json/version` first for CDP, then fall back to `/health` for Camofox
- share detection and reversible backend state between classic CLI and TUI/Desktop `browser.manage`
- preserve the exact prior `CAMOFOX_URL` on disconnect, including an identical URL
- document that `/browser connect` supports both backends
- add regression tests for Camofox connect/status/disconnect on both paths

## Why
`/browser connect http://localhost:9377` was treated as a live Chrome/CDP connection even though port 9377 commonly points at Camofox. Hermes already has a separate Camofox backend, so the CLI/TUI behavior was confusing unless `CAMOFOX_URL` was set explicitly.

## Review follow-up (current main)
Adapted to post-April browser-command ownership:
- detection + reversible env state live in `hermes_cli/browser_connect.py`
- classic CLI uses `hermes_cli/cli_commands_mixin.py`
- TUI/Desktop `browser.manage` uses the same helpers from `tui_gateway/server.py`
- connecting to the already-configured Camofox URL no longer clears that config on disconnect

## Test plan
Ran:
- `pytest tests/hermes_cli/test_browser_connect_detection.py tests/cli/test_browser_connect_detection.py -q`

Result:
- 12 passed