### PR TITLE
feat: add fastCRW as web backend (search, extract, crawl)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,13 @@
 # Get at: https://firecrawl.dev/
 # FIRECRAWL_API_KEY=
 
+# fastCRW - Single-binary web scraper (search + extract). Extract runs locally
+# with no key (auto-downloads the crw-mcp binary). Set a key for cloud search.
+# Get at: https://fastcrw.com
+# CRW_API_KEY=
+# Self-hosted CRW instance URL (alternative to cloud), e.g. http://localhost:3000
+# CRW_API_URL=
+
 
 # FAL.ai API Key - Image generation
 # Get at: https://fal.ai/

--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,13 @@
 # Get at: https://firecrawl.dev/
 # FIRECRAWL_API_KEY=
 
+# fastCRW API Key - Fastest web scraper for AI agents (search, extract, crawl)
+# Get at: https://fastcrw.com
+# CRW_API_KEY=
+
+# fastCRW Self-Hosted URL (alternative to cloud, single binary, 6MB RAM)
+# CRW_API_URL=
+
 
 # FAL.ai API Key - Image generation
 # Get at: https://fal.ai/

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -124,6 +124,11 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    # fastCRW trails the established paid backends so an upgrade never reroutes
+    # an existing setup. Its is_available() only reports True when cloud /
+    # self-hosted creds are set (or the binary is already local), so keyless
+    # subprocess installs stay opt-in via an explicit web.backend=crw.
+    "crw",
     "searxng",
     "brave-free",
     "ddgs",

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -349,6 +349,7 @@ def run_dump(args):
         ("KILOCODE_API_KEY", "kilocode"),
         ("FIRECRAWL_API_KEY", "firecrawl"),
         ("TAVILY_API_KEY", "tavily"),
+        ("CRW_API_KEY", "crw"),
         ("BROWSERBASE_API_KEY", "browserbase"),
         ("FAL_KEY", "fal"),
         ("ELEVENLABS_API_KEY", "elevenlabs"),

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -300,6 +300,7 @@ def run_dump(args):
         ("OPENCODE_GO_API_KEY", "opencode_go"),
         ("KILOCODE_API_KEY", "kilocode"),
         ("FIRECRAWL_API_KEY", "firecrawl"),
