### PR TITLE
feat(nix): shared-state permission model for interactive CLI users

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -197,14 +197,44 @@ def _ensure_default_soul_md(home: Path) -> None:
 
 
 def ensure_hermes_home():
-    """Ensure ~/.hermes directory structure exists with secure permissions."""
+    """Ensure ~/.hermes directory structure exists with secure permissions.
+
+    In managed mode (NixOS), dirs are created by the activation script with
+    setgid + group-writable (2770). We skip mkdir and set umask(0o007) so
+    any files created (e.g. SOUL.md) are group-writable (0660).
+    """
     home = get_hermes_home()
-    home.mkdir(parents=True, exist_ok=True)
-    _secure_dir(home)
+    if is_managed():
+        old_umask = os.umask(0o007)
+        try:
+            _ensure_hermes_home_managed(home)
+        finally:
+            os.umask(old_umask)
+    else:
+        home.mkdir(parents=True, exist_ok=True)
+        _secure_dir(home)
+        for subdir in ("cron", "sessions", "logs", "memories"):
+            d = home / subdir
+            d.mkdir(parents=True, exist_ok=True)
+            _secure_dir(d)
+        _ensure_default_soul_md(home)
+
+
+def _ensure_hermes_home_managed(home: Path):
+    """Managed-mode variant: verify dirs exist (activation creates them), seed SOUL.md."""
+    if not home.is_dir():
+        raise RuntimeError(
+            f"HERMES_HOME {home} does not exist. "
+            "Run 'sudo nixos-rebuild switch' first."
+        )
     for subdir in ("cron", "sessions", "logs", "memories"):
         d = home / subdir
-        d.mkdir(parents=True, exist_ok=True)
-        _secure_dir(d)
+        if not d.is_dir():
+            raise RuntimeError(
+                f"{d} does not exist. "
+                "Run 'sudo nixos-rebuild switch' first."
+            )
+    # Inside umask(0o007) scope — SOUL.md will be created as 0660
     _ensure_default_soul_md(home)
 
 

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -13,6 +13,7 @@ secrets are never written to disk.
 """
 
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
@@ -177,6 +178,26 @@ def setup_verbose_logging() -> None:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+class _ManagedRotatingFileHandler(RotatingFileHandler):
+    """RotatingFileHandler that ensures group-writable perms after rotation.
+
+    In managed mode (NixOS), the stateDir uses setgid (2770) so new files
+    inherit the hermes group. However, doRollover() creates the new log file
+    via open(), which uses the process umask — typically 0022, producing 0644.
+    This subclass applies chmod 0660 after rotation so both the gateway and
+    interactive users can write to the new log file.
+    """
+
+    def doRollover(self):
+        super().doRollover()
+        try:
+            from hermes_cli.config import is_managed
+            if is_managed():
+                os.chmod(self.baseFilename, 0o660)
+        except (OSError, ImportError):
+            pass
+
+
 def _add_rotating_handler(
     logger: logging.Logger,
     path: Path,
@@ -198,7 +219,7 @@ def _add_rotating_handler(
             return  # already attached
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    handler = RotatingFileHandler(
+    handler = _ManagedRotatingFileHandler(
         str(path), maxBytes=max_bytes, backupCount=backup_count,
     )
     handler.setLevel(level)

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -182,29 +182,32 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
     """RotatingFileHandler that ensures group-writable perms in managed mode.
 
     In managed mode (NixOS), the stateDir uses setgid (2770) so new files
-    inherit the hermes group. However, both initial creation (during __init__
-    via _open()) and rollover creation (via doRollover() -> _open()) use the
-    process umask — typically 0022, producing 0644. This subclass applies
-    chmod 0660 after each open path so both the gateway and interactive users
-    can write to the log file.
+    inherit the hermes group. However, both _open() (initial creation) and
+    doRollover() create files via open(), which uses the process umask —
+    typically 0022, producing 0644. This subclass applies chmod 0660 after
+    both operations so the gateway and interactive users can share log files.
     """
 
-    def _ensure_managed_file_mode(self) -> None:
-        try:
-            from hermes_cli.config import is_managed
-            if is_managed():
+    def __init__(self, *args, **kwargs):
+        from hermes_cli.config import is_managed
+        self._managed = is_managed()
+        super().__init__(*args, **kwargs)
+
+    def _chmod_if_managed(self):
+        if self._managed:
+            try:
                 os.chmod(self.baseFilename, 0o660)
-        except (OSError, ImportError):
-            pass
+            except OSError:
+                pass
 
     def _open(self):
         stream = super()._open()
-        self._ensure_managed_file_mode()
+        self._chmod_if_managed()
         return stream
 
     def doRollover(self):
         super().doRollover()
-        self._ensure_managed_file_mode()
+        self._chmod_if_managed()
 
 
 def _add_rotating_handler(

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -179,23 +179,32 @@ def setup_verbose_logging() -> None:
 # ---------------------------------------------------------------------------
 
 class _ManagedRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that ensures group-writable perms after rotation.
+    """RotatingFileHandler that ensures group-writable perms in managed mode.
 
     In managed mode (NixOS), the stateDir uses setgid (2770) so new files
