### PR TITLE
fix(plugins): roll back failed staged registrations

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -31,7 +31,6 @@ import importlib
 import importlib.metadata
 import importlib.util
 import logging
-import os
 import sys
 import types
 from dataclasses import dataclass, field
@@ -117,6 +116,21 @@ class LoadedPlugin:
     error: Optional[str] = None
 
 
+@dataclass
+class _PendingToolRegistration:
+    """A tool staged during plugin register() until the plugin commits."""
+
+    name: str
+    toolset: str
+    schema: dict
+    handler: Callable
+    check_fn: Callable | None = None
+    requires_env: list | None = None
+    is_async: bool = False
+    description: str = ""
+    emoji: str = ""
+
+
 # ---------------------------------------------------------------------------
 # PluginContext  – handed to each plugin's ``register()`` function
 # ---------------------------------------------------------------------------
@@ -127,6 +141,9 @@ class PluginContext:
     def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
         self.manifest = manifest
         self._manager = manager
+        self._pending_tools: List[_PendingToolRegistration] = []
+        self._pending_hooks: List[tuple[str, Callable]] = []
+        self._pending_cli_commands: Dict[str, dict] = {}
 
     # -- tool registration --------------------------------------------------
 
@@ -142,22 +159,21 @@ class PluginContext:
         description: str = "",
         emoji: str = "",
     ) -> None:
-        """Register a tool in the global registry **and** track it as plugin-provided."""
-        from tools.registry import registry
-
-        registry.register(
-            name=name,
-            toolset=toolset,
-            schema=schema,
-            handler=handler,
-            check_fn=check_fn,
-            requires_env=requires_env,
-            is_async=is_async,
-            description=description,
-            emoji=emoji,
+        """Stage a tool registration until the plugin finishes register()."""
+        self._pending_tools.append(
+            _PendingToolRegistration(
+                name=name,
+                toolset=toolset,
+                schema=schema,
+                handler=handler,
+                check_fn=check_fn,
+                requires_env=requires_env,
+                is_async=is_async,
+                description=description,
+                emoji=emoji,
+            )
         )
-        self._manager._plugin_tool_names.add(name)
-        logger.debug("Plugin %s registered tool: %s", self.manifest.name, name)
+        logger.debug("Plugin %s staged tool: %s", self.manifest.name, name)
 
     # -- message injection --------------------------------------------------
 
@@ -203,7 +219,7 @@ class PluginContext:
         arguments/sub-subparsers.  If *handler_fn* is provided it is set
         as the default dispatch function via ``set_defaults(func=...)``.
         """
-        self._manager._cli_commands[name] = {
+        self._pending_cli_commands[name] = {
             "name": name,
             "help": help,
             "description": description,
@@ -211,7 +227,7 @@ class PluginContext:
             "handler_fn": handler_fn,
             "plugin": self.manifest.name,
         }
-        logger.debug("Plugin %s registered CLI command: %s", self.manifest.name, name)
+        logger.debug("Plugin %s staged CLI command: %s", self.manifest.name, name)
 
     # -- hook registration --------------------------------------------------
 
@@ -229,8 +245,43 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
-        self._manager._hooks.setdefault(hook_name, []).append(callback)
-        logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
+        self._pending_hooks.append((hook_name, callback))
+        logger.debug("Plugin %s staged hook: %s", self.manifest.name, hook_name)
+
+    def commit(self) -> tuple[List[str], List[str]]:
+        """Apply staged registrations after plugin register() succeeds."""
+        from tools.registry import registry
+
+        applied_tool_names: List[str] = []
+        try:
+            for registration in self._pending_tools:
+                registry.register(
+                    name=registration.name,
+                    toolset=registration.toolset,
+                    schema=registration.schema,
+                    handler=registration.handler,
+                    check_fn=registration.check_fn,
+                    requires_env=registration.requires_env,
+                    is_async=registration.is_async,
+                    description=registration.description,
+                    emoji=registration.emoji,
+                )
+                self._manager._plugin_tool_names.add(registration.name)
+                applied_tool_names.append(registration.name)
+        except Exception:
+            for tool_name in reversed(applied_tool_names):
+                registry.deregister(tool_name)
+                self._manager._plugin_tool_names.discard(tool_name)
+            raise
+
+        for hook_name, callback in self._pending_hooks:
+            self._manager._hooks.setdefault(hook_name, []).append(callback)
+
+        self._manager._cli_commands.update(self._pending_cli_commands)
+        return (
+            [registration.name for registration in self._pending_tools],
+            list(dict.fromkeys(hook_name for hook_name, _ in self._pending_hooks)),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -385,26 +436,7 @@ class PluginManager:
             else:
                 ctx = PluginContext(manifest, self)
                 register_fn(ctx)
-                loaded.tools_registered = [
-                    t for t in self._plugin_tool_names
-                    if t not in {
-                        n
-                        for name, p in self._plugins.items()
-                        for n in p.tools_registered
-                    }
-                ]
-                loaded.hooks_registered = list(
-                    {
-                        h
-                        for h, cbs in self._hooks.items()
-                        if cbs  # non-empty
-                    }
-                    - {
-                        h
-                        for name, p in self._plugins.items()
-                        for h in p.hooks_registered
-                    }
-                )
+                loaded.tools_registered, loaded.hooks_registered = ctx.commit()
                 loaded.enabled = True
 
         except Exception as exc:

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -9,9 +9,7 @@ Covers:
 """
 
 import argparse
-import os
 import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -44,6 +42,7 @@ class TestRegisterCliCommand:
             handler_fn=handler,
             description="Full description",
         )
