### PR TITLE
feat: add blocked-wait heartbeat across CLI and gateway sessions

### DIFF
--- a/BLOCKED_WAIT_PROXY_VISION.md
+++ b/BLOCKED_WAIT_PROXY_VISION.md
@@ -65,6 +65,9 @@ Current implementation status on this branch
 - blocked-session proxy config + runtime exists
 - gateway can prompt to enable the proxy when a wait kind lacks config
 - gateway can use the proxy for blocked clarify/delegate meta-questions
+- gateway-backed CLI sessions now emit structured blocked-wait/activity events over the run SSE stream
+- gateway-backed CLI sessions can round-trip blocking clarify requests through the local interactive client
+- blocked-session helpers can target a named Hermes profile and launch through that profile's gateway runtime
 - normal free-text during delegate waits still falls through as steering/interruption
 
 Endgame

--- a/BLOCKED_WAIT_PROXY_VISION.md
+++ b/BLOCKED_WAIT_PROXY_VISION.md
@@ -1,0 +1,73 @@
+# Blocked Wait Proxy Vision
+
+Goal: when the main Hermes session is blocked on an interactive/tool wait, Hermes should still feel socially present and steerable instead of looking frozen.
+
+Core idea
+- Treat every blocked state as a generic blocked-session substrate.
+- The substrate records:
+  - wait kind
+  - when it started
+  - current activity
+  - child-agent summaries
+  - allowed actions
+- Then attach a thin per-wait adapter (clarify, delegate, approval, update, etc.).
+- A cheap continuity proxy can be launched on top of that substrate so the user is still talking to “Hermes” while the main run is paused.
+
+Proxy model
+- Prefer a cheap local Qwen-style model when configured.
+- If no dedicated proxy model is configured, inherit the current Hermes runtime.
+- The proxy is not a separate persona; it is the blocked-session face of the main Hermes thread.
+
+Proxy prompt shape
+1. Identity / continuity layer
+- “You are the blocked-session continuity proxy for the active Hermes session.”
+- “You are not a separate assistant from the user’s perspective.”
+- “Speak like the main assistant and preserve its goals.”
+
+2. Recent-context layer
+- recent assistant style samples
+- recent transcript excerpt (bounded)
+- current blocked wait snapshot
+
+3. Adapter layer
+- dynamic instructions based on the current wait kind
+- example: delegate adapter explains the child’s status and what steering/abort means
+- example: clarify adapter explains what answer Hermes is waiting for and what `/answer` does
+
+No-config behavior
+- If the user tries to use the helper for a wait kind that has no config, Hermes should pause and ask whether to create a default config.
+- Timeout: 90 seconds.
+- A “yes” response writes a small default adapter config for that wait kind.
+- A “no” response leaves the helper disabled and falls back to normal behavior.
+
+Implementation layers
+1. Base substrate
+- `run_agent.py` activity + wait-state metadata
+- generic blocked-wait dispatch path in the gateway
+
+2. Thin adapters
+- update prompt wait
+- dangerous-command approval wait
+- clarify wait
+- delegate wait
+
+3. Proxy runtime
+- `agent/blocked_wait_proxy.py`
+- bounded context excerpt
+- continuity prompt
+- per-kind adapter instructions
+- cheap runtime override from config when available
+
+Current implementation status on this branch
+- generic wait-state metadata exists
+- blocked-wait dispatch exists
+- delegate watchdog / child heartbeat exists
+- blocked-session proxy config + runtime exists
+- gateway can prompt to enable the proxy when a wait kind lacks config
+- gateway can use the proxy for blocked clarify/delegate meta-questions
+- normal free-text during delegate waits still falls through as steering/interruption
+
+Endgame
+- make the proxy/profile system fully reusable across all blocked waits
+- allow named profiles / launch presets for reviewer, delegate supervisor, or continuity helper roles
+- let tools specify only their adapter instructions while the substrate + launch mechanism remain generic

--- a/agent/blocked_wait_proxy.py
+++ b/agent/blocked_wait_proxy.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import load_config, save_config
@@ -93,15 +95,70 @@ def identity_prompt(config: Optional[dict] = None) -> str:
     return str(cfg.get("identity_prompt") or DEFAULT_IDENTITY_PROMPT).strip()
 
 
-def helper_runtime(parent_agent, config: Optional[dict] = None) -> dict:
+def _kind_cfg(kind: str, config: Optional[dict] = None) -> dict:
+    cfg = config or load_blocked_wait_proxy_config()
+    kinds = cfg.get("kinds", {}) or {}
+    kind_cfg = kinds.get(kind, {}) or {}
+    return kind_cfg if isinstance(kind_cfg, dict) else {}
+
+
+
+def helper_profile(kind: str, config: Optional[dict] = None) -> str:
+    cfg = config or load_blocked_wait_proxy_config()
+    kind_cfg = _kind_cfg(kind, cfg)
+    return str(kind_cfg.get("profile") or cfg.get("profile") or "").strip()
+
+
+
+def helper_launcher(kind: str, parent_agent, config: Optional[dict] = None) -> str:
+    cfg = config or load_blocked_wait_proxy_config()
+    kind_cfg = _kind_cfg(kind, cfg)
+    raw = str(kind_cfg.get("launcher") or cfg.get("launcher") or "auto").strip().lower()
+    if raw not in {"auto", "direct", "gateway"}:
+        raw = "auto"
+    if raw == "auto":
+        if helper_profile(kind, cfg):
+            return "gateway"
+        if bool(getattr(parent_agent, "gateway_hosted_session", False)):
+            return "gateway"
+        return "direct"
+    return raw
+
+
+
+def helper_gateway_autostart(kind: str, config: Optional[dict] = None) -> bool:
+    cfg = config or load_blocked_wait_proxy_config()
+    kind_cfg = _kind_cfg(kind, cfg)
+    value = kind_cfg.get("gateway_autostart")
+    if value is None:
+        value = cfg.get("gateway_autostart", True)
+    return bool(value)
+
+
+
+def helper_runtime(kind: str, parent_agent, config: Optional[dict] = None) -> dict:
     cfg = config or load_blocked_wait_proxy_config()
     return {
+        "launcher": helper_launcher(kind, parent_agent, cfg),
+        "profile": helper_profile(kind, cfg),
+        "gateway_autostart": helper_gateway_autostart(kind, cfg),
         "model": str(cfg.get("model") or "").strip() or getattr(parent_agent, "model", ""),
         "provider": str(cfg.get("provider") or "").strip() or getattr(parent_agent, "provider", None),
         "base_url": str(cfg.get("base_url") or "").strip() or getattr(parent_agent, "base_url", None),
         "api_key": str(cfg.get("api_key") or "").strip() or getattr(parent_agent, "api_key", None),
         "api_mode": getattr(parent_agent, "api_mode", None),
     }
+
+
+
+def _helper_home_for_profile(profile_name: str) -> Optional[Path]:
+    if not profile_name:
+        return None
+    from hermes_cli.profiles import resolve_profile_env
+
+    resolved = resolve_profile_env(profile_name)
+    return Path(resolved).expanduser().resolve()
+
 
 
 def looks_like_meta_question(text: str) -> bool:
