### PR TITLE
feat: add Codex fast mode toggle

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -189,6 +189,25 @@ def _prompt_fast_mode_selection(current_tier: str | None = None) -> str | None:
             return None
 
 
+def _resolve_fast_mode_status(model_id: str | None) -> tuple[bool, str | None]:
+    """Return whether the fast backend is currently reachable for *model_id*."""
+    try:
+        from hermes_cli.models import resolve_fast_mode_runtime
+    except Exception:
+        return False, None
+
+    try:
+        fast_runtime = resolve_fast_mode_runtime(model_id)
+    except Exception:
+        return False, None
+    if not fast_runtime:
+        return False, None
+
+    runtime = fast_runtime.get("runtime") or {}
+    provider = str(runtime.get("provider") or "").strip() or None
+    return True, provider
+
+
 def _get_chrome_debug_candidates(system: str) -> list[str]:
     """Return likely browser executables for local CDP auto-launch."""
     candidates: list[str] = []
@@ -5476,6 +5495,7 @@ class HermesCLI:
             _cprint("  (._.) /fast is only available for models that explicitly expose a fast backend.")
             return
 
+        active_model = getattr(getattr(self, "agent", None), "model", None) or getattr(self, "model", None)
         parts = cmd.strip().split(maxsplit=1)
         if len(parts) < 2:
             selected = _prompt_fast_mode_selection(current_tier=self.service_tier)
@@ -5488,6 +5508,15 @@ class HermesCLI:
         if arg == "status":
             status = "fast" if self.service_tier == "priority" else "normal"
             _cprint(f"  {_GOLD}Codex inference tier: {status}{_RST}")
+            if self.service_tier == "priority":
+                backend_ready, backend_provider = _resolve_fast_mode_status(active_model)
+                if backend_ready:
+                    backend_label = backend_provider or "openai-codex"
+                    _cprint(f"  {_DIM}Fast backend ready via {backend_label}.{_RST}")
+                else:
+                    _cprint(
+                        f"  {_DIM}Fast backend unavailable right now — Hermes will stay on the normal route until Codex credentials resolve.{_RST}"
+                    )
             _cprint(f"  {_DIM}Usage: /fast [normal|fast|status]{_RST}")
             return
 
@@ -5509,6 +5538,16 @@ class HermesCLI:
             _cprint(f"  {_GOLD}✓ Codex inference tier set to {label} (saved to config){_RST}")
         else:
             _cprint(f"  {_GOLD}✓ Codex inference tier set to {label} (session only){_RST}")
+
+        if self.service_tier == "priority":
+            backend_ready, backend_provider = _resolve_fast_mode_status(active_model)
+            if backend_ready:
+                backend_label = backend_provider or "openai-codex"
+                _cprint(f"  {_DIM}Fast backend ready via {backend_label}.{_RST}")
+            else:
+                _cprint(
+                    f"  {_DIM}Fast backend unavailable right now — Hermes will stay on the normal route until Codex credentials resolve.{_RST}"
+                )
 
     def _on_reasoning(self, reasoning_text: str):
         """Callback for intermediate reasoning display during tool-call loops."""

--- a/cli.py
+++ b/cli.py
@@ -120,6 +120,75 @@ def _parse_reasoning_config(effort: str) -> dict | None:
     return result
 
 
+def _parse_service_tier_config(raw: str) -> str | None:
+    """Parse a persisted service-tier preference into a Responses API value."""
+    value = str(raw or "").strip().lower()
+    if not value or value in {"normal", "default", "standard", "off", "none"}:
+        return None
+    if value in {"fast", "priority", "on"}:
+        return "priority"
+    logger.warning("Unknown service_tier '%s', ignoring", raw)
+    return None
+
+
+def _prompt_fast_mode_selection(current_tier: str | None = None) -> str | None:
+    """Prompt for a Codex fast-mode selection. Returns 'normal', 'fast', or None."""
+    current = "fast" if current_tier == "priority" else "normal"
+    ordered = ["normal", "fast"]
+    default_idx = ordered.index(current)
+
+    def _label(name: str) -> str:
+        text = name.capitalize()
+        if name == current:
+            return f"{text}  ← currently in use"
+        return text
+
+    try:
+        from simple_term_menu import TerminalMenu
+
+        choices = [f"  {_label(name)}" for name in ordered]
+        choices.append("  Cancel")
+        menu = TerminalMenu(
+            choices,
+            cursor_index=default_idx,
+            menu_cursor="-> ",
+            menu_cursor_style=("fg_green", "bold"),
+            menu_highlight_style=("fg_green",),
+            cycle_cursor=True,
+            clear_screen=False,
+            title="Select Codex inference tier:",
+        )
+        idx = menu.show()
+        if idx is None or idx >= len(ordered):
+            return None
+        print()
+        return ordered[idx]
+    except (ImportError, NotImplementedError):
+        pass
+
+    print("Select Codex inference tier:")
+    for i, name in enumerate(ordered, 1):
+        print(f"  {i}. {_label(name)}")
+    print(f"  {len(ordered) + 1}. Cancel")
+    print()
+
+    while True:
+        try:
+            choice = input(f"Choice [1-{len(ordered) + 1}] (default: cancel): ").strip()
+            if not choice:
+                return None
+            idx = int(choice)
+            if 1 <= idx <= len(ordered):
+                return ordered[idx - 1]
+            if idx == len(ordered) + 1:
+                return None
+            print(f"Please enter 1-{len(ordered) + 1}")
+        except ValueError:
+            print("Please enter a number")
+        except (KeyboardInterrupt, EOFError):
+            return None
+
+
 def _get_chrome_debug_candidates(system: str) -> list[str]:
     """Return likely browser executables for local CDP auto-launch."""
     candidates: list[str] = []
