### PR TITLE
fix: align auth-by-message with 401 path, decode URLs before secret check

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -700,12 +700,15 @@ def _classify_by_message(
             should_compress=True,
         )
 
-    # Auth patterns
+    # Auth patterns — match the status-code-based 401 classification
+    # (retryable=False, should_fallback=True) so message-only auth
+    # errors don't waste retries on credentials that will never work.
     if any(p in error_msg for p in _AUTH_PATTERNS):
         return result_fn(
             FailoverReason.auth,
-            retryable=True,
+            retryable=False,
             should_rotate_credential=True,
+            should_fallback=True,
         )
 
     # Model not found patterns

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1190,10 +1190,12 @@ async def web_extract_tool(
     Raises:
         Exception: If extraction fails or API key is not set
     """
-    # Block URLs containing embedded secrets (exfiltration prevention)
+    # Block URLs containing embedded secrets (exfiltration prevention).
+    # URL-decode first so percent-encoded secrets (%73k- = sk-) are caught.
     from agent.redact import _PREFIX_RE
+    from urllib.parse import unquote
     for _url in urls:
-        if _PREFIX_RE.search(_url):
+        if _PREFIX_RE.search(_url) or _PREFIX_RE.search(unquote(_url)):
             return json.dumps({
                 "success": False,
                 "error": "Blocked: URL contains what appears to be an API key or token. "


### PR DESCRIPTION
## Summary

- **error_classifier.py — auth retryable inconsistency**: Message-only auth errors ("invalid api key", "unauthorized", etc.) are classified as `retryable=True` (line 707), while the HTTP 401 code path (line 432) correctly uses `retryable=False` + `should_fallback=True`. This mismatch causes **3 wasted retries** with the same broken credential before fallback is attempted, while 401 errors immediately try fallback. The credential pool rotation also never fires because `status_code is None` for message-only errors, making the retries completely futile. Aligned to `retryable=False, should_fallback=True`.

- **web_tools.py — URL-encoded secret bypass**: The `_PREFIX_RE` check in `web_extract_tool()` runs against the raw URL string (line 1196). URL-encoded secrets like `%73k-1234...` (`sk-1234...`) bypass the filter because the regex expects literal ASCII characters. Added `urllib.parse.unquote()` before the check so percent-encoded variants are also caught.

## Test plan

- [ ] Verify auth error from message-only path (no HTTP status) immediately attempts fallback
- [ ] Verify URL with literal `sk-...` is still blocked
- [ ] Verify URL with `%73k-...` (URL-encoded `sk-`) is now blocked
- [ ] Verify normal URLs without secrets still pass through

🤖 Generated with [Claude Code](https://claude.com/claude-code)