### PR TITLE
fix(tools): guard against ValueError on int() env var and header parsing

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -579,7 +579,10 @@ class ProcessRegistry:
         from tools.ansi_strip import strip_ansi
         from tools.terminal_tool import _interrupt_event
 
-        default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
+        try:
+            default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
+        except (ValueError, TypeError):
+            default_timeout = 180
         max_timeout = default_timeout
         requested_timeout = timeout
         timeout_note = None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -666,7 +666,10 @@ async def _send_email(extra, chat_id, message):
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
     password = os.getenv("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
-    smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+    try:
+        smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+    except (ValueError, TypeError):
+        smtp_port = 587
 
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1788,7 +1788,10 @@ class ClawHubSource(SkillSource):
                     follow_redirects=True,
                 )
                 if resp.status_code == 429:
-                    retry_after = int(resp.headers.get("retry-after", "5"))
+                    try:
+                        retry_after = int(resp.headers.get("retry-after", "5"))
+                    except (ValueError, TypeError):
+                        retry_after = 5
                     retry_after = min(retry_after, 15)  # Cap wait time
                     logger.debug(
                         "ClawHub download rate-limited for %s, retrying in %ds (attempt %d/%d)",


### PR DESCRIPTION
## Summary

- **`send_message_tool.py`** — `EMAIL_SMTP_PORT` is parsed with `int()` outside the `try/except` block. A non-numeric env var value (e.g. `"smtp"`) causes an unhandled `ValueError`, crashing `_send_email()` instead of returning an error dict.

- **`process_registry.py`** — `TERMINAL_TIMEOUT` is parsed with `int()` without any protection. A non-numeric value crashes the `wait()` method before it can proceed.

- **`skills_hub.py`** — The HTTP `Retry-After` header can contain date strings per RFC 7231 (e.g. `"Thu, 10 Apr 2026 12:00:00 GMT"`). The `int()` conversion crashes on non-numeric values during ClawHub download rate-limiting.

All three now catch `ValueError`/`TypeError` and fall back to their respective defaults (587, 180, 5).

## Test plan

- [ ] Set `EMAIL_SMTP_PORT=abc` and verify email sending returns an error instead of crashing
- [ ] Set `TERMINAL_TIMEOUT=invalid` and verify `wait()` falls back to 180s
- [ ] Verify 429 responses with date-format `Retry-After` headers don't crash skill downloads