### PR TITLE
fix(stream_consumer): handle overflow when no message exists yet

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -136,7 +136,34 @@ class GatewayStreamConsumer:
 
                 if should_edit and self._accumulated:
                     # Split overflow: if accumulated text exceeds the platform
-                    # limit, finalize the current message and start a new one.
+                    # limit, split into properly sized chunks.
+                    if (
+                        len(self._accumulated) > _safe_limit
+                        and self._message_id is None
+                    ):
+                        # No existing message to edit (first message or after a
+                        # segment break).  Use truncate_message — the same
+                        # helper the non-streaming path uses — to split with
+                        # proper word/code-fence boundaries and chunk
+                        # indicators like "(1/2)".
+                        chunks = self.adapter.truncate_message(
+                            self._accumulated, _safe_limit
+                        )
+                        for chunk in chunks:
+                            await self._send_new_chunk(chunk, self._message_id)
+                        self._accumulated = ""
+                        self._last_sent_text = ""
+                        self._last_edit_time = time.monotonic()
+                        if got_done:
+                            return
+                        if got_segment_break:
+                            self._message_id = None
+                            self._fallback_final_send = False
+                            self._fallback_prefix = ""
+                        continue
+
+                    # Existing message: edit it with the first chunk, then
+                    # start a new message for the overflow remainder.
                     while (
                         len(self._accumulated) > _safe_limit
                         and self._message_id is not None
@@ -225,6 +252,34 @@ class GatewayStreamConsumer:
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
+
+    async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
+        """Send a new message chunk, optionally threaded to a previous message.
+
+        Returns the message_id so callers can thread subsequent chunks.
+        """
+        text = self._clean_for_display(text)
+        if not text.strip():
+            return reply_to_id
+        try:
+            meta = dict(self.metadata) if self.metadata else {}
+            result = await self.adapter.send(
+                chat_id=self.chat_id,
+                content=text,
+                reply_to=reply_to_id,
+                metadata=meta,
+            )
+            if result.success and result.message_id:
+                self._message_id = str(result.message_id)
+                self._already_sent = True
+                self._last_sent_text = text
+                return str(result.message_id)
+            else:
+                self._edit_supported = False
+                return reply_to_id
+        except Exception as e:
+            logger.error("Stream send chunk error: %s", e)
+            return reply_to_id
 
     def _visible_prefix(self) -> str:
         """Return the visible text already shown in the streamed message."""


### PR DESCRIPTION
## Summary

Salvage of #6816 by @dangelo352 — fixes silent message truncation on Telegram for long streamed responses.

## Root cause

The overflow split loop in `stream_consumer.py` required `self._message_id is not None` to enter, but `_message_id` starts as `None` on the first streamed message (and after segment breaks). When the first accumulated text exceeded ~3993 chars:

1. Overflow loop skipped (message_id is None)
2. Full oversized text sent via `_send_or_edit()` → `adapter.send()`
3. Telegram adapter internally split via `truncate_message()`, but returned only chunk 1's message_id
4. Subsequent edits tried to stuff growing text into chunk 1 → Telegram rejected with 'message_too_long'
5. Telegram adapter silently truncated to 4076 chars + '…' and returned `success=True`
6. User sees message cut off with '…'

## Fix

Add a new code path before the existing while loop for the `_message_id is None` case:
- Uses `truncate_message()` (same helper the non-streaming path uses) for proper word/code-fence boundary splitting with chunk indicators like `(1/2)`
- Sends each chunk as a new message via new `_send_new_chunk()` helper
- Properly handles `got_done` (returns immediately) and `got_segment_break`

The existing while loop for the `_message_id is not None` case is preserved untouched.

## Changes from original PR #6816

- Kept the original while loop (handles existing-message overflow correctly)
- Dropped broken regex that produced garbled output (`(1/\2\)` instead of `(1/3)`)
- Fixed `continue` that would skip `got_done` handling (causing infinite loop when final message overflows)
- Used `_safe_limit` instead of `_raw_limit` for truncate_message to account for formatting expansion

## Test

- 24/24 existing stream consumer tests pass
- E2E: 6840-char message correctly split into 2 chunks (3982 + 2869), consumer terminates cleanly