### PR TITLE
fix: cap image download at 50 MB, validate tool call parser fields

### DIFF
--- a/environments/tool_call_parsers/hermes_parser.py
+++ b/environments/tool_call_parsers/hermes_parser.py
@@ -49,6 +49,8 @@ class HermesToolCallParser(ToolCallParser):
                     continue
 
                 tc_data = json.loads(raw_json)
+                if "name" not in tc_data:
+                    continue
                 tool_calls.append(
                     ChatCompletionMessageToolCall(
                         id=f"call_{uuid.uuid4().hex[:8]}",

--- a/environments/tool_call_parsers/mistral_parser.py
+++ b/environments/tool_call_parsers/mistral_parser.py
@@ -89,6 +89,8 @@ class MistralToolCallParser(ToolCallParser):
                         parsed = [parsed]
 
                     for tc in parsed:
+                        if "name" not in tc:
+                            continue
                         args = tc.get("arguments", {})
                         if isinstance(args, dict):
                             args = json.dumps(args, ensure_ascii=False)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -67,6 +67,10 @@ def _resolve_download_timeout() -> float:
 
 _VISION_DOWNLOAD_TIMEOUT = _resolve_download_timeout()
 
+# Hard cap on downloaded image file size (50 MB). Prevents OOM from
+# attacker-hosted multi-gigabyte files or decompression bombs.
+_VISION_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
+
 
 def _validate_image_url(url: str) -> bool:
     """
@@ -181,13 +185,25 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
                 )
                 response.raise_for_status()
 
+                # Reject overly large images early via Content-Length header.
+                cl = response.headers.get("content-length")
+                if cl and int(cl) > _VISION_MAX_DOWNLOAD_BYTES:
+                    raise ValueError(
+                        f"Image too large ({int(cl)} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
+                    )
+
                 final_url = str(response.url)
                 blocked = check_website_access(final_url)
                 if blocked:
                     raise PermissionError(blocked["message"])
                 
-                # Save the image content
-                destination.write_bytes(response.content)
+                # Save the image content (double-check actual size)
+                body = response.content
+                if len(body) > _VISION_MAX_DOWNLOAD_BYTES:
+                    raise ValueError(
+                        f"Image too large ({len(body)} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
+                    )
+                destination.write_bytes(body)
             
             return destination
         except Exception as e:


### PR DESCRIPTION
## Summary

- **vision_tools.py — OOM via unbounded image download**: `_download_image()` loads the full HTTP response body into memory via `response.content` (line 190) with **no Content-Length check and no max file size limit**. An attacker-hosted multi-gigabyte image file or decompression bomb causes OOM and crashes the agent. Added a `_VISION_MAX_DOWNLOAD_BYTES = 50 MB` hard cap: first checks `Content-Length` header before downloading, then verifies actual body size before writing to disk. Consistent with the 20 MB limits used by the Slack and WeCom adapters.

- **hermes_parser.py — KeyError on missing "name" field**: `tc_data["name"]` at line 57 raises `KeyError` when an LLM outputs a tool call JSON without a `"name"` field (e.g., `{"arguments": {"x": 1}}`). The outer `except Exception` catches it silently, causing the **entire tool call to be lost** with zero diagnostics. Added `"name" in tc_data` validation before constructing the tool call.

- **mistral_parser.py — same KeyError in primary path**: `tc["name"]` at line 101 has the same issue. Notably, the **fallback decoder** at line 112 already checks `"name" in obj` correctly, but the **primary path** does not. Added validation to match the fallback's pattern.

## Test plan

- [ ] Download an image from a URL with Content-Length > 50 MB → verify rejected with clear error
- [ ] Download a normal-sized image → verify success
- [ ] Feed Hermes parser with `{"arguments": {}}` (no name) → verify graceful skip, no crash
- [ ] Feed Mistral parser with `[{"arguments": {}}]` (no name) → verify graceful skip
- [ ] Normal tool calls with "name" field → verify unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)