-    inherit the hermes group. However, doRollover() creates the new log file
-    via open(), which uses the process umask — typically 0022, producing 0644.
-    This subclass applies chmod 0660 after rotation so both the gateway and
-    interactive users can write to the new log file.
+    inherit the hermes group. However, both initial creation (during __init__
+    via _open()) and rollover creation (via doRollover() -> _open()) use the
+    process umask — typically 0022, producing 0644. This subclass applies
+    chmod 0660 after each open path so both the gateway and interactive users
+    can write to the log file.
     """
 
-    def doRollover(self):
-        super().doRollover()
+    def _ensure_managed_file_mode(self) -> None:
         try:
             from hermes_cli.config import is_managed
             if is_managed():
                 os.chmod(self.baseFilename, 0o660)
         except (OSError, ImportError):
             pass
+
+    def _open(self):
+        stream = super()._open()
+        self._ensure_managed_file_mode()
+        return stream
+
+    def doRollover(self):
+        super().doRollover()
+        self._ensure_managed_file_mode()
 
 
 def _add_rotating_handler(

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -560,10 +560,14 @@
       # ── Directories ───────────────────────────────────────────────────
       {
         systemd.tmpfiles.rules = [
-          "d ${cfg.stateDir}                0750 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/.hermes        0750 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}                2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes        2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes/cron   2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes/logs   2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes/memories 2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/home           0750 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.workingDirectory}         0750 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.workingDirectory}         2770 ${cfg.user} ${cfg.group} - -"
         ];
       }
 
@@ -574,8 +578,24 @@
           mkdir -p ${cfg.stateDir}/.hermes
           mkdir -p ${cfg.stateDir}/home
           mkdir -p ${cfg.workingDirectory}
+          for _subdir in cron sessions logs memories; do
+            mkdir -p "${cfg.stateDir}/.hermes/$_subdir"
+          done
           chown ${cfg.user}:${cfg.group} ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.stateDir}/home ${cfg.workingDirectory}
-          chmod 0750 ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.stateDir}/home ${cfg.workingDirectory}
+          chmod 2770 ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.workingDirectory}
+          chmod 0750 ${cfg.stateDir}/home
+
+          # Set subdirs to setgid + group-writable, migrate existing files.
+          # Nix-managed files (config.yaml, .env, .managed) stay 0640/0644.
+          find ${cfg.stateDir}/.hermes -maxdepth 1 \
+            \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
+            -exec chmod g+rw {} + 2>/dev/null || true
+          for _subdir in cron sessions logs memories; do
+            chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/$_subdir"
+            chmod 2770 "${cfg.stateDir}/.hermes/$_subdir"
+            find "${cfg.stateDir}/.hermes/$_subdir" -type f \
+              -exec chmod g+rw {} + 2>/dev/null || true
+          done
 
           # Merge Nix settings into existing config.yaml.
           # Preserves user-added keys (skills, streaming, etc.); Nix keys win.
@@ -661,6 +681,10 @@ HERMES_NIX_ENV_EOF
 
             Restart = cfg.restart;
             RestartSec = cfg.restartSec;
+
+            # Shared-state: files created by the gateway should be group-writable
+            # so interactive users in the hermes group can read/write them.
+            UMask = "0007";
 
             # Hardening
             NoNewPrivileges = true;

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -578,19 +578,17 @@
           mkdir -p ${cfg.stateDir}/.hermes
           mkdir -p ${cfg.stateDir}/home
           mkdir -p ${cfg.workingDirectory}
-          for _subdir in cron sessions logs memories; do
-            mkdir -p "${cfg.stateDir}/.hermes/$_subdir"
-          done
           chown ${cfg.user}:${cfg.group} ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.stateDir}/home ${cfg.workingDirectory}
           chmod 2770 ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.workingDirectory}
           chmod 0750 ${cfg.stateDir}/home
 
-          # Set subdirs to setgid + group-writable, migrate existing files.
+          # Create subdirs, set setgid + group-writable, migrate existing files.
           # Nix-managed files (config.yaml, .env, .managed) stay 0640/0644.
           find ${cfg.stateDir}/.hermes -maxdepth 1 \
             \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
             -exec chmod g+rw {} + 2>/dev/null || true
           for _subdir in cron sessions logs memories; do
+            mkdir -p "${cfg.stateDir}/.hermes/$_subdir"
             chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/$_subdir"
             chmod 2770 "${cfg.stateDir}/.hermes/$_subdir"
             find "${cfg.stateDir}/.hermes/$_subdir" -type f \

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import stat
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from unittest.mock import patch
@@ -295,6 +296,59 @@ class TestAddRotatingHandler:
         ]
         assert len(rotating_handlers) == 1
         # Clean up
+        for h in list(logger.handlers):
+            if isinstance(h, RotatingFileHandler):
+                logger.removeHandler(h)
+                h.close()
+
+    def test_managed_mode_initial_open_sets_group_writable(self, tmp_path):
+        log_path = tmp_path / "managed-open.log"
+        logger = logging.getLogger("_test_rotating_managed_open")
+        formatter = logging.Formatter("%(message)s")
+
+        old_umask = os.umask(0o022)
+        try:
+            with patch("hermes_cli.config.is_managed", return_value=True):
+                hermes_logging._add_rotating_handler(
+                    logger, log_path,
+                    level=logging.INFO, max_bytes=1024, backup_count=1,
+                    formatter=formatter,
+                )
+        finally:
+            os.umask(old_umask)
+
+        assert log_path.exists()
+        assert stat.S_IMODE(log_path.stat().st_mode) == 0o660
+
+        for h in list(logger.handlers):
+            if isinstance(h, RotatingFileHandler):
+                logger.removeHandler(h)
+                h.close()
+
+    def test_managed_mode_rollover_sets_group_writable(self, tmp_path):
+        log_path = tmp_path / "managed-rollover.log"
+        logger = logging.getLogger("_test_rotating_managed_rollover")
+        formatter = logging.Formatter("%(message)s")
+
+        old_umask = os.umask(0o022)
+        try:
+            with patch("hermes_cli.config.is_managed", return_value=True):
+                hermes_logging._add_rotating_handler(
+                    logger, log_path,
+                    level=logging.INFO, max_bytes=1, backup_count=1,
+                    formatter=formatter,
+                )
+                handler = next(
+                    h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+                )
+                logger.info("a" * 256)
+                handler.flush()
+        finally:
+            os.umask(old_umask)
+
+        assert log_path.exists()
+        assert stat.S_IMODE(log_path.stat().st_mode) == 0o660
+
         for h in list(logger.handlers):
             if isinstance(h, RotatingFileHandler):
                 logger.removeHandler(h)


### PR DESCRIPTION
## Summary

Enables interactive CLI users in the `hermes` group to share full read-write state (sessions, memories, logs, cron) with the gateway service.

Builds on #6317 (which fixed `addToSystemPackages` to export `HERMES_HOME`) and addresses the deeper permission issues that made shared state impossible even after that fix. See also #6044 and #6145.

## Problem

Three layers prevented interactive users from writing to the managed `HERMES_HOME`:

1. **Dirs were `0750`** — group could read/traverse but not write
2. **Python forced `0700`** — `_secure_dir()` clobbered permissions on every startup (fixed by #6317's `is_managed()` guard)
3. **No mechanism for group-writable files** — even with writable dirs, files created by the gateway (umask `0022`) would be `0644`, not group-writable

## Changes

**`nix/nixosModules.nix`**
- Dirs use setgid `2770` (was `0750`) — new files inherit the `hermes` group
- `home/` stays `0750` (no interactive write needed)
- Activation script creates `HERMES_HOME` subdirs (`cron`, `sessions`, `logs`, `memories`)
- Activation migrates existing runtime files to group-writable (`chmod g+rw`); Nix-managed files (`config.yaml`, `.env`, `.managed`) stay `0640`/`0644`
- Gateway systemd unit gets `UMask=0007` so files it creates are `0660`

**`hermes_cli/config.py`**
- `ensure_hermes_home()` splits into managed/unmanaged paths
- Managed mode verifies dirs exist (raises `RuntimeError` if not) instead of `mkdir`
- Scoped `umask(0o007)` around `_ensure_default_soul_md()` so `SOUL.md` is `0660`

**`hermes_logging.py`**
- `_ManagedRotatingFileHandler` subclass applies `chmod 0660` after log rotation in managed mode
- `RotatingFileHandler.doRollover()` creates new files via `open()` which uses process umask (`0022` -> `0644`), not the scoped umask

## Usage

```nix
{
  services.hermes-agent = {
    enable = true;
    addToSystemPackages = true;
  };
  # Grant interactive user access to shared state
  users.users.myuser.extraGroups = [ "hermes" ];
}
```

## Test plan

Verified with a 13-subtest NixOS VM integration test (`pkgs.testers.nixosTest`):

- [x] stateDir dirs have setgid bit (`2770`)
- [x] `home/` retains `0750`
- [x] Interactive user can write to `state.db`
- [x] Interactive user can create files in `memories/`, `logs/`, `sessions/`, `cron/`
- [x] `hermes version` and `hermes config` work from interactive user
- [x] New files inherit `hermes` group (setgid)
- [x] New files are group-writable
- [x] `SOUL.md` created as `0660` (umask scoped correctly)
- [x] `config.yaml` and `.env` remain `0640`
- [x] `.managed` remains `0644`
- [x] Gateway service env has `HERMES_HOME`
- [x] Gateway + interactive bidirectional read/write on shared files
- [x] Migration from old `0750`/`0600` perms auto-fixes on rebuild
- [x] All 6 existing `nix flake check` checks pass