### PR TITLE
fix(agent): handle multimodal content during context compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -13,6 +13,7 @@ Improvements over v1:
   - Richer tool call/result detail in summarizer input
 """
 
+import json
 import logging
 import time
 from typing import Any, Dict, List, Optional
@@ -148,6 +149,84 @@ class ContextCompressor:
             "compression_count": self.compression_count,
         }
 
+    @staticmethod
+    def _content_to_text(content: Any) -> str:
+        """Best-effort text rendering for multimodal and non-string content."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            try:
+                return json.dumps(content, ensure_ascii=False, sort_keys=True)
+            except TypeError:
+                return str(content)
+
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                if part:
+                    parts.append(part)
+                continue
+            if not isinstance(part, dict):
+                continue
+            ptype = str(part.get("type", "") or "")
+            if ptype in {"text", "input_text", "output_text"}:
+                text = str(part.get("text", "") or "")
+                if text:
+                    parts.append(text)
+            elif ptype in {"image_url", "input_image"}:
+                parts.append("[image]")
+            elif ptype in {"audio", "audio_url", "input_audio"}:
+                parts.append("[audio]")
+            elif ptype:
+                parts.append(f"[{ptype}]")
+        return " ".join(part for part in parts if part).strip()
+
+    @staticmethod
+    def _content_text_block_type(content: Any) -> str:
+        """Choose a compatible text block type when extending multimodal content."""
+        if isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                ptype = str(part.get("type", "") or "")
+                if ptype in {"text", "input_text", "output_text"}:
+                    return ptype
+        return "text"
+
+    @classmethod
+    def _append_text_to_content(cls, content: Any, text: str) -> Any:
+        """Append text while preserving multimodal list content when possible."""
+        if not text:
+            return content
+        if content is None:
+            return text
+        if isinstance(content, str):
+            return content + text
+        if isinstance(content, list):
+            return [
+                *content,
+                {"type": cls._content_text_block_type(content), "text": text},
+            ]
+        return cls._content_to_text(content) + text
+
+    @classmethod
+    def _prepend_text_to_content(cls, text: str, content: Any) -> Any:
+        """Prepend text while preserving multimodal list content when possible."""
+        if not text:
+            return content
+        if content is None:
+            return text
+        if isinstance(content, str):
+            return text + content
+        if isinstance(content, list):
+            return [
+                {"type": cls._content_text_block_type(content), "text": text},
+                *content,
+            ]
+        return text + cls._content_to_text(content)
+
     # ------------------------------------------------------------------
     # Tool output pruning (cheap pre-pass, no LLM call)
     # ------------------------------------------------------------------
@@ -180,7 +259,7 @@ class ContextCompressor:
             min_protect = min(protect_tail_count, len(result) - 1)
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                content_len = len(msg.get("content") or "")
+                content_len = len(self._content_to_text(msg.get("content")))
                 msg_tokens = content_len // _CHARS_PER_TOKEN + 10
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
@@ -200,10 +279,11 @@ class ContextCompressor:
             if msg.get("role") != "tool":
                 continue
             content = msg.get("content", "")
-            if not content or content == _PRUNED_TOOL_PLACEHOLDER:
+            content_text = self._content_to_text(content)
+            if not content_text or content_text == _PRUNED_TOOL_PLACEHOLDER:
                 continue
             # Only prune if the content is substantial (>200 chars)
-            if len(content) > 200:
+            if len(content_text) > 200:
                 result[i] = {**msg, "content": _PRUNED_TOOL_PLACEHOLDER}
                 pruned += 1
 
