### PR TITLE
fix(docker): --init for zombie reaping + sleep infinity for idle-based lifetime

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -410,11 +410,12 @@ class DockerEnvironment(BaseEnvironment):
         container_name = f"hermes-{uuid.uuid4().hex[:8]}"
         run_cmd = [
             self._docker_exe, "run", "-d",
+            "--init",           # tini/catatonit as PID 1 — reaps zombie children
             "--name", container_name,
             "-w", cwd,
             *all_run_args,
             image,
-            "sleep", "2h",
+            "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
         ]
         logger.debug(f"Starting container: {' '.join(run_cmd)}")
         result = subprocess.run(


### PR DESCRIPTION
Fixes #6908.

## Problem

Sandbox containers spawned by the Docker backend have two issues:

1. **Zombie accumulation.** PID 1 is `sleep 2h`, which doesn't call `wait()`. Every background process (`terminal(background=true)`) that exits becomes a zombie. The `process` tool reports them as "running" because zombie PIDs still exist in the process table.

2. **Fixed 2-hour lifetime.** Arbitrary and sometimes too short for long agent sessions. The idle reaper (`_cleanup_inactive_envs`, gated by `terminal.lifetime_seconds`) already handles cleanup based on last activity — the container doesn't need its own death timer.

## Fix

Two one-line changes:

| Line | Before | After |
|---|---|---|
| `docker run` flags | (none) | `--init` — tini (Docker) / catatonit (Podman) as PID 1, reaps zombies |
| Entrypoint | `sleep 2h` | `sleep infinity` — no fixed lifetime, idle reaper handles it |

Both Docker and Podman support `--init` natively. `sleep infinity` is POSIX (GNU coreutils). The idle reaper's `terminal.lifetime_seconds` (default 300s) controls when inactive containers are cleaned up.

## Verification

Tested on Podman 5.x (Alpine LXC):
- `podman run --rm --init <image> sh -c "sleep 10 & wait"` — no zombies
- Background processes reap correctly; `process(action="list")` reflects actual state
- Container lives indefinitely until idle reaper fires or task ends