### PR TITLE
fix(security): require auth for session continuation, warn on missing API key

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -554,8 +554,26 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
+        #
+        # Security: session continuation exposes conversation history, so it is
+        # only allowed when the API key is configured and the request is
+        # authenticated.  Without this gate, any unauthenticated client could
+        # read arbitrary session history by guessing/enumerating session IDs.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
         if provided_session_id:
+            if not self._api_key:
+                logger.warning(
+                    "Session continuation via X-Hermes-Session-Id rejected: "
+                    "no API key configured.  Set API_SERVER_KEY to enable "
+                    "session continuity."
+                )
+                return web.json_response(
+                    _openai_error(
+                        "Session continuation requires API key authentication. "
+                        "Configure API_SERVER_KEY to enable this feature."
+                    ),
+                    status=403,
+                )
             session_id = provided_session_id
             try:
                 db = self._ensure_session_db()
@@ -1675,6 +1693,14 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._site.start()
 
             self._mark_connected()
+            if not self._api_key:
+                logger.warning(
+                    "[%s] ⚠️  No API key configured (API_SERVER_KEY / platforms.api_server.key). "
+                    "All requests will be accepted without authentication. "
+                    "Set an API key for production deployments to prevent "
+                    "unauthorized access to sessions, responses, and cron jobs.",
+                    self.name,
+                )
             logger.info(
                 "[%s] API server listening on http://%s:%d (model: %s)",
                 self.name, self._host, self._port, self._model_name,


### PR DESCRIPTION
## Summary

Two security hardening changes for the API server:

### 1. Startup warning when no API key is configured

When `API_SERVER_KEY` is not set (the default), **all API endpoints accept unauthenticated requests** — including response retrieval, response deletion, and cron job management. A prominent `logger.warning()` at startup now makes this risk visible to operators.

### 2. Require authentication for `X-Hermes-Session-Id` session continuation

**Vulnerability:** The `X-Hermes-Session-Id` header allows any caller to load and continue any session stored in `state.db` by providing an arbitrary session ID. Without authentication, an attacker who can reach the API server could:

1. Enumerate or guess session IDs (UUIDs, but leaked via response headers)
2. Load the victim's complete conversation history — which may contain API keys, passwords, code, or other sensitive data shared with the agent
3. Continue the victim's session and execute agent actions under their context

**Attack vectors:**
- **DNS rebinding**: Malicious web page rebinds to `127.0.0.1:8642` and sends fetch requests
- **Shared host**: Another user on the same machine can reach localhost
- **Misconfigured binding**: If `host` is set to `0.0.0.0` without an API key

**Fix:** Session continuation via `X-Hermes-Session-Id` now returns **403 Forbidden** when no API key is configured, with a clear error message. When an API key IS configured, the existing Bearer token check already gates access — so authenticated clients continue to work as before.

This is a **non-breaking change**: 
- Clients that don't use `X-Hermes-Session-Id` are unaffected
- Clients that use `X-Hermes-Session-Id` with a configured API key are unaffected
- Only the insecure case (session continuation without authentication) is blocked

## Test plan

- [ ] Start API server **without** `API_SERVER_KEY` → verify warning appears in logs
- [ ] Send request with `X-Hermes-Session-Id` header without API key → verify 403 response
- [ ] Configure `API_SERVER_KEY`, send authenticated request with `X-Hermes-Session-Id` → verify session loads normally
- [ ] Send request **without** `X-Hermes-Session-Id` and without API key → verify it still works (new session created, no regression)