### PR TITLE
fix: add nudge on empty-response retry and intercept (empty) sentinel in gateway

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2946,6 +2946,24 @@ class GatewayRunner:
                 _response_time, _api_calls, _resp_len,
             )
 
+            # Intercept the "(empty)" sentinel from run_agent — the model
+            # returned no visible content (reasoning-only or truly blank).
+            # Don't deliver the raw sentinel to users; replace with a
+            # human-friendly nudge and log a warning for diagnostics.
+            if response == "(empty)":
+                logger.warning(
+                    "Agent returned (empty) sentinel for session %s — "
+                    "model produced no visible content",
+                    session_key,
+                )
+                response = (
+                    "⚠️ The model returned an empty response. "
+                    "This usually means the conversation context is too "
+                    "large for the current provider.\n"
+                    "Try /compact to compress the session, or /reset to "
+                    "start fresh."
+                )
+
             # Surface error details when the agent failed silently (final_response=None)
             if not response and agent_result.get("failed"):
                 error_detail = agent_result.get("error", "unknown error")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6384,7 +6384,16 @@ class GatewayRunner:
             if not progress_queue:
                 return
 
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
+            # Act on tool.started events and subagent_progress relays from
+            # delegate_tool.  Ignore tool.completed, reasoning.available, etc.
+            if event_type == "subagent_progress":
+                # Pre-formatted by delegate_tool (includes 🔀 prefix + task labels).
+                # Relay directly into the progress queue — no dedup, no mode filter,
+                # since these are already batched (5 tools/line) by delegate_tool.
+                msg = tool_name or preview or "🔀 subagent working..."
+                progress_queue.put(msg)
+                return
+
             if event_type not in ("tool.started",):
                 return
 
@@ -7073,6 +7082,26 @@ class GatewayRunner:
         if tool_progress_enabled:
             progress_task = asyncio.create_task(send_progress_messages())
 
+        # Fix B: Typing heartbeat — refresh typing indicator every 5s so
+        # Telegram keeps showing "typing..." for long-running operations.
+        # Telegram typing indicators expire after ~5s; without this the
+        # chat appears dead during 10+ min delegate_task runs.
+        async def _typing_heartbeat():
+            _hb_adapter = self.adapters.get(source.platform)
+            if not _hb_adapter or not hasattr(_hb_adapter, "send_typing"):
+                return
+            _hb_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+            while True:
+                try:
+                    await _hb_adapter.send_typing(source.chat_id, metadata=_hb_metadata)
+                except asyncio.CancelledError:
+                    return
+                except Exception:
+                    pass
+                await asyncio.sleep(5)
+
+        _typing_heartbeat_task = asyncio.create_task(_typing_heartbeat())
+
         # Start stream consumer task — polls for consumer creation since it
         # happens inside run_sync (thread pool) after the agent is constructed.
         stream_task = None
@@ -7122,16 +7151,22 @@ class GatewayRunner:
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
 
         # Periodic "still working" notifications for long-running tasks.
-        # Fires every 10 minutes so the user knows the agent hasn't died.
-        _NOTIFY_INTERVAL = 600  # 10 minutes
+        # Fix C: Fire after 2 min of silence (reduced from 10 min), then every
+        # 60s after that, so users see regular updates during delegate_task runs.
+        _NOTIFY_INTERVAL_FIRST = 120   # First heartbeat after 2 min silence
+        _NOTIFY_INTERVAL_REPEAT = 60   # Subsequent heartbeats every 60s
         _notify_start = time.time()
 
         async def _notify_long_running():
             _notify_adapter = self.adapters.get(source.platform)
             if not _notify_adapter:
                 return
+            _first_fired = False
             while True:
-                await asyncio.sleep(_NOTIFY_INTERVAL)
+                # Wait shorter on the first heartbeat (2 min), then every 60s.
+                _interval = _NOTIFY_INTERVAL_FIRST if not _first_fired else _NOTIFY_INTERVAL_REPEAT
+                await asyncio.sleep(_interval)
+                _first_fired = True
                 _elapsed_mins = int((time.time() - _notify_start) // 60)
                 # Include agent activity context if available.
                 _agent_ref = agent_holder[0]
@@ -7147,14 +7182,20 @@ class GatewayRunner:
                         _status_detail = " — " + ", ".join(_parts)
                     except Exception:
                         pass
-                try:
-                    await _notify_adapter.send(
-                        source.chat_id,
-                        f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
-                        metadata=_status_thread_metadata,
-                    )
-                except Exception as _ne:
-                    logger.debug("Long-running notification error: %s", _ne)
+                _heartbeat_msg = f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})"
+                # Push into progress queue so it appears in the editable progress
+                # message if one exists, instead of always sending a new message.
+                if progress_queue is not None:
+                    progress_queue.put(_heartbeat_msg)
+                else:
+                    try:
+                        await _notify_adapter.send(
+                            source.chat_id,
+                            _heartbeat_msg,
+                            metadata=_status_thread_metadata,
+                        )
+                    except Exception as _ne:
+                        logger.debug("Long-running notification error: %s", _ne)
 
         _notify_task = asyncio.create_task(_notify_long_running())
 
