### PR TITLE
feat(voice): add naga.ac provider for TTS/STT and setup support

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -408,7 +408,7 @@ DEFAULT_CONFIG = {
     
     # Text-to-speech configuration
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" | "naga" | "openai" | "neutts" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -416,6 +416,11 @@ DEFAULT_CONFIG = {
         "elevenlabs": {
             "voice_id": "pNInz6obpgDQGcFmaJgB",  # Adam
             "model_id": "eleven_multilingual_v2",
+        },
+        "naga": {
+            "model": "eleven-multilingual-v2:free",
+            "voice": "jsCqWAovK2LkecY7zXl4",
+            "base_url": "https://api.naga.ac/v1",
         },
         "openai": {
             "model": "gpt-4o-mini-tts",
@@ -432,7 +437,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" | "groq" | "openai" | "mistral" | "elevenlabs" | "naga"
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -442,6 +447,13 @@ DEFAULT_CONFIG = {
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
+        },
+        "elevenlabs": {
+            "model": "scribe_v1",  # scribe_v1, scribe_v1_experimental
+        },
+        "naga": {
+            "model": "whisper-large-v3:free",
+            "base_url": "https://api.naga.ac/v1",
         },
     },
 
@@ -950,6 +962,13 @@ OPTIONAL_ENV_VARS = {
         "description": "ElevenLabs API key for premium text-to-speech voices",
         "prompt": "ElevenLabs API key",
         "url": "https://elevenlabs.io/",
+        "password": True,
+        "category": "tool",
+    },
+    "NAGA_API_KEY": {
+        "description": "Naga.ac API key for TTS and STT",
+        "prompt": "Naga.ac API key",
+        "url": "https://naga.ac/",
         "password": True,
         "category": "tool",
     },
@@ -2424,6 +2443,7 @@ def show_config():
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
+        ("NAGA_API_KEY", "Naga.ac (STT/TTS)"),
         ("EXA_API_KEY", "Exa"),
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4478,12 +4478,12 @@ For more help on a command:
         "setup",
         help="Interactive setup wizard",
         description="Configure Hermes Agent with an interactive wizard. "
-                    "Run a specific section: hermes setup model|terminal|gateway|tools|agent"
+                    "Run a specific section: hermes setup model|tts|stt|terminal|gateway|tools|agent"
     )
     setup_parser.add_argument(
         "section",
         nargs="?",
-        choices=["model", "terminal", "gateway", "tools", "agent"],
+        choices=["model", "tts", "stt", "terminal", "gateway", "tools", "agent"],
         default=None,
         help="Run a specific setup section instead of the full wizard"
     )

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -142,6 +142,7 @@ def _tts_label(current_provider: str) -> str:
     mapping = {
         "openai": "OpenAI TTS",
         "elevenlabs": "ElevenLabs",
+        "naga": "Naga.ac",
         "edge": "Edge TTS",
         "neutts": "NeuTTS",
     }
