### PR TITLE
fix(banner): use skin agent_name in version label

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -247,7 +247,8 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
 
 def format_banner_version_label() -> str:
     """Return the version label shown in the startup banner title."""
-    base = f"Hermes Agent v{VERSION} ({RELEASE_DATE})"
+    agent_name = _skin_branding("agent_name", "Hermes Agent")
+    base = f"{agent_name} v{VERSION} ({RELEASE_DATE})"
     state = get_git_banner_state()
     if not state:
         return base
@@ -523,7 +524,6 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     right_content = "\n".join(right_lines)
     layout_table.add_row(left_content, right_content)
 
-    agent_name = _skin_branding("agent_name", "Hermes Agent")
     title_color = _skin_color("banner_title", "#FFD700")
     border_color = _skin_color("banner_border", "#CD7F32")
     outer_panel = Panel(

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -606,7 +606,12 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
 
 def format_banner_version_label() -> str:
     """Return the version label shown in the startup banner title."""
-    base = f"Hermes Agent v{VERSION} ({RELEASE_DATE})"
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+        agent_name = get_active_skin().get_branding("agent_name", "Hermes Agent")
+    except Exception:
+        agent_name = "Hermes Agent"
+    base = f"{agent_name} v{VERSION} ({RELEASE_DATE})"
     state = get_git_banner_state()
     if not state:
         return base

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -480,7 +480,12 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
 
 def format_banner_version_label() -> str:
     """Return the version label shown in the startup banner title."""
-    base = f"Hermes Agent v{VERSION} ({RELEASE_DATE})"
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+        agent_name = get_active_skin().get_branding("agent_name", "Hermes Agent")
+    except Exception:
+        agent_name = "Hermes Agent"
+    base = f"{agent_name} v{VERSION} ({RELEASE_DATE})"
     state = get_git_banner_state()
     if not state:
         return base

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -1,10 +1,16 @@
 from unittest.mock import MagicMock, patch
 
 
+def _patch_skin_default(banner):
+    """Patch _skin_branding so tests don't depend on the active skin."""
+    return patch.object(banner, "_skin_branding", side_effect=lambda key, default: default)
+
+
 def test_format_banner_version_label_without_git_state():
     from hermes_cli import banner
 
-    with patch.object(banner, "get_git_banner_state", return_value=None):
+    with patch.object(banner, "get_git_banner_state", return_value=None), \
+         _patch_skin_default(banner):
         value = banner.format_banner_version_label()
 
     assert value == f"Hermes Agent v{banner.VERSION} ({banner.RELEASE_DATE})"
@@ -17,7 +23,7 @@ def test_format_banner_version_label_on_upstream_main():
         banner,
         "get_git_banner_state",
         return_value={"upstream": "b2f477a3", "local": "b2f477a3", "ahead": 0},
-    ):
+    ), _patch_skin_default(banner):
         value = banner.format_banner_version_label()
 
     assert value.endswith("· upstream b2f477a3")
@@ -31,12 +37,22 @@ def test_format_banner_version_label_with_carried_commits():
         banner,
         "get_git_banner_state",
         return_value={"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3},
-    ):
+    ), _patch_skin_default(banner):
         value = banner.format_banner_version_label()
 
     assert "upstream b2f477a3" in value
     assert "local af8aad31" in value
     assert "+3 carried commits" in value
+
+
+def test_format_banner_version_label_uses_skin_agent_name():
+    from hermes_cli import banner
+
+    with patch.object(banner, "get_git_banner_state", return_value=None), \
+         patch.object(banner, "_skin_branding", side_effect=lambda key, default: "My Agent" if key == "agent_name" else default):
+        value = banner.format_banner_version_label()
+
+    assert value == f"My Agent v{banner.VERSION} ({banner.RELEASE_DATE})"
 
 
 def test_get_git_banner_state_reads_origin_and_head(tmp_path):

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -17,6 +17,18 @@ def test_format_banner_version_label_on_upstream_main():
     assert "local" not in value
 
 
+def test_format_banner_version_label_uses_skin_agent_name():
+    from hermes_cli import banner
+
+    with patch.object(banner, "get_git_banner_state", return_value=None), patch(
+        "hermes_cli.skin_engine.get_active_skin"
+    ) as get_active_skin:
+        get_active_skin.return_value.get_branding.return_value = "My Agent"
+        value = banner.format_banner_version_label()
+
+    assert value == f"My Agent v{banner.VERSION} ({banner.RELEASE_DATE})"
+
+
 def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     from hermes_cli import banner
 
@@ -39,7 +51,6 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
         state = banner.get_git_banner_state(repo_dir)
 
     assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
-
 
 def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
     """SSH fast path must not report an ahead (carried) HEAD as behind.

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -17,6 +17,18 @@ def test_format_banner_version_label_on_upstream_main():
     assert "local" not in value
 
 
+def test_format_banner_version_label_uses_skin_agent_name():
+    from hermes_cli import banner
+
+    with patch.object(banner, "get_git_banner_state", return_value=None), patch(
+        "hermes_cli.skin_engine.get_active_skin"
+    ) as get_active_skin:
+        get_active_skin.return_value.get_branding.return_value = "My Agent"
+        value = banner.format_banner_version_label()
+
+    assert value == f"My Agent v{banner.VERSION} ({banner.RELEASE_DATE})"
+
+
 def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     from hermes_cli import banner
 
@@ -39,5 +51,4 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
         state = banner.get_git_banner_state(repo_dir)
 
     assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
-
 


### PR DESCRIPTION
## Summary

- `format_banner_version_label()` hardcoded `"Hermes Agent"` instead of reading the active skin's `branding.agent_name`, causing the banner title to always show "Hermes Agent" regardless of skin configuration.
- Moved the `_skin_branding("agent_name", ...)` call into the version-label helper and removed the now-dead assignment in `build_welcome_banner()`.

Closes #6768

## Test plan

- [x] All 21 existing banner tests pass (`test_banner.py`, `test_banner_git_state.py`, `test_cli_skin_integration.py`)
- [x] `format_banner_version_label()` still returns `"Hermes Agent v..."` when no skin is active (default fallback unchanged)
- [x] Verify with a custom skin that sets `branding.agent_name` — title should show the custom name
  - Verified: `test_format_banner_version_label_uses_skin_agent_name` patches `_skin_branding` to return `"My Agent"` for `agent_name` and asserts the output matches `"My Agent v{VERSION} ({RELEASE_DATE})"` — passes in CI