@@ -239,6 +308,7 @@ def load_cli_config() -> Dict[str, Any]:
             "system_prompt": "",
             "prefill_messages_file": "",
             "reasoning_effort": "",
+            "service_tier": "",
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",
                 "concise": "You are a concise assistant. Keep responses brief and to the point.",
@@ -1478,6 +1548,9 @@ class HermesCLI:
         self.reasoning_config = _parse_reasoning_config(
             CLI_CONFIG["agent"].get("reasoning_effort", "")
         )
+        self.service_tier = _parse_service_tier_config(
+            CLI_CONFIG["agent"].get("service_tier", "")
+        )
         
         # OpenRouter provider routing preferences
         pr = CLI_CONFIG.get("provider_routing", {}) or {}
@@ -2452,6 +2525,7 @@ class HermesCLI:
                 ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
+                service_tier=self.service_tier,
                 providers_allowed=self._providers_only,
                 providers_ignored=self._providers_ignore,
                 providers_order=self._providers_order,
@@ -3073,6 +3147,21 @@ class HermesCLI:
             f"{toolsets_info}{provider_info}"
         )
     
+    def _fast_command_available(self) -> bool:
+        try:
+            from hermes_cli.models import codex_model_supports_fast_mode
+        except Exception:
+            return False
+        agent = getattr(self, "agent", None)
+        model = getattr(agent, "model", None) or self.model
+        provider = self.provider or self.requested_provider
+        return codex_model_supports_fast_mode(provider, model)
+
+    def _command_available(self, slash_command: str) -> bool:
+        if slash_command == "/fast":
+            return self._fast_command_available()
+        return True
+
     def show_help(self):
         """Display help information with categorized commands."""
         from hermes_cli.commands import COMMANDS_BY_CATEGORY
@@ -3093,6 +3182,8 @@ class HermesCLI:
         for category, commands in COMMANDS_BY_CATEGORY.items():
             _cprint(f"\n  {_BOLD}── {category} ──{_RST}")
             for cmd, desc in commands.items():
+                if not self._command_available(cmd):
+                    continue
                 ChatConsole().print(f"    [bold {_accent_hex()}]{cmd:<15}[/] [dim]-[/] {_escape(desc)}")
 
         if _skill_commands:
@@ -4542,6 +4633,8 @@ class HermesCLI:
             self._toggle_yolo()
         elif canonical == "reasoning":
             self._handle_reasoning_command(cmd_original)
+        elif canonical == "fast":
+            self._handle_fast_command(cmd_original)
         elif canonical == "compress":
             self._manual_compress()
         elif canonical == "usage":
@@ -4779,6 +4872,7 @@ class HermesCLI:
                     platform="cli",
                     session_db=self._session_db,
                     reasoning_config=self.reasoning_config,
+                    service_tier=self.service_tier,
                     providers_allowed=self._providers_only,
                     providers_ignored=self._providers_ignore,
                     providers_order=self._providers_order,
@@ -4914,6 +5008,7 @@ class HermesCLI:
                     session_id=task_id,
                     platform="cli",
                     reasoning_config=self.reasoning_config,
+                    service_tier=self.service_tier,
                     providers_allowed=self._providers_only,
                     providers_ignored=self._providers_ignore,
                     providers_order=self._providers_order,