@@ -242,26 +299,51 @@ def run_blocked_wait_proxy(*, kind: str, activity: dict, history: List[Dict[str,
     from run_agent import AIAgent
 
     cfg = load_blocked_wait_proxy_config()
-    runtime = helper_runtime(parent_agent, cfg)
+    runtime = helper_runtime(kind, parent_agent, cfg)
     system_prompt = build_system_prompt(kind=kind, activity=activity, history=history, config=cfg)
 
-    helper = AIAgent(
-        model=runtime["model"],
-        provider=runtime["provider"],
-        base_url=runtime["base_url"],
-        api_key=runtime["api_key"],
-        api_mode=runtime["api_mode"],
-        max_iterations=2,
-        enabled_toolsets=[],
-        quiet_mode=True,
-        verbose_logging=False,
-        ephemeral_system_prompt=system_prompt,
-        skip_context_files=True,
-        skip_memory=True,
-        platform=getattr(parent_agent, "platform", None),
-    )
-    helper._print_fn = lambda *_a, **_kw: None
-    result = helper.run_conversation(user_message=user_message)
+    result: Any
+    launcher = runtime.get("launcher") or "direct"
+    if launcher == "gateway":
+        from hermes_cli.gateway_session_client import GatewaySessionAgentProxy, ensure_gateway_session_bridge
+
+        target_home = _helper_home_for_profile(str(runtime.get("profile") or ""))
+        endpoint = ensure_gateway_session_bridge(
+            hermes_home=target_home,
+            autostart=bool(runtime.get("gateway_autostart", True)),
+        )
+        helper = GatewaySessionAgentProxy(
+            endpoint=endpoint,
+            session_id=f"blocked-wait-{kind}-{uuid.uuid4().hex[:10]}",
+            model=runtime["model"],
+            provider=runtime["provider"],
+            base_url=runtime["base_url"],
+            api_key=runtime["api_key"],
+            api_mode=runtime["api_mode"],
+            enabled_toolsets=[],
+            quiet_mode=True,
+            verbose_logging=False,
+            ephemeral_system_prompt=system_prompt,
+        )
+        result = helper.run_conversation(user_message=user_message)
+    else:
+        helper = AIAgent(
+            model=runtime["model"],
+            provider=runtime["provider"],
+            base_url=runtime["base_url"],
+            api_key=runtime["api_key"],
+            api_mode=runtime["api_mode"],
+            max_iterations=2,
+            enabled_toolsets=[],
+            quiet_mode=True,
+            verbose_logging=False,
+            ephemeral_system_prompt=system_prompt,
+            skip_context_files=True,
+            skip_memory=True,
+            platform=getattr(parent_agent, "platform", None),
+        )
+        helper._print_fn = lambda *_a, **_kw: None
+        result = helper.run_conversation(user_message=user_message)
     response = (result or {}).get("final_response", "") if isinstance(result, dict) else str(result or "")
     response = re.sub(r"^\s*Hermes:\s*", "", response or "", flags=re.IGNORECASE)
     return response.strip()

--- a/agent/blocked_wait_proxy.py
+++ b/agent/blocked_wait_proxy.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.config import load_config, save_config
+
+
+DEFAULT_PROXY_CONTEXT_CHARS = 32000
+DEFAULT_SETUP_PROMPT_TIMEOUT = 90
+DEFAULT_IDENTITY_PROMPT = (
+    "You are the blocked-session continuity proxy for the active Hermes session. "
+    "You are not a separate assistant from the user's perspective. Speak like the "
+    "main assistant, preserve its tone and goals, and stay focused on the current "
+    "blocked state instead of inventing a new task."
+)
+
+DEFAULT_KIND_INSTRUCTIONS: dict[str, str] = {
+    "clarify": (
+        "The main Hermes session is blocked waiting for a clarify answer from the user. "
+        "Explain what Hermes is waiting on, restate options when helpful, and guide the "
+        "user toward replying with /answer when they are ready. Do not claim the answer "
+        "was submitted unless the surrounding system tells you it was."
+    ),
+    "delegate": (
+        "The main Hermes session is blocked while a delegated child agent is working. "
+        "You can explain what the child appears to be doing, whether it looks idle or stuck, "
+        "and what the user can do next. If the user clearly wants status, summarize status. "
+        "If they clearly want to steer the child, tell them their next plain message will be "
+        "treated as a steer/interruption request by the main session. If they clearly want to abort, "
+        "say so plainly."
+    ),
+    "approval": (
+        "The main Hermes session is blocked on a dangerous-command approval. "
+        "Explain what is pending and how approval/denial works."
+    ),
+    "update": (
+        "The main Hermes session is blocked on an update prompt. Explain what input Hermes needs."
+    ),
+}
+
+
+def load_blocked_wait_proxy_config() -> dict:
+    cfg = load_config() or {}
+    section = cfg.get("blocked_wait_proxy", {})
+    return section if isinstance(section, dict) else {}
+
+
+def save_default_blocked_wait_proxy_kind(kind: str) -> None:
+    cfg = load_config() or {}
+    section = cfg.setdefault("blocked_wait_proxy", {})
+    section["enabled"] = True
+    section.setdefault("context_char_budget", DEFAULT_PROXY_CONTEXT_CHARS)
+    section.setdefault("setup_prompt_timeout", DEFAULT_SETUP_PROMPT_TIMEOUT)
+    section.setdefault("identity_prompt", DEFAULT_IDENTITY_PROMPT)
+    kinds = section.setdefault("kinds", {})
+    kind_cfg = kinds.setdefault(kind, {})
+    kind_cfg["enabled"] = True
+    kind_cfg["instructions"] = str(kind_cfg.get("instructions") or DEFAULT_KIND_INSTRUCTIONS.get(kind, ""))
+    save_config(cfg)
+
+
+def blocked_wait_proxy_kind_enabled(kind: str, config: Optional[dict] = None) -> bool:
+    cfg = config or load_blocked_wait_proxy_config()
+    if not cfg.get("enabled"):
+        return False
+    kinds = cfg.get("kinds", {}) or {}
+    kind_cfg = kinds.get(kind, {}) or {}
+    if not kind_cfg:
+        return False
+    return bool(kind_cfg.get("enabled"))
+
+
+def blocked_wait_proxy_setup_timeout(config: Optional[dict] = None) -> int:
+    cfg = config or load_blocked_wait_proxy_config()
+    return max(1, int(cfg.get("setup_prompt_timeout") or DEFAULT_SETUP_PROMPT_TIMEOUT))
+
+
+def blocked_wait_proxy_context_budget(config: Optional[dict] = None) -> int:
+    cfg = config or load_blocked_wait_proxy_config()
+    return max(4000, int(cfg.get("context_char_budget") or DEFAULT_PROXY_CONTEXT_CHARS))
+
+
+def kind_instructions(kind: str, config: Optional[dict] = None) -> str:
+    cfg = config or load_blocked_wait_proxy_config()
+    kinds = cfg.get("kinds", {}) or {}
+    kind_cfg = kinds.get(kind, {}) or {}
+    return str(kind_cfg.get("instructions") or DEFAULT_KIND_INSTRUCTIONS.get(kind, "")).strip()
+
+
+def identity_prompt(config: Optional[dict] = None) -> str:
+    cfg = config or load_blocked_wait_proxy_config()
+    return str(cfg.get("identity_prompt") or DEFAULT_IDENTITY_PROMPT).strip()
+
+
+def helper_runtime(parent_agent, config: Optional[dict] = None) -> dict:
+    cfg = config or load_blocked_wait_proxy_config()
+    return {
+        "model": str(cfg.get("model") or "").strip() or getattr(parent_agent, "model", ""),
+        "provider": str(cfg.get("provider") or "").strip() or getattr(parent_agent, "provider", None),
+        "base_url": str(cfg.get("base_url") or "").strip() or getattr(parent_agent, "base_url", None),
+        "api_key": str(cfg.get("api_key") or "").strip() or getattr(parent_agent, "api_key", None),
+        "api_mode": getattr(parent_agent, "api_mode", None),
+    }
+
+
+def looks_like_meta_question(text: str) -> bool:
+    raw = str(text or "").strip()
+    if not raw:
+        return False
+    if raw.endswith("?"):
+        return True
+    lowered = raw.lower()
+    return lowered.startswith((
+        "what", "why", "how", "is ", "are ", "did ", "does ", "where", "when", "status", "stuck", "loop",
+    ))
+
+
+def looks_like_abort_request(text: str) -> bool:
+    lowered = str(text or "").strip().lower()
+    return any(token in lowered for token in ("abort", "stop it", "kill it", "cancel it", "give up"))
+
+
+def looks_like_yes(text: str) -> bool:
+    return str(text or "").strip().lower() in {"y", "yes", "enable", "ok", "okay", "sure"}
+
+
+def looks_like_no(text: str) -> bool:
+    return str(text or "").strip().lower() in {"n", "no", "disable", "skip", "not now"}
+
+
+def _flatten_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text" and item.get("text"):
+                    parts.append(str(item["text"]))
+                elif item.get("type") in {"input_image", "image_url"}:
+                    parts.append("[image]")
+            elif item:
+                parts.append(str(item))
+        return "\n".join(parts)
+    return "" if content is None else str(content)
+
+
+def build_style_examples(messages: List[Dict[str, Any]], max_chars: int = 1600) -> str:
+    chunks: List[str] = []
+    total = 0
+    for msg in reversed(messages or []):
+        if msg.get("role") != "assistant":
+            continue
+        text = _flatten_content(msg.get("content", "")).strip()
+        if not text:
+            continue
+        snippet = text[:280]
+        add = f"Assistant style sample:\n{snippet}\n"
+        if total + len(add) > max_chars:
+            break
+        chunks.append(add)
+        total += len(add)
+        if len(chunks) >= 4:
+            break
+    return "\n".join(reversed(chunks))
+
+
+def build_context_excerpt(messages: List[Dict[str, Any]], max_chars: int) -> str:
+    rows: List[str] = []
+    total = 0
+    for msg in reversed(messages or []):
+        role = msg.get("role")
+        if role not in {"user", "assistant", "tool"}:
+            continue
+        text = _flatten_content(msg.get("content", "")).strip()
+        if not text:
+            continue
+        if role == "tool":
+            tool_name = msg.get("tool_name") or msg.get("name") or "tool"
+            entry = f"Tool {tool_name}: {text[:220]}"
+        else:
+            label = "User" if role == "user" else "Assistant"
+            entry = f"{label}: {text[:320]}"
+        add_len = len(entry) + 2
+        if total + add_len > max_chars:
+            break
+        rows.append(entry)
+        total += add_len
+    return "\n\n".join(reversed(rows))
+
+
+def build_wait_snapshot(kind: str, activity: dict) -> str:
+    wait = activity.get("wait_state") or {}
+    parts = [f"Wait kind: {kind}"]
+    if wait.get("question_preview"):
+        parts.append(f"Question: {wait['question_preview']}")
+    if wait.get("mode"):
+        parts.append(f"Mode: {wait['mode']}")
+    if activity.get("current_tool"):
+        parts.append(f"Current tool: {activity['current_tool']}")
+    if activity.get("last_activity_desc"):
+        parts.append(f"Last activity: {activity['last_activity_desc']}")
+    children = activity.get("active_children") or []
+    if children:
+        child_lines = []
+        for idx, child in enumerate(children[:3], start=1):
+            desc = child.get("current_tool") or child.get("last_activity_desc") or "active"
+            idle = child.get("seconds_since_activity")
+            suffix = f" ({int(idle)}s idle)" if isinstance(idle, (int, float)) else ""
+            line = f"child {idx}: {desc}{suffix}"
+            if child.get("watchdog_reason"):
+                line += f" | watchdog={child['watchdog_reason']}"
+            child_lines.append(line)
+        parts.append("Children:\n" + "\n".join(child_lines))
+    return "\n".join(parts)
+
+
+def build_system_prompt(*, kind: str, activity: dict, history: List[Dict[str, Any]], config: Optional[dict] = None) -> str:
+    cfg = config or load_blocked_wait_proxy_config()
+    context_budget = blocked_wait_proxy_context_budget(cfg)
+    style = build_style_examples(history)
+    excerpt = build_context_excerpt(history, max_chars=max(2000, context_budget - 4000))
+    wait_snapshot = build_wait_snapshot(kind, activity)
+    sections = [
+        identity_prompt(cfg),
+        "Current blocked-session context:\n" + wait_snapshot,
+        "Adapter instructions:\n" + kind_instructions(kind, cfg),
+    ]
+    if style:
+        sections.append("Recent voice/style samples:\n" + style)
+    if excerpt:
+        sections.append("Recent session context excerpt:\n" + excerpt)
+    sections.append(
+        "Your job is to help the user understand and navigate the blocked state. "
+        "Be concrete, concise, and continuity-preserving. Do not fabricate resumed work."
+    )
+    return "\n\n".join(section for section in sections if section.strip())
+
+
+def run_blocked_wait_proxy(*, kind: str, activity: dict, history: List[Dict[str, Any]], user_message: str, parent_agent) -> str:
+    from run_agent import AIAgent
+
+    cfg = load_blocked_wait_proxy_config()
+    runtime = helper_runtime(parent_agent, cfg)
+    system_prompt = build_system_prompt(kind=kind, activity=activity, history=history, config=cfg)
+
+    helper = AIAgent(
+        model=runtime["model"],
+        provider=runtime["provider"],
+        base_url=runtime["base_url"],
+        api_key=runtime["api_key"],
+        api_mode=runtime["api_mode"],
+        max_iterations=2,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        verbose_logging=False,
+        ephemeral_system_prompt=system_prompt,
+        skip_context_files=True,
+        skip_memory=True,
+        platform=getattr(parent_agent, "platform", None),
+    )
+    helper._print_fn = lambda *_a, **_kw: None
+    result = helper.run_conversation(user_message=user_message)
+    response = (result or {}).get("final_response", "") if isinstance(result, dict) else str(result or "")
+    response = re.sub(r"^\s*Hermes:\s*", "", response or "", flags=re.IGNORECASE)
+    return response.strip()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -729,6 +729,29 @@ clarify:
   default_wait_mode: wait   # wait | auto (CLI hotkeys: Esc+A auto, Esc+W wait)
 
 # =============================================================================
+# Blocked-session helper
+# =============================================================================
+# Optional cheap continuity proxy for blocked waits (clarify, delegated work,
+# approvals, update prompts). Leave model/provider/base_url empty to inherit the
+# active Hermes runtime, or point them at a cheap local Qwen-style lane.
+blocked_wait_proxy:
+  enabled: false
+  context_char_budget: 32000
+  setup_prompt_timeout: 90
+  # model: "Qwen/Qwen3-4B-Instruct"
+  # provider: "openrouter"
+  # base_url: "http://127.0.0.1:8000/v1"
+  # api_key: ""
+  # identity_prompt: "You are the blocked-session continuity proxy for Hermes."
+  kinds:
+    clarify:
+      enabled: false
+      instructions: ""
+    delegate:
+      enabled: false
+      instructions: ""
+
+# =============================================================================
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -733,9 +733,13 @@ clarify:
 # =============================================================================
 # Optional cheap continuity proxy for blocked waits (clarify, delegated work,
 # approvals, update prompts). Leave model/provider/base_url empty to inherit the
-# active Hermes runtime, or point them at a cheap local Qwen-style lane.
+# active Hermes runtime, point them at a cheap local Qwen-style lane, or route
+# the helper through a named Hermes profile's gateway runtime.
 blocked_wait_proxy:
   enabled: false
+  launcher: auto          # auto | direct | gateway
+  profile: ""             # optional named profile for the helper runtime
+  gateway_autostart: true
   context_char_budget: 32000
   setup_prompt_timeout: 90
   # model: "Qwen/Qwen3-4B-Instruct"
@@ -743,6 +747,11 @@ blocked_wait_proxy:
   # base_url: "http://127.0.0.1:8000/v1"
   # api_key: ""
   # identity_prompt: "You are the blocked-session continuity proxy for Hermes."
+  # kinds:
+  #   delegate:
+  #     enabled: true
+  #     profile: helper
+  #     launcher: gateway
   kinds:
     clarify:
       enabled: false

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -722,6 +722,13 @@ code_execution:
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
 
 # =============================================================================
+# Clarify prompts
+# =============================================================================
+clarify:
+  timeout: 120              # AUTO mode: seconds of no user activity before proceeding
+  default_wait_mode: wait   # wait | auto (CLI hotkeys: Esc+A auto, Esc+W wait)
+
+# =============================================================================
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.
@@ -729,6 +736,8 @@ code_execution:
 delegation:
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
   default_toolsets: ["terminal", "file", "web"]  # Default toolsets for subagents
+  watchdog_idle_seconds: 180                  # Interrupt a child that shows no activity for too long
+  watchdog_same_tool_limit: 8                 # Interrupt a child that repeats the same tool suspiciously often
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/cli.py
+++ b/cli.py
@@ -285,6 +285,9 @@ def load_cli_config() -> Dict[str, Any]:
         },
         "blocked_wait_proxy": {
             "enabled": False,
+            "launcher": "auto",
+            "profile": "",
+            "gateway_autostart": True,
             "model": "",
             "provider": "",
             "base_url": "",
@@ -293,10 +296,10 @@ def load_cli_config() -> Dict[str, Any]:
             "setup_prompt_timeout": 90,
             "identity_prompt": "",
             "kinds": {
-                "clarify": {"enabled": False, "instructions": ""},
-                "delegate": {"enabled": False, "instructions": ""},
-                "approval": {"enabled": False, "instructions": ""},
-                "update": {"enabled": False, "instructions": ""},
+                "clarify": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
+                "delegate": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
+                "approval": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
+                "update": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
             },
         },
         "code_execution": {
@@ -2759,6 +2762,7 @@ class HermesCLI:
                     ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
                     tool_progress_callback=self._on_tool_progress,
                     reasoning_callback=self._current_reasoning_callback(),
+                    clarify_callback=self._clarify_callback,
                 )
             else:
                 self.agent = AIAgent(
@@ -6120,6 +6124,28 @@ class HermesCLI:
             marker = "⚠️" if event_type == "subagent.warning" else "💓"
             label = preview or function_name or "subagent active"
             self._spinner_text = f"{marker} {label}"
+            self._invalidate(min_interval=0)
+            return
+
+        if event_type == "agent.activity":
+            activity = kwargs.get("activity") or {}
+            wait_state = activity.get("wait_state") or {}
+            if wait_state:
+                kind = str(wait_state.get("kind") or "waiting")
+                mode = str(wait_state.get("mode") or "wait").upper()
+                question = str(wait_state.get("question_preview") or "").strip()
+                label = f"⏳ {kind} ({mode})"
+                if question:
+                    label += f": {question[:48]}"
+                self._spinner_text = label
+            elif activity.get("active_children_count"):
+                child = (activity.get("active_children") or [{}])[0]
+                child_desc = child.get("current_tool") or child.get("last_activity_desc") or "delegate active"
+                self._spinner_text = f"💓 {child_desc}"
+            else:
+                desc = activity.get("last_activity_desc") or activity.get("current_tool")
+                if desc:
+                    self._spinner_text = str(desc)
             self._invalidate(min_interval=0)
             return
 

--- a/cli.py
+++ b/cli.py
@@ -283,6 +283,22 @@ def load_cli_config() -> Dict[str, Any]:
             "timeout": 120,  # Seconds of no user activity before AUTO clarify mode proceeds
             "default_wait_mode": "wait",  # wait | auto
         },
+        "blocked_wait_proxy": {
+            "enabled": False,
+            "model": "",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "context_char_budget": 32000,
+            "setup_prompt_timeout": 90,
+            "identity_prompt": "",
+            "kinds": {
+                "clarify": {"enabled": False, "instructions": ""},
+                "delegate": {"enabled": False, "instructions": ""},
+                "approval": {"enabled": False, "instructions": ""},
+                "update": {"enabled": False, "instructions": ""},
+            },
+        },
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
             "max_tool_calls": 50,  # Max RPC tool calls per execution

--- a/cli.py
+++ b/cli.py
@@ -1494,6 +1494,7 @@ class HermesCLI:
         resume: str = None,
         checkpoints: bool = False,
         pass_session_id: bool = False,
+        gateway_session_mode: bool = False,
     ):
         """
         Initialize the Hermes CLI.
@@ -1513,6 +1514,7 @@ class HermesCLI:
         # Initialize Rich console
         self.console = Console()
         self.config = CLI_CONFIG
+        self.gateway_session_mode = bool(gateway_session_mode)
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
@@ -1712,6 +1714,7 @@ class HermesCLI:
         self._pending_input = queue.Queue()
         self._interrupt_queue = queue.Queue()
         self._should_exit = False
+        self._detaching_gateway_session = False
         self._last_ctrl_c_time = 0
         self._clarify_state = None
         self._clarify_freetext = False
@@ -1749,6 +1752,20 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+
+    def _detach_gateway_session_and_exit(self, event, *, message: str) -> bool:
+        """Detach this terminal client from a gateway-hosted session without cancelling it."""
+        if not (self.gateway_session_mode and self._agent_running and self.agent and hasattr(self.agent, "detach")):
+            return False
+        self._detaching_gateway_session = True
+        self._should_exit = True
+        print(f"\n{message}")
+        try:
+            self.agent.detach()
+        except Exception:
+            logger.debug("Failed to detach gateway session cleanly", exc_info=True)
+        event.app.exit()
+        return True
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -2672,47 +2689,86 @@ class HermesCLI:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
-            self.agent = AIAgent(
-                model=effective_model,
-                api_key=runtime.get("api_key"),
-                base_url=runtime.get("base_url"),
-                provider=runtime.get("provider"),
-                api_mode=runtime.get("api_mode"),
-                acp_command=runtime.get("command"),
-                acp_args=runtime.get("args"),
-                credential_pool=runtime.get("credential_pool"),
-                max_iterations=self.max_turns,
-                enabled_toolsets=self.enabled_toolsets,
-                verbose_logging=self.verbose,
-                quiet_mode=not self.verbose,
-                ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
-                prefill_messages=self.prefill_messages or None,
-                reasoning_config=self.reasoning_config,
-                service_tier=self.service_tier,
-                request_overrides=request_overrides,
-                providers_allowed=self._providers_only,
-                providers_ignored=self._providers_ignore,
-                providers_order=self._providers_order,
-                provider_sort=self._provider_sort,
-                provider_require_parameters=self._provider_require_params,
-                provider_data_collection=self._provider_data_collection,
-                session_id=self.session_id,
-                platform="cli",
-                session_db=self._session_db,
-                clarify_callback=self._clarify_callback,
-                reasoning_callback=self._current_reasoning_callback(),
+            if self.gateway_session_mode:
+                from hermes_cli.gateway_session_client import (
+                    GatewaySessionAgentProxy,
+                    ensure_gateway_session_bridge,
+                )
 
-                fallback_model=self._fallback_model,
-                thinking_callback=self._on_thinking,
-                checkpoints_enabled=self.checkpoints_enabled,
-                checkpoint_max_snapshots=self.checkpoint_max_snapshots,
-                pass_session_id=self.pass_session_id,
-                tool_progress_callback=self._on_tool_progress,
-                tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
-                tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
-                stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
-                tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
-            )
+                endpoint = ensure_gateway_session_bridge()
+
+                self.agent = GatewaySessionAgentProxy(
+                    endpoint=endpoint,
+                    session_id=self.session_id,
+                    model=effective_model,
+                    provider=runtime.get("provider"),
+                    api_key=runtime.get("api_key"),
+                    base_url=runtime.get("base_url"),
+                    api_mode=runtime.get("api_mode"),
+                    enabled_toolsets=self.enabled_toolsets,
+                    service_tier=self.service_tier,
+                    context_length_override=self.context_length_override,
+                    compression_threshold=self.context_compaction_threshold,
+                    verbose_logging=self.verbose,
+                    quiet_mode=not self.verbose,
+                    ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
+                    tool_progress_callback=self._on_tool_progress,
+                    reasoning_callback=self._current_reasoning_callback(),
+                )
+            else:
+                self.agent = AIAgent(
+                    model=effective_model,
+                    api_key=runtime.get("api_key"),
+                    base_url=runtime.get("base_url"),
+                    provider=runtime.get("provider"),
+                    api_mode=runtime.get("api_mode"),
+                    acp_command=runtime.get("command"),
+                    acp_args=runtime.get("args"),
+                    credential_pool=runtime.get("credential_pool"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=self.enabled_toolsets,
+                    verbose_logging=self.verbose,
+                    quiet_mode=not self.verbose,
+                    ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
+                    prefill_messages=self.prefill_messages or None,
+                    reasoning_config=self.reasoning_config,
+                    service_tier=self.service_tier,
+                    request_overrides=request_overrides,
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    session_id=self.session_id,
+                    platform="cli",
+                    session_db=self._session_db,
+                    clarify_callback=self._clarify_callback,
+                    reasoning_callback=self._current_reasoning_callback(),
+                    fallback_model=self._fallback_model,
+                    thinking_callback=self._on_thinking,
+                    checkpoints_enabled=self.checkpoints_enabled,
+                    checkpoint_max_snapshots=self.checkpoint_max_snapshots,
+                    pass_session_id=self.pass_session_id,
+                    tool_progress_callback=self._on_tool_progress,
+                    tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
+                    tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
+                    stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
+                    tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+                )
+                self._set_session_context_profile(
+                    context_length=self.context_length_override,
+                    compression_threshold=self.context_compaction_threshold,
+                )
+                try:
+                    local_store = getattr(self, "_local_todo_store", None)
+                    if local_store and hasattr(local_store, "read") and hasattr(self.agent, "_todo_store"):
+                        seed_items = local_store.read()
+                        if seed_items and not self.agent._todo_store.has_items():
+                            self.agent._todo_store.write(seed_items, merge=False)
+                except Exception:
+                    pass
+
             # Store reference for atexit memory provider shutdown
             global _active_agent_ref
             _active_agent_ref = self.agent
@@ -7072,6 +7128,9 @@ class HermesCLI:
             # Update history with full conversation
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
+            if result and result.get("detached"):
+                return None
+
             # Get the final response
             response = result.get("final_response", "") if result else ""
 
@@ -7825,6 +7884,11 @@ class HermesCLI:
                 return
 
             if self._agent_running and self.agent:
+                if self._detach_gateway_session_and_exit(
+                    event,
+                    message="⚡ Detaching from gateway-hosted session...",
+                ):
+                    return
                 if now - self._last_ctrl_c_time < 2.0:
                     print("\n⚡ Force exiting...")
                     self._should_exit = True
@@ -7848,6 +7912,11 @@ class HermesCLI:
         @kb.add('c-d')
         def handle_ctrl_d(event):
             """Handle Ctrl+D - exit."""
+            if self._detach_gateway_session_and_exit(
+                event,
+                message="⚡ Detaching from gateway-hosted session...",
+            ):
+                return
             self._should_exit = True
             event.app.exit()
 
@@ -9022,6 +9091,13 @@ def main(
     
     parsed_skills = _parse_skills_argument(skills)
 
+    gateway_session_mode = (
+        not query
+        and sys.stdin.isatty()
+        and str(os.getenv("HERMES_GATEWAY_SESSION_MODE", "1")).strip().lower()
+        not in {"0", "false", "no", "off"}
+    )
+
     # Create CLI instance
     cli = HermesCLI(
         model=model,
@@ -9035,6 +9111,7 @@ def main(
         resume=resume,
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
+        gateway_session_mode=gateway_session_mode,
     )
 
     if parsed_skills:

--- a/cli.py
+++ b/cli.py
@@ -2045,6 +2045,21 @@ class HermesCLI:
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]
 
+    def _fallback_model_for_provider(self, resolved_provider: str) -> str:
+        """Return a stable default model slug for a provider when config is blank."""
+        try:
+            from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS, normalize_provider
+
+            normalized = normalize_provider(resolved_provider)
+            if normalized == "openrouter":
+                return OPENROUTER_MODELS[0][0] if OPENROUTER_MODELS else ""
+            provider_models = _PROVIDER_MODELS.get(normalized, [])
+            if provider_models:
+                return str(provider_models[0]).strip()
+        except Exception:
+            logger.debug("Could not derive fallback model for provider %s", resolved_provider, exc_info=True)
+        return ""
+
     def _normalize_model_for_provider(self, resolved_provider: str) -> bool:
         """Normalize provider-specific model IDs and routing."""
         current_model = (self.model or "").strip()
@@ -2577,6 +2592,11 @@ class HermesCLI:
         # Normalize model for the resolved provider (e.g. swap non-Codex
         # models when provider is openai-codex).  Fixes #651.
         model_changed = self._normalize_model_for_provider(resolved_provider)
+        if not (self.model or "").strip():
+            fallback_model = self._fallback_model_for_provider(resolved_provider)
+            if fallback_model:
+                self.model = fallback_model
+                model_changed = True
 
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
         # routing, or the effective model changed.

--- a/cli.py
+++ b/cli.py
@@ -1612,9 +1612,16 @@ class HermesCLI:
         )
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
+        from hermes_cli.context_limit import CONTEXT_MODE_DEFAULT, CONTEXT_MODE_PROFILES
+
         self.api_mode = "chat_completions"
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []
+        _default_context_profile = CONTEXT_MODE_PROFILES[CONTEXT_MODE_DEFAULT]
+        self.context_length_override: Optional[int] = int(_default_context_profile["context_length"])
+        self.context_compaction_threshold: float = float(
+            _default_context_profile["compression_threshold"]
+        )
         self.base_url = (
             base_url
             or CLI_CONFIG["model"].get("base_url", "")
@@ -1818,6 +1825,87 @@ class HermesCLI:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
+
+    def _current_context_limit(self) -> Optional[int]:
+        agent = getattr(self, "agent", None)
+        compressor = getattr(agent, "context_compressor", None) if agent else None
+        context_length = getattr(compressor, "context_length", None) if compressor else None
+        if context_length:
+            return int(context_length)
+        override = getattr(self, "context_length_override", None)
+        return int(override) if override else None
+
+    def _current_context_threshold(self) -> Optional[float]:
+        agent = getattr(self, "agent", None)
+        compressor = getattr(agent, "context_compressor", None) if agent else None
+        threshold_percent = getattr(compressor, "threshold_percent", None) if compressor else None
+        if threshold_percent is not None:
+            return float(threshold_percent)
+        threshold_percent = getattr(self, "context_compaction_threshold", None)
+        return float(threshold_percent) if threshold_percent is not None else None
+
+    def _current_context_mode(self) -> str:
+        from hermes_cli.context_limit import detect_context_mode
+
+        return (
+            detect_context_mode(
+                self._current_context_limit(),
+                self._current_context_threshold(),
+            )
+            or "custom"
+        )
+
+    def _set_session_context_profile(
+        self,
+        *,
+        context_length: int | None,
+        compression_threshold: float | None,
+    ) -> int:
+        if context_length is not None:
+            self.context_length_override = int(context_length)
+        if compression_threshold is not None:
+            self.context_compaction_threshold = float(compression_threshold)
+
+        applied = self.context_length_override or 0
+        if self.agent:
+            if hasattr(self.agent, "set_context_profile"):
+                applied = self.agent.set_context_profile(
+                    context_length=self.context_length_override,
+                    compression_threshold=self.context_compaction_threshold,
+                )
+            elif hasattr(self.agent, "set_context_length_override"):
+                applied = self.agent.set_context_length_override(self.context_length_override)
+
+        if hasattr(self, "_invalidate"):
+            self._invalidate()
+        return int(applied or 0)
+
+    def _print_context_profile_status(
+        self,
+        *,
+        context_mode: str,
+        context_length: int,
+        compression_threshold: float | None,
+    ) -> None:
+        _cprint(f"  {_GOLD}Context mode: {context_mode}{_RST}")
+        _cprint(f"  {_GOLD}Context limit: {context_length:,} tokens{_RST}")
+        if compression_threshold is not None:
+            threshold_tokens = int(context_length * compression_threshold)
+            _cprint(
+                "  "
+                f"{_DIM}Auto-compaction at {int(compression_threshold * 100)}% = "
+                f"{threshold_tokens:,} tokens{_RST}"
+            )
+        _cprint(f"  {_DIM}Session only — not saved to config. Resets on /new or /resume.{_RST}")
+
+    def _reset_session_context_mode(self) -> None:
+        from hermes_cli.context_limit import CONTEXT_MODE_DEFAULT, CONTEXT_MODE_PROFILES
+
+        profile = CONTEXT_MODE_PROFILES[CONTEXT_MODE_DEFAULT]
+        self._set_session_context_profile(
+            context_length=int(profile["context_length"]),
+            compression_threshold=float(profile["compression_threshold"]),
+        )
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.

--- a/cli.py
+++ b/cli.py
@@ -280,7 +280,8 @@ def load_cli_config() -> Dict[str, Any]:
             "skin": "default",
         },
         "clarify": {
-            "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
+            "timeout": 120,  # Seconds of no user activity before AUTO clarify mode proceeds
+            "default_wait_mode": "wait",  # wait | auto
         },
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
@@ -307,6 +308,8 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+            "watchdog_idle_seconds": 180,
+            "watchdog_same_tool_limit": 8,
         },
     }
     
@@ -1530,6 +1533,11 @@ class HermesCLI:
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
 
+        clarify_cfg = CLI_CONFIG.get("clarify", {}) or {}
+        self._clarify_auto_timeout_seconds = max(1, int(clarify_cfg.get("timeout", 120) or 120))
+        _clarify_mode = str(clarify_cfg.get("default_wait_mode", "wait") or "wait").strip().lower()
+        self._clarify_wait_mode_default = "auto" if _clarify_mode == "auto" else "wait"
+
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
@@ -1719,6 +1727,7 @@ class HermesCLI:
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
+        self._clarify_last_typing_at = 0.0
         self._sudo_state = None
         self._sudo_deadline = 0
         self._modal_input_snapshot = None
@@ -6091,6 +6100,13 @@ class HermesCLI:
         is doing during tool execution (fills the gap between thinking
         spinner and next response).  Also plays audio cue in voice mode.
         """
+        if event_type in ("subagent.heartbeat", "subagent.warning"):
+            marker = "⚠️" if event_type == "subagent.warning" else "💓"
+            label = preview or function_name or "subagent active"
+            self._spinner_text = f"{marker} {label}"
+            self._invalidate(min_interval=0)
+            return
+
         # Only act on tool.started; ignore tool.completed, reasoning.available, etc.
         if event_type != "tool.started":
             return
@@ -6103,7 +6119,7 @@ class HermesCLI:
             if _pl > 0 and len(label) > _pl:
                 label = label[:_pl - 3] + "..."
             self._spinner_text = f"{emoji} {label}"
-            self._invalidate()
+            self._invalidate(min_interval=0)
 
         if not self._voice_mode:
             return
@@ -6548,68 +6564,124 @@ class HermesCLI:
         for line in reqs["details"].split("\n"):
             _cprint(f"    {line}")
 
+    def _set_clarify_wait_mode(self, mode: str, *, persist: bool = True) -> str:
+        """Set the default clarify wait mode and optionally persist it."""
+        normalized = "auto" if str(mode or "").strip().lower() == "auto" else "wait"
+        self._clarify_wait_mode_default = normalized
+        if persist:
+            save_config_value("clarify.default_wait_mode", normalized)
+            try:
+                CLI_CONFIG.setdefault("clarify", {})["default_wait_mode"] = normalized
+            except Exception:
+                pass
+        if self._clarify_state is not None:
+            self._clarify_state["wait_mode"] = normalized
+            self._refresh_clarify_agent_wait_state()
+            self._invalidate(min_interval=0)
+        return normalized
+
+    def _refresh_clarify_agent_wait_state(self) -> None:
+        state = self._clarify_state or {}
+        agent = getattr(self, "agent", None)
+        if not agent or not hasattr(agent, "set_wait_state"):
+            return
+        if not state:
+            try:
+                agent.clear_wait_state()
+            except Exception:
+                pass
+            return
+        try:
+            typing_idle = max(0.0, time.monotonic() - float(self._clarify_last_typing_at or 0.0))
+            agent.set_wait_state(
+                "clarify",
+                mode=state.get("wait_mode") or self._clarify_wait_mode_default,
+                question_preview=str(state.get("question", ""))[:160],
+                choices_count=len(state.get("choices") or []),
+                typing_active=bool(self._clarify_freetext and self._app and self._app.current_buffer.text.strip()),
+                typing_idle_seconds=round(typing_idle, 1),
+            )
+        except Exception:
+            pass
+
     def _clarify_callback(self, question, choices):
         """
         Platform callback for the clarify tool. Called from the agent thread.
 
         Sets up the interactive selection UI (or freetext prompt for open-ended
         questions), then blocks until the user responds via the prompt_toolkit
-        key bindings.  If no response arrives within the configured timeout the
-        question is dismissed and the agent is told to decide on its own.
+        key bindings. WAIT mode blocks indefinitely until the user responds or
+        cancels. AUTO mode proceeds after the configured idle timeout.
         """
         import time as _time
 
-        timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+        timeout = self._clarify_auto_timeout_seconds
         response_queue = queue.Queue()
         is_open_ended = not choices
+        wait_mode = self._clarify_wait_mode_default
 
         self._clarify_state = {
             "question": question,
             "choices": choices if not is_open_ended else [],
             "selected": 0,
             "response_queue": response_queue,
+            "wait_mode": wait_mode,
         }
-        self._clarify_deadline = _time.monotonic() + timeout
+        self._clarify_last_typing_at = _time.monotonic()
+        self._clarify_deadline = (_time.monotonic() + timeout) if wait_mode == "auto" else 0
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
+        self._refresh_clarify_agent_wait_state()
 
         # Trigger prompt_toolkit repaint from this (non-main) thread
-        self._invalidate()
+        self._invalidate(min_interval=0)
 
-        # Poll for the user's response.  The countdown in the hint line
-        # updates on each invalidate — but frequent repaints cause visible
-        # flicker in some terminals (Kitty, ghostty).  We only refresh the
-        # countdown every 5 s; selection changes (↑/↓) trigger instant
-        # Poll for the user's response.  The countdown in the hint line
-        # updates on each invalidate — but frequent repaints cause visible
-        # flicker in some terminals (Kitty, ghostty).  We only refresh the
-        # countdown every 5 s; selection changes (↑/↓) trigger instant
-        # repaints via the key bindings.
         _last_countdown_refresh = _time.monotonic()
         while True:
             try:
                 result = response_queue.get(timeout=1)
                 self._clarify_deadline = 0
+                self._clarify_state = None
+                self._clarify_freetext = False
+                self._refresh_clarify_agent_wait_state()
+                self._invalidate(min_interval=0)
                 return result
             except queue.Empty:
-                remaining = self._clarify_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
-                # Only repaint every 5 s for the countdown — avoids flicker
                 now = _time.monotonic()
-                if now - _last_countdown_refresh >= 5.0:
+                state = self._clarify_state or {}
+                active_mode = state.get("wait_mode", wait_mode)
+                if active_mode == "auto":
+                    if not self._clarify_deadline:
+                        self._clarify_deadline = now + timeout
+                    if self._clarify_freetext:
+                        draft_text = ""
+                        if getattr(self, "_app", None) and self._app.current_buffer:
+                            draft_text = self._app.current_buffer.text.strip()
+                        typing_active = bool(draft_text)
+                        if typing_active:
+                            self._clarify_last_typing_at = now
+                        idle_for = now - float(self._clarify_last_typing_at or now)
+                        self._refresh_clarify_agent_wait_state()
+                        if idle_for < timeout:
+                            if now - _last_countdown_refresh >= 1.0:
+                                _last_countdown_refresh = now
+                                self._invalidate(min_interval=0)
+                            continue
+                    remaining = self._clarify_deadline - now
+                    if remaining <= 0:
+                        break
+                if now - _last_countdown_refresh >= 1.0:
                     _last_countdown_refresh = now
-                    self._invalidate()
-                if now - _last_countdown_refresh >= 5.0:
-                    _last_countdown_refresh = now
-                    self._invalidate()
+                    self._refresh_clarify_agent_wait_state()
+                    self._invalidate(min_interval=0)
 
-        # Timed out — tear down the UI and let the agent decide
+        # AUTO timed out — tear down the UI and let the agent decide
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
-        self._invalidate()
-        _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
+        self._refresh_clarify_agent_wait_state()
+        self._invalidate(min_interval=0)
+        _cprint(f"\n{_DIM}(clarify AUTO mode timed out after {timeout}s of inactivity — agent will decide){_RST}")
         return (
             "The user did not provide a response within the time limit. "
             "Use your best judgement to make the choice and proceed."
@@ -7594,7 +7666,8 @@ class HermesCLI:
         # the prompt_toolkit UI switches to a selection mode.
         self._clarify_state = None      # dict with question, choices, selected, response_queue
         self._clarify_freetext = False  # True when user chose "Other" and is typing
-        self._clarify_deadline = 0      # monotonic timestamp when the clarify times out
+        self._clarify_deadline = 0      # monotonic timestamp when AUTO clarify mode proceeds
+        self._clarify_last_typing_at = 0.0
 
         # Sudo password prompt state (similar mechanism to clarify)
         self._sudo_state = None         # dict with response_queue when active
@@ -7695,6 +7768,8 @@ class HermesCLI:
                     self._clarify_state["response_queue"].put(text)
                     self._clarify_state = None
                     self._clarify_freetext = False
+                    self._clarify_deadline = 0
+                    self._refresh_clarify_agent_wait_state()
                     event.app.current_buffer.reset()
                     event.app.invalidate()
                 return
@@ -7707,10 +7782,14 @@ class HermesCLI:
                 if selected < len(choices):
                     state["response_queue"].put(choices[selected])
                     self._clarify_state = None
+                    self._clarify_deadline = 0
+                    self._refresh_clarify_agent_wait_state()
                     event.app.invalidate()
                 else:
                     # "Other" selected → switch to freetext
                     self._clarify_freetext = True
+                    self._clarify_last_typing_at = time.monotonic()
+                    self._refresh_clarify_agent_wait_state()
                     event.app.invalidate()
                 return
 
@@ -7806,6 +7885,16 @@ class HermesCLI:
                 self._clarify_state["selected"] = min(max_idx, self._clarify_state["selected"] + 1)
                 event.app.invalidate()
 
+        @kb.add('escape', 'a', filter=Condition(lambda: bool(self._clarify_state)))
+        def clarify_set_auto(event):
+            self._set_clarify_wait_mode("auto")
+            event.app.invalidate()
+
+        @kb.add('escape', 'w', filter=Condition(lambda: bool(self._clarify_state)))
+        def clarify_set_wait(event):
+            self._set_clarify_wait_mode("wait")
+            event.app.invalidate()
+
         # --- Dangerous command approval: arrow-key navigation ---
 
         @kb.add('up', filter=Condition(lambda: bool(self._approval_state)))
@@ -7899,6 +7988,8 @@ class HermesCLI:
                 )
                 self._clarify_state = None
                 self._clarify_freetext = False
+                self._clarify_deadline = 0
+                self._refresh_clarify_agent_wait_state()
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
@@ -8163,6 +8254,11 @@ class HermesCLI:
         _paste_just_collapsed = [False]
 
         def _on_text_changed(buf):
+            if cli_ref._clarify_state and cli_ref._clarify_freetext:
+                cli_ref._clarify_last_typing_at = time.monotonic()
+                cli_ref._refresh_clarify_agent_wait_state()
+                cli_ref._invalidate(min_interval=0)
+
             """Detect large pastes and collapse them to a file reference.
 
             When bracketed paste is available, handle_paste collapses
@@ -8247,6 +8343,14 @@ class HermesCLI:
                 status = cli_ref._command_status or "Processing command..."
                 return f"{frame} {status}"
             if cli_ref._agent_running:
+                _agent = getattr(cli_ref, "agent", None)
+                if _agent and hasattr(_agent, "get_activity_summary"):
+                    try:
+                        _activity = _agent.get_activity_summary()
+                        if _activity.get("current_tool") == "delegate_task" and _activity.get("active_children_count"):
+                            return "type a message + Enter to interrupt and redirect delegation, Ctrl+C to cancel"
+                    except Exception:
+                        pass
                 return "type a message + Enter to interrupt, Ctrl+C to cancel"
             if cli_ref._voice_mode:
                 return "type or Ctrl+B to record"
@@ -8282,16 +8386,20 @@ class HermesCLI:
                 ]
 
             if cli_ref._clarify_state:
-                remaining = max(0, int(cli_ref._clarify_deadline - _time.monotonic()))
-                countdown = f'  ({remaining}s)' if cli_ref._clarify_deadline else ''
+                _mode = (cli_ref._clarify_state.get("wait_mode") or cli_ref._clarify_wait_mode_default).upper()
+                remaining = max(0, int(cli_ref._clarify_deadline - _time.monotonic())) if cli_ref._clarify_deadline else 0
+                countdown = f'  ({remaining}s idle)' if cli_ref._clarify_deadline else '  (waiting)'
+                mode_hint = f'  mode={_mode} · Esc+A auto · Esc+W wait'
                 if cli_ref._clarify_freetext:
                     return [
                         ('class:hint', '  type your answer and press Enter'),
                         ('class:clarify-countdown', countdown),
+                        ('class:hint', mode_hint),
                     ]
                 return [
                     ('class:hint', '  ↑/↓ to select, Enter to confirm'),
                     ('class:clarify-countdown', countdown),
+                    ('class:hint', mode_hint),
                 ]
 
             if cli_ref._command_running:
@@ -8375,14 +8483,15 @@ class HermesCLI:
                 else "  Other (type your answer)"
             )
             preview_lines.extend(_wrap_panel_text(other_label, 60, subsequent_indent="  "))
-            box_width = _panel_box_width("Hermes needs your input", preview_lines)
+            title = f"Hermes needs your input · {(state.get('wait_mode') or cli_ref._clarify_wait_mode_default).upper()}"
+            box_width = _panel_box_width(title, preview_lines)
             inner_text_width = max(8, box_width - 2)
 
             lines = []
             # Box top border
             lines.append(('class:clarify-border', '╭─ '))
-            lines.append(('class:clarify-title', 'Hermes needs your input'))
-            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - len("Hermes needs your input") - 3)) + '╮\n'))
+            lines.append(('class:clarify-title', title))
+            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - len(title) - 3)) + '╮\n'))
             _append_blank_panel_line(lines, 'class:clarify-border', box_width)
 
             # Question text

--- a/docs/plans/2026-04-10-gateway-session-worker-processes.md
+++ b/docs/plans/2026-04-10-gateway-session-worker-processes.md
@@ -1,0 +1,213 @@
+# Gateway Session Worker Processes Migration Plan
+
+> For Hermes: use architecture-migration-eval-rails. Freeze behavior first, then migrate the runtime substrate in thin slices.
+
+Goal
+- Make gateway-backed Hermes sessions use real OS-level worker processes instead of in-process agent tasks, so an active session is genuinely isolated and can be supervised/managed as its own worker.
+
+Why this plan exists
+- Right now the gateway is the long-lived background process, but `/v1/runs` mostly executes agents as in-process asyncio tasks + executor work inside that gateway.
+- That is workable for heartbeat/status plumbing, but it is not the clean "each session is its own worker process" architecture.
+- We want the clean version: one gateway/front-door process per profile, plus explicit worker processes for active sessions.
+
+Non-goals
+- Rewriting unrelated gateway/platform logic.
+- Replacing the existing blocked-wait heartbeat UX.
+- Shipping PTY attach/detach UX improvements before the core worker substrate is solid.
+- Migrating every surface at once. Start with gateway-backed CLI/API sessions first.
+
+Definition of done
+- Active gateway-backed sessions are backed by real worker processes on the host.
+- The gateway owns only routing/supervision, not the live conversation loop for those sessions.
+- Clarify, cancel, blocked-wait heartbeat, delegate heartbeat, and final response streaming all continue to work.
+- Worker lifecycle is explicit: spawn, stream, clarify reply, cancel, exit, cleanup.
+- A killed/stuck worker does not poison sibling sessions.
+- Focused pytest and full targeted gateway/CLI suite pass.
+
+Current reality (truth anchor)
+- Background gateway process per profile: yes.
+- Individual gateway-backed session as its own process: no.
+- Current code path:
+  - `hermes_cli/gateway.py` starts the gateway with `subprocess.Popen(...)`
+  - `gateway/platforms/api_server.py` handles `/v1/runs`
+  - each run is tracked in in-memory maps like `_run_streams`, `_run_agents`, `_run_clarify_queues`
+  - the actual agent turn runs via `asyncio.create_task(...)` + `run_in_executor(...)`
+
+ASCII: current vs target
+
+Current
+
+  +--------------------+
+  | gateway process    |
+  | (per profile)      |
+  +--------------------+
+            |
+            +--> run A (async task + threadpool work)
+            |
+            +--> run B (async task + threadpool work)
+            |
+            +--> run C (async task + threadpool work)
+
+Target
+
+  +--------------------+
+  | gateway process    |
+  | (per profile)      |
+  +--------------------+
+            |
+            +--> session worker proc A
+            |
+            +--> session worker proc B
+            |
+            +--> session worker proc C
+
+Structured data flow target
+
+  CLI client
+     |
+     | HTTP + SSE
+     v
+  gateway API server
+     |
+     | spawn/supervise worker
+     v
+  session worker process
+     |
+     +--> model/tool loop
+     +--> blocked wait state
+     +--> delegate child state
+
+Worker IPC sketch
+
+  parent (gateway)                  child (session worker)
+  ----------------                  ----------------------
+  spawn worker  ------------------> start agent
+  send turn payload  -------------> run turn
+  read JSONL events <------------- message.delta / tool.started / agent.activity / clarify.request / run.completed
+  send clarify reply -------------> unblock clarify callback
+  send cancel --------------------> interrupt agent / terminate if needed
+  reap exit code <---------------- process exits
+
+Recommended transport for v1
+- Use JSONL over stdio for worker IPC, not terminal scraping.
+- The worker should print one JSON object per event line.
+- Parent process owns framing, backpressure, and cleanup.
+- Do not use pretty console output as the protocol.
+
+Why not PTY-first
+- PTY is great for attachable human-facing shells.
+- It is bad as the primary machine protocol for reliable structured events.
+- We can still add PTY-backed attach later if we want a real interactive worker terminal.
+- First get the worker substrate clean with JSONL/stdin/stdout.
+
+Likely files
+- `docs/plans/2026-04-10-gateway-session-worker-processes.md`
+- `gateway/platforms/api_server.py`
+- `gateway/session_worker_protocol.py` (new)
+- `gateway/session_worker_process.py` (new)
+- `gateway/session_worker_manager.py` (new)
+- `hermes_cli/gateway_session_client.py`
+- `tools/clarify_tool.py`
+- `run_agent.py`
+- `tests/gateway/test_api_server.py`
+- `tests/hermes_cli/test_gateway_cli_sessions.py`
+- `tests/cli/test_gateway_session_agent.py`
+- `tests/gateway/test_session_worker_protocol.py` (new)
+- `tests/gateway/test_session_worker_manager.py` (new)
+
+Stage plan
+
+## Stage 0: eval rails
+1. Add this plan doc.
+2. Add protocol/contract tests for worker event vocabulary.
+3. Add manager tests for spawn/cleanup/cancel/clarify routing.
+4. Preserve current user-visible expectations already covered by:
+   - `tests/cli/test_gateway_session_agent.py`
+   - `tests/gateway/test_api_server.py`
+   - `tests/gateway/test_blocked_wait_proxy.py`
+   - `tests/hermes_cli/test_gateway_cli_sessions.py`
+5. Commit rails before deeper runtime changes.
+
+## Stage 1: worker protocol module
+1. Create `gateway/session_worker_protocol.py`.
+2. Define canonical event names and validation helpers.
+3. Include event builders for:
+   - `message.delta`
+   - `tool.started`
+   - `tool.completed`
+   - `reasoning.available`
+   - `subagent.heartbeat`
+   - `subagent.warning`
+   - `agent.activity`
+   - `clarify.request`
+   - `run.completed`
+   - `run.failed`
+   - `run.cancelled`
+4. Add tests that validate required keys and terminal events.
+
+## Stage 2: one-shot worker process manager
+1. Create `gateway/session_worker_manager.py`.
+2. Spawn a child process with sanitized env and explicit working directory.
+3. Parent sends a single turn payload to child stdin.
+4. Parent consumes child JSONL stdout and forwards it into existing run SSE queues.
+5. Parent can send clarify replies and cancel requests.
+6. Add tests for:
+   - spawn success
+   - stdout event relay
+   - clarify response routing
+   - cancel path
+   - orphan cleanup
+
+## Stage 3: worker process entrypoint
+1. Create `gateway/session_worker_process.py`.
+2. Read one JSON payload from stdin.
+3. Construct `AIAgent` in child process.
+4. Hook `stream_delta_callback`, `tool_progress_callback`, and `clarify_callback` to emit JSONL events.
+5. Return terminal event and exit code.
+6. Add focused tests using a fake/stub agent path where possible.
+
+## Stage 4: wire `/v1/runs` onto the manager
+1. Replace in-process `_run_agents` turn execution in `gateway/platforms/api_server.py` with the new manager.
+2. Keep existing HTTP/SSE contract stable.
+3. Keep current blocked-wait UI behavior stable from the CLI client's perspective.
+4. Validate clarify/cancel/heartbeat paths again.
+
+## Stage 5: promote from per-run worker to per-session worker
+This is the actual clean endgame.
+
+1. Key worker processes by `session_id`, not `run_id`.
+2. If a worker for that session already exists, submit the next user turn to it instead of spawning a new child.
+3. Maintain session-local conversation state inside the worker process, not only in the gateway parent.
+4. Keep persistence checkpoints in the session DB so crash recovery still works.
+5. Add worker idle timeout / reap policy.
+6. Add explicit attach/detach semantics if needed.
+
+This stage is where we can honestly say:
+- yes, gateway-backed active sessions are their own background workers.
+
+## Stage 6: helper/profile sidecars
+1. Let blocked-wait helper / reviewer roles reuse the same worker manager.
+2. Support named profile launch presets cleanly.
+3. Keep helper workers separate from the main session worker.
+
+Validation commands
+- Focused worker/protocol tests:
+  - `uv run --extra dev pytest -q tests/gateway/test_session_worker_protocol.py tests/gateway/test_session_worker_manager.py -o addopts=''`
+- Existing gateway-backed session coverage:
+  - `uv run --extra dev pytest -q tests/cli/test_gateway_session_agent.py tests/gateway/test_api_server.py tests/gateway/test_blocked_wait_proxy.py tests/hermes_cli/test_gateway_cli_sessions.py tests/cli/test_cli_clarify_ui.py tests/gateway/test_gateway_clarify.py tests/tools/test_delegate_watchdog.py tests/hermes_cli/test_gateway_service.py tests/gateway/test_status_command.py tests/gateway/test_approve_deny_commands.py tests/tools/test_clarify_tool.py tests/tools/test_delegate.py tests/gateway/test_session_race_guard.py tests/gateway/test_unknown_command.py -o addopts=''`
+- Syntax:
+  - `python3 -m py_compile gateway/session_worker_protocol.py gateway/session_worker_manager.py gateway/session_worker_process.py gateway/platforms/api_server.py hermes_cli/gateway_session_client.py`
+
+Commit discipline
+- Commit after Stage 0 rails.
+- Commit after protocol module.
+- Commit after worker manager.
+- Commit after entrypoint.
+- Commit after `/v1/runs` switchover.
+- Commit after persistent per-session worker promotion.
+
+Immediate next slice
+- Stage 0/1 only:
+  1. add this plan
+  2. add worker protocol contract module + tests
+  3. commit before touching the runtime substrate

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -9,6 +9,8 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/models                  — lists hermes-agent as an available model
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
+- POST /v1/runs/{run_id}/cancel    — interrupt an active structured run
+- POST /v1/runs/{run_id}/clarify   — submit a clarify response for a blocked run
 - GET  /health                     — health check
 
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
@@ -25,8 +27,10 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 import time
 import uuid
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 try:
@@ -49,6 +53,14 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+
+
+@dataclass
+class _RunClarifyEntry:
+    question: str
+    choices: list[str]
+    event: threading.Event
+    result: Optional[str] = None
 
 
 def check_api_server_requirements() -> bool:
@@ -308,6 +320,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._response_store = ResponseStore()
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
+        # Live agent refs for cancellation / activity polling: run_id -> [agent_or_none]
+        self._run_agents: Dict[str, list[Any]] = {}
+        # Pending clarify waits for structured runs: run_id -> queued clarify prompts
+        self._run_clarify_queues: Dict[str, list[_RunClarifyEntry]] = {}
+        self._run_clarify_lock = threading.Lock()
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
@@ -420,8 +437,70 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("SessionDB unavailable for API server: %s", e)
         return self._session_db
 
+    def _resolve_run_clarify(self, run_id: str, response_text: str) -> int:
+        """Resolve the oldest pending clarify wait for a structured run."""
+        with self._run_clarify_lock:
+            queue = self._run_clarify_queues.get(run_id) or []
+            if not queue:
+                return 0
+            entry = queue.pop(0)
+            if not queue:
+                self._run_clarify_queues.pop(run_id, None)
+        entry.result = str(response_text)
+        entry.event.set()
+        return 1
+
+    def _clear_run_clarify(self, run_id: str, *, default_response: str) -> None:
+        with self._run_clarify_lock:
+            queue = list(self._run_clarify_queues.pop(run_id, []))
+        for entry in queue:
+            if entry.result is None:
+                entry.result = default_response
+            entry.event.set()
+
+    def _wait_for_run_clarify(
+        self,
+        *,
+        run_id: str,
+        question: str,
+        choices: Optional[list[str]],
+        push_event,
+        timeout_seconds: Optional[float] = None,
+    ) -> str:
+        entry = _RunClarifyEntry(
+            question=question,
+            choices=list(choices or []),
+            event=threading.Event(),
+        )
+        with self._run_clarify_lock:
+            self._run_clarify_queues.setdefault(run_id, []).append(entry)
+
+        push_event({
+            "event": "clarify.request",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "question": question,
+            "choices": list(choices or []),
+        })
+
+        resolved = entry.event.wait(timeout_seconds) if timeout_seconds and timeout_seconds > 0 else entry.event.wait()
+        if not resolved:
+            with self._run_clarify_lock:
+                queue = self._run_clarify_queues.get(run_id) or []
+                if entry in queue:
+                    queue.remove(entry)
+                if not queue:
+                    self._run_clarify_queues.pop(run_id, None)
+            return (
+                "The user did not provide a response within the time limit. "
+                "Use your best judgement to make the choice and proceed."
+            )
+        if entry.result is not None:
+            return entry.result
+        return "The clarify request was cancelled before the user responded."
+
     # ------------------------------------------------------------------
-    # Agent creation helper
+    # Agent creation / runtime resolution
     # ------------------------------------------------------------------
 
     def _create_agent(
@@ -430,6 +509,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        clarify_callback=None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -468,6 +548,7 @@ class APIServerAdapter(BasePlatformAdapter):
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
+            clarify_callback=clarify_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
         )
@@ -1389,6 +1470,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     "duration": round(kwargs.get("duration", 0), 3),
                     "error": kwargs.get("is_error", False),
                 })
+            elif event_type in {"subagent.heartbeat", "subagent.warning"}:
+                _push({
+                    "event": event_type,
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "tool": tool_name,
+                    "preview": preview,
+                })
             elif event_type == "reasoning.available":
                 _push({
                     "event": "reasoning.available",
@@ -1432,21 +1521,24 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = time.time()
 
+        def _push_run_event(event: Dict[str, Any]) -> None:
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, event)
+            except Exception:
+                logger.debug("[api_server] failed to enqueue event for %s", run_id, exc_info=True)
+
         event_cb = self._make_run_event_callback(run_id, loop)
 
         # Also wire stream_delta_callback so message.delta events flow through
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, {
-                    "event": "message.delta",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "delta": delta,
-                })
-            except Exception:
-                pass
+            _push_run_event({
+                "event": "message.delta",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "delta": delta,
+            })
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
@@ -1495,15 +1587,68 @@ class APIServerAdapter(BasePlatformAdapter):
 
         session_id = body.get("session_id") or run_id
         ephemeral_system_prompt = instructions
+        agent_ref: list[Any] = [None]
 
         async def _run_and_close():
+            activity_task: Optional[asyncio.Task] = None
+            stop_activity = asyncio.Event()
             try:
+                def _clarify_cb(question: str, choices: Optional[list[str]]) -> str:
+                    agent = agent_ref[0]
+                    if agent is not None and hasattr(agent, "set_wait_state"):
+                        try:
+                            agent.set_wait_state(
+                                "clarify",
+                                mode="wait",
+                                question_preview=str(question or "")[:160],
+                                choices_count=len(choices or []),
+                            )
+                        except Exception:
+                            logger.debug("[api_server] failed to set clarify wait state", exc_info=True)
+                    try:
+                        return self._wait_for_run_clarify(
+                            run_id=run_id,
+                            question=str(question or ""),
+                            choices=list(choices or []),
+                            push_event=_push_run_event,
+                        )
+                    finally:
+                        if agent is not None and hasattr(agent, "clear_wait_state"):
+                            try:
+                                agent.clear_wait_state()
+                            except Exception:
+                                logger.debug("[api_server] failed to clear clarify wait state", exc_info=True)
+
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    clarify_callback=_clarify_cb,
                 )
+                agent_ref[0] = agent
+                self._run_agents[run_id] = agent_ref
+
+                async def _emit_activity() -> None:
+                    while not stop_activity.is_set():
+                        try:
+                            activity = await asyncio.to_thread(agent.get_activity_summary)
+                        except Exception:
+                            activity = None
+                        if activity is not None:
+                            _push_run_event({
+                                "event": "agent.activity",
+                                "run_id": run_id,
+                                "timestamp": time.time(),
+                                "activity": activity,
+                            })
+                        try:
+                            await asyncio.wait_for(stop_activity.wait(), timeout=1.0)
+                        except asyncio.TimeoutError:
+                            continue
+
+                activity_task = asyncio.create_task(_emit_activity())
+
                 def _run_sync():
                     r = agent.run_conversation(
                         user_message=user_message,
@@ -1518,7 +1663,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                q.put_nowait({
+                _push_run_event({
                     "event": "run.completed",
                     "run_id": run_id,
                     "timestamp": time.time(),
@@ -1527,16 +1672,25 @@ class APIServerAdapter(BasePlatformAdapter):
                 })
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
-                try:
-                    q.put_nowait({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": str(exc),
-                    })
-                except Exception:
-                    pass
+                _push_run_event({
+                    "event": "run.failed",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "error": str(exc),
+                })
             finally:
+                stop_activity.set()
+                if activity_task is not None:
+                    activity_task.cancel()
+                    try:
+                        await activity_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+                self._clear_run_clarify(
+                    run_id,
+                    default_response="The clarify request was cancelled before the user responded.",
+                )
+                self._run_agents.pop(run_id, None)
                 # Sentinel: signal SSE stream to close
                 try:
                     q.put_nowait(None)
@@ -1552,6 +1706,59 @@ class APIServerAdapter(BasePlatformAdapter):
             task.add_done_callback(self._background_tasks.discard)
 
         return web.json_response({"run_id": run_id, "status": "started"}, status=202)
+
+    async def _handle_cancel_run(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        agent_ref = self._run_agents.get(run_id)
+        if not agent_ref:
+            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+
+        agent = agent_ref[0] if agent_ref else None
+        if agent is not None and hasattr(agent, "interrupt"):
+            try:
+                agent.interrupt("Run cancelled by client")
+            except Exception:
+                logger.debug("[api_server] failed to interrupt run %s", run_id, exc_info=True)
+
+        self._clear_run_clarify(run_id, default_response="The clarify request was cancelled before the user responded.")
+        _push = self._run_streams.get(run_id)
+        if _push is not None:
+            try:
+                _push.put_nowait({
+                    "event": "run.cancelled",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "reason": "Run cancelled by client",
+                })
+            except Exception:
+                logger.debug("[api_server] failed to enqueue cancel event for %s", run_id, exc_info=True)
+
+        return web.json_response({"run_id": run_id, "status": "cancelling"}, status=202)
+
+    async def _handle_submit_run_clarify(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        response_text = str(body.get("response") or "").strip()
+        if not response_text:
+            return web.json_response(_openai_error("Missing 'response' field"), status=400)
+
+        resolved = self._resolve_run_clarify(run_id, response_text)
+        if not resolved:
+            return web.json_response(_openai_error(f"No pending clarify request for run: {run_id}", code="run_not_found"), status=404)
+
+        return web.json_response({"run_id": run_id, "resolved": resolved, "status": "ok"}, status=200)
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
@@ -1616,6 +1823,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("[api_server] sweeping orphaned run %s", run_id)
                 self._run_streams.pop(run_id, None)
                 self._run_streams_created.pop(run_id, None)
+                self._run_agents.pop(run_id, None)
+                self._clear_run_clarify(
+                    run_id,
+                    default_response="The clarify request was cancelled before the user responded.",
+                )
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface
@@ -1650,6 +1862,8 @@ class APIServerAdapter(BasePlatformAdapter):
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            self._app.router.add_post("/v1/runs/{run_id}/cancel", self._handle_cancel_run)
+            self._app.router.add_post("/v1/runs/{run_id}/clarify", self._handle_submit_run_clarify)
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())
             try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1357,6 +1357,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _MAX_CONCURRENT_RUNS = 10  # Prevent unbounded resource allocation
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
+    _RUN_EVENTS_KEEPALIVE = 1.0  # short keepalive so detach/disconnect is noticed quickly
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
@@ -1583,7 +1584,7 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             while True:
                 try:
-                    event = await asyncio.wait_for(q.get(), timeout=30.0)
+                    event = await asyncio.wait_for(q.get(), timeout=self._RUN_EVENTS_KEEPALIVE)
                 except asyncio.TimeoutError:
                     await response.write(b": keepalive\n\n")
                     continue

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1294,7 +1294,7 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset"):
+            if cmd in ("approve", "deny", "answer", "status", "stop", "new", "reset"):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -496,6 +496,7 @@ class GatewayRunner:
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
+    _blocked_wait_proxy_setup_pending: Dict[str, Dict[str, Any]] = {}
     
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
@@ -529,6 +530,7 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._blocked_wait_proxy_setup_pending: Dict[str, Dict[str, Any]] = {}
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -855,6 +857,155 @@ class GatewayRunner:
             return True, await self._handle_deny_command(event)
         return False, None
 
+    def _blocked_wait_context(self, event: MessageEvent, session_key: str) -> Optional[dict]:
+        running_agent = self._running_agents.get(session_key)
+        if not running_agent or running_agent is _AGENT_PENDING_SENTINEL:
+            return None
+        if not hasattr(running_agent, "get_activity_summary"):
+            return None
+        try:
+            activity = running_agent.get_activity_summary() or {}
+        except Exception:
+            return None
+
+        wait_state = activity.get("wait_state") or {}
+        kind = wait_state.get("kind")
+        if not kind and activity.get("current_tool") == "delegate_task" and activity.get("active_children_count"):
+            kind = "delegate"
+        if not kind:
+            return None
+
+        session_entry = None
+        if getattr(self, "session_store", None) is not None:
+            try:
+                session_entry = self.session_store.get_or_create_session(event.source)
+            except Exception:
+                session_entry = None
+
+        history = []
+        if session_entry and getattr(self, "session_store", None) is not None:
+            try:
+                history = self.session_store.load_transcript(session_entry.session_id) or []
+            except Exception:
+                history = []
+
+        return {
+            "kind": str(kind),
+            "activity": activity,
+            "agent": running_agent,
+            "history": history,
+        }
+
+    async def _resolve_blocked_wait_proxy_setup(self, event: MessageEvent, session_key: str) -> tuple[bool, Optional[str]]:
+        """Prompt once to enable the blocked-session helper when a wait kind has no config."""
+        from agent.blocked_wait_proxy import (
+            blocked_wait_proxy_kind_enabled,
+            blocked_wait_proxy_setup_timeout,
+            looks_like_meta_question,
+            looks_like_no,
+            looks_like_yes,
+            save_default_blocked_wait_proxy_kind,
+        )
+
+        pending = self._blocked_wait_proxy_setup_pending.get(session_key)
+        now = time.time()
+        if pending and float(pending.get("expires_at") or 0) <= now:
+            self._blocked_wait_proxy_setup_pending.pop(session_key, None)
+            pending = None
+
+        raw = (event.text or "").strip()
+        cmd = event.get_command()
+        response_text = event.get_command_args().strip() if cmd == "answer" else raw
+
+        if pending:
+            if looks_like_yes(response_text):
+                save_default_blocked_wait_proxy_kind(pending["kind"])
+                self._blocked_wait_proxy_setup_pending.pop(session_key, None)
+                return True, (
+                    f"✅ Enabled blocked-session helper defaults for `{pending['kind']}`. "
+                    "Ask again and Hermes will answer through the helper."
+                )
+            if looks_like_no(response_text):
+                self._blocked_wait_proxy_setup_pending.pop(session_key, None)
+                return True, f"Okay — keeping blocked-session helper disabled for `{pending['kind']}`."
+            return True, f"Reply yes or no within {int(pending['expires_at'] - now)}s."
+
+        context = self._blocked_wait_context(event, session_key)
+        if not context:
+            return False, None
+        kind = context["kind"]
+        if blocked_wait_proxy_kind_enabled(kind):
+            return False, None
+        if cmd in {"answer", "approve", "deny", "stop", "status", "new", "reset"}:
+            return False, None
+        if not looks_like_meta_question(response_text):
+            return False, None
+
+        timeout = blocked_wait_proxy_setup_timeout()
+        self._blocked_wait_proxy_setup_pending[session_key] = {
+            "kind": kind,
+            "expires_at": now + timeout,
+        }
+        return True, (
+            f"I can spawn a blocked-session helper for `{kind}` waits so Hermes keeps talking in-context while the main run is blocked. "
+            f"Reply yes or no within {timeout}s."
+        )
+
+    async def _resolve_blocked_wait_proxy(self, event: MessageEvent, session_key: str) -> tuple[bool, Optional[str]]:
+        """Route blocked-state questions through the cheap continuity proxy."""
+        from agent.blocked_wait_proxy import (
+            blocked_wait_proxy_kind_enabled,
+            looks_like_abort_request,
+            looks_like_meta_question,
+            run_blocked_wait_proxy,
+        )
+
+        context = self._blocked_wait_context(event, session_key)
+        if not context:
+            return False, None
+
+        kind = context["kind"]
+        if not blocked_wait_proxy_kind_enabled(kind):
+            return False, None
+
+        raw = (event.text or "").strip()
+        cmd = event.get_command()
+        if cmd:
+            return False, None
+
+        if kind == "delegate":
+            if looks_like_abort_request(raw):
+                context["agent"].interrupt("Blocked-session helper abort requested")
+                adapter = self.adapters.get(event.source.platform)
+                if adapter:
+                    adapter.resume_typing_for_chat(event.source.chat_id)
+                return True, "⚡ Aborting the delegated work now."
+            if not looks_like_meta_question(raw):
+                return False, None  # Let normal free-text fall through as a steer/interruption request.
+        elif kind == "clarify":
+            if not looks_like_meta_question(raw):
+                return False, None
+        else:
+            if not looks_like_meta_question(raw):
+                return False, None
+
+        try:
+            response = await asyncio.to_thread(
+                run_blocked_wait_proxy,
+                kind=kind,
+                activity=context["activity"],
+                history=context["history"],
+                user_message=raw,
+                parent_agent=context["agent"],
+            )
+        except Exception as exc:
+            logger.debug("blocked wait proxy failed: %s", exc, exc_info=True)
+            return True, "I’m still blocked in that wait state, but the helper proxy failed to start."
+
+        if not response:
+            response = "I’m still blocked on that wait state, but I don’t have a useful update yet."
+        return True, response
+
     async def _resolve_clarify_wait(self, event: MessageEvent, session_key: str) -> tuple[bool, Optional[str]]:
         """Adapter for blocked clarify prompts while an agent is running."""
         from hermes_cli.commands import resolve_command as _resolve_cmd
@@ -865,16 +1016,12 @@ class GatewayRunner:
 
         cmd = event.get_command()
         cmd_def = _resolve_cmd(cmd) if cmd else None
-        response_text = None
-        if cmd_def and cmd_def.name == "answer":
-            response_text = event.get_command_args().strip()
-            if not response_text:
-                return True, "Usage: /answer <response>"
-        elif not cmd_def:
-            response_text = (event.text or "").strip()
-
-        if not response_text:
+        if not cmd_def or cmd_def.name != "answer":
             return False, None
+
+        response_text = event.get_command_args().strip()
+        if not response_text:
+            return True, "Usage: /answer <response>"
 
         count = resolve_gateway_clarify(session_key, response_text)
         if not count:
@@ -891,10 +1038,11 @@ class GatewayRunner:
 
         This is the base path for user input that arrives while Hermes is paused
         behind a blocking interaction. Each waiting flow contributes a small
-        adapter (`update`, `approval`, `clarify`) instead of open-coding command
-        handling in multiple branches.
+        adapter instead of open-coding command handling in multiple branches.
         """
         for adapter in (
+            self._resolve_blocked_wait_proxy_setup,
+            self._resolve_blocked_wait_proxy,
             self._resolve_update_prompt_wait,
             self._resolve_approval_wait,
             self._resolve_clarify_wait,
@@ -1604,6 +1752,7 @@ class GatewayRunner:
         for session_key, agent in list(self._running_agents.items()):
             from tools.clarify_tool import clear_gateway_clarify_session
             clear_gateway_clarify_session(session_key)
+            self._blocked_wait_proxy_setup_pending.pop(session_key, None)
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
@@ -2042,6 +2191,7 @@ class GatewayRunner:
                     running_agent.interrupt("Stop requested")
                 from tools.clarify_tool import clear_gateway_clarify_session
                 clear_gateway_clarify_session(_quick_key)
+                self._blocked_wait_proxy_setup_pending.pop(_quick_key, None)
                 # Force-clean: remove the session lock regardless of agent state
                 adapter = self.adapters.get(source.platform)
                 if adapter and hasattr(adapter, 'get_pending_message'):
@@ -2065,6 +2215,7 @@ class GatewayRunner:
                     running_agent.interrupt("Session reset requested")
                 from tools.clarify_tool import clear_gateway_clarify_session
                 clear_gateway_clarify_session(_quick_key)
+                self._blocked_wait_proxy_setup_pending.pop(_quick_key, None)
                 # Clear any pending messages so the old text doesn't replay
                 adapter = self.adapters.get(source.platform)
                 if adapter and hasattr(adapter, 'get_pending_message'):
@@ -3574,6 +3725,7 @@ class GatewayRunner:
             # Force-clean the sentinel so the session is unlocked.
             from tools.clarify_tool import clear_gateway_clarify_session
             clear_gateway_clarify_session(session_key)
+            self._blocked_wait_proxy_setup_pending.pop(session_key, None)
             if session_key in self._running_agents:
                 del self._running_agents[session_key]
             logger.info("HARD STOP (pending) for session %s — sentinel cleared", session_key[:20])
@@ -3582,6 +3734,7 @@ class GatewayRunner:
             agent.interrupt("Stop requested")
             from tools.clarify_tool import clear_gateway_clarify_session
             clear_gateway_clarify_session(session_key)
+            self._blocked_wait_proxy_setup_pending.pop(session_key, None)
             # Force-clean the session lock so a truly hung agent doesn't
             # keep it locked forever.
             if session_key in self._running_agents:
@@ -5642,6 +5795,12 @@ class GatewayRunner:
         _adapter = self.adapters.get(source.platform)
         if _adapter:
             _adapter.resume_typing_for_chat(source.chat_id)
+        running_agent = self._running_agents.get(session_key)
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL and hasattr(running_agent, "clear_wait_state"):
+            try:
+                running_agent.clear_wait_state()
+            except Exception:
+                pass
 
         count_msg = f" ({count} commands)" if count > 1 else ""
         logger.info("User approved %d dangerous command(s) via /approve%s", count, scope_msg)
@@ -5679,6 +5838,12 @@ class GatewayRunner:
         _adapter = self.adapters.get(source.platform)
         if _adapter:
             _adapter.resume_typing_for_chat(source.chat_id)
+        running_agent = self._running_agents.get(session_key)
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL and hasattr(running_agent, "clear_wait_state"):
+            try:
+                running_agent.clear_wait_state()
+            except Exception:
+                pass
 
         count_msg = f" ({count} commands)" if count > 1 else ""
         logger.info("User denied %d dangerous command(s) via /deny", count)
@@ -7103,6 +7268,16 @@ class GatewayRunner:
                 # status; pausing prevents _keep_typing from re-setting it.
                 # Typing resumes in _handle_approve_command/_handle_deny_command.
                 _status_adapter.pause_typing_for_chat(_status_chat_id)
+                _agent = agent_holder[0]
+                if _agent and hasattr(_agent, "set_wait_state"):
+                    try:
+                        _agent.set_wait_state(
+                            "approval",
+                            mode="wait",
+                            question_preview=str(approval_data.get("description") or "Dangerous command approval")[:160],
+                        )
+                    except Exception:
+                        pass
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -418,18 +418,43 @@ def _load_gateway_config() -> dict:
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:
-    """Read model from config.yaml — single source of truth.
+    """Read model from config.yaml and fall back to the active provider default.
 
-    Without this, temporary AIAgent instances (memory flush, /compress) fall
-    back to the hardcoded default which fails when the active provider is
-    openai-codex.
+    Without this, temporary AIAgent instances (memory flush, /compress, API
+    server runs, gateway-backed CLI chats) can end up with an empty model name,
+    which fails for providers like Nous and Codex.
     """
     cfg = config if config is not None else _load_gateway_config()
     model_cfg = cfg.get("model", {})
+    configured_provider = ""
+
     if isinstance(model_cfg, str):
-        return model_cfg
+        model_name = model_cfg.strip()
+        if model_name:
+            return model_name
     elif isinstance(model_cfg, dict):
-        return model_cfg.get("default") or model_cfg.get("model") or ""
+        model_name = str(model_cfg.get("default") or model_cfg.get("model") or model_cfg.get("name") or "").strip()
+        if model_name:
+            return model_name
+        configured_provider = str(model_cfg.get("provider") or "").strip()
+
+    try:
+        from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS, normalize_provider
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        requested_provider = configured_provider or os.getenv("HERMES_INFERENCE_PROVIDER") or None
+        runtime = resolve_runtime_provider(requested=requested_provider)
+        resolved_provider = normalize_provider(runtime.get("provider") or requested_provider)
+
+        if resolved_provider == "openrouter":
+            return OPENROUTER_MODELS[0][0] if OPENROUTER_MODELS else ""
+
+        provider_models = _PROVIDER_MODELS.get(resolved_provider, [])
+        if provider_models:
+            return str(provider_models[0]).strip()
+    except Exception:
+        logger.debug("Could not derive fallback gateway model", exc_info=True)
+
     return ""
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -805,6 +805,105 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    async def _resolve_update_prompt_wait(self, event: MessageEvent, session_key: str) -> tuple[bool, Optional[str]]:
+        """Adapter for detached /update prompts that are waiting for user input."""
+        update_prompts = getattr(self, "_update_prompt_pending", {})
+        if not update_prompts.get(session_key):
+            return False, None
+
+        raw = (event.text or "").strip()
+        cmd = event.get_command()
+        if cmd in ("approve", "yes"):
+            response_text = "y"
+        elif cmd in ("deny", "no"):
+            response_text = "n"
+        elif cmd == "answer":
+            response_text = event.get_command_args().strip()
+        else:
+            response_text = raw
+
+        if not response_text:
+            return True, "Usage: /answer <response>"
+
+        from utils import atomic_yaml_write
+        response_path = _hermes_home / ".update_response"
+        try:
+            atomic_yaml_write(response_path, {"response": response_text})
+        except Exception as e:
+            logger.warning("Failed to write update response: %s", e)
+            return True, f"✗ Failed to send response to update process: {e}"
+
+        update_prompts.pop(session_key, None)
+        label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
+        return True, f"✓ Sent `{label}` to the update process."
+
+    async def _resolve_approval_wait(self, event: MessageEvent, session_key: str) -> tuple[bool, Optional[str]]:
+        """Adapter for dangerous-command approval waits."""
+        from hermes_cli.commands import resolve_command as _resolve_cmd
+        from tools.approval import has_blocking_approval
+
+        if not has_blocking_approval(session_key):
+            return False, None
+
+        cmd = event.get_command()
+        cmd_def = _resolve_cmd(cmd) if cmd else None
+        if not cmd_def:
+            return False, None
+        if cmd_def.name == "approve":
+            return True, await self._handle_approve_command(event)
+        if cmd_def.name == "deny":
+            return True, await self._handle_deny_command(event)
+        return False, None
+
+    async def _resolve_clarify_wait(self, event: MessageEvent, session_key: str) -> tuple[bool, Optional[str]]:
+        """Adapter for blocked clarify prompts while an agent is running."""
+        from hermes_cli.commands import resolve_command as _resolve_cmd
+        from tools.clarify_tool import has_blocking_gateway_clarify, resolve_gateway_clarify
+
+        if not has_blocking_gateway_clarify(session_key):
+            return False, None
+
+        cmd = event.get_command()
+        cmd_def = _resolve_cmd(cmd) if cmd else None
+        response_text = None
+        if cmd_def and cmd_def.name == "answer":
+            response_text = event.get_command_args().strip()
+            if not response_text:
+                return True, "Usage: /answer <response>"
+        elif not cmd_def:
+            response_text = (event.text or "").strip()
+
+        if not response_text:
+            return False, None
+
+        count = resolve_gateway_clarify(session_key, response_text)
+        if not count:
+            return True, "No pending clarify question to answer."
+
+        source = event.source
+        adapter = self.adapters.get(source.platform)
+        if adapter:
+            adapter.resume_typing_for_chat(source.chat_id)
+        return True, "✅ Clarify response received. The agent is resuming..."
+
+    async def _try_handle_blocking_wait(self, event: MessageEvent, session_key: str) -> tuple[bool, Optional[str]]:
+        """Shared blocked-wait dispatcher with small per-wait adapters.
+
+        This is the base path for user input that arrives while Hermes is paused
+        behind a blocking interaction. Each waiting flow contributes a small
+        adapter (`update`, `approval`, `clarify`) instead of open-coding command
+        handling in multiple branches.
+        """
+        for adapter in (
+            self._resolve_update_prompt_wait,
+            self._resolve_approval_wait,
+            self._resolve_clarify_wait,
+        ):
+            handled, response = await adapter(event, session_key)
+            if handled:
+                return True, response
+        return False, None
+
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         from agent.smart_model_routing import resolve_turn_route
 
@@ -1503,6 +1602,8 @@ class GatewayRunner:
         self._running = False
 
         for session_key, agent in list(self._running_agents.items()):
+            from tools.clarify_tool import clear_gateway_clarify_session
+            clear_gateway_clarify_session(session_key)
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
@@ -1856,34 +1957,13 @@ class GatewayRunner:
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
         
-        # Intercept messages that are responses to a pending /update prompt.
-        # The update process (detached) wrote .update_prompt.json; the watcher
-        # forwarded it to the user; now the user's reply goes back via
-        # .update_response so the update process can continue.
+        # Generic blocking-wait dispatch: detached update prompts, dangerous
+        # command approvals, and clarify waits all plug into the same base path
+        # through small adapters instead of open-coding bespoke command logic.
         _quick_key = self._session_key_for_source(source)
-        _update_prompts = getattr(self, "_update_prompt_pending", {})
-        if _update_prompts.get(_quick_key):
-            raw = (event.text or "").strip()
-            # Accept /approve and /deny as shorthand for yes/no
-            cmd = event.get_command()
-            if cmd in ("approve", "yes"):
-                response_text = "y"
-            elif cmd in ("deny", "no"):
-                response_text = "n"
-            else:
-                response_text = raw
-            if response_text:
-                response_path = _hermes_home / ".update_response"
-                try:
-                    tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text(response_text)
-                    tmp.replace(response_path)
-                except OSError as e:
-                    logger.warning("Failed to write update response: %s", e)
-                    return f"✗ Failed to send response to update process: {e}"
-                _update_prompts.pop(_quick_key, None)
-                label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
-                return f"✓ Sent `{label}` to the update process."
+        _wait_handled, _wait_response = await self._try_handle_blocking_wait(event, _quick_key)
+        if _wait_handled:
+            return _wait_response
 
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
@@ -1960,6 +2040,8 @@ class GatewayRunner:
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Stop requested")
+                from tools.clarify_tool import clear_gateway_clarify_session
+                clear_gateway_clarify_session(_quick_key)
                 # Force-clean: remove the session lock regardless of agent state
                 adapter = self.adapters.get(source.platform)
                 if adapter and hasattr(adapter, 'get_pending_message'):
@@ -1981,6 +2063,8 @@ class GatewayRunner:
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Session reset requested")
+                from tools.clarify_tool import clear_gateway_clarify_session
+                clear_gateway_clarify_session(_quick_key)
                 # Clear any pending messages so the old text doesn't replay
                 adapter = self.adapters.get(source.platform)
                 if adapter and hasattr(adapter, 'get_pending_message'):
@@ -2012,15 +2096,6 @@ class GatewayRunner:
             # /model must not be used while the agent is running.
             if _cmd_def_inner and _cmd_def_inner.name == "model":
                 return "Agent is running — wait or /stop first, then switch models."
-
-            # /approve and /deny must bypass the running-agent interrupt path.
-            # The agent thread is blocked on a threading.Event inside
-            # tools/approval.py — sending an interrupt won't unblock it.
-            # Route directly to the approval handler so the event is signalled.
-            if _cmd_def_inner and _cmd_def_inner.name in ("approve", "deny"):
-                if _cmd_def_inner.name == "approve":
-                    return await self._handle_approve_command(event)
-                return await self._handle_deny_command(event)
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
@@ -2166,6 +2241,9 @@ class GatewayRunner:
 
         if canonical == "deny":
             return await self._handle_deny_command(event)
+
+        if canonical == "answer":
+            return await self._handle_answer_command(event)
 
         if canonical == "update":
             return await self._handle_update_command(event)
@@ -3402,6 +3480,34 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+    def _format_running_activity(self, activity: dict) -> list[str]:
+        if not activity:
+            return []
+        lines: list[str] = []
+        wait_state = activity.get("wait_state") or {}
+        if wait_state:
+            mode = str(wait_state.get("mode") or "wait").upper()
+            kind = str(wait_state.get("kind") or "waiting")
+            lines.append(f"**Waiting:** {kind} ({mode})")
+            question = str(wait_state.get("question_preview") or "").strip()
+            if question:
+                lines.append(f"**Wait Prompt:** {question}")
+        active_children = activity.get("active_children") or []
+        if active_children:
+            lines.append(f"**Delegate Children:** {len(active_children)}")
+            for idx, child in enumerate(active_children[:3], start=1):
+                desc = child.get("current_tool") or child.get("last_activity_desc") or "active"
+                idle = child.get("seconds_since_activity")
+                detail = f"{desc}" if idle is None else f"{desc} ({int(idle)}s idle)"
+                lines.append(f"  - child {idx}: {detail}")
+                if child.get("watchdog_reason"):
+                    lines.append(f"    watchdog: {child['watchdog_reason']}")
+        elif activity.get("current_tool"):
+            lines.append(f"**Current Tool:** {activity['current_tool']}")
+        if activity.get("last_activity_desc"):
+            lines.append(f"**Agent Activity:** {activity['last_activity_desc']}")
+        return lines
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
@@ -3411,7 +3517,14 @@ class GatewayRunner:
 
         # Check if there's an active agent
         session_key = session_entry.session_key
-        is_running = session_key in self._running_agents
+        running_agent = self._running_agents.get(session_key)
+        is_running = running_agent is not None
+        activity = {}
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL and hasattr(running_agent, "get_activity_summary"):
+            try:
+                activity = running_agent.get_activity_summary() or {}
+            except Exception:
+                activity = {}
 
         title = None
         if self._session_db:
@@ -3432,6 +3545,11 @@ class GatewayRunner:
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Tokens:** {session_entry.total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
+        ])
+        activity_lines = self._format_running_activity(activity)
+        if activity_lines:
+            lines.extend(["", *activity_lines])
+        lines.extend([
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ])
@@ -3454,12 +3572,16 @@ class GatewayRunner:
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
             # Force-clean the sentinel so the session is unlocked.
+            from tools.clarify_tool import clear_gateway_clarify_session
+            clear_gateway_clarify_session(session_key)
             if session_key in self._running_agents:
                 del self._running_agents[session_key]
             logger.info("HARD STOP (pending) for session %s — sentinel cleared", session_key[:20])
             return "⚡ Force-stopped. The agent was still starting — session unlocked."
         if agent:
             agent.interrupt("Stop requested")
+            from tools.clarify_tool import clear_gateway_clarify_session
+            clear_gateway_clarify_session(session_key)
             # Force-clean the session lock so a truly hung agent doesn't
             # keep it locked forever.
             if session_key in self._running_agents:
@@ -5562,6 +5684,28 @@ class GatewayRunner:
         logger.info("User denied %d dangerous command(s) via /deny", count)
         return f"❌ Command{'s' if count > 1 else ''} denied{count_msg}."
 
+    async def _handle_answer_command(self, event: MessageEvent) -> str:
+        """Handle /answer <response> — answer the oldest pending clarify question."""
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        from tools.clarify_tool import has_blocking_gateway_clarify, resolve_gateway_clarify
+
+        if not has_blocking_gateway_clarify(session_key):
+            return "No pending clarify question to answer."
+
+        response_text = event.get_command_args().strip()
+        if not response_text:
+            return "Usage: /answer <response>"
+
+        count = resolve_gateway_clarify(session_key, response_text)
+        if not count:
+            return "No pending clarify question to answer."
+
+        _adapter = self.adapters.get(source.platform)
+        if _adapter:
+            _adapter.resume_typing_for_chat(source.chat_id)
+        return "✅ Clarify response received. The agent is resuming..."
+
     # Platforms where /update is allowed.  ACP, API server, and webhooks are
     # programmatic interfaces that should not trigger system updates.
     _UPDATE_ALLOWED_PLATFORMS = frozenset({
@@ -6391,6 +6535,11 @@ class GatewayRunner:
             if not progress_queue:
                 return
 
+            if event_type in ("subagent.heartbeat", "subagent.warning"):
+                msg = preview or tool_name or "subagent active"
+                progress_queue.put(msg)
+                return
+
             # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
             if event_type not in ("tool.started",):
                 return
@@ -6639,6 +6788,64 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
+        def _clarify_notify_sync(clarify_data: dict) -> None:
+            if not _status_adapter:
+                return
+            question = str(clarify_data.get("question") or "").strip()
+            choices = list(clarify_data.get("choices") or [])
+            try:
+                _status_adapter.pause_typing_for_chat(_status_chat_id)
+            except Exception:
+                pass
+
+            lines = ["❓ Hermes needs your input:", question]
+            if choices:
+                lines.append("")
+                for idx, choice in enumerate(choices, start=1):
+                    lines.append(f"{idx}. {choice}")
+                lines.append("")
+                lines.append("Reply with `/answer <number or text>`.")
+            else:
+                lines.append("")
+                lines.append("Reply with `/answer <your text>`.")
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    _status_adapter.send(
+                        _status_chat_id,
+                        "\n".join(lines),
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                ).result(timeout=15)
+            except Exception as _e:
+                logger.debug("clarify notify error: %s", _e)
+
+        def _clarify_callback_sync(question: str, choices: list[str] | None) -> str:
+            from tools.clarify_tool import wait_for_gateway_clarify
+            _agent = agent_holder[0]
+            if _agent and hasattr(_agent, "set_wait_state"):
+                try:
+                    _agent.set_wait_state(
+                        "clarify",
+                        mode="wait",
+                        question_preview=str(question or "")[:160],
+                        choices_count=len(choices or []),
+                    )
+                except Exception:
+                    pass
+            try:
+                return wait_for_gateway_clarify(
+                    question=question,
+                    choices=choices,
+                    session_key=session_key,
+                )
+            finally:
+                if _agent and hasattr(_agent, "clear_wait_state"):
+                    try:
+                        _agent.clear_wait_state()
+                    except Exception:
+                        pass
+
         def run_sync():
             # The conditional re-assignment of `message` further below
             # (prepending model-switch notes) makes Python treat it as a
@@ -6773,6 +6980,7 @@ class GatewayRunner:
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
+            agent.clarify_callback = _clarify_callback_sync
             agent.reasoning_config = reasoning_config
 
             # Background review delivery — send "💾 Memory updated" etc. to user
@@ -6874,6 +7082,10 @@ class GatewayRunner:
                 set_current_session_key,
                 unregister_gateway_notify,
             )
+            from tools.clarify_tool import (
+                register_gateway_clarify_notify,
+                unregister_gateway_clarify_notify,
+            )
 
             def _approval_notify_sync(approval_data: dict) -> None:
                 """Send the approval request to the user from the agent thread.
@@ -6946,9 +7158,11 @@ class GatewayRunner:
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            register_gateway_clarify_notify(_approval_session_key, _clarify_notify_sync)
             try:
                 result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             finally:
+                unregister_gateway_clarify_notify(_approval_session_key)
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
@@ -7147,7 +7361,12 @@ class GatewayRunner:
                     try:
                         _a = _agent_ref.get_activity_summary()
                         _parts = [f"iteration {_a['api_call_count']}/{_a['max_iterations']}"]
-                        if _a.get("current_tool"):
+                        _wait = _a.get("wait_state") or {}
+                        if _wait:
+                            _parts.append(f"waiting: {_wait.get('kind', 'input')}")
+                        elif _a.get("active_children_count"):
+                            _parts.append(f"delegate children: {_a['active_children_count']}")
+                        elif _a.get("current_tool"):
                             _parts.append(f"running: {_a['current_tool']}")
                         else:
                             _parts.append(_a.get("last_activity_desc", ""))
@@ -7206,12 +7425,16 @@ class GatewayRunner:
                     # Agent still running — check inactivity.
                     _agent_ref = agent_holder[0]
                     _idle_secs = 0.0
+                    _act = {}
                     if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                         try:
                             _act = _agent_ref.get_activity_summary()
                             _idle_secs = _act.get("seconds_since_activity", 0.0)
                         except Exception:
-                            pass
+                            _act = {}
+                    _wait_state = _act.get("wait_state") or {}
+                    if _wait_state.get("kind") == "clarify" and str(_wait_state.get("mode") or "wait").lower() == "wait":
+                        _idle_secs = 0.0
                     # Staged warning: fire once before escalating to full timeout.
                     if (not _warning_fired and _agent_warning is not None
                             and _idle_secs >= _agent_warning):

--- a/gateway/session_worker_manager.py
+++ b/gateway/session_worker_manager.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from gateway.session_worker_protocol import decode_event_line
+
+
+@dataclass
+class WorkerProcessHandle:
+    run_id: str
+    process: subprocess.Popen
+    command: list[str]
+    cwd: str
+    env: dict[str, str]
+    started_at: float = field(default_factory=time.time)
+    _events: "queue.Queue[dict[str, Any]]" = field(default_factory=queue.Queue, repr=False)
+    _stderr: list[str] = field(default_factory=list, repr=False)
+    _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
+
+    def start_reader(self) -> None:
+        if self._reader_thread is not None:
+            return
+        reader = threading.Thread(target=self._reader_loop, daemon=True, name=f"session-worker-{self.run_id}")
+        self._reader_thread = reader
+        reader.start()
+
+    def _reader_loop(self) -> None:
+        stdout = getattr(self.process, "stdout", None)
+        if stdout is None:
+            return
+        for raw_line in iter(stdout.readline, ""):
+            line = raw_line.strip()
+            if not line:
+                continue
+            event = decode_event_line(line)
+            self._events.put(event)
+
+    def send_message(self, message: dict[str, Any]) -> None:
+        stdin = getattr(self.process, "stdin", None)
+        if stdin is None:
+            raise RuntimeError("Worker stdin is unavailable")
+        stdin.write(json.dumps(message, ensure_ascii=False) + "\n")
+        stdin.flush()
+
+    def submit_clarify_response(self, response_text: str) -> None:
+        self.send_message({"type": "clarify.response", "response": str(response_text)})
+
+    def cancel(self) -> None:
+        try:
+            self.send_message({"type": "control.cancel"})
+        except Exception:
+            pass
+        try:
+            self.process.terminate()
+        except Exception:
+            pass
+
+    def poll_event(self, timeout: float | None = None) -> dict[str, Any]:
+        return self._events.get(timeout=timeout)
+
+
+class SessionWorkerManager:
+    """Scaffold manager for future per-session worker-process runtime."""
+
+    module_name = "gateway.session_worker_process"
+
+    def __init__(self, *, python_executable: str | None = None):
+        self.python_executable = python_executable or sys.executable
+
+    def build_command(self) -> list[str]:
+        return [self.python_executable, "-m", self.module_name]
+
+    def build_env(self, *, base_env: Optional[dict[str, str]] = None, extra_env: Optional[dict[str, str]] = None) -> dict[str, str]:
+        env = dict(base_env or os.environ)
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        if extra_env:
+            env.update({str(k): str(v) for k, v in extra_env.items()})
+        return env
+
+    def spawn(
+        self,
+        *,
+        run_id: str,
+        request_payload: dict[str, Any],
+        hermes_home: str | Path | None = None,
+        cwd: str | Path | None = None,
+        extra_env: Optional[dict[str, str]] = None,
+    ) -> WorkerProcessHandle:
+        env = self.build_env(extra_env=extra_env)
+        if hermes_home is not None:
+            env["HERMES_HOME"] = str(Path(hermes_home).expanduser().resolve())
+
+        working_dir = str(Path(cwd or Path.cwd()).resolve())
+        proc = subprocess.Popen(
+            self.build_command(),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=working_dir,
+            env=env,
+            bufsize=1,
+        )
+        handle = WorkerProcessHandle(
+            run_id=run_id,
+            process=proc,
+            command=self.build_command(),
+            cwd=working_dir,
+            env=env,
+        )
+        handle.start_reader()
+        handle.send_message({"type": "run.request", "run_id": run_id, "payload": request_payload})
+        return handle

--- a/gateway/session_worker_process.py
+++ b/gateway/session_worker_process.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from gateway.session_worker_protocol import encode_event_line, make_event
+
+
+"""Temporary scaffold entrypoint for future session worker processes.
+
+This module is intentionally minimal for the Stage 1/2 substrate work.
+It accepts one JSON message on stdin and emits a single structured failure event
+explaining that the real worker runtime is not wired yet.
+"""
+
+
+def main() -> int:
+    raw = sys.stdin.readline()
+    if not raw:
+        return 1
+    try:
+        message: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.stdout.write(
+            encode_event_line(
+                make_event("run.failed", run_id="unknown", error=f"invalid worker payload: {exc}")
+            )
+            + "\n"
+        )
+        sys.stdout.flush()
+        return 1
+
+    run_id = str(message.get("run_id") or "unknown")
+    sys.stdout.write(
+        encode_event_line(
+            make_event(
+                "run.failed",
+                run_id=run_id,
+                error="session worker scaffold is not wired into the runtime yet",
+            )
+        )
+        + "\n"
+    )
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gateway/session_worker_protocol.py
+++ b/gateway/session_worker_protocol.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Mapping
+
+EVENT_TYPES = frozenset({
+    "message.delta",
+    "tool.started",
+    "tool.completed",
+    "reasoning.available",
+    "subagent.heartbeat",
+    "subagent.warning",
+    "agent.activity",
+    "clarify.request",
+    "run.completed",
+    "run.failed",
+    "run.cancelled",
+})
+
+TERMINAL_EVENT_TYPES = frozenset({
+    "run.completed",
+    "run.failed",
+    "run.cancelled",
+})
+
+_REQUIRED_FIELDS: dict[str, frozenset[str]] = {
+    "message.delta": frozenset({"delta"}),
+    "tool.started": frozenset(),
+    "tool.completed": frozenset(),
+    "reasoning.available": frozenset({"text"}),
+    "subagent.heartbeat": frozenset(),
+    "subagent.warning": frozenset(),
+    "agent.activity": frozenset({"activity"}),
+    "clarify.request": frozenset({"question", "choices"}),
+    "run.completed": frozenset({"output", "usage"}),
+    "run.failed": frozenset({"error"}),
+    "run.cancelled": frozenset({"reason"}),
+}
+
+
+def is_terminal_event(event_type: str) -> bool:
+    return str(event_type) in TERMINAL_EVENT_TYPES
+
+
+
+def make_event(event_type: str, *, run_id: str, timestamp: float | None = None, **payload: Any) -> dict[str, Any]:
+    event_type = str(event_type)
+    if event_type not in EVENT_TYPES:
+        raise ValueError(f"Unknown worker event type: {event_type}")
+    if not str(run_id).strip():
+        raise ValueError("run_id is required")
+
+    event: dict[str, Any] = {
+        "event": event_type,
+        "run_id": str(run_id),
+        "timestamp": float(timestamp if timestamp is not None else time.time()),
+    }
+    event.update(payload)
+
+    missing = [key for key in _REQUIRED_FIELDS[event_type] if key not in event]
+    if missing:
+        raise ValueError(f"Missing required fields for {event_type}: {', '.join(sorted(missing))}")
+
+    if event_type == "clarify.request":
+        choices = event.get("choices")
+        if not isinstance(choices, list):
+            raise ValueError("clarify.request choices must be a list")
+    if event_type == "agent.activity":
+        activity = event.get("activity")
+        if not isinstance(activity, Mapping):
+            raise ValueError("agent.activity activity must be a mapping")
+    if event_type == "run.completed":
+        usage = event.get("usage")
+        if not isinstance(usage, Mapping):
+            raise ValueError("run.completed usage must be a mapping")
+
+    return event
+
+
+
+def validate_event(event: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(event, Mapping):
+        raise ValueError("Worker event must be a mapping")
+    payload = dict(event)
+    event_type = payload.pop("event", None)
+    run_id = payload.pop("run_id", None)
+    timestamp = payload.pop("timestamp", None)
+    return make_event(str(event_type), run_id=str(run_id or ""), timestamp=timestamp, **payload)
+
+
+
+def encode_event_line(event: Mapping[str, Any]) -> str:
+    validated = validate_event(event)
+    return json.dumps(validated, ensure_ascii=False)
+
+
+
+def decode_event_line(line: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid worker event JSON: {exc}") from exc
+    return validate_event(payload)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -67,6 +67,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="[session|always]"),
     CommandDef("deny", "Deny a pending dangerous command", "Session",
                gateway_only=True),
+    CommandDef("answer", "Answer a pending clarify question", "Session",
+               gateway_only=True, args_hint="<response>"),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg",), args_hint="<prompt>"),
     CommandDef("btw", "Ephemeral side question using session context (no tools, not persisted)", "Session",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -438,6 +438,26 @@ DEFAULT_CONFIG = {
         "default_wait_mode": "wait",  # wait | auto
     },
 
+    # Blocked-session helper -- a cheap continuity proxy that can take over the
+    # social/control surface while the main agent is blocked on clarify,
+    # delegated work, approvals, etc.
+    "blocked_wait_proxy": {
+        "enabled": False,
+        "model": "",
+        "provider": "",
+        "base_url": "",
+        "api_key": "",
+        "context_char_budget": 32000,
+        "setup_prompt_timeout": 90,
+        "identity_prompt": "",
+        "kinds": {
+            "clarify": {"enabled": False, "instructions": ""},
+            "delegate": {"enabled": False, "instructions": ""},
+            "approval": {"enabled": False, "instructions": ""},
+            "update": {"enabled": False, "instructions": ""},
+        },
+    },
+
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
@@ -608,7 +628,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 14,
+    "_config_version": 15,
 }
 
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -443,6 +443,9 @@ DEFAULT_CONFIG = {
     # delegated work, approvals, etc.
     "blocked_wait_proxy": {
         "enabled": False,
+        "launcher": "auto",  # auto | direct | gateway
+        "profile": "",       # optional named Hermes profile for the helper runtime
+        "gateway_autostart": True,
         "model": "",
         "provider": "",
         "base_url": "",
@@ -451,10 +454,10 @@ DEFAULT_CONFIG = {
         "setup_prompt_timeout": 90,
         "identity_prompt": "",
         "kinds": {
-            "clarify": {"enabled": False, "instructions": ""},
-            "delegate": {"enabled": False, "instructions": ""},
-            "approval": {"enabled": False, "instructions": ""},
-            "update": {"enabled": False, "instructions": ""},
+            "clarify": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
+            "delegate": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
+            "approval": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
+            "update": {"enabled": False, "instructions": "", "launcher": "", "profile": ""},
         },
     },
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -432,6 +432,12 @@ DEFAULT_CONFIG = {
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
     },
 
+    # Clarify prompt behavior
+    "clarify": {
+        "timeout": 120,               # Seconds of no user activity before AUTO clarify mode proceeds
+        "default_wait_mode": "wait",  # wait | auto
+    },
+
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
@@ -514,6 +520,8 @@ DEFAULT_CONFIG = {
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
+        "watchdog_idle_seconds": 180,
+        "watchdog_same_tool_limit": 8,
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
@@ -600,7 +608,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 13,
+    "_config_version": 14,
 }
 
 # =============================================================================

--- a/hermes_cli/context_limit.py
+++ b/hermes_cli/context_limit.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import re
+
+CONTEXT_MODE_DEFAULT = "1m"
+CONTEXT_MODE_USAGE = "/context-mode [1m|272k|status]"
+CONTEXT_MODE_PROFILES: dict[str, dict[str, float | int]] = {
+    "272k": {
+        "context_length": 272_000,
+        "compression_threshold": 0.95,
+    },
+    "1m": {
+        "context_length": 1_000_000,
+        "compression_threshold": 0.75,
+    },
+}
+
+_SUFFIX_MULTIPLIERS = {
+    "": 1,
+    "k": 1_000,
+    "m": 1_000_000,
+}
+
+
+def parse_context_limit_value(raw: str) -> int | None:
+    """Parse token counts like 500000, 272k, 1m, or 500,000."""
+    cleaned = (raw or "").strip().lower().replace(",", "").replace("_", "")
+    if not cleaned:
+        return None
+
+    match = re.fullmatch(r"(\d+)([km]?)", cleaned)
+    if not match:
+        return None
+
+    value = int(match.group(1)) * _SUFFIX_MULTIPLIERS[match.group(2)]
+    return value if value > 0 else None
+
+
+def parse_context_mode_arg(raw: str | None) -> str | None:
+    """Parse /context-mode args into a canonical mode name."""
+    cleaned = (raw or "").strip().lower()
+    if not cleaned:
+        return "toggle"
+    if cleaned == "status":
+        return "status"
+    if cleaned in CONTEXT_MODE_PROFILES:
+        return cleaned
+
+    parsed_limit = parse_context_limit_value(cleaned)
+    if parsed_limit is None:
+        return None
+
+    for mode_name, profile in CONTEXT_MODE_PROFILES.items():
+        if parsed_limit == int(profile["context_length"]):
+            return mode_name
+    return None
+
+
+def cycle_context_mode(current: str | None) -> str:
+    """Toggle between the named session context profiles."""
+    if current == "1m":
+        return "272k"
+    return "1m"
+
+
+def detect_context_mode(
+    context_length: int | None,
+    compression_threshold: float | None,
+) -> str | None:
+    """Return the named mode matching the live context profile, if any."""
+    if context_length is None or compression_threshold is None:
+        return None
+
+    for mode_name, profile in CONTEXT_MODE_PROFILES.items():
+        if (
+            int(profile["context_length"]) == int(context_length)
+            and abs(float(profile["compression_threshold"]) - float(compression_threshold)) < 1e-9
+        ):
+            return mode_name
+    return None

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -222,22 +222,30 @@ def stop_profile_gateway() -> bool:
     return True
 
 
-def launch_gateway_background() -> bool:
-    """Launch the current profile's gateway as a detached background process."""
-    try:
-        from gateway.status import get_running_pid
-        if get_running_pid() is not None:
-            return True
-    except Exception:
-        pass
+def launch_gateway_background_for_home(hermes_home: str | Path | None = None) -> bool:
+    """Launch a profile's gateway as a detached background process.
 
-    logs_dir = get_hermes_home() / "logs"
+    When *hermes_home* is omitted, uses the current process HERMES_HOME.
+    """
+    target_home = Path(hermes_home or get_hermes_home()).expanduser().resolve()
+    current_home = get_hermes_home().resolve()
+
+    if target_home == current_home:
+        try:
+            from gateway.status import get_running_pid
+            if get_running_pid() is not None:
+                return True
+        except Exception:
+            pass
+
+    logs_dir = target_home / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_path = logs_dir / "gateway-autostart.log"
     log_handle = open(log_path, "a", encoding="utf-8")
 
     cmd = [sys.executable, "-m", "hermes_cli.main", "gateway", "run", "--replace", "--quiet"]
     env = os.environ.copy()
+    env["HERMES_HOME"] = str(target_home)
     popen_kwargs = {
         "stdin": subprocess.DEVNULL,
         "stdout": log_handle,
@@ -265,6 +273,11 @@ def launch_gateway_background() -> bool:
             pass
         print_warning(f"Could not auto-start the gateway in background. See {log_path}")
         return False
+
+
+def launch_gateway_background() -> bool:
+    """Launch the current profile's gateway as a detached background process."""
+    return launch_gateway_background_for_home(get_hermes_home())
 
 
 def is_linux() -> bool:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -222,6 +222,51 @@ def stop_profile_gateway() -> bool:
     return True
 
 
+def launch_gateway_background() -> bool:
+    """Launch the current profile's gateway as a detached background process."""
+    try:
+        from gateway.status import get_running_pid
+        if get_running_pid() is not None:
+            return True
+    except Exception:
+        pass
+
+    logs_dir = get_hermes_home() / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / "gateway-autostart.log"
+    log_handle = open(log_path, "a", encoding="utf-8")
+
+    cmd = [sys.executable, "-m", "hermes_cli.main", "gateway", "run", "--replace", "--quiet"]
+    env = os.environ.copy()
+    popen_kwargs = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_handle,
+        "stderr": log_handle,
+        "env": env,
+        "cwd": str(PROJECT_ROOT),
+        "close_fds": True,
+    }
+
+    if is_windows():
+        detached = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        if detached:
+            popen_kwargs["creationflags"] = detached
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    try:
+        subprocess.Popen(cmd, **popen_kwargs)
+        log_handle.close()
+        return True
+    except Exception:
+        try:
+            log_handle.close()
+        except Exception:
+            pass
+        print_warning(f"Could not auto-start the gateway in background. See {log_path}")
+        return False
+
+
 def is_linux() -> bool:
     return sys.platform.startswith('linux')
 
@@ -2190,7 +2235,7 @@ def gateway_command(args):
             print("Not supported on this platform.")
             sys.exit(1)
     
-    elif subcmd == "stop":
+    elif subcmd in {"stop", "close"}:
         stop_all = getattr(args, 'all', False)
         system = getattr(args, 'system', False)
 

--- a/hermes_cli/gateway_session_client.py
+++ b/hermes_cli/gateway_session_client.py
@@ -6,6 +6,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, Optional
 
@@ -13,9 +14,26 @@ import requests
 
 from gateway.config import Platform, load_gateway_config
 from gateway.platforms.api_server import DEFAULT_HOST, DEFAULT_PORT
-from run_agent import message_content_to_text
+from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+def message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text" and item.get("text"):
+                    parts.append(str(item["text"]))
+                elif item.get("content"):
+                    parts.append(str(item["content"]))
+            elif item is not None:
+                parts.append(str(item))
+        return "\n".join(part for part in parts if part)
+    return "" if content is None else str(content)
 
 
 class GatewaySessionClientError(RuntimeError):
@@ -28,16 +46,62 @@ class GatewaySessionEndpoint:
     api_key: Optional[str] = None
 
 
-def resolve_gateway_session_endpoint() -> GatewaySessionEndpoint:
-    """Resolve the loopback API-server endpoint used for gateway-backed CLI sessions."""
-    config = load_gateway_config()
-    platform_cfg = config.platforms.get(Platform.API_SERVER)
-    extra = dict(getattr(platform_cfg, "extra", {}) or {})
+def _normalize_hermes_home(hermes_home: str | Path | None) -> Optional[Path]:
+    if hermes_home is None or str(hermes_home).strip() == "":
+        return None
+    return Path(hermes_home).expanduser().resolve()
 
-    host = str(os.getenv("API_SERVER_HOST") or extra.get("host") or DEFAULT_HOST)
-    port = int(os.getenv("API_SERVER_PORT") or extra.get("port") or DEFAULT_PORT)
-    api_key = os.getenv("API_SERVER_KEY") or extra.get("key") or None
+
+def _load_profile_api_server_settings(hermes_home: Path) -> tuple[str, int, Optional[str]]:
+    host = DEFAULT_HOST
+    port = DEFAULT_PORT
+    api_key: Optional[str] = None
+
+    gateway_json = hermes_home / "gateway.json"
+    if gateway_json.exists():
+        try:
+            data = json.loads(gateway_json.read_text(encoding="utf-8")) or {}
+            platform_cfg = dict((data.get("platforms") or {}).get(Platform.API_SERVER.value, {}) or {})
+            extra = dict(platform_cfg.get("extra") or {})
+            host = str(extra.get("host") or host)
+            port = int(extra.get("port") or port)
+            api_key = extra.get("key") or api_key
+        except Exception:
+            logger.debug("Failed to read %s", gateway_json, exc_info=True)
+
+    config_yaml = hermes_home / "config.yaml"
+    if config_yaml.exists():
+        try:
+            import yaml
+
+            yaml_cfg = yaml.safe_load(config_yaml.read_text(encoding="utf-8")) or {}
+            platform_cfg = dict((yaml_cfg.get("platforms") or {}).get(Platform.API_SERVER.value, {}) or {})
+            extra = dict(platform_cfg.get("extra") or {})
+            host = str(extra.get("host") or host)
+            port = int(extra.get("port") or port)
+            api_key = extra.get("key") or api_key
+        except Exception:
+            logger.debug("Failed to read %s", config_yaml, exc_info=True)
+
+    return host, port, api_key
+
+
+def resolve_gateway_session_endpoint(hermes_home: str | Path | None = None) -> GatewaySessionEndpoint:
+    """Resolve the loopback API-server endpoint used for gateway-backed CLI sessions."""
+    target_home = _normalize_hermes_home(hermes_home)
+    current_home = get_hermes_home().resolve()
+    if target_home is None or target_home == current_home:
+        config = load_gateway_config()
+        platform_cfg = config.platforms.get(Platform.API_SERVER)
+        extra = dict(getattr(platform_cfg, "extra", {}) or {})
+        host = str(os.getenv("API_SERVER_HOST") or extra.get("host") or DEFAULT_HOST)
+        port = int(os.getenv("API_SERVER_PORT") or extra.get("port") or DEFAULT_PORT)
+        api_key = os.getenv("API_SERVER_KEY") or extra.get("key") or None
+        return GatewaySessionEndpoint(base_url=f"http://{host}:{port}", api_key=api_key)
+
+    host, port, api_key = _load_profile_api_server_settings(target_home)
     return GatewaySessionEndpoint(base_url=f"http://{host}:{port}", api_key=api_key)
+
 
 
 def check_gateway_session_endpoint(endpoint: GatewaySessionEndpoint, timeout: float = 1.5) -> bool:
@@ -51,17 +115,22 @@ def check_gateway_session_endpoint(endpoint: GatewaySessionEndpoint, timeout: fl
     return payload.get("status") == "ok"
 
 
-def ensure_gateway_session_bridge(timeout: float = 15.0, autostart: bool = True) -> GatewaySessionEndpoint:
-    """Ensure the local gateway-backed session bridge is running and reachable."""
-    endpoint = resolve_gateway_session_endpoint()
+def ensure_gateway_session_bridge(
+    timeout: float = 15.0,
+    autostart: bool = True,
+    hermes_home: str | Path | None = None,
+) -> GatewaySessionEndpoint:
+    """Ensure the chosen profile's gateway-backed session bridge is running and reachable."""
+    target_home = _normalize_hermes_home(hermes_home)
+    endpoint = resolve_gateway_session_endpoint(target_home)
     if check_gateway_session_endpoint(endpoint):
         return endpoint
     if not autostart:
         raise GatewaySessionClientError("Gateway session bridge is not running")
 
-    from hermes_cli.gateway import launch_gateway_background
+    from hermes_cli.gateway import launch_gateway_background_for_home
 
-    if not launch_gateway_background():
+    if not launch_gateway_background_for_home(target_home or get_hermes_home()):
         raise GatewaySessionClientError("Failed to launch the Hermes gateway in the background")
 
     deadline = time.time() + max(timeout, 1.0)
@@ -97,6 +166,7 @@ class GatewaySessionAgentProxy:
         ephemeral_system_prompt: Optional[str] = None,
         tool_progress_callback: Optional[Callable[..., Any]] = None,
         reasoning_callback: Optional[Callable[[str], Any]] = None,
+        clarify_callback: Optional[Callable[[str, Optional[list[str]]], Any]] = None,
         http_session: Optional[requests.Session] = None,
     ):
         self.endpoint = endpoint
@@ -115,6 +185,7 @@ class GatewaySessionAgentProxy:
         self.ephemeral_system_prompt = ephemeral_system_prompt
         self.tool_progress_callback = tool_progress_callback
         self.reasoning_callback = reasoning_callback
+        self.clarify_callback = clarify_callback
         self.http_session = http_session or requests.Session()
 
         self.context_compressor = SimpleNamespace(
@@ -196,6 +267,15 @@ class GatewaySessionAgentProxy:
             raise GatewaySessionClientError("Gateway did not return a run_id")
         return str(run_id)
 
+    def _submit_clarify_response(self, run_id: str, response_text: str) -> None:
+        response = self.http_session.post(
+            f"{self.endpoint.base_url}/v1/runs/{run_id}/clarify",
+            json={"response": response_text},
+            headers=self._headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+
     def run_conversation(
         self,
         *,
@@ -262,10 +342,10 @@ class GatewaySessionAgentProxy:
                     reasoning_text = str(event.get("text") or "")
                     if reasoning_text and self.reasoning_callback is not None:
                         self.reasoning_callback(reasoning_text)
-                elif event_type == "tool.started":
+                elif event_type in {"tool.started", "subagent.heartbeat", "subagent.warning"}:
                     if self.tool_progress_callback is not None:
                         self.tool_progress_callback(
-                            "tool.started",
+                            event_type,
                             event.get("tool"),
                             event.get("preview"),
                             None,
@@ -280,6 +360,34 @@ class GatewaySessionAgentProxy:
                             duration=event.get("duration"),
                             is_error=event.get("error", False),
                         )
+                elif event_type == "agent.activity":
+                    if self.tool_progress_callback is not None:
+                        self.tool_progress_callback(
+                            "agent.activity",
+                            None,
+                            None,
+                            None,
+                            activity=event.get("activity") or {},
+                        )
+                elif event_type == "clarify.request":
+                    question = str(event.get("question") or "").strip()
+                    raw_choices = event.get("choices") or []
+                    choices = [str(choice) for choice in raw_choices] if isinstance(raw_choices, list) else None
+                    try:
+                        if self.clarify_callback is not None:
+                            clarify_result = self.clarify_callback(question, choices)
+                        else:
+                            clarify_result = (
+                                "The interactive client could not collect a clarify response. "
+                                "Use your best judgement to proceed."
+                            )
+                    except Exception as exc:
+                        logger.debug("Gateway clarify callback failed: %s", exc, exc_info=True)
+                        clarify_result = (
+                            "The interactive client could not collect a clarify response. "
+                            "Use your best judgement to proceed."
+                        )
+                    self._submit_clarify_response(run_id, str(clarify_result or "").strip())
                 elif event_type == "run.completed":
                     final_response = str(event.get("output") or "")
                     raw_usage = event.get("usage") or {}

--- a/hermes_cli/gateway_session_client.py
+++ b/hermes_cli/gateway_session_client.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Callable, Optional
+
+import requests
+
+from gateway.config import Platform, load_gateway_config
+from gateway.platforms.api_server import DEFAULT_HOST, DEFAULT_PORT
+from run_agent import message_content_to_text
+
+logger = logging.getLogger(__name__)
+
+
+class GatewaySessionClientError(RuntimeError):
+    """Raised when the local gateway session bridge is unavailable or fails."""
+
+
+@dataclass(frozen=True)
+class GatewaySessionEndpoint:
+    base_url: str
+    api_key: Optional[str] = None
+
+
+def resolve_gateway_session_endpoint() -> GatewaySessionEndpoint:
+    """Resolve the loopback API-server endpoint used for gateway-backed CLI sessions."""
+    config = load_gateway_config()
+    platform_cfg = config.platforms.get(Platform.API_SERVER)
+    extra = dict(getattr(platform_cfg, "extra", {}) or {})
+
+    host = str(os.getenv("API_SERVER_HOST") or extra.get("host") or DEFAULT_HOST)
+    port = int(os.getenv("API_SERVER_PORT") or extra.get("port") or DEFAULT_PORT)
+    api_key = os.getenv("API_SERVER_KEY") or extra.get("key") or None
+    return GatewaySessionEndpoint(base_url=f"http://{host}:{port}", api_key=api_key)
+
+
+def check_gateway_session_endpoint(endpoint: GatewaySessionEndpoint, timeout: float = 1.5) -> bool:
+    """Return True when the local gateway API server responds to /health."""
+    try:
+        response = requests.get(f"{endpoint.base_url}/health", timeout=timeout)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception:
+        return False
+    return payload.get("status") == "ok"
+
+
+def ensure_gateway_session_bridge(timeout: float = 15.0, autostart: bool = True) -> GatewaySessionEndpoint:
+    """Ensure the local gateway-backed session bridge is running and reachable."""
+    endpoint = resolve_gateway_session_endpoint()
+    if check_gateway_session_endpoint(endpoint):
+        return endpoint
+    if not autostart:
+        raise GatewaySessionClientError("Gateway session bridge is not running")
+
+    from hermes_cli.gateway import launch_gateway_background
+
+    if not launch_gateway_background():
+        raise GatewaySessionClientError("Failed to launch the Hermes gateway in the background")
+
+    deadline = time.time() + max(timeout, 1.0)
+    while time.time() < deadline:
+        if check_gateway_session_endpoint(endpoint):
+            return endpoint
+        time.sleep(0.25)
+
+    raise GatewaySessionClientError(
+        f"Gateway session bridge did not become ready at {endpoint.base_url} within {timeout:.1f}s"
+    )
+
+
+class GatewaySessionAgentProxy:
+    """Small AIAgent-compatible proxy that routes CLI turns through the gateway API server."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: GatewaySessionEndpoint,
+        session_id: str,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_mode: Optional[str] = None,
+        enabled_toolsets: Optional[list[str]] = None,
+        service_tier: Optional[str] = None,
+        context_length_override: Optional[int] = None,
+        compression_threshold: float = 0.5,
+        verbose_logging: bool = False,
+        quiet_mode: bool = True,
+        ephemeral_system_prompt: Optional[str] = None,
+        tool_progress_callback: Optional[Callable[..., Any]] = None,
+        reasoning_callback: Optional[Callable[[str], Any]] = None,
+        http_session: Optional[requests.Session] = None,
+    ):
+        self.endpoint = endpoint
+        self.session_id = session_id
+        self.session_start = None
+        self.model = model
+        self.provider = provider
+        self.api_key = api_key
+        self.base_url = base_url
+        self.api_mode = api_mode or "chat_completions"
+        self.enabled_toolsets = list(enabled_toolsets or [])
+        self.service_tier = service_tier
+        self.context_length_override = context_length_override
+        self.verbose_logging = verbose_logging
+        self.quiet_mode = quiet_mode
+        self.ephemeral_system_prompt = ephemeral_system_prompt
+        self.tool_progress_callback = tool_progress_callback
+        self.reasoning_callback = reasoning_callback
+        self.http_session = http_session or requests.Session()
+
+        self.context_compressor = SimpleNamespace(
+            context_length=context_length_override,
+            threshold_percent=compression_threshold,
+        )
+        self.gateway_hosted_session = True
+        self.compression_enabled = False
+        self._checkpoint_mgr = SimpleNamespace(enabled=False)
+        self._active_children: list[Any] = []
+        self._interrupt_requested = False
+        self._detach_requested = False
+        self._interrupt_message: Optional[str] = None
+        self._active_run_id: Optional[str] = None
+        self._active_events_response: Any = None
+        self._active_lock = threading.Lock()
+        self._last_flushed_db_idx = 0
+        self.tools: list[Any] = []
+        self.valid_tool_names: set[str] = set()
+
+        self.session_cache_write_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_api_calls = 0
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.endpoint.api_key:
+            headers["Authorization"] = f"Bearer {self.endpoint.api_key}"
+        return headers
+
+    def _normalized_history(self, conversation_history: Optional[list[dict[str, Any]]]) -> list[dict[str, str]]:
+        normalized: list[dict[str, str]] = []
+        for message in conversation_history or []:
+            if not isinstance(message, dict):
+                continue
+            role = str(message.get("role") or "")
+            if role not in {"user", "assistant"}:
+                continue
+            normalized.append({
+                "role": role,
+                "content": message_content_to_text(message.get("content", "")),
+            })
+        return normalized
+
+    def _runtime_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "api_mode": self.api_mode,
+            "toolsets": list(self.enabled_toolsets or []),
+            "service_tier": self.service_tier,
+            "context_length_override": self.context_length_override,
+        }
+        return {k: v for k, v in payload.items() if v not in (None, "", [])}
+
+    def _start_run(self, *, user_message: str, conversation_history: list[dict[str, str]]) -> str:
+        payload: dict[str, Any] = {
+            "input": user_message,
+            "session_id": self.session_id,
+            "conversation_history": conversation_history,
+        }
+        if self.ephemeral_system_prompt:
+            payload["instructions"] = self.ephemeral_system_prompt
+        payload.update(self._runtime_payload())
+
+        response = self.http_session.post(
+            f"{self.endpoint.base_url}/v1/runs",
+            json=payload,
+            headers=self._headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        run_id = data.get("run_id")
+        if not run_id:
+            raise GatewaySessionClientError("Gateway did not return a run_id")
+        return str(run_id)
+
+    def run_conversation(
+        self,
+        *,
+        user_message: str,
+        conversation_history: Optional[list[dict[str, Any]]] = None,
+        stream_callback: Optional[Callable[[str], Any]] = None,
+        task_id: Optional[str] = None,
+        persist_user_message: Any = None,
+        **_: Any,
+    ) -> dict[str, Any]:
+        del task_id
+        normalized_history = self._normalized_history(conversation_history)
+        visible_user_message = message_content_to_text(
+            persist_user_message if persist_user_message is not None else user_message
+        )
+        wire_user_message = message_content_to_text(user_message)
+        reasoning_text = ""
+        streamed_chunks: list[str] = []
+        final_response = ""
+        failed = False
+        interrupted = False
+        detached = False
+        error_message: Optional[str] = None
+        usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+        run_id = self._start_run(user_message=wire_user_message, conversation_history=normalized_history)
+        events_response = self.http_session.get(
+            f"{self.endpoint.base_url}/v1/runs/{run_id}/events",
+            headers=self._headers(),
+            stream=True,
+            timeout=300,
+        )
+        events_response.raise_for_status()
+
+        with self._active_lock:
+            self._active_run_id = run_id
+            self._active_events_response = events_response
+            self._interrupt_requested = False
+            self._detach_requested = False
+            self._interrupt_message = None
+
+        try:
+            for raw_line in events_response.iter_lines(decode_unicode=True):
+                if raw_line is None:
+                    continue
+                line = raw_line.strip()
+                if not line or line.startswith(":"):
+                    continue
+                if not line.startswith("data:"):
+                    continue
+                payload_text = line.split(":", 1)[1].strip()
+                if not payload_text:
+                    continue
+                event = json.loads(payload_text)
+                event_type = str(event.get("event") or "")
+
+                if event_type == "message.delta":
+                    delta = str(event.get("delta") or "")
+                    if delta:
+                        streamed_chunks.append(delta)
+                        if stream_callback is not None:
+                            stream_callback(delta)
+                elif event_type == "reasoning.available":
+                    reasoning_text = str(event.get("text") or "")
+                    if reasoning_text and self.reasoning_callback is not None:
+                        self.reasoning_callback(reasoning_text)
+                elif event_type == "tool.started":
+                    if self.tool_progress_callback is not None:
+                        self.tool_progress_callback(
+                            "tool.started",
+                            event.get("tool"),
+                            event.get("preview"),
+                            None,
+                        )
+                elif event_type == "tool.completed":
+                    if self.tool_progress_callback is not None:
+                        self.tool_progress_callback(
+                            "tool.completed",
+                            event.get("tool"),
+                            None,
+                            None,
+                            duration=event.get("duration"),
+                            is_error=event.get("error", False),
+                        )
+                elif event_type == "run.completed":
+                    final_response = str(event.get("output") or "")
+                    raw_usage = event.get("usage") or {}
+                    usage = {
+                        "input_tokens": int(raw_usage.get("input_tokens") or 0),
+                        "output_tokens": int(raw_usage.get("output_tokens") or 0),
+                        "total_tokens": int(raw_usage.get("total_tokens") or 0),
+                    }
+                elif event_type == "run.failed":
+                    failed = True
+                    error_message = str(event.get("error") or "Gateway run failed")
+                elif event_type == "run.cancelled":
+                    interrupted = True
+                    error_message = self._interrupt_message or str(event.get("reason") or "Interrupted")
+
+            if self._detach_requested:
+                detached = True
+                final_response = ""
+            elif not final_response:
+                final_response = "".join(streamed_chunks)
+            if self._interrupt_requested:
+                interrupted = True
+                error_message = self._interrupt_message or error_message or "Interrupted"
+
+        except Exception as exc:
+            if self._detach_requested:
+                detached = True
+            elif self._interrupt_requested:
+                interrupted = True
+                error_message = self._interrupt_message or "Interrupted"
+            else:
+                logger.debug("Gateway event stream failed for %s: %s", run_id, exc, exc_info=True)
+                raise GatewaySessionClientError(str(exc)) from exc
+        finally:
+            try:
+                events_response.close()
+            except Exception:
+                pass
+            with self._active_lock:
+                self._active_run_id = None
+                self._active_events_response = None
+
+        self.session_prompt_tokens += usage["input_tokens"]
+        self.session_completion_tokens += usage["output_tokens"]
+        self.session_total_tokens += usage["total_tokens"]
+        self.session_api_calls += 1
+
+        messages = list(normalized_history)
+        messages.append({"role": "user", "content": visible_user_message})
+        if final_response:
+            messages.append({"role": "assistant", "content": final_response})
+
+        result = {
+            "final_response": final_response,
+            "messages": messages,
+            "api_calls": 1,
+            "completed": not failed and not interrupted and not detached,
+            "failed": failed,
+            "interrupted": interrupted,
+            "detached": detached,
+            "response_previewed": bool(streamed_chunks),
+        }
+        if reasoning_text:
+            result["last_reasoning"] = reasoning_text
+        if error_message:
+            result["error"] = error_message
+        if interrupted:
+            result["interrupt_message"] = error_message
+        return result
+
+    def interrupt(self, message: Optional[str] = None) -> None:
+        with self._active_lock:
+            self._interrupt_requested = True
+            self._detach_requested = False
+            self._interrupt_message = message or "Interrupted"
+            run_id = self._active_run_id
+            response = self._active_events_response
+
+        if run_id:
+            try:
+                cancel_response = self.http_session.post(
+                    f"{self.endpoint.base_url}/v1/runs/{run_id}/cancel",
+                    headers=self._headers(),
+                    timeout=10,
+                )
+                cancel_response.raise_for_status()
+            except Exception:
+                logger.debug("Gateway run cancel failed for %s", run_id, exc_info=True)
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                pass
+
+    def detach(self) -> None:
+        with self._active_lock:
+            self._detach_requested = True
+            response = self._active_events_response
+
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                pass
+
+    def switch_model(
+        self,
+        *,
+        new_model: Optional[str] = None,
+        new_provider: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_mode: Optional[str] = None,
+    ) -> None:
+        if new_model:
+            self.model = new_model
+        if new_provider:
+            self.provider = new_provider
+        if api_key:
+            self.api_key = api_key
+        if base_url:
+            self.base_url = base_url
+        if api_mode:
+            self.api_mode = api_mode
+
+    def set_context_profile(self, *, context_length: Optional[int] = None, compression_threshold: Optional[float] = None) -> Optional[int]:
+        if context_length is not None:
+            self.context_length_override = context_length
+            self.context_compressor.context_length = context_length
+        if compression_threshold is not None:
+            self.context_compressor.threshold_percent = compression_threshold
+        return self.context_length_override
+
+    def set_context_length_override(self, context_length: Optional[int] = None) -> Optional[int]:
+        return self.set_context_profile(context_length=context_length)
+
+    def reset_session_state(self) -> None:
+        self._interrupt_requested = False
+        self._detach_requested = False
+        self._interrupt_message = None
+
+    def flush_memories(self, conversation_history: Optional[list[dict[str, Any]]] = None) -> None:
+        del conversation_history
+
+    def shutdown_memory_provider(self, conversation_history: Optional[list[dict[str, Any]]] = None) -> None:
+        del conversation_history
+
+    def _invalidate_system_prompt(self) -> None:
+        return None
+
+    def _persist_session(self, conversation_history: Optional[list[dict[str, Any]]] = None, *args: Any, **kwargs: Any) -> None:
+        del conversation_history, args, kwargs
+
+    @staticmethod
+    def _summarize_api_error(exc: Exception) -> str:
+        return str(exc)[:300]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -585,8 +585,16 @@ def cmd_chat(args):
         # If resolution fails, keep the original value — _init_agent will
         # report "Session not found" with the original input
 
-    # First-run guard: check if any provider is configured before launching
-    if not _has_any_provider_configured():
+    gateway_session_mode = (
+        not getattr(args, "query", None)
+        and sys.stdin.isatty()
+        and str(os.getenv("HERMES_GATEWAY_SESSION_MODE", "1")).strip().lower()
+        not in {"0", "false", "no", "off"}
+    )
+
+    # First-run guard: interactive gateway-backed CLI sessions use the gateway's
+    # runtime, so they do not require a locally configured provider.
+    if not gateway_session_mode and not _has_any_provider_configured():
         print()
         print("It looks like Hermes isn't configured yet -- no API keys or providers found.")
         print()
@@ -611,6 +619,14 @@ def cmd_chat(args):
         print()
         print("You can run 'hermes setup' at any time to configure.")
         sys.exit(1)
+
+    if gateway_session_mode:
+        try:
+            from hermes_cli.gateway_session_client import ensure_gateway_session_bridge
+            ensure_gateway_session_bridge()
+        except Exception as exc:
+            print(f"Error starting gateway session bridge: {exc}")
+            sys.exit(1)
 
     # Start update check in background (runs while other init happens)
     try:
@@ -4454,6 +4470,11 @@ For more help on a command:
     gateway_stop = gateway_subparsers.add_parser("stop", help="Stop gateway service")
     gateway_stop.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
     gateway_stop.add_argument("--all", action="store_true", help="Stop ALL gateway processes across all profiles")
+
+    # gateway close (same as stop; explicit user-facing wording for hosted sessions)
+    gateway_close = gateway_subparsers.add_parser("close", help="Close the hosted gateway for this profile")
+    gateway_close.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_close.add_argument("--all", action="store_true", help="Close ALL gateway processes across all profiles")
     
     # gateway restart
     gateway_restart = gateway_subparsers.add_parser("restart", help="Restart gateway service")

--- a/run_agent.py
+++ b/run_agent.py
@@ -698,6 +698,8 @@ class AIAgent:
         self._last_activity_desc: str = "initializing"
         self._current_tool: str | None = None
         self._api_call_count: int = 0
+        self._wait_state_lock = threading.Lock()
+        self._wait_state: Optional[Dict[str, Any]] = None
 
         # Rate limit tracking — updated from x-ratelimit-* response headers
         # after each API call.  Accessed by /usage slash command.
@@ -2597,22 +2599,107 @@ class AIAgent:
         """Return the last captured RateLimitState, or None."""
         return self._rate_limit_state
 
+    def set_wait_state(self, kind: str, **details: Any) -> None:
+        """Record a blocking wait state such as clarify or delegated supervision."""
+        now = time.time()
+        payload: Dict[str, Any] = {
+            "kind": str(kind or "").strip() or "unknown",
+            "started_at": now,
+            "updated_at": now,
+        }
+        for key, value in details.items():
+            if value is not None:
+                payload[key] = value
+        with self._wait_state_lock:
+            existing = self._wait_state or {}
+            if existing.get("kind") == payload["kind"] and existing.get("started_at"):
+                payload["started_at"] = existing["started_at"]
+            self._wait_state = payload
+        self._touch_activity(f"waiting: {payload['kind']}")
+
+    def update_wait_state(self, **details: Any) -> None:
+        """Update details on the current wait state without resetting its start time."""
+        with self._wait_state_lock:
+            if not self._wait_state:
+                return
+            self._wait_state.update({k: v for k, v in details.items() if v is not None})
+            self._wait_state["updated_at"] = time.time()
+
+    def clear_wait_state(self) -> None:
+        """Clear any active blocking wait state."""
+        with self._wait_state_lock:
+            self._wait_state = None
+
+    def _active_child_activity_snapshot(self) -> list[dict]:
+        """Return compact activity summaries for any currently running child agents."""
+        with self._active_children_lock:
+            children = list(self._active_children)
+
+        snapshots: list[dict] = []
+        for child in children[:3]:
+            if not hasattr(child, "get_activity_summary"):
+                continue
+            try:
+                summary = child.get_activity_summary()
+            except Exception:
+                continue
+            snapshots.append({
+                "session_id": getattr(child, "session_id", None),
+                "model": getattr(child, "model", None),
+                "current_tool": summary.get("current_tool"),
+                "last_activity_desc": summary.get("last_activity_desc"),
+                "seconds_since_activity": summary.get("seconds_since_activity"),
+                "api_call_count": summary.get("api_call_count"),
+                "wait_state": summary.get("wait_state"),
+                "goal_preview": getattr(child, "_delegate_goal_preview", None),
+                "watchdog_reason": getattr(child, "_delegate_watchdog_reason", None),
+            })
+        return snapshots
+
     def get_activity_summary(self) -> dict:
         """Return a snapshot of the agent's current activity for diagnostics.
 
         Called by the gateway timeout handler to report what the agent was doing
         when it was killed, and by the periodic "still working" notifications.
         """
-        elapsed = time.time() - self._last_activity_ts
+        now = time.time()
+        last_activity_ts = self._last_activity_ts
+        last_activity_desc = self._last_activity_desc
+        current_tool = self._current_tool
+
+        with self._wait_state_lock:
+            wait_state = dict(self._wait_state) if self._wait_state else None
+        if wait_state and wait_state.get("started_at"):
+            wait_state["elapsed_seconds"] = round(now - float(wait_state["started_at"]), 1)
+            if wait_state.get("kind") == "clarify" and not wait_state.get("typing_active"):
+                # A deliberate user wait should not look like a hung agent.
+                last_activity_ts = max(last_activity_ts, float(wait_state["updated_at"]))
+                last_activity_desc = f"waiting: {wait_state['kind']}"
+
+        child_snapshots = self._active_child_activity_snapshot()
+        if current_tool == "delegate_task" and child_snapshots:
+            freshest = min(
+                child_snapshots,
+                key=lambda item: float(item.get("seconds_since_activity") or 0.0),
+            )
+            child_idle = float(freshest.get("seconds_since_activity") or 0.0)
+            last_activity_ts = max(last_activity_ts, now - child_idle)
+            child_desc = freshest.get("last_activity_desc") or freshest.get("current_tool") or "child active"
+            last_activity_desc = f"delegate child: {child_desc}"
+
+        elapsed = max(0.0, now - last_activity_ts)
         return {
-            "last_activity_ts": self._last_activity_ts,
-            "last_activity_desc": self._last_activity_desc,
+            "last_activity_ts": last_activity_ts,
+            "last_activity_desc": last_activity_desc,
             "seconds_since_activity": round(elapsed, 1),
-            "current_tool": self._current_tool,
+            "current_tool": current_tool,
             "api_call_count": self._api_call_count,
             "max_iterations": self.max_iterations,
             "budget_used": self.iteration_budget.used,
             "budget_max": self.iteration_budget.max_total,
+            "wait_state": wait_state,
+            "active_children_count": len(child_snapshots),
+            "active_children": child_snapshots,
         }
 
     def shutdown_memory_provider(self, messages: list = None) -> None:

--- a/tests/cli/test_cli_clarify_ui.py
+++ b/tests/cli/test_cli_clarify_ui.py
@@ -1,0 +1,95 @@
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import cli as cli_module
+from cli import HermesCLI
+
+
+class _FakeBuffer:
+    def __init__(self, text=""):
+        self.text = text
+        self.cursor_position = len(text)
+
+    def reset(self, append_to_history=False):
+        self.text = ""
+        self.cursor_position = 0
+
+
+def _make_cli_stub():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._clarify_state = None
+    cli._clarify_freetext = False
+    cli._clarify_deadline = 0
+    cli._clarify_last_typing_at = 0.0
+    cli._clarify_wait_mode_default = "wait"
+    cli._clarify_auto_timeout_seconds = 1
+    cli._invalidate = MagicMock()
+    cli._app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
+    cli.agent = MagicMock()
+    cli.agent.set_wait_state = MagicMock()
+    cli.agent.clear_wait_state = MagicMock()
+    return cli
+
+
+class TestCliClarifyUi:
+    def test_wait_mode_blocks_until_response(self):
+        cli = _make_cli_stub()
+        cli._clarify_wait_mode_default = "wait"
+        cli._clarify_auto_timeout_seconds = 1
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._clarify_callback("Pick one", ["a", "b"])
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._clarify_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._clarify_state is not None
+        time.sleep(1.2)
+        assert thread.is_alive(), "WAIT mode should not auto-time-out"
+
+        cli._clarify_state["response_queue"].put("a")
+        thread.join(timeout=2)
+        assert result["value"] == "a"
+
+    def test_auto_mode_times_out_without_response(self):
+        cli = _make_cli_stub()
+        cli._clarify_wait_mode_default = "auto"
+        cli._clarify_auto_timeout_seconds = 1
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._clarify_callback("Pick one", ["a", "b"])
+
+        with patch.object(cli_module, "_cprint"):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert "best judgement" in result["value"]
+
+    def test_set_clarify_wait_mode_persists_and_updates_active_prompt(self):
+        cli = _make_cli_stub()
+        cli._clarify_state = {
+            "question": "What now?",
+            "choices": ["a"],
+            "selected": 0,
+            "response_queue": None,
+            "wait_mode": "wait",
+        }
+
+        with patch.object(cli_module, "save_config_value", return_value=True) as mock_save:
+            mode = cli._set_clarify_wait_mode("auto")
+
+        assert mode == "auto"
+        assert cli._clarify_wait_mode_default == "auto"
+        assert cli._clarify_state["wait_mode"] == "auto"
+        mock_save.assert_called_once_with("clarify.default_wait_mode", "auto")
+        cli.agent.set_wait_state.assert_called()

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,6 +200,30 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_runtime_resolution_backfills_blank_model_from_provider_default(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "nous",
+            "api_mode": "chat_completions",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "***",
+            "source": "portal",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="", compact=True, max_turns=1)
+    shell.model = ""
+    shell._model_is_default = True
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.provider == "nous"
+    assert shell.model == "anthropic/claude-opus-4.6"
+
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)

--- a/tests/cli/test_gateway_session_agent.py
+++ b/tests/cli/test_gateway_session_agent.py
@@ -43,16 +43,19 @@ class _BlockingResponse(_FakeResponse):
 
 
 class _FakeSession:
-    def __init__(self, *, run_response, event_response, cancel_response=None):
+    def __init__(self, *, run_response, event_response, cancel_response=None, clarify_response=None):
         self.run_response = run_response
         self.event_response = event_response
         self.cancel_response = cancel_response or _FakeResponse({"status": "cancelling"})
+        self.clarify_response = clarify_response or _FakeResponse({"status": "ok"})
         self.calls = []
 
     def post(self, url, **kwargs):
         self.calls.append(("POST", url, kwargs))
         if url.endswith("/cancel"):
             return self.cancel_response
+        if url.endswith("/clarify"):
+            return self.clarify_response
         return self.run_response
 
     def get(self, url, **kwargs):
@@ -114,6 +117,37 @@ def test_run_conversation_streams_gateway_events_and_updates_usage():
     assert kwargs["json"]["session_id"] == "sess_1"
     assert kwargs["json"]["conversation_history"] == [{"role": "assistant", "content": "Earlier"}]
     assert kwargs["json"]["toolsets"] == ["terminal", "file"]
+
+
+def test_gateway_run_conversation_handles_clarify_request_and_activity_events():
+    events = [
+        'data: {"event":"agent.activity","activity":{"wait_state":{"kind":"delegate","mode":"wait"},"active_children_count":1,"active_children":[{"current_tool":"read_file"}]}}',
+        'data: {"event":"clarify.request","question":"Keep waiting?","choices":["Yes","No"]}',
+        'data: {"event":"run.completed","output":"done","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}',
+        ': stream closed',
+    ]
+    fake_session = _FakeSession(
+        run_response=_FakeResponse({"run_id": "run_123", "status": "started"}),
+        event_response=_FakeResponse(lines=events),
+    )
+    tool_events = []
+    clarify_requests = []
+    proxy = GatewaySessionAgentProxy(
+        endpoint=GatewaySessionEndpoint(base_url="http://127.0.0.1:8642", api_key=None),
+        session_id="sess_1",
+        http_session=fake_session,
+        tool_progress_callback=lambda event_type, name=None, preview=None, args=None, **kwargs: tool_events.append((event_type, kwargs.get("activity"))),
+        clarify_callback=lambda question, choices: clarify_requests.append((question, choices)) or "Yes",
+    )
+
+    result = proxy.run_conversation(user_message="hello", conversation_history=[])
+
+    assert result["final_response"] == "done"
+    assert clarify_requests == [("Keep waiting?", ["Yes", "No"])]
+    assert tool_events[0][0] == "agent.activity"
+    clarify_post = [call for call in fake_session.calls if call[0] == "POST" and call[1].endswith("/clarify")]
+    assert len(clarify_post) == 1
+    assert clarify_post[0][2]["json"] == {"response": "Yes"}
 
 
 def test_interrupt_posts_run_cancel_and_closes_stream():

--- a/tests/cli/test_gateway_session_agent.py
+++ b/tests/cli/test_gateway_session_agent.py
@@ -1,0 +1,169 @@
+import json
+import threading
+import time
+
+from hermes_cli.gateway_session_client import (
+    GatewaySessionAgentProxy,
+    GatewaySessionEndpoint,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload=None, lines=None, status_code=200):
+        self._payload = payload or {}
+        self._lines = list(lines or [])
+        self.status_code = status_code
+        self.closed = False
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"http {self.status_code}")
+
+    def iter_lines(self, decode_unicode=True):
+        for line in self._lines:
+            yield line if decode_unicode else line.encode()
+
+    def close(self):
+        self.closed = True
+
+
+class _BlockingResponse(_FakeResponse):
+    def __init__(self, payload=None, status_code=200):
+        super().__init__(payload=payload, lines=[], status_code=status_code)
+        self._started = threading.Event()
+
+    def iter_lines(self, decode_unicode=True):
+        self._started.set()
+        while not self.closed:
+            time.sleep(0.01)
+        return
+
+
+class _FakeSession:
+    def __init__(self, *, run_response, event_response, cancel_response=None):
+        self.run_response = run_response
+        self.event_response = event_response
+        self.cancel_response = cancel_response or _FakeResponse({"status": "cancelling"})
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        if url.endswith("/cancel"):
+            return self.cancel_response
+        return self.run_response
+
+    def get(self, url, **kwargs):
+        self.calls.append(("GET", url, kwargs))
+        return self.event_response
+
+
+def test_run_conversation_streams_gateway_events_and_updates_usage():
+    events = [
+        'data: {"event":"reasoning.available","text":"thinking..."}',
+        'data: {"event":"tool.started","tool":"search_files","preview":"searching"}',
+        'data: {"event":"message.delta","delta":"Hi"}',
+        'data: {"event":"message.delta","delta":" there"}',
+        'data: {"event":"run.completed","output":"Hi there","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7}}',
+        ': stream closed',
+    ]
+    fake_session = _FakeSession(
+        run_response=_FakeResponse({"run_id": "run_123", "status": "started"}),
+        event_response=_FakeResponse(lines=events),
+    )
+    streamed = []
+    tool_events = []
+    reasoning = []
+    proxy = GatewaySessionAgentProxy(
+        endpoint=GatewaySessionEndpoint(base_url="http://127.0.0.1:8642", api_key=None),
+        session_id="sess_1",
+        model="gpt-test",
+        provider="openai",
+        api_mode="chat_completions",
+        enabled_toolsets=["terminal", "file"],
+        http_session=fake_session,
+        tool_progress_callback=lambda event_type, name=None, preview=None, args=None, **kwargs: tool_events.append((event_type, name, preview)),
+        reasoning_callback=lambda text: reasoning.append(text),
+    )
+
+    result = proxy.run_conversation(
+        user_message="Hello",
+        conversation_history=[{"role": "assistant", "content": "Earlier"}],
+        stream_callback=lambda delta: streamed.append(delta),
+    )
+
+    assert streamed == ["Hi", " there"]
+    assert reasoning == ["thinking..."]
+    assert tool_events == [("tool.started", "search_files", "searching")]
+    assert result["final_response"] == "Hi there"
+    assert result["messages"] == [
+        {"role": "assistant", "content": "Earlier"},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+    ]
+    assert proxy.session_prompt_tokens == 3
+    assert proxy.session_completion_tokens == 4
+    assert proxy.session_total_tokens == 7
+    assert proxy.session_api_calls == 1
+
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "POST"
+    assert url.endswith("/v1/runs")
+    assert kwargs["json"]["session_id"] == "sess_1"
+    assert kwargs["json"]["conversation_history"] == [{"role": "assistant", "content": "Earlier"}]
+    assert kwargs["json"]["toolsets"] == ["terminal", "file"]
+
+
+def test_interrupt_posts_run_cancel_and_closes_stream():
+    fake_stream = _FakeResponse(lines=[])
+    fake_session = _FakeSession(
+        run_response=_FakeResponse({"run_id": "run_123", "status": "started"}),
+        event_response=fake_stream,
+    )
+    proxy = GatewaySessionAgentProxy(
+        endpoint=GatewaySessionEndpoint(base_url="http://127.0.0.1:8642", api_key=None),
+        session_id="sess_1",
+        http_session=fake_session,
+    )
+    proxy._active_run_id = "run_123"
+    proxy._active_events_response = fake_stream
+
+    proxy.interrupt("new message")
+
+    assert fake_stream.closed is True
+    assert fake_session.calls[-1][0] == "POST"
+    assert fake_session.calls[-1][1].endswith("/v1/runs/run_123/cancel")
+
+
+def test_detach_closes_stream_without_cancelling_run():
+    fake_stream = _BlockingResponse()
+    fake_session = _FakeSession(
+        run_response=_FakeResponse({"run_id": "run_123", "status": "started"}),
+        event_response=fake_stream,
+    )
+    proxy = GatewaySessionAgentProxy(
+        endpoint=GatewaySessionEndpoint(base_url="http://127.0.0.1:8642", api_key=None),
+        session_id="sess_1",
+        http_session=fake_session,
+    )
+    result_box = {}
+
+    def _run():
+        result_box["result"] = proxy.run_conversation(
+            user_message="Hello",
+            conversation_history=[],
+        )
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    fake_stream._started.wait(timeout=1)
+
+    proxy.detach()
+    thread.join(timeout=2)
+
+    assert thread.is_alive() is False
+    assert fake_stream.closed is True
+    assert result_box["result"]["detached"] is True
+    assert not any(call[1].endswith("/cancel") for call in fake_session.calls)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -12,7 +12,9 @@ Tests cover:
 - Error handling (invalid JSON, missing fields)
 """
 
+import asyncio
 import json
+import threading
 import time
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -225,6 +227,10 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
+    app.router.add_post("/v1/runs/{run_id}/cancel", adapter._handle_cancel_run)
+    app.router.add_post("/v1/runs/{run_id}/clarify", adapter._handle_submit_run_clarify)
     return app
 
 
@@ -1053,6 +1059,48 @@ class TestRunsCancellation:
 
         assert seen["timeout"] == adapter._RUN_EVENTS_KEEPALIVE
         assert seen["timeout"] <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_submit_run_clarify_resolves_pending_wait(self, adapter):
+        app = _create_app(adapter)
+        run_id = "run_clarify"
+        result_box = {}
+
+        def _waiter():
+            result_box["result"] = adapter._wait_for_run_clarify(
+                run_id=run_id,
+                question="Need input?",
+                choices=["Yes"],
+                push_event=lambda _event: None,
+            )
+
+        thread = threading.Thread(target=_waiter)
+        thread.start()
+        time.sleep(0.05)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/v1/runs/{run_id}/clarify", json={"response": "Yes"})
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["run_id"] == run_id
+            assert data["resolved"] == 1
+
+        thread.join(timeout=1)
+        assert thread.is_alive() is False
+        assert result_box["result"] == "Yes"
+
+    @pytest.mark.asyncio
+    async def test_run_event_callback_forwards_subagent_heartbeat(self, adapter):
+        import asyncio
+
+        run_id = "run_subagent_event"
+        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_streams_created[run_id] = time.time()
+        cb = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+        cb("subagent.heartbeat", preview="child active")
+        event = await asyncio.wait_for(adapter._run_streams[run_id].get(), timeout=1)
+        assert event["event"] == "subagent.heartbeat"
+        assert event["preview"] == "child active"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1009,6 +1009,52 @@ class TestConfigIntegration:
         assert Platform.API_SERVER not in connected
 
 
+class TestRunsCancellation:
+    @pytest.mark.asyncio
+    async def test_cancel_endpoint_interrupts_active_run(self, adapter):
+        app = _create_app(adapter)
+        run_id = "run_test_cancel"
+        agent = MagicMock()
+        adapter._run_agents[run_id] = [agent]
+        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_streams_created[run_id] = time.time()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/v1/runs/{run_id}/cancel")
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["run_id"] == run_id
+            assert data["status"] == "cancelling"
+
+        agent.interrupt.assert_called_once()
+        queued = adapter._run_streams[run_id].get_nowait()
+        assert queued["event"] == "run.cancelled"
+        assert queued["run_id"] == run_id
+
+    @pytest.mark.asyncio
+    async def test_run_events_uses_short_keepalive_timeout(self, adapter):
+        app = _create_app(adapter)
+        run_id = "run_keepalive_timeout"
+        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_streams_created[run_id] = time.time()
+        seen = {}
+
+        async def _fake_wait_for(awaitable, timeout):
+            seen["timeout"] = timeout
+            if hasattr(awaitable, "close"):
+                awaitable.close()
+            return None
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.asyncio.wait_for", side_effect=_fake_wait_for):
+                resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert resp.status == 200
+                await resp.text()
+
+        assert seen["timeout"] == adapter._RUN_EVENTS_KEEPALIVE
+        assert seen["timeout"] <= 1.0
+
+
 # ---------------------------------------------------------------------------
 # Multiple system messages
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -125,5 +125,35 @@ class TestApiServerAdapterToolset:
 
             mock_agent_cls.assert_called_once()
             call_kwargs = mock_agent_cls.call_args
-            toolsets = call_kwargs.kwargs.get("enabled_toolsets")
-            assert sorted(toolsets) == ["terminal", "web"]
+            toolsets = set(call_kwargs.kwargs.get("enabled_toolsets") or [])
+            assert {"terminal", "web"}.issubset(toolsets)
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_falls_back_to_provider_default_model_when_config_model_is_blank(self):
+        """Gateway-backed chat should still pick a real model when config.yaml has no model.default yet."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_runtime, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {
+                "api_key": "***",
+                "base_url": "https://inference-api.nousresearch.com/v1",
+                "provider": "nous",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+            }
+            mock_config.return_value = {"model": {"provider": "nous"}}
+            mock_runtime.return_value = {"provider": "nous"}
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            mock_agent_cls.assert_called_once()
+            assert mock_agent_cls.call_args.kwargs.get("model") == "anthropic/claude-opus-4.6"

--- a/tests/gateway/test_blocked_wait_proxy.py
+++ b/tests/gateway/test_blocked_wait_proxy.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -165,3 +166,69 @@ async def test_delegate_abort_request_is_handled_by_proxy_layer():
     assert handled is True
     assert "aborting" in response.lower()
     running_agent.interrupt.assert_called_once()
+
+
+def test_blocked_wait_proxy_uses_profile_gateway_runtime_when_configured(monkeypatch):
+    from agent import blocked_wait_proxy as proxy_mod
+
+    monkeypatch.setattr(
+        proxy_mod,
+        "load_blocked_wait_proxy_config",
+        lambda: {
+            "enabled": True,
+            "launcher": "gateway",
+            "profile": "helper",
+            "gateway_autostart": False,
+            "kinds": {"delegate": {"enabled": True, "instructions": "stay concise"}},
+        },
+    )
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.resolve_profile_env",
+        lambda profile_name: "/tmp/helper-profile",
+    )
+
+    def _fake_ensure(*, hermes_home=None, autostart=True, timeout=15.0):
+        captured["ensure"] = {
+            "hermes_home": Path(hermes_home).resolve() if hermes_home is not None else None,
+            "autostart": autostart,
+            "timeout": timeout,
+        }
+        return SimpleNamespace(base_url="http://127.0.0.1:8642", api_key=None)
+
+    class _FakeProxy:
+        def __init__(self, **kwargs):
+            captured["proxy_kwargs"] = kwargs
+
+        def run_conversation(self, user_message):
+            captured["user_message"] = user_message
+            return {"final_response": "proxy gateway answer"}
+
+    monkeypatch.setattr("hermes_cli.gateway_session_client.ensure_gateway_session_bridge", _fake_ensure)
+    monkeypatch.setattr("hermes_cli.gateway_session_client.GatewaySessionAgentProxy", _FakeProxy)
+
+    parent_agent = SimpleNamespace(
+        model="test-model",
+        provider="openrouter",
+        base_url=None,
+        api_key=None,
+        api_mode="chat_completions",
+        gateway_hosted_session=False,
+        platform="telegram",
+    )
+
+    response = proxy_mod.run_blocked_wait_proxy(
+        kind="delegate",
+        activity={"wait_state": {"kind": "delegate"}},
+        history=[{"role": "assistant", "content": "Working on it."}],
+        user_message="what is it doing?",
+        parent_agent=parent_agent,
+    )
+
+    assert response == "proxy gateway answer"
+    assert captured["ensure"]["hermes_home"] == Path("/tmp/helper-profile").resolve()
+    assert captured["ensure"]["autostart"] is False
+    assert captured["proxy_kwargs"]["enabled_toolsets"] == []
+    assert captured["user_message"] == "what is it doing?"

--- a/tests/gateway/test_blocked_wait_proxy.py
+++ b/tests/gateway/test_blocked_wait_proxy.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.blocked_wait_proxy import save_default_blocked_wait_proxy_kind
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+from hermes_cli.config import load_config
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.resume_typing_for_chat = MagicMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._background_tasks = set()
+    runner._blocked_wait_proxy_setup_pending = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    return runner
+
+
+def _install_running_agent(runner, *, wait_kind=None, current_tool=None, active_children=None):
+    source = _make_source()
+    session_key = build_session_key(source)
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "Please keep working."},
+        {"role": "assistant", "content": "I am checking the delegated agent now."},
+    ]
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {
+        "wait_state": {"kind": wait_kind} if wait_kind else None,
+        "current_tool": current_tool,
+        "active_children_count": len(active_children or []),
+        "active_children": active_children or [],
+        "last_activity_desc": "delegate child: read_file",
+        "api_call_count": 3,
+        "max_iterations": 50,
+    }
+    runner._running_agents[session_key] = running_agent
+    return session_key, running_agent
+
+
+@pytest.mark.asyncio
+async def test_proxy_setup_prompt_is_generic_for_blocked_wait():
+    runner = _make_runner()
+    session_key, _ = _install_running_agent(
+        runner,
+        wait_kind=None,
+        current_tool="delegate_task",
+        active_children=[{"current_tool": "read_file", "seconds_since_activity": 4}],
+    )
+
+    handled, response = await runner._try_handle_blocking_wait(_make_event("is it stuck?"), session_key)
+
+    assert handled is True
+    assert "blocked-session helper" in response
+    assert "delegate" in response
+
+
+@pytest.mark.asyncio
+async def test_proxy_setup_yes_saves_default_and_proxy_runs():
+    runner = _make_runner()
+    session_key, _ = _install_running_agent(
+        runner,
+        wait_kind="clarify",
+        current_tool="clarify",
+    )
+
+    handled, response = await runner._try_handle_blocking_wait(_make_event("what are you waiting on?"), session_key)
+    assert handled is True
+    assert "reply yes or no" in response.lower()
+
+    handled, response = await runner._try_handle_blocking_wait(_make_event("yes"), session_key)
+    assert handled is True
+    assert "enabled blocked-session helper defaults" in response.lower()
+
+    cfg = load_config()
+    assert cfg["blocked_wait_proxy"]["enabled"] is True
+    assert cfg["blocked_wait_proxy"]["kinds"]["clarify"]["enabled"] is True
+
+    with patch("agent.blocked_wait_proxy.run_blocked_wait_proxy", return_value="proxy says hello") as mock_proxy:
+        handled, response = await runner._try_handle_blocking_wait(_make_event("what are the options again?"), session_key)
+
+    assert handled is True
+    assert response == "proxy says hello"
+    mock_proxy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delegate_plaintext_falls_through_as_steer_when_helper_enabled():
+    save_default_blocked_wait_proxy_kind("delegate")
+    runner = _make_runner()
+    session_key, _ = _install_running_agent(
+        runner,
+        wait_kind=None,
+        current_tool="delegate_task",
+        active_children=[{"current_tool": "read_file", "seconds_since_activity": 4}],
+    )
+
+    handled, response = await runner._try_handle_blocking_wait(
+        _make_event("tell it to inspect the real stack trace path"),
+        session_key,
+    )
+
+    assert handled is False
+    assert response is None
+
+
+@pytest.mark.asyncio
+async def test_delegate_abort_request_is_handled_by_proxy_layer():
+    save_default_blocked_wait_proxy_kind("delegate")
+    runner = _make_runner()
+    session_key, running_agent = _install_running_agent(
+        runner,
+        wait_kind=None,
+        current_tool="delegate_task",
+        active_children=[{"current_tool": "read_file", "seconds_since_activity": 4}],
+    )
+
+    handled, response = await runner._try_handle_blocking_wait(_make_event("abort it"), session_key)
+
+    assert handled is True
+    assert "aborting" in response.lower()
+    running_agent.interrupt.assert_called_once()

--- a/tests/gateway/test_gateway_clarify.py
+++ b/tests/gateway/test_gateway_clarify.py
@@ -1,0 +1,135 @@
+import threading
+import time
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.resume_typing_for_chat = MagicMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._background_tasks = set()
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    return runner
+
+
+def _clear_clarify_state():
+    from tools import clarify_tool as mod
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+
+
+class TestGatewayClarifyState:
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def test_wait_for_gateway_clarify_unblocks(self):
+        from tools.clarify_tool import (
+            register_gateway_clarify_notify,
+            unregister_gateway_clarify_notify,
+            resolve_gateway_clarify,
+            wait_for_gateway_clarify,
+            has_blocking_gateway_clarify,
+        )
+
+        session_key = "clarify-session"
+        register_gateway_clarify_notify(session_key, lambda data: None)
+        result = {}
+
+        def _run_wait():
+            result["value"] = wait_for_gateway_clarify(
+                question="Pick one",
+                choices=["a", "b"],
+                session_key=session_key,
+            )
+
+        thread = threading.Thread(target=_run_wait, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while not has_blocking_gateway_clarify(session_key) and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert has_blocking_gateway_clarify(session_key) is True
+        assert resolve_gateway_clarify(session_key, "2") == 1
+        thread.join(timeout=2)
+        assert result["value"] == "b"
+        unregister_gateway_clarify_notify(session_key)
+
+    @pytest.mark.asyncio
+    async def test_answer_command_resolves_pending_clarify(self):
+        from tools.clarify_tool import _ClarifyEntry, _gateway_queues
+
+        runner = _make_runner()
+        session_key = build_session_key(_make_source())
+        _gateway_queues[session_key] = [_ClarifyEntry("Pick one", ["a", "b"])]
+
+        result = await runner._handle_answer_command(_make_event("/answer 2"))
+
+        assert "resuming" in result.lower()
+        assert runner.adapters[Platform.TELEGRAM].resume_typing_for_chat.called
+        assert _gateway_queues.get(session_key) in (None, [])
+
+    @pytest.mark.asyncio
+    async def test_running_agent_answer_bypasses_interrupt_path(self):
+        from tools.clarify_tool import _ClarifyEntry, _gateway_queues
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        session_entry = SessionEntry(
+            session_key=session_key,
+            session_id="sess-1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+        )
+        runner.session_store.get_or_create_session.return_value = session_entry
+
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+        _gateway_queues[session_key] = [_ClarifyEntry("Pick one", ["a", "b"])]
+
+        result = await runner._handle_message(_make_event("/answer 1"))
+
+        assert "clarify response received" in result.lower()
+        running_agent.interrupt.assert_not_called()

--- a/tests/gateway/test_session_worker_manager.py
+++ b/tests/gateway/test_session_worker_manager.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from gateway.session_worker_manager import SessionWorkerManager
+
+
+class _FakeProcess:
+    def __init__(self, *, stdout_lines=None):
+        self.stdin = io.StringIO()
+        text = "".join((stdout_lines or []))
+        self.stdout = io.StringIO(text)
+        self.stderr = io.StringIO("")
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+
+
+def test_build_command_points_at_worker_entrypoint():
+    manager = SessionWorkerManager(python_executable="python-test")
+    assert manager.build_command() == ["python-test", "-m", "gateway.session_worker_process"]
+
+
+def test_spawn_sends_initial_request_and_reads_events(monkeypatch, tmp_path):
+    captured = {}
+    fake_process = _FakeProcess(
+        stdout_lines=[
+            '{"event":"message.delta","run_id":"run_123","timestamp":1.0,"delta":"hello"}\n'
+        ]
+    )
+
+    def _fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return fake_process
+
+    monkeypatch.setattr("subprocess.Popen", _fake_popen)
+
+    manager = SessionWorkerManager(python_executable="python-test")
+    handle = manager.spawn(
+        run_id="run_123",
+        request_payload={"input": "hi"},
+        hermes_home=tmp_path / "hermes-home",
+        cwd=tmp_path,
+    )
+
+    event = handle.poll_event(timeout=1)
+    assert event["event"] == "message.delta"
+    assert event["delta"] == "hello"
+    assert captured["cmd"] == ["python-test", "-m", "gateway.session_worker_process"]
+    assert captured["kwargs"]["cwd"] == str(Path(tmp_path).resolve())
+    assert captured["kwargs"]["env"]["HERMES_HOME"] == str((tmp_path / "hermes-home").resolve())
+    stdin_payload = fake_process.stdin.getvalue().strip()
+    assert '"type": "run.request"' in stdin_payload
+    assert '"run_id": "run_123"' in stdin_payload
+
+
+def test_submit_clarify_response_and_cancel_write_control_messages(monkeypatch, tmp_path):
+    fake_process = _FakeProcess()
+    monkeypatch.setattr("subprocess.Popen", lambda *args, **kwargs: fake_process)
+
+    manager = SessionWorkerManager()
+    handle = manager.spawn(run_id="run_123", request_payload={"input": "hi"}, cwd=tmp_path)
+    handle.submit_clarify_response("yes")
+    handle.cancel()
+
+    data = fake_process.stdin.getvalue()
+    assert '"type": "clarify.response"' in data
+    assert '"response": "yes"' in data
+    assert '"type": "control.cancel"' in data
+    assert fake_process.terminated is True

--- a/tests/gateway/test_session_worker_protocol.py
+++ b/tests/gateway/test_session_worker_protocol.py
@@ -1,0 +1,71 @@
+import pytest
+
+from gateway.session_worker_protocol import (
+    decode_event_line,
+    encode_event_line,
+    is_terminal_event,
+    make_event,
+    validate_event,
+)
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload"),
+    [
+        ("message.delta", {"delta": "hi"}),
+        ("tool.started", {"tool": "search_files", "preview": "searching"}),
+        ("tool.completed", {"tool": "search_files", "duration": 0.1, "error": False}),
+        ("reasoning.available", {"text": "thinking"}),
+        ("subagent.heartbeat", {"preview": "child active"}),
+        ("subagent.warning", {"preview": "child maybe looping"}),
+        ("agent.activity", {"activity": {"wait_state": {"kind": "clarify"}}}),
+        ("clarify.request", {"question": "continue?", "choices": ["yes", "no"]}),
+        ("run.completed", {"output": "done", "usage": {"input_tokens": 1}}),
+        ("run.failed", {"error": "boom"}),
+        ("run.cancelled", {"reason": "cancelled"}),
+    ],
+)
+def test_make_event_accepts_known_event_shapes(event_type, payload):
+    event = make_event(event_type, run_id="run_123", **payload)
+    assert event["event"] == event_type
+    assert event["run_id"] == "run_123"
+    assert isinstance(event["timestamp"], float)
+
+
+@pytest.mark.parametrize("event_type", ["run.completed", "run.failed", "run.cancelled"])
+def test_terminal_events_are_marked(event_type):
+    assert is_terminal_event(event_type) is True
+
+
+@pytest.mark.parametrize("event_type", ["message.delta", "tool.started", "clarify.request"])
+def test_non_terminal_events_are_not_marked(event_type):
+    assert is_terminal_event(event_type) is False
+
+
+def test_validate_event_rejects_unknown_type():
+    with pytest.raises(ValueError, match="Unknown worker event type"):
+        validate_event({"event": "weird.event", "run_id": "run_123", "timestamp": 1.0})
+
+
+def test_validate_event_rejects_bad_clarify_choices_shape():
+    with pytest.raises(ValueError, match="choices must be a list"):
+        validate_event(
+            {
+                "event": "clarify.request",
+                "run_id": "run_123",
+                "timestamp": 1.0,
+                "question": "continue?",
+                "choices": "yes",
+            }
+        )
+
+
+def test_encode_decode_round_trip_preserves_event_shape():
+    original = make_event(
+        "agent.activity",
+        run_id="run_123",
+        activity={"wait_state": {"kind": "delegate", "mode": "wait"}},
+    )
+    encoded = encode_event_line(original)
+    decoded = decode_event_line(encoded)
+    assert decoded == original

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -209,3 +209,41 @@ async def test_status_command_bypasses_active_session_guard():
     assert "Agent Running" in sent[0]
     assert not interrupt_event.is_set(), "/status incorrectly triggered an agent interrupt"
     assert session_key not in adapter._pending_messages, "/status was incorrectly queued"
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_wait_and_delegate_activity():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-2",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {
+        "wait_state": {
+            "kind": "clarify",
+            "mode": "wait",
+            "question_preview": "Which branch should I use?",
+        },
+        "active_children": [
+            {
+                "current_tool": "read_file",
+                "seconds_since_activity": 3,
+                "watchdog_reason": None,
+            }
+        ],
+        "last_activity_desc": "delegate child: read_file",
+        "current_tool": "delegate_task",
+    }
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Waiting:** clarify (WAIT)" in result
+    assert "**Wait Prompt:** Which branch should I use?" in result
+    assert "**Delegate Children:** 1" in result

--- a/tests/hermes_cli/test_gateway_cli_sessions.py
+++ b/tests/hermes_cli/test_gateway_cli_sessions.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from hermes_cli.gateway_session_client import (
     GatewaySessionClientError,
     GatewaySessionEndpoint,
+    ensure_gateway_session_bridge,
 )
 from hermes_cli.main import cmd_chat
 
@@ -66,3 +68,32 @@ def test_cmd_chat_interactive_exits_when_gateway_unavailable(monkeypatch):
         cmd_chat(_args())
 
     assert exc.value.code == 1
+
+
+def test_ensure_gateway_session_bridge_uses_target_profile_home(monkeypatch, tmp_path):
+    profile_home = tmp_path / "helper"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "platforms:\n  api_server:\n    extra:\n      host: 127.0.0.1\n      port: 9988\n      key: profile-key\n",
+        encoding="utf-8",
+    )
+
+    checks = []
+    launches = {}
+
+    def _fake_check(endpoint, timeout=1.5):
+        checks.append((endpoint.base_url, endpoint.api_key, timeout))
+        return len(checks) > 1
+
+    monkeypatch.setattr("hermes_cli.gateway_session_client.check_gateway_session_endpoint", _fake_check)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.launch_gateway_background_for_home",
+        lambda hermes_home=None: launches.setdefault("home", Path(hermes_home).resolve()) or True,
+    )
+
+    endpoint = ensure_gateway_session_bridge(timeout=0.2, hermes_home=profile_home)
+
+    assert endpoint.base_url == "http://127.0.0.1:9988"
+    assert endpoint.api_key == "profile-key"
+    assert launches["home"] == profile_home.resolve()
+    assert checks[0][0] == "http://127.0.0.1:9988"

--- a/tests/hermes_cli/test_gateway_cli_sessions.py
+++ b/tests/hermes_cli/test_gateway_cli_sessions.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.gateway_session_client import (
+    GatewaySessionClientError,
+    GatewaySessionEndpoint,
+)
+from hermes_cli.main import cmd_chat
+
+
+def _args(**overrides):
+    base = {
+        "continue_last": None,
+        "resume": None,
+        "query": None,
+        "model": None,
+        "provider": None,
+        "toolsets": None,
+        "skills": None,
+        "verbose": False,
+        "quiet": False,
+        "worktree": False,
+        "checkpoints": False,
+        "pass_session_id": False,
+        "max_turns": None,
+        "source": None,
+        "yolo": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_cmd_chat_interactive_uses_gateway_without_local_provider(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.gateway_session_client.ensure_gateway_session_bridge",
+        lambda timeout=15.0, autostart=True: GatewaySessionEndpoint(base_url="http://127.0.0.1:8642", api_key=None),
+    )
+    import cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module,
+        "main",
+        lambda **kwargs: captured.update({"called": True, "kwargs": kwargs}),
+    )
+
+    cmd_chat(_args())
+
+    assert captured["called"] is True
+    assert captured["kwargs"].get("provider") is None
+
+
+def test_cmd_chat_interactive_exits_when_gateway_unavailable(monkeypatch):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.gateway_session_client.ensure_gateway_session_bridge",
+        lambda timeout=15.0, autostart=True: (_ for _ in ()).throw(GatewaySessionClientError("bridge down")),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_chat(_args())
+
+    assert exc.value.code == 1

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -130,6 +130,16 @@ class TestGatewayStopCleanup:
         # Global kill should NOT be called without --all
         assert kill_calls == []
 
+    def test_close_alias_stops_current_profile_gateway(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        calls = []
+        monkeypatch.setattr(gateway_cli, "stop_profile_gateway", lambda: calls.append("close") or True)
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="close", all=False, system=False))
+
+        assert calls == ["close"]
+
     def test_stop_all_sweeps_all_gateway_processes(self, tmp_path, monkeypatch):
         """With --all, stop uses systemd AND calls the global kill_gateway_processes()."""
         unit_path = tmp_path / "hermes-gateway.service"

--- a/tests/tools/test_delegate_watchdog.py
+++ b/tests/tools/test_delegate_watchdog.py
@@ -1,0 +1,22 @@
+from tools.delegate_tool import _watchdog_reason
+
+
+def test_watchdog_reason_triggers_on_idle_child():
+    activity = {"seconds_since_activity": 190, "current_tool": "read_file"}
+    watch_state = {"same_tool_repeat_count": 0, "last_tool_name": None}
+    reason = _watchdog_reason(activity, watch_state, idle_timeout=180, same_tool_limit=8)
+    assert reason == "Delegate watchdog: child idle on read_file for 190s"
+
+
+def test_watchdog_reason_triggers_on_repeat_tool_loop():
+    activity = {"seconds_since_activity": 1, "current_tool": "search_files"}
+    watch_state = {"same_tool_repeat_count": 8, "last_tool_name": "search_files"}
+    reason = _watchdog_reason(activity, watch_state, idle_timeout=180, same_tool_limit=8)
+    assert reason == "Delegate watchdog: suspected loop — search_files repeated 8 times"
+
+
+def test_watchdog_reason_returns_none_when_child_is_healthy():
+    activity = {"seconds_since_activity": 5, "current_tool": "read_file"}
+    watch_state = {"same_tool_repeat_count": 2, "last_tool_name": "read_file"}
+    reason = _watchdog_reason(activity, watch_state, idle_timeout=180, same_tool_limit=8)
+    assert reason is None

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -4,20 +4,159 @@ Clarify Tool Module - Interactive Clarifying Questions
 
 Allows the agent to present structured multiple-choice questions or open-ended
 prompts to the user. In CLI mode, choices are navigable with arrow keys. On
-messaging platforms, choices are rendered as a numbered list.
+messaging platforms, questions can block on a per-session queue until the user
+responds.
 
 The actual user-interaction logic lives in the platform layer (cli.py for CLI,
 gateway/run.py for messaging). This module defines the schema, validation, and
 a thin dispatcher that delegates to a platform-provided callback.
 """
 
+from __future__ import annotations
+
 import json
-from typing import List, Optional, Callable
+import threading
+from typing import Callable, List, Optional
 
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
+
+
+# =============================================================================
+# Blocking gateway clarify infrastructure
+# =============================================================================
+
+_gateway_lock = threading.Lock()
+_gateway_notify_cbs: dict[str, object] = {}
+_gateway_queues: dict[str, list["_ClarifyEntry"]] = {}
+
+
+class _ClarifyEntry:
+    """One pending clarify question inside a gateway session."""
+
+    __slots__ = ("event", "question", "choices", "result")
+
+    def __init__(self, question: str, choices: Optional[List[str]]):
+        self.event = threading.Event()
+        self.question = question
+        self.choices = list(choices or [])
+        self.result: Optional[str] = None
+
+
+def register_gateway_clarify_notify(session_key: str, cb) -> None:
+    """Register a per-session callback for sending clarify prompts to the user."""
+    with _gateway_lock:
+        _gateway_notify_cbs[session_key] = cb
+
+
+def unregister_gateway_clarify_notify(session_key: str) -> None:
+    """Unregister a gateway clarify callback and unblock all waiters."""
+    with _gateway_lock:
+        _gateway_notify_cbs.pop(session_key, None)
+        entries = _gateway_queues.pop(session_key, [])
+        for entry in entries:
+            entry.event.set()
+
+
+def clear_gateway_clarify_session(session_key: str) -> None:
+    """Clear all pending clarify waits for a session and unblock waiters."""
+    unregister_gateway_clarify_notify(session_key)
+
+
+def has_blocking_gateway_clarify(session_key: str) -> bool:
+    """Return True when a session has at least one pending clarify wait."""
+    with _gateway_lock:
+        return bool(_gateway_queues.get(session_key))
+
+
+def pending_gateway_clarify_count(session_key: str) -> int:
+    """Return the number of pending clarify waits for a session."""
+    with _gateway_lock:
+        return len(_gateway_queues.get(session_key, []))
+
+
+def peek_blocking_gateway_clarify(session_key: str) -> Optional[dict]:
+    """Return a preview of the oldest pending clarify question for a session."""
+    with _gateway_lock:
+        queue = _gateway_queues.get(session_key) or []
+        if not queue:
+            return None
+        entry = queue[0]
+        return {
+            "question": entry.question,
+            "choices": list(entry.choices),
+            "choices_count": len(entry.choices),
+        }
+
+
+def _coerce_gateway_response(entry: _ClarifyEntry, response_text: str) -> str:
+    text = str(response_text or "").strip()
+    if entry.choices:
+        if text.isdigit():
+            idx = int(text) - 1
+            if 0 <= idx < len(entry.choices):
+                return entry.choices[idx]
+        lowered = text.casefold()
+        for choice in entry.choices:
+            if lowered == choice.casefold():
+                return choice
+    return text
+
+
+def resolve_gateway_clarify(session_key: str, response_text: str, *, resolve_all: bool = False) -> int:
+    """Resolve one or more pending clarify waits for a session.
+
+    Returns the number of waits resolved.
+    """
+    with _gateway_lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return 0
+        if resolve_all:
+            targets = list(queue)
+            queue.clear()
+        else:
+            targets = [queue.pop(0)]
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+
+    for entry in targets:
+        entry.result = _coerce_gateway_response(entry, response_text)
+        entry.event.set()
+    return len(targets)
+
+
+def wait_for_gateway_clarify(question: str, choices: Optional[List[str]], *, session_key: str, timeout_seconds: Optional[float] = None) -> str:
+    """Block a gateway agent thread until the user answers a clarify question."""
+    entry = _ClarifyEntry(question=question, choices=choices)
+    notify_cb = None
+    with _gateway_lock:
+        _gateway_queues.setdefault(session_key, []).append(entry)
+        notify_cb = _gateway_notify_cbs.get(session_key)
+
+    if notify_cb is not None:
+        notify_cb({
+            "question": question,
+            "choices": list(choices or []),
+            "session_key": session_key,
+        })
+
+    resolved = entry.event.wait(timeout_seconds) if timeout_seconds and timeout_seconds > 0 else entry.event.wait()
+    if not resolved:
+        return (
+            "The user did not provide a response within the time limit. "
+            "Use your best judgement to make the choice and proceed."
+        )
+    if entry.result is not None:
+        return entry.result
+    return "The clarify request was cancelled before the user responded."
+
+
+# =============================================================================
+# Main clarify tool
+# =============================================================================
 
 
 def clarify_tool(

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -697,6 +697,15 @@ def delegate_task(
     n_tasks = len(task_list)
     # Track goal labels for progress display (truncated for readability)
     task_labels = [t["goal"][:40] for t in task_list]
+    if hasattr(parent_agent, "set_wait_state"):
+        try:
+            parent_agent.set_wait_state(
+                "delegate",
+                child_count=n_tasks,
+                goals=task_labels,
+            )
+        except Exception:
+            pass
 
     # Save parent tool names BEFORE any child construction mutates the global.
     # _build_child_agent() calls AIAgent() which calls get_tool_definitions(),
@@ -805,6 +814,12 @@ def delegate_task(
                 pass
 
     total_duration = round(time.monotonic() - overall_start, 2)
+
+    if hasattr(parent_agent, "clear_wait_state"):
+        try:
+            parent_agent.clear_wait_state()
+        except Exception:
+            pass
 
     return json.dumps({
         "results": results,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -20,7 +20,9 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import threading
 import time
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
@@ -38,6 +40,9 @@ MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+DEFAULT_WATCHDOG_IDLE_SECONDS = 180
+DEFAULT_WATCHDOG_SAME_TOOL_LIMIT = 8
+WATCHDOG_POLL_SECONDS = 5
 
 
 def check_delegate_requirements() -> bool:
@@ -113,7 +118,25 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
-def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
+def _watchdog_reason(activity: dict, watch_state: dict, *, idle_timeout: int, same_tool_limit: int) -> Optional[str]:
+    """Return a watchdog interrupt reason for a child agent, or None."""
+    idle_for = float(activity.get("seconds_since_activity") or 0.0)
+    if idle_timeout > 0 and idle_for >= idle_timeout:
+        current_tool = activity.get("current_tool")
+        if current_tool:
+            return f"Delegate watchdog: child idle on {current_tool} for {int(idle_for)}s"
+        return f"Delegate watchdog: child idle for {int(idle_for)}s"
+
+    if same_tool_limit > 0 and int(watch_state.get("same_tool_repeat_count") or 0) >= same_tool_limit:
+        tool_name = watch_state.get("last_tool_name") or "unknown tool"
+        return (
+            f"Delegate watchdog: suspected loop — {tool_name} repeated "
+            f"{int(watch_state.get('same_tool_repeat_count') or 0)} times"
+        )
+    return None
+
+
+def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1, watch_state: Optional[dict] = None) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
     Two display paths:
@@ -126,8 +149,8 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
     spinner = getattr(parent_agent, '_delegate_spinner', None)
     parent_cb = getattr(parent_agent, 'tool_progress_callback', None)
 
-    if not spinner and not parent_cb:
-        return None  # No display → no callback → zero behavior change
+    if not spinner and not parent_cb and watch_state is None:
+        return None  # No display and no supervision state → zero behavior change
 
     # Show 1-indexed prefix only in batch mode (multiple tasks)
     prefix = f"[{task_index + 1}] " if task_count > 1 else ""
@@ -138,7 +161,11 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
 
     def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
         # event_type is one of: "tool.started", "tool.completed",
-        # "reasoning.available", "_thinking", "subagent_progress"
+        # "reasoning.available", "_thinking", "subagent_progress",
+        # "subagent.heartbeat", "subagent.warning"
+
+        if watch_state is not None:
+            watch_state["last_progress_event_at"] = time.time()
 
         # "_thinking" / reasoning events
         if event_type in ("_thinking", "reasoning.available"):
@@ -152,9 +179,35 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
             # Don't relay thinking to gateway (too noisy for chat)
             return
 
+        if event_type in ("subagent.heartbeat", "subagent.warning"):
+            text = preview or tool_name or "subagent active"
+            if spinner:
+                try:
+                    marker = "⚠️" if event_type == "subagent.warning" else "💓"
+                    spinner.print_above(f" {prefix}├─ {marker} {text}")
+                except Exception as e:
+                    logger.debug("Spinner print_above failed: %s", e)
+            if parent_cb:
+                try:
+                    parent_cb(event_type, text)
+                except Exception as e:
+                    logger.debug("Parent callback failed: %s", e)
+            return
+
         # tool.completed — no display needed here (spinner shows on started)
         if event_type == "tool.completed":
             return
+
+        if watch_state is not None and event_type == "tool.started":
+            last_tool = watch_state.get("last_tool_name")
+            if tool_name and tool_name == last_tool:
+                watch_state["same_tool_repeat_count"] = int(watch_state.get("same_tool_repeat_count") or 0) + 1
+            else:
+                watch_state["same_tool_repeat_count"] = 1 if tool_name else 0
+                watch_state["last_tool_name"] = tool_name
+            recent = watch_state.setdefault("recent_tools", deque(maxlen=12))
+            if tool_name:
+                recent.append(tool_name)
 
         # tool.started — display and batch for parent relay
         if spinner:
@@ -255,8 +308,15 @@ def _build_child_agent(
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
+    watch_state = {
+        "recent_tools": deque(maxlen=12),
+        "last_tool_name": None,
+        "same_tool_repeat_count": 0,
+        "last_progress_event_at": time.time(),
+    }
+
     # Build progress callback to relay tool calls to parent display
-    child_progress_cb = _build_child_progress_callback(task_index, parent_agent)
+    child_progress_cb = _build_child_progress_callback(task_index, parent_agent, watch_state=watch_state)
 
     # Each subagent gets its own iteration budget capped at max_iterations
     # (configurable via delegation.max_iterations, default 50).  This means
@@ -315,6 +375,9 @@ def _build_child_agent(
         iteration_budget=None,  # fresh budget per subagent
     )
     child._print_fn = getattr(parent_agent, '_print_fn', None)
+    child._delegate_watch_state = watch_state
+    child._delegate_watchdog_reason = None
+    child._delegate_goal_preview = goal[:120]
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
 
@@ -368,6 +431,60 @@ def _run_single_child(
                     child._swap_credential(leased_entry)
             except Exception as exc:
                 logger.debug("Failed to bind child to leased credential: %s", exc)
+
+    watchdog_cfg = _load_config()
+    idle_timeout = int(watchdog_cfg.get("watchdog_idle_seconds") or DEFAULT_WATCHDOG_IDLE_SECONDS)
+    same_tool_limit = int(watchdog_cfg.get("watchdog_same_tool_limit") or DEFAULT_WATCHDOG_SAME_TOOL_LIMIT)
+    watch_state = getattr(child, "_delegate_watch_state", {}) or {}
+    watchdog_stop = threading.Event()
+
+    def _watchdog_loop() -> None:
+        heartbeat_every = max(15, WATCHDOG_POLL_SECONDS)
+        last_heartbeat = 0.0
+        while not watchdog_stop.wait(WATCHDOG_POLL_SECONDS):
+            if getattr(child, "_interrupt_requested", False):
+                return
+            activity = {}
+            if hasattr(child, "get_activity_summary"):
+                try:
+                    activity = child.get_activity_summary()
+                except Exception:
+                    activity = {}
+            reason = _watchdog_reason(
+                activity,
+                watch_state,
+                idle_timeout=idle_timeout,
+                same_tool_limit=same_tool_limit,
+            )
+            if reason:
+                child._delegate_watchdog_reason = reason
+                try:
+                    if child_progress_cb:
+                        child_progress_cb("subagent.warning", preview=reason)
+                except Exception:
+                    pass
+                try:
+                    child.interrupt(reason)
+                except Exception as exc:
+                    logger.debug("Delegate watchdog interrupt failed: %s", exc)
+                return
+
+            now = time.time()
+            if child_progress_cb and now - last_heartbeat >= heartbeat_every and activity:
+                last_heartbeat = now
+                child_tool = activity.get("current_tool") or activity.get("last_activity_desc") or "child active"
+                idle = activity.get("seconds_since_activity")
+                if isinstance(idle, (int, float)):
+                    msg = f"{child_tool} · {int(idle)}s since last activity"
+                else:
+                    msg = str(child_tool)
+                try:
+                    child_progress_cb("subagent.heartbeat", preview=msg)
+                except Exception:
+                    pass
+
+    watchdog_thread = threading.Thread(target=_watchdog_loop, daemon=True, name=f"delegate-watchdog-{task_index}")
+    watchdog_thread.start()
 
     try:
         result = child.run_conversation(user_message=goal)
@@ -461,6 +578,9 @@ def _run_single_child(
             },
             "tool_trace": tool_trace,
         }
+        watchdog_reason = getattr(child, "_delegate_watchdog_reason", None)
+        if watchdog_reason:
+            entry["watchdog_reason"] = watchdog_reason
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
@@ -479,6 +599,7 @@ def _run_single_child(
         }
 
     finally:
+        watchdog_stop.set()
         if child_pool is not None and leased_cred_id is not None:
             try:
                 child_pool.release_lease(leased_cred_id)
@@ -813,26 +934,29 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from the active HERMES_HOME, with CLI fallback.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Prefer ``hermes_cli.config.load_config()`` because it resolves against the
+    current ``HERMES_HOME`` (important for tests, profiles, gateway, and cron).
+    Fall back to the already-loaded CLI module config only when the persistent
+    loader is unavailable.
     """
     try:
-        from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
-        if cfg:
+        from hermes_cli.config import load_config
+        full = load_config()
+        cfg = full.get("delegation", {})
+        if isinstance(cfg, dict):
             return cfg
     except Exception:
         pass
     try:
-        from hermes_cli.config import load_config
-        full = load_config()
-        return full.get("delegation", {})
+        from cli import CLI_CONFIG
+        cfg = CLI_CONFIG.get("delegation", {})
+        if isinstance(cfg, dict):
+            return cfg
     except Exception:
-        return {}
+        pass
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -137,6 +137,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/commands [page]` | Browse all commands and skills (paginated). |
 | `/approve [session\|always]` | Approve and execute a pending dangerous command. `session` approves for this session only; `always` adds to permanent allowlist. |
 | `/deny` | Reject a pending dangerous command. |
+| `/answer <response>` | Answer a pending clarify question in messaging surfaces while the agent is blocked waiting for input. |
 | `/update` | Update Hermes Agent to the latest version. |
 | `/help` | Show messaging help. |
 | `/<skill-name>` | Invoke any installed skill by name. |
@@ -145,6 +146,6 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 
 - `/skin`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/skills`, `/platforms`, `/paste`, `/statusbar`, and `/plugins` are **CLI-only** commands.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
-- `/status`, `/sethome`, `/update`, `/approve`, `/deny`, and `/commands` are **messaging-only** commands.
+- `/status`, `/sethome`, `/update`, `/approve`, `/deny`, `/answer`, and `/commands` are **messaging-only** commands.
 - `/background`, `/voice`, `/reload-mcp`, `/rollback`, and `/yolo` work in **both** the CLI and the messaging gateway.
 - `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.


### PR DESCRIPTION
## Summary
- add explicit wait-state heartbeat metadata to `AIAgent` so blocked clarify/delegate/approval flows stop looking hung
- add CLI clarify wait-vs-auto behavior with persistent default, typing-aware auto timeout, and live hotkeys (`Esc+A` / `Esc+W`)
- add delegate watchdog + heartbeat reporting for child agents, including idle/loop interruption heuristics and status visibility
- add a shared gateway blocked-wait dispatcher with thin adapters instead of command-specific branching
- add a configurable blocked-session continuity proxy that can answer meta-questions while the main run is blocked
- integrate the blocked-wait work with the local gateway-backed session bridge and named Hermes profiles

## Details
- `run_agent.py` now exposes generic wait-state + active-child activity in `get_activity_summary()`
- `tools/delegate_tool.py` now emits subagent heartbeat/warning events, marks delegate waits explicitly, and interrupts obviously stuck children
- `tools/clarify_tool.py` now includes blocking gateway clarify queue/notify plumbing
- `gateway/run.py` now routes blocked waits through a common dispatcher, including:
  - update prompt waits
  - dangerous-command approval waits
  - clarify waits
  - blocked-session helper setup + proxy dispatch
- `gateway/platforms/api_server.py` now supports gateway-session blocked waits better by adding:
  - structured `agent.activity` SSE events for gateway-backed CLI/API sessions
  - forwarded `subagent.heartbeat` / `subagent.warning` events
  - run cancellation endpoint support for the structured run bridge
  - blocking clarify round-trips for gateway-backed sessions via `/v1/runs/{run_id}/clarify`
- `hermes_cli/gateway_session_client.py` now:
  - consumes `agent.activity` / subagent heartbeat SSE events
  - round-trips `clarify.request` through the interactive local CLI client
  - can resolve and autostart gateway session bridges for an explicit profile home
- `agent/blocked_wait_proxy.py` now supports helper launcher selection:
  - direct inline helper runtime
  - gateway-backed helper runtime
  - optional named-profile targeting for the helper runtime
- `hermes_cli/gateway.py` now supports background gateway autostart for an explicit `HERMES_HOME`
- `BLOCKED_WAIT_PROXY_VISION.md` describes the intended generalized substrate + thin-adapter + cheap-proxy architecture and now reflects the gateway/profile integration work
- docs/config examples updated for the new clarify/delegation/proxy controls

## Behavior notes
- normal free-text during delegate waits still falls through as a steering/interruption message
- question-like text during supported blocked waits can be routed to the cheap continuity proxy
- if the user tries to use the proxy for a wait kind that has no config, Hermes pauses and asks whether to create a default config (90s timeout)
- blocked-session helpers can now be pinned to a named Hermes profile and launched through that profile's gateway runtime

## Test Plan
- `env -u HERMES_YOLO_MODE -u HERMES_INTERACTIVE -u HERMES_QUIET uv run --extra dev pytest -q tests/cli/test_gateway_session_agent.py tests/gateway/test_api_server.py tests/gateway/test_blocked_wait_proxy.py tests/hermes_cli/test_gateway_cli_sessions.py tests/cli/test_cli_clarify_ui.py tests/gateway/test_gateway_clarify.py tests/tools/test_delegate_watchdog.py tests/hermes_cli/test_gateway_service.py tests/gateway/test_status_command.py tests/gateway/test_approve_deny_commands.py tests/tools/test_clarify_tool.py tests/tools/test_delegate.py tests/gateway/test_session_race_guard.py tests/gateway/test_unknown_command.py -o addopts=''`
- `python3 -m py_compile agent/blocked_wait_proxy.py cli.py gateway/platforms/api_server.py hermes_cli/gateway.py hermes_cli/gateway_session_client.py hermes_cli/config.py`
