### PR TITLE
fix: restore CLIProxyAPI Anthropic routing and restrict Discord access

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -547,6 +547,13 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(discord_cfg, dict):
                 if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                allowed = discord_cfg.get("allowed_channels")
+                if allowed is not None and not os.getenv("DISCORD_ALLOWED_CHANNELS"):
+                    if isinstance(allowed, list):
+                        allowed = ",".join(str(v) for v in allowed)
+                    os.environ["DISCORD_ALLOWED_CHANNELS"] = str(allowed)
+                if "allow_dms" in discord_cfg and not os.getenv("DISCORD_ALLOW_DMS"):
+                    os.environ["DISCORD_ALLOW_DMS"] = str(discord_cfg["allow_dms"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1547,6 +1547,10 @@ class DiscordAdapter(BasePlatformAdapter):
         the "thinking..." indicator is replaced with that text; otherwise it
         is deleted so the channel isn't cluttered.
         """
+        channel = await self._resolve_interaction_channel(interaction)
+        if channel is None or not self._is_allowed_discord_channel(channel):
+            await self._reject_disallowed_interaction(interaction)
+            return
         await interaction.response.defer(ephemeral=True)
         event = self._build_slash_event(interaction, command_text)
         await self.handle_message(event)
@@ -1794,6 +1798,10 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_archive_duration: int = 1440,
     ) -> None:
         """Create a Discord thread from a slash command and start a session in it."""
+        channel = await self._resolve_interaction_channel(interaction)
+        if channel is None or not self._is_allowed_discord_channel(channel):
+            await self._reject_disallowed_interaction(interaction)
+            return
         result = await self._create_thread(
             interaction,
             name=name,
@@ -2114,6 +2122,41 @@ class DiscordAdapter(BasePlatformAdapter):
             return str(parent_id)
         return None
 
+    def _discord_allowed_channels(self) -> set[str]:
+        raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+        return {ch.strip() for ch in raw.split(",") if ch.strip()}
+
+    def _discord_allow_dms(self) -> bool:
+        return os.getenv("DISCORD_ALLOW_DMS", "true").lower() in ("true", "1", "yes")
+
+    def _channel_ids_for_access(self, channel: Any) -> set[str]:
+        ids: set[str] = set()
+        channel_id = getattr(channel, "id", None)
+        if channel_id is not None:
+            ids.add(str(channel_id))
+        parent_channel_id = self._get_parent_channel_id(channel)
+        if parent_channel_id:
+            ids.add(parent_channel_id)
+        return ids
+
+    def _is_allowed_discord_channel(self, channel: Any) -> bool:
+        if isinstance(channel, discord.DMChannel):
+            return self._discord_allow_dms() and not self._discord_allowed_channels()
+        allowed_channels = self._discord_allowed_channels()
+        if not allowed_channels:
+            return True
+        return bool(self._channel_ids_for_access(channel) & allowed_channels)
+
+    async def _reject_disallowed_interaction(self, interaction: discord.Interaction) -> None:
+        message = "Hermes는 #hermes 채널에서만 반응하도록 제한되어 있어요."
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(message, ephemeral=True)
+            else:
+                await interaction.response.send_message(message, ephemeral=True)
+        except Exception as e:
+            logger.debug("[%s] Failed to reject disallowed interaction: %s", self.name, e)
+
     def _is_forum_parent(self, channel: Any) -> bool:
         """Best-effort check for whether a Discord channel is a forum channel."""
         if channel is None:
@@ -2206,6 +2249,10 @@ class DiscordAdapter(BasePlatformAdapter):
         if is_thread:
             thread_id = str(message.channel.id)
             parent_channel_id = self._get_parent_channel_id(message.channel)
+
+        if not self._is_allowed_discord_channel(message.channel):
+            logger.debug("[%s] Ignoring message outside allowed Discord channels", self.name)
+            return
 
         if not isinstance(message.channel, discord.DMChannel):
             # Check ignored channels first - never respond even when mentioned

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -488,6 +488,8 @@ DEFAULT_CONFIG = {
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
+        "allowed_channels": "",       # Comma-separated channel IDs where bot is allowed to respond
+        "allow_dms": True,             # Whether bot may respond to Discord DMs
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
     },

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -643,6 +643,29 @@ def run_doctor(args):
         check_warn("OpenRouter API", "(not configured)")
     
     anthropic_key = os.getenv("ANTHROPIC_TOKEN") or os.getenv("ANTHROPIC_API_KEY")
+    anthropic_base_url = "https://api.anthropic.com"
+    anthropic_is_third_party = False
+    anthropic_cfg_key = ""
+    try:
+        from hermes_cli.config import load_config
+
+        model_cfg = load_config().get("model")
+        if isinstance(model_cfg, dict) and str(model_cfg.get("provider") or "").strip().lower() == "anthropic":
+            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+            if cfg_base_url:
+                anthropic_base_url = cfg_base_url
+                anthropic_is_third_party = "anthropic.com" not in cfg_base_url.lower()
+            for key_name in ("api_key", "api"):
+                value = model_cfg.get(key_name)
+                if isinstance(value, str) and value.strip():
+                    anthropic_cfg_key = value.strip()
+                    break
+    except Exception:
+        pass
+
+    if anthropic_is_third_party and anthropic_cfg_key:
+        anthropic_key = anthropic_cfg_key
+
     if anthropic_key:
         print("  Checking Anthropic API...", end="", flush=True)
         try:
@@ -650,13 +673,23 @@ def run_doctor(args):
             from agent.anthropic_adapter import _is_oauth_token, _COMMON_BETAS, _OAUTH_ONLY_BETAS
 
             headers = {"anthropic-version": "2023-06-01"}
-            if _is_oauth_token(anthropic_key):
+            target_url = "https://api.anthropic.com/v1/models"
+            if anthropic_is_third_party:
+                base = anthropic_base_url.rstrip("/")
+                if base.endswith("/v1"):
+                    target_url = f"{base}/models"
+                else:
+                    target_url = f"{base}/v1/models"
+                headers["x-api-key"] = anthropic_key
+                if _COMMON_BETAS:
+                    headers["anthropic-beta"] = ",".join(_COMMON_BETAS)
+            elif _is_oauth_token(anthropic_key):
                 headers["Authorization"] = f"Bearer {anthropic_key}"
                 headers["anthropic-beta"] = ",".join(_COMMON_BETAS + _OAUTH_ONLY_BETAS)
             else:
                 headers["x-api-key"] = anthropic_key
             response = httpx.get(
-                "https://api.anthropic.com/v1/models",
+                target_url,
                 headers=headers,
                 timeout=10
             )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -27,6 +27,11 @@ from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
 
 
+def _is_third_party_anthropic_base_url(base_url: str) -> bool:
+    normalized = (base_url or "").strip().rstrip("/").lower()
+    return bool(normalized) and "anthropic.com" not in normalized
+
+
 def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
@@ -598,6 +603,23 @@ def resolve_runtime_provider(
         return explicit_runtime
 
     should_use_pool = provider != "openrouter"
+    if provider == "anthropic":
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        cfg_api_key = ""
+        for key in ("api_key", "api"):
+            value = model_cfg.get(key)
+            if isinstance(value, str) and value.strip():
+                cfg_api_key = value.strip()
+                break
+        if (
+            cfg_provider == "anthropic"
+            and _is_third_party_anthropic_base_url(cfg_base_url)
+            and has_usable_secret(cfg_api_key)
+            and not explicit_api_key
+            and not explicit_base_url
+        ):
+            should_use_pool = False
     if provider == "openrouter":
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
@@ -696,6 +718,27 @@ def resolve_runtime_provider(
 
     # Anthropic (native Messages API)
     if provider == "anthropic":
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = ""
+        if cfg_provider == "anthropic":
+            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+        cfg_api_key = ""
+        for key in ("api_key", "api"):
+            value = model_cfg.get(key)
+            if isinstance(value, str) and value.strip():
+                cfg_api_key = value.strip()
+                break
+
+        if _is_third_party_anthropic_base_url(cfg_base_url) and has_usable_secret(cfg_api_key):
+            return {
+                "provider": "anthropic",
+                "api_mode": "anthropic_messages",
+                "base_url": cfg_base_url,
+                "api_key": cfg_api_key,
+                "source": "config",
+                "requested_provider": requested_provider,
+            }
+
         from agent.anthropic_adapter import resolve_anthropic_token
         token = resolve_anthropic_token()
         if not token:
@@ -706,10 +749,6 @@ def resolve_runtime_provider(
         # Allow base URL override from config.yaml model.base_url, but only
         # when the configured provider is anthropic — otherwise a non-Anthropic
         # base_url (e.g. Codex endpoint) would leak into Anthropic requests.
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-        cfg_base_url = ""
-        if cfg_provider == "anthropic":
-            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or "https://api.anthropic.com"
         return {
             "provider": "anthropic",

--- a/run_agent.py
+++ b/run_agent.py
@@ -105,6 +105,38 @@ from agent.trajectory import (
 from utils import atomic_json_write, env_var_enabled
 
 
+def _resolve_effective_anthropic_key(preferred_key: str = "", *, base_url: str = "") -> str:
+    normalized_base = str(base_url or "").strip().rstrip("/")
+    if normalized_base and "anthropic.com" not in normalized_base.lower():
+        try:
+            from hermes_cli.config import load_config as _load_runtime_config
+
+            model_cfg = _load_runtime_config().get("model")
+            if isinstance(model_cfg, dict) and str(model_cfg.get("provider") or "").strip().lower() == "anthropic":
+                cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+                if cfg_base_url == normalized_base:
+                    for key_name in ("api_key", "api"):
+                        value = model_cfg.get(key_name)
+                        if isinstance(value, str) and value.strip():
+                            return value.strip()
+        except Exception:
+            pass
+    if preferred_key:
+        return preferred_key
+    from agent.anthropic_adapter import resolve_anthropic_token
+
+    return resolve_anthropic_token() or ""
+
+
+def _anthropic_runtime_uses_oauth(api_key: str = "", *, base_url: str = "") -> bool:
+    from agent.anthropic_adapter import _is_oauth_token
+
+    normalized_base = str(base_url or "").strip().rstrip("/").lower()
+    if normalized_base and "anthropic.com" not in normalized_base:
+        return False
+    return _is_oauth_token(api_key)
+
+
 
 class _SafeWriter:
     """Transparent stdio wrapper that catches OSError/ValueError from broken pipes.
@@ -769,17 +801,23 @@ class AIAgent:
         self._is_anthropic_oauth = False
 
         if self.api_mode == "anthropic_messages":
-            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
+            from agent.anthropic_adapter import build_anthropic_client
             # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
             # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
             _is_native_anthropic = self.provider == "anthropic"
-            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
+            effective_key = (
+                _resolve_effective_anthropic_key(api_key, base_url=base_url)
+                if _is_native_anthropic
+                else (api_key or "")
+            )
             self.api_key = effective_key
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url
-            from agent.anthropic_adapter import _is_oauth_token as _is_oat
-            self._is_anthropic_oauth = _is_oat(effective_key)
+            self._is_anthropic_oauth = _anthropic_runtime_uses_oauth(
+                effective_key,
+                base_url=base_url,
+            )
             self._anthropic_client = build_anthropic_client(effective_key, base_url)
             # No OpenAI client needed for Anthropic mode
             self.client = None
@@ -1358,19 +1396,21 @@ class AIAgent:
 
         # ── Build new client ──
         if api_mode == "anthropic_messages":
-            from agent.anthropic_adapter import (
-                build_anthropic_client,
-                resolve_anthropic_token,
-                _is_oauth_token,
+            from agent.anthropic_adapter import build_anthropic_client
+            effective_key = _resolve_effective_anthropic_key(
+                api_key or self.api_key,
+                base_url=base_url or getattr(self, "_anthropic_base_url", None) or self.base_url,
             )
-            effective_key = api_key or self.api_key or resolve_anthropic_token() or ""
             self.api_key = effective_key
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url or getattr(self, "_anthropic_base_url", None)
             self._anthropic_client = build_anthropic_client(
                 effective_key, self._anthropic_base_url,
             )
-            self._is_anthropic_oauth = _is_oauth_token(effective_key)
+            self._is_anthropic_oauth = _anthropic_runtime_uses_oauth(
+                effective_key,
+                base_url=self._anthropic_base_url,
+            )
             self.client = None
             self._client_kwargs = {}
         else:
@@ -4093,9 +4133,13 @@ class AIAgent:
             return False
 
         try:
-            from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client
+            from agent.anthropic_adapter import build_anthropic_client
 
-            new_token = resolve_anthropic_token()
+            anthropic_base_url = getattr(self, "_anthropic_base_url", None) or self.base_url
+            new_token = _resolve_effective_anthropic_key(
+                getattr(self, "_anthropic_api_key", "") or self.api_key,
+                base_url=anthropic_base_url,
+            )
         except Exception as exc:
             logger.debug("Anthropic credential refresh failed: %s", exc)
             return False
@@ -4112,15 +4156,17 @@ class AIAgent:
             pass
 
         try:
-            self._anthropic_client = build_anthropic_client(new_token, getattr(self, "_anthropic_base_url", None))
+            self._anthropic_client = build_anthropic_client(new_token, anthropic_base_url)
         except Exception as exc:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
             return False
 
         self._anthropic_api_key = new_token
         # Update OAuth flag — token type may have changed (API key ↔ OAuth)
-        from agent.anthropic_adapter import _is_oauth_token
-        self._is_anthropic_oauth = _is_oauth_token(new_token)
+        self._is_anthropic_oauth = _anthropic_runtime_uses_oauth(
+            new_token,
+            base_url=anthropic_base_url,
+        )
         return True
 
     def _apply_client_headers_for_base_url(self, base_url: str) -> None:
@@ -4143,7 +4189,7 @@ class AIAgent:
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
 
         if self.api_mode == "anthropic_messages":
-            from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
+            from agent.anthropic_adapter import build_anthropic_client
 
             try:
                 self._anthropic_client.close()
@@ -4153,7 +4199,11 @@ class AIAgent:
             self._anthropic_api_key = runtime_key
             self._anthropic_base_url = runtime_base
             self._anthropic_client = build_anthropic_client(runtime_key, runtime_base)
-            self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
+            self._is_anthropic_oauth = (
+                _anthropic_runtime_uses_oauth(runtime_key, base_url=runtime_base)
+                if self.provider == "anthropic"
+                else False
+            )
             self.api_key = runtime_key
             self.base_url = runtime_base
             return
@@ -4921,13 +4971,23 @@ class AIAgent:
 
             if fb_api_mode == "anthropic_messages":
                 # Build native Anthropic client instead of using OpenAI client
-                from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-                effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
+                from agent.anthropic_adapter import build_anthropic_client
+                effective_key = (
+                    _resolve_effective_anthropic_key(
+                        fb_client.api_key or "",
+                        base_url=str(getattr(fb_client, "base_url", "") or ""),
+                    )
+                    if fb_provider == "anthropic"
+                    else (fb_client.api_key or "")
+                )
                 self.api_key = effective_key
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = getattr(fb_client, "base_url", None)
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)
-                self._is_anthropic_oauth = _is_oauth_token(effective_key)
+                self._is_anthropic_oauth = _anthropic_runtime_uses_oauth(
+                    effective_key,
+                    base_url=self._anthropic_base_url,
+                )
                 self.client = None
                 self._client_kwargs = {}
             else:


### PR DESCRIPTION
## Summary
- fix Hermes Anthropic routing so third-party CLIProxyAPI endpoints use configured proxy credentials instead of falling back to Claude OAuth
- harden Discord gateway access so Hermes only responds in #hermes (1490340360197505136), allows parent-channel threads, and blocks DMs/other channels
- reduce local runtime regressions with targeted tests, syntax checks, and CLI/gateway smoke verification

## Validation
- pytest -q tests/gateway/test_discord_channel_controls.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_doctor.py tests/run_agent/test_anthropic_error_handling.py
- python -m py_compile gateway/platforms/discord.py gateway/config.py hermes_cli/config.py hermes_cli/doctor.py hermes_cli/runtime_provider.py run_agent.py
- hermes --yolo chat -q "Reply with the single word OK."
- hermes gateway restart && status verified locally

## Notes
- Prepared with OpenCode and committed with explicit AI attribution in commit metadata.