### PR TITLE
fix(gateway): honor explicit HERMES_HOME in systemd install

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -618,7 +618,40 @@ def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
     return [p for p in candidates if p not in path_entries and Path(p).exists()]
 
 
-def _hermes_home_for_target_user(target_home_dir: str) -> str:
+def _probe_target_user_hermes_home(username: str) -> str | None:
+    """Return the target user's explicit HERMES_HOME from their login env."""
+    if not is_linux():
+        return None
+
+    probe_commands: list[list[str]] = []
+    if shutil.which("su"):
+        probe_commands.append(["su", "-", username, "-c", 'printf "%s" "${HERMES_HOME-}"'])
+    if shutil.which("sudo"):
+        probe_commands.append(["sudo", "-iu", username, "sh", "-lc", 'printf "%s" "${HERMES_HOME-}"'])
+
+    for cmd in probe_commands:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+
+        if result.returncode != 0:
+            continue
+
+        value = (result.stdout or "").strip()
+        if value:
+            return value
+
+    return None
+
+
+def _hermes_home_for_target_user(target_home_dir: str, current_hermes: str | Path | None = None) -> str:
     """Remap the current HERMES_HOME to the equivalent under a target user's home.
 
     When installing a system service via sudo, get_hermes_home() resolves to
@@ -627,7 +660,7 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
       /root/.hermes/profiles/coder     → /home/alice/.hermes/profiles/coder
       /opt/custom-hermes               → /opt/custom-hermes  (kept as-is)
     """
-    current_hermes = get_hermes_home().resolve()
+    current_hermes = Path(current_hermes).expanduser().resolve() if current_hermes is not None else get_hermes_home().resolve()
     current_default = (Path.home() / ".hermes").resolve()
     target_default = Path(target_home_dir) / ".hermes"
 
@@ -642,6 +675,19 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
     except ValueError:
         # Completely custom path (not under ~/.hermes) — keep as-is
         return str(current_hermes)
+
+
+def _resolve_system_service_hermes_home(username: str, target_home_dir: str) -> str:
+    """Resolve HERMES_HOME for Linux system service units."""
+    explicit_current = (os.getenv("HERMES_HOME") or "").strip()
+    if explicit_current:
+        return _hermes_home_for_target_user(target_home_dir, current_hermes=explicit_current)
+
+    probed = _probe_target_user_hermes_home(username)
+    if probed:
+        return probed
+
+    return _hermes_home_for_target_user(target_home_dir)
 
 
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
@@ -663,7 +709,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
-        hermes_home = _hermes_home_for_target_user(home_dir)
+        hermes_home = _resolve_system_service_hermes_home(username, home_dir)
         profile_arg = _profile_arg(hermes_home)
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
         path_entries.extend(common_bin_paths)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -101,6 +101,38 @@ class TestGeneratedSystemdUnits:
         assert "TimeoutStopSec=60" in unit
         assert "WantedBy=multi-user.target" in unit
 
+    def test_system_unit_uses_probed_target_user_custom_hermes_home(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_probe_target_user_hermes_home", lambda username: "/opt/hermes-shared")
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: [])
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert 'HERMES_HOME=/opt/hermes-shared' in unit
+
+    def test_system_unit_uses_probed_target_user_profile_hermes_home(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_probe_target_user_hermes_home",
+            lambda username: "/home/alice/.hermes/profiles/coder",
+        )
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: [])
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert 'HERMES_HOME=/home/alice/.hermes/profiles/coder' in unit
+
 
 class TestGatewayStopCleanup:
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):
@@ -527,6 +559,26 @@ class TestHermesHomeForTargetUser:
         monkeypatch.delenv("HERMES_HOME", raising=False)
 
         result = gateway_cli._hermes_home_for_target_user("/home/alice")
+        assert result == "/home/alice/.hermes"
+
+
+class TestResolveSystemServiceHermesHome:
+    def test_prefers_explicit_current_process_hermes_home(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.setenv("HERMES_HOME", "/root/.hermes/profiles/coder")
+        monkeypatch.setattr(gateway_cli, "_probe_target_user_hermes_home", lambda username: (_ for _ in ()).throw(AssertionError("probe should not run")))
+
+        result = gateway_cli._resolve_system_service_hermes_home("alice", "/home/alice")
+
+        assert result == "/home/alice/.hermes/profiles/coder"
+
+    def test_falls_back_to_default_when_probe_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(gateway_cli, "_probe_target_user_hermes_home", lambda username: None)
+
+        result = gateway_cli._resolve_system_service_hermes_home("alice", "/home/alice")
+
         assert result == "/home/alice/.hermes"
 
 


### PR DESCRIPTION
## What does this PR do?

Preserves an explicitly configured `HERMES_HOME` when generating Linux systemd gateway units, including the common `sudo` case where the current process environment no longer carries the target user's custom Hermes home.

## Related Issue

Fixes #6729
Related to #5947, but intentionally limited to the systemd gateway install path

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `hermes_cli/gateway.py` to preserve explicit `HERMES_HOME` and probe the target user's login environment before falling back to the existing remap/default logic
- preserved the current explicit-env remap behavior for `/root/.hermes` and `/root/.hermes/profiles/<name>` sudo cases
- added regression coverage in `tests/hermes_cli/test_gateway_service.py` for explicit env precedence, probed custom/profile homes, and empty-probe fallback
- kept this branch limited to the systemd install fix instead of bundling separate env/pairing hardening

## How to Test

1. Run `/Users/kennyxie/Documents/Code/clawspace/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q`
2. Run `hermes gateway install --system` with a non-default `HERMES_HOME` under `sudo` and confirm the generated unit uses that home
3. Repeat without an explicit custom home and confirm the existing fallback behavior remains unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `/Users/kennyxie/Documents/Code/clawspace/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q` → `54 passed`
