### PR TITLE
feat: add task completion memory pipeline and Mem0 curation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Treat at least these areas as protected Hermes internals:
 - `model_tools.py`
 - `toolsets.py`
 - `cli.py`
-- `agent/**`
+- `agent/**` (includes `agent/task_review.py` — task completion review engine)
 - `hermes_cli/**`
 - `tools/**`
 - `gateway/**`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,41 @@ Instructions for AI coding assistants and developers working on the hermes-agent
 source venv/bin/activate  # ALWAYS activate before running Python
 ```
 
+## Hermes Core Change Control (SIP)
+
+Hermes internals are protected. Do not change Hermes core configs, file structure,
+agent architecture, system defaults, or tool/runtime internals unless all three
+conditions are satisfied:
+
+1. The change is documented
+2. The change is verified
+3. The change is explicitly authorized by the user
+
+If any of those are missing, stop and ask.
+
+The only escape hatch is an explicit user authorization containing the keyword
+`SIP-OVERRIDE`. Even with `SIP-OVERRIDE`, keep blast radius minimal, document what
+changed, and verify the affected path.
+
+Treat at least these areas as protected Hermes internals:
+- `run_agent.py`
+- `model_tools.py`
+- `toolsets.py`
+- `cli.py`
+- `agent/**`
+- `hermes_cli/**`
+- `tools/**`
+- `gateway/**`
+- `cron/**`
+- config defaults/migrations
+- memory/provider architecture
+- system prompt assembly
+- tool registry behavior
+- session/state persistence behavior
+
+Undocumented incremental drift in Hermes core is a reliability bug, not harmless
+cleanup. Do not make silent core changes.
+
 ## Project Structure
 
 ```

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -67,6 +68,54 @@ def build_memory_context_block(raw_context: str) -> str:
         f"{clean}\n"
         "</memory-context>"
     )
+
+
+def load_recall_artifact(memories_dir: Path) -> str:
+    """Load the recall artifact and format it as prefetch-compatible text.
+
+    Returns an empty string if the file is missing, corrupt, or empty.
+    The returned text is sanitized (no nested ``<memory-context>`` tags).
+    """
+    from agent.task_review import RECALL_ARTIFACT_FILENAME, RECALL_ARTIFACT_VERSION
+
+    artifact_path = memories_dir / RECALL_ARTIFACT_FILENAME
+    if not artifact_path.is_file():
+        return ""
+
+    try:
+        raw = artifact_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (json.JSONDecodeError, OSError):
+        logger.debug("Failed to load recall artifact", exc_info=True)
+        return ""
+
+    # Version check — silently skip incompatible future versions.
+    if data.get("version", 0) != RECALL_ARTIFACT_VERSION:
+        return ""
+
+    parts: list[str] = []
+    parts.append("## Recall from previous session")
+
+    if data.get("session_summary"):
+        parts.append(f"Last session: {data['session_summary']}")
+
+    for label, key in [
+        ("User changes", "user_changes"),
+        ("Environment changes", "environment_changes"),
+        ("Workflow learned", "workflow_learned"),
+    ]:
+        items = data.get(key) or []
+        if items:
+            parts.append(f"{label}:")
+            for item in items:
+                parts.append(f"  - {item}")
+
+    if data.get("generated_at"):
+        parts.append(f"(generated: {data['generated_at']})")
+
+    text = "\n".join(parts)
+    # Sanitize before returning — prevents nested fence injection.
+    return sanitize_context(text)
 
 
 class MemoryManager:
@@ -169,13 +218,20 @@ class MemoryManager:
 
     # -- Prefetch / recall ---------------------------------------------------
 
-    def prefetch_all(self, query: str, *, session_id: str = "") -> str:
+    def prefetch_all(self, query: str, *, session_id: str = "",
+                     recall_preamble: str = "") -> str:
         """Collect prefetch context from all providers.
 
         Returns merged context text labeled by provider. Empty providers
         are skipped. Failures in one provider don't block others.
+
+        If *recall_preamble* is non-empty it is prepended before provider
+        results so the recall artifact appears first in the memory-context
+        block without altering provider behaviour.
         """
         parts = []
+        if recall_preamble and recall_preamble.strip():
+            parts.append(recall_preamble.strip())
         for provider in self._providers:
             try:
                 result = provider.prefetch(query, session_id=session_id)

--- a/agent/task_review.py
+++ b/agent/task_review.py
@@ -9,8 +9,13 @@ routing of classified memory-write candidates to the built-in memory store.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import re
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
@@ -297,3 +302,117 @@ def apply_memory_writeback(
             )
 
     return written
+
+
+# ---------------------------------------------------------------------------
+# Recall artifact — bounded JSON written at task-completion, read at session
+# start.  Replace-on-write, never appended.
+# ---------------------------------------------------------------------------
+
+#: Maximum number of items per list field in the recall artifact.
+_RECALL_LIST_CAP = 5
+
+#: Current schema version for forward-compatibility checks.
+RECALL_ARTIFACT_VERSION = 1
+
+#: Filename (relative to HERMES_HOME/memories/).
+RECALL_ARTIFACT_FILENAME = "recall_artifact.json"
+
+_RECALL_FENCE_TAG_RE = re.compile(r'</?\s*memory-context\s*>', re.IGNORECASE)
+
+
+def _sanitize_recall_text(text: str) -> str:
+    """Strip any accidental memory-context fence tags from artifact content."""
+    return _RECALL_FENCE_TAG_RE.sub('', (text or '').strip())
+
+
+def _truncate_list(items: List[str], cap: int = _RECALL_LIST_CAP) -> List[str]:
+    """Return at most *cap* items, each truncated to 200 chars and sanitized."""
+    out = []
+    for item in items[:cap]:
+        clean = _sanitize_recall_text(item)
+        if clean:
+            out.append(clean[:200])
+    return out
+
+
+def generate_recall_artifact(
+    task_payload: Dict[str, Any],
+    review: TaskReviewResult,
+) -> Dict[str, Any]:
+    """Produce a bounded recall artifact dict from completed-task data.
+
+    Conservative: only extracts information already present in the payload
+    and review result.  No LLM calls.
+
+    Returns a dict ready for JSON serialization.
+    """
+    # User changes: extract from memory-write candidates categorized as user_facts.
+    user_changes = [
+        c.content for c in review.memory_write_candidates
+        if c.category == "user_facts" and c.content
+    ]
+
+    # Environment changes: extract environment_facts candidates.
+    env_changes = [
+        c.content for c in review.memory_write_candidates
+        if c.category == "environment_facts" and c.content
+    ]
+
+    # Workflow learned: extract workflow_facts candidates.
+    workflow_learned = [
+        c.content for c in review.memory_write_candidates
+        if c.category == "workflow_facts" and c.content
+    ]
+
+    # Session summary: compact one-liner from the payload.
+    tools = task_payload.get("tools_used") or []
+    model = task_payload.get("model") or ""
+    completed = task_payload.get("completed", False)
+    status = "completed" if completed else "incomplete"
+    tool_summary = f"tools: {', '.join(tools[:5])}" if tools else "no tools"
+    session_summary = _sanitize_recall_text(
+        f"{status} | {tool_summary} | model: {model}"
+    )
+
+    return {
+        "version": RECALL_ARTIFACT_VERSION,
+        "user_changes": _truncate_list(user_changes),
+        "environment_changes": _truncate_list(env_changes),
+        "workflow_learned": _truncate_list(workflow_learned),
+        "session_summary": session_summary[:500],
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def write_recall_artifact(
+    artifact: Dict[str, Any],
+    memories_dir: Path,
+) -> bool:
+    """Atomically write the recall artifact to disk (replace-on-write).
+
+    Args:
+        artifact: Dict produced by :func:`generate_recall_artifact`.
+        memories_dir: The ``{HERMES_HOME}/memories/`` directory.
+
+    Returns:
+        True on success, False on any error.
+    """
+    try:
+        memories_dir.mkdir(parents=True, exist_ok=True)
+        target = memories_dir / RECALL_ARTIFACT_FILENAME
+        data = json.dumps(artifact, indent=2, ensure_ascii=False)
+        # Bound check: refuse to write if serialized size exceeds ~4KB.
+        if len(data.encode("utf-8")) > 4096:
+            logger.warning(
+                "Recall artifact exceeds 4KB (%d bytes), skipping write",
+                len(data.encode("utf-8")),
+            )
+            return False
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_text(data, encoding="utf-8")
+        os.replace(tmp, target)
+        return True
+    except Exception:
+        logger.debug("Failed to write recall artifact", exc_info=True)
+        return False

--- a/agent/task_review.py
+++ b/agent/task_review.py
@@ -2,17 +2,54 @@
 
 Analyzes a task-completion payload and produces a typed review result
 indicating what follow-up actions (memory save, skill save) are warranted.
-The actual writeback is handled separately — this module only decides *what*
-to review.
+
+Also provides policy-based memory writeback: conservative, deterministic
+routing of classified memory-write candidates to the built-in memory store.
 """
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from typing import Any, Dict, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Memory write candidate categories and routing
+# ---------------------------------------------------------------------------
+
+#: Valid categories for memory write candidates.
+MEMORY_WRITE_CATEGORIES = frozenset({
+    "user_facts",
+    "environment_facts",
+    "workflow_facts",
+    "ignore",
+})
+
+#: Deterministic mapping from category to built-in memory target.
+#: ``"ignore"`` is intentionally absent — it produces no write.
+_CATEGORY_TO_TARGET: Dict[str, str] = {
+    "user_facts": "user",
+    "environment_facts": "memory",
+    "workflow_facts": "memory",
+}
+
+
+@dataclass(frozen=True)
+class MemoryWriteCandidate:
+    """A candidate fact for built-in memory writeback.
+
+    Attributes:
+        category: One of :data:`MEMORY_WRITE_CATEGORIES`.
+        content: The text to persist.
+        source: Where this candidate originated (for debugging/logging).
+    """
+
+    category: str
+    content: str
+    source: str = ""
 
 
 @dataclass(frozen=True)
@@ -24,12 +61,16 @@ class TaskReviewResult:
         should_review_skills: Whether the task warrants a skill review pass.
         review_reasons: Human-readable reasons explaining why review is needed.
         payload: The original task-completion payload (kept for downstream use).
+        memory_write_candidates: Classified candidates for built-in memory
+            writeback.  May be empty even when *should_review_memory* is True
+            (the background LLM review handles the rest).
     """
 
     should_review_memory: bool
     should_review_skills: bool
     review_reasons: List[str]
     payload: Dict[str, Any]
+    memory_write_candidates: List[MemoryWriteCandidate] = field(default_factory=list)
 
 
 def review_completed_task(task_payload: Dict[str, Any]) -> TaskReviewResult:
@@ -84,9 +125,163 @@ def review_completed_task(task_payload: Dict[str, Any]) -> TaskReviewResult:
             payload=task_payload,
         )
 
+    # Extract deterministic memory-write candidates from the payload.
+    candidates = extract_memory_candidates(task_payload)
+
     return TaskReviewResult(
         should_review_memory=should_memory,
         should_review_skills=should_skills,
         review_reasons=reasons,
         payload=task_payload,
+        memory_write_candidates=candidates,
     )
+
+
+# ---------------------------------------------------------------------------
+# Memory candidate extraction (conservative / deterministic)
+# ---------------------------------------------------------------------------
+
+_MEMORY_PREFIXES = (
+    "remember this:",
+    "remember that:",
+    "save this:",
+    "save that:",
+    "remember this",
+    "remember that",
+    "save this",
+    "save that",
+)
+
+
+def _strip_memory_prefix(text: str) -> str:
+    """Strip common 'remember/save' prefixes from a user message.
+
+    Returns the remainder after stripping, or the original text if no
+    recognized prefix is found.
+    """
+    lower = text.lower().strip()
+    for prefix in _MEMORY_PREFIXES:
+        if lower.startswith(prefix):
+            remainder = text[len(prefix):].strip()
+            if remainder:
+                return remainder
+    return text
+
+
+def extract_memory_candidates(
+    task_payload: Dict[str, Any],
+) -> List[MemoryWriteCandidate]:
+    """Extract deterministic memory-write candidates from a task payload.
+
+    Conservative by design — only produces candidates when there is clear,
+    unambiguous signal in the payload.  Prefers no-write over speculative
+    write.
+
+    Returns:
+        A (possibly empty) list of :class:`MemoryWriteCandidate`.
+    """
+    if not task_payload:
+        return []
+
+    candidates: List[MemoryWriteCandidate] = []
+    trigger_reasons: List[str] = task_payload.get("trigger_reasons") or []
+
+    # ── Explicit memory request ──────────────────────────────────────────
+    # The user said "remember this" / "save that" — persist the user's own
+    # statement as a user fact.  We strip the command prefix so the stored
+    # entry reads naturally.
+    if "explicit_memory_request" in trigger_reasons:
+        user_msg = (task_payload.get("original_user_message") or "").strip()
+        if user_msg:
+            content = _strip_memory_prefix(user_msg)
+            if content:
+                candidates.append(MemoryWriteCandidate(
+                    category="user_facts",
+                    content=content,
+                    source="explicit_memory_request",
+                ))
+
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Centralized memory writeback
+# ---------------------------------------------------------------------------
+
+def _content_key(category: str, content: str) -> str:
+    """Produce a normalized key for same-turn duplicate detection."""
+    return f"{category}:{content.strip().lower()}"
+
+
+def apply_memory_writeback(
+    candidates: List[MemoryWriteCandidate],
+    memory_store: Any,
+    *,
+    written_keys: Optional[Set[str]] = None,
+) -> List[MemoryWriteCandidate]:
+    """Route classified candidates to the built-in memory store.
+
+    Deterministic routing:
+    - ``user_facts``        → ``memory_store.add("user", ...)``
+    - ``environment_facts`` → ``memory_store.add("memory", ...)``
+    - ``workflow_facts``    → ``memory_store.add("memory", ...)``
+    - ``ignore``            → no write
+
+    Duplicate suppression: normalizes ``(category, content)`` into a key
+    and skips any candidate whose key already appears in *written_keys*.
+    New writes are added to *written_keys* in place so the caller can
+    accumulate across multiple calls within the same turn.
+
+    Args:
+        candidates: Classified memory-write candidates.
+        memory_store: A ``MemoryStore`` instance (or compatible object with
+            an ``add(target, content)`` method returning a dict with a
+            ``"success"`` key).
+        written_keys: Mutable set for cross-call duplicate suppression.
+            Created internally if ``None``.
+
+    Returns:
+        The subset of *candidates* that were successfully written.
+    """
+    if not candidates or memory_store is None:
+        return []
+
+    if written_keys is None:
+        written_keys = set()
+
+    written: List[MemoryWriteCandidate] = []
+    for candidate in candidates:
+        # Skip ignored or unrecognized categories.
+        if candidate.category not in _CATEGORY_TO_TARGET:
+            continue
+
+        # Same-turn duplicate suppression.
+        key = _content_key(candidate.category, candidate.content)
+        if key in written_keys:
+            logger.debug("Duplicate suppressed for key: %s", key)
+            continue
+
+        target = _CATEGORY_TO_TARGET[candidate.category]
+        try:
+            result = memory_store.add(target, candidate.content)
+        except Exception:
+            logger.debug(
+                "memory_store.add(%s) raised for category=%s",
+                target, candidate.category, exc_info=True,
+            )
+            continue
+
+        if result.get("success"):
+            written_keys.add(key)
+            written.append(candidate)
+            logger.debug(
+                "Memory writeback: %s → %s (%s)",
+                candidate.category, target, candidate.source,
+            )
+        else:
+            logger.debug(
+                "Memory writeback skipped for %s: %s",
+                candidate.category, result.get("error", "unknown"),
+            )
+
+    return written

--- a/agent/task_review.py
+++ b/agent/task_review.py
@@ -1,0 +1,92 @@
+"""Structured review engine for completed tasks.
+
+Analyzes a task-completion payload and produces a typed review result
+indicating what follow-up actions (memory save, skill save) are warranted.
+The actual writeback is handled separately — this module only decides *what*
+to review.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TaskReviewResult:
+    """Typed, immutable result from reviewing a completed task.
+
+    Attributes:
+        should_review_memory: Whether the task warrants a memory review pass.
+        should_review_skills: Whether the task warrants a skill review pass.
+        review_reasons: Human-readable reasons explaining why review is needed.
+        payload: The original task-completion payload (kept for downstream use).
+    """
+
+    should_review_memory: bool
+    should_review_skills: bool
+    review_reasons: List[str]
+    payload: Dict[str, Any]
+
+
+def review_completed_task(task_payload: Dict[str, Any]) -> TaskReviewResult:
+    """Analyze a completed-task payload and return a structured review result.
+
+    This is a pure function — it reads the payload and produces a decision
+    without side effects.  The caller decides what to do with the result.
+
+    Args:
+        task_payload: Dict produced by ``AIAgent._build_task_completion_payload``.
+
+    Returns:
+        A :class:`TaskReviewResult` with review recommendations.
+
+    Raises:
+        ValueError: If ``task_payload`` is ``None`` or missing required keys.
+    """
+    if not task_payload:
+        raise ValueError("task_payload must be a non-empty dict")
+
+    trigger_reasons: List[str] = task_payload.get("trigger_reasons") or []
+    tools_used: List[str] = task_payload.get("tools_used") or []
+
+    reasons: List[str] = []
+    should_memory = False
+    should_skills = False
+
+    # Explicit memory request from user always triggers memory review.
+    if "explicit_memory_request" in trigger_reasons:
+        should_memory = True
+        reasons.append("user explicitly asked to remember/save")
+
+    # Tool use indicates a non-trivial task — worth checking for skill patterns
+    # and also for memory-worthy context (user preferences revealed during work).
+    if "tool_used" in trigger_reasons:
+        should_skills = True
+        reasons.append("tools were used during the task")
+
+        # Memory-specific tools hint that the user interacted with their
+        # knowledge store — review for additional memory-worthy content.
+        _memory_tools = {"memory", "memory_manage", "user_profile"}
+        if _memory_tools & set(tools_used):
+            should_memory = True
+            reasons.append("memory/profile tools were invoked")
+
+    # If we have no reasons at all, nothing to review.
+    if not reasons:
+        return TaskReviewResult(
+            should_review_memory=False,
+            should_review_skills=False,
+            review_reasons=[],
+            payload=task_payload,
+        )
+
+    return TaskReviewResult(
+        should_review_memory=should_memory,
+        should_review_skills=should_skills,
+        review_reasons=reasons,
+        payload=task_payload,
+    )

--- a/agent/task_review.py
+++ b/agent/task_review.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -218,6 +218,7 @@ def apply_memory_writeback(
     memory_store: Any,
     *,
     written_keys: Optional[Set[str]] = None,
+    on_write: Optional[Callable[[str, str, str], None]] = None,
 ) -> List[MemoryWriteCandidate]:
     """Route classified candidates to the built-in memory store.
 
@@ -239,6 +240,9 @@ def apply_memory_writeback(
             ``"success"`` key).
         written_keys: Mutable set for cross-call duplicate suppression.
             Created internally if ``None``.
+        on_write: Optional callback invoked after each successful write
+            with ``(action, target, content)`` — used to notify external
+            memory providers (e.g. Mem0) so they can curate their store.
 
     Returns:
         The subset of *candidates* that were successfully written.
@@ -278,6 +282,14 @@ def apply_memory_writeback(
                 "Memory writeback: %s → %s (%s)",
                 candidate.category, target, candidate.source,
             )
+            if on_write:
+                try:
+                    on_write("add", target, candidate.content)
+                except Exception:
+                    logger.debug(
+                        "on_write callback failed for %s",
+                        candidate.category, exc_info=True,
+                    )
         else:
             logger.debug(
                 "Memory writeback skipped for %s: %s",

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -14,6 +14,7 @@ Events:
   - agent:start         -- Agent begins processing a message
   - agent:step          -- Each turn in the tool-calling loop
   - agent:end           -- Agent finishes processing
+  - agent:task_complete -- A substantial task finished and produced a review payload
   - command:*           -- Any slash command executed (wildcard match)
 
 Errors in hooks are caught and logged but never block the main pipeline.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2976,6 +2976,14 @@ class GatewayRunner:
                 **hook_ctx,
                 "response": (response or "")[:500],
             })
+
+            task_payload = agent_result.get("task_completion_payload")
+            if task_payload:
+                await self.hooks.emit("agent:task_complete", {
+                    **hook_ctx,
+                    "response": (response or "")[:500],
+                    "task_payload": task_payload,
+                })
             
             # Check for pending process watchers (check_interval on background processes)
             try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -61,6 +61,7 @@ VALID_HOOKS: Set[str] = {
     "post_api_request",
     "on_session_start",
     "on_session_end",
+    "on_task_complete",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -28,6 +28,15 @@ Config file: `$HERMES_HOME/mem0.json`
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `true` | Enable reranking for recall |
+| `top_k` / `topK` | `3` | Max memories returned by automatic pre-turn recall |
+| `search_threshold` / `searchThreshold` | `0.5` | Minimum score for automatic recall filtering when scores are present |
+| `auto_capture` / `autoCapture` | `false` | Automatically capture each completed turn into Mem0 |
+| `auto_recall` / `autoRecall` | `true` | Automatically recall relevant memories before each turn |
+
+Notes:
+- `top_k` / `search_threshold` apply to automatic prefetch recall, not manual `mem0_search` calls.
+- `search_threshold` only filters results that include a score; results without scores are preserved.
+- `auto_capture: false` is useful on the Hobby plan when you want to rely on explicit memory tools instead of per-turn ingestion.
 
 ## Tools
 

--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -33,6 +33,8 @@ Config file: `$HERMES_HOME/mem0.json`
 
 | Tool | Description |
 |------|-------------|
-| `mem0_profile` | All stored memories about the user |
-| `mem0_search` | Semantic search with optional reranking |
+| `mem0_profile` | All stored memories about the user, including memory IDs for curation |
+| `mem0_search` | Semantic search with optional reranking, returning memory IDs |
 | `mem0_conclude` | Store a fact verbatim (no LLM extraction) |
+| `mem0_update` | Update an existing memory by ID |
+| `mem0_delete` | Delete an existing memory by ID |

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -46,13 +46,52 @@ _CURATE_DELETE_THRESHOLD = 0.85
 # Config
 # ---------------------------------------------------------------------------
 
+_CAMEL_TO_SNAKE = {
+    "topK": "top_k",
+    "searchThreshold": "search_threshold",
+    "autoCapture": "auto_capture",
+    "autoRecall": "auto_recall",
+}
+
+
 def _normalize_config_values(config: dict) -> dict:
-    """Normalize bool-ish fields loaded from env/setup prompts into booleans."""
+    """Normalize bool-ish fields and camelCase aliases into canonical snake_case."""
     normalized = dict(config)
+
+    # Accept camelCase aliases from config — map to snake_case canonical keys.
+    # Important: base defaults may already contain snake_case keys, so precedence
+    # must be decided from the *incoming* config rather than the copied dict.
+    for camel, snake in _CAMEL_TO_SNAKE.items():
+        incoming_has_snake = snake in config
+        if camel in normalized and not incoming_has_snake:
+            normalized[snake] = normalized.pop(camel)
+        elif camel in normalized:
+            normalized.pop(camel)  # explicit snake_case input takes precedence
+
+    # Boolean coercion
     normalized["rerank"] = is_truthy_value(normalized.get("rerank"), default=True)
     normalized["keyword_search"] = is_truthy_value(
         normalized.get("keyword_search"), default=False
     )
+    normalized["auto_capture"] = is_truthy_value(
+        normalized.get("auto_capture"), default=False
+    )
+    normalized["auto_recall"] = is_truthy_value(
+        normalized.get("auto_recall"), default=True
+    )
+
+    # Numeric coercion with bounds
+    try:
+        normalized["top_k"] = max(1, min(int(normalized.get("top_k", 3)), 50))
+    except (TypeError, ValueError):
+        normalized["top_k"] = 3
+    try:
+        normalized["search_threshold"] = max(
+            0.0, min(float(normalized.get("search_threshold", 0.5)), 1.0)
+        )
+    except (TypeError, ValueError):
+        normalized["search_threshold"] = 0.5
+
     return normalized
 
 
@@ -71,12 +110,23 @@ def _load_config() -> dict:
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "rerank": True,
         "keyword_search": False,
+        "top_k": 3,
+        "search_threshold": 0.5,
+        "auto_capture": False,
+        "auto_recall": True,
     }
 
     config_path = get_hermes_home() / "mem0.json"
     if config_path.exists():
         try:
             file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            # Canonicalize file-local aliases before merging onto defaults so a
+            # camelCase override can beat the built-in snake_case default.
+            for camel, snake in _CAMEL_TO_SNAKE.items():
+                if camel in file_cfg and snake not in file_cfg:
+                    file_cfg[snake] = file_cfg.pop(camel)
+                elif camel in file_cfg:
+                    file_cfg.pop(camel)
             config.update({k: v for k, v in file_cfg.items()
                            if v is not None and v != ""})
         except Exception:
@@ -176,6 +226,10 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = "hermes-user"
         self._agent_id = "hermes"
         self._rerank = True
+        self._top_k = 3
+        self._search_threshold = 0.5
+        self._auto_capture = False
+        self._auto_recall = True
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
@@ -213,6 +267,10 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
+            {"key": "top_k", "description": "Max memories returned by auto-recall prefetch (1-50)", "default": "3"},
+            {"key": "search_threshold", "description": "Min similarity score for auto-recall filtering (0.0-1.0). Only applied when scores are present.", "default": "0.5"},
+            {"key": "auto_capture", "description": "Automatically capture facts from each turn (sync_turn). Disable to save API usage on hobby plans.", "default": "false", "choices": ["true", "false"]},
+            {"key": "auto_recall", "description": "Automatically recall relevant memories before each turn (prefetch). Disable to use manual mem0_search only.", "default": "true", "choices": ["true", "false"]},
         ]
 
     def _get_client(self):
@@ -258,6 +316,10 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
         self._agent_id = self._config.get("agent_id", "hermes")
         self._rerank = self._config.get("rerank", True)
+        self._top_k = self._config.get("top_k", 3)
+        self._search_threshold = self._config.get("search_threshold", 0.5)
+        self._auto_capture = self._config.get("auto_capture", False)
+        self._auto_recall = self._config.get("auto_recall", True)
 
     def _read_filters(self) -> Dict[str, Any]:
         """Filters for search/get_all — scoped to user only for cross-session recall."""
@@ -299,7 +361,21 @@ class Mem0MemoryProvider(MemoryProvider):
             return ""
         return f"## Mem0 Memory\n{result}"
 
+    def _filter_by_threshold(self, results: list) -> list:
+        """Drop results below search_threshold when scores are present.
+
+        If a result has no ``score`` key, it passes through — we never invent
+        scores or discard results that simply lack scoring metadata.
+        """
+        threshold = self._search_threshold
+        return [
+            r for r in results
+            if "score" not in r or r["score"] >= threshold
+        ]
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not self._auto_recall:
+            return
         if self._is_breaker_open():
             return
 
@@ -310,8 +386,9 @@ class Mem0MemoryProvider(MemoryProvider):
                     query=query,
                     filters=self._read_filters(),
                     rerank=self._rerank,
-                    top_k=5,
+                    top_k=self._top_k,
                 ))
+                results = self._filter_by_threshold(results)
                 if results:
                     lines = [r.get("memory", "") for r in results if r.get("memory")]
                     with self._prefetch_lock:
@@ -326,6 +403,8 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
+        if not self._auto_capture:
+            return
         if self._is_breaker_open():
             return
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,16 @@ _BREAKER_COOLDOWN_SECS = 120
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
+
+def _normalize_config_values(config: dict) -> dict:
+    """Normalize bool-ish fields loaded from env/setup prompts into booleans."""
+    normalized = dict(config)
+    normalized["rerank"] = is_truthy_value(normalized.get("rerank"), default=True)
+    normalized["keyword_search"] = is_truthy_value(
+        normalized.get("keyword_search"), default=False
+    )
+    return normalized
+
 
 def _load_config() -> dict:
     """Load config from env vars, with $HERMES_HOME/mem0.json overrides.
@@ -63,7 +74,7 @@ def _load_config() -> dict:
         except Exception:
             pass
 
-    return config
+    return _normalize_config_values(config)
 
 
 # ---------------------------------------------------------------------------
@@ -111,6 +122,36 @@ CONCLUDE_SCHEMA = {
     },
 }
 
+UPDATE_SCHEMA = {
+    "name": "mem0_update",
+    "description": (
+        "Update an existing Mem0 memory by ID. Use this when a stored fact is wrong, stale, "
+        "or needs correction without keeping the old version."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "The Mem0 memory ID to update."},
+            "text": {"type": "string", "description": "The replacement memory text."},
+        },
+        "required": ["memory_id", "text"],
+    },
+}
+
+DELETE_SCHEMA = {
+    "name": "mem0_delete",
+    "description": (
+        "Delete an existing Mem0 memory by ID. Use this to remove wrong, duplicate, or stale memories."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "The Mem0 memory ID to delete."},
+        },
+        "required": ["memory_id"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
@@ -155,7 +196,7 @@ class Mem0MemoryProvider(MemoryProvider):
             except Exception:
                 pass
         existing.update(values)
-        config_path.write_text(json.dumps(existing, indent=2))
+        config_path.write_text(json.dumps(_normalize_config_values(existing), indent=2))
 
     def get_config_schema(self):
         return [
@@ -219,12 +260,17 @@ class Mem0MemoryProvider(MemoryProvider):
 
     @staticmethod
     def _unwrap_results(response: Any) -> list:
-        """Normalize Mem0 API response — v2 wraps results in {"results": [...]}."""
+        """Normalize Mem0 API response — v2 wraps results in {"results": [...]}"""
         if isinstance(response, dict):
             return response.get("results", [])
         if isinstance(response, list):
             return response
         return []
+
+    @staticmethod
+    def _memory_id(item: dict) -> str:
+        """Extract Mem0 memory ID across response variants."""
+        return str(item.get("id") or item.get("memory_id") or "")
 
     def system_prompt_block(self) -> str:
         return (
@@ -295,7 +341,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._sync_thread.start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [PROFILE_SCHEMA, SEARCH_SCHEMA, CONCLUDE_SCHEMA]
+        return [PROFILE_SCHEMA, SEARCH_SCHEMA, CONCLUDE_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if self._is_breaker_open():
@@ -314,8 +360,12 @@ class Mem0MemoryProvider(MemoryProvider):
                 self._record_success()
                 if not memories:
                     return json.dumps({"result": "No memories stored yet."})
-                lines = [m.get("memory", "") for m in memories if m.get("memory")]
-                return json.dumps({"result": "\n".join(lines), "count": len(lines)})
+                items = [
+                    {"id": self._memory_id(m), "memory": m.get("memory", "")}
+                    for m in memories if m.get("memory")
+                ]
+                lines = [item["memory"] for item in items]
+                return json.dumps({"result": "\n".join(lines), "count": len(items), "items": items})
             except Exception as e:
                 self._record_failure()
                 return tool_error(f"Failed to fetch profile: {e}")
@@ -336,7 +386,14 @@ class Mem0MemoryProvider(MemoryProvider):
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                items = [{"memory": r.get("memory", ""), "score": r.get("score", 0)} for r in results]
+                items = [
+                    {
+                        "id": self._memory_id(r),
+                        "memory": r.get("memory", ""),
+                        "score": r.get("score", 0),
+                    }
+                    for r in results
+                ]
                 return json.dumps({"results": items, "count": len(items)})
             except Exception as e:
                 self._record_failure()
@@ -357,6 +414,33 @@ class Mem0MemoryProvider(MemoryProvider):
             except Exception as e:
                 self._record_failure()
                 return tool_error(f"Failed to store: {e}")
+
+        elif tool_name == "mem0_update":
+            memory_id = str(args.get("memory_id", "")).strip()
+            text = str(args.get("text", "")).strip()
+            if not memory_id:
+                return tool_error("Missing required parameter: memory_id")
+            if not text:
+                return tool_error("Missing required parameter: text")
+            try:
+                client.update(memory_id=memory_id, text=text)
+                self._record_success()
+                return json.dumps({"result": "Memory updated.", "id": memory_id})
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"Failed to update: {e}")
+
+        elif tool_name == "mem0_delete":
+            memory_id = str(args.get("memory_id", "")).strip()
+            if not memory_id:
+                return tool_error("Missing required parameter: memory_id")
+            try:
+                client.delete(memory_id)
+                self._record_success()
+                return json.dumps({"result": "Memory deleted.", "id": memory_id})
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"Failed to delete: {e}")
 
         return tool_error(f"Unknown tool: {tool_name}")
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -33,6 +33,14 @@ logger = logging.getLogger(__name__)
 _BREAKER_THRESHOLD = 5
 _BREAKER_COOLDOWN_SECS = 120
 
+# Curation thresholds for on_memory_write deduplication.
+# When the built-in memory store writes a fact, we search Mem0 for similar
+# existing memories.  These thresholds determine how we act:
+#   UPDATE — best-match score >= this → update existing memory instead of adding
+_CURATE_UPDATE_THRESHOLD = 0.7
+#   DELETE — additional matches scoring >= this are treated as stale duplicates
+_CURATE_DELETE_THRESHOLD = 0.85
+
 
 # ---------------------------------------------------------------------------
 # Config
@@ -172,6 +180,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
         self._sync_thread = None
+        self._curate_thread = None
         # Circuit breaker state
         self._consecutive_failures = 0
         self._breaker_open_until = 0.0
@@ -444,8 +453,129 @@ class Mem0MemoryProvider(MemoryProvider):
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    # -- Curation: dedupe/update/delete on built-in memory writes ----------
+
+    def _curate_memory_write(self, content: str) -> Dict[str, Any]:
+        """Search Mem0 for similar facts and dedupe/update/conclude.
+
+        Synchronous — callers that need non-blocking behaviour should run
+        this in a background thread (see :meth:`on_memory_write`).
+
+        Returns a dict describing what happened::
+
+            {"action": "concluded"}           — new fact stored
+            {"action": "updated", "id": ...}  — existing memory updated
+            {"action": "skipped"}             — exact duplicate, no-op
+            {"action": "failed", ...}         — error (logged, non-fatal)
+
+        Extra key ``deleted_ids`` lists any stale duplicates removed.
+        """
+        try:
+            client = self._get_client()
+        except Exception as exc:
+            return {"action": "failed", "error": str(exc)}
+
+        try:
+            results = self._unwrap_results(client.search(
+                query=content,
+                filters=self._read_filters(),
+                rerank=True,
+                top_k=3,
+            ))
+        except Exception as exc:
+            self._record_failure()
+            return {"action": "failed", "error": str(exc)}
+
+        deleted_ids: list = []
+
+        if not results:
+            # No existing memories — store as new fact.
+            try:
+                client.add(
+                    [{"role": "user", "content": content}],
+                    **self._write_filters(),
+                    infer=False,
+                )
+                self._record_success()
+                return {"action": "concluded"}
+            except Exception as exc:
+                self._record_failure()
+                return {"action": "failed", "error": str(exc)}
+
+        best = results[0]
+        best_score = best.get("score", 0)
+        best_id = self._memory_id(best)
+        best_text = best.get("memory", "")
+
+        if best_score >= _CURATE_UPDATE_THRESHOLD and best_id:
+            # High similarity — same semantic fact.
+            if best_text.strip().lower() == content.strip().lower():
+                # Exact duplicate — nothing to do.
+                self._record_success()
+                return {"action": "skipped", "deleted_ids": deleted_ids}
+
+            # Reworded/corrected — update the existing memory.
+            try:
+                client.update(memory_id=best_id, text=content)
+            except Exception as exc:
+                self._record_failure()
+                return {"action": "failed", "error": str(exc)}
+
+            # Clean up additional near-duplicates beyond the primary match.
+            for extra in results[1:]:
+                extra_score = extra.get("score", 0)
+                extra_id = self._memory_id(extra)
+                if (extra_score >= _CURATE_DELETE_THRESHOLD
+                        and extra_id
+                        and extra_id != best_id):
+                    try:
+                        client.delete(extra_id)
+                        deleted_ids.append(extra_id)
+                    except Exception:
+                        logger.debug(
+                            "Mem0 curate: failed to delete stale duplicate %s",
+                            extra_id,
+                        )
+
+            self._record_success()
+            return {"action": "updated", "id": best_id, "deleted_ids": deleted_ids}
+
+        # No strong match — store as genuinely new fact.
+        try:
+            client.add(
+                [{"role": "user", "content": content}],
+                **self._write_filters(),
+                infer=False,
+            )
+            self._record_success()
+            return {"action": "concluded"}
+        except Exception as exc:
+            self._record_failure()
+            return {"action": "failed", "error": str(exc)}
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Curate Mem0 state when the built-in memory store writes.
+
+        Searches for semantically similar existing memories and prefers
+        updating or deleting stale entries over appending duplicates.
+        Runs in a background thread so the main loop is never blocked.
+        """
+        if not content or action not in ("add", "replace"):
+            return
+        if self._is_breaker_open():
+            return
+
+        def _run():
+            result = self._curate_memory_write(content)
+            logger.debug("Mem0 curate result: %s", result)
+
+        self._curate_thread = threading.Thread(
+            target=_run, daemon=True, name="mem0-curate",
+        )
+        self._curate_thread.start()
+
     def shutdown(self) -> None:
-        for t in (self._prefetch_thread, self._sync_thread):
+        for t in (self._prefetch_thread, self._sync_thread, self._curate_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
         with self._client_lock:

--- a/run_agent.py
+++ b/run_agent.py
@@ -9176,10 +9176,14 @@ class AIAgent:
             completed=completed,
             interrupted=interrupted,
         )
-        # Track whether centralized writeback handled memory for this turn.
-        _centralized_memory_written = False
+        # Track whether the structured task-complete review ran this turn.
+        # When it fires, generic background nudge reviews are redundant —
+        # the task review already handles memory/skill decisions.
+        _task_review_ran = False
 
         if self._should_run_task_completion_review(task_completion_payload):
+            _task_review_ran = True
+            logger.debug("Task-complete review firing — will suppress generic background reviews")
             result["task_completion_payload"] = task_completion_payload
             try:
                 task_review = review_completed_task(task_completion_payload)
@@ -9204,7 +9208,6 @@ class AIAgent:
                         ),
                     )
                     if written:
-                        _centralized_memory_written = True
                         logger.debug(
                             "Centralized writeback wrote %d entries", len(written),
                         )
@@ -9241,11 +9244,21 @@ class AIAgent:
             except Exception:
                 pass
 
-        # If centralized writeback already handled memory for this turn,
-        # suppress the background LLM memory review to prevent near-duplicate
-        # entries.  Skill review is unaffected.
-        if _centralized_memory_written:
+        # If the structured task-complete review ran this turn, suppress
+        # both generic background memory AND skill reviews — the task review
+        # already made targeted decisions about what to persist.
+        if _task_review_ran:
+            logger.debug(
+                "Suppressing generic background reviews (memory=%s, skills=%s) — task review handled this turn",
+                _should_review_memory, _should_review_skills,
+            )
             _should_review_memory = False
+            _should_review_skills = False
+        else:
+            logger.debug(
+                "No task-complete review — generic reviews proceed (memory=%s, skills=%s)",
+                _should_review_memory, _should_review_skills,
+            )
 
         # Background memory/skill review — runs AFTER the response is delivered
         # so it never competes with the user's task for model attention.

--- a/run_agent.py
+++ b/run_agent.py
@@ -74,7 +74,7 @@ from tools.browser_tool import cleanup_browser
 from hermes_constants import OPENROUTER_BASE_URL
 
 # Agent internals extracted to agent/ package for modularity
-from agent.memory_manager import build_memory_context_block
+from agent.memory_manager import build_memory_context_block, load_recall_artifact
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
@@ -97,7 +97,12 @@ from agent.display import (
     _detect_tool_failure,
     get_tool_emoji as _get_tool_emoji,
 )
-from agent.task_review import apply_memory_writeback, review_completed_task
+from agent.task_review import (
+    apply_memory_writeback,
+    generate_recall_artifact,
+    review_completed_task,
+    write_recall_artifact,
+)
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
@@ -7171,6 +7176,16 @@ class AIAgent:
             except Exception:
                 pass
 
+        try:
+            _recall_artifact = load_recall_artifact(_hermes_home / "memories")
+            if _recall_artifact:
+                _ext_prefetch_cache = (
+                    f"{_recall_artifact}\n\n{_ext_prefetch_cache}"
+                    if _ext_prefetch_cache else _recall_artifact
+                )
+        except Exception:
+            pass
+
         while api_call_count < self.max_iterations and self.iteration_budget.remaining > 0:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
@@ -9169,6 +9184,13 @@ class AIAgent:
             try:
                 task_review = review_completed_task(task_completion_payload)
                 result["task_review"] = task_review
+
+                try:
+                    _artifact = generate_recall_artifact(task_completion_payload, task_review)
+                    if _artifact:
+                        write_recall_artifact(_artifact, _hermes_home / "memories")
+                except Exception:
+                    logger.debug("recall artifact generation failed", exc_info=True)
 
                 # Centralized memory writeback — deterministic, runs before
                 # the background LLM review to prevent duplicate writes.

--- a/run_agent.py
+++ b/run_agent.py
@@ -97,7 +97,7 @@ from agent.display import (
     _detect_tool_failure,
     get_tool_emoji as _get_tool_emoji,
 )
-from agent.task_review import review_completed_task
+from agent.task_review import apply_memory_writeback, review_completed_task
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
@@ -9161,19 +9161,36 @@ class AIAgent:
             completed=completed,
             interrupted=interrupted,
         )
+        # Track whether centralized writeback handled memory for this turn.
+        _centralized_memory_written = False
+
         if self._should_run_task_completion_review(task_completion_payload):
             result["task_completion_payload"] = task_completion_payload
             try:
-                result["task_review"] = review_completed_task(task_completion_payload)
+                task_review = review_completed_task(task_completion_payload)
+                result["task_review"] = task_review
+
+                # Centralized memory writeback — deterministic, runs before
+                # the background LLM review to prevent duplicate writes.
+                if task_review.memory_write_candidates and self._memory_store:
+                    written = apply_memory_writeback(
+                        task_review.memory_write_candidates,
+                        self._memory_store,
+                    )
+                    if written:
+                        _centralized_memory_written = True
+                        logger.debug(
+                            "Centralized writeback wrote %d entries", len(written),
+                        )
             except Exception:
                 logger.debug("task review engine failed", exc_info=True)
 
         self._response_was_previewed = False
-        
+
         # Include interrupt message if one triggered the interrupt
         if interrupted and self._interrupt_message:
             result["interrupt_message"] = self._interrupt_message
-        
+
         # Clear interrupt state after handling
         self.clear_interrupt()
 
@@ -9197,6 +9214,12 @@ class AIAgent:
                 self._memory_manager.queue_prefetch_all(original_user_message)
             except Exception:
                 pass
+
+        # If centralized writeback already handled memory for this turn,
+        # suppress the background LLM memory review to prevent near-duplicate
+        # entries.  Skill review is unaffected.
+        if _centralized_memory_written:
+            _should_review_memory = False
 
         # Background memory/skill review — runs AFTER the response is delivered
         # so it never competes with the user's task for model attention.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1848,6 +1848,67 @@ class AIAgent:
         t = threading.Thread(target=_run_review, daemon=True, name="bg-review")
         t.start()
 
+    def _build_task_completion_payload(
+        self,
+        *,
+        original_user_message: str,
+        final_response: str,
+        messages: List[Dict],
+        completed: bool,
+        interrupted: bool,
+    ) -> Dict[str, Any]:
+        """Build a compact, stable payload describing a completed task."""
+        tools_used = []
+        for msg in messages:
+            if msg.get("role") == "tool" and msg.get("tool_name"):
+                tools_used.append(msg["tool_name"])
+                continue
+            if msg.get("role") != "assistant":
+                continue
+            for tool_call in msg.get("tool_calls") or []:
+                try:
+                    tool_name = tool_call.get("function", {}).get("name")
+                except AttributeError:
+                    tool_name = None
+                if tool_name:
+                    tools_used.append(tool_name)
+        tools_used = list(dict.fromkeys(tools_used))
+
+        trigger_reasons = []
+        if tools_used:
+            trigger_reasons.append("tool_used")
+
+        user_lc = (original_user_message or "").lower()
+        if any(phrase in user_lc for phrase in (
+            "remember this",
+            "save this",
+            "remember that",
+            "save that",
+        )):
+            trigger_reasons.append("explicit_memory_request")
+
+        return {
+            "session_id": self.session_id,
+            "platform": getattr(self, "platform", None) or "",
+            "model": self.model,
+            "completed": bool(completed),
+            "interrupted": bool(interrupted),
+            "original_user_message": original_user_message or "",
+            "final_response": final_response or "",
+            "tool_call_count": len(tools_used),
+            "tools_used": tools_used,
+            "trigger_reasons": trigger_reasons,
+        }
+
+    def _should_run_task_completion_review(self, task_payload: Dict[str, Any]) -> bool:
+        """Return True when this turn looks like a meaningful completed task."""
+        return bool(
+            task_payload.get("completed")
+            and not task_payload.get("interrupted")
+            and task_payload.get("final_response")
+            and task_payload.get("trigger_reasons")
+        )
+
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
         """Rewrite the current-turn user message before persistence/return.
 
@@ -9089,7 +9150,19 @@ class AIAgent:
             "estimated_cost_usd": self.session_estimated_cost_usd,
             "cost_status": self.session_cost_status,
             "cost_source": self.session_cost_source,
+            "task_completion_payload": None,
         }
+
+        task_completion_payload = self._build_task_completion_payload(
+            original_user_message=original_user_message,
+            final_response=final_response,
+            messages=messages,
+            completed=completed,
+            interrupted=interrupted,
+        )
+        if self._should_run_task_completion_review(task_completion_payload):
+            result["task_completion_payload"] = task_completion_payload
+
         self._response_was_previewed = False
         
         # Include interrupt message if one triggered the interrupt
@@ -9131,6 +9204,21 @@ class AIAgent:
                 )
             except Exception:
                 pass  # Background review is best-effort
+
+        if result.get("task_completion_payload"):
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_task_complete",
+                    session_id=self.session_id,
+                    task_payload=result["task_completion_payload"],
+                    completed=completed,
+                    interrupted=interrupted,
+                    model=self.model,
+                    platform=getattr(self, "platform", None) or "",
+                )
+            except Exception as exc:
+                logger.warning("on_task_complete hook failed: %s", exc)
 
         # Note: Memory provider on_session_end() + shutdown_all() are NOT
         # called here — run_conversation() is called once per user message in

--- a/run_agent.py
+++ b/run_agent.py
@@ -9176,6 +9176,10 @@ class AIAgent:
                     written = apply_memory_writeback(
                         task_review.memory_write_candidates,
                         self._memory_store,
+                        on_write=(
+                            self._memory_manager.on_memory_write
+                            if self._memory_manager else None
+                        ),
                     )
                     if written:
                         _centralized_memory_written = True

--- a/run_agent.py
+++ b/run_agent.py
@@ -97,6 +97,7 @@ from agent.display import (
     _detect_tool_failure,
     get_tool_emoji as _get_tool_emoji,
 )
+from agent.task_review import review_completed_task
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
@@ -9162,6 +9163,10 @@ class AIAgent:
         )
         if self._should_run_task_completion_review(task_completion_payload):
             result["task_completion_payload"] = task_completion_payload
+            try:
+                result["task_review"] = review_completed_task(task_completion_payload)
+            except Exception:
+                logger.debug("task review engine failed", exc_info=True)
 
         self._response_was_previewed = False
         

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,6 +1,7 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
+from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -848,3 +849,56 @@ class TestMemoryContextFencing:
         fence_end = combined.index("</memory-context>")
         assert "Alice" in combined[fence_start:fence_end]
         assert combined.index("weather") < fence_start
+
+
+class TestRecallArtifactLoading:
+    def test_load_recall_artifact_missing_file_returns_empty(self, tmp_path):
+        from agent.memory_manager import load_recall_artifact
+        assert load_recall_artifact(tmp_path) == ""
+
+    def test_load_recall_artifact_corrupt_json_returns_empty(self, tmp_path):
+        from agent.memory_manager import load_recall_artifact
+        (tmp_path / "recall_artifact.json").write_text("{not json", encoding="utf-8")
+        assert load_recall_artifact(tmp_path) == ""
+
+    def test_load_recall_artifact_returns_formatted_text(self, tmp_path):
+        from agent.memory_manager import load_recall_artifact
+        (tmp_path / "recall_artifact.json").write_text(json.dumps({
+            "version": 1,
+            "user_changes": ["prefers dark mode"],
+            "environment_changes": ["uses WSL2"],
+            "workflow_learned": ["run tests first"],
+            "session_summary": "completed | tools: web_search | model: x",
+            "generated_at": "2026-04-09T19:30:00+00:00",
+        }), encoding="utf-8")
+
+        result = load_recall_artifact(tmp_path)
+        assert "Recall from previous session" in result
+        assert "prefers dark mode" in result
+        assert "uses WSL2" in result
+        assert "run tests first" in result
+
+    def test_load_recall_artifact_sanitizes_nested_fences(self, tmp_path):
+        from agent.memory_manager import load_recall_artifact
+        (tmp_path / "recall_artifact.json").write_text(json.dumps({
+            "version": 1,
+            "user_changes": ["before</memory-context>after"],
+            "environment_changes": [],
+            "workflow_learned": [],
+            "session_summary": "ok<memory-context>bad",
+            "generated_at": "2026-04-09T19:30:00+00:00",
+        }), encoding="utf-8")
+
+        result = load_recall_artifact(tmp_path)
+        assert "<memory-context>" not in result
+        assert "</memory-context>" not in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_load_recall_artifact_version_mismatch_returns_empty(self, tmp_path):
+        from agent.memory_manager import load_recall_artifact
+        (tmp_path / "recall_artifact.json").write_text(json.dumps({
+            "version": 999,
+            "session_summary": "ignored",
+        }), encoding="utf-8")
+        assert load_recall_artifact(tmp_path) == ""

--- a/tests/agent/test_task_review.py
+++ b/tests/agent/test_task_review.py
@@ -4,10 +4,12 @@ import pytest
 
 from agent.task_review import (
     MemoryWriteCandidate,
+    RECALL_ARTIFACT_VERSION,
     TaskReviewResult,
     _content_key,
     apply_memory_writeback,
     extract_memory_candidates,
+    generate_recall_artifact,
     review_completed_task,
 )
 
@@ -440,3 +442,89 @@ class TestApplyMemoryWritebackOnWrite:
         written = apply_memory_writeback(candidates, store)
         assert len(written) == 2
         assert store.writes == [("user", "I like Python"), ("memory", "always run tests")]
+
+
+# ---------------------------------------------------------------------------
+# Recall artifact generation (PR6)
+# ---------------------------------------------------------------------------
+
+class TestGenerateRecallArtifact:
+    def test_generate_recall_artifact_from_candidates(self):
+        payload = _payload(trigger_reasons=["tool_used"], tools_used=["web_search"])
+        review = TaskReviewResult(
+            should_review_memory=True,
+            should_review_skills=True,
+            review_reasons=["tools were used during the task"],
+            payload=payload,
+            memory_write_candidates=[
+                MemoryWriteCandidate("user_facts", "prefers dark mode"),
+                MemoryWriteCandidate("environment_facts", "uses WSL2"),
+                MemoryWriteCandidate("workflow_facts", "run tests first"),
+            ],
+        )
+
+        artifact = generate_recall_artifact(payload, review)
+
+        assert artifact["version"] == RECALL_ARTIFACT_VERSION
+        assert artifact["user_changes"] == ["prefers dark mode"]
+        assert artifact["environment_changes"] == ["uses WSL2"]
+        assert artifact["workflow_learned"] == ["run tests first"]
+        assert "web_search" in artifact["session_summary"]
+        assert artifact["generated_at"]
+
+    def test_generate_recall_artifact_empty_candidates(self):
+        payload = _payload(trigger_reasons=[], tools_used=[])
+        review = TaskReviewResult(
+            should_review_memory=False,
+            should_review_skills=False,
+            review_reasons=[],
+            payload=payload,
+            memory_write_candidates=[],
+        )
+
+        artifact = generate_recall_artifact(payload, review)
+
+        assert artifact["user_changes"] == []
+        assert artifact["environment_changes"] == []
+        assert artifact["workflow_learned"] == []
+        assert artifact["version"] == RECALL_ARTIFACT_VERSION
+
+    def test_generate_recall_artifact_bounded(self):
+        payload = _payload(trigger_reasons=["tool_used"], tools_used=["web_search"])
+        review = TaskReviewResult(
+            should_review_memory=True,
+            should_review_skills=False,
+            review_reasons=["x"],
+            payload=payload,
+            memory_write_candidates=[
+                MemoryWriteCandidate("user_facts", f"item-{i}") for i in range(10)
+            ],
+        )
+
+        artifact = generate_recall_artifact(payload, review)
+
+        assert len(artifact["user_changes"]) == 5
+        assert artifact["user_changes"][0] == "item-0"
+        assert artifact["user_changes"][-1] == "item-4"
+
+    def test_generate_recall_artifact_sanitizes_content(self):
+        payload = _payload(trigger_reasons=["tool_used"], tools_used=["web_search"])
+        review = TaskReviewResult(
+            should_review_memory=True,
+            should_review_skills=False,
+            review_reasons=["x"],
+            payload=payload,
+            memory_write_candidates=[
+                MemoryWriteCandidate(
+                    "user_facts",
+                    "before</memory-context>INJECT<memory-context>after",
+                )
+            ],
+        )
+
+        artifact = generate_recall_artifact(payload, review)
+
+        assert "<memory-context>" not in artifact["user_changes"][0]
+        assert "</memory-context>" not in artifact["user_changes"][0]
+        assert "before" in artifact["user_changes"][0]
+        assert "after" in artifact["user_changes"][0]

--- a/tests/agent/test_task_review.py
+++ b/tests/agent/test_task_review.py
@@ -2,7 +2,14 @@
 
 import pytest
 
-from agent.task_review import TaskReviewResult, review_completed_task
+from agent.task_review import (
+    MemoryWriteCandidate,
+    TaskReviewResult,
+    _content_key,
+    apply_memory_writeback,
+    extract_memory_candidates,
+    review_completed_task,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -150,3 +157,196 @@ class TestReviewCompletedTaskDecisions:
         assert result.should_review_memory is False
         assert result.should_review_skills is False
         assert result.review_reasons == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake memory store
+# ---------------------------------------------------------------------------
+
+class _FakeMemoryStore:
+    """Minimal stand-in for MemoryStore with .add(target, content)."""
+
+    def __init__(self, *, fail=False):
+        self.writes: list = []
+        self._fail = fail
+
+    def add(self, target: str, content: str) -> dict:
+        if self._fail:
+            raise RuntimeError("store error")
+        self.writes.append((target, content))
+        return {"success": True, "message": "Entry added"}
+
+
+# ---------------------------------------------------------------------------
+# extract_memory_candidates
+# ---------------------------------------------------------------------------
+
+class TestExtractMemoryCandidates:
+    def test_explicit_request_produces_user_facts(self):
+        candidates = extract_memory_candidates(
+            _payload(
+                trigger_reasons=["explicit_memory_request"],
+                original_user_message="remember this: I prefer dark mode",
+            )
+        )
+        assert len(candidates) == 1
+        assert candidates[0].category == "user_facts"
+        assert candidates[0].content == "I prefer dark mode"
+        assert candidates[0].source == "explicit_memory_request"
+
+    def test_no_explicit_request_returns_empty(self):
+        candidates = extract_memory_candidates(
+            _payload(trigger_reasons=["tool_used"], tools_used=["web_search"])
+        )
+        assert candidates == []
+
+    def test_empty_payload_returns_empty(self):
+        assert extract_memory_candidates({}) == []
+
+    def test_none_payload_returns_empty(self):
+        assert extract_memory_candidates(None) == []
+
+
+# ---------------------------------------------------------------------------
+# _content_key
+# ---------------------------------------------------------------------------
+
+class TestContentKey:
+    def test_normalizes_case_and_whitespace(self):
+        assert _content_key("user_facts", "  Hello World  ") == "user_facts:hello world"
+
+    def test_different_categories_produce_different_keys(self):
+        assert _content_key("user_facts", "x") != _content_key("workflow_facts", "x")
+
+    def test_identical_inputs_produce_same_key(self):
+        assert _content_key("user_facts", "foo") == _content_key("user_facts", "foo")
+
+
+# ---------------------------------------------------------------------------
+# apply_memory_writeback — write routing
+# ---------------------------------------------------------------------------
+
+class TestApplyMemoryWritebackRouting:
+    def test_user_facts_route_to_user_target(self):
+        store = _FakeMemoryStore()
+        candidates = [MemoryWriteCandidate("user_facts", "likes dark mode")]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 1
+        assert store.writes == [("user", "likes dark mode")]
+
+    def test_environment_facts_route_to_memory_target(self):
+        store = _FakeMemoryStore()
+        candidates = [MemoryWriteCandidate("environment_facts", "uses WSL2")]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 1
+        assert store.writes == [("memory", "uses WSL2")]
+
+    def test_workflow_facts_route_to_memory_target(self):
+        store = _FakeMemoryStore()
+        candidates = [MemoryWriteCandidate("workflow_facts", "prefers TDD")]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 1
+        assert store.writes == [("memory", "prefers TDD")]
+
+    def test_ignore_category_produces_no_write(self):
+        store = _FakeMemoryStore()
+        candidates = [MemoryWriteCandidate("ignore", "transient info")]
+        written = apply_memory_writeback(candidates, store)
+        assert written == []
+        assert store.writes == []
+
+    def test_empty_candidates_returns_empty(self):
+        store = _FakeMemoryStore()
+        assert apply_memory_writeback([], store) == []
+
+    def test_none_store_returns_empty(self):
+        candidates = [MemoryWriteCandidate("user_facts", "x")]
+        assert apply_memory_writeback(candidates, None) == []
+
+    def test_store_exception_skips_candidate(self):
+        store = _FakeMemoryStore(fail=True)
+        candidates = [MemoryWriteCandidate("user_facts", "x")]
+        written = apply_memory_writeback(candidates, store)
+        assert written == []
+
+    def test_store_failure_response_skips_candidate(self):
+        """Store returns {success: False} — candidate is not counted as written."""
+        store = _FakeMemoryStore()
+        store.add = lambda t, c: {"success": False, "error": "limit reached"}
+        candidates = [MemoryWriteCandidate("user_facts", "x")]
+        written = apply_memory_writeback(candidates, store)
+        assert written == []
+
+
+# ---------------------------------------------------------------------------
+# apply_memory_writeback — duplicate suppression
+# ---------------------------------------------------------------------------
+
+class TestApplyMemoryWritebackDedup:
+    def test_exact_duplicate_suppressed(self):
+        store = _FakeMemoryStore()
+        candidates = [
+            MemoryWriteCandidate("user_facts", "likes dark mode"),
+            MemoryWriteCandidate("user_facts", "likes dark mode"),
+        ]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 1
+        assert len(store.writes) == 1
+
+    def test_case_insensitive_duplicate_suppressed(self):
+        store = _FakeMemoryStore()
+        candidates = [
+            MemoryWriteCandidate("user_facts", "Likes Dark Mode"),
+            MemoryWriteCandidate("user_facts", "likes dark mode"),
+        ]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 1
+
+    def test_whitespace_normalized_duplicate_suppressed(self):
+        store = _FakeMemoryStore()
+        candidates = [
+            MemoryWriteCandidate("user_facts", "  likes dark mode  "),
+            MemoryWriteCandidate("user_facts", "likes dark mode"),
+        ]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 1
+
+    def test_different_categories_not_treated_as_duplicates(self):
+        store = _FakeMemoryStore()
+        candidates = [
+            MemoryWriteCandidate("user_facts", "foo"),
+            MemoryWriteCandidate("workflow_facts", "foo"),
+        ]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 2
+        assert len(store.writes) == 2
+
+    def test_written_keys_accumulate_across_calls(self):
+        store = _FakeMemoryStore()
+        shared_keys: set = set()
+
+        # First call writes one entry.
+        written1 = apply_memory_writeback(
+            [MemoryWriteCandidate("user_facts", "x")],
+            store,
+            written_keys=shared_keys,
+        )
+        assert len(written1) == 1
+
+        # Second call with the same content is suppressed.
+        written2 = apply_memory_writeback(
+            [MemoryWriteCandidate("user_facts", "x")],
+            store,
+            written_keys=shared_keys,
+        )
+        assert len(written2) == 0
+        # Store received only one write total.
+        assert len(store.writes) == 1
+
+    def test_pre_populated_keys_suppress_matching_candidate(self):
+        store = _FakeMemoryStore()
+        pre_keys = {_content_key("user_facts", "existing")}
+        candidates = [MemoryWriteCandidate("user_facts", "existing")]
+        written = apply_memory_writeback(candidates, store, written_keys=pre_keys)
+        assert written == []
+        assert store.writes == []

--- a/tests/agent/test_task_review.py
+++ b/tests/agent/test_task_review.py
@@ -350,3 +350,93 @@ class TestApplyMemoryWritebackDedup:
         written = apply_memory_writeback(candidates, store, written_keys=pre_keys)
         assert written == []
         assert store.writes == []
+
+
+# ---------------------------------------------------------------------------
+# apply_memory_writeback — on_write callback (PR5: external provider bridge)
+# ---------------------------------------------------------------------------
+
+class TestApplyMemoryWritebackOnWrite:
+    """Verify on_write callback is invoked for each successful write."""
+
+    def test_on_write_called_for_each_successful_write(self):
+        store = _FakeMemoryStore()
+        calls = []
+        candidates = [
+            MemoryWriteCandidate("user_facts", "fact one"),
+            MemoryWriteCandidate("environment_facts", "fact two"),
+        ]
+        written = apply_memory_writeback(
+            candidates, store, on_write=lambda a, t, c: calls.append((a, t, c)),
+        )
+        assert len(written) == 2
+        assert calls == [
+            ("add", "user", "fact one"),
+            ("add", "memory", "fact two"),
+        ]
+
+    def test_on_write_not_called_for_duplicates(self):
+        store = _FakeMemoryStore()
+        calls = []
+        candidates = [
+            MemoryWriteCandidate("user_facts", "same"),
+            MemoryWriteCandidate("user_facts", "same"),
+        ]
+        written = apply_memory_writeback(
+            candidates, store, on_write=lambda a, t, c: calls.append((a, t, c)),
+        )
+        assert len(written) == 1
+        assert len(calls) == 1
+
+    def test_on_write_not_called_for_ignored_category(self):
+        store = _FakeMemoryStore()
+        calls = []
+        candidates = [MemoryWriteCandidate("ignore", "transient")]
+        apply_memory_writeback(
+            candidates, store, on_write=lambda a, t, c: calls.append((a, t, c)),
+        )
+        assert calls == []
+
+    def test_on_write_failure_does_not_affect_return(self):
+        """Callback exception should not prevent the write from being counted."""
+        store = _FakeMemoryStore()
+
+        def _exploding_callback(action, target, content):
+            raise RuntimeError("callback boom")
+
+        candidates = [MemoryWriteCandidate("user_facts", "fact")]
+        written = apply_memory_writeback(
+            candidates, store, on_write=_exploding_callback,
+        )
+        # Write succeeded despite callback failure
+        assert len(written) == 1
+        assert len(store.writes) == 1
+
+    def test_on_write_not_called_when_store_fails(self):
+        """Callback should not fire when the store write itself fails."""
+        store = _FakeMemoryStore(fail=True)
+        calls = []
+        candidates = [MemoryWriteCandidate("user_facts", "fact")]
+        written = apply_memory_writeback(
+            candidates, store, on_write=lambda a, t, c: calls.append((a, t, c)),
+        )
+        assert written == []
+        assert calls == []
+
+    def test_none_on_write_is_safe(self):
+        """on_write=None (default) works without errors."""
+        store = _FakeMemoryStore()
+        candidates = [MemoryWriteCandidate("user_facts", "fact")]
+        written = apply_memory_writeback(candidates, store, on_write=None)
+        assert len(written) == 1
+
+    def test_builtin_memory_still_works_without_on_write(self):
+        """PR4 behaviour preserved: built-in writeback works without any callback."""
+        store = _FakeMemoryStore()
+        candidates = [
+            MemoryWriteCandidate("user_facts", "I like Python"),
+            MemoryWriteCandidate("workflow_facts", "always run tests"),
+        ]
+        written = apply_memory_writeback(candidates, store)
+        assert len(written) == 2
+        assert store.writes == [("user", "I like Python"), ("memory", "always run tests")]

--- a/tests/agent/test_task_review.py
+++ b/tests/agent/test_task_review.py
@@ -1,0 +1,152 @@
+"""Unit tests for agent.task_review — structured task-review engine."""
+
+import pytest
+
+from agent.task_review import TaskReviewResult, review_completed_task
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _payload(
+    *,
+    trigger_reasons=None,
+    tools_used=None,
+    completed=True,
+    interrupted=False,
+    final_response="Done",
+    original_user_message="do something",
+):
+    """Build a minimal task-completion payload dict for testing."""
+    return {
+        "session_id": "test-session",
+        "platform": "",
+        "model": "test/model",
+        "completed": completed,
+        "interrupted": interrupted,
+        "original_user_message": original_user_message,
+        "final_response": final_response,
+        "tool_call_count": len(tools_used or []),
+        "tools_used": tools_used or [],
+        "trigger_reasons": trigger_reasons or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# TaskReviewResult dataclass
+# ---------------------------------------------------------------------------
+
+class TestTaskReviewResult:
+    def test_is_frozen(self):
+        r = TaskReviewResult(
+            should_review_memory=False,
+            should_review_skills=False,
+            review_reasons=[],
+            payload={},
+        )
+        with pytest.raises(AttributeError):
+            r.should_review_memory = True  # type: ignore[misc]
+
+    def test_fields_accessible(self):
+        p = {"key": "val"}
+        r = TaskReviewResult(
+            should_review_memory=True,
+            should_review_skills=False,
+            review_reasons=["reason"],
+            payload=p,
+        )
+        assert r.should_review_memory is True
+        assert r.should_review_skills is False
+        assert r.review_reasons == ["reason"]
+        assert r.payload is p
+
+
+# ---------------------------------------------------------------------------
+# review_completed_task — input validation
+# ---------------------------------------------------------------------------
+
+class TestReviewCompletedTaskValidation:
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            review_completed_task(None)  # type: ignore[arg-type]
+
+    def test_empty_dict_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            review_completed_task({})
+
+
+# ---------------------------------------------------------------------------
+# review_completed_task — decision logic
+# ---------------------------------------------------------------------------
+
+class TestReviewCompletedTaskDecisions:
+    def test_no_triggers_returns_no_review(self):
+        result = review_completed_task(_payload(trigger_reasons=[]))
+        assert result.should_review_memory is False
+        assert result.should_review_skills is False
+        assert result.review_reasons == []
+
+    def test_tool_used_triggers_skill_review(self):
+        result = review_completed_task(
+            _payload(trigger_reasons=["tool_used"], tools_used=["web_search"])
+        )
+        assert result.should_review_skills is True
+        assert result.should_review_memory is False
+        assert any("tools were used" in r for r in result.review_reasons)
+
+    def test_explicit_memory_request_triggers_memory_review(self):
+        result = review_completed_task(
+            _payload(
+                trigger_reasons=["explicit_memory_request"],
+                original_user_message="remember this preference",
+            )
+        )
+        assert result.should_review_memory is True
+        assert result.should_review_skills is False
+        assert any("explicitly asked" in r for r in result.review_reasons)
+
+    def test_memory_tool_used_triggers_both(self):
+        result = review_completed_task(
+            _payload(
+                trigger_reasons=["tool_used"],
+                tools_used=["web_search", "memory"],
+            )
+        )
+        assert result.should_review_memory is True
+        assert result.should_review_skills is True
+        assert len(result.review_reasons) == 2
+
+    def test_user_profile_tool_triggers_memory(self):
+        result = review_completed_task(
+            _payload(
+                trigger_reasons=["tool_used"],
+                tools_used=["user_profile"],
+            )
+        )
+        assert result.should_review_memory is True
+        assert result.should_review_skills is True
+
+    def test_combined_triggers(self):
+        result = review_completed_task(
+            _payload(
+                trigger_reasons=["tool_used", "explicit_memory_request"],
+                tools_used=["code_editor"],
+            )
+        )
+        assert result.should_review_memory is True
+        assert result.should_review_skills is True
+        assert len(result.review_reasons) == 2
+
+    def test_payload_passthrough(self):
+        p = _payload(trigger_reasons=["tool_used"], tools_used=["web_search"])
+        result = review_completed_task(p)
+        assert result.payload is p
+
+    def test_unknown_trigger_reason_ignored(self):
+        result = review_completed_task(
+            _payload(trigger_reasons=["some_future_reason"])
+        )
+        assert result.should_review_memory is False
+        assert result.should_review_skills is False
+        assert result.review_reasons == []

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -112,6 +112,17 @@ class TestDiscoverAndLoad:
 
         assert len(reg.loaded_hooks) == 2
 
+    def test_loads_task_complete_hook(self, tmp_path):
+        _create_hook(tmp_path, "task-complete-hook", '["agent:task_complete"]',
+                      "def handle(event_type, context):\n    pass\n")
+
+        reg = HookRegistry()
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        assert len(reg.loaded_hooks) == 1
+        assert reg.loaded_hooks[0]["events"] == ["agent:task_complete"]
+
 
 class TestEmit:
     @pytest.mark.asyncio

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -13,6 +13,7 @@ from plugins.memory.mem0 import (
     _CURATE_DELETE_THRESHOLD,
     _CURATE_UPDATE_THRESHOLD,
     _load_config,
+    _normalize_config_values,
 )
 
 
@@ -61,6 +62,7 @@ class TestMem0FiltersV2:
         provider.initialize("test-session")
         provider._user_id = "u123"
         provider._agent_id = "hermes"
+        provider._auto_capture = True
         monkeypatch.setattr(provider, "_get_client", lambda: client)
         return provider
 
@@ -328,6 +330,264 @@ class TestMem0ConfigNormalization:
 
 
 # ---------------------------------------------------------------------------
+# Hobby-plan tuning: configurable knobs for usage saving
+# ---------------------------------------------------------------------------
+
+
+class TestHobbyPlanConfigNormalization:
+    """_normalize_config_values handles the four new knobs correctly."""
+
+    def test_defaults_applied(self):
+        cfg = _normalize_config_values({})
+        assert cfg["top_k"] == 3
+        assert cfg["search_threshold"] == 0.5
+        assert cfg["auto_capture"] is False
+        assert cfg["auto_recall"] is True
+
+    def test_camel_case_aliases_mapped(self):
+        cfg = _normalize_config_values({
+            "topK": 5,
+            "searchThreshold": 0.7,
+            "autoCapture": "true",
+            "autoRecall": "false",
+        })
+        assert cfg["top_k"] == 5
+        assert cfg["search_threshold"] == 0.7
+        assert cfg["auto_capture"] is True
+        assert cfg["auto_recall"] is False
+        # camelCase keys removed
+        assert "topK" not in cfg
+        assert "searchThreshold" not in cfg
+        assert "autoCapture" not in cfg
+        assert "autoRecall" not in cfg
+
+    def test_snake_case_takes_precedence_over_camel(self):
+        cfg = _normalize_config_values({
+            "top_k": 10,
+            "topK": 20,
+            "auto_capture": True,
+            "autoCapture": False,
+        })
+        assert cfg["top_k"] == 10
+        assert cfg["auto_capture"] is True
+
+    def test_top_k_clamped(self):
+        assert _normalize_config_values({"top_k": 0})["top_k"] == 1
+        assert _normalize_config_values({"top_k": 100})["top_k"] == 50
+        assert _normalize_config_values({"top_k": "garbage"})["top_k"] == 3
+
+    def test_search_threshold_clamped(self):
+        assert _normalize_config_values({"search_threshold": -0.5})["search_threshold"] == 0.0
+        assert _normalize_config_values({"search_threshold": 1.5})["search_threshold"] == 1.0
+        assert _normalize_config_values({"search_threshold": "garbage"})["search_threshold"] == 0.5
+
+    def test_string_coercion_for_numeric_fields(self):
+        cfg = _normalize_config_values({"top_k": "7", "search_threshold": "0.8"})
+        assert cfg["top_k"] == 7
+        assert cfg["search_threshold"] == 0.8
+
+
+class TestHobbyPlanConfigLoading:
+    """New knobs load from mem0.json including camelCase aliases."""
+
+    def test_load_config_picks_up_new_knobs(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text(json.dumps({
+            "top_k": 5,
+            "search_threshold": 0.8,
+            "auto_capture": True,
+            "auto_recall": False,
+        }), encoding="utf-8")
+
+        cfg = _load_config()
+        assert cfg["top_k"] == 5
+        assert cfg["search_threshold"] == 0.8
+        assert cfg["auto_capture"] is True
+        assert cfg["auto_recall"] is False
+
+    def test_load_config_camel_case_from_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text(json.dumps({
+            "topK": 8,
+            "searchThreshold": 0.3,
+            "autoCapture": "true",
+            "autoRecall": "false",
+        }), encoding="utf-8")
+
+        cfg = _load_config()
+        assert cfg["top_k"] == 8
+        assert cfg["search_threshold"] == 0.3
+        assert cfg["auto_capture"] is True
+        assert cfg["auto_recall"] is False
+
+    def test_initialize_wires_knobs_to_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text(json.dumps({
+            "top_k": 7,
+            "search_threshold": 0.6,
+            "auto_capture": True,
+            "auto_recall": False,
+        }), encoding="utf-8")
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+        assert provider._top_k == 7
+        assert provider._search_threshold == 0.6
+        assert provider._auto_capture is True
+        assert provider._auto_recall is False
+
+
+class TestAutoRecallGate:
+    """queue_prefetch is gated by auto_recall."""
+
+    def _make_provider(self, monkeypatch, client, *, auto_recall=True, top_k=3,
+                       search_threshold=0.5):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._auto_recall = auto_recall
+        provider._top_k = top_k
+        provider._search_threshold = search_threshold
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_prefetch_skipped_when_auto_recall_false(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client, auto_recall=False)
+
+        provider.queue_prefetch("hello")
+
+        # Thread should not be started at all
+        assert provider._prefetch_thread is None
+        assert client.captured_search == {}
+
+    def test_prefetch_runs_when_auto_recall_true(self, monkeypatch):
+        client = FakeClientV2(search_results={
+            "results": [{"memory": "user likes tests"}]
+        })
+        provider = self._make_provider(monkeypatch, client, auto_recall=True)
+
+        provider.queue_prefetch("hello")
+        provider._prefetch_thread.join(timeout=2)
+
+        assert client.captured_search["query"] == "hello"
+
+    def test_prefetch_uses_configured_top_k(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client, top_k=7)
+
+        provider.queue_prefetch("hello")
+        provider._prefetch_thread.join(timeout=2)
+
+        assert client.captured_search["top_k"] == 7
+
+
+class TestSearchThresholdFiltering:
+    """Prefetch filters results by search_threshold when scores are present."""
+
+    def _make_provider(self, monkeypatch, client, *, search_threshold=0.5):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._auto_recall = True
+        provider._search_threshold = search_threshold
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_results_below_threshold_filtered(self, monkeypatch):
+        client = FakeClientV2(search_results={"results": [
+            {"memory": "high", "score": 0.9},
+            {"memory": "low", "score": 0.3},
+        ]})
+        provider = self._make_provider(monkeypatch, client, search_threshold=0.5)
+
+        provider.queue_prefetch("test")
+        provider._prefetch_thread.join(timeout=2)
+        result = provider.prefetch("test")
+
+        assert "high" in result
+        assert "low" not in result
+
+    def test_results_without_score_pass_through(self, monkeypatch):
+        client = FakeClientV2(search_results={"results": [
+            {"memory": "no score"},
+            {"memory": "has score", "score": 0.2},
+        ]})
+        provider = self._make_provider(monkeypatch, client, search_threshold=0.5)
+
+        provider.queue_prefetch("test")
+        provider._prefetch_thread.join(timeout=2)
+        result = provider.prefetch("test")
+
+        assert "no score" in result
+        assert "has score" not in result
+
+    def test_threshold_zero_passes_everything(self, monkeypatch):
+        client = FakeClientV2(search_results={"results": [
+            {"memory": "a", "score": 0.01},
+            {"memory": "b", "score": 0.0},
+        ]})
+        provider = self._make_provider(monkeypatch, client, search_threshold=0.0)
+
+        provider.queue_prefetch("test")
+        provider._prefetch_thread.join(timeout=2)
+        result = provider.prefetch("test")
+
+        assert "a" in result
+        assert "b" in result
+
+    def test_filter_by_threshold_unit(self):
+        provider = Mem0MemoryProvider()
+        provider._search_threshold = 0.5
+        results = [
+            {"memory": "a", "score": 0.9},
+            {"memory": "b", "score": 0.4},
+            {"memory": "c"},  # no score — passes through
+            {"memory": "d", "score": 0.5},  # exactly at threshold — passes
+        ]
+        filtered = provider._filter_by_threshold(results)
+        memories = [r["memory"] for r in filtered]
+        assert memories == ["a", "c", "d"]
+
+
+class TestAutoCaptureGate:
+    """sync_turn is gated by auto_capture."""
+
+    def _make_provider(self, monkeypatch, client, *, auto_capture=False):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._auto_capture = auto_capture
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_sync_turn_skipped_when_auto_capture_false(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client, auto_capture=False)
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+
+        # Thread should not be started at all
+        assert provider._sync_thread is None
+        assert len(client.captured_add) == 0
+
+    def test_sync_turn_runs_when_auto_capture_true(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client, auto_capture=True)
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+        provider._sync_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+
+
+
+# ---------------------------------------------------------------------------
 # Mem0 curation: on_memory_write dedupe/update/delete/conclude
 # ---------------------------------------------------------------------------
 
@@ -549,3 +809,102 @@ class TestMem0Curation:
         assert 0 < _CURATE_UPDATE_THRESHOLD < 1
         assert 0 < _CURATE_DELETE_THRESHOLD <= 1
         assert _CURATE_UPDATE_THRESHOLD < _CURATE_DELETE_THRESHOLD
+
+class TestManualToolsUnaffected:
+    """Manual tools (mem0_search, mem0_conclude, etc.) work regardless of auto_* settings."""
+
+    def _make_provider(self, monkeypatch, client):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._auto_capture = False
+        provider._auto_recall = False
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_mem0_search_works_when_auto_recall_off(self, monkeypatch):
+        client = FakeClientV2(search_results={
+            "results": [{"id": "m1", "memory": "test fact", "score": 0.9}]
+        })
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_search", {"query": "test", "top_k": 5}
+        ))
+        assert result["count"] == 1
+        assert result["results"][0]["memory"] == "test fact"
+
+    def test_mem0_conclude_works_when_auto_capture_off(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_conclude", {"conclusion": "user likes dark mode"}
+        ))
+        assert result["result"] == "Fact stored."
+        assert len(client.captured_add) == 1
+
+    def test_mem0_profile_works_when_auto_recall_off(self, monkeypatch):
+        client = FakeClientV2(all_results={"results": [
+            {"id": "m1", "memory": "a fact"}
+        ]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call("mem0_profile", {}))
+        assert result["count"] == 1
+
+    def test_mem0_update_works_when_auto_settings_off(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_update", {"memory_id": "m1", "text": "corrected"}
+        ))
+        assert result["result"] == "Memory updated."
+
+    def test_mem0_delete_works_when_auto_settings_off(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_delete", {"memory_id": "m1"}
+        ))
+        assert result["result"] == "Memory deleted."
+
+
+class TestConfigSchemaDocumentation:
+    """Config schema includes the new knobs with correct defaults."""
+
+    def test_schema_includes_all_new_keys(self):
+        provider = Mem0MemoryProvider()
+        schema = provider.get_config_schema()
+        keys = [s["key"] for s in schema]
+        assert "top_k" in keys
+        assert "search_threshold" in keys
+        assert "auto_capture" in keys
+        assert "auto_recall" in keys
+
+    def test_schema_defaults(self):
+        provider = Mem0MemoryProvider()
+        schema = {s["key"]: s for s in provider.get_config_schema()}
+        assert schema["top_k"]["default"] == "3"
+        assert schema["search_threshold"]["default"] == "0.5"
+        assert schema["auto_capture"]["default"] == "false"
+        assert schema["auto_recall"]["default"] == "true"
+
+    def test_save_config_normalizes_new_knobs(self, tmp_path):
+        provider = Mem0MemoryProvider()
+        provider.save_config({
+            "topK": 5,
+            "searchThreshold": 0.7,
+            "autoCapture": "true",
+            "autoRecall": "false",
+        }, tmp_path)
+
+        saved = json.loads((Path(tmp_path) / "mem0.json").read_text(encoding="utf-8"))
+        assert saved["top_k"] == 5
+        assert saved["search_threshold"] == 0.7
+        assert saved["auto_capture"] is True
+        assert saved["auto_recall"] is False
+        assert "topK" not in saved

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -4,9 +4,11 @@ Salvaged from PRs #5301 (qaqcvc) and #5117 (vvvanguards).
 """
 
 import json
+from pathlib import Path
+
 import pytest
 
-from plugins.memory.mem0 import Mem0MemoryProvider
+from plugins.memory.mem0 import Mem0MemoryProvider, _load_config
 
 
 class FakeClientV2:
@@ -18,6 +20,8 @@ class FakeClientV2:
         self.captured_search = {}
         self.captured_get_all = {}
         self.captured_add = []
+        self.captured_update = []
+        self.captured_delete = []
 
     def search(self, **kwargs):
         self.captured_search = kwargs
@@ -29,6 +33,14 @@ class FakeClientV2:
 
     def add(self, messages, **kwargs):
         self.captured_add.append({"messages": messages, **kwargs})
+
+    def update(self, memory_id, **kwargs):
+        self.captured_update.append({"memory_id": memory_id, **kwargs})
+        return {"memory_id": memory_id, **kwargs}
+
+    def delete(self, memory_id):
+        self.captured_delete.append(memory_id)
+        return {"memory_id": memory_id, "deleted": True}
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +146,10 @@ class TestMem0ResponseUnwrapping:
         return provider
 
     def test_profile_dict_response(self, monkeypatch):
-        client = FakeClientV2(all_results={"results": [{"memory": "alpha"}, {"memory": "beta"}]})
+        client = FakeClientV2(all_results={"results": [
+            {"id": "m1", "memory": "alpha"},
+            {"memory_id": "m2", "memory": "beta"},
+        ]})
         provider = self._make_provider(monkeypatch, client)
 
         result = json.loads(provider.handle_tool_call("mem0_profile", {}))
@@ -142,6 +157,8 @@ class TestMem0ResponseUnwrapping:
         assert result["count"] == 2
         assert "alpha" in result["result"]
         assert "beta" in result["result"]
+        assert result["items"][0]["id"] == "m1"
+        assert result["items"][1]["id"] == "m2"
 
     def test_profile_list_response_backward_compat(self, monkeypatch):
         """Old API returned bare lists — still works."""
@@ -154,7 +171,10 @@ class TestMem0ResponseUnwrapping:
 
     def test_search_dict_response(self, monkeypatch):
         client = FakeClientV2(search_results={
-            "results": [{"memory": "foo", "score": 0.9}, {"memory": "bar", "score": 0.7}]
+            "results": [
+                {"id": "m1", "memory": "foo", "score": 0.9},
+                {"memory_id": "m2", "memory": "bar", "score": 0.7},
+            ]
         })
         provider = self._make_provider(monkeypatch, client)
 
@@ -164,6 +184,8 @@ class TestMem0ResponseUnwrapping:
 
         assert result["count"] == 2
         assert result["results"][0]["memory"] == "foo"
+        assert result["results"][0]["id"] == "m1"
+        assert result["results"][1]["id"] == "m2"
 
     def test_search_list_response_backward_compat(self, monkeypatch):
         """Old API returned bare lists — still works."""
@@ -225,3 +247,76 @@ class TestMem0Defaults:
         provider.initialize("test")
 
         assert provider._agent_id == "hermes"
+
+
+class TestMem0LifecycleTools:
+    """Explicit Mem0 lifecycle tools should expose update/delete functionality."""
+
+    def _make_provider(self, monkeypatch, client):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_update_tool_updates_memory_by_id(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_update", {"memory_id": "m1", "text": "corrected fact"}
+        ))
+
+        assert client.captured_update == [{"memory_id": "m1", "text": "corrected fact"}]
+        assert result["result"] == "Memory updated."
+        assert result["id"] == "m1"
+
+    def test_delete_tool_deletes_memory_by_id(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call("mem0_delete", {"memory_id": "m1"}))
+
+        assert client.captured_delete == ["m1"]
+        assert result["result"] == "Memory deleted."
+        assert result["id"] == "m1"
+
+
+class TestMem0ConfigNormalization:
+    """Config should normalize bool-ish values from setup/env input."""
+
+    def test_load_config_coerces_rerank_string_to_bool(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"user_id": "u1", "agent_id": "a1", "rerank": "false"}),
+            encoding="utf-8",
+        )
+
+        cfg = _load_config()
+
+        assert cfg["rerank"] is False
+
+    def test_initialize_coerces_rerank_string_to_bool(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"user_id": "u1", "agent_id": "a1", "rerank": "true"}),
+            encoding="utf-8",
+        )
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+
+        assert provider._rerank is True
+        assert isinstance(provider._rerank, bool)
+
+    def test_save_config_writes_rerank_as_boolean(self, tmp_path):
+        provider = Mem0MemoryProvider()
+
+        provider.save_config({"user_id": "u1", "agent_id": "a1", "rerank": "false"}, tmp_path)
+
+        saved = json.loads((Path(tmp_path) / "mem0.json").read_text(encoding="utf-8"))
+        assert saved["rerank"] is False
+        assert isinstance(saved["rerank"], bool)

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 import pytest
 
-from plugins.memory.mem0 import Mem0MemoryProvider, _load_config
+from plugins.memory.mem0 import (
+    Mem0MemoryProvider,
+    _CURATE_DELETE_THRESHOLD,
+    _CURATE_UPDATE_THRESHOLD,
+    _load_config,
+)
 
 
 class FakeClientV2:
@@ -320,3 +325,227 @@ class TestMem0ConfigNormalization:
         saved = json.loads((Path(tmp_path) / "mem0.json").read_text(encoding="utf-8"))
         assert saved["rerank"] is False
         assert isinstance(saved["rerank"], bool)
+
+
+# ---------------------------------------------------------------------------
+# Mem0 curation: on_memory_write dedupe/update/delete/conclude
+# ---------------------------------------------------------------------------
+
+
+class TestMem0Curation:
+    """Test _curate_memory_write: search Mem0 → decide → update/delete/conclude."""
+
+    def _make_provider(self, monkeypatch, client):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    # -- Genuinely new fact → conclude ------------------------------------
+
+    def test_new_fact_no_existing_memories_concludes(self, monkeypatch):
+        """No existing memories → conclude as new fact."""
+        client = FakeClientV2(search_results={"results": []})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("I prefer dark mode")
+
+        assert result["action"] == "concluded"
+        assert len(client.captured_add) == 1
+        call = client.captured_add[0]
+        assert call["messages"] == [{"role": "user", "content": "I prefer dark mode"}]
+        assert call["infer"] is False
+
+    def test_new_fact_low_similarity_concludes(self, monkeypatch):
+        """Existing memories with low similarity → conclude as new fact."""
+        client = FakeClientV2(search_results={"results": [
+            {"id": "m1", "memory": "User uses Linux", "score": 0.3},
+        ]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("I prefer dark mode")
+
+        assert result["action"] == "concluded"
+        assert len(client.captured_add) == 1
+        assert client.captured_update == []
+
+    # -- Corrected/reworded fact → update ---------------------------------
+
+    def test_similar_fact_updates_existing(self, monkeypatch):
+        """Semantically similar but reworded fact → update existing memory."""
+        client = FakeClientV2(search_results={"results": [
+            {"id": "m1", "memory": "User prefers light mode", "score": 0.8},
+        ]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("I prefer dark mode")
+
+        assert result["action"] == "updated"
+        assert result["id"] == "m1"
+        assert client.captured_update == [{"memory_id": "m1", "text": "I prefer dark mode"}]
+        assert client.captured_add == []  # No conclude — updated instead
+
+    # -- Exact duplicate → skip -------------------------------------------
+
+    def test_exact_duplicate_skips(self, monkeypatch):
+        """Exact same text already in Mem0 → skip (no write)."""
+        client = FakeClientV2(search_results={"results": [
+            {"id": "m1", "memory": "I prefer dark mode", "score": 0.99},
+        ]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("I prefer dark mode")
+
+        assert result["action"] == "skipped"
+        assert client.captured_add == []
+        assert client.captured_update == []
+        assert client.captured_delete == []
+
+    def test_exact_duplicate_case_insensitive(self, monkeypatch):
+        """Case-insensitive exact match → skip."""
+        client = FakeClientV2(search_results={"results": [
+            {"id": "m1", "memory": "I Prefer Dark Mode", "score": 0.95},
+        ]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("i prefer dark mode")
+
+        assert result["action"] == "skipped"
+
+    # -- Stale duplicate cleanup → delete ---------------------------------
+
+    def test_stale_duplicates_deleted_during_update(self, monkeypatch):
+        """When updating, additional high-similarity results are deleted."""
+        client = FakeClientV2(search_results={"results": [
+            {"id": "m1", "memory": "User prefers light mode", "score": 0.82},
+            {"id": "m2", "memory": "User likes light theme", "score": 0.90},
+            {"id": "m3", "memory": "Something unrelated", "score": 0.4},
+        ]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("I prefer dark mode")
+
+        assert result["action"] == "updated"
+        assert result["id"] == "m1"
+        # m2 scores above DELETE threshold → deleted as stale duplicate
+        assert "m2" in result["deleted_ids"]
+        assert client.captured_delete == ["m2"]
+        # m3 below DELETE threshold → kept
+        assert "m3" not in result.get("deleted_ids", [])
+
+    def test_no_stale_duplicates_when_extras_below_threshold(self, monkeypatch):
+        """Additional results below DELETE threshold are not deleted."""
+        client = FakeClientV2(search_results={"results": [
+            {"id": "m1", "memory": "User prefers light mode", "score": 0.8},
+            {"id": "m2", "memory": "Something moderate", "score": 0.6},
+        ]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("I prefer dark mode")
+
+        assert result["action"] == "updated"
+        assert result.get("deleted_ids", []) == []
+        assert client.captured_delete == []
+
+    # -- on_memory_write integration --------------------------------------
+
+    def test_on_memory_write_triggers_curate_for_add(self, monkeypatch):
+        """on_memory_write with action='add' triggers curation."""
+        client = FakeClientV2(search_results={"results": []})
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.on_memory_write("add", "user", "I prefer dark mode")
+        # Join the background thread to ensure it completes
+        if provider._curate_thread:
+            provider._curate_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+
+    def test_on_memory_write_triggers_curate_for_replace(self, monkeypatch):
+        """on_memory_write with action='replace' triggers curation."""
+        client = FakeClientV2(search_results={"results": []})
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.on_memory_write("replace", "user", "I prefer dark mode")
+        if provider._curate_thread:
+            provider._curate_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+
+    def test_on_memory_write_skips_remove_action(self, monkeypatch):
+        """on_memory_write with action='remove' does nothing."""
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.on_memory_write("remove", "user", "something")
+
+        assert provider._curate_thread is None
+        assert client.captured_add == []
+
+    def test_on_memory_write_skips_empty_content(self, monkeypatch):
+        """on_memory_write with empty content does nothing."""
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.on_memory_write("add", "user", "")
+
+        assert provider._curate_thread is None
+
+    def test_on_memory_write_skips_when_breaker_open(self, monkeypatch):
+        """on_memory_write does nothing when circuit breaker is tripped."""
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+        # Trip the circuit breaker
+        provider._consecutive_failures = 10
+        provider._breaker_open_until = float("inf")
+
+        provider.on_memory_write("add", "user", "fact")
+
+        assert provider._curate_thread is None
+
+    # -- Error handling ---------------------------------------------------
+
+    def test_curate_search_failure_returns_failed(self, monkeypatch):
+        """Search failure in curate → returns failed, doesn't crash."""
+        client = FakeClientV2()
+        client.search = lambda **kw: (_ for _ in ()).throw(RuntimeError("API down"))
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("some fact")
+
+        assert result["action"] == "failed"
+
+    def test_curate_conclude_failure_returns_failed(self, monkeypatch):
+        """Conclude failure after no match → returns failed."""
+        client = FakeClientV2(search_results={"results": []})
+        client.add = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("write fail"))
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("some fact")
+
+        assert result["action"] == "failed"
+
+    def test_curate_update_failure_returns_failed(self, monkeypatch):
+        """Update failure → returns failed, doesn't attempt delete."""
+        client = FakeClientV2(search_results={"results": [
+            {"id": "m1", "memory": "old version", "score": 0.9},
+            {"id": "m2", "memory": "duplicate", "score": 0.95},
+        ]})
+        client.update = lambda **kw: (_ for _ in ()).throw(RuntimeError("update fail"))
+        provider = self._make_provider(monkeypatch, client)
+
+        result = provider._curate_memory_write("new version")
+
+        assert result["action"] == "failed"
+        # Should NOT attempt to delete m2 since update failed
+        assert client.captured_delete == []
+
+    # -- Threshold sanity -------------------------------------------------
+
+    def test_threshold_constants_are_reasonable(self):
+        """Thresholds are in (0, 1] and UPDATE < DELETE."""
+        assert 0 < _CURATE_UPDATE_THRESHOLD < 1
+        assert 0 < _CURATE_DELETE_THRESHOLD <= 1
+        assert _CURATE_UPDATE_THRESHOLD < _CURATE_DELETE_THRESHOLD

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -199,6 +199,7 @@ class TestPluginHooks:
     def test_valid_hooks_include_request_scoped_api_hooks(self):
         assert "pre_api_request" in VALID_HOOKS
         assert "post_api_request" in VALID_HOOKS
+        assert "on_task_complete" in VALID_HOOKS
 
     def test_register_and_invoke_hook(self, tmp_path, monkeypatch):
         """Registered hooks are called on invoke_hook()."""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1586,34 +1586,8 @@ class TestRunConversation:
 
         assert result.get("task_review") is None
 
-    def test_centralized_writeback_suppresses_background_memory_review(self, agent_with_memory_tool):
-        """Task-complete writeback should suppress the generic background memory review."""
-        agent = agent_with_memory_tool
-        self._setup_agent(agent)
-        agent._memory_store = MagicMock()
-        agent._memory_store.add.return_value = {"success": True, "message": "Entry added"}
-        agent._memory_nudge_interval = 1
-        agent._turns_since_memory = 0
-        agent.client.chat.completions.create.return_value = _mock_response(
-            content="Saved.", finish_reason="stop",
-        )
-
-        with (
-            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
-            patch.object(agent, "_spawn_background_review") as mock_bg_review,
-            patch.object(agent, "_persist_session"),
-            patch.object(agent, "_save_trajectory"),
-            patch.object(agent, "_cleanup_task_resources"),
-        ):
-            result = agent.run_conversation("remember this: I prefer dark mode")
-
-        assert result["final_response"] == "Saved."
-        agent._memory_store.add.assert_called_once_with("user", "I prefer dark mode")
-        assert result["task_review"].memory_write_candidates
-        mock_bg_review.assert_not_called()
-
-    def test_centralized_writeback_preserves_skill_review_when_due(self, agent_with_memory_tool):
-        """Centralized memory writeback should not suppress the skill-review path."""
+    def test_task_review_suppresses_both_generic_reviews(self, agent_with_memory_tool):
+        """Task-complete review should suppress both generic memory and skill background reviews."""
         agent = agent_with_memory_tool
         self._setup_agent(agent)
         agent.valid_tool_names = {"web_search", "memory", "skill_manage"}
@@ -1640,11 +1614,76 @@ class TestRunConversation:
             result = agent.run_conversation("remember this: I prefer dark mode")
 
         assert result["final_response"] == "Done"
+        # Centralized writeback still runs
         agent._memory_store.add.assert_called_once_with("user", "I prefer dark mode")
+        assert result["task_review"].memory_write_candidates
+        # Both generic background reviews are suppressed
+        mock_bg_review.assert_not_called()
+
+    def test_task_review_suppresses_skill_review_even_when_due(self, agent_with_memory_tool):
+        """Even when skill nudge counter is due, task-complete review suppresses it."""
+        agent = agent_with_memory_tool
+        self._setup_agent(agent)
+        agent.valid_tool_names = {"web_search", "memory", "skill_manage"}
+        agent._memory_store = MagicMock()
+        agent._memory_store.add.return_value = {"success": True, "message": "Entry added"}
+        # Memory nudge NOT due (interval=0 disables), but skill IS due.
+        agent._memory_nudge_interval = 0
+        agent._skill_nudge_interval = 1
+        agent._iters_since_skill = 0
+
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(agent, "_spawn_background_review") as mock_bg_review,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("remember this: I prefer dark mode")
+
+        assert result["final_response"] == "Done"
+        # Task-complete review ran, so generic skill review is suppressed
+        assert result.get("task_review") is not None
+        mock_bg_review.assert_not_called()
+
+    def test_generic_reviews_fire_when_task_review_does_not_run(self, agent_with_memory_tool):
+        """When task-complete review does not fire, generic nudge reviews still proceed."""
+        agent = agent_with_memory_tool
+        self._setup_agent(agent)
+        agent.valid_tool_names = {"web_search", "memory", "skill_manage"}
+        agent._memory_store = MagicMock()
+        agent._memory_nudge_interval = 1
+        agent._turns_since_memory = 0
+        agent._skill_nudge_interval = 1
+        agent._iters_since_skill = 0
+
+        # Trivial no-tool reply — task-complete review does NOT fire.
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="hello", finish_reason="stop",
+        )
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(agent, "_spawn_background_review") as mock_bg_review,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "hello"
+        # No task review ran
+        assert result.get("task_review") is None
+        # Generic memory review should fire (nudge interval reached)
         mock_bg_review.assert_called_once()
         _, kwargs = mock_bg_review.call_args
-        assert kwargs["review_memory"] is False
-        assert kwargs["review_skills"] is True
+        assert kwargs["review_memory"] is True
 
     def test_interrupt_breaks_loop(self, agent):
         self._setup_agent(agent)

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1487,6 +1487,63 @@ class TestRunConversation:
         assert all("message_count" in c and "messages" not in c for c in pre_request_calls)
         assert all("usage" in c and "response" not in c for c in post_request_calls)
 
+    def test_task_complete_hook_emitted_for_completed_tool_run(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        hook_calls = []
+
+        def _record_hook(name, **kwargs):
+            hook_calls.append((name, kwargs))
+            return []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_record_hook),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done searching"
+        task_complete_calls = [kw for name, kw in hook_calls if name == "on_task_complete"]
+        assert len(task_complete_calls) == 1
+        payload = task_complete_calls[0]["task_payload"]
+        assert payload["completed"] is True
+        assert payload["interrupted"] is False
+        assert payload["tool_call_count"] == 1
+        assert payload["tools_used"] == ["web_search"]
+        assert payload["trigger_reasons"] == ["tool_used"]
+        assert payload["final_response"] == "Done searching"
+
+    def test_task_complete_hook_not_emitted_for_trivial_no_tool_reply(self, agent):
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="hello",
+            finish_reason="stop",
+        )
+
+        hook_calls = []
+
+        def _record_hook(name, **kwargs):
+            hook_calls.append((name, kwargs))
+            return []
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_record_hook),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "hello"
+        assert not any(name == "on_task_complete" for name, _ in hook_calls)
+
     def test_interrupt_breaks_loop(self, agent):
         self._setup_agent(agent)
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1586,6 +1586,66 @@ class TestRunConversation:
 
         assert result.get("task_review") is None
 
+    def test_centralized_writeback_suppresses_background_memory_review(self, agent_with_memory_tool):
+        """Task-complete writeback should suppress the generic background memory review."""
+        agent = agent_with_memory_tool
+        self._setup_agent(agent)
+        agent._memory_store = MagicMock()
+        agent._memory_store.add.return_value = {"success": True, "message": "Entry added"}
+        agent._memory_nudge_interval = 1
+        agent._turns_since_memory = 0
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Saved.", finish_reason="stop",
+        )
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(agent, "_spawn_background_review") as mock_bg_review,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("remember this: I prefer dark mode")
+
+        assert result["final_response"] == "Saved."
+        agent._memory_store.add.assert_called_once_with("user", "I prefer dark mode")
+        assert result["task_review"].memory_write_candidates
+        mock_bg_review.assert_not_called()
+
+    def test_centralized_writeback_preserves_skill_review_when_due(self, agent_with_memory_tool):
+        """Centralized memory writeback should not suppress the skill-review path."""
+        agent = agent_with_memory_tool
+        self._setup_agent(agent)
+        agent.valid_tool_names = {"web_search", "memory", "skill_manage"}
+        agent._memory_store = MagicMock()
+        agent._memory_store.add.return_value = {"success": True, "message": "Entry added"}
+        agent._memory_nudge_interval = 1
+        agent._turns_since_memory = 0
+        agent._skill_nudge_interval = 1
+        agent._iters_since_skill = 0
+
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(agent, "_spawn_background_review") as mock_bg_review,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("remember this: I prefer dark mode")
+
+        assert result["final_response"] == "Done"
+        agent._memory_store.add.assert_called_once_with("user", "I prefer dark mode")
+        mock_bg_review.assert_called_once()
+        _, kwargs = mock_bg_review.call_args
+        assert kwargs["review_memory"] is False
+        assert kwargs["review_skills"] is True
+
     def test_interrupt_breaks_loop(self, agent):
         self._setup_agent(agent)
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1544,6 +1544,48 @@ class TestRunConversation:
         assert result["final_response"] == "hello"
         assert not any(name == "on_task_complete" for name, _ in hook_calls)
 
+    def test_task_review_result_populated_for_tool_run(self, agent):
+        """run_conversation should attach a TaskReviewResult for completed tool tasks."""
+        from agent.task_review import TaskReviewResult
+
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Search done", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Search done"
+        review = result.get("task_review")
+        assert isinstance(review, TaskReviewResult)
+        assert review.should_review_skills is True
+        assert review.payload is result["task_completion_payload"]
+
+    def test_task_review_absent_for_trivial_reply(self, agent):
+        """Trivial no-tool replies should not produce a task_review entry."""
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="hi", finish_reason="stop",
+        )
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result.get("task_review") is None
+
     def test_interrupt_breaks_loop(self, agent):
         self._setup_agent(agent)
 

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -183,7 +183,7 @@ At minimum, treat these as protected Hermes internals:
 - `model_tools.py`
 - `toolsets.py`
 - `cli.py`
-- `agent/**`
+- `agent/**` (includes `agent/task_review.py` — task completion review engine)
 - `hermes_cli/**`
 - `tools/**`
 - `gateway/**`

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -161,6 +161,55 @@ Hermes has terminal access. Security matters.
 - Catch broad exceptions around tool execution
 - Test on all platforms if your change touches file paths or processes
 
+## Hermes Core Change Control (SIP)
+
+Some files define Hermes itself rather than a user project. Those internals are
+protected because small undocumented changes accumulate and degrade reliability.
+
+Do not modify Hermes core configs, file structure, agent architecture, system
+defaults, or tool/runtime internals unless all three conditions are satisfied:
+
+1. The change is documented
+2. The change is verified
+3. The change is explicitly authorized
+
+If any of those are missing, stop and get approval before proceeding.
+
+### Protected areas
+
+At minimum, treat these as protected Hermes internals:
+
+- `run_agent.py`
+- `model_tools.py`
+- `toolsets.py`
+- `cli.py`
+- `agent/**`
+- `hermes_cli/**`
+- `tools/**`
+- `gateway/**`
+- `cron/**`
+- config defaults and migrations
+- memory/provider architecture
+- system prompt assembly
+- tool registry behavior
+- session/state persistence behavior
+
+### SIP-OVERRIDE
+
+If the user explicitly includes the keyword `SIP-OVERRIDE`, the agent may proceed
+through a missing default process gate, but should still keep blast radius small,
+document what changed, and verify the affected paths.
+
+### Checklist for protected-core changes
+
+Before editing protected Hermes internals, confirm:
+
+- [ ] explicitly authorized
+- [ ] documentation updated
+- [ ] verification plan defined
+- [ ] protected paths identified
+- [ ] if bypassing a normal gate, the user explicitly said `SIP-OVERRIDE`
+
 ## Pull Request Process
 
 ### Branch Naming

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -80,6 +80,7 @@ async def handle(event_type: str, context: dict):
 | `agent:start` | Agent begins processing a message | `platform`, `user_id`, `session_id`, `message` |
 | `agent:step` | Each iteration of the tool-calling loop | `platform`, `user_id`, `session_id`, `iteration`, `tool_names` |
 | `agent:end` | Agent finishes processing | `platform`, `user_id`, `session_id`, `message`, `response` |
+| `agent:task_complete` | A substantial task finished and produced a review payload | `platform`, `user_id`, `session_id`, `message`, `response`, `task_payload` |
 | `command:*` | Any slash command executed | `platform`, `user_id`, `command`, `args` |
 
 #### Wildcard Matching
@@ -242,7 +243,8 @@ def register(ctx):
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | context injection |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
-| [`on_session_end`](#on_session_end) | Session ends | ignored |
+| [`on_session_end`](#on_session_end) | End of every `run_conversation()` call + CLI exit handler | ignored |
+| [`on_task_complete`](#on_task_complete) | A substantial task finished and produced a review payload | ignored |
 
 ---
 
@@ -596,6 +598,55 @@ def on_end(session_id, completed, interrupted, **kwargs):
 def register(ctx):
     ctx.register_hook("on_session_start", on_start)
     ctx.register_hook("on_session_end", on_end)
+```
+
+---
+
+### `on_task_complete`
+
+Fires when the structured task-complete review path runs for a substantial task. This is the hook to use when you want post-task automation without competing with the generic background review nudges.
+
+**Callback signature:**
+
+```python
+def my_callback(session_id: str, task_payload: dict, completed: bool,
+                interrupted: bool, model: str, platform: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_id` | `str` | Unique identifier for the session |
+| `task_payload` | `dict` | Structured payload from task-completion review (`original_user_message`, `final_response`, `tools_used`, `trigger_reasons`, etc.) |
+| `completed` | `bool` | `True` if the agent produced a final response |
+| `interrupted` | `bool` | `True` if the turn was interrupted |
+| `model` | `str` | The model identifier |
+| `platform` | `str` | Where the session is running |
+
+**Fires:** In `run_agent.py`, after the task-complete review path finishes and before `on_session_end`.
+
+**Return value:** Ignored.
+
+**Use cases:** post-task analytics, notifications, summarization, downstream sync, or auditing substantial completed work.
+
+**Example — compact task audit log:**
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+def log_task_complete(session_id, task_payload, completed, interrupted, **kwargs):
+    logger.info(
+        "TASK_COMPLETE session=%s completed=%s interrupted=%s tools=%s reasons=%s",
+        session_id,
+        completed,
+        interrupted,
+        task_payload.get("tools_used", []),
+        task_payload.get("trigger_reasons", []),
+    )
+
+
+def register(ctx):
+    ctx.register_hook("on_task_complete", log_task_complete)
 ```
 
 ---

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -258,6 +258,16 @@ echo "MEM0_API_KEY=your-key" >> ~/.hermes/.env
 |-----|---------|-------------|
 | `user_id` | `hermes-user` | User identifier |
 | `agent_id` | `hermes` | Agent identifier |
+| `rerank` | `true` | Enable reranking for recall |
+| `top_k` / `topK` | `3` | Max memories returned by automatic pre-turn recall |
+| `search_threshold` / `searchThreshold` | `0.5` | Minimum score for automatic recall filtering when scores are present |
+| `auto_capture` / `autoCapture` | `false` | Automatically capture each completed turn into Mem0 |
+| `auto_recall` / `autoRecall` | `true` | Automatically recall relevant memories before each turn |
+
+Notes:
+- `top_k` / `search_threshold` apply to automatic prefetch recall, not manual `mem0_search` calls.
+- `search_threshold` only filters results that include a score; results without scores are preserved.
+- `auto_capture: false` is useful on constrained Mem0 plans when you want to rely on explicit memory tools instead of per-turn ingestion.
 
 ---
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -450,7 +450,7 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 |----------|---------|------|-------|-------------|----------------|
 | **Honcho** | Cloud | Paid | 4 | `honcho-ai` | Dialectic user modeling |
 | **OpenViking** | Self-hosted | Free | 5 | `openviking` + server | Filesystem hierarchy + tiered loading |
-| **Mem0** | Cloud | Paid | 3 | `mem0ai` | Server-side LLM extraction |
+| **Mem0** | Cloud | Paid | 5 | `mem0ai` | Server-side LLM extraction |
 | **Hindsight** | Cloud/Local | Free/Paid | 3 | `hindsight-client` | Knowledge graph + reflect synthesis |
 | **Holographic** | Local | Free | 2 | None | HRR algebra + trust scoring |
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -242,7 +242,7 @@ Server-side LLM fact extraction with semantic search, reranking, and automatic d
 | **Data storage** | Mem0 Cloud |
 | **Cost** | Mem0 pricing |
 
-**Tools:** `mem0_profile` (all stored memories), `mem0_search` (semantic search + reranking), `mem0_conclude` (store verbatim facts)
+**Tools:** `mem0_profile` (all stored memories + IDs), `mem0_search` (semantic search + reranking + IDs), `mem0_conclude` (store verbatim facts), `mem0_update` (update by ID), `mem0_delete` (delete by ID)
 
 **Setup:**
 ```bash

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -110,6 +110,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 | [`post_llm_call`](/docs/user-guide/features/hooks#post_llm_call) | Once per turn, after the LLM loop (successful turns only) |
 | [`on_session_start`](/docs/user-guide/features/hooks#on_session_start) | New session created (first turn only) |
 | [`on_session_end`](/docs/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit handler |
+| [`on_task_complete`](/docs/user-guide/features/hooks#on_task_complete) | Agent marks a task as complete (after review) |
 
 ## Managing plugins
 


### PR DESCRIPTION
## Summary
- add a structured task-completion memory pipeline to Hermes
- add task-complete lifecycle hooks/events
- add deterministic built-in memory writeback and recall artifact generation
- integrate Mem0 curation via update/delete/conclude
- add Mem0 hobby-plan tuning controls
- document the new workflow and SIP guardrails

## Included work
- SIP guardrail docs for Hermes core changes
- on_task_complete / agent:task_complete
- agent/task_review.py structured review engine
- policy-based built-in memory writeback
- Mem0 curation in completed-task writeback
- compact next-session recall artifact
- reconciliation of task-complete review vs generic background review
- Mem0 tuning controls: top_k/search_threshold/auto_capture/auto_recall
- docs cleanup for hooks/plugins/memory providers

## Verification
Focused suites passed during implementation, including:
- tests/plugins/memory/test_mem0_v2.py
- tests/agent/test_task_review.py
- tests/test_run_agent.py
- tests/gateway/test_hooks.py

Most recent merged-area verification:
- 341 passed across task-review / run-agent / Mem0 suites

## Caveat
- a full repo-wide pytest run is not green, but the remaining failures are spread across unrelated areas outside this feature scope (telegram, update-check, approval flows, browser/camofox, MCP, matrix send formatting, agent_loop, etc.)
- package.json/package-lock.json were intentionally split into a separate PR to keep this review scoped
