### PR TITLE
fix(security): validate OAuth state parameter in MCP OAuth callback

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -84,6 +84,10 @@ class OAuthNonInteractiveError(RuntimeError):
 # tests can verify the callback server and the redirect_uri share a port.
 _oauth_port: int | None = None
 
+# Expected OAuth state parameter extracted from the authorization URL.
+# Used to validate the callback against CSRF / session-fixation attacks.
+_expected_oauth_state: str | None = None
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -288,7 +292,16 @@ async def _redirect_handler(authorization_url: str) -> None:
 
     Opens the browser automatically when possible; always prints the URL
     as a fallback for headless/SSH/gateway environments.
+
+    Also extracts and stores the ``state`` parameter from the authorization
+    URL so the callback handler can validate it against CSRF attacks.
     """
+    global _expected_oauth_state
+    parsed_url = urlparse(authorization_url)
+    url_params = parse_qs(parsed_url.query)
+    state_values = url_params.get("state")
+    _expected_oauth_state = state_values[0] if state_values else None
+
     msg = (
         f"\n  MCP OAuth: authorization required.\n"
         f"  Open this URL in your browser:\n\n"
@@ -357,6 +370,25 @@ async def _wait_for_callback() -> tuple[str, str | None]:
         raise OAuthNonInteractiveError(
             "OAuth callback timed out — no authorization code received. "
             "Ensure you completed the browser authorization flow."
+        )
+
+    # Validate the state parameter to defend against CSRF / session-fixation.
+    # The expected state was captured from the authorization URL by the
+    # redirect handler; the callback state comes from the OAuth provider's
+    # redirect.  A mismatch means the callback did not originate from the
+    # authorization request we initiated.
+    callback_state = result["state"]
+    if _expected_oauth_state is not None and callback_state != _expected_oauth_state:
+        logger.error(
+            "OAuth state mismatch: expected=%s, received=%s — "
+            "possible CSRF or session-fixation attack",
+            _expected_oauth_state,
+            callback_state,
+        )
+        raise RuntimeError(
+            "OAuth state parameter mismatch — the callback did not match "
+            "the authorization request. This may indicate a CSRF attack. "
+            "Please retry the authorization flow."
         )
 
     return result["auth_code"], result["state"]


### PR DESCRIPTION
## Summary

The MCP OAuth 2.1 callback handler in `tools/mcp_oauth.py` extracts the `state` parameter from the OAuth redirect but **never validates it** against the state sent in the original authorization request. This defeats the CSRF protection that the `state` parameter is designed to provide per [RFC 6749 §10.12](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12).

### Vulnerability

An attacker who can reach the localhost callback server (e.g. via DNS rebinding, same-machine access, or a malicious web page triggering a cross-origin request) could:

1. Observe or guess the callback port
2. Send a crafted HTTP request to `http://127.0.0.1:{port}/callback?code=ATTACKER_CODE&state=ARBITRARY`
3. The callback server accepts it without validating `state`
4. The attacker's authorization code is exchanged for tokens
5. The attacker's MCP server credentials are injected into the victim's Hermes instance

### Fix

- **`_redirect_handler`**: Now extracts and stores the expected `state` from the authorization URL when the browser redirect is shown to the user.
- **`_wait_for_callback`**: Validates the callback's `state` against the stored expected value before returning the authorization code. Raises `RuntimeError` with a clear error message on mismatch.

This provides defense-in-depth alongside any state validation the MCP SDK may perform internally.

### Code changes

- `_expected_oauth_state` module-level variable added to store the state from the authorization URL
- `_redirect_handler()`: extracts `state` from authorization URL query params
- `_wait_for_callback()`: compares `result["state"]` against `_expected_oauth_state` before returning

## Test plan

- [ ] Normal OAuth flow: verify state matches and authorization completes successfully
- [ ] Tampered callback: send a callback with wrong `state` → verify `RuntimeError` is raised
- [ ] Missing state: verify graceful handling when authorization URL has no state parameter
- [ ] Verify log message identifies the mismatch for incident response