### PR TITLE
fix: update Kimi Coding User-Agent to KimiCLI/1.30.0

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -702,7 +702,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
             extra = {}
             if "api.kimi.com" in base_url.lower():
-                extra["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
+                extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
             elif "api.githubcopilot.com" in base_url.lower():
                 from hermes_cli.models import copilot_default_headers
 
@@ -721,7 +721,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
         extra = {}
         if "api.kimi.com" in base_url.lower():
-            extra["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
+            extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
         elif "api.githubcopilot.com" in base_url.lower():
             from hermes_cli.models import copilot_default_headers
 
@@ -1195,7 +1195,7 @@ def _to_async_client(sync_client, model: str):
 
         async_kwargs["default_headers"] = copilot_default_headers()
     elif "api.kimi.com" in base_lower:
-        async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
+        async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -1317,7 +1317,7 @@ def resolve_provider_client(
             final_model = model or _read_main_model() or "gpt-4o-mini"
             extra = {}
             if "api.kimi.com" in custom_base.lower():
-                extra["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
+                extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
             elif "api.githubcopilot.com" in custom_base.lower():
                 from hermes_cli.models import copilot_default_headers
                 extra["default_headers"] = copilot_default_headers()
@@ -1400,7 +1400,7 @@ def resolve_provider_client(
         # Provider-specific headers
         headers = {}
         if "api.kimi.com" in base_url.lower():
-            headers["User-Agent"] = "KimiCLI/1.3"
+            headers["User-Agent"] = "KimiCLI/1.30.0"
         elif "api.githubcopilot.com" in base_url.lower():
             from hermes_cli.models import copilot_default_headers
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -752,7 +752,7 @@ def run_doctor(args):
                 _url = (_base.rstrip("/") + "/models") if _base else _default_url
                 _headers = {"Authorization": f"Bearer {_key}"}
                 if "api.kimi.com" in _url.lower():
-                    _headers["User-Agent"] = "KimiCLI/1.0"
+                    _headers["User-Agent"] = "KimiCLI/1.30.0"
                 _resp = httpx.get(
                     _url,
                     headers=_headers,

--- a/run_agent.py
+++ b/run_agent.py
@@ -790,7 +790,7 @@ class AIAgent:
                     client_kwargs["default_headers"] = copilot_default_headers()
                 elif "api.kimi.com" in effective_base.lower():
                     client_kwargs["default_headers"] = {
-                        "User-Agent": "KimiCLI/1.3",
+                        "User-Agent": "KimiCLI/1.30.0",
                     }
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
@@ -4174,7 +4174,7 @@ class AIAgent:
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif "api.kimi.com" in normalized:
-            self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
+            self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
         elif "portal.qwen.ai" in normalized:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         else:


### PR DESCRIPTION
## Summary

Update the hardcoded Kimi Coding `User-Agent` header from `KimiCLI/1.3` (and `KimiCLI/1.0` in doctor.py) to `KimiCLI/1.30.0` to match the current official Kimi CLI version.

## Problem

Kimi's coding endpoint (`api.kimi.com/coding/v1`) validates the `User-Agent` header to restrict access to recognized coding agents. Hermes was sending `KimiCLI/1.3`, which is a stale version — the official Kimi CLI is now at v1.30.0. This causes intermittent 403 errors:

```
Error code: 403 - {'error': {'message': 'Kimi For Coding is currently only available for
Coding Agents such as Kimi CLI, Claude Code, Roo Code, Kilo Code, etc.',
'type': 'access_terminated_error'}}
```

## Fix

Simple string replacement across 3 files (8 occurrences):

| File | Occurrences | Old | New |
|------|------------|-----|-----|
| `run_agent.py` | 2 | `KimiCLI/1.3` | `KimiCLI/1.30.0` |
| `agent/auxiliary_client.py` | 5 | `KimiCLI/1.3` | `KimiCLI/1.30.0` |
| `hermes_cli/doctor.py` | 1 | `KimiCLI/1.0` | `KimiCLI/1.30.0` |

## Testing

- 4086 passed, 8 skipped (1 flaky async test unrelated to this change)
- Targeted: `test_api_key_providers.py` + `test_auxiliary_client.py` — 223 passed