@@ -263,6 +264,7 @@ def get_nous_subscription_features(
     direct_fal = bool(get_env_value("FAL_KEY"))
     direct_openai_tts = bool(resolve_openai_audio_api_key())
     direct_elevenlabs = bool(get_env_value("ELEVENLABS_API_KEY"))
+    direct_naga = bool(get_env_value("NAGA_API_KEY"))
     direct_camofox = bool(get_env_value("CAMOFOX_URL"))
     direct_browserbase = bool(get_env_value("BROWSERBASE_API_KEY") and get_env_value("BROWSERBASE_PROJECT_ID"))
     direct_browser_use = bool(get_env_value("BROWSER_USE_API_KEY"))
@@ -309,6 +311,7 @@ def get_nous_subscription_features(
         tts_current_provider in {"edge", "neutts"}
         or (tts_current_provider == "openai" and (managed_tts_available or direct_openai_tts))
         or (tts_current_provider == "elevenlabs" and direct_elevenlabs)
+        or (tts_current_provider == "naga" and direct_naga)
     )
     tts_active = bool(tts_tool_enabled and tts_available)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -688,6 +688,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (OpenAI via Nous subscription)", True, None))
     elif tts_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
         tool_status.append(("Text-to-Speech (ElevenLabs)", True, None))
+    elif tts_provider == "naga" and get_env_value("NAGA_API_KEY"):
+        tool_status.append(("Text-to-Speech (Naga.ac)", True, None))
     elif tts_provider == "openai" and (
         get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
     ):
@@ -1179,6 +1181,7 @@ def _setup_tts_provider(config: dict):
     provider_labels = {
         "edge": "Edge TTS",
         "elevenlabs": "ElevenLabs",
+        "naga": "Naga.ac",
         "openai": "OpenAI TTS",
         "minimax": "MiniMax TTS",
         "neutts": "NeuTTS",
@@ -1199,12 +1202,13 @@ def _setup_tts_provider(config: dict):
         [
             "Edge TTS (free, cloud-based, no setup needed)",
             "ElevenLabs (premium quality, needs API key)",
+            "Naga.ac (OpenAI-compatible TTS, needs API key)",
             "OpenAI TTS (good quality, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "minimax", "neutts"])
+    providers.extend(["edge", "elevenlabs", "naga", "openai", "minimax", "neutts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1270,6 +1274,19 @@ def _setup_tts_provider(config: dict):
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"
 
+    elif selected == "naga":
+        existing = get_env_value("NAGA_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Naga.ac API key for TTS", password=True)
+            if api_key:
+                save_env_value("NAGA_API_KEY", api_key)
+                print_success("Naga.ac API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+        config.setdefault("tts", {}).setdefault("naga", {})["voice"] = "jsCqWAovK2LkecY7zXl4"
+
     elif selected == "minimax":
         existing = get_env_value("MINIMAX_API_KEY")
         if not existing:
@@ -1293,6 +1310,110 @@ def _setup_tts_provider(config: dict):
 def setup_tts(config: dict):
     """Standalone TTS setup (for 'hermes setup tts')."""
     _setup_tts_provider(config)
+
+
+def _setup_stt_provider(config: dict):
+    """Interactive STT provider selection."""
+    stt_config = config.get("stt", {})
+    current_provider = stt_config.get("provider", "local")
+
+    provider_labels = {
+        "local": "Local (faster-whisper)",
+        "groq": "Groq",
+        "openai": "OpenAI",
+        "mistral": "Mistral",
+        "elevenlabs": "ElevenLabs",
+        "naga": "Naga.ac",
+    }
+    current_label = provider_labels.get(current_provider, current_provider)
+
+    print()
+    print_header("Speech-to-Text Provider")
+    print_info(f"Current: {current_label}")
+    print()
+
+    choices = [
+        "Local (free, on-device faster-whisper)",
+        "Groq (free tier available, needs API key)",
+        "OpenAI Whisper (needs API key)",
+        "Mistral Voxtral (needs API key)",
+        "ElevenLabs STT (needs API key)",
+        "Naga.ac (OpenAI-compatible STT, needs API key)",
+        f"Keep current ({current_label})",
+    ]
+    providers = ["local", "groq", "openai", "mistral", "elevenlabs", "naga"]
+    keep_current_idx = len(choices) - 1
+    idx = prompt_choice("Select STT provider:", choices, keep_current_idx)
+
+    if idx == keep_current_idx:
+        return
+
+    selected = providers[idx]
+
+    if selected == "groq":
+        existing = get_env_value("GROQ_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Groq API key for STT", password=True)
+            if api_key:
+                save_env_value("GROQ_API_KEY", api_key)
+                print_success("Groq API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "openai":
+        existing = get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("OpenAI API key for STT", password=True)
+            if api_key:
+                save_env_value("VOICE_TOOLS_OPENAI_KEY", api_key)
+                print_success("OpenAI STT API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "mistral":
+        existing = get_env_value("MISTRAL_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Mistral API key for STT", password=True)
+            if api_key:
+                save_env_value("MISTRAL_API_KEY", api_key)
+                print_success("Mistral API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "elevenlabs":
+        existing = get_env_value("ELEVENLABS_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("ElevenLabs API key for STT", password=True)
+            if api_key:
+                save_env_value("ELEVENLABS_API_KEY", api_key)
+                print_success("ElevenLabs API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "naga":
+        existing = get_env_value("NAGA_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Naga.ac API key for STT", password=True)
+            if api_key:
+                save_env_value("NAGA_API_KEY", api_key)
+                print_success("Naga.ac API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+
+    config.setdefault("stt", {})["provider"] = selected
+    save_config(config)
+    print_success(f"STT provider set to: {provider_labels.get(selected, selected)}")
+
+
+def setup_stt(config: dict):
+    """Standalone STT setup (for 'hermes setup stt')."""
+    _setup_stt_provider(config)
 
 
 # =============================================================================
@@ -2820,6 +2941,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
 SETUP_SECTIONS = [
     ("model", "Model & Provider", setup_model_provider),
     ("tts", "Text-to-Speech", setup_tts),
+    ("stt", "Speech-to-Text", setup_stt),
     ("terminal", "Terminal Backend", setup_terminal_backend),
     ("gateway", "Messaging Platforms (Gateway)", setup_gateway),
     ("tools", "Tools", setup_tools),
@@ -2844,6 +2966,8 @@ def run_setup_wizard(args):
     Supports full, quick, and section-specific setup:
       hermes setup           — full or quick (auto-detected)
       hermes setup model     — just model/provider
+      hermes setup tts       — just text-to-speech provider
+      hermes setup stt       — just speech-to-text provider
       hermes setup terminal  — just terminal backend
       hermes setup gateway   — just messaging platforms
       hermes setup tools     — just tool configuration

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -180,6 +180,14 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "elevenlabs",
             },
+            {
+                "name": "Naga.ac",
+                "tag": "OpenAI-compatible TTS/STT",
+                "env_vars": [
+                    {"key": "NAGA_API_KEY", "prompt": "Naga.ac API key", "url": "https://naga.ac/"},
+                ],
+                "tts_provider": "naga",
+            },
         ],
     },
     "web": {

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -305,3 +305,33 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
 
     assert config["terminal"]["backend"] == "modal"
     assert config["terminal"]["modal_mode"] == "direct"
+
+
+def test_setup_sections_include_stt():
+    from hermes_cli.setup import SETUP_SECTIONS
+
+    section_keys = [key for key, _label, _func in SETUP_SECTIONS]
+    assert "stt" in section_keys
+
+
+def test_setup_stt_provider_naga_saves_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.setup import setup_stt
+
+    config = {"stt": {"provider": "local"}}
+    saved_env = {}
+
+    def fake_prompt_choice(question, choices, default=0):
+        assert question == "Select STT provider:"
+        return choices.index("Naga.ac (OpenAI-compatible STT, needs API key)")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *_a, **_kw: "ng-test-key")
+    monkeypatch.setattr("hermes_cli.setup.get_env_value", lambda _k: "")
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda k, v: saved_env.setdefault(k, v))
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda _cfg: None)
+
+    setup_stt(config)
+
+    assert config["stt"]["provider"] == "naga"
+    assert saved_env.get("NAGA_API_KEY") == "ng-test-key"

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -49,6 +49,7 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.delenv("NAGA_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
@@ -1003,6 +1004,78 @@ class TestGetProviderMistral:
 
 
 # ============================================================================
+# _get_provider — ElevenLabs
+# ============================================================================
+
+class TestGetProviderElevenLabs:
+    """ElevenLabs-specific provider selection tests."""
+
+    def test_elevenlabs_when_key_and_sdk_available(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+        with patch("tools.transcription_tools._HAS_ELEVENLABS", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "elevenlabs"}) == "elevenlabs"
+
+    def test_elevenlabs_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_ELEVENLABS", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "elevenlabs"}) == "none"
+
+    def test_elevenlabs_explicit_no_sdk_returns_none(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+        with patch("tools.transcription_tools._HAS_ELEVENLABS", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "elevenlabs"}) == "none"
+
+
+# ============================================================================
+# _get_provider — Naga.ac
+# ============================================================================
+
+class TestGetProviderNaga:
+    """Naga-specific provider selection tests."""
+
+    def test_naga_when_key_available(self, monkeypatch):
+        monkeypatch.setenv("NAGA_API_KEY", "ng-test-key")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "naga"}) == "naga"
+
+    def test_naga_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("NAGA_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "naga"}) == "none"
+
+
+# ============================================================================
+# _transcribe_naga
+# ============================================================================
+
+class TestTranscribeNaga:
+    def test_no_key(self, monkeypatch, sample_ogg):
+        monkeypatch.delenv("NAGA_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_naga
+        result = _transcribe_naga(sample_ogg, "whisper-large-v3:free")
+        assert result["success"] is False
+        assert "NAGA_API_KEY" in result["error"]
+
+    def test_successful_transcription(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("NAGA_API_KEY", "ng-test-key")
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"text": "hello from naga"}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_naga
+            result = _transcribe_naga(sample_ogg, "whisper-large-v3:free")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello from naga"
+        assert result["provider"] == "naga"
+        assert mock_post.call_args.kwargs["data"]["model"] == "whisper-large-v3:free"
+
+
+# ============================================================================
 # transcribe_audio — Mistral dispatch
 # ============================================================================
 
@@ -1030,6 +1103,51 @@ class TestTranscribeAudioMistralDispatch:
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
 
+
+# ============================================================================
+# transcribe_audio — ElevenLabs dispatch
+# ============================================================================
+
+class TestTranscribeAudioElevenLabsDispatch:
+    def test_dispatches_to_elevenlabs(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "elevenlabs"}), \
+             patch("tools.transcription_tools._get_provider", return_value="elevenlabs"), \
+             patch(
+                 "tools.transcription_tools._transcribe_elevenlabs",
+                 return_value={"success": True, "transcript": "hi", "provider": "elevenlabs"},
+             ) as mock_eleven:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "elevenlabs"
+        mock_eleven.assert_called_once()
+
+    def test_config_elevenlabs_model_used(self, sample_ogg):
+        config = {"provider": "elevenlabs", "elevenlabs": {"model": "scribe_v1_experimental"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="elevenlabs"), \
+             patch(
+                 "tools.transcription_tools._transcribe_elevenlabs",
+                 return_value={"success": True, "transcript": "hi"},
+             ) as mock_eleven:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_eleven.call_args[0][1] == "scribe_v1_experimental"
+
+    def test_model_override_passed_to_elevenlabs(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="elevenlabs"), \
+             patch(
+                 "tools.transcription_tools._transcribe_elevenlabs",
+                 return_value={"success": True, "transcript": "hi"},
+             ) as mock_eleven:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="scribe_v1")
+
+        assert mock_eleven.call_args[0][1] == "scribe_v1"
+
     def test_model_override_passed_to_mistral(self, sample_ogg):
         with patch("tools.transcription_tools._load_stt_config", return_value={}), \
              patch("tools.transcription_tools._get_provider", return_value="mistral"), \
@@ -1039,3 +1157,36 @@ class TestTranscribeAudioMistralDispatch:
             transcribe_audio(sample_ogg, model="voxtral-mini-2602")
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
+
+
+# ============================================================================
+# transcribe_audio — Naga dispatch
+# ============================================================================
+
+class TestTranscribeAudioNagaDispatch:
+    def test_dispatches_to_naga(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "naga"}), \
+             patch("tools.transcription_tools._get_provider", return_value="naga"), \
+             patch(
+                 "tools.transcription_tools._transcribe_naga",
+                 return_value={"success": True, "transcript": "hi", "provider": "naga"},
+             ) as mock_naga:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "naga"
+        mock_naga.assert_called_once()
+
+    def test_config_naga_model_used(self, sample_ogg):
+        config = {"provider": "naga", "naga": {"model": "whisper-large-v3:free"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="naga"), \
+             patch(
+                 "tools.transcription_tools._transcribe_naga",
+                 return_value={"success": True, "transcript": "hi"},
+             ) as mock_naga:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_naga.call_args[0][1] == "whisper-large-v3:free"

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -295,6 +295,95 @@ class TestStreamingTTSActivation:
 
 
 # ============================================================================
+# ElevenLabs API key resolution (config fallback)
+# ============================================================================
+
+class TestElevenLabsApiKeyResolution:
+    def test_generate_elevenlabs_uses_config_api_key_when_env_missing(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = [b"audio-bytes"]
+        mock_elevenlabs_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_elevenlabs", return_value=mock_elevenlabs_cls):
+            from tools.tts_tool import _generate_elevenlabs
+
+            output_path = tmp_path / "tts.mp3"
+            _generate_elevenlabs(
+                "hello",
+                str(output_path),
+                {
+                    "elevenlabs": {
+                        "api_key": "cfg-key",
+                        "voice_id": "voice-id",
+                        "model_id": "model-id",
+                    }
+                },
+            )
+
+        assert output_path.exists()
+        assert output_path.read_bytes() == b"audio-bytes"
+        assert mock_elevenlabs_cls.call_args.kwargs["api_key"] == "cfg-key"
+
+    def test_check_tts_requirements_accepts_config_api_key(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError("no edge")), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock()), \
+             patch("tools.tts_tool._load_tts_config", return_value={"elevenlabs": {"api_key": "cfg-key"}}), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError("no openai")), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False):
+            from tools.tts_tool import check_tts_requirements
+            assert check_tts_requirements() is True
+
+
+# ============================================================================
+# Naga.ac API key resolution
+# ============================================================================
+
+class TestNagaApiKeyResolution:
+    def test_generate_naga_uses_config_api_key_when_env_missing(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("NAGA_API_KEY", raising=False)
+
+        mock_response = MagicMock()
+        mock_response.stream_to_file.side_effect = lambda path: open(path, "wb").write(b"audio-bytes")
+        mock_client = MagicMock()
+        mock_client.audio.speech.create.return_value = mock_response
+        mock_openai_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_openai_cls):
+            from tools.tts_tool import _generate_naga_tts
+
+            output_path = tmp_path / "tts.mp3"
+            _generate_naga_tts(
+                "hello",
+                str(output_path),
+                {
+                    "naga": {
+                        "api_key": "cfg-key",
+                        "voice": "alloy",
+                        "model": "eleven-multilingual-v2:free",
+                    }
+                },
+            )
+
+        assert output_path.exists()
+        assert output_path.read_bytes() == b"audio-bytes"
+        assert mock_openai_cls.call_args.kwargs["api_key"] == "cfg-key"
+        assert mock_openai_cls.call_args.kwargs["base_url"] == "https://api.naga.ac/v1"
+
+    def test_check_tts_requirements_accepts_naga_config_api_key(self, monkeypatch):
+        monkeypatch.delenv("NAGA_API_KEY", raising=False)
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError("no edge")), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError("no eleven")), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError("no openai")), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._load_tts_config", return_value={"naga": {"api_key": "cfg-key"}}):
+            from tools.tts_tool import check_tts_requirements
+            assert check_tts_requirements() is True
+
+
+# ============================================================================
 # Voice mode user message prefix (Bug B fix)
 # ============================================================================
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,15 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with three providers:
+Provides speech-to-text transcription with multiple providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **elevenlabs** (paid) — ElevenLabs Speech-to-Text API, requires ``ELEVENLABS_API_KEY``.
+  - **naga** (paid/free-tier models) — Naga.ac STT API, requires ``NAGA_API_KEY``.
+  - **mistral** (paid) — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -58,6 +61,7 @@ def _safe_find_spec(module_name: str) -> bool:
 _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
 _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
+_HAS_ELEVENLABS = _safe_find_spec("elevenlabs")
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -69,6 +73,9 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v1")
+DEFAULT_NAGA_STT_MODEL = os.getenv("STT_NAGA_MODEL", "whisper-large-v3:free")
+DEFAULT_NAGA_STT_BASE_URL = os.getenv("STT_NAGA_BASE_URL", "https://api.naga.ac/v1")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -238,6 +245,23 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "elevenlabs":
+            if _HAS_ELEVENLABS and _resolve_elevenlabs_stt_api_key(stt_config):
+                return "elevenlabs"
+            logger.warning(
+                "STT provider 'elevenlabs' configured but elevenlabs package "
+                "not installed or no API key available"
+            )
+            return "none"
+
+        if provider == "naga":
+            if _resolve_naga_stt_api_key(stt_config):
+                return "naga"
+            logger.warning(
+                "STT provider 'naga' configured but no NAGA_API_KEY available"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider): local > groq > openai > mistral -
@@ -252,6 +276,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
+    if _resolve_naga_stt_api_key():
+        logger.info("No local STT available, using Naga STT API")
+        return "naga"
     if _HAS_MISTRAL and os.getenv("MISTRAL_API_KEY"):
         logger.info("No local STT available, using Mistral Voxtral Transcribe API")
         return "mistral"
@@ -570,6 +597,125 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: elevenlabs (Speech-to-Text API)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_elevenlabs_stt_api_key(stt_config: Optional[dict] = None) -> str:
+    """Resolve ElevenLabs API key from config first, then env."""
+    config = stt_config if stt_config is not None else _load_stt_config()
+    if isinstance(config, dict):
+        eleven_cfg = config.get("elevenlabs", {})
+        if isinstance(eleven_cfg, dict):
+            cfg_key = str(eleven_cfg.get("api_key", "")).strip()
+            if cfg_key:
+                return cfg_key
+    return os.getenv("ELEVENLABS_API_KEY", "").strip()
+
+
+def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using ElevenLabs Speech-to-Text API."""
+    if not _HAS_ELEVENLABS:
+        return {"success": False, "transcript": "", "error": "elevenlabs package not installed"}
+
+    stt_config = _load_stt_config()
+    api_key = _resolve_elevenlabs_stt_api_key(stt_config)
+    if not api_key:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Neither stt.elevenlabs.api_key in config nor ELEVENLABS_API_KEY is set",
+        }
+
+    try:
+        from elevenlabs.client import ElevenLabs
+        client = ElevenLabs(api_key=api_key)
+        with open(file_path, "rb") as audio_file:
+            transcription = client.speech_to_text.convert(
+                model_id=model_name,
+                file=audio_file,
+            )
+
+        transcript_text = _extract_transcript_text(transcription)
+        logger.info(
+            "Transcribed %s via ElevenLabs API (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "elevenlabs"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("ElevenLabs transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"ElevenLabs transcription failed: {type(e).__name__}"}
+
+
+# ---------------------------------------------------------------------------
+# Provider: naga (OpenAI-compatible STT API)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_naga_stt_api_key(stt_config: Optional[dict] = None) -> str:
+    """Resolve Naga API key from config first, then env."""
+    config = stt_config if stt_config is not None else _load_stt_config()
+    if isinstance(config, dict):
+        naga_cfg = config.get("naga", {})
+        if isinstance(naga_cfg, dict):
+            cfg_key = str(naga_cfg.get("api_key", "")).strip()
+            if cfg_key:
+                return cfg_key
+    return os.getenv("NAGA_API_KEY", "").strip()
+
+
+def _transcribe_naga(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Naga.ac STT API."""
+    stt_config = _load_stt_config()
+    api_key = _resolve_naga_stt_api_key(stt_config)
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "NAGA_API_KEY not set"}
+
+    naga_cfg = stt_config.get("naga", {}) if isinstance(stt_config, dict) else {}
+    base_url = str(naga_cfg.get("base_url") or DEFAULT_NAGA_STT_BASE_URL).strip().rstrip("/")
+    endpoint = f"{base_url}/audio/transcriptions"
+
+    try:
+        import requests
+    except ImportError:
+        return {"success": False, "transcript": "", "error": "requests package not installed"}
+
+    try:
+        headers = {"Authorization": f"Bearer {api_key}"}
+        data = {"model": model_name}
+        with open(file_path, "rb") as audio_file:
+            files = {
+                "file": (Path(file_path).name, audio_file, "application/octet-stream"),
+            }
+            response = requests.post(endpoint, headers=headers, files=files, data=data, timeout=60)
+        response.raise_for_status()
+
+        try:
+            payload = response.json()
+            transcript_text = _extract_transcript_text(payload)
+        except ValueError:
+            transcript_text = response.text.strip()
+
+        logger.info(
+            "Transcribed %s via Naga STT API (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "naga"}
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Naga transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Naga transcription failed: {type(e).__name__}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -580,7 +726,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     Provider priority:
       1. User config (``stt.provider`` in config.yaml)
-      2. Auto-detect: local faster-whisper (free) > Groq (free tier) > OpenAI (paid)
+      2. Auto-detect: local faster-whisper (free) > Groq (free tier) > OpenAI > Naga > Mistral
 
     Args:
         file_path: Absolute path to the audio file to transcribe.
@@ -635,6 +781,16 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "elevenlabs":
+        eleven_cfg = stt_config.get("elevenlabs", {})
+        model_name = model or eleven_cfg.get("model", DEFAULT_ELEVENLABS_STT_MODEL)
+        return _transcribe_elevenlabs(file_path, model_name)
+
+    if provider == "naga":
+        naga_cfg = stt_config.get("naga", {})
+        model_name = model or naga_cfg.get("model", DEFAULT_NAGA_STT_MODEL)
+        return _transcribe_naga(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -643,7 +799,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, or set VOICE_TOOLS_OPENAI_KEY "
+            "Voxtral Transcribe, set ELEVENLABS_API_KEY for ElevenLabs STT, set NAGA_API_KEY for Naga STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,9 +2,10 @@
 """
 Text-to-Speech Tool Module
 
-Supports five TTS providers:
+Supports six TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
+- Naga.ac (OpenAI-compatible): needs NAGA_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
@@ -76,6 +77,9 @@ DEFAULT_EDGE_VOICE = "en-US-AriaNeural"
 DEFAULT_ELEVENLABS_VOICE_ID = "pNInz6obpgDQGcFmaJgB"  # Adam
 DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
+DEFAULT_NAGA_MODEL = "eleven-multilingual-v2:free"
+DEFAULT_NAGA_VOICE = "jsCqWAovK2LkecY7zXl4"
+DEFAULT_NAGA_TTS_BASE_URL = "https://api.naga.ac/v1"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
@@ -116,6 +120,28 @@ def _load_tts_config() -> Dict[str, Any]:
 def _get_provider(tts_config: Dict[str, Any]) -> str:
     """Get the configured TTS provider name."""
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
+
+
+def _resolve_elevenlabs_api_key(tts_config: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve ElevenLabs API key from config first, then environment."""
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    el_cfg = cfg.get("elevenlabs", {}) if isinstance(cfg, dict) else {}
+    if isinstance(el_cfg, dict):
+        cfg_key = str(el_cfg.get("api_key", "")).strip()
+        if cfg_key:
+            return cfg_key
+    return os.getenv("ELEVENLABS_API_KEY", "").strip()
+
+
+def _resolve_naga_api_key(tts_config: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve Naga API key from config first, then environment."""
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    naga_cfg = cfg.get("naga", {}) if isinstance(cfg, dict) else {}
+    if isinstance(naga_cfg, dict):
+        cfg_key = str(naga_cfg.get("api_key", "")).strip()
+        if cfg_key:
+            return cfg_key
+    return os.getenv("NAGA_API_KEY", "").strip()
 
 
 # ===========================================================================
@@ -200,7 +226,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     Returns:
         Path to the saved audio file.
     """
-    api_key = os.getenv("ELEVENLABS_API_KEY", "")
+    api_key = _resolve_elevenlabs_api_key(tts_config)
     if not api_key:
         raise ValueError("ELEVENLABS_API_KEY not set. Get one at https://elevenlabs.io/")
 
@@ -276,6 +302,76 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         close = getattr(client, "close", None)
         if callable(close):
             close()
+
+
+# ===========================================================================
+# Provider: Naga.ac TTS
+# ===========================================================================
+def _generate_naga_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Naga.ac TTS API."""
+    api_key = _resolve_naga_api_key(tts_config)
+    if not api_key:
+        raise ValueError("NAGA_API_KEY not set. Get one at https://naga.ac/")
+
+    naga_config = tts_config.get("naga", {})
+    model = naga_config.get("model", DEFAULT_NAGA_MODEL)
+    # Force the validated Naga voice ID to avoid provider-side 400s from
+    # unsupported aliases (for example "alloy").
+    voice = DEFAULT_NAGA_VOICE
+    base_url = naga_config.get("base_url", DEFAULT_NAGA_TTS_BASE_URL)
+    # Backward compatibility: users may still have the old full endpoint
+    # configured (https://api.naga.ac/v1/audio/speech). Normalize to API root.
+    normalized_base_url = str(base_url).rstrip("/")
+    if normalized_base_url.endswith("/audio/speech"):
+        normalized_base_url = normalized_base_url[: -len("/audio/speech")]
+
+    try:
+        OpenAIClient = _import_openai_client()
+        client = OpenAIClient(api_key=api_key, base_url=normalized_base_url)
+        try:
+            response = client.audio.speech.create(
+                model=model,
+                voice=voice,
+                input=text,
+                response_format="opus" if output_path.endswith(".ogg") else "mp3",
+                extra_headers={"x-idempotency-key": str(uuid.uuid4())},
+            )
+            response.stream_to_file(output_path)
+            return output_path
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+    except Exception as e:
+        # Keep a direct HTTP fallback with detailed error body in case
+        # the OpenAI SDK is unavailable/incompatible with this endpoint.
+        try:
+            import requests
+
+            endpoint = normalized_base_url + "/audio/speech"
+            payload = {"model": model, "voice": voice, "input": text}
+            headers = {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            }
+            response = requests.post(endpoint, json=payload, headers=headers, timeout=60)
+            if response.status_code >= 400:
+                error_body = (response.text or "").strip()
+                if len(error_body) > 800:
+                    error_body = error_body[:800] + "... [truncated]"
+                detail = error_body or response.reason or "unknown error"
+                raise ValueError(
+                    f"Naga API error {response.status_code} (model={model}, voice={voice}): {detail}"
+                ) from e
+            with open(output_path, "wb") as f:
+                f.write(response.content)
+            return output_path
+        except ValueError:
+            raise
+        except Exception as fallback_exc:
+            raise ValueError(
+                f"Naga TTS failed via OpenAI-compatible client and HTTP fallback (model={model}, voice={voice}): {fallback_exc}"
+            ) from e
 
 
 # ===========================================================================
@@ -514,6 +610,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with ElevenLabs...")
             _generate_elevenlabs(text, file_str, tts_config)
 
+        elif provider == "naga":
+            logger.info("Generating speech with Naga.ac TTS...")
+            _generate_naga_tts(text, file_str, tts_config)
+
         elif provider == "openai":
             try:
                 _import_openai_client()
@@ -578,7 +678,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "naga") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -639,10 +739,17 @@ def check_tts_requirements() -> bool:
     except ImportError:
         pass
     try:
+        tts_config = _load_tts_config()
         _import_elevenlabs()
-        if os.getenv("ELEVENLABS_API_KEY"):
+        if _resolve_elevenlabs_api_key(tts_config):
             return True
     except ImportError:
+        pass
+    try:
+        tts_config = _load_tts_config()
+        if _resolve_naga_api_key(tts_config):
+            return True
+    except Exception:
         pass
     try:
         _import_openai_client()
@@ -746,7 +853,7 @@ def stream_tts_to_speaker(
         model_id = el_config.get("streaming_model_id",
                                  el_config.get("model_id", model_id))
 
-        api_key = os.getenv("ELEVENLABS_API_KEY", "")
+        api_key = _resolve_elevenlabs_api_key(tts_config)
         if not api_key:
             logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
         else:
@@ -932,7 +1039,7 @@ if __name__ == "__main__":
     print("\nProvider availability:")
     print(f"  Edge TTS:   {'installed' if _check(_import_edge_tts, 'edge') else 'not installed (pip install edge-tts)'}")
     print(f"  ElevenLabs: {'installed' if _check(_import_elevenlabs, 'el') else 'not installed (pip install elevenlabs)'}")
-    print(f"    API Key:  {'set' if os.getenv('ELEVENLABS_API_KEY') else 'not set'}")
+    print(f"    API Key:  {'set' if _resolve_elevenlabs_api_key(_load_tts_config()) else 'not set'}")
     print(f"  OpenAI:     {'installed' if _check(_import_openai_client, 'oai') else 'not installed'}")
     print(
         "    API Key:  "

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -758,10 +758,14 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (Groq)")
     elif stt_provider == "openai":
         details_parts.append("STT provider: OK (OpenAI)")
+    elif stt_provider == "elevenlabs":
+        details_parts.append("STT provider: OK (ElevenLabs)")
+    elif stt_provider == "naga":
+        details_parts.append("STT provider: OK (Naga.ac)")
     else:
         details_parts.append(
             "STT provider: MISSING (pip install faster-whisper, "
-            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY)"
+            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY / ELEVENLABS_API_KEY / NAGA_API_KEY)"
         )
 
     for warning in env_check["warnings"]:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `naga.ac` as a provider for both TTS and STT.
- Added setup support for Naga in `hermes setup`:
- Naga option in TTS provider selection
- New `hermes setup stt` section
- Parser updated to accept `setup tts|stt`
- Naga TTS now uses OpenAI-compatible client flow (`base_url=https://api.naga.ac/v1`), with HTTP fallback for compatibility.
- Improved Naga TTS error visibility by surfacing detailed API response text on failures.
- Enforced validated Naga voice ID at runtime to avoid provider-side 400s:
- `jsCqWAovK2LkecY7zXl4`
- Updated config defaults and provider labels/status reporting to include Naga.
- Added/updated tests covering Naga TTS/STT dispatch and setup behavior.


## How to Test

1. Configure credentials:
- Set `NAGA_API_KEY` in `~/.hermes/.env`.

2. Configure providers:
- `hermes setup tts` -> choose `Naga.ac`
- `hermes setup stt` -> choose `Naga.ac` (or keep preferred STT)

3. Restart gateway:
- `hermes gateway restart`
(or stop/start if running foreground)

4. TTS validation:
- Trigger a TTS response.
- Confirm audio file/message is generated successfully.
- Confirm runtime uses voice `jsCqWAovK2LkecY7zXl4`.

5. STT validation:
- Send an audio clip and confirm transcription succeeds via Naga provider.

6. Optional tests:
- Run targeted tests for Naga/setup flows.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

