### PR TITLE
fix: resolve STT model precedence and pip resolver depth in .[all]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,28 +74,38 @@ rl = [
 ]
 yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; python_version >= '3.12'"]
 all = [
-  "hermes-agent[modal]",
-  "hermes-agent[daytona]",
-  "hermes-agent[messaging]",
+  # Keep this list flattened instead of referencing "hermes-agent[extra]".
+  # Recursive self-references significantly increase pip backtracking on
+  # Python 3.13 and can trigger resolver failures in Docker/CI.
+  "modal>=1.0.0,<2",
+  "daytona>=0.148.0,<1",
+  "python-telegram-bot[webhooks]>=22.6,<23",
+  "discord.py[voice]>=2.7.1,<3",
+  "aiohttp>=3.13.3,<4",
+  "slack-bolt>=1.18.0,<2",
+  "slack-sdk>=3.27.0,<4",
   # matrix excluded: python-olm (required by matrix-nio[e2e]) is upstream-broken
   # on modern macOS (archived libolm, C++ errors with Clang 21+). Including it
   # here causes the entire [all] install to fail, dropping all other extras.
   # Users who need Matrix can install manually: pip install 'hermes-agent[matrix]'
-  "hermes-agent[cron]",
-  "hermes-agent[cli]",
-  "hermes-agent[dev]",
-  "hermes-agent[tts-premium]",
-  "hermes-agent[slack]",
-  "hermes-agent[pty]",
-  "hermes-agent[honcho]",
-  "hermes-agent[mcp]",
-  "hermes-agent[homeassistant]",
-  "hermes-agent[sms]",
-  "hermes-agent[acp]",
-  "hermes-agent[voice]",
-  "hermes-agent[dingtalk]",
-  "hermes-agent[feishu]",
-  "hermes-agent[mistral]",
+  "croniter>=6.0.0,<7",
+  "simple-term-menu>=1.0,<2",
+  "debugpy>=1.8.0,<2",
+  "pytest>=9.0.2,<10",
+  "pytest-asyncio>=1.3.0,<2",
+  "pytest-xdist>=3.0,<4",
+  "mcp>=1.2.0,<2",
+  "elevenlabs>=1.0,<2",
+  "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
+  "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
+  "honcho-ai>=2.0.1,<3",
+  "agent-client-protocol>=0.9.0,<1.0",
+  "faster-whisper>=1.0.0,<2",
+  "sounddevice>=0.4.6,<1",
+  "numpy>=1.24.0,<3",
+  "dingtalk-stream>=0.1.0,<1",
+  "lark-oapi>=1.5.3,<2",
+  "mistralai>=2.3.0,<3",
 ]
 
 [project.scripts]

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -860,6 +860,21 @@ class TestGetSttModelFromConfig:
         from tools.transcription_tools import get_stt_model_from_config
         assert get_stt_model_from_config() is None
 
+    def test_prefers_local_model_over_legacy_top_level_model(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "stt:\n"
+            "  enabled: true\n"
+            "  provider: local\n"
+            "  model: whisper-1\n"
+            "  local:\n"
+            "    model: base\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+        assert get_stt_model_from_config() == "base"
+
 
 # ============================================================================
 # _transcribe_mistral

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -94,14 +94,35 @@ _local_model_name: Optional[str] = None
 
 
 def get_stt_model_from_config() -> Optional[str]:
-    """Read the STT model name from ~/.hermes/config.yaml.
+    """Return the effective STT model from raw user config.
 
-    Returns the value of ``stt.model`` if present, otherwise ``None``.
-    Silently returns ``None`` on any error (missing file, bad YAML, etc.).
+    Preference order:
+    - provider-specific model (e.g. ``stt.local.model`` when provider=local)
+    - legacy ``stt.model`` fallback for backwards compatibility
+
+    Raw config is used here instead of merged defaults so callers can tell the
+    difference between "user explicitly set a model" and "use provider default".
+    This avoids passing cloud-only model names like ``whisper-1`` into the
+    local faster-whisper path while preserving historical helper semantics.
     """
     try:
         from hermes_cli.config import read_raw_config
-        return read_raw_config().get("stt", {}).get("model")
+
+        stt = read_raw_config().get("stt", {})
+        if not isinstance(stt, dict) or not stt:
+            return None
+
+        provider = stt.get("provider")
+        if provider in {"local", "local_command"}:
+            return stt.get("local", {}).get("model") or stt.get("model")
+        if provider == "openai":
+            return stt.get("openai", {}).get("model") or stt.get("model")
+        if provider == "groq":
+            return stt.get("groq", {}).get("model") or stt.get("model")
+        if provider == "mistral":
+            return stt.get("mistral", {}).get("model") or stt.get("model")
+
+        return stt.get("model")
     except Exception:
         pass
     return None


### PR DESCRIPTION
## Summary
- fix `get_stt_model_from_config()` to prefer provider-specific STT model settings over legacy `stt.model`
- flatten the `all` extra to avoid pip `resolution-too-deep` failures on Python 3.13 / Docker CI
- add a regression test for `provider: local` with stale `stt.model: whisper-1`

## Problem 1: wrong STT model could reach local faster-whisper
Voice/gateway transcription paths call `get_stt_model_from_config()` and pass its result as an explicit `model=` override to `transcribe_audio(...)`.

Before this change, the helper always returned the top-level `stt.model` value when present. That meant a migrated config like:

```yaml
stt:
  provider: local
  model: whisper-1
  local:
    model: base
```

would send `whisper-1` into the local faster-whisper backend, which fails with:

```text
Invalid model size 'whisper-1'
```

### Fix
`get_stt_model_from_config()` now resolves the effective model from raw user config using provider-specific precedence:
- `stt.local.model` for `provider: local` / `local_command`
- `stt.openai.model` for `provider: openai`
- `stt.groq.model` for `provider: groq`
- `stt.mistral.model` for `provider: mistral`
- legacy `stt.model` only as a fallback

Using raw config preserves the existing distinction between "no explicit user model set" and "use provider default".

## Problem 2: Docker build hit pip `resolution-too-deep`
The Docker workflow installs `.[all]`. On Python 3.13, pip could hit `resolution-too-deep` while resolving the recursively-defined `all` extra.

### Fix
Flatten `all` so it contains the concrete dependency specifiers directly instead of recursive `hermes-agent[extra]` self-references. This significantly reduces resolver backtracking and makes `pip install -e '.[all]'` succeed in the reproduced Python 3.13 environment.

## Test Plan
- `python -m pytest tests/tools/test_transcription_tools.py tests/gateway/test_stt_config.py -q`
- `python -m pip install --dry-run -e '.[all]'` in a Python 3.13 virtualenv
