### PR TITLE
fix(docker): bootstrap all expected directories in entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,14 +2,14 @@
 # Docker entrypoint: bootstrap config files into the mounted volume, then run hermes.
 set -e
 
-HERMES_HOME="/opt/data"
+HERMES_HOME="${HERMES_HOME:-/opt/data}"
 INSTALL_DIR="/opt/hermes"
 
 # Create essential directory structure.  Cache and platform directories
 # (cache/images, cache/audio, platforms/whatsapp, etc.) are created on
 # demand by the application — don't pre-create them here so new installs
 # get the consolidated layout from get_hermes_dir().
-mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills}
+mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,skins,plans,workspace,profiles}
 
 # .env
 if [ ! -f "$HERMES_HOME/.env" ]; then

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -64,6 +64,9 @@ The `/opt/data` volume is the single source of truth for all Hermes state. It ma
 | `hooks/` | Event hooks |
 | `logs/` | Runtime logs |
 | `skins/` | Custom CLI skins |
+| `plans/` | Saved plans |
+| `workspace/` | Agent working files |
+| `profiles/` | Named agent profiles |
 
 :::warning
 Never run two Hermes containers against the same data directory simultaneously — session files and memory stores are not designed for concurrent access.
@@ -110,6 +113,22 @@ services:
 ```
 
 Start with `docker compose up -d` and view logs with `docker compose logs -f hermes`.
+
+### Custom data directory
+
+By default the container stores data in `/opt/data`. Override this with `HERMES_HOME`:
+
+```yaml
+services:
+  hermes:
+    image: nousresearch/hermes-agent:latest
+    environment:
+      - HERMES_HOME=/opt/data
+    volumes:
+      - ~/.hermes:/opt/data
+```
+
+This is useful when running multiple containers with different configurations — point each to a separate host directory and `HERMES_HOME` path.
 
 ## Resource limits
 


### PR DESCRIPTION
## Summary

Fixes #6877

The Docker entrypoint only created 6 directories (`cron`, `sessions`, `logs`, `hooks`, `memories`, `skills`), but profiles expect additional directories (`skins`, `plans`, `workspace`, `profiles` — per `hermes_cli/profiles.py` lines 36-45). These were lost on container rebuild.

Additionally, the entrypoint hardcoded `HERMES_HOME="/opt/data"` instead of reading the environment variable that the Dockerfile already sets and the codebase already supports via `hermes_constants.get_hermes_home()`.

## Changes

### `docker/entrypoint.sh`
- Read `HERMES_HOME` from env var with fallback: `HERMES_HOME="${HERMES_HOME:-/opt/data}"`
- Add missing directories to `mkdir -p`: `skins`, `plans`, `workspace`, `profiles`

### `website/docs/user-guide/docker.md`
- Add `plans/`, `workspace/`, `profiles/` to the persistent volumes table
- Document `HERMES_HOME` override for multi-container setups

## Related PRs

PR #6822 (`fix(gateway): honor explicit HERMES_HOME in systemd install`) touches HERMES_HOME in the systemd path only — no overlap with the Docker entrypoint changes here.

## Test plan

- [ ] `docker build` succeeds
- [ ] Fresh container creates all expected directories under `/opt/data`
- [ ] `HERMES_HOME=/custom/path` override works when passed via `-e`
- [ ] Existing containers with only the original 6 directories gain the new ones on restart

## Platform

Tested on macOS (Darwin 24.6.0)