### PR TITLE
fix: always show model selection for multi-model custom providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1683,8 +1683,9 @@ def _remove_custom_provider(config):
 def _model_flow_named_custom(config, provider_info):
     """Handle a named custom provider from config.yaml custom_providers list.
 
-    If the entry has a saved model name, activates it immediately.
-    Otherwise probes the endpoint's /models API to let the user pick one.
+    Always probes the endpoint's /models API to let the user pick a model.
+    If a model was previously saved, it is pre-selected in the menu.
+    Falls back to the saved model if probing fails.
     """
     from hermes_cli.auth import _save_model_choice, deactivate_provider
     from hermes_cli.config import load_config, save_config
@@ -1695,40 +1696,29 @@ def _model_flow_named_custom(config, provider_info):
     api_key = provider_info.get("api_key", "")
     saved_model = provider_info.get("model", "")
 
-    # If a model is saved, just activate immediately — no probing needed
-    if saved_model:
-        _save_model_choice(saved_model)
-
-        cfg = load_config()
-        model = cfg.get("model")
-        if not isinstance(model, dict):
-            model = {"default": model} if model else {}
-            cfg["model"] = model
-        model["provider"] = "custom"
-        model["base_url"] = base_url
-        if api_key:
-            model["api_key"] = api_key
-        save_config(cfg)
-        deactivate_provider()
-
-        print(f"✅ Switched to: {saved_model}")
-        print(f"   Provider: {name} ({base_url})")
-        return
-
-    # No saved model — probe endpoint and let user pick
     print(f"  Provider: {name}")
     print(f"  URL:      {base_url}")
+    if saved_model:
+        print(f"  Current:  {saved_model}")
     print()
-    print("No model saved for this provider. Fetching available models...")
+
+    print("Fetching available models...")
     models = fetch_api_models(api_key, base_url, timeout=8.0)
 
     if models:
+        default_idx = 0
+        if saved_model and saved_model in models:
+            default_idx = models.index(saved_model)
+
         print(f"Found {len(models)} model(s):\n")
         try:
             from simple_term_menu import TerminalMenu
-            menu_items = [f"  {m}" for m in models] + ["  Cancel"]
+            menu_items = [
+                f"  {m} (current)" if m == saved_model else f"  {m}"
+                for m in models
+            ] + ["  Cancel"]
             menu = TerminalMenu(
-                menu_items, cursor_index=0,
+                menu_items, cursor_index=default_idx,
                 menu_cursor="-> ", menu_cursor_style=("fg_green", "bold"),
                 menu_highlight_style=("fg_green",),
                 cycle_cursor=True, clear_screen=False,
@@ -1742,7 +1732,8 @@ def _model_flow_named_custom(config, provider_info):
             model_name = models[idx]
         except (ImportError, NotImplementedError):
             for i, m in enumerate(models, 1):
-                print(f"  {i}. {m}")
+                suffix = " (current)" if m == saved_model else ""
+                print(f"  {i}. {m}{suffix}")
             print(f"  {len(models) + 1}. Cancel")
             print()
             try:
@@ -1758,6 +1749,13 @@ def _model_flow_named_custom(config, provider_info):
             except (ValueError, KeyboardInterrupt, EOFError):
                 print("\nCancelled.")
                 return
+    elif saved_model:
+        print("Could not fetch models from endpoint.")
+        try:
+            model_name = input(f"Model name [{saved_model}]: ").strip() or saved_model
+        except (KeyboardInterrupt, EOFError):
+            print("\nCancelled.")
+            return
     else:
         print("Could not fetch models from endpoint. Enter model name manually.")
         try:

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -45,7 +45,8 @@ class TestCustomProviderModelSwitch:
             "model": "model-A",  # already saved
         }
 
-        with patch("hermes_cli.main.fetch_api_models", return_value=["model-A", "model-B"]) as mock_fetch, \
+        with patch("hermes_cli.models.fetch_api_models", return_value=["model-A", "model-B"]) as mock_fetch, \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
              patch("builtins.input", return_value="2"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -65,7 +66,8 @@ class TestCustomProviderModelSwitch:
             "model": "model-A",
         }
 
