### PR TITLE
fix(cli): implement missing models.dev fallback for provider model li…

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -772,6 +772,9 @@ def list_authenticated_providers(
 
         # Use curated list, falling back to models.dev if no curated list
         model_ids = curated.get(hermes_id, [])
+        if not model_ids:
+            model_ids = list_provider_models(hermes_id) or list_provider_models(mdev_id) or []
+            
         total = len(model_ids)
         top = model_ids[:max_models]
 
@@ -811,8 +814,11 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list
+        # Use curated list, falling back to models.dev catalog
         model_ids = curated.get(pid, [])
+        if not model_ids:
+            model_ids = list_provider_models(pid) or []
+            
         total = len(model_ids)
         top = model_ids[:max_models]
 


### PR DESCRIPTION
…sts (#6756)

## What does this PR do?


Fixes #6756

### **The Bug**
When running `/model` in Telegram, Discord, or the CLI, certain providers without a hardcoded curated list (like GitHub Copilot or OpenAI Codex) incorrectly displayed as having `(0)` available models. The code contained a comment stating `# Use curated list, falling back to models.dev if no curated list`, but the actual fallback logic was missing.

### **The Fix**
Implemented the missing fallback logic in `hermes_cli/model_switch.py`. If `curated.get(...)` returns an empty list, the function now explicitly calls `list_provider_models(...)` to dynamically fetch the available models from the registry.

### **Summary of Changes**
- Added fallback logic for standard providers using `list_provider_models(hermes_id)`.
- Added identical fallback logic for Hermes-specific provider overlays (e.g., Copilot, OpenAI API subscriptions).
- Ensures accurate model counts and lists are correctly surfaced in the messaging UI and CLI.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

