### PR TITLE
fix(gateway): preserve quoted media paths from tool results

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -314,6 +314,45 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _iter_tool_result_text_values(value: Any):
+    """Yield string leaves from structured tool results."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from _iter_tool_result_text_values(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_tool_result_text_values(child)
+
+
+def _extract_tool_result_media_paths(content: str) -> tuple[list[str], bool]:
+    """Parse tool-emitted MEDIA tags using the gateway's canonical parser."""
+    candidates = [content or ""]
+    if isinstance(content, str):
+        stripped = content.strip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            try:
+                parsed = json.loads(stripped)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                parsed = None
+            if parsed is not None:
+                parsed_candidates = list(_iter_tool_result_text_values(parsed))
+                candidates = parsed_candidates or candidates
+
+    paths: list[str] = []
+    seen_paths: set[str] = set()
+    has_voice_directive = False
+    for candidate in candidates:
+        media, _ = BasePlatformAdapter.extract_media(candidate or "")
+        for path, send_as_voice in media:
+            if path and path not in seen_paths:
+                seen_paths.add(path)
+                paths.append(path)
+            has_voice_directive = has_voice_directive or send_as_voice
+    return paths, has_voice_directive
+
+
 def _build_media_placeholder(event) -> str:
     """Build a text placeholder for media-only events so they aren't dropped.
 
@@ -6832,12 +6871,8 @@ class GatewayRunner:
             _history_media_paths: set = set()
             for _hm in agent_history:
                 if _hm.get("role") in ("tool", "function"):
-                    _hc = _hm.get("content", "")
-                    if "MEDIA:" in _hc:
-                        for _match in re.finditer(r'MEDIA:(\S+)', _hc):
-                            _p = _match.group(1).strip().rstrip('",}')
-                            if _p:
-                                _history_media_paths.add(_p)
+                    _paths, _ = _extract_tool_result_media_paths(_hm.get("content", ""))
+                    _history_media_paths.update(_paths)
             
             # Register per-session gateway approval callback so dangerous
             # command approval blocks the agent thread (mirrors CLI input()).
@@ -6975,14 +7010,13 @@ class GatewayRunner:
                 has_voice_directive = False
                 for msg in result.get("messages", []):
                     if msg.get("role") in ("tool", "function"):
-                        content = msg.get("content", "")
-                        if "MEDIA:" in content:
-                            for match in re.finditer(r'MEDIA:(\S+)', content):
-                                path = match.group(1).strip().rstrip('",}')
-                                if path and path not in _history_media_paths:
-                                    media_tags.append(f"MEDIA:{path}")
-                            if "[[audio_as_voice]]" in content:
-                                has_voice_directive = True
+                        paths, has_voice = _extract_tool_result_media_paths(
+                            msg.get("content", "")
+                        )
+                        for path in paths:
+                            if path and path not in _history_media_paths:
+                                media_tags.append(f"MEDIA:{path}")
+                        has_voice_directive = has_voice_directive or has_voice
                 
                 if media_tags:
                     seen = set()

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -7,8 +7,11 @@ This prevents voice messages from accumulating and being sent multiple
 times per reply. (Regression test for #160)
 """
 
-import pytest
 import re
+
+import pytest
+
+from gateway.run import _extract_tool_result_media_paths
 
 
 def extract_media_tags_fixed(result_messages, history_len):
@@ -31,15 +34,10 @@ def extract_media_tags_fixed(result_messages, history_len):
     
     for msg in new_messages:
         if msg.get("role") == "tool" or msg.get("role") == "function":
-            content = msg.get("content", "")
-            if "MEDIA:" in content:
-                for match in re.finditer(r'MEDIA:(\S+)', content):
-                    path = match.group(1).strip().rstrip('",}')
-                    if path:
-                        media_tags.append(f"MEDIA:{path}")
-                if "[[audio_as_voice]]" in content:
-                    has_voice_directive = True
-    
+            paths, has_voice = _extract_tool_result_media_paths(msg.get("content", ""))
+            media_tags.extend(f"MEDIA:{path}" for path in paths)
+            has_voice_directive = has_voice_directive or has_voice
+
     return media_tags, has_voice_directive
 
 