-        with patch("hermes_cli.main.fetch_api_models", return_value=["model-A", "model-B"]), \
+        with patch("hermes_cli.models.fetch_api_models", return_value=["model-A", "model-B"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
              patch("builtins.input", return_value="2"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -88,7 +90,7 @@ class TestCustomProviderModelSwitch:
         }
 
         # fetch returns empty list (probe failed), user presses Enter (empty input)
-        with patch("hermes_cli.main.fetch_api_models", return_value=[]), \
+        with patch("hermes_cli.models.fetch_api_models", return_value=[]), \
              patch("builtins.input", return_value=""), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -110,7 +112,8 @@ class TestCustomProviderModelSwitch:
             # no "model" key
         }
 
-        with patch("hermes_cli.main.fetch_api_models", return_value=["model-X"]), \
+        with patch("hermes_cli.models.fetch_api_models", return_value=["model-X"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -1,0 +1,121 @@
+"""Tests that `hermes model` always shows the model selection menu for custom
+providers, even when a model is already saved.
+
+Regression test for the bug where _model_flow_named_custom() returned
+immediately when provider_info had a saved ``model`` field, making it
+impossible to switch models on multi-model endpoints.
+"""
+
+import os
+from unittest.mock import patch, MagicMock, call
+
+import pytest
+
+
+@pytest.fixture
+def config_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a minimal config."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    config_yaml = home / "config.yaml"
+    config_yaml.write_text("model: old-model\ncustom_providers: []\n")
+    env_file = home / ".env"
+    env_file.write_text("")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    return home
+
+
+class TestCustomProviderModelSwitch:
+    """Ensure _model_flow_named_custom always probes and shows menu."""
+
+    def test_saved_model_still_probes_endpoint(self, config_home):
+        """When a model is already saved, the function must still call
+        fetch_api_models to probe the endpoint — not skip with early return."""
+        from hermes_cli.main import _model_flow_named_custom
+
+        provider_info = {
+            "name": "My vLLM",
+            "base_url": "https://vllm.example.com/v1",
+            "api_key": "sk-test",
+            "model": "model-A",  # already saved
+        }
+
+        with patch("hermes_cli.main.fetch_api_models", return_value=["model-A", "model-B"]) as mock_fetch, \
+             patch("builtins.input", return_value="2"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        # fetch_api_models MUST be called even though model was saved
+        mock_fetch.assert_called_once_with("sk-test", "https://vllm.example.com/v1", timeout=8.0)
+
+    def test_can_switch_to_different_model(self, config_home):
+        """User selects a different model than the saved one."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        provider_info = {
+            "name": "My vLLM",
+            "base_url": "https://vllm.example.com/v1",
+            "api_key": "sk-test",
+            "model": "model-A",
+        }
+
+        with patch("hermes_cli.main.fetch_api_models", return_value=["model-A", "model-B"]), \
+             patch("builtins.input", return_value="2"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model["default"] == "model-B"
+
+    def test_probe_failure_falls_back_to_saved(self, config_home):
+        """When endpoint probe fails and user presses Enter, saved model is used."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        provider_info = {
+            "name": "My vLLM",
+            "base_url": "https://vllm.example.com/v1",
+            "api_key": "sk-test",
+            "model": "model-A",
+        }
+
+        # fetch returns empty list (probe failed), user presses Enter (empty input)
+        with patch("hermes_cli.main.fetch_api_models", return_value=[]), \
+             patch("builtins.input", return_value=""), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model["default"] == "model-A"
+
+    def test_no_saved_model_still_works(self, config_home):
+        """First-time flow (no saved model) still works as before."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        provider_info = {
+            "name": "My vLLM",
+            "base_url": "https://vllm.example.com/v1",
+            "api_key": "sk-test",
+            # no "model" key
+        }
+
+        with patch("hermes_cli.main.fetch_api_models", return_value=["model-X"]), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model["default"] == "model-X"


### PR DESCRIPTION
## Summary

`hermes model` locks users to the first model they pick on multi-model custom endpoints (OpenRouter, vLLM clusters, any OpenAI-compatible API serving 2+ models). Running `hermes model` again and selecting the same endpoint immediately re-activates the saved model without showing the selection menu.

## Root cause

`_model_flow_named_custom()` has an early-return path (L1698-1716) that fires when `provider_info["model"]` is non-empty, skipping endpoint probing and the selection menu entirely.

## Fix

Remove the early-return. Always probe the endpoint and show the model selection menu:
- Current model is pre-selected in the menu and marked `(current)`
- If endpoint probe fails but a model is saved, offer it as default with manual override
- If no saved model and probe fails, fall back to manual input (unchanged behavior)

**Default behavior unchanged**: first-time model selection works exactly as before.

## Changes

- `hermes_cli/main.py`: Rewrote `_model_flow_named_custom()` to always probe and show menu (~30 net LOC change, one function)
- `tests/hermes_cli/test_custom_provider_model_switch.py`: 4 regression tests covering: probe always called, model switch works, probe failure fallback, first-time flow

Fixes #6862