### PR TITLE
fix(agent): reset truncated tool call retry counter after successful turns

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7950,6 +7950,10 @@ class AIAgent:
                                 "error": "First response truncated due to output length limit"
                             }
                     
+                    # Reset truncated-tool-call retry counter after a successful
+                    # (non-truncated) response so future turns get a fair retry.
+                    truncated_tool_call_retries = 0
+
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
                         canonical_usage = normalize_usage(


### PR DESCRIPTION
## Summary

- The `truncated_tool_call_retries` counter is initialized to `0` before the main conversation loop (line 7333) but never reset between turns.
- After the first truncated-tool-call event in a conversation consumes the single retry, the counter stays at `1` for the rest of the session.
- All subsequent turns that encounter truncation immediately error out (`"refusing to execute incomplete tool arguments"`) without getting their retry.

**Fix:** Reset the counter to `0` after each successful (non-truncated) API response, so every turn in the conversation gets a fair retry opportunity.

## Reproduction scenario

1. Agent makes API call on turn 5 → response truncated with tool calls → retry succeeds
2. Agent continues normally for turns 6-14
3. Turn 15 → response truncated with tool calls → **immediately errors out** (no retry) because `truncated_tool_call_retries` is still `1` from turn 5

## Test plan

- [ ] Verify that after a successful retry on one turn, a later turn still gets its retry attempt
- [ ] Verify that within a single truncation event, the retry-once limit is preserved (no infinite retry loop)