### PR TITLE
fix(docker): install all extras in a uv-managed venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ RUN apt-get update && \
 COPY . /opt/hermes
 WORKDIR /opt/hermes
 
-# Install Python and Node dependencies in one layer, no cache
-RUN pip install --no-cache-dir -e ".[all]" --break-system-packages && \
+# Install Python and Node dependencies in one layer, no cache.
+# Use uv instead of pip for the giant [all] extra set — pip now hits
+# resolution-too-deep on GitHub Actions' Debian 13 / Python 3.13 image.
+RUN pip install --no-cache-dir uv --break-system-packages && \
+    uv pip install --system -e ".[all]" && \
     npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
     cd /opt/hermes/scripts/whatsapp-bridge && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM debian:13.4
 
 # Disable Python stdout buffering to ensure logs are printed immediately
 ENV PYTHONUNBUFFERED=1
+ENV VIRTUAL_ENV=/opt/hermes/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
@@ -16,7 +18,8 @@ WORKDIR /opt/hermes
 # Use uv instead of pip for the giant [all] extra set — pip now hits
 # resolution-too-deep on GitHub Actions' Debian 13 / Python 3.13 image.
 RUN pip install --no-cache-dir uv --break-system-packages && \
-    uv pip install --system -e ".[all]" && \
+    uv venv "$VIRTUAL_ENV" && \
+    uv pip install --python "$VIRTUAL_ENV/bin/python" -e ".[all]" && \
     npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
     cd /opt/hermes/scripts/whatsapp-bridge && \

--- a/tests/test_dockerfile_install.py
+++ b/tests/test_dockerfile_install.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+
+def test_dockerfile_uses_uv_for_all_extras_install():
+    content = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert 'pip install --no-cache-dir uv --break-system-packages' in content
+    assert 'uv pip install --system -e ".[all]"' in content
+    assert 'pip install --no-cache-dir -e ".[all]" --break-system-packages' not in content

--- a/tests/test_dockerfile_install.py
+++ b/tests/test_dockerfile_install.py
@@ -5,9 +5,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 
 
-def test_dockerfile_uses_uv_for_all_extras_install():
+def test_dockerfile_uses_uv_venv_for_all_extras_install():
     content = DOCKERFILE.read_text(encoding="utf-8")
 
+    assert 'ENV VIRTUAL_ENV=/opt/hermes/.venv' in content
+    assert 'ENV PATH="$VIRTUAL_ENV/bin:$PATH"' in content
     assert 'pip install --no-cache-dir uv --break-system-packages' in content
-    assert 'uv pip install --system -e ".[all]"' in content
+    assert 'uv venv "$VIRTUAL_ENV"' in content
+    assert 'uv pip install --python "$VIRTUAL_ENV/bin/python" -e ".[all]"' in content
     assert 'pip install --no-cache-dir -e ".[all]" --break-system-packages' not in content


### PR DESCRIPTION
## Summary
- switch the Docker image build away from `pip install -e ".[all]"`
- install `uv`, create `/opt/hermes/.venv`, and install `.[all]` into that uv-managed environment
- keep the existing Node / Playwright steps unchanged
- add a regression test that locks the Dockerfile to the uv-venv install path

## Why
The current upstream `Docker Build and Publish` workflow is failing on `main` because pip hits `resolution-too-deep` while resolving the giant `.[all]` extra set on Debian 13 / Python 3.13.

A straight `uv --system` install also trips Debian's externally-managed interpreter guard, so the fix needs its own virtualenv inside the image.

Failed baseline run: https://github.com/NousResearch/hermes-agent/actions/runs/24221111425

## Test plan
- `python -m pytest tests/test_dockerfile_install.py -q -o addopts=''`
- `uv venv .uvci && uv pip install --python .uvci/bin/python -e '.[all]'`

Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.

Carried patch: patch-fix-test-pr6922
Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.
