### PR TITLE
fix(approval,mcp): log silent exception handlers, narrow OAuth catches, close server on error

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -342,7 +342,8 @@ def load_permanent_allowlist() -> set:
         if patterns:
             load_permanent(patterns)
         return patterns
-    except Exception:
+    except Exception as e:
+        logger.warning("Failed to load permanent allowlist: %s", e)
         return set()
 
 
@@ -384,7 +385,8 @@ def prompt_dangerous_approval(command: str, description: str,
         try:
             return approval_callback(command, description,
                                      allow_permanent=allow_permanent)
-        except Exception:
+        except Exception as e:
+            logger.error("Approval callback failed: %s", e, exc_info=True)
             return "deny"
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
@@ -466,7 +468,8 @@ def _get_approval_config() -> dict:
         from hermes_cli.config import load_config
         config = load_config()
         return config.get("approvals", {}) or {}
-    except Exception:
+    except Exception as e:
+        logger.warning("Failed to load approval config: %s", e)
         return {}
 
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -198,8 +198,8 @@ class HermesTokenStorage:
             return None
         try:
             return OAuthToken.model_validate(data)
-        except Exception:
-            logger.warning("Corrupt tokens at %s -- ignoring", self._tokens_path())
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning("Corrupt tokens at %s -- ignoring: %s", self._tokens_path(), exc)
             return None
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
@@ -214,8 +214,8 @@ class HermesTokenStorage:
             return None
         try:
             return OAuthClientInformationFull.model_validate(data)
-        except Exception:
-            logger.warning("Corrupt client info at %s -- ignoring", self._client_info_path())
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning("Corrupt client info at %s -- ignoring: %s", self._client_info_path(), exc)
             return None
 
     async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
@@ -343,13 +343,14 @@ async def _wait_for_callback() -> tuple[str, str | None]:
     timeout = 300.0
     poll_interval = 0.5
     elapsed = 0.0
-    while elapsed < timeout:
-        if result["auth_code"] is not None or result["error"] is not None:
-            break
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-
-    server.server_close()
+    try:
+        while elapsed < timeout:
+            if result["auth_code"] is not None or result["error"] is not None:
+                break
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+    finally:
+        server.server_close()
 
     if result["error"]:
         raise RuntimeError(f"OAuth authorization failed: {result['error']}")


### PR DESCRIPTION
## Summary

- **approval.py**: Three `except Exception` blocks (lines 345, 387, 469) silently return fallback values (`set()`, `"deny"`, `{}`) with **zero logging** — making callback failures, allowlist load errors, and config read issues impossible to diagnose. Added `logger.warning`/`logger.error` calls consistent with the existing pattern used by `save_permanent_allowlist()` (line 357) and `_smart_approve()` (line 535) in the same file.

- **mcp_oauth.py – get_tokens() / get_client_info()**: Narrowed overly-broad `except Exception` to `(ValueError, TypeError, KeyError)` — the specific exceptions Pydantic's `model_validate()` raises for corrupt data. The broad catch previously swallowed unexpected errors (e.g. `MemoryError`, filesystem bugs) that should propagate. Also added the exception message to the warning log.

- **mcp_oauth.py – _wait_for_callback()**: Wrapped the polling loop in `try/finally` so `server.server_close()` is always called. Previously, an `asyncio.CancelledError` or any exception during `await asyncio.sleep()` would skip the close and leak the HTTPServer socket.

## Test plan

- [ ] Verify approval callback works normally (no regression in interactive approval flow)
- [ ] Verify MCP OAuth flow still completes (tokens saved/loaded correctly)
- [ ] Inject a broken approval callback and confirm the error is now logged
- [ ] Cancel an OAuth flow mid-wait and confirm the server socket is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)