### PR TITLE
fix(matrix): remove eyes reaction on processing complete

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -171,6 +171,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self._reactions_enabled: bool = os.getenv(
             "MATRIX_REACTIONS", "true"
         ).lower() not in ("false", "0", "no")
+        # Tracks the reaction event_id for in-progress (eyes) reactions.
+        # Key: (room_id, message_event_id) → reaction_event_id (for the eyes reaction).
+        self._pending_reactions: dict[tuple[str, str], str] = {}
 
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
@@ -1350,12 +1353,14 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _send_reaction(
         self, room_id: str, event_id: str, emoji: str,
-    ) -> bool:
-        """Send an emoji reaction to a message in a room."""
+    ) -> Optional[str]:
+        """Send an emoji reaction to a message in a room.
+        Returns the reaction event_id on success, None on failure.
+        """
         import nio
 
         if not self._client:
-            return False
+            return None
         content = {
             "m.relates_to": {
                 "rel_type": "m.annotation",
@@ -1370,12 +1375,12 @@ class MatrixAdapter(BasePlatformAdapter):
             )
             if isinstance(resp, nio.RoomSendResponse):
                 logger.debug("Matrix: sent reaction %s to %s", emoji, event_id)
-                return True
+                return resp.event_id
             logger.debug("Matrix: reaction send failed: %s", resp)
-            return False
+            return None
         except Exception as exc:
             logger.debug("Matrix: reaction send error: %s", exc)
-            return False
+            return None
 
     async def _redact_reaction(
         self, room_id: str, reaction_event_id: str, reason: str = "",
@@ -1390,7 +1395,9 @@ class MatrixAdapter(BasePlatformAdapter):
         msg_id = event.message_id
         room_id = event.source.chat_id
         if msg_id and room_id:
-            await self._send_reaction(room_id, msg_id, "\U0001f440")
+            reaction_event_id = await self._send_reaction(room_id, msg_id, "\U0001f440")
+            if reaction_event_id:
+                self._pending_reactions[(room_id, msg_id)] = reaction_event_id
 
     async def on_processing_complete(
         self, event: MessageEvent, success: bool,
@@ -1402,9 +1409,12 @@ class MatrixAdapter(BasePlatformAdapter):
         room_id = event.source.chat_id
         if not msg_id or not room_id:
             return
-        # Note: Matrix doesn't support removing a specific reaction easily
-        # without tracking the reaction event_id. We send the new reaction;
-        # the eyes stays (acceptable UX — both are visible).
+        # Remove the eyes reaction first, if we tracked its event_id.
+        reaction_key = (room_id, msg_id)
+        if reaction_key in self._pending_reactions:
+            eyes_event_id = self._pending_reactions.pop(reaction_key)
+            await self._redact_reaction(room_id, eyes_event_id)
+        # Now send the completion reaction.
         await self._send_reaction(
             room_id, msg_id, "\u2705" if success else "\u274c",
         )

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1413,7 +1413,8 @@ class MatrixAdapter(BasePlatformAdapter):
         reaction_key = (room_id, msg_id)
         if reaction_key in self._pending_reactions:
             eyes_event_id = self._pending_reactions.pop(reaction_key)
-            await self._redact_reaction(room_id, eyes_event_id)
+            if not await self._redact_reaction(room_id, eyes_event_id):
+                logger.debug("Matrix: failed to redact eyes reaction %s", eyes_event_id)
         # Now send the completion reaction.
         await self._send_reaction(
             room_id, msg_id, "\u2705" if success else "\u274c",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1943,7 +1943,7 @@ class TestMatrixReactions:
 
         with patch.dict("sys.modules", {"nio": fake_nio}):
             result = await self.adapter._send_reaction("!room:ex", "$event1", "👍")
-        assert result is True
+        assert result == "$reaction1"
         mock_client.room_send.assert_called_once()
         args = mock_client.room_send.call_args
         assert args[0][1] == "m.reaction"
@@ -1956,7 +1956,7 @@ class TestMatrixReactions:
         self.adapter._client = None
         with patch.dict("sys.modules", {"nio": _make_fake_nio()}):
             result = await self.adapter._send_reaction("!room:ex", "$ev", "👍")
-        assert result is False
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_on_processing_start_sends_eyes(self):
@@ -1964,7 +1964,7 @@ class TestMatrixReactions:
         from gateway.platforms.base import MessageEvent, MessageType
 
         self.adapter._reactions_enabled = True
-        self.adapter._send_reaction = AsyncMock(return_value=True)
+        self.adapter._send_reaction = AsyncMock(return_value="$reaction_event_123")
 
         source = MagicMock()
         source.chat_id = "!room:ex"
@@ -1977,13 +1977,16 @@ class TestMatrixReactions:
         )
         await self.adapter.on_processing_start(event)
         self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "👀")
+        assert self.adapter._pending_reactions == {("!room:ex", "$msg1"): "$reaction_event_123"}
 
     @pytest.mark.asyncio
     async def test_on_processing_complete_sends_check(self):
         from gateway.platforms.base import MessageEvent, MessageType
 
         self.adapter._reactions_enabled = True
-        self.adapter._send_reaction = AsyncMock(return_value=True)
+        self.adapter._pending_reactions = {("!room:ex", "$msg1"): "$eyes_reaction_123"}
+        self.adapter._redact_reaction = AsyncMock(return_value=True)
+        self.adapter._send_reaction = AsyncMock(return_value="$check_reaction_456")
 
         source = MagicMock()
         source.chat_id = "!room:ex"
@@ -1995,6 +1998,7 @@ class TestMatrixReactions:
             message_id="$msg1",
         )
         await self.adapter.on_processing_complete(event, success=True)
+        self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
         self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "✅")
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2002,6 +2002,51 @@ class TestMatrixReactions:
         self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "✅")
 
     @pytest.mark.asyncio
