### PR TITLE
fix: make LobeHub skill source prefix case-insensitive

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -961,6 +961,49 @@ class TestConvertToSkillMd:
 
 
 # ---------------------------------------------------------------------------
+# LobeHubSource — case-insensitive prefix handling
+# ---------------------------------------------------------------------------
+
+
+class TestLobeHubCaseInsensitivePrefix:
+    """Ensure fetch() and inspect() accept any casing of the 'lobehub/' prefix."""
+
+    def test_fetch_uppercase_prefix(self):
+        src = LobeHubSource()
+        with patch.object(src, "_fetch_agent", return_value=None) as mock_fetch:
+            src.fetch("LobeHub/test-agent")
+            mock_fetch.assert_called_once_with("test-agent")
+
+    def test_fetch_mixed_case_prefix(self):
+        src = LobeHubSource()
+        with patch.object(src, "_fetch_agent", return_value=None) as mock_fetch:
+            src.fetch("LOBEHUB/test-agent")
+            mock_fetch.assert_called_once_with("test-agent")
+
+    def test_fetch_lowercase_prefix(self):
+        src = LobeHubSource()
+        with patch.object(src, "_fetch_agent", return_value=None) as mock_fetch:
+            src.fetch("lobehub/test-agent")
+            mock_fetch.assert_called_once_with("test-agent")
+
+    def test_inspect_uppercase_prefix(self):
+        src = LobeHubSource()
+        fake_index = {"agents": [{"identifier": "test-agent", "meta": {"title": "Test", "description": "Desc", "tags": []}}]}
+        with patch.object(src, "_fetch_index", return_value=fake_index):
+            result = src.inspect("LobeHub/test-agent")
+            assert result is not None
+            assert result.name == "test-agent"
+
+    def test_inspect_mixed_case_prefix(self):
+        src = LobeHubSource()
+        fake_index = {"agents": [{"identifier": "test-agent", "meta": {"title": "Test", "description": "Desc", "tags": []}}]}
+        with patch.object(src, "_fetch_index", return_value=fake_index):
+            result = src.inspect("LOBEHUB/test-agent")
+            assert result is not None
+            assert result.name == "test-agent"
+
+
+# ---------------------------------------------------------------------------
 # unified_search — dedup logic
 # ---------------------------------------------------------------------------
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1978,9 +1978,9 @@ class LobeHubSource(SkillSource):
             desc = meta.get("description", "")
             tags = meta.get("tags", [])
 
-            searchable = f"{title} {desc} {' '.join(tags) if isinstance(tags, list) else ''}".lower()
+            identifier = agent.get("identifier", title.lower().replace(" ", "-"))
+            searchable = f"{identifier} {title} {desc} {' '.join(tags) if isinstance(tags, list) else ''}".lower()
             if query_lower in searchable:
-                identifier = agent.get("identifier", title.lower().replace(" ", "-"))
                 results.append(SkillMeta(
                     name=identifier,
                     description=desc[:200],
@@ -1996,8 +1996,8 @@ class LobeHubSource(SkillSource):
         return results
 
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
-        # Strip "lobehub/" prefix if present
-        agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
+        # Strip "lobehub/" prefix if present (case-insensitive)
+        agent_id = identifier.split("/", 1)[-1] if identifier.lower().startswith("lobehub/") else identifier
 
         agent_data = self._fetch_agent(agent_id)
         if not agent_data:
@@ -2013,7 +2013,7 @@ class LobeHubSource(SkillSource):
         )
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
-        agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
+        agent_id = identifier.split("/", 1)[-1] if identifier.lower().startswith("lobehub/") else identifier
         index = self._fetch_index()
         if not index:
             return None

--- a/website/src/pages/skills/index.tsx
+++ b/website/src/pages/skills/index.tsx
@@ -107,6 +107,16 @@ function highlightMatch(text: string, query: string): React.ReactNode {
   );
 }
 
+/** Map docs source labels to the CLI prefix needed for `hermes skills install`. */
+const SOURCE_PREFIX: Record<string, string> = {
+  LobeHub: "lobehub/",
+};
+
+function installIdentifier(skill: Skill): string {
+  const prefix = SOURCE_PREFIX[skill.source] || "";
+  return `${prefix}${skill.name}`;
+}
+
 function SkillCard({
   skill,
   query,
@@ -208,7 +218,7 @@ function SkillCard({
               </div>
             )}
             <div className={styles.installHint}>
-              <code>hermes skills install {skill.name}</code>
+              <code>hermes skills install {installIdentifier(skill)}</code>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Three fixes for LobeHub skill installation UX:

1. **Case-insensitive prefix** — `LobeHub/code-companion` now works, not just `lobehub/`
2. **Bare name resolution** — `hermes skills install api-docs-writer` now resolves to `lobehub/api-docs-writer` when unambiguous
3. **Docs install command** — Skills Hub page shows the full installable identifier

## Problem

```bash
# Case-sensitive prefix — fails
❯ hermes skills install LobeHub/code-companion
Error: Could not fetch 'LobeHub/code-companion' from any source.

# Bare name — fails
❯ hermes skills install api-docs-writer
Error: No skill named 'api-docs-writer' found in any source.

# Only this worked
❯ hermes skills install lobehub/code-companion
```

**Root causes:**
- `fetch()`/`inspect()` used case-sensitive `startswith("lobehub/")`
- `search()` built searchable text from title + description + tags but **not** the agent identifier. For `api-docs-writer`, the LobeHub title is "API Documentation Optimization Expert" — the identifier never appeared in the search text, so `_resolve_short_name` found zero matches
- Docs page showed bare names in install commands

## Fix

- **`tools/skills_hub.py`**:
  - `fetch()`/`inspect()`: `identifier.lower().startswith("lobehub/")`
  - `search()`: include `identifier` in searchable text. The existing `_resolve_short_name` already handles disambiguation when multiple sources match the same bare name.
- **`website/src/pages/skills/index.tsx`**: `installIdentifier()` helper prepends source prefix to install command on skill cards

## Changes

| File | Change |
|------|--------|
| `tools/skills_hub.py` | Case-insensitive prefix in `fetch()`/`inspect()`, identifier in search text |
| `website/src/pages/skills/index.tsx` | `SOURCE_PREFIX` map + `installIdentifier()` helper |
| `tests/tools/test_skills_hub.py` | 5 new tests for case-insensitive prefix handling |

## Tests

All 85 tests in `test_skills_hub.py` pass.

Fixes #6866