@@ -5342,6 +5437,46 @@ class HermesCLI:
             _cprint(f"  {_GOLD}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
         else:
             _cprint(f"  {_GOLD}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+
+    def _handle_fast_command(self, cmd: str):
+        """Handle /fast — choose the Codex Responses service tier."""
+        if not self._fast_command_available():
+            _cprint("  (._.) /fast is only available for models that explicitly expose a fast backend.")
+            return
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2:
+            selected = _prompt_fast_mode_selection(current_tier=self.service_tier)
+            if selected is None:
+                return
+            arg = selected
+        else:
+            arg = parts[1].strip().lower()
+
+        if arg == "status":
+            status = "fast" if self.service_tier == "priority" else "normal"
+            _cprint(f"  {_GOLD}Codex inference tier: {status}{_RST}")
+            _cprint(f"  {_DIM}Usage: /fast [normal|fast|status]{_RST}")
+            return
+
+        if arg in {"fast", "on"}:
+            self.service_tier = "priority"
+            saved_value = "fast"
+            label = "FAST"
+        elif arg in {"normal", "off"}:
+            self.service_tier = None
+            saved_value = "normal"
+            label = "NORMAL"
+        else:
+            _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
+            _cprint(f"  {_DIM}Usage: /fast [normal|fast|status]{_RST}")
+            return
+
+        self.agent = None  # Force agent re-init with new service-tier config
+        if save_config_value("agent.service_tier", saved_value):
+            _cprint(f"  {_GOLD}✓ Codex inference tier set to {label} (saved to config){_RST}")
+        else:
+            _cprint(f"  {_GOLD}✓ Codex inference tier set to {label} (session only){_RST}")
 
     def _on_reasoning(self, reasoning_text: str):
         """Callback for intermediate reasoning display during tool-call loops."""
@@ -7647,6 +7782,7 @@ class HermesCLI:
 
         _completer = SlashCommandCompleter(
             skill_commands_provider=lambda: _skill_commands,
+            command_filter=cli_ref._command_available,
         )
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),

--- a/cli.py
+++ b/cli.py
@@ -2422,8 +2422,9 @@ class HermesCLI:
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Resolve model/runtime overrides for a single user turn."""
         from agent.smart_model_routing import resolve_turn_route
+        from hermes_cli.models import resolve_fast_mode_runtime
 
-        return resolve_turn_route(
+        route = resolve_turn_route(
             user_message,
             self._smart_model_routing,
             {
@@ -2438,7 +2439,35 @@ class HermesCLI:
             },
         )
 
-    def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, route_label: str = None) -> bool:
+        if not self.service_tier:
+            route["request_overrides"] = None
+            return route
+
+        try:
+            fast_runtime = resolve_fast_mode_runtime(route.get("model"))
+        except Exception:
+            route["request_overrides"] = None
+            return route
+        if not fast_runtime:
+            route["request_overrides"] = None
+            return route
+
+        runtime = fast_runtime["runtime"]
+        route["runtime"] = runtime
+        route["request_overrides"] = fast_runtime["request_overrides"]
+        route["label"] = f"fast route → {route.get('model')} ({runtime.get('provider')})"
+        route["signature"] = (
+            route.get("model"),
+            runtime.get("provider"),
+            runtime.get("base_url"),
+            runtime.get("api_mode"),
+            runtime.get("command"),
+            tuple(runtime.get("args") or ()),
+            json.dumps(route["request_overrides"], sort_keys=True),
+        )
+        return route
+
+    def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, route_label: str = None, request_overrides: dict | None = None) -> bool:
         """
         Initialize the agent on first use.
         When resuming a session, restores conversation history from SQLite.
@@ -2526,6 +2555,7 @@ class HermesCLI:
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
                 service_tier=self.service_tier,
+                request_overrides=request_overrides,
                 providers_allowed=self._providers_only,
                 providers_ignored=self._providers_ignore,
                 providers_order=self._providers_order,
@@ -3149,13 +3179,12 @@ class HermesCLI:
     
     def _fast_command_available(self) -> bool:
         try:
-            from hermes_cli.models import codex_model_supports_fast_mode
+            from hermes_cli.models import model_supports_fast_mode
         except Exception:
             return False
         agent = getattr(self, "agent", None)
         model = getattr(agent, "model", None) or self.model
-        provider = self.provider or self.requested_provider
-        return codex_model_supports_fast_mode(provider, model)
+        return model_supports_fast_mode(model)
 
     def _command_available(self, slash_command: str) -> bool:
         if slash_command == "/fast":
@@ -4873,6 +4902,7 @@ class HermesCLI:
                     session_db=self._session_db,
                     reasoning_config=self.reasoning_config,
                     service_tier=self.service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=self._providers_only,
                     providers_ignored=self._providers_ignore,
                     providers_order=self._providers_order,
@@ -5009,6 +5039,7 @@ class HermesCLI:
                     platform="cli",
                     reasoning_config=self.reasoning_config,
                     service_tier=self.service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=self._providers_only,
                     providers_ignored=self._providers_ignore,
                     providers_order=self._providers_order,
@@ -6612,6 +6643,7 @@ class HermesCLI:
             model_override=turn_route["model"],
             runtime_override=turn_route["runtime"],
             route_label=turn_route["label"],
+            request_overrides=turn_route.get("request_overrides"),
         ):
             return None
         
@@ -8858,6 +8890,7 @@ def main(
                     model_override=turn_route["model"],
                     runtime_override=turn_route["runtime"],
                     route_label=turn_route["label"],
+                    request_overrides=turn_route.get("request_overrides"),
                 ):
                     cli.agent.quiet_mode = True
                     result = cli.agent.run_conversation(

--- a/cli.py
+++ b/cli.py
@@ -2439,7 +2439,8 @@ class HermesCLI:
             },
         )
 
-        if not self.service_tier:
+        service_tier = getattr(self, "service_tier", None)
+        if not service_tier:
             route["request_overrides"] = None
             return route
 
@@ -3183,7 +3184,7 @@ class HermesCLI:
         except Exception:
             return False
         agent = getattr(self, "agent", None)
-        model = getattr(agent, "model", None) or self.model
+        model = getattr(agent, "model", None) or getattr(self, "model", None)
         return model_supports_fast_mode(model)
 
     def _command_available(self, slash_command: str) -> bool:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -100,6 +100,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide]",
                subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