+        ("CRW_API_KEY", "crw"),
         ("TAVILY_API_KEY", "tavily"),
         ("BROWSERBASE_API_KEY", "browserbase"),
         ("FAL_KEY", "fal"),

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -411,6 +411,7 @@ def get_nous_subscription_features(
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
     direct_searxng = bool(get_env_value("SEARXNG_URL"))
+    direct_crw = bool(get_env_value("CRW_API_KEY") or get_env_value("CRW_API_URL"))
     direct_fal = fal_key_is_configured()
     direct_fal_video = direct_fal  # same FAL_KEY; separate var so use_gateway is independent
     direct_openai_tts = bool(resolve_openai_audio_api_key())
@@ -442,6 +443,7 @@ def get_nous_subscription_features(
         direct_exa = False
         direct_parallel = False
         direct_tavily = False
+        direct_crw = False
     if image_use_gateway:
         direct_fal = False
     if video_use_gateway:
@@ -518,6 +520,7 @@ def get_nous_subscription_features(
             or (web_backend == "parallel" and direct_parallel)
             or (web_backend == "tavily" and direct_tavily)
             or (web_backend == "searxng" and direct_searxng)
+            or (web_backend == "crw" and direct_crw)
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
             or (web_search_backend == "searxng" and direct_searxng)
@@ -525,10 +528,11 @@ def get_nous_subscription_features(
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
             or (web_search_backend == "tavily" and direct_tavily)
+            or (web_search_backend == "crw" and direct_crw)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng or direct_crw
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -261,6 +261,11 @@ def get_nous_subscription_features(
     direct_firecrawl = bool(get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL"))
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
+    try:
+        from tools.web_tools import _is_crw_available
+        direct_crw = _is_crw_available()
+    except Exception:
+        direct_crw = bool(get_env_value("CRW_API_KEY") or get_env_value("CRW_API_URL"))
     direct_fal = bool(get_env_value("FAL_KEY"))
     direct_openai_tts = bool(resolve_openai_audio_api_key())
     direct_elevenlabs = bool(get_env_value("ELEVENLABS_API_KEY"))
@@ -289,10 +294,11 @@ def get_nous_subscription_features(
             or (web_backend == "firecrawl" and direct_firecrawl)
             or (web_backend == "parallel" and direct_parallel)
             or (web_backend == "tavily" and direct_tavily)
+            or (web_backend == "crw" and direct_crw)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily
+        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_crw
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -208,6 +208,28 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "fastCRW Cloud",
+                "tag": "Cloud API with search, extract, and crawl",
+                "web_backend": "crw",
+                "env_vars": [
+                    {"key": "CRW_API_KEY", "prompt": "fastCRW API key", "url": "https://fastcrw.com"},
+                ],
+            },
+            {
+                "name": "fastCRW Local",
+                "tag": "Free - runs locally, no API key needed (pip install crw)",
+                "web_backend": "crw",
+                "env_vars": [],
+            },
+            {
+                "name": "fastCRW Self-Hosted",
+                "tag": "Point to your own CRW server instance",
+                "web_backend": "crw",
+                "env_vars": [
+                    {"key": "CRW_API_URL", "prompt": "Your CRW instance URL (e.g., http://localhost:3000)"},
+                ],
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "tag": "Free - run your own instance",
                 "web_backend": "firecrawl",

--- a/plugins/web/crw/__init__.py
+++ b/plugins/web/crw/__init__.py
@@ -1,0 +1,10 @@
+"""fastCRW web search + extract plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.crw.provider import CrwWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the fastCRW provider with the plugin context."""
+    ctx.register_web_search_provider(CrwWebSearchProvider())

--- a/plugins/web/crw/plugin.yaml
+++ b/plugins/web/crw/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-crw
+version: 1.0.0
+description: "fastCRW web search + content extraction via the single-binary crw scraper (https://fastcrw.com). Extract runs locally with zero config (auto-downloads the crw-mcp binary); set CRW_API_KEY (cloud) or CRW_API_URL (self-hosted) to enable search."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - crw

--- a/plugins/web/crw/provider.py
+++ b/plugins/web/crw/provider.py
@@ -1,0 +1,400 @@
+"""fastCRW web search + content extraction — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Wraps the
+``crw`` Python SDK (https://fastcrw.com), the single-binary web scraper for
+AI agents (Firecrawl-compatible API).
+
+Three operating modes, selected automatically from the environment:
+
+- **Cloud** — ``CRW_API_KEY`` set (no URL): HTTP mode against the hosted
+  fastCRW API. Supports both search and extract.
+- **Self-hosted** — ``CRW_API_URL`` set: HTTP mode against your own CRW
+  instance. Supports both search and extract.
+- **Local / subprocess** — neither set: spawns the ``crw-mcp`` binary
+  (auto-downloaded on first use). Extract works with zero config; search is
+  cloud-only (the SDK raises in subprocess mode), so :meth:`supports_search`
+  reports ``False`` and the dispatcher falls back to another search backend.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "crw"     # explicit per-capability (cloud/self-hosted)
+      extract_backend: "crw"    # explicit per-capability (any mode)
+      backend: "crw"            # shared fallback for both
+
+Env vars::
+
+    CRW_API_KEY=...   # https://fastcrw.com — enables cloud search + extract
+    CRW_API_URL=...   # self-hosted instance, e.g. http://localhost:3000
+
+The SDK is lazy-loaded via :func:`tools.lazy_deps.ensure` ("search.crw") so
+cold-start CLI users who haven't configured CRW never pay the import cost.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+from tools.website_policy import check_website_access
+
+logger = logging.getLogger(__name__)
+
+# Hosted fastCRW API base — used when only CRW_API_KEY is set (cloud mode).
+_CRW_DEFAULT_URL = "https://fastcrw.com/api"
+
+
+def _crw_cloud_configured() -> bool:
+    """Return True when cloud or self-hosted mode is configured.
+
+    Either credential gives the SDK an ``api_url`` and therefore enables
+    ``search()`` (which is cloud-only). Cheap env probe — no network, no
+    package import — safe to call on every ``hermes tools`` paint.
+    """
+    return bool(
+        os.getenv("CRW_API_KEY", "").strip() or os.getenv("CRW_API_URL", "").strip()
+    )
+
+
+def _crw_binary_present() -> bool:
+    """Return True when the ``crw-mcp`` binary is already available locally.
+
+    Network-free: checks the ``CRW_BINARY`` override, the system ``PATH``,
+    and the SDK's download cache, but never triggers a download (that would
+    make ``is_available()`` — called at registration time and on every
+    picker paint — block on a network fetch).
+    """
+    env_path = os.environ.get("CRW_BINARY", "").strip()
+    if env_path:
+        return Path(env_path).exists()
+    if shutil.which("crw-mcp"):
+        return True
+    try:
+        from crw._binary import _find_cached_latest
+
+        return _find_cached_latest() is not None
+    except Exception:  # noqa: BLE001 — crw not installed / cache unreadable
+        return False
+
+
+def _get_crw_client() -> Any:
+    """Lazy-import and cache a ``CrwClient`` configured for the active mode.
+
+    Cache lives on :mod:`tools.web_tools` (as ``_crw_client``) so unit tests
+    that reset that name between cases keep working — mirrors the exa/parallel
+    plugins.
+    """
+    import tools.web_tools as _wt
+
+    cached = getattr(_wt, "_crw_client", None)
+    if cached is not None:
+        return cached
+
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+
+        _lazy_ensure("search.crw", prompt=False)
+    except ImportError:
+        pass
+    except Exception as exc:  # noqa: BLE001 — lazy_deps surfaces install hints
+        raise ImportError(str(exc))
+
+    from crw import CrwClient  # noqa: WPS433 — deliberately lazy
+
+    api_url = os.getenv("CRW_API_URL", "").strip().rstrip("/")
+    api_key = os.getenv("CRW_API_KEY", "").strip()
+
+    if api_url:
+        client = CrwClient(api_url=api_url, api_key=api_key or None)
+    elif api_key:
+        client = CrwClient(api_url=_CRW_DEFAULT_URL, api_key=api_key)
+    else:
+        # Subprocess mode — no server needed, binary auto-downloaded on use.
+        client = CrwClient()
+
+    _wt._crw_client = client
+    return client
+
+
+def _reset_client_for_tests() -> None:
+    """Drop the cached CRW client so tests can re-instantiate cleanly."""
+    import tools.web_tools as _wt
+
+    _wt._crw_client = None
+
+
+class CrwWebSearchProvider(WebSearchProvider):
+    """fastCRW search + extract provider.
+
+    ``extract()`` is async (mirrors firecrawl/parallel) so the per-URL scrape
+    runs in a worker thread with a timeout without blocking the event loop.
+    ``search()`` is sync — the SDK call is a blocking HTTP request.
+    """
+
+    @property
+    def name(self) -> str:
+        return "crw"
+
+    @property
+    def display_name(self) -> str:
+        return "fastCRW"
+
+    def is_available(self) -> bool:
+        """Return True when CRW can service calls in the current environment.
+
+        Cloud / self-hosted creds → available (SDK is lazy-installed on first
+        use, like exa). Otherwise available only when the subprocess binary is
+        already present locally (network-free check — never downloads here).
+        """
+        if _crw_cloud_configured():
+            return True
+        return _crw_binary_present()
+
+    def supports_search(self) -> bool:
+        """Search is cloud-only. Advertise it only in cloud/self-hosted mode.
+
+        In subprocess mode the SDK's ``search()`` raises, so reporting False
+        lets the dispatcher fall back to another available search backend
+        instead of surfacing an error.
+        """
+        return _crw_cloud_configured()
+
+    def supports_extract(self) -> bool:
+        """Extract (scrape) works in every mode, including keyless subprocess."""
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a fastCRW search (cloud / self-hosted only).
+
+        Returns ``{"success": True, "data": {"web": [...]}}`` on success, or
+        ``{"success": False, "error": str}`` on failure (incl. subprocess-mode
+        ``CrwError`` and SDK install errors).
+        """
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            logger.info("fastCRW search: '%s' (limit=%d)", query, limit)
+            raw = _get_crw_client().search(query, limit=min(limit, 20))
+
+            # The SDK already unwraps the API envelope's ``data``, leaving one of
+            # several shapes (verified against a live crw instance + the
+            # crw-server response contract):
+            #   • a flat list                  — some instances return data=[...]
+            #   • {"results": [...]}           — crw-server canonical (no sources)
+            #   • {"results": {"web": [...]}}  — canonical, grouped by source
+            #   • {"web": [...]}               — grouped, no results wrapper
+            #   • None                         — data: null
+            # Walk these without assuming a single one so a successful search
+            # never silently yields zero results, and ``data: null`` can't raise.
+            # (Genuine upstream failures — ``success: false`` / non-2xx — are
+            # raised by the SDK and caught below, never reaching this point.)
+            payload = raw.get("results", raw) if isinstance(raw, dict) else raw
+            if isinstance(payload, list):
+                items = payload
+            elif isinstance(payload, dict):
+                items = payload.get("web")
+                if not isinstance(items, list):
+                    items = next(
+                        (v for v in payload.values() if isinstance(v, list)), []
+                    )
+            else:
+                items = []
+
+            web_results = []
+            for i, result in enumerate(items):
+                if not isinstance(result, dict):
+                    continue
+                web_results.append(
+                    {
+                        "title": result.get("title", ""),
+                        "url": result.get("url", ""),
+                        "description": result.get("description", "")
+                        or result.get("snippet", ""),
+                        "position": i + 1,
+                    }
+                )
+
+            return {"success": True, "data": {"web": web_results}}
+        except ImportError as exc:
+            return {"success": False, "error": f"crw SDK not installed: {exc}"}
+        except Exception as exc:  # noqa: BLE001 — surface as failure
+            logger.warning("fastCRW search error: %s", exc)
+            return {"success": False, "error": f"fastCRW search failed: {exc}"}
+
+    async def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via fastCRW ``scrape``.
+
+        Async — each URL is scraped in a worker thread with a 60s timeout so a
+        slow page can't stall the event loop or the whole batch. Per-URL
+        failures (policy block, redirect re-block, timeout, scrape error)
+        become result entries with an ``error`` field rather than raising.
+        SSRF filtering already happened in the web_extract dispatcher; here we
+        enforce the website-access policy before and after redirects, matching
+        the firecrawl provider.
+        """
+        from tools.interrupt import is_interrupted
+
+        format = kwargs.get("format")
+        formats: List[str]
+        if format == "markdown":
+            formats = ["markdown"]
+        elif format == "html":
+            formats = ["html"]
+        else:
+            formats = ["markdown", "html"]
+
+        try:
+            client = _get_crw_client()
+        except ImportError as exc:
+            return [
+                {"url": u, "title": "", "content": "", "error": f"crw SDK not installed: {exc}"}
+                for u in urls
+            ]
+        except Exception as exc:  # noqa: BLE001
+            return [
+                {"url": u, "title": "", "content": "", "error": f"fastCRW unavailable: {exc}"}
+                for u in urls
+            ]
+
+        results: List[Dict[str, Any]] = []
+        for url in urls:
+            if is_interrupted():
+                results.append({"url": url, "error": "Interrupted", "title": ""})
+                continue
+
+            # Pre-scrape website policy gate
+            blocked = check_website_access(url)
+            if blocked:
+                logger.info(
+                    "Blocked web_extract for %s by rule %s",
+                    blocked["host"],
+                    blocked["rule"],
+                )
+                results.append(
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "error": blocked["message"],
+                        "blocked_by_policy": {
+                            "host": blocked["host"],
+                            "rule": blocked["rule"],
+                            "source": blocked["source"],
+                        },
+                    }
+                )
+                continue
+
+            try:
+                logger.info("fastCRW scraping: %s", url)
+                try:
+                    scrape_data = await asyncio.wait_for(
+                        asyncio.to_thread(client.scrape, url, formats=formats),
+                        timeout=60,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning("fastCRW scrape timed out for %s", url)
+                    results.append(
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "error": (
+                                "Scrape timed out after 60s — page may be too large "
+                                "or unresponsive. Try browser_navigate instead."
+                            ),
+                        }
+                    )
+                    continue
+
+                if not isinstance(scrape_data, dict):
+                    scrape_data = {}
+                metadata = scrape_data.get("metadata") or {}
+                if not isinstance(metadata, dict):
+                    metadata = {}
+                title = metadata.get("title", "")
+                final_url = metadata.get("sourceURL", url)
+
+                # Re-check website-access policy after any redirect
+                final_blocked = check_website_access(final_url)
+                if final_blocked:
+                    logger.info(
+                        "Blocked redirected web_extract for %s by rule %s",
+                        final_blocked["host"],
+                        final_blocked["rule"],
+                    )
+                    results.append(
+                        {
+                            "url": final_url,
+                            "title": title,
+                            "content": "",
+                            "raw_content": "",
+                            "error": final_blocked["message"],
+                            "blocked_by_policy": {
+                                "host": final_blocked["host"],
+                                "rule": final_blocked["rule"],
+                                "source": final_blocked["source"],
+                            },
+                        }
+                    )
+                    continue
+
+                content_markdown = scrape_data.get("markdown")
+                content_html = scrape_data.get("html")
+                if format == "markdown" or (format is None and content_markdown):
+                    chosen_content = content_markdown or ""
+                else:
+                    chosen_content = content_html or content_markdown or ""
+
+                results.append(
+                    {
+                        "url": final_url,
+                        "title": title,
+                        "content": chosen_content,
+                        "raw_content": chosen_content,
+                        "metadata": metadata,
+                    }
+                )
+            except Exception as scrape_err:  # noqa: BLE001
+                logger.debug("fastCRW scrape failed for %s: %s", url, scrape_err)
+                results.append(
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": str(scrape_err),
+                    }
+                )
+
+        return results
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "fastCRW",
+            "badge": "free",
+            "tag": (
+                "Single-binary web scraper. Extract runs locally with no key "
+                "(auto-installs the crw-mcp binary); add a cloud key or "
+                "self-hosted URL to enable search."
+            ),
+            "env_vars": [
+                {
+                    "key": "CRW_API_KEY",
+                    "prompt": "fastCRW cloud API key (optional — enables search)",
+                    "url": "https://fastcrw.com",
+                },
+                {
+                    "key": "CRW_API_URL",
+                    "prompt": "Self-hosted CRW URL (optional, e.g. http://localhost:3000)",
+                },
+            ],
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,10 @@ anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
 exa = ["exa-py==2.10.2"]
 firecrawl = ["firecrawl-py==4.17.0"]
 parallel-web = ["parallel-web==0.4.2"]
+# fastCRW — single-binary web scraper (https://fastcrw.com). Extract runs
+# locally with no key (the SDK auto-downloads the crw-mcp binary); cloud /
+# self-hosted mode enables search. Lazy-installed via LAZY_DEPS["search.crw"].
+crw = ["crw==0.3.2"]
 # Image generation backends
 fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit>=3.0.52,<4",
   # Tools
+  "crw>=0.3.0,<1",
   "exa-py>=2.9.0,<3",
   "firecrawl-py>=4.16.0,<5",
   "parallel-web>=0.4.2,<1",

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -45,6 +45,8 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "CRW_API_KEY",
+        "CRW_API_URL",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -63,8 +65,17 @@ def _ensure_plugins_loaded() -> None:
 
 @pytest.fixture(autouse=True)
 def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Each test starts with a clean web-provider env."""
+    """Each test starts with a clean web-provider env.
+
+    fastCRW's ``is_available()`` also reports True when the ``crw-mcp`` binary
+    is already cached locally (subprocess mode), which would make resolution
+    machine-dependent. Pin that probe to False here so every test sees crw as
+    creds-gated only; the dedicated crw subprocess test re-patches it True.
+    """
     _clear_web_env(monkeypatch)
+    monkeypatch.setattr(
+        "plugins.web.crw.provider._crw_binary_present", lambda: False
+    )
 
 
 class TestBundledPluginsRegister:
@@ -77,6 +88,7 @@ class TestBundledPluginsRegister:
         names = sorted(p.name for p in list_providers())
         assert names == [
             "brave-free",
+            "crw",
             "ddgs",
             "exa",
             "firecrawl",
@@ -142,6 +154,324 @@ class TestBundledPluginsRegister:
         assert isinstance(schema, dict)
         assert "name" in schema
         assert "env_vars" in schema
+
+
+# ---------------------------------------------------------------------------
+# fastCRW provider (search [cloud-only] + extract [all modes])
+# ---------------------------------------------------------------------------
+
+
+class TestCrwProvider:
+    """fastCRW's mode-dependent capabilities and availability."""
+
+    def _provider(self):
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("crw")
+        assert p is not None
+        return p
+
+    def test_registered_with_names(self) -> None:
+        p = self._provider()
+        assert p.name == "crw"
+        assert p.display_name == "fastCRW"
+
+    def test_extract_always_supported_search_is_cloud_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        p = self._provider()
+        # Subprocess mode (no creds): extract works, search does not.
+        assert p.supports_extract() is True
+        assert p.supports_search() is False
+        # Cloud / self-hosted creds enable search.
+        monkeypatch.setenv("CRW_API_KEY", "real")
+        assert p.supports_search() is True
+        monkeypatch.delenv("CRW_API_KEY", raising=False)
+        monkeypatch.setenv("CRW_API_URL", "http://localhost:3000")
+        assert p.supports_search() is True
+
+    def test_is_available_creds_based(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        p = self._provider()
+        # Fixture pins the subprocess binary probe to False, so no creds → unavailable.
+        assert p.is_available() is False
+        monkeypatch.setenv("CRW_API_KEY", "real")
+        assert p.is_available() is True
+        monkeypatch.delenv("CRW_API_KEY", raising=False)
+        monkeypatch.setenv("CRW_API_URL", "http://localhost:3000")
+        assert p.is_available() is True
+
+    def test_is_available_subprocess_binary_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no creds, a locally-present crw-mcp binary makes extract usable."""
+        p = self._provider()
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._crw_binary_present", lambda: True
+        )
+        assert p.is_available() is True
+
+    def test_extract_is_async(self) -> None:
+        p = self._provider()
+        assert inspect.iscoroutinefunction(p.extract) is True
+
+    def test_setup_schema_shape(self) -> None:
+        p = self._provider()
+        schema = p.get_setup_schema()
+        assert isinstance(schema, dict)
+        assert schema["name"] == "fastCRW"
+        keys = {e["key"] for e in schema["env_vars"]}
+        assert keys == {"CRW_API_KEY", "CRW_API_URL"}
+
+    def test_search_subprocess_returns_error_dict(self) -> None:
+        """Search is cloud-only; in subprocess mode it returns a typed error."""
+        p = self._provider()
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_search_cloud_normalizes_results(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cloud search maps SDK rows to the {success, data: {web: [...]}} shape."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _FakeClient:
+            def search(self, query: str, limit: int = 5):
+                return [
+                    {"title": "T1", "url": "https://a.example", "description": "d1"},
+                    {"title": "T2", "url": "https://b.example", "snippet": "d2"},
+                ]
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _FakeClient()
+        )
+        p = self._provider()
+        result = p.search("hi", limit=5)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert [r["url"] for r in web] == ["https://a.example", "https://b.example"]
+        assert web[0]["description"] == "d1"
+        assert web[1]["description"] == "d2"  # falls back to snippet
+        assert [r["position"] for r in web] == [1, 2]
+
+    def test_search_propagates_upstream_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An upstream failure (SDK raises on success:false / non-2xx) is a
+        failure, not a successful empty search."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _FailingClient:
+            def search(self, query: str, limit: int = 5):
+                raise RuntimeError("HTTP 500: boom")
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _FailingClient()
+        )
+        p = self._provider()
+        result = p.search("hi", limit=5)
+        assert result["success"] is False
+        assert "boom" in result["error"]
+
+    def test_search_null_data_does_not_crash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``data: null`` response (SDK returns None) yields no results rather
+        than raising an AttributeError."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _NullClient:
+            def search(self, query: str, limit: int = 5):
+                return None
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _NullClient()
+        )
+        p = self._provider()
+        result = p.search("hi", limit=5)
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_search_grouped_dict_shape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the server groups by source type ({"web": [...]}), pull web."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _GroupedClient:
+            def search(self, query: str, limit: int = 5):
+                return {"web": [{"title": "T", "url": "https://a.example"}]}
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _GroupedClient()
+        )
+        p = self._provider()
+        result = p.search("hi", limit=5)
+        assert [r["url"] for r in result["data"]["web"]] == ["https://a.example"]
+
+    def test_search_canonical_results_wrapper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """crw-server returns data={"results": [...]} — must not drop results.
+
+        (Regression guard: a flat-list-only parser would yield zero results
+        against the real server contract.)"""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _WrappedClient:
+            def search(self, query: str, limit: int = 5):
+                return {
+                    "results": [
+                        {"title": "T1", "url": "https://a.example", "snippet": "s1"},
+                        {"title": "T2", "url": "https://b.example", "description": "d2"},
+                    ],
+                    "number_of_results": 2,
+                }
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _WrappedClient()
+        )
+        p = self._provider()
+        result = p.search("hi", limit=5)
+        web = result["data"]["web"]
+        assert [r["url"] for r in web] == ["https://a.example", "https://b.example"]
+        assert web[0]["description"] == "s1"  # snippet alias
+
+    def test_search_canonical_grouped_results_wrapper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With sources, data={"results": {"web": [...]}} — pull the web bucket."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _GroupedWrappedClient:
+            def search(self, query: str, limit: int = 5):
+                return {
+                    "results": {
+                        "web": [{"title": "T", "url": "https://a.example"}],
+                        "news": [{"title": "N", "url": "https://n.example"}],
+                    }
+                }
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client",
+            lambda: _GroupedWrappedClient(),
+        )
+        p = self._provider()
+        result = p.search("hi", limit=5)
+        assert [r["url"] for r in result["data"]["web"]] == ["https://a.example"]
+
+    def test_self_hosted_search_supported_and_errors_cleanly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Self-hosted (CRW_API_URL) advertises search; a server without SearXNG
+        raises (search_disabled), surfaced as a clean error dict — not a crash."""
+        monkeypatch.setenv("CRW_API_URL", "http://localhost:3000")
+        p = self._provider()
+        assert p.supports_search() is True
+
+        class _DisabledClient:
+            def search(self, query: str, limit: int = 5):
+                raise RuntimeError("search_disabled")
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _DisabledClient()
+        )
+        result = p.search("hi", limit=5)
+        assert result["success"] is False
+        assert "search_disabled" in result["error"]
+
+    def _run_extract(self, provider, urls, monkeypatch, **kwargs):
+        """Run the async extract with policy + interrupt gates stubbed open."""
+        monkeypatch.setattr(
+            "plugins.web.crw.provider.check_website_access", lambda url: None
+        )
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+        return asyncio.run(provider.extract(urls, **kwargs))
+
+    def test_extract_format_html_selects_html(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """format='html' must return the HTML, not the markdown (review #3)."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _ScrapeClient:
+            def scrape(self, url, formats=None):
+                assert formats == ["html"]
+                return {
+                    "markdown": "# md",
+                    "html": "<p>html</p>",
+                    "metadata": {"title": "T", "sourceURL": url},
+                }
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _ScrapeClient()
+        )
+        p = self._provider()
+        out = self._run_extract(p, ["https://a.example"], monkeypatch, format="html")
+        assert out[0]["content"] == "<p>html</p>"
+        assert out[0]["title"] == "T"
+
+    def test_extract_format_markdown_selects_markdown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _ScrapeClient:
+            def scrape(self, url, formats=None):
+                assert formats == ["markdown"]
+                return {
+                    "markdown": "# md",
+                    "html": "<p>html</p>",
+                    "metadata": {"sourceURL": url},
+                }
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _ScrapeClient()
+        )
+        p = self._provider()
+        out = self._run_extract(
+            p, ["https://a.example"], monkeypatch, format="markdown"
+        )
+        assert out[0]["content"] == "# md"
+
+    def test_extract_null_data_does_not_crash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A null scrape payload yields empty content, never a crash."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _NullClient:
+            def scrape(self, url, formats=None):
+                return None
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _NullClient()
+        )
+        p = self._provider()
+        out = self._run_extract(p, ["https://a.example"], monkeypatch)
+        assert out[0]["content"] == ""
+        assert "error" not in out[0]  # empty-but-successful, matches firecrawl
+
+    def test_extract_scrape_error_becomes_error_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A scrape failure (SDK raises) becomes a per-URL error entry, not a
+        silent empty success (review #5)."""
+        monkeypatch.setenv("CRW_API_KEY", "real")
+
+        class _FailingClient:
+            def scrape(self, url, formats=None):
+                raise RuntimeError("scrape blew up")
+
+        monkeypatch.setattr(
+            "plugins.web.crw.provider._get_crw_client", lambda: _FailingClient()
+        )
+        p = self._provider()
+        out = self._run_extract(p, ["https://a.example"], monkeypatch)
+        assert out[0]["content"] == ""
+        assert "scrape blew up" in out[0]["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -109,6 +109,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "search.exa": ("exa-py==2.10.2",),
     "search.firecrawl": ("firecrawl-py==4.17.0",),
     "search.parallel": ("parallel-web==0.4.2",),
+    # fastCRW — single-binary scraper SDK (https://fastcrw.com). Bump in
+    # lockstep with the `crw` extra in pyproject.toml and uv.lock.
+    "search.crw": ("crw==0.3.2",),
 
     # ─── TTS providers ─────────────────────────────────────────────────────
     # Pinned to exact versions to match pyproject.toml's no-ranges policy

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -16,6 +16,7 @@ Backend compatibility:
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
 - Tavily: https://tavily.com (search, extract)
+- fastCRW: https://fastcrw.com (search [cloud/self-hosted], extract; single binary, runs locally with no key)
 
 LLM Processing:
 - Uses OpenRouter API with Gemini 3 Flash Preview for intelligent content extraction
@@ -73,6 +74,7 @@ from plugins.web.parallel.provider import (  # noqa: F401 — backward-compat na
     _get_parallel_client,
 )
 from plugins.web.exa.provider import _get_exa_client  # noqa: F401
+from plugins.web.crw.provider import _get_crw_client  # noqa: F401
 
 # Module-level cache slots for the per-vendor clients. The plugins read/write
 # these via tools.web_tools so unit tests that reset
@@ -82,6 +84,7 @@ _firecrawl_client_config: Optional[Any] = None
 _parallel_client: Optional[Any] = None
 _async_parallel_client: Optional[Any] = None
 _exa_client: Optional[Any] = None
+_crw_client: Optional[Any] = None
 
 from agent.auxiliary_client import (
     async_call_llm,
@@ -149,7 +152,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "crw", "searxng", "brave-free", "ddgs", "xai"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -165,6 +168,12 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
         ("firecrawl", _is_tool_gateway_ready()),
+        # fastCRW only auto-selects when explicit cloud / self-hosted creds are
+        # set (CRW_API_KEY / CRW_API_URL). Keyless subprocess mode is NOT
+        # auto-detected here — it stays opt-in via web.backend=crw — so simply
+        # having the crw extra installed never silently hijacks the default
+        # backend for existing users.
+        ("crw", _has_env("CRW_API_KEY") or _has_env("CRW_API_URL")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -230,6 +239,18 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "crw":
+        # Cloud / self-hosted creds → usable. Otherwise usable only when the
+        # crw-mcp binary is already present locally (network-free check — never
+        # downloads here, since this runs on every dispatch + `hermes tools`
+        # repaint). Mirrors CrwWebSearchProvider.is_available().
+        if _has_env("CRW_API_KEY") or _has_env("CRW_API_URL"):
+            return True
+        try:
+            from plugins.web.crw.provider import _crw_binary_present
+            return _crw_binary_present()
+        except Exception:
+            return False
     if backend == "xai":
         # Cheap probe — env var OR auth.json has OAuth tokens. Must not
         # call resolve_xai_http_credentials() here because the OAuth path
@@ -1231,6 +1252,15 @@ if __name__ == "__main__":
             print("   Using Brave Search free tier (search only)")
         elif backend == "ddgs":
             print("   Using DuckDuckGo via ddgs package (search only)")
+        elif backend == "crw":
+            crw_url = os.getenv("CRW_API_URL", "").strip().rstrip("/")
+            crw_key = os.getenv("CRW_API_KEY", "").strip()
+            if crw_url:
+                print(f"   Using fastCRW self-hosted: {crw_url}")
+            elif crw_key:
+                print("   Using fastCRW cloud API (fastcrw.com)")
+            else:
+                print("   Using fastCRW subprocess mode (crw-mcp binary, extract only)")
         elif firecrawl_url_available:
             print(f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}")
         elif firecrawl_key_available:
@@ -1242,7 +1272,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, CRW_API_KEY, CRW_API_URL, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -13,6 +13,7 @@ Available tools:
 - web_crawl_tool: Crawl websites with specific instructions
 
 Backend compatibility:
+- CRW/fastCRW: https://fastcrw.com (search, extract, crawl; cloud or self-hosted single binary)
 - Exa: https://exa.ai (search, extract)
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
@@ -88,7 +89,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "crw"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -96,6 +97,7 @@ def _get_backend() -> str:
     # tool gateway is configured for Nous subscribers.
     backend_candidates = (
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
+        ("crw", _is_crw_available()),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
@@ -117,6 +119,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "crw":
+        return _is_crw_available()
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -189,6 +193,8 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "CRW_API_KEY",
+        "CRW_API_URL",
     ]
     if managed_nous_tools_enabled():
         requires.extend(
@@ -359,6 +365,57 @@ def _normalize_tavily_documents(response: dict, fallback_url: str = "") -> List[
             "metadata": {"sourceURL": url_str},
         })
     return documents
+
+
+# ─── fastCRW Client (via crw Python SDK) ─────────────────────────────────────
+
+_CRW_DEFAULT_URL = "https://fastcrw.com/api"
+_crw_client: Any = None
+
+
+def _get_crw_client():
+    """Return a singleton ``CrwClient``.
+
+    Mode selection:
+    - ``CRW_API_URL`` set → HTTP mode to that URL.
+    - ``CRW_API_KEY`` set (no URL) → HTTP mode to cloud (fastcrw.com/api).
+    - Neither set → subprocess mode (auto-downloads crw-mcp binary).
+    """
+    global _crw_client
+    if _crw_client is not None:
+        return _crw_client
+
+    from crw import CrwClient
+
+    api_url = os.getenv("CRW_API_URL", "").strip().rstrip("/")
+    api_key = os.getenv("CRW_API_KEY", "").strip()
+
+    if api_url:
+        _crw_client = CrwClient(api_url=api_url, api_key=api_key or None)
+    elif api_key:
+        _crw_client = CrwClient(api_url=_CRW_DEFAULT_URL, api_key=api_key)
+    else:
+        # Subprocess mode — no server needed, binary auto-downloaded
+        _crw_client = CrwClient()
+
+    return _crw_client
+
+
+def _is_crw_available() -> bool:
+    """Return True if the CRW backend can be used.
+
+    Available when an API key or URL is configured, or when the crw-mcp
+    binary is reachable (subprocess mode works without any env vars).
+    """
+    if _has_env("CRW_API_KEY") or _has_env("CRW_API_URL"):
+        return True
+    # Check if crw-mcp binary is available for subprocess mode
+    try:
+        from crw._binary import ensure_binary
+        ensure_binary()
+        return True
+    except Exception:
+        return False
 
 
 def _to_plain_object(value: Any) -> Any:
@@ -1117,6 +1174,28 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "crw":
+            logger.info("fastCRW search: '%s' (limit: %d)", query, limit)
+            client = _get_crw_client()
+            raw_results = client.search(query, limit=min(limit, 100))
+            # Normalize to standard format
+            items = raw_results if isinstance(raw_results, list) else raw_results.get("data") or []
+            web_results = []
+            for i, r in enumerate(items):
+                web_results.append({
+                    "title": r.get("title", ""),
+                    "url": r.get("url", ""),
+                    "description": r.get("description", ""),
+                    "position": i + 1,
+                })
+            response_data = {"success": True, "data": {"web": web_results}}
+            debug_call_data["results_count"] = len(web_results)
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
 
         response = _get_firecrawl_client().search(
@@ -1251,6 +1330,77 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "crw":
+                # ── fastCRW extraction (via crw SDK) ──
+                results: List[Dict[str, Any]] = []
+                from tools.interrupt import is_interrupted as _is_interrupted
+                client = _get_crw_client()
+                for url in safe_urls:
+                    if _is_interrupted():
+                        results.append({"url": url, "error": "Interrupted", "title": ""})
+                        continue
+
+                    # Website policy check — block before fetching
+                    blocked = check_website_access(url)
+                    if blocked:
+                        logger.info("Blocked web_extract for %s by rule %s", blocked["host"], blocked["rule"])
+                        results.append({
+                            "url": url, "title": "", "content": "",
+                            "error": blocked["message"],
+                            "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
+                        })
+                        continue
+
+                    try:
+                        logger.info("fastCRW scraping: %s", url)
+                        try:
+                            scrape_data = await asyncio.wait_for(
+                                asyncio.to_thread(
+                                    client.scrape, url, formats=["markdown", "html"],
+                                ),
+                                timeout=60,
+                            )
+                        except asyncio.TimeoutError:
+                            logger.warning("fastCRW scrape timed out for %s", url)
+                            results.append({
+                                "url": url, "title": "", "content": "",
+                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
+                            })
+                            continue
+
+                        # Normalize SDK response
+                        metadata = scrape_data.get("metadata") or {}
+                        if not isinstance(metadata, dict):
+                            metadata = {}
+                        content = scrape_data.get("markdown", "") or scrape_data.get("html", "") or ""
+                        doc = {
+                            "url": metadata.get("sourceURL", url),
+                            "title": metadata.get("title", ""),
+                            "content": content,
+                            "raw_content": content,
+                            "metadata": metadata,
+                        }
+
+                        # Re-check final URL after redirect
+                        final_url = doc.get("url", url)
+                        final_blocked = check_website_access(final_url)
+                        if final_blocked:
+                            logger.info("Blocked redirected web_extract for %s by rule %s", final_blocked["host"], final_blocked["rule"])
+                            results.append({
+                                "url": final_url, "title": doc.get("title", ""), "content": "", "raw_content": "",
+                                "error": final_blocked["message"],
+                                "blocked_by_policy": {"host": final_blocked["host"], "rule": final_blocked["rule"], "source": final_blocked["source"]},
+                            })
+                            continue
+
+                        results.append(doc)
+
+                    except Exception as scrape_err:
+                        logger.debug("fastCRW scrape failed for %s: %s", url, scrape_err)
+                        results.append({
+                            "url": url, "title": "", "content": "", "raw_content": "",
+                            "error": str(scrape_err),
+                        })
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
@@ -1626,6 +1776,98 @@ async def web_crawl_tool(
             _debug.save()
             return cleaned_result
 
+        # ── fastCRW crawl ──
+        if backend == "crw":
+            if not url.startswith(('http://', 'https://')):
+                url = f'https://{url}'
+
+            if not is_safe_url(url):
+                return json.dumps({"results": [{"url": url, "title": "", "content": "",
+                    "error": "Blocked: URL targets a private or internal network address"}]}, ensure_ascii=False)
+
+            blocked = check_website_access(url)
+            if blocked:
+                logger.info("Blocked web_crawl for %s by rule %s", blocked["host"], blocked["rule"])
+                return json.dumps({"results": [{"url": url, "title": "", "content": "", "error": blocked["message"],
+                    "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]}}]}, ensure_ascii=False)
+
+            from tools.interrupt import is_interrupted as _is_int
+            if _is_int():
+                return tool_error("Interrupted", success=False)
+
+            logger.info("fastCRW crawl: %s (depth=%s)", url, depth)
+            client = _get_crw_client()
+            max_depth = 2 if depth == "basic" else 5
+            max_pages = 5 if depth == "basic" else 20
+
+            crawl_pages = await asyncio.to_thread(
+                client.crawl, url, max_depth=max_depth, max_pages=max_pages,
+                poll_interval=5.0, timeout=300.0,
+            )
+
+            # Normalize crawl results
+            results = []
+            for page in crawl_pages:
+                page_content = page.get("markdown", "") or page.get("html", "")
+                page_meta = page.get("metadata") or {}
+                if not isinstance(page_meta, dict):
+                    page_meta = {}
+                results.append({
+                    "url": page_meta.get("sourceURL", url),
+                    "title": page_meta.get("title", ""),
+                    "content": page_content,
+                    "raw_content": page_content,
+                })
+
+            response = {"results": results}
+            pages_crawled = len(results)
+            logger.info("Crawled %d pages", pages_crawled)
+            debug_call_data["pages_crawled"] = pages_crawled
+            debug_call_data["original_response_size"] = len(json.dumps(response))
+
+            # Process each result with LLM if enabled
+            if use_llm_processing and auxiliary_available:
+                logger.info("Processing crawled content with LLM (parallel)...")
+                debug_call_data["processing_applied"].append("llm_processing")
+
+                async def _process_crw_crawl(result):
+                    page_url = result.get('url', 'Unknown URL')
+                    title = result.get('title', '')
+                    content = result.get('content', '')
+                    if not content:
+                        return result, None, "no_content"
+                    original_size = len(content)
+                    processed = await process_content_with_llm(content, page_url, title, effective_model, min_length)
+                    if processed:
+                        result['raw_content'] = content
+                        result['content'] = processed
+                        metrics = {"url": page_url, "original_size": original_size, "processed_size": len(processed),
+                                   "compression_ratio": len(processed) / original_size if original_size else 1.0, "model_used": effective_model}
+                        return result, metrics, "processed"
+                    metrics = {"url": page_url, "original_size": original_size, "processed_size": original_size,
+                               "compression_ratio": 1.0, "model_used": None, "reason": "content_too_short"}
+                    return result, metrics, "too_short"
+
+                tasks = [_process_crw_crawl(r) for r in response.get('results', [])]
+                processed_results = await asyncio.gather(*tasks)
+                for result, metrics, status in processed_results:
+                    if status == "processed":
+                        debug_call_data["compression_metrics"].append(metrics)
+                        debug_call_data["pages_processed_with_llm"] += 1
+
+            if use_llm_processing and not auxiliary_available:
+                logger.warning("LLM processing requested but no auxiliary model available, returning raw content")
+                debug_call_data["processing_applied"].append("llm_processing_unavailable")
+
+            trimmed_results = [{"url": r.get("url", ""), "title": r.get("title", ""), "content": r.get("content", ""), "error": r.get("error"),
+                **({  "blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {})} for r in response.get("results", [])]
+            result_json = json.dumps({"results": trimmed_results}, indent=2, ensure_ascii=False)
+            cleaned_result = clean_base64_images(result_json)
+            debug_call_data["final_response_size"] = len(cleaned_result)
+            _debug.log_call("web_crawl_tool", debug_call_data)
+            _debug.save()
+            return cleaned_result
+
         # web_crawl requires Firecrawl or the Firecrawl tool-gateway — Parallel has no crawl API
         if not check_firecrawl_api_key():
             return json.dumps({
@@ -1921,9 +2163,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "crw"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "crw"))
 
 
 def check_auxiliary_model() -> bool:
@@ -1961,6 +2203,15 @@ if __name__ == "__main__":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
+        elif backend == "crw":
+            crw_url = os.getenv("CRW_API_URL", "").strip().rstrip("/")
+            crw_key = os.getenv("CRW_API_KEY", "").strip()
+            if crw_url:
+                print(f"   Using fastCRW HTTP mode: {crw_url}")
+            elif crw_key:
+                print("   Using fastCRW cloud API (fastcrw.com)")
+            else:
+                print("   Using fastCRW subprocess mode (crw-mcp binary)")
         else:
             if firecrawl_url_available:
                 print(f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}")
@@ -1973,7 +2224,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, CRW_API_KEY, CRW_API_URL, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -711,6 +711,18 @@ wheels = [
 ]
 
 [[package]]
+name = "crw"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/90/37a7d03bdc7b22cbb77a1d6d28a2100e1cabf8f849490898e4f931308189/crw-0.3.2.tar.gz", hash = "sha256:0a49ec900894c3585e05d20b2e81e047c73585b553e9879fcc05a5ff4ae380cb", size = 9725, upload-time = "2026-04-08T13:04:37.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/d1/e68ec3e4e44ad5b75ca22cc5202e3a2c3076f934f1b8c1edf2ecd88804fd/crw-0.3.2-py3-none-any.whl", hash = "sha256:de0b26ceeeac684610dfb1386b1db6d35ca3d9978b22958e9b36c03788cd3f19", size = 8732, upload-time = "2026-04-08T13:04:36.491Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1575,6 +1587,9 @@ computer-use = [
     { name = "mcp" },
     { name = "starlette" },
 ]
+crw = [
+    { name = "crw" },
+]
 daytona = [
     { name = "daytona" },
 ]
@@ -1735,6 +1750,7 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.5.20" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
+    { name = "crw", marker = "extra == 'crw'", specifier = "==0.3.2" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
@@ -1836,7 +1852,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "crw", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2994,6 +3010,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
     { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **fastCRW** ([fastcrw.com](https://fastcrw.com)) as a new web tool backend alongside Firecrawl, Tavily, Exa, and Parallel. Uses the [`crw` Python SDK](https://pypi.org/project/crw/) which supports three modes:

| Mode | Setup | What it does |
|------|-------|-------------|
| **Local** | `pip install crw` | Spawns crw-mcp binary as subprocess — no server, no API key, no config |
| **Cloud** | `CRW_API_KEY=...` | Routes to fastcrw.com cloud API — includes search, extract, crawl |
| **Self-hosted** | `CRW_API_URL=...` | Routes to your own CRW server instance |

### Why another backend?

The existing backends (Firecrawl, Tavily, Exa, Parallel) all require API keys and cloud subscriptions. fastCRW is the first backend where you can just do `pip install crw` and it works — the SDK auto-downloads a single static binary (~13MB), runs it as a subprocess, and handles scrape/crawl locally. No Docker, no server process, no API key. The binary itself uses ~6MB RAM at idle.

For users who want search (which needs an index), the cloud API at fastcrw.com is available. And for teams running their own infrastructure, there's the self-hosted server option. Same Firecrawl-compatible API shape across all three modes.

## What changed

**`pyproject.toml`** — Added `crw>=0.3.0` dependency

**`tools/web_tools.py`** — Core integration:
- `_get_crw_client()` — Singleton SDK client with auto mode selection (subprocess / cloud / self-hosted)
- `_is_crw_available()` — Checks API keys, URL, or binary on PATH
- Search dispatch → `client.search()` (cloud mode only)
- Extract dispatch → `client.scrape()` per URL with async timeout, SSRF checks, redirect re-checks
- Crawl dispatch → `client.crawl()` with SDK-managed polling
- Backend detection, `check_web_api_key()`, status display updated

**`hermes_cli/tools_config.py`** — Three provider entries: fastCRW Cloud, Local, Self-Hosted

**`hermes_cli/nous_subscription.py`** — Uses `_is_crw_available()` for status detection (covers subprocess mode)

**`hermes_cli/dump.py`** — `CRW_API_KEY` in API keys display

**`.env.example`** — `CRW_API_KEY` / `CRW_API_URL` documentation

## Test results

All three modes tested:

**Subprocess mode** (no env vars, binary auto-detected):
- [x] `_is_crw_available()` returns True when crw-mcp binary is on PATH
- [x] `_get_backend()` selects "crw" automatically
- [x] Extract works via subprocess
- [x] Crawl works via subprocess with SDK polling

**Cloud mode** (`CRW_API_KEY` set):
- [x] Search returns results from fastcrw.com/api
- [x] Extract works via cloud API
- [x] Client correctly routes to `https://fastcrw.com/api`

**Self-hosted mode** (`CRW_API_URL` set):
- [x] Extract and crawl work against local crw-server
- [x] Search gracefully returns 404 error (no search route in self-hosted)

**Security & edge cases:**
- [x] SSRF protection blocks private IPs (127.0.0.1)
- [x] Website policy checks applied before and after redirect
- [x] `hermes tools` shows all three provider options
- [x] `hermes status` correctly detects CRW in all modes
- [x] Existing backends (Firecrawl/Tavily/Exa/Parallel) unaffected