### PR TITLE
fix(mcp): fall back when SIGKILL is unavailable on Windows

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -104,6 +104,45 @@ class TestStdioPidTracking:
         with _lock:
             assert fake_pid not in _stdio_pids
 
+    def test_kill_orphaned_uses_sigkill_when_available(self, monkeypatch):
+        """Unix-like platforms should keep using SIGKILL for orphan cleanup."""
+        from tools.mcp_tool import _kill_orphaned_mcp_children, _stdio_pids, _lock
+
+        fake_pid = 424242
+        with _lock:
+            _stdio_pids.clear()
+            _stdio_pids.add(fake_pid)
+
+        fake_sigkill = 9
+        monkeypatch.setattr(signal, "SIGKILL", fake_sigkill, raising=False)
+
+        with patch("tools.mcp_tool.os.kill") as mock_kill:
+            _kill_orphaned_mcp_children()
+
+        mock_kill.assert_called_once_with(fake_pid, fake_sigkill)
+
+        with _lock:
+            assert fake_pid not in _stdio_pids
+
+    def test_kill_orphaned_falls_back_without_sigkill(self, monkeypatch):
+        """Windows-like signal modules without SIGKILL should fall back to SIGTERM."""
+        from tools.mcp_tool import _kill_orphaned_mcp_children, _stdio_pids, _lock
+
+        fake_pid = 434343
+        with _lock:
+            _stdio_pids.clear()
+            _stdio_pids.add(fake_pid)
+
+        monkeypatch.delattr(signal, "SIGKILL", raising=False)
+
+        with patch("tools.mcp_tool.os.kill") as mock_kill:
+            _kill_orphaned_mcp_children()
+
+        mock_kill.assert_called_once_with(fake_pid, signal.SIGTERM)
+
+        with _lock:
+            assert fake_pid not in _stdio_pids
+
 
 # ---------------------------------------------------------------------------
 # Fix 3: MCP reload timeout (cli.py)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2152,6 +2152,7 @@ def _kill_orphaned_mcp_children() -> None:
     Only kills PIDs tracked in ``_stdio_pids`` — never arbitrary children.
     """
     import signal as _signal
+    kill_signal = getattr(_signal, "SIGKILL", _signal.SIGTERM)
 
     with _lock:
         pids = list(_stdio_pids)
@@ -2159,7 +2160,7 @@ def _kill_orphaned_mcp_children() -> None:
 
     for pid in pids:
         try:
-            os.kill(pid, _signal.SIGKILL)
+            os.kill(pid, kill_signal)
             logger.debug("Force-killed orphaned MCP stdio process %d", pid)
         except (ProcessLookupError, PermissionError, OSError):
             pass  # Already exited or inaccessible


### PR DESCRIPTION
What does this PR do?
This patch fixes a cross-platform crash in tools.mcp_tool._kill_orphaned_mcp_children(). On Windows, the signal module does not expose SIGKILL, leading to an AttributeError during MCP shutdown when trying to clean up orphaned stdio child processes.

The fix uses getattr to provide a safe fallback to SIGTERM on Windows while maintaining the existing SIGKILL behavior on POSIX systems.

Changes Made

tools/mcp_tool.py: Implemented dynamic signal lookup for orphan cleanup.

tests/tools/test_mcp_stability.py: Added regression tests to verify both standard SIGKILL usage and the SIGTERM fallback path.

How to Test
Execute the following test suite:
python -m pytest tests/tools/test_mcp_stability.py -q


Checklist

[x] Fixes AttributeError on Windows.

[x] No breaking changes for Unix/macOS.

[x] Minimalist technical fix.