### PR TITLE
feat(discord): add layered auto-skill bindings for forums/channels

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -534,6 +534,11 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
+                if plat == Platform.DISCORD:
+                    if "shared_auto_skills" in platform_cfg:
+                        bridged["shared_auto_skills"] = platform_cfg["shared_auto_skills"]
+                    if "forum_skill_bindings" in platform_cfg:
+                        bridged["forum_skill_bindings"] = platform_cfg["forum_skill_bindings"]
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -537,8 +537,8 @@ def load_gateway_config() -> GatewayConfig:
                 if plat == Platform.DISCORD:
                     if "shared_auto_skills" in platform_cfg:
                         bridged["shared_auto_skills"] = platform_cfg["shared_auto_skills"]
-                    if "forum_skill_bindings" in platform_cfg:
-                        bridged["forum_skill_bindings"] = platform_cfg["forum_skill_bindings"]
+                    if "channel_skill_bindings" in platform_cfg:
+                        bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -405,8 +405,9 @@ class MessageEvent:
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
     
-    # Auto-loaded skill for topic/channel bindings (e.g., Telegram DM Topics)
-    auto_skill: Optional[str] = None
+    # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
+    # Discord forum roles). Can be a single skill name or an ordered list.
+    auto_skill: Optional[str | List[str]] = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1787,6 +1787,7 @@ class DiscordAdapter(BasePlatformAdapter):
             message_type=msg_type,
             source=source,
             raw_message=interaction,
+            auto_skill=self._resolve_auto_skills_for_channel(interaction.channel),
         )
 
     # ------------------------------------------------------------------
@@ -1862,6 +1863,7 @@ class DiscordAdapter(BasePlatformAdapter):
             message_type=MessageType.TEXT,
             source=source,
             raw_message=interaction,
+            auto_skill=self._resolve_auto_skills_for_channel(_chan),
         )
         await self.handle_message(event)
 
@@ -2148,6 +2150,66 @@ class DiscordAdapter(BasePlatformAdapter):
             if parent and self._is_forum_parent(parent):
                 topic = getattr(parent, "topic", None)
         return topic
+
+    @staticmethod
+    def _normalize_skill_names(value: Any) -> list[str]:
+        if not value:
+            return []
+        if isinstance(value, str):
+            items = [value]
+        elif isinstance(value, (list, tuple, set)):
+            items = list(value)
+        else:
+            items = [value]
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in items:
+            name = str(item or "").strip()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            normalized.append(name)
+        return normalized
+
+    def _resolve_auto_skills_for_channel(self, channel: Any) -> Optional[list[str]]:
+        """Resolve ordered auto-loaded skills for a Discord channel or forum thread."""
+        bindings = self.config.extra.get("forum_skill_bindings", []) or []
+        shared_global = self._normalize_skill_names(self.config.extra.get("shared_auto_skills", []))
+        if not bindings:
+            return shared_global or None
+
+        candidate_ids: list[str] = []
+        channel_id = getattr(channel, "id", None)
+        if channel_id is not None:
+            candidate_ids.append(str(channel_id))
+        parent = getattr(channel, "parent", None)
+        parent_id = getattr(parent, "id", None)
+        if parent_id is not None:
+            candidate_ids.append(str(parent_id))
+
+        for binding in bindings:
+            if not isinstance(binding, dict):
+                continue
+            binding_channel_id = binding.get("channel_id") or binding.get("forum_id") or binding.get("id")
+            if str(binding_channel_id or "") not in candidate_ids:
+                continue
+
+            binding_shared = self._normalize_skill_names(binding.get("shared_skills", []))
+            binding_skills = self._normalize_skill_names(binding.get("skills", []))
+            if not binding_skills:
+                binding_skills = self._normalize_skill_names(binding.get("skill"))
+
+            combined: list[str] = []
+            seen: set[str] = set()
+            for name in [*shared_global, *binding_shared, *binding_skills]:
+                if name in seen:
+                    continue
+                seen.add(name)
+                combined.append(name)
+            return combined or None
+
+        return None
 
     def _format_thread_chat_name(self, thread: Any) -> str:
         """Build a readable chat name for thread-like Discord channels, including forum context when available."""
