### PR TITLE
fix: guard delegate tool-name restoration with lock, add spinner thread synchronization

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -575,6 +575,7 @@ class KawaiiSpinner:
         self.frame_idx = 0
         self.start_time = None
         self.last_line_len = 0
+        self._lock = threading.Lock()  # guards message, last_line_len
         # Optional callable to route all output through (e.g. a no-op for silent
         # background agents).  When set, bypasses self._out entirely so that
         # agents with _print_fn overridden remain fully silent.
@@ -656,14 +657,17 @@ class KawaiiSpinner:
                 continue
             frame = self.spinner_frames[self.frame_idx % len(self.spinner_frames)]
             elapsed = time.time() - self.start_time
+            with self._lock:
+                msg = self.message
             if wings:
                 left, right = wings[self.frame_idx % len(wings)]
-                line = f"  {left} {frame} {self.message} {right} ({elapsed:.1f}s)"
+                line = f"  {left} {frame} {msg} {right} ({elapsed:.1f}s)"
             else:
-                line = f"  {frame} {self.message} ({elapsed:.1f}s)"
+                line = f"  {frame} {msg} ({elapsed:.1f}s)"
             pad = max(self.last_line_len - len(line), 0)
             self._write(f"\r{line}{' ' * pad}", end='', flush=True)
-            self.last_line_len = len(line)
+            with self._lock:
+                self.last_line_len = len(line)
             self.frame_idx += 1
             time.sleep(0.12)
 
@@ -676,7 +680,8 @@ class KawaiiSpinner:
         self.thread.start()
 
     def update_text(self, new_message: str):
-        self.message = new_message
+        with self._lock:
+            self.message = new_message
 
     def print_above(self, text: str):
         """Print a line above the spinner without disrupting animation.
@@ -693,7 +698,8 @@ class KawaiiSpinner:
         # Clear spinner line with spaces (not \033[K) to avoid garbled escape
         # codes when prompt_toolkit's patch_stdout is active — same approach
         # as stop(). Then print text; spinner redraws on next tick.
-        blanks = ' ' * max(self.last_line_len + 5, 40)
+        with self._lock:
+            blanks = ' ' * max(self.last_line_len + 5, 40)
         self._write(f"\r{blanks}\r  {text}", flush=True)
 
     def stop(self, final_message: str = None):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -18,11 +18,17 @@ never the child's intermediate tool calls or reasoning.
 
 import json
 import logging
+import threading
 logger = logging.getLogger(__name__)
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
+
+# Lock for process-global model_tools._last_resolved_tool_names restoration.
+# Concurrent _run_single_child threads restore the parent's tool names in their
+# finally blocks; without synchronization the last writer wins non-deterministically.
+_tool_names_lock = threading.Lock()
 
 
 # Tools that children must never have access to
@@ -491,7 +497,8 @@ def _run_single_child(
 
         saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
         if isinstance(saved_tool_names, list):
-            model_tools._last_resolved_tool_names = list(saved_tool_names)
+            with _tool_names_lock:
+                model_tools._last_resolved_tool_names = list(saved_tool_names)
 
         # Remove child from active tracking
 


### PR DESCRIPTION
## Summary

- **delegate_tool.py — global tool names race condition**: `_run_single_child()` threads (via `ThreadPoolExecutor`, up to `MAX_CONCURRENT_CHILDREN` workers) restore `model_tools._last_resolved_tool_names` in their `finally` blocks (line 494) without synchronization. When multiple children finish near-simultaneously, the last writer wins non-deterministically, potentially leaving the global in an incorrect state. Added a module-level `threading.Lock` to serialize the restoration.

- **display.py — KawaiiSpinner thread safety**: `_animate()` runs in a daemon thread reading `self.message` and writing `self.last_line_len` every 120ms. `update_text()` and `print_above()` called from the main thread modify the same fields with zero synchronization, causing potential garbled spinner output or stale `last_line_len` reads. Added a `threading.Lock` to guard `message` reads/writes and `last_line_len` access. The lock is minimal (held only for attribute access, not I/O) to avoid impacting animation smoothness.

## Test plan

- [ ] Run multi-task delegation and verify tool names are correctly restored after all children complete
- [ ] Rapidly call `update_text()` while spinner is running and verify no garbled output
- [ ] Verify `print_above()` correctly clears the spinner line before printing

🤖 Generated with [Claude Code](https://claude.com/claude-code)