### PR TITLE
fix(cron): missing field init, unnecessary save, and shutdown cleanup

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -452,6 +452,7 @@ def create_job(
         "last_run_at": None,
         "last_status": None,
         "last_error": None,
+        "last_delivery_error": None,
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -620,8 +621,8 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
 
             save_jobs(jobs)
             return
-    
-    save_jobs(jobs)
+
+    logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
 
 
 def advance_next_run(job_id: str) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -711,7 +711,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
             raise
         finally:
-            _cron_pool.shutdown(wait=False)
+            _cron_pool.shutdown(wait=False, cancel_futures=True)
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.


### PR DESCRIPTION
## Summary

Three small bug fixes in the cron module:

- **Add missing `last_delivery_error` field initialization in `create_job()`** — `mark_job_run()` sets `job["last_delivery_error"]` on execution, but newly created jobs never initialize this field. This causes inconsistent job schemas between new and executed jobs.

- **Replace unnecessary `save_jobs()` on missing job_id with a warning log** — When `mark_job_run()` is called with a non-existent `job_id` (possible race between deletion and execution), the function silently wrote unchanged data to disk. Now it logs a warning and skips the write.

- **Add `cancel_futures=True` to thread pool shutdown in `finally` block** — The `except` path on line 711 already cancels futures (`_cron_pool.shutdown(wait=False, cancel_futures=True)`), but the `finally` block on line 714 did not, leaving futures potentially running after inactivity timeout.

## Test plan

- [ ] Verify new cron jobs include `last_delivery_error: null` in their schema
- [ ] Verify `mark_job_run()` with a deleted job_id logs a warning instead of silently saving
- [ ] Verify cron inactivity timeout properly cancels pending futures