### PR TITLE
fix: cleanup_all_camofox_sessions respects managed persistence

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -594,13 +594,20 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
 # ---------------------------------------------------------------------------
 
 def cleanup_all_camofox_sessions() -> None:
-    """Close all active camofox sessions."""
+    """Close all active camofox sessions.
+
+    When managed persistence is enabled, only clears local tracking state
+    without destroying server-side browser profiles (cookies, logins, etc.
+    must survive).  Ephemeral sessions are fully deleted on the server.
+    """
+    managed = _managed_persistence_enabled()
     with _sessions_lock:
         sessions = list(_sessions.items())
-    for task_id, session in sessions:
-        try:
-            _delete(f"/sessions/{session['user_id']}")
-        except Exception:
-            pass
+    if not managed:
+        for _task_id, session in sessions:
+            try:
+                _delete(f"/sessions/{session['user_id']}")
+            except Exception:
+                pass
     with _sessions_lock:
         _sessions.clear()


### PR DESCRIPTION
## Summary

When `managed_persistence` is enabled in config.yaml, `cleanup_all_camofox_sessions()` was unconditionally sending DELETE requests to the Camofox server — destroying persistent browser profiles (cookies, logins, localStorage) that should survive across restarts.

Now it checks `_managed_persistence_enabled()` first:
- **Managed mode**: only clears local in-memory tracking state, server-side profiles preserved
- **Ephemeral mode** (default): sends DELETEs as before, no behavior change

## Context

User report from Ivan Larin (@woriwka) about Camoufox sessions not persisting. The per-task cleanup path (`camofox_soft_cleanup`) was already correct, but the bulk cleanup function was a footgun — if anything ever wired it into a shutdown hook, it would nuke persistent sessions.

## Test plan

- E2E tested: ephemeral mode sends DELETEs, managed mode skips them, identity is stable across tasks
- 54 existing Camofox unit tests pass