### PR TITLE
fix(gateway): honor explicit HERMES_HOME in systemd install

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -608,7 +608,40 @@ def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
     return [p for p in candidates if p not in path_entries and Path(p).exists()]
 
 
-def _hermes_home_for_target_user(target_home_dir: str) -> str:
+def _probe_target_user_hermes_home(username: str) -> str | None:
+    """Return the target user's explicit HERMES_HOME from their login env."""
+    if not is_linux():
+        return None
+
+    probe_commands: list[list[str]] = []
+    if shutil.which("su"):
+        probe_commands.append(["su", "-", username, "-c", 'printf "%s" "${HERMES_HOME-}"'])
+    if shutil.which("sudo"):
+        probe_commands.append(["sudo", "-iu", username, "sh", "-lc", 'printf "%s" "${HERMES_HOME-}"'])
+
+    for cmd in probe_commands:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+
+        if result.returncode != 0:
+            continue
+
+        value = (result.stdout or "").strip()
+        if value:
+            return value
+
+    return None
+
+
+def _hermes_home_for_target_user(target_home_dir: str, current_hermes: str | Path | None = None) -> str:
     """Remap the current HERMES_HOME to the equivalent under a target user's home.
 
     When installing a system service via sudo, get_hermes_home() resolves to
@@ -617,7 +650,7 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
       /root/.hermes/profiles/coder     → /home/alice/.hermes/profiles/coder
       /opt/custom-hermes               → /opt/custom-hermes  (kept as-is)
     """
-    current_hermes = get_hermes_home().resolve()
+    current_hermes = Path(current_hermes).expanduser().resolve() if current_hermes is not None else get_hermes_home().resolve()
     current_default = (Path.home() / ".hermes").resolve()
     target_default = Path(target_home_dir) / ".hermes"
 
@@ -632,6 +665,19 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
     except ValueError:
         # Completely custom path (not under ~/.hermes) — keep as-is
         return str(current_hermes)
+
+
+def _resolve_system_service_hermes_home(username: str, target_home_dir: str) -> str:
+    """Resolve HERMES_HOME for Linux system service units."""
+    explicit_current = (os.getenv("HERMES_HOME") or "").strip()
+    if explicit_current:
+        return _hermes_home_for_target_user(target_home_dir, current_hermes=explicit_current)
+
+    probed = _probe_target_user_hermes_home(username)
+    if probed:
+        return probed
+
+    return _hermes_home_for_target_user(target_home_dir)
 
 
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
@@ -653,7 +699,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
-        hermes_home = _hermes_home_for_target_user(home_dir)
+        hermes_home = _resolve_system_service_hermes_home(username, home_dir)
         profile_arg = _profile_arg(hermes_home)
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
         path_entries.extend(common_bin_paths)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -101,6 +101,38 @@ class TestGeneratedSystemdUnits:
         assert "TimeoutStopSec=60" in unit
         assert "WantedBy=multi-user.target" in unit
 
+    def test_system_unit_uses_probed_target_user_custom_hermes_home(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_probe_target_user_hermes_home", lambda username: "/opt/hermes-shared")
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: [])
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert 'HERMES_HOME=/opt/hermes-shared' in unit
+
+    def test_system_unit_uses_probed_target_user_profile_hermes_home(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_probe_target_user_hermes_home",
+            lambda username: "/home/alice/.hermes/profiles/coder",
+        )
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: [])
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert 'HERMES_HOME=/home/alice/.hermes/profiles/coder' in unit
+
 
 class TestGatewayStopCleanup:
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):
@@ -490,6 +522,26 @@ class TestHermesHomeForTargetUser:
         monkeypatch.delenv("HERMES_HOME", raising=False)
 
         result = gateway_cli._hermes_home_for_target_user("/home/alice")
+        assert result == "/home/alice/.hermes"
+
+
+class TestResolveSystemServiceHermesHome:
+    def test_prefers_explicit_current_process_hermes_home(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.setenv("HERMES_HOME", "/root/.hermes/profiles/coder")
+        monkeypatch.setattr(gateway_cli, "_probe_target_user_hermes_home", lambda username: (_ for _ in ()).throw(AssertionError("probe should not run")))
+
+        result = gateway_cli._resolve_system_service_hermes_home("alice", "/home/alice")
+
+        assert result == "/home/alice/.hermes/profiles/coder"
+
+    def test_falls_back_to_default_when_probe_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(gateway_cli, "_probe_target_user_hermes_home", lambda username: None)
+
+        result = gateway_cli._resolve_system_service_hermes_home("alice", "/home/alice")
+
         assert result == "/home/alice/.hermes"
 
 


### PR DESCRIPTION
## Summary
- preserve an explicitly configured `HERMES_HOME` when generating Linux systemd gateway units
- probe the target user's login environment for `HERMES_HOME` when sudo strips it from the current process
- keep the existing target-user remap/default behavior as the deterministic fallback

## Issues
- Fixes #6729
- Related to #5947, but intentionally limited to the systemd gateway install path

## Root Cause
`hermes gateway install --system` resolved `HERMES_HOME` only from the current process context. When the install ran via `sudo`, the current environment often no longer carried the target user's custom `HERMES_HOME`, so the generated unit fell back to `~/.hermes` even when the user had configured a different home.

## What Changed
- added a dedicated system-service resolver in `hermes_cli/gateway.py`
- preserved the current explicit-env remap behavior for `/root/.hermes` and `/root/.hermes/profiles/<name>` sudo cases
- added a non-fatal target-user login-env probe before falling back to the existing remap/default logic
- extended gateway service tests to cover explicit env precedence, probed custom/profile homes, and empty-probe fallback

## Testing
- `/Users/kennyxie/Documents/Code/clawspace/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q`