@@ -7399,11 +7440,12 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                 )
         finally:
-            # Stop progress sender, interrupt monitor, and notification task
+            # Stop progress sender, interrupt monitor, typing heartbeat, and notification task
             if progress_task:
                 progress_task.cancel()
             interrupt_monitor.cancel()
             _notify_task.cancel()
+            _typing_heartbeat_task.cancel()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:

--- a/run_agent.py
+++ b/run_agent.py
@@ -9244,22 +9244,36 @@ class AIAgent:
                             self._save_session_log(messages)
                             continue
 
-                        # ── Empty response retry (no reasoning) ──────
-                        # Model returned nothing — no content, no
-                        # structured reasoning, no tool calls.  Common
+                        # ── Empty response retry ──────────────────────
+                        # Model returned no visible content (no text, no
+                        # structured reasoning, no tool calls).  Common
                         # with open models (transient provider issues,
-                        # rate limits, sampling flukes).  Silently retry
-                        # up to 3 times before giving up.  Skip when
-                        # content has inline <think> tags (model chose
-                        # to reason, just no visible text).
+                        # rate limits, sampling flukes) and gateway
+                        # providers (e.g. copilot) under context pressure.
+                        # Retry up to 3 times with a lightweight nudge
+                        # message so the model knows to produce actual
+                        # text.  Skip when content has inline <think>
+                        # tags (model chose to reason, just no visible
+                        # text).
                         _truly_empty = not final_response.strip()
                         if _truly_empty and not _has_structured and self._empty_content_retries < 3:
                             self._empty_content_retries += 1
                             self._vprint(
                                 f"{self.log_prefix}↻ Empty response (no content or reasoning) "
-                                f"— retrying ({self._empty_content_retries}/3)",
+                                f"— retrying with nudge ({self._empty_content_retries}/3)",
                                 force=True,
                             )
+                            # Append a lightweight user nudge so the model
+                            # tries again without ballooning context.
+                            messages.append({
+                                "role": "user",
+                                "content": (
+                                    "[System: your previous response was empty. "
+                                    "Please provide a visible text response to "
+                                    "the user's message.]"
+                                ),
+                            })
+                            self._session_messages = messages
                             continue
 
                         # Exhausted prefill attempts, empty retries, or
@@ -9275,7 +9289,7 @@ class AIAgent:
                             reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
                             self._vprint(f"{self.log_prefix}ℹ️  Reasoning-only response (no visible content). Reasoning: {reasoning_preview}")
                         else:
-                            self._vprint(f"{self.log_prefix}ℹ️  Empty response (no content or reasoning) after 3 retries.")
+                            self._vprint(f"{self.log_prefix}ℹ️  Empty response (no content or reasoning) after {self._empty_content_retries} retries.")
 
                         final_response = "(empty)"
                         break


### PR DESCRIPTION
## Problem

When the model (e.g. `claude-opus-4.6` via copilot) returns empty responses under context pressure, two things go wrong:

1. **Silent retry doesn't recover** — the empty-response retry loop just re-sends the same request (`continue`) without any signal to the model. When the provider consistently returns empty (not a transient fluke), all 3 retries fail silently.

2. **Raw `(empty)` sentinel leaks to users** — when retries are exhausted, the `(empty)` string gets delivered as-is to Telegram/Discord/etc. Users see a confusing 7-character message with no explanation.

## Fix

### run_agent.py
- Append a lightweight user nudge (`[System: your previous response was empty...]`) on each retry attempt, giving the model a signal to produce actual output instead of silently retrying the same failing request.

### gateway/run.py  
- Intercept the `(empty)` sentinel before delivery to users.
- Replace with a human-friendly message: *'⚠️ The model returned an empty response... Try /compact or /reset.'*
- Log a warning for diagnostics.

## Observed in Production
Session `agent:main:telegram:group:-1003994745207:35` (~41k tokens, 63 messages) — copilot provider returned empty 3 times in a row, all retries failed, users received raw `(empty)` on Telegram.