### PR TITLE
fix(gateway): track unowned watcher tasks in GatewayRunner

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -570,6 +570,12 @@ class GatewayRunner:
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
 
+    def _track_background_task(self, task: asyncio.Task) -> asyncio.Task:
+        """Retain a strong reference to a fire-and-forget task until completion."""
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
+
 
 
 
@@ -1246,13 +1252,17 @@ class GatewayRunner:
             from tools.process_registry import process_registry
             while process_registry.pending_watchers:
                 watcher = process_registry.pending_watchers.pop(0)
-                asyncio.create_task(self._run_process_watcher(watcher))
+                self._track_background_task(
+                    asyncio.create_task(self._run_process_watcher(watcher))
+                )
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher for proactive memory flushing
-        asyncio.create_task(self._session_expiry_watcher())
+        self._track_background_task(
+            asyncio.create_task(self._session_expiry_watcher())
+        )
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -1261,7 +1271,9 @@ class GatewayRunner:
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        asyncio.create_task(self._platform_reconnect_watcher())
+        self._track_background_task(
+            asyncio.create_task(self._platform_reconnect_watcher())
+        )
 
         logger.info("Press Ctrl+C to stop")
         
@@ -3003,7 +3015,9 @@ class GatewayRunner:
                 from tools.process_registry import process_registry
                 while process_registry.pending_watchers:
                     watcher = process_registry.pending_watchers.pop(0)
-                    asyncio.create_task(self._run_process_watcher(watcher))
+                    self._track_background_task(
+                        asyncio.create_task(self._run_process_watcher(watcher))
+                    )
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -37,6 +37,32 @@ def _source(chat_id="123456", chat_type="dm"):
     )
 
 
+class _FakeProcessRegistry:
+    def __init__(self, watchers=None):
+        self.pending_watchers = list(watchers or [])
+
+    def recover_from_checkpoint(self):
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_track_background_task_releases_completed_tasks():
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    async def complete_soon():
+        await asyncio.sleep(0)
+
+    task = runner._track_background_task(asyncio.create_task(complete_soon()))
+
+    assert task in runner._background_tasks
+
+    await task
+    await asyncio.sleep(0)
+
+    assert runner._background_tasks == set()
+
+
 @pytest.mark.asyncio
 async def test_cancel_background_tasks_cancels_inflight_message_processing():
     adapter = StubAdapter()
@@ -105,3 +131,41 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
     assert runner._pending_messages == {}
     assert runner._pending_approvals == {}
     assert runner._shutdown_event.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_runner_start_tracks_startup_watchers(monkeypatch, tmp_path):
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=False, token="***")},
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    blocker = asyncio.Event()
+
+    async def hold(*_args, **_kwargs):
+        await blocker.wait()
+
+    runner._send_update_notification = AsyncMock(return_value=False)
+    runner._run_process_watcher = AsyncMock(side_effect=hold)
+    runner._session_expiry_watcher = AsyncMock(side_effect=hold)
+    runner._platform_reconnect_watcher = AsyncMock(side_effect=hold)
+
+    import tools.process_registry as pr_module
+
+    monkeypatch.setattr(
+        pr_module,
+        "process_registry",
+        _FakeProcessRegistry([{"session_id": "proc_1"}]),
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert len(runner._background_tasks) == 3
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    await asyncio.sleep(0)
+    assert runner._background_tasks == set()


### PR DESCRIPTION
What does this PR do?
I noticed a lifecycle issue in GatewayRunner where several critical watcher tasks were being created as "unowned" asyncio tasks.

Specifically, the tasks for process watching, session expiry loops, and platform reconnection were triggered via bare asyncio.create_task() calls. Without maintaining a strong reference in self._background_tasks, these are at risk of being prematurely reaped by Python's Garbage Collector (GC) during long-running gateway sessions.

This PR introduces a _track_background_task helper to ensure these tasks have a strong reference and are deterministically cancelled during gateway shutdown, following asyncio best practices.

Type of Change
[x] 🐛 Bug fix (non-breaking change that fixes an issue)

[x] ✅ Tests (adding or improving test coverage)

Changes Made
gateway/run.py:

Implemented _track_background_task() which adds tasks to the internal tracking set with an add_done_callback for automatic cleanup (discard).

Migrated 4 callsites (reconnect loops, session flusher, and process watchers) to use this tracking helper.

tests/gateway/test_gateway_shutdown.py:

Added a regression test to verify that background tasks are correctly registered in the runner's tracking set and cleared upon stop().

How to Test
I've verified the code syntax using compileall (since my current env lacks some RL dependencies).

The logic can be validated by running pytest tests/gateway/test_gateway_shutdown.py.

You should see that len(runner._background_tasks) remains stable and doesn't lose tasks during extended idle periods.

Checklist
[x] My commit messages follow [Conventional Commits]

[x] This isn't a duplicate of existing PRs

[x] I've added tests to cover the lifecycle of these watchers