### PR TITLE
fix(gateway): force launchd plist re-read after refresh

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1159,9 +1159,17 @@ def launchd_start():
         print("✓ Service started")
         return
 
-    refresh_launchd_plist_if_needed()
+    plist_refreshed = refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        if plist_refreshed:
+            # Plist was updated — kickstart does NOT re-read the plist file,
+            # so we need a full bootout/bootstrap cycle to force launchd to
+            # pick up the new service definition.
+            subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
+            subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+            subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        else:
+            subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
         if e.returncode not in (3, 113):
             raise


### PR DESCRIPTION
When `hermes gateway start` detects a stale launchd plist, it updates the file on disk but `launchctl kickstart` does NOT re-read it — launchd uses its cached service definition indefinitely, causing restart loops.

Fix: when the plist was refreshed, do `bootout + bootstrap + kickstart` instead of just `kickstart`, forcing launchd to drop its cache and pick up the new service definition.

**Root cause:** `refresh_launchd_plist_if_needed()` was called but its return value was discarded. Even when the plist file changed, the subsequent `kickstart` call would restart the gateway with launchd's stale cached definition.

**Test:** Simulated a Hermes upgrade that changes the binary path, then ran `hermes gateway start` — gateway now correctly picks up the new path without a restart loop.