@@ -2444,6 +2506,7 @@ class DiscordAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             reply_to_message_id=str(message.reference.message_id) if message.reference else None,
+            auto_skill=self._resolve_auto_skills_for_channel(message.channel),
             timestamp=message.created_at,
         )
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2174,7 +2174,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _resolve_auto_skills_for_channel(self, channel: Any) -> Optional[list[str]]:
         """Resolve ordered auto-loaded skills for a Discord channel or forum thread."""
-        bindings = self.config.extra.get("forum_skill_bindings", []) or []
+        bindings = self.config.extra.get("channel_skill_bindings", []) or []
         shared_global = self._normalize_skill_names(self.config.extra.get("shared_auto_skills", []))
         if not bindings:
             return shared_global or None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -282,6 +282,67 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
 
 logger = logging.getLogger(__name__)
 
+# Imported at module scope so tests can monkeypatch these helpers directly.
+from agent.skill_commands import _build_skill_message, _load_skill_payload
+
+
+def _normalize_auto_skill_names(auto_skill: Any) -> list[str]:
+    """Normalize auto_skill payloads into an ordered de-duplicated list."""
+    if not auto_skill:
+        return []
+    if isinstance(auto_skill, str):
+        items = [auto_skill]
+    elif isinstance(auto_skill, (list, tuple, set)):
+        items = list(auto_skill)
+    else:
+        items = [str(auto_skill)]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        name = str(item or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        normalized.append(name)
+    return normalized
+
+
+def _build_auto_skill_message(auto_skill: Any, user_instruction: str, task_id: str | None = None) -> str:
+    """Build a combined prompt payload from one or more auto-loaded skills."""
+    skill_names = _normalize_auto_skill_names(auto_skill)
+    if not skill_names:
+        return user_instruction
+
+    loaded_chunks: list[tuple[str, Any, str]] = []
+    for skill_name in skill_names:
+        loaded = _load_skill_payload(skill_name, task_id=task_id)
+        if not loaded:
+            logger.warning("[Gateway] Auto-skill '%s' not found in available skills", skill_name)
+            continue
+        loaded_chunks.append((skill_name, *loaded))
+
+    if not loaded_chunks:
+        return user_instruction
+
+    chunks: list[str] = []
+    total_loaded = len(loaded_chunks)
+    for idx, (_, loaded_skill, skill_dir, display_name) in enumerate(loaded_chunks, start=1):
+        activation_note = (
+            f'[SYSTEM: This conversation has the auto-loaded skill "{display_name}" '
+            f'({idx}/{total_loaded}). Follow its instructions for the duration of this session.]'
+        )
+        skill_msg = _build_skill_message(
+            loaded_skill,
+            skill_dir,
+            activation_note,
+            user_instruction=user_instruction if idx == total_loaded else "",
+        )
+        if skill_msg:
+            chunks.append(skill_msg)
+
+    return "\n\n".join(chunk for chunk in chunks if chunk)
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -2420,37 +2481,21 @@ class GatewayRunner:
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
 
-        # Auto-load skill for DM topic bindings (e.g., Telegram Private Chat Topics)
-        # Only inject on NEW sessions — for ongoing conversations the skill content
-        # is already in the conversation history from the first message.
+        # Auto-load skill(s) for topic/channel bindings (e.g., Telegram topics,
+        # Discord forum role bindings). Only inject on NEW sessions — for ongoing
+        # conversations the skill content is already in the history from the first message.
         if _is_new_session and getattr(event, "auto_skill", None):
             try:
-                from agent.skill_commands import _load_skill_payload, _build_skill_message
-                _skill_name = event.auto_skill
-                _loaded = _load_skill_payload(_skill_name, task_id=_quick_key)
-                if _loaded:
-                    _loaded_skill, _skill_dir, _display_name = _loaded
-                    _activation_note = (
-                        f'[SYSTEM: This conversation is in a topic with the "{_display_name}" skill '
-                        f"auto-loaded. Follow its instructions for the duration of this session.]"
-                    )
-                    _skill_msg = _build_skill_message(
-                        _loaded_skill, _skill_dir, _activation_note,
-                        user_instruction=event.text,
-                    )
-                    if _skill_msg:
-                        event.text = _skill_msg
-                        logger.info(
-                            "[Gateway] Auto-loaded skill '%s' for DM topic session %s",
-                            _skill_name, session_key,
-                        )
-                else:
-                    logger.warning(
-                        "[Gateway] DM topic skill '%s' not found in available skills",
-                        _skill_name,
+                _skill_names = _normalize_auto_skill_names(event.auto_skill)
+                _skill_msg = _build_auto_skill_message(_skill_names, event.text, task_id=_quick_key)
+                if _skill_msg:
+                    event.text = _skill_msg
+                    logger.info(
+                        "[Gateway] Auto-loaded skill(s) %s for session %s",
+                        ", ".join(_skill_names), session_key,
                     )
             except Exception as e:
-                logger.warning("[Gateway] Failed to auto-load topic skill '%s': %s", event.auto_skill, e)
+                logger.warning("[Gateway] Failed to auto-load topic skill(s) '%s': %s", event.auto_skill, e)
 
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -223,6 +223,30 @@ class TestLoadGatewayConfig:
         assert config.unauthorized_dm_behavior == "ignore"
         assert config.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
 
+    def test_bridges_discord_auto_skill_bindings_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  shared_auto_skills:\n"
+            "    - neomesh-core\n"
+            "  forum_skill_bindings:\n"
+            "    - channel_id: '123'\n"
+            "      skills:\n"
+            "        - backend\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["shared_auto_skills"] == ["neomesh-core"]
+        assert config.platforms[Platform.DISCORD].extra["forum_skill_bindings"] == [
+            {"channel_id": "123", "skills": ["backend"]}
+        ]
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -231,7 +231,7 @@ class TestLoadGatewayConfig:
             "discord:\n"
             "  shared_auto_skills:\n"
             "    - neomesh-core\n"
-            "  forum_skill_bindings:\n"
+            "  channel_skill_bindings:\n"
             "    - channel_id: '123'\n"
             "      skills:\n"
             "        - backend\n",
@@ -243,7 +243,7 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.platforms[Platform.DISCORD].extra["shared_auto_skills"] == ["neomesh-core"]
-        assert config.platforms[Platform.DISCORD].extra["forum_skill_bindings"] == [
+        assert config.platforms[Platform.DISCORD].extra["channel_skill_bindings"] == [
             {"channel_id": "123", "skills": ["backend"]}
         ]
 

--- a/tests/gateway/test_discord_auto_skill_bindings.py
+++ b/tests/gateway/test_discord_auto_skill_bindings.py
@@ -1,0 +1,148 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, danger=3, green=1, blurple=2, red=3, grey=4, secondary=5)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock()
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import gateway.platforms.discord as discord_platform  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+class FakeForumChannel:
+    def __init__(self, channel_id: int, name: str = "forum", topic: str | None = None):
+        self.id = channel_id
+        self.name = name
+        self.topic = topic
+        self.guild = SimpleNamespace(name="Neomesh Lab")
+
+
+class FakeThread:
+    def __init__(self, thread_id: int, parent):
+        self.id = thread_id
+        self.parent = parent
+        self.guild = getattr(parent, "guild", None)
+        self.name = "thread"
+        self.topic = None
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={
+            "shared_auto_skills": ["neomesh-core"],
+            "forum_skill_bindings": [
+                {"channel_id": "200", "skill": "backend"},
+                {"channel_id": "300", "skills": ["qa", "release-gate"]},
+            ],
+        },
+    )
+    return DiscordAdapter(config)
+
+
+def test_resolve_auto_skills_from_forum_parent_binding(adapter):
+    parent = FakeForumChannel(200, topic="Backend work")
+    thread = FakeThread(201, parent)
+
+    assert adapter._resolve_auto_skills_for_channel(thread) == ["neomesh-core", "backend"]
+
+
+def test_resolve_auto_skills_from_direct_channel_binding(adapter):
+    channel = SimpleNamespace(id=300, parent=None)
+
+    assert adapter._resolve_auto_skills_for_channel(channel) == ["neomesh-core", "qa", "release-gate"]
+
+
+def test_resolve_auto_skills_returns_none_without_match(adapter):
+    channel = SimpleNamespace(id=999, parent=None)
+
+    assert adapter._resolve_auto_skills_for_channel(channel) is None
+
+
+def test_resolve_auto_skills_dedupes_and_preserves_order(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={
+            "shared_auto_skills": ["neomesh-core", "backend"],
+            "forum_skill_bindings": [
+                {
+                    "channel_id": "500",
+                    "shared_skills": ["backend", "release-principles"],
+                    "skills": ["backend", "qa"],
+                }
+            ],
+        },
+    )
+    adapter = DiscordAdapter(config)
+    channel = FakeForumChannel(500, topic="Release")
+
+    assert adapter._resolve_auto_skills_for_channel(channel) == [
+        "neomesh-core",
+        "backend",
+        "release-principles",
+        "qa",
+    ]
+
+
+def test_resolve_auto_skills_supports_binding_specific_shared_skills(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={
+            "forum_skill_bindings": [
+                {
+                    "channel_id": "400",
+                    "shared_skills": ["neomesh-core"],
+                    "skills": ["cto"],
+                }
+            ]
+        },
+    )
+    adapter = DiscordAdapter(config)
+    channel = FakeForumChannel(400, topic="CTO")
+
+    assert adapter._resolve_auto_skills_for_channel(channel) == ["neomesh-core", "cto"]

--- a/tests/gateway/test_discord_auto_skill_bindings.py
+++ b/tests/gateway/test_discord_auto_skill_bindings.py
@@ -72,7 +72,7 @@ def adapter(monkeypatch):
         token="fake-token",
         extra={
             "shared_auto_skills": ["neomesh-core"],
-            "forum_skill_bindings": [
+            "channel_skill_bindings": [
                 {"channel_id": "200", "skill": "backend"},
                 {"channel_id": "300", "skills": ["qa", "release-gate"]},
             ],
@@ -107,7 +107,7 @@ def test_resolve_auto_skills_dedupes_and_preserves_order(monkeypatch):
         token="fake-token",
         extra={
             "shared_auto_skills": ["neomesh-core", "backend"],
-            "forum_skill_bindings": [
+            "channel_skill_bindings": [
                 {
                     "channel_id": "500",
                     "shared_skills": ["backend", "release-principles"],
@@ -133,7 +133,7 @@ def test_resolve_auto_skills_supports_binding_specific_shared_skills(monkeypatch
         enabled=True,
         token="fake-token",
         extra={
-            "forum_skill_bindings": [
+            "channel_skill_bindings": [
                 {
                     "channel_id": "400",
                     "shared_skills": ["neomesh-core"],

--- a/tests/gateway/test_run_auto_skills.py
+++ b/tests/gateway/test_run_auto_skills.py
@@ -1,0 +1,70 @@
+from agent.skill_commands import _build_skill_message
+from gateway.run import _build_auto_skill_message
+
+
+def test_build_auto_skill_message_supports_multiple_skills(monkeypatch):
+    loaded = {
+        "neomesh-core": ({"content": "NEOMESH CORE"}, None, "neomesh-core"),
+        "backend": ({"content": "BACKEND ROLE"}, None, "backend"),
+    }
+
+    monkeypatch.setattr(
+        "gateway.run._load_skill_payload",
+        lambda skill_identifier, task_id=None: loaded.get(skill_identifier),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "gateway.run._build_skill_message",
+        lambda loaded_skill, skill_dir, activation_note, user_instruction="", runtime_note="": _build_skill_message(
+            loaded_skill,
+            skill_dir,
+            activation_note,
+            user_instruction=user_instruction,
+            runtime_note=runtime_note,
+        ),
+        raising=False,
+    )
+
+    text = _build_auto_skill_message(["neomesh-core", "backend"], "Investigate API latency", task_id="t1")
+
+    assert "neomesh-core" in text
+    assert "backend" in text
+    assert "NEOMESH CORE" in text
+    assert "BACKEND ROLE" in text
+    assert "Investigate API latency" in text
+
+
+def test_build_auto_skill_message_returns_original_text_when_skills_missing(monkeypatch):
+    monkeypatch.setattr("gateway.run._load_skill_payload", lambda skill_identifier, task_id=None: None, raising=False)
+
+    text = _build_auto_skill_message(["missing-skill"], "Hello", task_id="t1")
+
+    assert text == "Hello"
+
+
+def test_build_auto_skill_message_preserves_user_text_when_last_skill_is_missing(monkeypatch):
+    loaded = {
+        "neomesh-core": ({"content": "NEOMESH CORE"}, None, "neomesh-core"),
+    }
+
+    monkeypatch.setattr(
+        "gateway.run._load_skill_payload",
+        lambda skill_identifier, task_id=None: loaded.get(skill_identifier),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "gateway.run._build_skill_message",
+        lambda loaded_skill, skill_dir, activation_note, user_instruction="", runtime_note="": _build_skill_message(
+            loaded_skill,
+            skill_dir,
+            activation_note,
+            user_instruction=user_instruction,
+            runtime_note=runtime_note,
+        ),
+        raising=False,
+    )
+
+    text = _build_auto_skill_message(["neomesh-core", "missing-skill"], "Keep the user text", task_id="t1")
+
+    assert "NEOMESH CORE" in text
+    assert "Keep the user text" in text


### PR DESCRIPTION
## Motivation

Teams often organize work in Discord by forum or channel (for example: backend, QA, ops, architecture) but still want to run a single Hermes bot with shared project context.

Hermes already has a topic -> skill pattern on Telegram, but Discord had two gaps:

1. there was no equivalent way to bind a Discord forum/channel to skills
2. `auto_skill` could only inject a single skill, which made it awkward to model a shared project skill plus a role-specific skill

This PR adds a general Discord-side binding path and lets gateway auto-load multiple skills in order.

## What this changes

### 1. Layered auto-skill support in the gateway runtime
- `MessageEvent.auto_skill` can now be either a single skill name or an ordered list of skills
- gateway runtime normalizes and injects multiple auto-loaded skills for new sessions
- user input is preserved even if some configured skills fail to load

### 2. Discord forum/channel skill bindings
- adds Discord-side binding resolution for the current channel and its parent forum/channel
- allows one binding to combine:
  - shared project skills
  - binding-specific shared skills
  - binding-specific role skills
- applies this to:
  - normal Discord messages
  - slash command entry points
  - slash-created thread entry points

### 3. Config bridge from top-level `discord:` config
This PR also bridges the new Discord config fields from `config.yaml` into gateway runtime:
- `shared_auto_skills`
- `channel_skill_bindings`

## Example

```yaml
discord:
  shared_auto_skills:
    - project-core

  channel_skill_bindings:
    - channel_id: "123456789012345678"
      skills:
        - backend

    - channel_id: "234567890123456789"
      skills:
        - qa
```

With this setup, a backend forum/thread can automatically load:
- `project-core`
- `backend`

while a QA forum/thread can automatically load:
- `project-core`
- `qa`

## Why this is useful

This makes it possible to model:
- one shared project brain
- one bot token
- different forum responsibilities

without requiring:
- multiple Discord bots
- multiple concurrent Hermes profiles
- duplicated project context across roles

## Implementation notes

- injection only happens on new sessions, so ongoing threads do not unexpectedly change behavior mid-conversation
- `channel_skill_bindings` currently matches either the current Discord channel ID or the parent forum/channel ID, so the same config shape works for direct channel entry and forum-thread entry

## Tests

```bash
source venv/bin/activate && pytest \
  tests/gateway/test_config.py \
  tests/gateway/test_dm_topics.py \
  tests/gateway/test_discord_connect.py \
  tests/gateway/test_discord_document_handling.py \
  tests/gateway/test_discord_auto_skill_bindings.py \
  tests/gateway/test_run_auto_skills.py -q
```

Result:
- 68 passed

## Scope intentionally excluded
- no project-specific skills
- no local/user config changes
- no unrelated lockfile changes
