### PR TITLE
fix(delegate): sync self.base_url with client_kwargs after credential resolution

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -864,6 +864,7 @@ class AIAgent:
                     client_kwargs["default_headers"] = headers
 
             self.api_key = client_kwargs.get("api_key", "")
+            self.base_url = client_kwargs.get("base_url", self.base_url)
             try:
                 self.client = self._create_openai_client(client_kwargs, reason="agent_init", shared=True)
                 if not self.quiet_mode:


### PR DESCRIPTION
## Summary

Fixes #6825

When `delegation.base_url` routes subagents to a different endpoint, the correct URL is passed through `_resolve_delegation_credentials()` and `_build_child_agent()` into `AIAgent.__init__()`, but `self.base_url` can fall out of sync with `client_kwargs["base_url"]` — the value the OpenAI client actually uses.

This causes `billing_base_url` in session records to show the parent's endpoint while actual API calls go to the correct delegation target.

## Root cause

At `run_agent.py:852`, `self.api_key` is synced from `client_kwargs` after credential resolution, but `self.base_url` (set earlier at line 584) is never updated to match. When the `else` branch at line 797 resolves credentials via `resolve_provider_client()`, the resolved `base_url` goes into `client_kwargs` but `self.base_url` stays stale.

## Fix

One-line addition after line 852 — `self.base_url = client_kwargs.get("base_url", self.base_url)` — mirrors the existing `self.api_key` sync pattern. This also ensures the `_primary_runtime` snapshot (line 1241) captures the correct base_url for fallback recovery.

## Test plan

- [ ] Existing delegation test suite passes (104 tests in `test_delegate.py`, `test_delegate_toolset_scope.py`, `test_agent_loop.py`)
- [ ] Verify with local dual-endpoint setup: parent on `:8001`, delegation target on `:8000` — child session `billing_base_url` should show `:8000`

## Platform

Tested on macOS (Darwin 24.6.0), Python 3.14.2