### PR TITLE
docs: fix ASCII diagram width mismatch in architecture.md

### DIFF
--- a/website/docs/developer-guide/architecture.md
+++ b/website/docs/developer-guide/architecture.md
@@ -16,7 +16,7 @@ This page is the top-level map of Hermes Agent internals. Use it to orient yours
 │                                                                      │
 │  CLI (cli.py)    Gateway (gateway/run.py)    ACP (acp_adapter/)     │
 │  Batch Runner    API Server                  Python Library          │
-└──────────┬──────────────┬───────────────────────┬────────────────────┘
+└──────────┬──────────────┬───────────────────────┬───────────────────┘
            │              │                       │
            ▼              ▼                       ▼
 ┌─────────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

Fixes a pre-existing ASCII diagram error in `website/docs/developer-guide/architecture.md` that was causing the `docs-site-checks` CI workflow to fail on every docs-only PR.

**Issue**: The System Overview diagram had inconsistent box widths - the Entry Points box bottom border was 73 characters while the top border was 71 characters.

**Fix**: Normalized the Entry Points bottom border to 71 characters, matching the top border width.

## Test plan

- [ ] Verify CI passes with `ascii-guard lint docs` on this change
- [ ] Check that the diagram renders correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)