### PR TITLE
fix(install): handle Playwright deps correctly on non-apt systems

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1082,10 +1082,19 @@ install_node_deps() {
         log_success "Node.js dependencies installed"
 
         # Install Playwright browser + system dependencies.
-        # Playwright's install-deps only supports apt/dnf/zypper natively.
+        # Playwright's --with-deps only supports apt-based systems natively.
         # For Arch/Manjaro we install the system libs via pacman first.
+        # Other systems must install Chromium dependencies manually.
         log_info "Installing browser engine (Playwright Chromium)..."
         case "$DISTRO" in
+            ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
+                log_info "Playwright may request sudo to install browser system dependencies (shared libraries)."
+                log_info "This is standard Playwright setup — Hermes itself does not require root access."
+                cd "$INSTALL_DIR" && npx playwright install --with-deps chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — browser tools will not work."
+                    log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install --with-deps chromium"
+                }
+                ;;
             arch|manjaro)
                 if command -v pacman &> /dev/null; then
                     log_info "Arch/Manjaro detected — installing Chromium system dependencies via pacman..."
@@ -1100,15 +1109,35 @@ install_node_deps() {
                         log_warn "  sudo pacman -S nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib"
                     fi
                 fi
-                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || true
+                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — browser tools will not work."
+                }
+                ;;
+            fedora|rhel|centos|rocky|alma)
+                log_warn "Playwright does not support automatic dependency installation on RPM-based systems."
+                log_info "Install Chromium system dependencies manually before using browser tools:"
+                log_info "  sudo dnf install nss atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm pango cairo alsa-lib"
+                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — install dependencies above and retry."
+                }
+                ;;
+            opensuse*|sles)
+                log_warn "Playwright does not support automatic dependency installation on zypper-based systems."
+                log_info "Install Chromium system dependencies manually before using browser tools:"
+                log_info "  sudo zypper install mozilla-nss libatk-1_0-0 at-spi2-core cups-libs libdrm2 libxkbcommon0 Mesa-libgbm1 pango cairo libasound2"
+                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
+                    log_warn "Playwright browser installation failed — install dependencies above and retry."
+                }
                 ;;
             *)
-                log_info "Playwright may request sudo to install browser system dependencies (shared libraries)."
-                log_info "This is standard Playwright setup — Hermes itself does not require root access."
-                cd "$INSTALL_DIR" && npx playwright install --with-deps chromium 2>/dev/null || true
+                log_warn "Playwright does not support automatic dependency installation on $DISTRO."
+                log_info "Install Chromium/browser system dependencies for your distribution, then run:"
+                log_info "  cd $INSTALL_DIR && npx playwright install chromium"
+                log_info "Browser tools will not work until dependencies are installed."
+                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || true
                 ;;
         esac
-        log_success "Browser engine installed"
+        log_success "Browser engine setup complete"
     fi
 
     # Install WhatsApp bridge dependencies


### PR DESCRIPTION
## Summary

Fixes #6865

Playwright's `--with-deps` flag only supports apt-based dependency installation. The install script previously ran it on all non-Arch systems, failing silently on Gentoo, Fedora, openSUSE, and others. The comment at line 1085 incorrectly claimed dnf/zypper support.

## Changes

- Restrict `--with-deps` to known apt-based distributions (ubuntu, debian, raspbian, pop, linuxmint, elementary, zorin, kali, parrot)
- Add explicit cases for RPM-based (dnf) and zypper-based systems with manual dependency instructions
- Show visible warnings instead of suppressing failures with `|| true`
- Correct misleading comment that claimed dnf/zypper support
- Change final message from "installed" to "setup complete" (more accurate when deps are manual)

## Cross-platform note

Checked `scripts/install.ps1` — the PowerShell installer has no Playwright/Chromium section (Windows uses a different browser approach), so no parallel change is needed.

## Test plan

- [ ] Install on apt-based system (Ubuntu/Debian) — should work as before with `--with-deps`
- [ ] Install on Arch/Manjaro — should work as before with pacman deps
- [ ] Install on Fedora — should show manual dnf instructions instead of failing silently
- [ ] Install on Gentoo — should show generic manual instructions instead of failing silently

## Platform

Tested on macOS (Darwin 24.6.0)