@@ -243,7 +323,7 @@ class ContextCompressor:
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = msg.get("content") or ""
+            content = self._content_to_text(msg.get("content"))
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":
@@ -577,7 +657,7 @@ Write only the summary body. Do not include any preamble or prefix."""
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
-            content = msg.get("content") or ""
+            content = self._content_to_text(msg.get("content"))
             msg_tokens = len(content) // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
             # Include tool call arguments in estimate
             for tc in msg.get("tool_calls") or []:
@@ -685,9 +765,9 @@ Write only the summary body. Do not include any preamble or prefix."""
         for i in range(compress_start):
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system" and self.compression_count == 0:
-                msg["content"] = (
-                    (msg.get("content") or "")
-                    + "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
+                msg["content"] = self._append_text_to_content(
+                    msg.get("content"),
+                    "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]",
                 )
             compressed.append(msg)
 
@@ -732,8 +812,7 @@ Write only the summary body. Do not include any preamble or prefix."""
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
             if _merge_summary_into_tail and i == compress_end:
-                original = msg.get("content") or ""
-                msg["content"] = summary + "\n\n" + original
+                msg["content"] = self._prepend_text_to_content(f"{summary}\n\n", msg.get("content"))
                 _merge_summary_into_tail = False
             compressed.append(msg)
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -118,6 +118,137 @@ class TestCompress:
         assert msgs[-2]["content"] in result[-2]["content"]
 
 
+class TestMultimodalContent:
+    def test_content_to_text_flattens_multimodal_blocks(self, compressor):
+        content = [
+            {"type": "input_text", "text": "What is in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            {"type": "audio", "audio": {"id": "clip-1"}},
+            {"type": "tool_result"},
+        ]
+
+        result = compressor._content_to_text(content)
+
+        assert "What is in this image?" in result
+        assert "[image]" in result
+        assert "[audio]" in result
+        assert "[tool_result]" in result
+
+    def test_generate_summary_flattens_multimodal_prompt(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "[CONTEXT SUMMARY]: multimodal summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Please inspect this image"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                ],
+            },
+            {"role": "assistant", "content": "It looks like a cat."},
+            {"role": "user", "content": "thanks"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
+            summary = c._generate_summary(messages)
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert isinstance(summary, str)
+        assert "Please inspect this image" in prompt
+        assert "[image]" in prompt
+        assert "image_url" not in prompt
+
+    def test_compress_preserves_multimodal_system_message(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "[CONTEXT SUMMARY]: compressed middle"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        msgs = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "System prompt"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/rules.png"}},
+                ],
+            },
+            *[
+                {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+                for i in range(10)
+            ],
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        assert isinstance(result[0]["content"], list)
+        assert result[0]["content"][0] == {"type": "text", "text": "System prompt"}
+        assert result[0]["content"][1]["type"] == "image_url"
+        assert result[0]["content"][-1]["type"] == "text"
+        assert "Some earlier conversation turns have been compacted" in result[0]["content"][-1]["text"]
+
+    def test_double_collision_preserves_multimodal_tail_message(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=3)
+
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "msg 1"},
+            {"role": "assistant", "content": "msg 2"},
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+            {"role": "user", "content": "msg 5"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "msg 6"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/tail.png"}},
+                ],
+            },
+            {"role": "assistant", "content": "msg 7"},
+            {"role": "user", "content": "msg 8"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        merged_tail = next(
+            msg
+            for msg in result
+            if isinstance(msg.get("content"), list)
+            and any(
+                isinstance(part, dict)
+                and part.get("type") == "image_url"
+                for part in msg["content"]
+            )
+        )
+        assert merged_tail["content"][0]["type"] == "text"
+        assert merged_tail["content"][0]["text"].startswith(SUMMARY_PREFIX)
+        assert merged_tail["content"][0]["text"].endswith("summary text\n\n")
+        assert any(
+            isinstance(part, dict)
+            and part.get("type") == "text"
+            and part.get("text") == "msg 6"
+            for part in merged_tail["content"]
+        )
+        assert any(
+            isinstance(part, dict)
+            and part.get("type") == "image_url"
+            for part in merged_tail["content"]
+        )
+
+
 class TestGenerateSummaryNoneContent:
     """Regression: content=None (from tool-call-only assistant messages) must not crash."""
 


### PR DESCRIPTION
Supersedes #917.
Related: #6954.

## Problem
The current context compressor still assumes `message["content"]` is a plain string in several places. That works for text-only turns, but multimodal Codex/Responses-style payloads can still be list-based (`text`, `image_url`, `input_image`, etc.), which means:

- tail heuristics can count list items instead of characters
- summary serialization can feed raw structures into the compaction prompt
- compaction note / summary merges can break on list-shaped content

## Fix
- add `_content_to_text()` to normalize multimodal and non-string content for compaction heuristics and summary serialization
- use normalized text when sizing the protected tail and deciding whether old tool results are large enough to prune
- preserve list-shaped content when appending the first-compaction system note and when merging a summary into the first tail message on double-collision layouts
- add focused regression coverage for multimodal prompt serialization, multimodal system messages, and multimodal tail merges

## Testing
- `venv/bin/python -m pytest tests/agent/test_context_compressor.py tests/run_agent/test_compression_boundary.py -q -n 0` (52 passed)
- manual smoke exercising `ContextCompressor.compress()` with multimodal system and tail messages; verified the compaction note and merged summary stay list-based and preserve the original `image_url` block
- `venv/bin/python -m pytest tests/ -q` still reports existing unrelated failures on current `origin/main`; representative approval/transcription failures reproduce on a clean `origin/main` worktree (`tests/gateway/test_approve_deny_commands.py`, `tests/tools/test_transcription.py`)
