### PR TITLE
fix: hidden_div regex bypass with newlines, credential config silent failure, webhook route error severity

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -40,7 +40,7 @@ _CONTEXT_THREAT_PATTERNS = [
     (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),
     (r'act\s+as\s+(if|though)\s+you\s+(have\s+no|don\'t\s+have)\s+(restrictions|limits|rules)', "bypass_restrictions"),
     (r'<!--[^>]*(?:ignore|override|system|secret|hidden)[^>]*-->', "html_comment_injection"),
-    (r'<\s*div\s+style\s*=\s*["\'].*display\s*:\s*none', "hidden_div"),
+    (r'<\s*div\s+style\s*=\s*["\'][\s\S]*?display\s*:\s*none', "hidden_div"),
     (r'translate\s+.*\s+into\s+.*\s+and\s+(execute|run|eval)', "translate_execute"),
     (r'curl\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)', "exfil_curl"),
     (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass)', "read_secrets"),

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -262,7 +262,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 ", ".join(self._dynamic_routes.keys()) or "(none)",
             )
         except Exception as e:
-            logger.warning("[webhook] Failed to reload dynamic routes: %s", e)
+            logger.error("[webhook] Failed to reload dynamic routes: %s", e)
 
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -168,7 +168,7 @@ def _load_config_files() -> List[Dict[str, str]]:
                             "container_path": container_path,
                         })
     except Exception as e:
-        logger.debug("Could not read terminal.credential_files from config: %s", e)
+        logger.warning("Could not read terminal.credential_files from config: %s", e)
 
     _config_files = result
     return _config_files


### PR DESCRIPTION
## Summary

- **prompt_builder.py** — The `hidden_div` context injection detection pattern uses `.*` which does not cross newlines in Python regex (no `re.DOTALL`). An attacker can bypass it by splitting the style attribute:
  ```html
  <div style="color:red;
  display: none">injected prompt</div>
  ```
  Fix: replace `.*` with `[\s\S]*?` (lazy cross-line match).

- **credential_files.py** — `_load_config_files()` catches all exceptions at `DEBUG` level (line 171), making YAML parse failures invisible in production. Credential files silently fail to mount into sandboxes with zero diagnostic output. Promoted to `WARNING` to match the severity of the path validation warnings (lines 150, 158) in the same function.

- **webhook.py** — `_reload_dynamic_routes()` logs JSON parse failures at `WARNING` (line 265). When the subscriptions file is corrupted, stale/compromised routes persist silently. Promoted to `ERROR` to ensure operator visibility in alerting pipelines.

## Test plan

- [ ] Verify hidden div detection catches multiline style attributes: `<div style="x;\ndisplay: none">`
- [ ] Verify credential_files warning appears in logs when config.yaml has invalid YAML
- [ ] Verify webhook route reload errors appear at ERROR level in gateway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)