### PR TITLE
fix(dingtalk,api): validate webhook URL origin, cap cache, reject header injection

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -24,6 +24,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import sqlite3
 import time
 import uuid
@@ -533,6 +534,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # When provided, history is loaded from state.db instead of from the request body.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
         if provided_session_id:
+            # Sanitize: reject control characters that could enable header injection.
+            if re.search(r'[\r\n\x00]', provided_session_id):
+                return web.json_response(
+                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
+                    status=400,
+                )
             session_id = provided_session_id
             try:
                 db = self._ensure_session_db()

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -20,6 +20,7 @@ Configuration in config.yaml:
 import asyncio
 import logging
 import os
+import re
 import time
 import uuid
 from datetime import datetime, timezone
@@ -54,6 +55,8 @@ MAX_MESSAGE_LENGTH = 20000
 DEDUP_WINDOW_SECONDS = 300
 DEDUP_MAX_SIZE = 1000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+_SESSION_WEBHOOKS_MAX = 500
+_DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
 
 
 def check_dingtalk_requirements() -> bool:
@@ -195,9 +198,15 @@ class DingTalkAdapter(BasePlatformAdapter):
         chat_id = conversation_id or sender_id
         chat_type = "group" if is_group else "dm"
 
-        # Store session webhook for reply routing
+        # Store session webhook for reply routing (validate origin to prevent SSRF)
         session_webhook = getattr(message, "session_webhook", None) or ""
-        if session_webhook and chat_id:
+        if session_webhook and chat_id and _DINGTALK_WEBHOOK_RE.match(session_webhook):
+            if len(self._session_webhooks) >= _SESSION_WEBHOOKS_MAX:
+                # Evict oldest entry to cap memory growth
+                try:
+                    self._session_webhooks.pop(next(iter(self._session_webhooks)))
+                except StopIteration:
+                    pass
             self._session_webhooks[chat_id] = session_webhook
 
         source = self.build_source(


### PR DESCRIPTION
## Summary

- **dingtalk.py — SSRF via session_webhook**: The `session_webhook` URL from incoming DingTalk messages is stored and later POSTed to (line 290) without any origin validation. An attacker controlling the DingTalk message can set `session_webhook` to `http://169.254.169.254/latest/meta-data/` (cloud metadata), `http://127.0.0.1:6379` (Redis), or any internal service. Fix: add a regex check that only accepts the official `https://api.dingtalk.com/` origin.

- **dingtalk.py — unbounded memory growth**: `_session_webhooks` dict grows without limit — every unique `chat_id` creates a permanent entry, cleared only on `disconnect()`. A long-running gateway instance (months) accumulates millions of entries → OOM. Fix: cap at 500 entries with FIFO eviction (consistent with the dedup pattern at lines 55-56).

- **api_server.py — HTTP header injection**: `X-Hermes-Session-Id` is accepted from request headers (line 534) and echoed directly into response headers (lines 675, 697) without sanitization. A session ID containing `\r\n` enables HTTP response splitting. Fix: reject session IDs containing control characters (`\r`, `\n`, `\x00`) with a 400 response.

## Test plan

- [ ] DingTalk: verify legitimate `https://api.dingtalk.com/...` webhook URLs are accepted
- [ ] DingTalk: verify non-DingTalk URLs (e.g., `http://169.254.169.254/`) are silently rejected
- [ ] DingTalk: verify cache eviction when exceeding 500 entries
- [ ] API Server: verify normal session IDs are accepted
- [ ] API Server: verify session IDs with `\r\n` are rejected with 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)