### PR TITLE
fix: handle numeric MCP server names and case-insensitive LobeHub prefix

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8929,7 +8929,7 @@ def main(
     else:
         # Use the shared resolver so MCP servers are included at runtime
         from hermes_cli.tools_config import _get_platform_tools
-        toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
+        toolsets_list = sorted([str(ts) for ts in _get_platform_tools(CLI_CONFIG, "cli"))
     
     parsed_skills = _parse_skills_argument(skills)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -447,7 +447,7 @@ class APIServerAdapter(BasePlatformAdapter):
         model = _resolve_gateway_model()
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        enabled_toolsets = sorted([str(ts) for ts in _get_platform_tools(user_config, "api_server"))
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4573,7 +4573,7 @@ class GatewayRunner:
             platform_key = _platform_config_key(source.platform)
 
             from hermes_cli.tools_config import _get_platform_tools
-            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            enabled_toolsets = sorted([str(ts) for ts in _get_platform_tools(user_config, platform_key)])
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
@@ -6320,7 +6320,7 @@ class GatewayRunner:
         platform_key = _platform_config_key(source.platform)
 
         from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        enabled_toolsets = sorted([str(ts) for ts in _get_platform_tools(user_config, platform_key)])
 
         # Apply tool preview length config (0 = no limit)
         try:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1997,7 +1997,7 @@ class LobeHubSource(SkillSource):
 
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
         # Strip "lobehub/" prefix if present
-        agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
+        agent_id = identifier.split("/", 1)[-1] if identifier.lower().startswith("lobehub/") else identifier
 
         agent_data = self._fetch_agent(agent_id)
         if not agent_data:
@@ -2013,7 +2013,7 @@ class LobeHubSource(SkillSource):
         )
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
-        agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
+        agent_id = identifier.split("/", 1)[-1] if identifier.lower().startswith("lobehub/") else identifier
         index = self._fetch_index()
         if not index:
             return None


### PR DESCRIPTION
## Summary

Fix two bugs:

1. **Numeric MCP server names cause TypeError** — When a numeric MCP server name (e.g., `12306`) is used in `config.yaml`, Python's YAML parser interprets it as an integer. When `sorted()` is called on a mixed list of strings and integers, Python 3 raises `TypeError: '<' not supported between instances of 'int' and 'str'`. Fixed by explicitly converting toolset names to strings before sorting in `gateway/run.py`, `gateway/platforms/api_server.py`, and `cli.py`.

2. **LobeHub source prefix is case-sensitive** — `hermes skills install LobeHub/code-compass` fails because the prefix check uses `startswith("lobehub/")` (lowercase), but users may type `LobeHub/`. Fixed by using `startswith("lobehub/")` on the lowercased identifier in `tools/skills_hub.py`.

## Test plan

- [ ] Verify `sorted([str(ts) for ts in ...])` pattern compiles correctly in all three files
- [ ] Test that `hermes skills install LobeHub/code-companion` works (case-insensitive)
- [ ] Test that numeric MCP server names (e.g., `12306`) no longer cause TypeError

## Related issues

- Fixes issue #6901 (numeric MCP server TypeError)
- Fixes issue #6866 (LobeHub case-sensitivity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)