### PR TITLE
feat(plugins): pass sender_id to pre_llm_call hook

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7071,6 +7071,7 @@ class AIAgent:
                 is_first_turn=(not bool(conversation_history)),
                 model=self.model,
                 platform=getattr(self, "platform", None) or "",
+                sender_id=getattr(self, "_user_id", None) or "",
             )
             _ctx_parts: list[str] = []
             for r in _pre_results:


### PR DESCRIPTION
## What

The `pre_llm_call` plugin hook currently receives `session_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, and `platform` — but **not** the sender's user ID. This means plugins cannot perform per-user access control (e.g. restricting knowledge base recall to authorized users on messaging platforms).

## Why

The gateway already passes `source.user_id` as `user_id` to `AIAgent`, which stores it in `self._user_id`. This information is available at the agent level but is not forwarded to plugins, making it impossible to implement ACL in plugins that need to know *who* is making the request.

Real-world use case: a ClawKB auto-recall plugin that injects knowledge base context before each LLM call needs to restrict recall access to authorized users. Without `sender_id`, all users either get full access or no access.

## How

One-line change: forward `self._user_id` as `sender_id` in the `pre_llm_call` kwargs.

- For messaging platforms (Telegram, Discord, Slack, WhatsApp, Signal, etc.): `sender_id` will be the platform-specific user ID string (e.g. `"8541626028"` for Telegram, `"212609985698332672"` for Discord)
- For CLI sessions: `sender_id` will be an empty string `""` (no user ID on local terminal)
- For older Hermes versions that don't pass this field: plugins using `kwargs.get("sender_id")` will get `None`, which is safe

## Testing

- All 336 plugin-related tests pass (`pytest tests/ -v -x -k "plugin"`)
- Manually tested on Telegram gateway: `sender_id` correctly receives the Telegram user ID
- Verified CLI session returns empty string for `sender_id`

## Breaking Changes

None. This is additive — existing plugins that don't use `sender_id` are unaffected. The kwargs dict simply has one more key.