### PR TITLE
fix: use PROVIDER_REGISTRY env vars in list_authenticated_providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -24,6 +24,7 @@ import logging
 from dataclasses import dataclass
 from typing import List, NamedTuple, Optional
 
+from hermes_cli.auth import PROVIDER_REGISTRY
 from hermes_cli.providers import (
     determine_api_mode,
     get_label,


### PR DESCRIPTION
## Problem

The `list_authenticated_providers` function in `hermes_cli/model_switch.py` uses `models.dev` data for credential detection. However, `models.dev` can have incorrect env var names for some providers (e.g. `minimax-cn` lists `MINIMAX_API_KEY` instead of `MINIMAX_CN_API_KEY`).

This causes `minimax-cn` (and potentially other providers with similar mismatches) to be invisible in the `/model` interactive picker on Telegram/Discord, even when the correct API key is set.

The code already had a comment acknowledging this issue:


But the `list_authenticated_providers` function was still using `models.dev` env vars directly, while `_model_flow_api_key_provider` correctly uses `PROVIDER_REGISTRY`.

## Fix

Use `PROVIDER_REGISTRY` from `hermes_cli/auth.py` as the source of truth for env var names in `list_authenticated_providers`, consistent with how `_model_flow_api_key_provider` already works.

```python
# Before:
env_vars = pdata.get("env", [])

# After:
pconfig = PROVIDER_REGISTRY.get(hermes_id)
if pconfig and pconfig.api_key_env_vars:
    env_vars = list(pconfig.api_key_env_vars)
else:
    env_vars = pdata.get("env", [])
```

## Testing

```python
# Before fix: MiniMax-CN not visible in picker even with MINIMAX_CN_API_KEY set
# After fix: MiniMax-CN visible in picker
providers = list_authenticated_providers(current_provider='minimax-cn', max_models=50)
assert any('minimax' in p['slug'] for p in providers)  # ✓ passes
```