### PR TITLE
fix: add Alibaba/DashScope rate-limit pattern to error classifier

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -122,6 +122,7 @@ _RATE_LIMIT_PATTERNS = [
     "try again in",
     "please retry after",
     "resource_exhausted",
+    "rate increased too quickly",  # Alibaba/DashScope throttling
 ]
 
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -271,6 +271,22 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_fallback is True
 
+    def test_alibaba_rate_increased_too_quickly(self):
+        """Alibaba/DashScope returns a unique throttling message.
+
+        Port from anomalyco/opencode#21355.
+        """
+        msg = (
+            "Upstream error from Alibaba: Request rate increased too quickly. "
+            "To ensure system stability, please adjust your client logic to "
+            "scale requests more smoothly over time."
+        )
+        e = MockAPIError(msg, status_code=400)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is True
+
     # ── Server errors ──
 
     def test_500_server_error(self):


### PR DESCRIPTION
## Summary

Port from [anomalyco/opencode#21355](https://github.com/anomalyco/opencode/pull/21355): Alibaba's DashScope API returns a unique throttling message that doesn't match hermes-agent's existing rate-limit patterns.

**The gap:** Alibaba returns `"Request rate increased too quickly. To ensure system stability, please adjust your client logic to scale requests more smoothly over time."` — this contains neither `rate limit` nor `too many requests`, so it fell through to the `unknown` error category instead of being properly classified as `rate_limit` with backoff/rotation.

**The fix:** Add `"rate increased too quickly"` to `_RATE_LIMIT_PATTERNS` in `agent/error_classifier.py`.

## Changes
- `agent/error_classifier.py`: Add Alibaba/DashScope pattern to rate-limit detection
- `tests/agent/test_error_classifier.py`: Add test with the exact upstream error message

## Test plan
- `python -m pytest tests/agent/test_error_classifier.py -n0 -q` → 93 passed

*Discovered via weekly OpenCode PR scout (cron job).*