### PR TITLE
fix(gateway): replace assertions with proper error handling in Telegram and Feishu

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -972,7 +972,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         return await original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
-        assert original_configure is not None
+        if original_configure is None:
+            raise RuntimeError("Feishu _configure_with_overrides called but original_configure is None")
         result = original_configure(conf)
         _apply_runtime_ws_overrides()
         return result

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -110,7 +110,8 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                 logger.warning("[Telegram] Fallback IP %s failed: %s", ip, exc)
                 continue
 
-        assert last_error is not None
+        if last_error is None:
+            raise RuntimeError("All Telegram fallback IPs exhausted but no error was recorded")
         raise last_error
 
     async def aclose(self) -> None:


### PR DESCRIPTION
## Summary

Python `assert` statements are stripped when running with `python -O` (optimized mode), making them unsuitable for runtime control flow. Two locations in the gateway use assertions for error handling:

- **`telegram_network.py:113`** — After exhausting all fallback IPs, `assert last_error is not None` guards a `raise last_error`. In `-O` mode, the assert is skipped; if `last_error` is unexpectedly `None`, `raise None` produces a confusing `TypeError: exceptions must derive from BaseException` instead of a meaningful error. Replaced with an explicit `if` check that raises `RuntimeError`.

- **`feishu.py:975`** — `_configure_with_overrides()` uses `assert original_configure is not None` as a guard. While the outer scope only installs this closure when `original_configure is not None`, the assert silently disappears in optimized mode. Replaced with an explicit `if` check for defensive safety.

## Test plan

- [ ] Run Telegram adapter with all fallback IPs unreachable — verify clear `RuntimeError` instead of `TypeError`
- [ ] Run Feishu adapter — verify WebSocket configure override works normally
- [ ] Run with `python -O` — verify error paths still function correctly