### PR TITLE
fix: propagate provider-specific headers in fallback activation

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -752,7 +752,7 @@ def run_doctor(args):
                 _url = (_base.rstrip("/") + "/models") if _base else _default_url
                 _headers = {"Authorization": f"Bearer {_key}"}
                 if "api.kimi.com" in _url.lower():
-                    _headers["User-Agent"] = "KimiCLI/1.0"
+                    _headers["User-Agent"] = "KimiCLI/1.3"
                 _resp = httpx.get(
                     _url,
                     headers=_headers,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5015,6 +5015,9 @@ class AIAgent:
                     "base_url": fb_base_url,
                     **({"default_headers": dict(fb_headers)} if fb_headers else {}),
                 }
+                # Apply provider-specific headers (e.g. User-Agent for Kimi)
+                # so per-request clients inherit them from _client_kwargs.
+                self._apply_client_headers_for_base_url(fb_base_url)
 
             # Re-evaluate prompt caching for the new provider/model
             is_native_anthropic = fb_api_mode == "anthropic_messages"


### PR DESCRIPTION
## Summary

- Fix HTTP 403 errors when Kimi Coding Plan (`sk-kimi-*` key) is used as a fallback provider
- Add `_apply_client_headers_for_base_url()` call in `_try_activate_fallback()` after `_client_kwargs` is rebuilt, ensuring provider-specific `default_headers` (e.g. `User-Agent: KimiCLI/1.3`) are propagated to per-request OpenAI clients
- Update stale `KimiCLI/1.0` User-Agent string in `hermes_cli/doctor.py` to `KimiCLI/1.3` to match `run_agent.py` and `auxiliary_client.py`

## Background: Kimi's Two APIs

Kimi operates two separate API products under the same `kimi-coding` provider in Hermes:

| | Moonshot Platform API | Kimi Coding Plan |
|---|---|---|
| **Endpoint** | `api.moonshot.ai/v1` | `api.kimi.com/coding/v1` |
| **Pricing** | Pay-per-token (usage-based) | Subscription (monthly plan) |
| **Key prefix** | `sk-...` | `sk-kimi-...` |
| **Models** | Multiple (moonshot-v1-*, kimi-k2, k2.5, etc.) | Single (`kimi-for-coding`) |
| **User-Agent required** | No | Yes (must match a known coding agent, returns 403 otherwise) |

Hermes treats these as a single provider (`kimi-coding`) with runtime detection: `_resolve_kimi_base_url()` checks the key prefix and reroutes `sk-kimi-*` keys to `api.kimi.com/coding/v1`. This rerouting works correctly — the issue is that the coding endpoint **requires** a `User-Agent` header identifying a known coding agent, and this header gets dropped in the fallback path.

Moonshot platform keys (`sk-...`) are unaffected since `api.moonshot.ai/v1` doesn't enforce User-Agent.

## Root Cause

When `_try_activate_fallback()` switches to a fallback provider, it rebuilds `_client_kwargs` with only `api_key` and `base_url`:

```python
self._client_kwargs = {
    "api_key": fb_client.api_key,
    "base_url": fb_base_url,
}
```

Hermes creates a **fresh** OpenAI client from `_client_kwargs` for each API request (`_create_request_openai_client`). Without `default_headers` in the kwargs, the per-request clients lose provider-specific headers like `User-Agent: KimiCLI/1.3`. The initial fallback client (`fb_client`) has the correct headers, but they don't survive into subsequent requests.

`_apply_client_headers_for_base_url()` — which canonically handles provider-specific header injection — is already used in credential rotation and primary client rebuilds, but was not called in the fallback path.

Note: this affects any fallback provider that requires custom headers. Kimi Coding Plan is currently the only provider that hard-fails (403) on missing headers, but OpenRouter attribution headers and Copilot headers would also be silently dropped.

## Fix

Call `_apply_client_headers_for_base_url(fb_base_url)` immediately after setting `_client_kwargs` in the fallback activation path. This ensures headers are applied through the same canonical codepath used everywhere else. The method handles all providers correctly (Kimi, OpenRouter, Copilot, Qwen) and is a no-op for providers that don't need custom headers.

## Test plan

- [x] Configure Kimi Coding Plan (`sk-kimi-*` key) as fallback and trigger primary failover — verify no 403
- [x] Configure Moonshot platform key (`sk-*`) as fallback — verify no regression
- [x] Verify `User-Agent: KimiCLI/1.3` appears in outgoing requests to `api.kimi.com` when Kimi is the fallback
- [x] Run `hermes doctor` and confirm Kimi connectivity check passes
- [x] Verify non-Kimi fallback providers (e.g. OpenRouter, DeepSeek) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)