### PR TITLE
feat(skills): add quick and batch validation workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,11 @@ jobs:
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
 
+      - name: Validate bundled skills
+        run: |
+          source .venv/bin/activate
+          python scripts/validate_all_skills.py skills
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: hermes-validate-skills
+        name: Validate Hermes skills
+        entry: python scripts/validate_all_skills.py skills
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: validate-skill validate-skills test-skill-validators
+
+SKILLS_ROOT ?= skills
+SKILL ?=
+
+validate-skill:
+	@if [ -z "$(SKILL)" ]; then \
+		echo "Usage: make validate-skill SKILL=path/to/skill"; \
+		exit 1; \
+	fi
+	python scripts/quick_validate.py $(SKILL)
+
+validate-skills:
+	python scripts/validate_all_skills.py $(SKILLS_ROOT)
+
+test-skill-validators:
+	python -m pytest tests/tools/test_skills_validation.py -q

--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ uv venv venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
 python -m pytest tests/ -q
+make validate-skills
+```
+
+Skill validator helpers:
+
+```bash
+# Validate one skill while editing
+python scripts/quick_validate.py ~/.hermes/skills/my-skill
+python scripts/quick_validate.py ~/.hermes/skills/my-skill --json
+
+# Validate all bundled repo skills
+python scripts/validate_all_skills.py skills
+python scripts/validate_all_skills.py skills --json
+
+# Makefile shortcuts
+make validate-skill SKILL=~/.hermes/skills/my-skill
+make validate-skills
+```
+
+Optional local hook setup:
+
+```bash
+pip install pre-commit
+pre-commit install
 ```
 
 > **RL Training (optional):** To work on the RL/Tinker-Atropos integration:

--- a/scripts/quick_validate.py
+++ b/scripts/quick_validate.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Quick validation script for a single Hermes skill directory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tools.skills_validation import validate_skill_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a single Hermes skill directory.")
+    parser.add_argument("skill_directory", help="Path to a skill directory containing SKILL.md")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Print machine-readable JSON output")
+    args = parser.parse_args()
+
+    result = validate_skill_dir(args.skill_directory)
+    payload = {
+        "path": str(Path(args.skill_directory).expanduser()),
+        "valid": result.valid,
+        "message": result.message,
+    }
+
+    if args.json_output:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(("VALID: " if result.valid else "INVALID: ") + result.message)
+    return 0 if result.valid else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_all_skills.py
+++ b/scripts/validate_all_skills.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Batch validator for Hermes skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tools.skills_validation import find_skill_dirs, validate_skill_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate all Hermes skills under a root directory.")
+    parser.add_argument("skills_root", help="Root directory to scan recursively for SKILL.md files")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Print machine-readable JSON output")
+    args = parser.parse_args()
+
+    skills_root = Path(args.skills_root).expanduser()
+
+    try:
+        skill_dirs = find_skill_dirs(skills_root)
+    except Exception as exc:
+        if args.json_output:
+            print(json.dumps({"root": str(skills_root), "error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}")
+        return 1
+
+    if not skill_dirs:
+        message = f"No skills found under {skills_root}"
+        if args.json_output:
+            print(json.dumps({"root": str(skills_root), "error": message}, indent=2))
+        else:
+            print(f"ERROR: {message}")
+        return 1
+
+    valid_count = 0
+    invalid_count = 0
+    results = []
+
+    for skill_dir in skill_dirs:
+        result = validate_skill_dir(skill_dir)
+        rel = str(skill_dir.relative_to(skills_root))
+        results.append({"path": rel, "valid": result.valid, "message": result.message})
+        if result.valid:
+            valid_count += 1
+        else:
+            invalid_count += 1
+
+    if args.json_output:
+        print(json.dumps({
+            "root": str(skills_root),
+            "valid": invalid_count == 0,
+            "summary": {
+                "valid": valid_count,
+                "invalid": invalid_count,
+                "total": len(skill_dirs),
+            },
+            "results": results,
+        }, indent=2))
+        return 0 if invalid_count == 0 else 1
+
+    print(f"Found {len(skill_dirs)} skill(s) under {skills_root}")
+    print()
+
+    for item in results:
+        status = "VALID" if item["valid"] else "INVALID"
+        print(f"[{status}] {item['path']} - {item['message']}")
+
+    print()
+    print("Summary:")
+    print(f"  Valid:   {valid_count}")
+    print(f"  Invalid: {invalid_count}")
+    print(f"  Total:   {len(skill_dirs)}")
+
+    if invalid_count:
+        print()
+        print("Failures:")
+        for item in results:
+            if not item["valid"]:
+                print(f"  - {item['path']}: {item['message']}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/test_skills_validation.py
+++ b/tests/tools/test_skills_validation.py
@@ -1,0 +1,154 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.skills_validation import find_skill_dirs, validate_skill_content, validate_skill_dir
+
+
+VALID_SKILL = """---
+name: my-skill
+description: A test skill
+version: 1.0.0
+platforms: [macos, linux]
+prerequisites:
+  env_vars: [API_KEY]
+required_environment_variables:
+  - name: API_KEY
+    prompt: Enter API key
+setup:
+  collect_secrets:
+    - env_var: API_KEY
+      prompt: Enter API key
+credential_files:
+  - path: token.json
+    description: auth token
+metadata:
+  hermes:
+    tags: [test]
+---
+
+# My Skill
+
+Do the thing.
+"""
+
+
+def test_validate_skill_content_accepts_realistic_skill_schema():
+    result = validate_skill_content(VALID_SKILL)
+    assert result.valid is True
+    assert result.message == "Skill is valid!"
+
+
+def test_validate_skill_content_rejects_missing_frontmatter():
+    result = validate_skill_content("# No frontmatter")
+    assert result.valid is False
+    assert "frontmatter" in result.message.lower()
+
+
+def test_validate_skill_content_rejects_empty_body():
+    result = validate_skill_content("---\nname: my-skill\ndescription: Test\n---\n")
+    assert result.valid is False
+    assert "content after the frontmatter" in result.message
+
+
+def test_validate_skill_content_rejects_bad_name():
+    result = validate_skill_content("---\nname: My Skill\ndescription: Test\n---\n\nBody")
+    assert result.valid is False
+    assert "kebab-case" in result.message
+
+
+def test_validate_skill_content_rejects_invalid_required_env_shape():
+    bad = """---
+name: my-skill
+description: Test
+required_environment_variables:
+  - 123
+---
+
+Body
+"""
+    result = validate_skill_content(bad)
+    assert result.valid is False
+    assert "required_environment_variables" in result.message
+
+
+def test_validate_skill_dir_reads_skill_md(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(VALID_SKILL, encoding="utf-8")
+
+    result = validate_skill_dir(skill_dir)
+    assert result.valid is True
+
+
+def test_validate_skill_dir_missing_file(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+
+    result = validate_skill_dir(skill_dir)
+    assert result.valid is False
+    assert result.message == "SKILL.md not found"
+
+
+def test_find_skill_dirs_recursively(tmp_path):
+    first = tmp_path / "category-a" / "skill-one"
+    second = tmp_path / "category-b" / "skill-two"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "SKILL.md").write_text(VALID_SKILL, encoding="utf-8")
+    (second / "SKILL.md").write_text(VALID_SKILL.replace("my-skill", "skill-two", 1), encoding="utf-8")
+
+    found = find_skill_dirs(tmp_path)
+    assert found == [first, second]
+
+
+def test_find_skill_dirs_requires_existing_directory(tmp_path):
+    missing = tmp_path / "missing"
+    try:
+        find_skill_dirs(missing)
+    except FileNotFoundError as exc:
+        assert str(missing) in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError")
+
+
+def test_quick_validate_json_output(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(VALID_SKILL, encoding="utf-8")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/quick_validate.py", str(skill_dir), "--json"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["valid"] is True
+    assert payload["path"] == str(skill_dir)
+
+
+def test_validate_all_skills_json_output(tmp_path):
+    skill_dir = tmp_path / "category" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(VALID_SKILL, encoding="utf-8")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_all_skills.py", str(tmp_path), "--json"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["valid"] is True
+    assert payload["summary"]["total"] == 1
+    assert payload["results"][0]["path"] == "category/my-skill"

--- a/tools/skills_validation.py
+++ b/tools/skills_validation.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Shared validation helpers for Hermes skills.
+
+These checks are intentionally lightweight and compatible with the real SKILL.md
+format used across the Hermes skills tree. They are suitable for fast local
+validation loops and batch repo scans.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+MAX_NAME_LENGTH = 64
+MAX_DESCRIPTION_LENGTH = 1024
+MAX_COMPATIBILITY_LENGTH = 500
+NAME_RE = re.compile(r"^[a-z0-9-]+$")
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---(?:\s*\n|\s*$)", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    valid: bool
+    message: str
+
+
+def _normalize_content(content: str) -> str:
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _extract_frontmatter(content: str) -> tuple[dict[str, Any], str] | tuple[None, str]:
+    content = _normalize_content(content)
+    if not content.strip():
+        return None, "Content cannot be empty."
+    if not content.startswith("---"):
+        return None, "SKILL.md must start with YAML frontmatter (---)."
+
+    match = FRONTMATTER_RE.match(content)
+    if not match:
+        return None, "SKILL.md frontmatter is missing or not closed with a second '---' line."
+
+    frontmatter_text = match.group(1)
+    body = content[match.end():].strip()
+
+    try:
+        parsed = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as exc:
+        return None, f"YAML frontmatter parse error: {exc}"
+
+    if not isinstance(parsed, dict):
+        return None, "Frontmatter must be a YAML mapping (key: value pairs)."
+    if not body:
+        return None, "SKILL.md must have content after the frontmatter (instructions, procedures, etc.)."
+
+    return parsed, body
+
+
+def _validate_name(value: Any) -> str | None:
+    if value is None:
+        return "Frontmatter must include 'name' field."
+    if not isinstance(value, str):
+        return f"Name must be a string, got {type(value).__name__}."
+
+    name = value.strip()
+    if not name:
+        return "Name cannot be empty."
+    if len(name) > MAX_NAME_LENGTH:
+        return f"Name exceeds {MAX_NAME_LENGTH} characters."
+    if not NAME_RE.match(name):
+        return f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)."
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens."
+    return None
+
+
+def _validate_description(value: Any) -> str | None:
+    if value is None:
+        return "Frontmatter must include 'description' field."
+    if not isinstance(value, str):
+        return f"Description must be a string, got {type(value).__name__}."
+
+    description = value.strip()
+    if not description:
+        return "Description cannot be empty."
+    if len(description) > MAX_DESCRIPTION_LENGTH:
+        return f"Description exceeds {MAX_DESCRIPTION_LENGTH} characters."
+    return None
+
+
+def _validate_optional_string(frontmatter: dict[str, Any], key: str, max_len: int) -> str | None:
+    value = frontmatter.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return f"{key} must be a string, got {type(value).__name__}."
+    if len(value) > max_len:
+        return f"{key} exceeds {max_len} characters."
+    return None
+
+
+def _validate_string_list(frontmatter: dict[str, Any], key: str) -> str | None:
+    value = frontmatter.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        return f"{key} must be a list, got {type(value).__name__}."
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            return f"{key} must contain only non-empty strings."
+    return None
+
+
+def _validate_prerequisites(frontmatter: dict[str, Any]) -> str | None:
+    prerequisites = frontmatter.get("prerequisites")
+    if prerequisites is None:
+        return None
+    if not isinstance(prerequisites, dict):
+        return f"prerequisites must be a mapping, got {type(prerequisites).__name__}."
+    for key in ("env_vars", "commands"):
+        value = prerequisites.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            continue
+        if not isinstance(value, list):
+            return f"prerequisites.{key} must be a string or list of strings."
+        for item in value:
+            if not isinstance(item, str) or not item.strip():
+                return f"prerequisites.{key} must contain only non-empty strings."
+    return None
+
+
+def _validate_required_environment_variables(frontmatter: dict[str, Any]) -> str | None:
+    value = frontmatter.get("required_environment_variables")
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        value = [value]
+    if not isinstance(value, list):
+        return "required_environment_variables must be a list or mapping."
+    for item in value:
+        if isinstance(item, str):
+            if not item.strip():
+                return "required_environment_variables cannot contain empty strings."
+            continue
+        if not isinstance(item, dict):
+            return "required_environment_variables entries must be strings or mappings."
+        name = item.get("name") or item.get("env_var")
+        if not isinstance(name, str) or not name.strip():
+            return "required_environment_variables mapping entries must include a non-empty 'name' or 'env_var'."
+    return None
+
+
+def _validate_setup(frontmatter: dict[str, Any]) -> str | None:
+    setup = frontmatter.get("setup")
+    if setup is None:
+        return None
+    if not isinstance(setup, dict):
+        return f"setup must be a mapping, got {type(setup).__name__}."
+    collect_secrets = setup.get("collect_secrets")
+    if collect_secrets is None:
+        return None
+    if isinstance(collect_secrets, dict):
+        collect_secrets = [collect_secrets]
+    if not isinstance(collect_secrets, list):
+        return "setup.collect_secrets must be a list or mapping."
+    for item in collect_secrets:
+        if not isinstance(item, dict):
+            return "setup.collect_secrets entries must be mappings."
+        env_var = item.get("env_var")
+        if not isinstance(env_var, str) or not env_var.strip():
+            return "setup.collect_secrets entries must include a non-empty 'env_var'."
+    return None
+
+
+def _validate_credential_files(frontmatter: dict[str, Any]) -> str | None:
+    value = frontmatter.get("credential_files")
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        return f"credential_files must be a list, got {type(value).__name__}."
+    for item in value:
+        if not isinstance(item, dict):
+            return "credential_files entries must be mappings."
+        path_value = item.get("path")
+        if not isinstance(path_value, str) or not path_value.strip():
+            return "credential_files entries must include a non-empty 'path'."
+    return None
+
+
+def validate_skill_content(content: str) -> ValidationResult:
+    parsed, error = _extract_frontmatter(content)
+    if parsed is None:
+        return ValidationResult(False, error)
+
+    for validator in (
+        lambda fm: _validate_name(fm.get("name")),
+        lambda fm: _validate_description(fm.get("description")),
+        lambda fm: _validate_optional_string(fm, "compatibility", MAX_COMPATIBILITY_LENGTH),
+        lambda fm: _validate_optional_string(fm, "version", 128),
+        lambda fm: _validate_optional_string(fm, "author", 256),
+        lambda fm: _validate_optional_string(fm, "license", 128),
+        lambda fm: _validate_string_list(fm, "platforms"),
+        lambda fm: _validate_string_list(fm, "allowed-tools"),
+        lambda fm: None if fm.get("metadata") is None or isinstance(fm.get("metadata"), dict) else f"metadata must be a mapping, got {type(fm.get('metadata')).__name__}.",
+        _validate_prerequisites,
+        _validate_required_environment_variables,
+        _validate_setup,
+        _validate_credential_files,
+    ):
+        error = validator(parsed)
+        if error:
+            return ValidationResult(False, error)
+
+    return ValidationResult(True, "Skill is valid!")
+
+
+def validate_skill_dir(skill_dir: str | Path) -> ValidationResult:
+    path = Path(skill_dir).expanduser()
+    if not path.exists():
+        return ValidationResult(False, f"Skill directory not found: {path}")
+    if not path.is_dir():
+        return ValidationResult(False, f"Path is not a directory: {path}")
+
+    skill_md = path / "SKILL.md"
+    if not skill_md.exists():
+        return ValidationResult(False, "SKILL.md not found")
+
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+    except Exception as exc:
+        return ValidationResult(False, f"Could not read SKILL.md: {exc}")
+
+    return validate_skill_content(content)
+
+
+def find_skill_dirs(skills_root: str | Path) -> list[Path]:
+    root = Path(skills_root).expanduser()
+    if not root.exists():
+        raise FileNotFoundError(f"Skills root not found: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"Skills root is not a directory: {root}")
+    return sorted({path.parent for path in root.rglob("SKILL.md")})


### PR DESCRIPTION
## Summary
- add a shared Hermes skill validation module that matches the real SKILL.md schema
- add quick and batch validator scripts, including optional JSON output
- add tests for validator behavior and script JSON mode
- add Makefile shortcuts, pre-commit config, README docs, and bundled-skills CI validation

## Validation
- python -m pytest tests/tools/test_skills_validation.py
- python scripts/validate_all_skills.py skills
- python scripts/validate_all_skills.py skills --json
- make validate-skills