### PR TITLE
fix(copilot): add missing Copilot-Integration-Id header

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -285,6 +285,7 @@ def copilot_request_headers(
     headers: dict[str, str] = {
         "Editor-Version": "vscode/1.104.1",
         "User-Agent": "HermesAgent/1.0",
+        "Copilot-Integration-Id": "vscode-chat",
         "Openai-Intent": "conversation-edits",
         "x-initiator": "agent" if is_agent_turn else "user",
     }


### PR DESCRIPTION
## Bug
Hermes Agent fails with `HTTP 400: bad request: missing required Copilot-Integration-Id header` when using GitHub Copilot as the inference provider. All API calls to `https://api.githubcopilot.com` are rejected.

## Root Cause
`copilot_request_headers()` in `hermes_cli/copilot_auth.py` does not include the `Copilot-Integration-Id` header, which the GitHub Copilot API now requires on all requests.

## Fix
Add one line to `copilot_request_headers()` in `hermes_cli/copilot_auth.py`:

```diff
     headers: dict[str, str] = {
         "Editor-Version": "vscode/1.104.1",
         "User-Agent": "HermesAgent/1.0",
+        "Copilot-Integration-Id": "vscode-chat",
         "Openai-Intent": "conversation-edits",
         "x-initiator": "agent" if is_agent_turn else "user",
     }
```

This matches the integration ID used by opencode (which shares the same OAuth client ID `Ov23li8tweQw6odWQebz`).

## Verification
All 24 unit tests in `tests/hermes_cli/test_copilot_auth.py` that are relevant to this change pass.