+        ctx.commit()
         assert "mycmd" in mgr._cli_commands
         entry = mgr._cli_commands["mycmd"]
         assert entry["name"] == "mycmd"
@@ -56,11 +55,13 @@ class TestRegisterCliCommand:
         ctx, mgr = self._make_ctx()
         ctx.register_cli_command("x", "first", MagicMock())
         ctx.register_cli_command("x", "second", MagicMock())
+        ctx.commit()
         assert mgr._cli_commands["x"]["help"] == "second"
 
     def test_handler_optional(self):
         ctx, mgr = self._make_ctx()
         ctx.register_cli_command("nocb", "test", MagicMock())
+        ctx.commit()
         assert mgr._cli_commands["nocb"]["handler_fn"] is None
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1,26 +1,17 @@
 """Tests for the Hermes plugin system (hermes_cli.plugins)."""
 
 import logging
-import os
 import sys
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 import yaml
 
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
-    LoadedPlugin,
-    PluginContext,
     PluginManager,
-    PluginManifest,
-    get_plugin_manager,
-    get_plugin_tool_names,
-    discover_plugins,
-    invoke_hook,
 )
 
 
@@ -188,6 +179,63 @@ class TestPluginLoading:
         mgr.discover_and_load()
 
         assert "hermes_plugins.ns_plugin" in sys.modules
+
+    def test_failed_commit_does_not_leave_partial_registrations(self, tmp_path, monkeypatch):
+        """A plugin that fails while publishing staged state stays fully inactive."""
+        from tools.registry import registry
+
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "broken_plugin",
+            register_body=(
+                "ctx.register_tool(\n"
+                '        name="safe_echo",\n'
+                '        toolset="plugin_broken_plugin",\n'
+                '        schema={"name": "safe_echo", "description": "Echo", "parameters": {"type": "object", "properties": {}}},\n'
+                '        handler=lambda args, **kw: "echo",\n'
+                "    )\n"
+                '    ctx.register_hook("pre_tool_call", lambda **kw: {"plugin": "broken"})\n'
+                '    ctx.register_cli_command("broken", "Broken command", lambda parser: None)\n'
+                "    ctx.register_tool(\n"
+                '        name="broken_echo",\n'
+                '        toolset="plugin_broken_plugin",\n'
+                '        schema={"name": "broken_echo", "description": "Echo", "parameters": {"type": "object", "properties": {}}},\n'
+                '        handler=lambda args, **kw: "echo",\n'
+                "    )"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        original_register = registry.register
+
+        def fail_on_second_tool(*args, **kwargs):
+            if kwargs.get("name") == "broken_echo":
+                raise RuntimeError("boom during staged tool publish")
+            return original_register(*args, **kwargs)
+
+        monkeypatch.setattr(registry, "register", fail_on_second_tool)
+
+        mgr = PluginManager()
+        try:
+            mgr.discover_and_load()
+
+            loaded = mgr._plugins["broken_plugin"]
+            assert not loaded.enabled
+            assert "boom during staged tool publish" in loaded.error
+            assert loaded.tools_registered == []
+            assert loaded.hooks_registered == []
+            assert "safe_echo" not in mgr._plugin_tool_names
+            assert "broken_echo" not in mgr._plugin_tool_names
+            assert "safe_echo" not in registry._tools
+            assert "broken_echo" not in registry._tools
+            assert "broken" not in mgr._cli_commands
+            assert mgr.invoke_hook(
+                "pre_tool_call", tool_name="test", args={}, task_id="t1"
+            ) == []
+        finally:
+            registry.deregister("safe_echo")
+            registry.deregister("broken_echo")
 
 
 # ── TestPluginHooks ────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

This fixes a plugin loading bug where Hermes could mark a plugin as failed but still leave some of its registrations active.

The bad path was during plugin startup. Hermes already called `register(ctx)` through a plugin context, but registration still was not fully atomic. If publishing staged tools failed halfway through, earlier tools could already be live in the global registry even though the plugin ended up disabled.

This patch closes that gap:

- `PluginContext` keeps tools, hooks, and CLI commands staged locally during `register(ctx)`.
- `commit()` only publishes that staged state after `register(ctx)` returns successfully.
- If one staged tool fails during publication, any tools already published in that same commit are rolled back before the error is raised.

The end result is simple: failed plugins stay inactive.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/plugins.py` so plugin tools, hooks, and CLI commands stay staged during `register(ctx)`.
- Added rollback in `PluginContext.commit()` so partially published tools are removed if a later staged tool fails to register.
- Added a regression test in `tests/hermes_cli/test_plugins.py` that forces the second staged tool publish to fail and verifies that no tool, hook, or CLI command leaks from the failed plugin.
- Updated `tests/hermes_cli/test_plugin_cli_registration.py` to match the staged-then-commit behavior.

## How to Test

1. Run `uv run pytest tests/hermes_cli/test_plugins.py -k failed_commit_does_not_leave_partial_registrations`
2. Run `uv run pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_cli_registration.py`
3. Run `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check hermes_cli/plugins.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_cli_registration.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification run:

- `uv run pytest tests/hermes_cli/test_plugins.py -k failed_commit_does_not_leave_partial_registrations`
- `uv run pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_cli_registration.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check hermes_cli/plugins.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_cli_registration.py`