@@ -63,6 +61,28 @@ def extract_media_tags_broken(result_messages):
                     has_voice_directive = True
     
     return media_tags, has_voice_directive
+
+
+def extract_history_media_paths_fixed(result_messages):
+    history_paths = set()
+    for msg in result_messages:
+        if msg.get("role") == "tool" or msg.get("role") == "function":
+            paths, _ = _extract_tool_result_media_paths(msg.get("content", ""))
+            history_paths.update(paths)
+    return history_paths
+
+
+def extract_history_media_paths_broken(result_messages):
+    history_paths = set()
+    for msg in result_messages:
+        if msg.get("role") == "tool" or msg.get("role") == "function":
+            content = msg.get("content", "")
+            if "MEDIA:" in content:
+                for match in re.finditer(r'MEDIA:(\S+)', content):
+                    path = match.group(1).strip().rstrip('",}')
+                    if path:
+                        history_paths.add(path)
+    return history_paths
 
 
 class TestMediaExtraction:
@@ -178,6 +198,41 @@ class TestMediaExtraction:
         seen = set()
         unique = [t for t in tags if t not in seen and not seen.add(t)]
         assert len(unique) == 2  # After dedup: same.ogg and different.ogg
+
+    def test_quoted_windows_media_paths_with_spaces_are_preserved(self):
+        """Quoted Windows-style paths from tool JSON should not be truncated."""
+        new_messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "content": '{"success": true, "media_tag": "[[audio_as_voice]]\\nMEDIA:\\"C:\\\\Users\\\\Test User\\\\voice clip.ogg\\""}',
+            },
+        ]
+
+        tags, voice_directive = extract_media_tags_fixed(new_messages, 0)
+        assert tags == [r"MEDIA:C:\Users\Test User\voice clip.ogg"]
+        assert voice_directive is True
+
+        broken_tags, broken_voice = extract_media_tags_broken(new_messages)
+        assert broken_tags == [r'MEDIA:\"C:\\Users\\Test']
+        assert broken_voice is True
+
+    def test_history_dedup_preserves_quoted_windows_media_paths(self):
+        """History-media tracking should keep full quoted paths for deduplication."""
+        history = [
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "content": '{"success": true, "media_tag": "MEDIA:\\"C:\\\\Users\\\\Test User\\\\voice clip.ogg\\""}',
+            },
+        ]
+
+        assert extract_history_media_paths_fixed(history) == {
+            r"C:\Users\Test User\voice clip.ogg"
+        }
+        assert extract_history_media_paths_broken(history) == {
+            r'\"C:\\Users\\Test'
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
What does this PR do?
This PR eliminates redundant and fragile regex-based media extraction in gateway/run.py in favor of the canonical extraction logic defined in BasePlatformAdapter.

The previous implementation used a primitive MEDIA:(\S+) pattern that failed to account for:

JSON-encoded tool results containing escape characters.

Windows-style paths containing spaces (which were truncated at the first whitespace).

Consistent history deduplication for quoted media directives.

By introducing _extract_tool_result_media_paths, we now properly decode structured tool outputs and delegate parsing to the hardened base adapter, ensuring cross-platform path integrity across the entire gateway lifecycle.

Type of Change

[x] 🐛 Bug fix (path truncation & history integrity)

[x] 🏗️ Architectural alignment (logic unification)

Changes Made

gateway/run.py: Implemented _extract_tool_result_media_paths to handle recursive string extraction from JSON/dict/list tool results.

gateway/run.py: Refactored GatewayRunner to use this unified helper for both current turn processing and history media tracking.

tests/gateway/test_media_extraction.py: Added regression cases for quoted Windows paths and tool-result JSON decoding.

How to Test
Execute the targeted test suite to verify the fix and prevent regressions:
python -m pytest tests/gateway/test_media_extraction.py tests/gateway/test_platform_base.py -q
Manual verification: Ensure a tool result returning MEDIA:"C:\Users\User Name\file.wav" is correctly delivered as a single attachment.

Checklist

[x] No breaking changes to POSIX path handling.

[x] Logic unified with BasePlatformAdapter.extract_media.

[x] Minimal architectural footprint.