+    async def test_on_processing_complete_sends_cross_on_failure(self):
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        self.adapter._reactions_enabled = True
+        self.adapter._pending_reactions = {("!room:ex", "$msg1"): "$eyes_reaction_123"}
+        self.adapter._redact_reaction = AsyncMock(return_value=True)
+        self.adapter._send_reaction = AsyncMock(return_value="$cross_reaction_456")
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+        await self.adapter.on_processing_complete(event, success=False)
+        self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "❌")
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_no_pending_reaction(self):
+        """on_processing_complete should skip redaction if no eyes reaction was tracked."""
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        self.adapter._reactions_enabled = True
+        self.adapter._pending_reactions = {}
+        self.adapter._redact_reaction = AsyncMock()
+        self.adapter._send_reaction = AsyncMock(return_value="$check_reaction_789")
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+        await self.adapter.on_processing_complete(event, success=True)
+        self.adapter._redact_reaction.assert_not_called()
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "✅")
+
+    @pytest.mark.asyncio
     async def test_reactions_disabled(self):
         from gateway.platforms.base import MessageEvent, MessageType
 


### PR DESCRIPTION
## Problem

When Hermes starts processing a Matrix message, it adds the 👀 (eyes) reaction. When processing completes, the 👀 is **never removed** — both 👀 and ✅/❌ appear together instead of the eyes being replaced.

## Root Cause

`_send_reaction()` returned only a `bool` and discarded the reaction event ID from the Matrix server. Without that event ID, `on_processing_complete` had no way to call `_redact_reaction()`, so it just added the completion emoji alongside the eyes.

Discord doesn't have this issue — its API lets you remove reactions by emoji name directly.

## Fix

1. **`_send_reaction` → `Optional[str]`**: Now returns the reaction event ID from `RoomSendResponse.event_id`.
2. **New `_pending_reactions` dict**: Tracks `(room_id, message_event_id) → reaction_event_id`.
3. **`on_processing_start`**: Stores the eyes reaction event ID after sending.
4. **`on_processing_complete`**: Redacts the eyes reaction before sending the completion emoji. Logs a debug message if redaction fails.

## Testing

✅ Fix has been running locally on this deployment. 👀 is now correctly removed and replaced with ✅/❌.

Test coverage includes:
- `success=True` path (eyes redacted, ✅ sent)
- `success=False` path (eyes redacted, ❌ sent)
- No pending reaction edge case (redaction skipped, completion emoji still sent)

**Note:** Telegram (issue #6068) may have the same pattern.

---

**Branch:** fxfitz/hermes-agent@8cdda296 (based on upstream main `3b554bf8`)
**Locally tested:** ✅