### PR TITLE
fix(run_agent): recover primary client on openai transport errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5096,6 +5096,7 @@ class AIAgent:
     _TRANSIENT_TRANSPORT_ERRORS = frozenset({
         "ReadTimeout", "ConnectTimeout", "PoolTimeout",
         "ConnectError", "RemoteProtocolError",
+        "APIConnectionError", "APITimeoutError",
     })
 
     def _try_recover_primary_transport(

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -262,6 +262,30 @@ class TestTryRecoverPrimaryTransport:
 
         assert result is True
 
+    def test_recovers_on_openai_api_connection_error(self):
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error("APIConnectionError")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+
+    def test_recovers_on_openai_api_timeout_error(self):
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error("APITimeoutError")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+
     def test_skipped_when_already_on_fallback(self):
         agent = _make_agent(provider="custom")
         agent._fallback_activated = True


### PR DESCRIPTION
## What does this PR do?

Fixes a gap in the primary transport recovery path for local and other direct OpenAI-compatible providers.

Hermes already classifies `APIConnectionError` and `APITimeoutError` as transient transport failures, but `_try_recover_primary_transport()` did not include those OpenAI SDK error types in its allowlist. That meant a session could exhaust retries on those errors without ever triggering the extra primary-client rebuild attempt that already exists for `ReadTimeout`, `ConnectTimeout`, `PoolTimeout`, `ConnectError`, and `RemoteProtocolError`.

This PR makes the recovery path consistent with the classifier and adds regression coverage.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `APIConnectionError` and `APITimeoutError` to `AIAgent._TRANSIENT_TRANSPORT_ERRORS` in `run_agent.py`
- Added regression tests in `tests/run_agent/test_primary_runtime_restore.py` to verify those two OpenAI SDK transport errors trigger the primary-client rebuild path

## How to Test

1. Run `python -m pytest tests/run_agent/test_openai_client_lifecycle.py tests/run_agent/test_primary_runtime_restore.py -q -n 0`
2. Confirm the new `APIConnectionError` and `APITimeoutError` recovery tests pass
3. Optionally reproduce with a local OpenAI-compatible endpoint that returns `APIConnectionError` and verify Hermes now attempts the extra primary client rebuild before falling through

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / WSL working tree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted checks passed:

- `python -m pytest tests/run_agent/test_primary_runtime_restore.py -q -n 0`
- `python -m pytest tests/run_agent/test_openai_client_lifecycle.py tests/run_agent/test_primary_runtime_restore.py -q -n 0`

Full suite on clean branch:

- `python -m pytest tests/ -q -n 0`
- Result: `29 failed, 9601 passed, 25 skipped, 50 deselected, 1 xpassed`

The full-suite failures appear to be pre-existing `origin/main` issues in unrelated areas including CLI usage report mocks, gateway approval flow, provider auto-detection, some agent-loop tool-calling tests, managed browser config, managed server tool support fixture pathing, Matrix send payload expectations, and Tirith marker behavior.
