### PR TITLE
fix(stream_consumer): use truncate_message for overflow splitting

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -136,26 +136,30 @@ class GatewayStreamConsumer:
 
                 if should_edit and self._accumulated:
                     # Split overflow: if accumulated text exceeds the platform
-                    # limit, finalize the current message and start a new one.
-                    while (
-                        len(self._accumulated) > _safe_limit
-                        and self._message_id is not None
-                        and self._edit_supported
-                    ):
-                        split_at = self._accumulated.rfind("\n", 0, _safe_limit)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
-                        chunk = self._accumulated[:split_at]
-                        await self._send_or_edit(chunk)
-                        if self._fallback_final_send:
-                            # Edit failed while attempting to split an oversized
-                            # message. Keep the full accumulated text intact so
-                            # the fallback final-send path can deliver the
-                            # remaining continuation without dropping content.
-                            break
-                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
-                        self._message_id = None
+                    # limit, use truncate_message (same as the non-streaming path)
+                    # to split with proper chunk indicators like "(1/2)".
+                    if len(self._accumulated) > _safe_limit:
+                        chunks = self.adapter.truncate_message(
+                            self._accumulated, _raw_limit
+                        )
+                        prev_id = self._message_id
+                        for i, chunk in enumerate(chunks):
+                            display_text = chunk
+                            if i < len(chunks) - 1:
+                                import re as _re
+                                display_text = _re.sub(
+                                    r" \((\d+)/(\d+)\)$",
+                                    r" \(\1/\\2\\)",
+                                    chunk,
+                                )
+                            prev_id = await self._send_new_chunk(
+                                display_text, prev_id
+                            )
+                        self._accumulated = ""
+                        self._message_id = prev_id
                         self._last_sent_text = ""
+                        self._last_edit_time = time.monotonic()
+                        continue
 
                     display_text = self._accumulated
                     if not got_done and not got_segment_break:
@@ -225,6 +229,34 @@ class GatewayStreamConsumer:
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
+
+    async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
+        """Send a new message chunk, optionally threaded to a previous message.
+
+        Returns the message_id so callers can thread subsequent chunks to it.
+        """
+        text = self._clean_for_display(text)
+        if not text.strip():
+            return reply_to_id
+        try:
+            meta = dict(self.metadata) if self.metadata else {}
+            result = await self.adapter.send(
+                chat_id=self.chat_id,
+                content=text,
+                reply_to=reply_to_id,
+                metadata=meta,
+            )
+            if result.success and result.message_id:
+                self._message_id = str(result.message_id)
+                self._already_sent = True
+                self._last_sent_text = text
+                return str(result.message_id)
+            else:
+                self._edit_supported = False
+                return reply_to_id
+        except Exception as e:
+            logger.error("Stream send chunk error: %s", e)
+            return reply_to_id
 
     def _visible_prefix(self) -> str:
         """Return the visible text already shown in the streamed message."""


### PR DESCRIPTION
## Bug
Long streamed messages were silently cut off on Telegram when exceeding ~3900 characters.

## Root cause
The overflow split loop in `stream_consumer.py` required `self._message_id is not None` to enter, but on the first streamed message `_message_id` starts as `None`. The loop never ran, so text over the safe limit was passed unsplit to Telegram, which rejected it with 'message too long' and broke streaming silently.

## Fix
Replace the broken manual split with `self.adapter.truncate_message()` — the same helper the non-streaming path already uses. Properly splits on word/newline boundaries, preserves code fences, and adds chunk indicators like `(1/3)`. Each overflow chunk is sent as a new threaded message via the new `_send_new_chunk()` helper.

## File
`gateway/stream_consumer.py`

## Test
Send any request that produces a response over ~3900 chars to Telegram. Before: silent cut-off. After: clean split into `(1/2)`, `(2/2)` etc.