+    CommandDef("fast", "Choose Codex inference tier (Normal/Fast)", "Configuration",
+               cli_only=True, args_hint="[normal|fast|status]",
+               subcommands=("normal", "fast", "status", "on", "off")),
     CommandDef("skin", "Show or change the display skin/theme", "Configuration",
                cli_only=True, args_hint="[name]"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
@@ -637,8 +640,18 @@ class SlashCommandCompleter(Completer):
     def __init__(
         self,
         skill_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
+        command_filter: Callable[[str], bool] | None = None,
     ) -> None:
         self._skill_commands_provider = skill_commands_provider
+        self._command_filter = command_filter
+
+    def _command_allowed(self, slash_command: str) -> bool:
+        if self._command_filter is None:
+            return True
+        try:
+            return bool(self._command_filter(slash_command))
+        except Exception:
+            return True
 
     def _iter_skill_commands(self) -> Mapping[str, dict[str, Any]]:
         if self._skill_commands_provider is None:
@@ -916,7 +929,7 @@ class SlashCommandCompleter(Completer):
                 return
 
             # Static subcommand completions
-            if " " not in sub_text and base_cmd in SUBCOMMANDS:
+            if " " not in sub_text and base_cmd in SUBCOMMANDS and self._command_allowed(base_cmd):
                 for sub in SUBCOMMANDS[base_cmd]:
                     if sub.startswith(sub_lower) and sub != sub_lower:
                         yield Completion(
@@ -929,6 +942,8 @@ class SlashCommandCompleter(Completer):
         word = text[1:]
 
         for cmd, desc in COMMANDS.items():
+            if not self._command_allowed(cmd):
+                continue
             cmd_name = cmd[1:]
             if cmd_name.startswith(word):
                 yield Completion(
@@ -987,6 +1002,8 @@ class SlashCommandAutoSuggest(AutoSuggest):
             # Still typing the command name: /upd → suggest "ate"
             word = text[1:].lower()
             for cmd in COMMANDS:
+                if self._completer is not None and not self._completer._command_allowed(cmd):
+                    continue
                 cmd_name = cmd[1:]  # strip leading /
                 if cmd_name.startswith(word) and cmd_name != word:
                     return Suggestion(cmd_name[len(word):])
@@ -997,6 +1014,8 @@ class SlashCommandAutoSuggest(AutoSuggest):
         sub_lower = sub_text.lower()
 
         # Static subcommands
+        if self._completer is not None and not self._completer._command_allowed(base_cmd):
+            return None
         if base_cmd in SUBCOMMANDS and SUBCOMMANDS[base_cmd]:
             if " " not in sub_text:
                 for sub in SUBCOMMANDS[base_cmd]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -225,6 +225,7 @@ DEFAULT_CONFIG = {
         # tools or receiving API responses.  Only fires when the agent has
         # been completely idle for this duration.  0 = unlimited.
         "gateway_timeout": 1800,
+        "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -710,22 +710,12 @@ def list_authenticated_providers(
     user_providers: dict = None,
     max_models: int = 8,
 ) -> List[dict]:
-    """Detect which providers have credentials and list their curated models.
+    """Detect which providers have credentials and list their best-known models.
 
-    Uses the curated model lists from hermes_cli/models.py (OPENROUTER_MODELS,
-    _PROVIDER_MODELS) — NOT the full models.dev catalog.  These are hand-picked
-    agentic models that work well as agent backends.
-
-    Returns a list of dicts, each with:
-      - slug: str — the --provider value to use
-      - name: str — display name
-      - is_current: bool
-      - is_user_defined: bool
-      - models: list[str] — curated model IDs (up to max_models)
-      - total_models: int — total curated count
-      - source: str — "built-in", "models.dev", "user-config"
-
-    Only includes providers that have API keys set or are user-defined endpoints.
+    The no-args `/model` picker should reflect the same provider catalogs Hermes
+    uses for actual switching, not a stale hand-maintained preview list. Use the
+    canonical `provider_model_ids()` lookup first, then fall back to curated
+    lists only when provider-specific discovery yields nothing.
     """
     import os
     from agent.models_dev import (
@@ -734,19 +724,28 @@ def list_authenticated_providers(
         get_provider_info as _mdev_pinfo,
     )
     from hermes_cli.auth import PROVIDER_REGISTRY
-    from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS
+    from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS, provider_model_ids
 
     results: List[dict] = []
     seen_slugs: set = set()
 
     data = fetch_models_dev()
 
-    # Build curated model lists keyed by hermes provider ID
+    # Build curated fallback lists keyed by hermes provider ID.
     curated: dict[str, list[str]] = dict(_PROVIDER_MODELS)
     curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
-    # "nous" shares OpenRouter's curated list if not separately defined
     if "nous" not in curated:
         curated["nous"] = curated["openrouter"]
+
+    def _catalog_preview(provider_id: str) -> tuple[list[str], int]:
+        model_ids: list[str] = []
+        try:
+            model_ids = list(provider_model_ids(provider_id) or [])
+        except Exception as exc:
+            logger.debug("Provider model catalog lookup failed for %s: %s", provider_id, exc)
+        if not model_ids:
+            model_ids = list(curated.get(provider_id, []))
+        return model_ids[:max_models], len(model_ids)
 
     # --- 1. Check Hermes-mapped providers ---
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():
@@ -765,16 +764,11 @@ def list_authenticated_providers(
             if not isinstance(env_vars, list):
                 continue
 
-        # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)
         if not has_creds:
             continue
 
-        # Use curated list, falling back to models.dev if no curated list
-        model_ids = curated.get(hermes_id, [])
-        total = len(model_ids)
-        top = model_ids[:max_models]
-
+        top, total = _catalog_preview(hermes_id)
         slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
         display_name = pinfo.name if pinfo else mdev_id
@@ -795,12 +789,10 @@ def list_authenticated_providers(
     for pid, overlay in HERMES_OVERLAYS.items():
         if pid in seen_slugs:
             continue
-        # Check if credentials exist
         has_creds = False
         if overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         if overlay.auth_type in ("oauth_device_code", "oauth_external", "external_process"):
-            # These use auth stores, not env vars — check for auth.json entries
             try:
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
@@ -811,11 +803,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list
-        model_ids = curated.get(pid, [])
-        total = len(model_ids)
-        top = model_ids[:max_models]
-
+        top, total = _catalog_preview(pid)
         results.append({
             "slug": pid,
             "name": get_label(pid),
@@ -840,8 +828,6 @@ def list_authenticated_providers(
             if default_model:
                 models_list.append(default_model)
 
-            # Try to probe /v1/models if URL is set (but don't block on it)
-            # For now just show what we know from config
             results.append({
                 "slug": ep_name,
                 "name": display_name,
@@ -853,7 +839,6 @@ def list_authenticated_providers(
                 "api_url": api_url,
             })
 
-    # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1017,6 +1017,31 @@ def provider_label(provider: Optional[str]) -> str:
     return _PROVIDER_LABELS.get(normalized, original or "OpenRouter")
 
 
+_FAST_MODE_BACKEND_CONFIG: dict[tuple[str, str], dict[str, str]] = {
+    ("openai-codex", "gpt-5.4"): {"service_tier": "priority"},
+}
+
+
+def fast_mode_backend_config(provider: Optional[str], model_id: Optional[str]) -> dict[str, str] | None:
+    """Return backend request overrides for models that expose Fast mode.
+
+    To expose Fast mode for a new model, add its ``(provider, model)`` tuple to
+    ``_FAST_MODE_BACKEND_CONFIG`` along with the backend-specific request
+    overrides Hermes should apply when the user enables Fast mode.
+    """
+    normalized_provider = normalize_provider(provider)
+    raw = str(model_id or "").strip().lower()
+    if "/" in raw:
+        raw = raw.split("/", 1)[1]
+    config = _FAST_MODE_BACKEND_CONFIG.get((normalized_provider, raw))
+    return dict(config) if config else None
+
+
+def codex_model_supports_fast_mode(provider: Optional[str], model_id: Optional[str]) -> bool:
+    """Return whether Hermes should expose Fast mode for the active model."""
+    return fast_mode_backend_config(provider, model_id) is not None
+
+
 def _resolve_copilot_catalog_api_key() -> str:
     """Best-effort GitHub token for fetching the Copilot model catalog."""
     try:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1017,29 +1017,58 @@ def provider_label(provider: Optional[str]) -> str:
     return _PROVIDER_LABELS.get(normalized, original or "OpenRouter")
 
 
-_FAST_MODE_BACKEND_CONFIG: dict[tuple[str, str], dict[str, str]] = {
-    ("openai-codex", "gpt-5.4"): {"service_tier": "priority"},
+_FAST_MODE_BACKEND_CONFIG: dict[str, dict[str, Any]] = {
+    "gpt-5.4": {
+        "provider": "openai-codex",
+        "request_overrides": {"service_tier": "priority"},
+    },
 }
 
 
-def fast_mode_backend_config(provider: Optional[str], model_id: Optional[str]) -> dict[str, str] | None:
-    """Return backend request overrides for models that expose Fast mode.
+def fast_mode_backend_config(model_id: Optional[str]) -> dict[str, Any] | None:
+    """Return backend config for models that expose Fast mode.
 
-    To expose Fast mode for a new model, add its ``(provider, model)`` tuple to
-    ``_FAST_MODE_BACKEND_CONFIG`` along with the backend-specific request
-    overrides Hermes should apply when the user enables Fast mode.
+    To expose Fast mode for a new model, add its normalized model slug to
+    ``_FAST_MODE_BACKEND_CONFIG`` along with the backend runtime selection and
+    backend-specific request overrides Hermes should apply.
     """
-    normalized_provider = normalize_provider(provider)
     raw = str(model_id or "").strip().lower()
     if "/" in raw:
         raw = raw.split("/", 1)[1]
-    config = _FAST_MODE_BACKEND_CONFIG.get((normalized_provider, raw))
+    config = _FAST_MODE_BACKEND_CONFIG.get(raw)
     return dict(config) if config else None
 
 
-def codex_model_supports_fast_mode(provider: Optional[str], model_id: Optional[str]) -> bool:
+def model_supports_fast_mode(model_id: Optional[str]) -> bool:
     """Return whether Hermes should expose Fast mode for the active model."""
-    return fast_mode_backend_config(provider, model_id) is not None
+    return fast_mode_backend_config(model_id) is not None
+
+
+def resolve_fast_mode_runtime(model_id: Optional[str]) -> dict[str, Any] | None:
+    """Resolve runtime selection and request overrides for a fast-mode model."""
+    cfg = fast_mode_backend_config(model_id)
+    if not cfg:
+        return None
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(
+        requested=cfg.get("provider"),
+        explicit_base_url=cfg.get("base_url"),
+        explicit_api_key=cfg.get("api_key"),
+    )
+    return {
+        "runtime": {
+            "api_key": runtime.get("api_key"),
+            "base_url": runtime.get("base_url"),
+            "provider": runtime.get("provider"),
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+            "credential_pool": runtime.get("credential_pool"),
+        },
+        "request_overrides": dict(cfg.get("request_overrides") or {}),
+    }
 
 
 def _resolve_copilot_catalog_api_key() -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -500,6 +500,7 @@ class AIAgent:
         status_callback: callable = None,
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
+        service_tier: str = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
         user_id: str = None,
@@ -661,6 +662,7 @@ class AIAgent:
         # Model response configuration
         self.max_tokens = max_tokens  # None = use model default
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
+        self.service_tier = service_tier
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         
         # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
@@ -3324,7 +3326,7 @@ class AIAgent:
         allowed_keys = {
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
-            "tool_choice", "parallel_tool_calls", "prompt_cache_key",
+            "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -3342,6 +3344,9 @@ class AIAgent:
         include = api_kwargs.get("include")
         if isinstance(include, list):
             normalized["include"] = include
+        service_tier = api_kwargs.get("service_tier")
+        if isinstance(service_tier, str) and service_tier.strip():
+            normalized["service_tier"] = service_tier.strip()
 
         # Pass through max_output_tokens and temperature
         max_output_tokens = api_kwargs.get("max_output_tokens")
@@ -5434,6 +5439,15 @@ class AIAgent:
                 "models.github.ai" in self.base_url.lower()
                 or "api.githubcopilot.com" in self.base_url.lower()
             )
+            is_codex_backend = (
+                self.provider == "openai-codex"
+                or "chatgpt.com/backend-api/codex" in self.base_url.lower()
+            )
+            try:
+                from hermes_cli.models import fast_mode_backend_config
+                fast_mode_config = fast_mode_backend_config(self.provider, self.model)
+            except Exception:
+                fast_mode_config = None
 
             # Resolve reasoning effort: config > default (medium)
             reasoning_effort = "medium"
@@ -5471,7 +5485,10 @@ class AIAgent:
             elif not is_github_responses:
                 kwargs["include"] = []
 
-            if self.max_tokens is not None:
+            if self.service_tier and fast_mode_config:
+                kwargs.update(fast_mode_config)
+
+            if self.max_tokens is not None and not is_codex_backend:
                 kwargs["max_output_tokens"] = self.max_tokens
 
             return kwargs

--- a/run_agent.py
+++ b/run_agent.py
@@ -501,6 +501,7 @@ class AIAgent:
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
         service_tier: str = None,
+        request_overrides: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
         user_id: str = None,
@@ -663,6 +664,7 @@ class AIAgent:
         self.max_tokens = max_tokens  # None = use model default
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.service_tier = service_tier
+        self.request_overrides = dict(request_overrides or {})
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         
         # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
@@ -5443,11 +5445,16 @@ class AIAgent:
                 self.provider == "openai-codex"
                 or "chatgpt.com/backend-api/codex" in self.base_url.lower()
             )
-            try:
-                from hermes_cli.models import fast_mode_backend_config
-                fast_mode_config = fast_mode_backend_config(self.provider, self.model)
-            except Exception:
-                fast_mode_config = None
+            fast_mode_request_overrides = None
+            if self.service_tier:
+                try:
+                    from hermes_cli.models import fast_mode_backend_config
+
+                    fast_cfg = fast_mode_backend_config(self.model)
+                    if fast_cfg and fast_cfg.get("provider") == self.provider:
+                        fast_mode_request_overrides = dict(fast_cfg.get("request_overrides") or {})
+                except Exception:
+                    fast_mode_request_overrides = None
 
             # Resolve reasoning effort: config > default (medium)
             reasoning_effort = "medium"
@@ -5485,8 +5492,10 @@ class AIAgent:
             elif not is_github_responses:
                 kwargs["include"] = []
 
-            if self.service_tier and fast_mode_config:
-                kwargs.update(fast_mode_config)
+            if self.request_overrides:
+                kwargs.update(self.request_overrides)
+            elif fast_mode_request_overrides:
+                kwargs.update(fast_mode_request_overrides)
 
             if self.max_tokens is not None and not is_codex_backend:
                 kwargs["max_output_tokens"] = self.max_tokens

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -53,6 +53,7 @@ class TestHandleFastCommand(unittest.TestCase):
             patch.object(cli_mod, "_cprint"),
             patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
             patch.object(cli_mod, "_prompt_fast_mode_selection", return_value="fast") as mock_prompt,
+            patch.object(cli_mod, "_resolve_fast_mode_status", return_value=(True, "openai-codex")),
         ):
             cli_mod.HermesCLI._handle_fast_command(stub, "/fast")
 
@@ -60,6 +61,32 @@ class TestHandleFastCommand(unittest.TestCase):
         mock_save.assert_called_once_with("agent.service_tier", "fast")
         self.assertEqual(stub.service_tier, "priority")
         self.assertIsNone(stub.agent)
+
+    def test_fast_argument_warns_when_backend_unavailable(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(service_tier=None)
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value", return_value=True),
+            patch.object(cli_mod, "_resolve_fast_mode_status", return_value=(False, None)),
+        ):
+            cli_mod.HermesCLI._handle_fast_command(stub, "/fast fast")
+
+        rendered = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        self.assertIn("Fast backend unavailable right now", rendered)
+
+    def test_fast_status_reports_backend_unavailable(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(service_tier="priority")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "_resolve_fast_mode_status", return_value=(False, None)),
+        ):
+            cli_mod.HermesCLI._handle_fast_command(stub, "/fast status")
+
+        rendered = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        self.assertIn("Codex inference tier: fast", rendered)
+        self.assertIn("Fast backend unavailable right now", rendered)
 
     def test_normal_argument_clears_service_tier(self):
         cli_mod = _import_cli()

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -1,0 +1,113 @@
+"""Tests for the /fast CLI command and service-tier config handling."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+class TestParseServiceTierConfig(unittest.TestCase):
+    def _parse(self, raw):
+        cli_mod = _import_cli()
+        return cli_mod._parse_service_tier_config(raw)
+
+    def test_fast_maps_to_priority(self):
+        self.assertEqual(self._parse("fast"), "priority")
+        self.assertEqual(self._parse("priority"), "priority")
+
+    def test_normal_disables_service_tier(self):
+        self.assertIsNone(self._parse("normal"))
+        self.assertIsNone(self._parse("off"))
+        self.assertIsNone(self._parse(""))
+
+
+class TestHandleFastCommand(unittest.TestCase):
+    def _make_cli(self, service_tier=None):
+        return SimpleNamespace(
+            service_tier=service_tier,
+            provider="openai-codex",
+            requested_provider="openai-codex",
+            model="gpt-5.4",
+            _fast_command_available=lambda: True,
+            agent=MagicMock(),
+        )
+
+    def test_no_args_uses_dropdown_selection(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(service_tier=None)
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+            patch.object(cli_mod, "_prompt_fast_mode_selection", return_value="fast") as mock_prompt,
+        ):
+            cli_mod.HermesCLI._handle_fast_command(stub, "/fast")
+
+        mock_prompt.assert_called_once_with(current_tier=None)
+        mock_save.assert_called_once_with("agent.service_tier", "fast")
+        self.assertEqual(stub.service_tier, "priority")
+        self.assertIsNone(stub.agent)
+
+    def test_normal_argument_clears_service_tier(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(service_tier="priority")
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_fast_command(stub, "/fast normal")
+
+        mock_save.assert_called_once_with("agent.service_tier", "normal")
+        self.assertIsNone(stub.service_tier)
+        self.assertIsNone(stub.agent)
+
+    def test_unsupported_model_does_not_expose_fast(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            service_tier=None,
+            provider="openai-codex",
+            requested_provider="openai-codex",
+            model="gpt-5.3-codex",
+            _fast_command_available=lambda: False,
+            agent=MagicMock(),
+        )
+
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_fast_command(stub, "/fast")
+
+        mock_save.assert_not_called()
+        self.assertTrue(mock_cprint.called)
+
+
+class TestFastModeRegistry(unittest.TestCase):
+    def test_only_gpt_5_4_is_enabled_for_codex(self):
+        from hermes_cli.models import fast_mode_backend_config
+
+        assert fast_mode_backend_config("openai-codex", "gpt-5.4") == {"service_tier": "priority"}
+        assert fast_mode_backend_config("openai-codex", "gpt-5.3-codex") is None
+        assert fast_mode_backend_config("openai", "gpt-5.4") is None
+
+
+class TestConfigDefault(unittest.TestCase):
+    def test_default_config_has_service_tier(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        agent = DEFAULT_CONFIG.get("agent", {})
+        self.assertIn("service_tier", agent)
+        self.assertEqual(agent["service_tier"], "")

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -99,9 +99,100 @@ class TestFastModeRegistry(unittest.TestCase):
     def test_only_gpt_5_4_is_enabled_for_codex(self):
         from hermes_cli.models import fast_mode_backend_config
 
-        assert fast_mode_backend_config("openai-codex", "gpt-5.4") == {"service_tier": "priority"}
-        assert fast_mode_backend_config("openai-codex", "gpt-5.3-codex") is None
-        assert fast_mode_backend_config("openai", "gpt-5.4") is None
+        assert fast_mode_backend_config("gpt-5.4") == {
+            "provider": "openai-codex",
+            "request_overrides": {"service_tier": "priority"},
+        }
+        assert fast_mode_backend_config("gpt-5.3-codex") is None
+
+
+class TestFastModeRouting(unittest.TestCase):
+    def test_fast_command_exposed_for_model_even_when_provider_is_auto(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(provider="auto", requested_provider="auto", model="gpt-5.4", agent=None)
+
+        assert cli_mod.HermesCLI._fast_command_available(stub) is True
+
+    def test_turn_route_switches_to_model_backend_when_fast_enabled(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="gpt-5.4",
+            api_key="primary-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _smart_model_routing={},
+            service_tier="priority",
+        )
+
+        with (
+            patch("agent.smart_model_routing.resolve_turn_route", return_value={
+                "model": "gpt-5.4",
+                "runtime": {
+                    "api_key": "primary-key",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                    "command": None,
+                    "args": [],
+                    "credential_pool": None,
+                },
+                "label": None,
+                "signature": ("gpt-5.4", "openrouter", "https://openrouter.ai/api/v1", "chat_completions", None, ()),
+            }),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "codex-key",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            }),
+        ):
+            route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["runtime"]["provider"] == "openai-codex"
+        assert route["runtime"]["api_mode"] == "codex_responses"
+        assert route["request_overrides"] == {"service_tier": "priority"}
+
+    def test_turn_route_keeps_primary_runtime_when_model_has_no_fast_backend(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="gpt-5.3-codex",
+            api_key="primary-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _smart_model_routing={},
+            service_tier="priority",
+        )
+
+        primary_route = {
+            "model": "gpt-5.3-codex",
+            "runtime": {
+                "api_key": "primary-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            },
+            "label": None,
+            "signature": ("gpt-5.3-codex", "openrouter", "https://openrouter.ai/api/v1", "chat_completions", None, ()),
+        }
+        with patch("agent.smart_model_routing.resolve_turn_route", return_value=primary_route):
+            route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["runtime"]["provider"] == "openrouter"
+        assert route.get("request_overrides") is None
 
 
 class TestConfigDefault(unittest.TestCase):

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -446,6 +446,13 @@ class TestSubcommands:
         assert "show" in subs
         assert "hide" in subs
 
+    def test_fast_has_subcommands(self):
+        assert "/fast" in SUBCOMMANDS
+        subs = SUBCOMMANDS["/fast"]
+        assert "fast" in subs
+        assert "normal" in subs
+        assert "status" in subs
+
     def test_voice_has_subcommands(self):
         assert "/voice" in SUBCOMMANDS
         assert "on" in SUBCOMMANDS["/voice"]
@@ -473,6 +480,20 @@ class TestSubcommandCompletion:
         texts = {c.text for c in completions}
         assert "high" in texts
         assert "show" in texts
+
+    def test_fast_subcommand_completion_after_space(self):
+        completions = _completions(SlashCommandCompleter(), "/fast ")
+        texts = {c.text for c in completions}
+        assert "fast" in texts
+        assert "normal" in texts
+
+    def test_fast_command_filtered_out_when_unavailable(self):
+        completions = _completions(
+            SlashCommandCompleter(command_filter=lambda cmd: cmd != "/fast"),
+            "/fa",
+        )
+        texts = {c.text for c in completions}
+        assert "fast" not in texts
 
     def test_subcommand_prefix_filters(self):
         """Typing '/reasoning sh' should only show 'show'."""
@@ -526,6 +547,13 @@ class TestGhostText:
     def test_subcommand_suggestion_show(self):
         """/reasoning sh → 'ow'"""
         assert _suggestion("/reasoning sh") == "ow"
+
+    def test_fast_subcommand_suggestion(self):
+        assert _suggestion("/fast f") == "ast"
+
+    def test_fast_subcommand_suggestion_hidden_when_filtered(self):
+        completer = SlashCommandCompleter(command_filter=lambda cmd: cmd != "/fast")
+        assert _suggestion("/fa", completer=completer) is None
 
     def test_no_suggestion_for_non_slash(self):
         assert _suggestion("hello") is None

--- a/tests/hermes_cli/test_model_picker_catalog.py
+++ b/tests/hermes_cli/test_model_picker_catalog.py
@@ -1,0 +1,51 @@
+class TestAuthenticatedProviderPickerCatalog:
+    def test_openai_codex_picker_uses_provider_catalog(self, monkeypatch):
+        from hermes_cli import model_switch as ms
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {})
+        monkeypatch.setattr(
+            "hermes_cli.models.provider_model_ids",
+            lambda provider: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"] if provider == "openai-codex" else [],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.auth._load_auth_store",
+            lambda: {"providers": {"openai-codex": {"tokens": {"access_token": "***"}}}},
+        )
+
+        providers = ms.list_authenticated_providers(
+            current_provider="openai-codex",
+            user_providers=None,
+            max_models=2,
+        )
+
+        codex = next(p for p in providers if p["slug"] == "openai-codex")
+        assert codex["is_current"] is True
+        assert codex["models"] == ["gpt-5.4", "gpt-5.4-mini"]
+        assert codex["total_models"] == 3
+
+    def test_mapped_provider_picker_uses_provider_catalog_before_curated_fallback(self, monkeypatch):
+        from hermes_cli import model_switch as ms
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {"zai": {"env": ["GLM_API_KEY"]}})
+        monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"zai": "zai"})
+        monkeypatch.setattr(
+            "agent.models_dev.get_provider_info",
+            lambda provider_id: type("P", (), {"name": "Z.AI / GLM"})(),
+        )
+        monkeypatch.setenv("GLM_API_KEY", "***")
+        monkeypatch.setattr(
+            "hermes_cli.models.provider_model_ids",
+            lambda provider: ["glm-5", "glm-4.7"] if provider == "zai" else [],
+        )
+
+        providers = ms.list_authenticated_providers(
+            current_provider="zai",
+            user_providers=None,
+            max_models=5,
+        )
+
+        zai = next(p for p in providers if p["slug"] == "zai")
+        assert zai["models"] == ["glm-5", "glm-4.7"]
+        assert zai["total_models"] == 2
+        assert zai["is_current"] is True

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -356,6 +356,24 @@ class TestBuildApiKwargsCodex:
         assert "reasoning" in kwargs
         assert kwargs["reasoning"]["effort"] == "medium"
 
+    def test_includes_service_tier_when_configured(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        agent.model = "gpt-5.4"
+        agent.service_tier = "priority"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["service_tier"] == "priority"
+
+    def test_omits_max_output_tokens_for_codex_backend(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        agent.model = "gpt-5.4"
+        agent.max_tokens = 20
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "max_output_tokens" not in kwargs
+
     def test_includes_encrypted_content_in_include(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
                             base_url="https://chatgpt.com/backend-api/codex")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -648,6 +648,15 @@ def test_preflight_codex_api_kwargs_allows_reasoning_and_temperature(monkeypatch
     assert result["max_output_tokens"] == 4096
 
 
+def test_preflight_codex_api_kwargs_allows_service_tier(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    kwargs = _codex_request_kwargs()
+    kwargs["service_tier"] = "priority"
+
+    result = agent._preflight_codex_api_kwargs(kwargs)
+    assert result["service_tier"] == "priority"
+
+
 def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
     agent = _build_agent(monkeypatch)
     responses = [_codex_tool_call_response(), _codex_message_response("done")]


### PR DESCRIPTION
## Summary
- add a `/fast` CLI slash command with a Normal/Fast picker and status subcommand
- only expose `/fast` for models listed in a central fast-mode backend registry (currently `openai-codex` + `gpt-5.4`)
- send backend-specific request overrides from that registry when fast mode is enabled
- pass `service_tier` through the Codex Responses request validator
- omit `max_output_tokens` on the ChatGPT Codex backend because it rejects that parameter

## Testing
- `pytest tests/cli/test_fast_command.py tests/hermes_cli/test_commands.py tests/run_agent/test_provider_parity.py tests/run_agent/test_run_agent_codex_responses.py -q`
- `python -m py_compile cli.py run_agent.py hermes_cli/commands.py hermes_cli/config.py hermes_cli/models.py tests/cli/test_fast_command.py tests/hermes_cli/test_commands.py tests/run_agent/test_provider_parity.py tests/run_agent/test_run_agent_codex_responses.py`

## Manual verification
- live-verified against `https://chatgpt.com/backend-api/codex` using the local `openai-codex` OAuth session
- normal request succeeds without `service_tier`
- fast request succeeds with `service_tier: "priority"`
- both paths omit `max_output_tokens` on the Codex backend
- observed a faster wall-clock response for the fast request on `gpt-5.4` in local spot checks
