### PR TITLE
fix(docker): use uv for dependency resolution to fix resolution-too-deep error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY . /opt/hermes
 WORKDIR /opt/hermes
 
 # Install Python and Node dependencies in one layer, no cache
-RUN pip install --no-cache-dir -e ".[all]" --break-system-packages && \
+RUN pip install --no-cache-dir uv --break-system-packages && \
+    uv pip install --system --break-system-packages --no-cache -e ".[all]" && \
     npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
     cd /opt/hermes/scripts/whatsapp-bridge && \


### PR DESCRIPTION
The hermes-agent Docker build currently fails with a `resolution-too-deep` error during the `pip install -e ".[all]"` step. This happens because standard pip struggles to resolve complex dependency graphs with recursive or highly interconnected extras. This failure in CI is also the likely reason the `linux/arm64` manifest is missing from Docker Hub.

This PR fixes the issue by transitioning the dependency installation inside the Docker container to use **uv**, the fast Python package manager already recommended for local development.

### Changes:
- Installs `uv` in the Docker image.
- Replaces `pip install -e ".[all]"` with `uv pip install --system --break-system-packages -e ".[all]"`.

### Verification:
- Verified the build succeeds on ARM64 macOS locally.