### PR TITLE
fix: prevent zombie processes, redact cron stderr, skip symlinks in skill enumeration

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -168,7 +168,7 @@ def _build_skill_message(
             subdir_path = skill_dir / subdir
             if subdir_path.exists():
                 for f in sorted(subdir_path.rglob("*")):
-                    if f.is_file():
+                    if f.is_file() and not f.is_symlink():
                         rel = str(f.relative_to(skill_dir))
                         supporting.append(rel)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -404,6 +404,14 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         stdout = (result.stdout or "").strip()
         stderr = (result.stderr or "").strip()
 
+        # Redact secrets from both stdout and stderr before any return path.
+        try:
+            from agent.redact import redact_sensitive_text
+            stdout = redact_sensitive_text(stdout)
+            stderr = redact_sensitive_text(stderr)
+        except Exception:
+            pass
+
         if result.returncode != 0:
             parts = [f"Script exited with code {result.returncode}"]
             if stderr:
@@ -412,13 +420,6 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 parts.append(f"stdout:\n{stdout}")
             return False, "\n".join(parts)
 
-        # Redact any secrets that may appear in script output before
-        # they are injected into the LLM prompt context.
-        try:
-            from agent.redact import redact_sensitive_text
-            stdout = redact_sensitive_text(stdout)
-        except Exception:
-            pass
         return True, stdout
 
     except subprocess.TimeoutExpired:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -375,15 +375,15 @@ class ProcessRegistry:
                         session.output_buffer = session.output_buffer[-session.max_output_chars:]
         except Exception as e:
             logger.debug("Process stdout reader ended: %s", e)
-
-        # Process exited
-        try:
-            session.process.wait(timeout=5)
-        except Exception as e:
-            logger.debug("Process wait timed out or failed: %s", e)
-        session.exited = True
-        session.exit_code = session.process.returncode
-        self._move_to_finished(session)
+        finally:
+            # Always reap the child to prevent zombie processes.
+            try:
+                session.process.wait(timeout=5)
+            except Exception as e:
+                logger.debug("Process wait timed out or failed: %s", e)
+            session.exited = True
+            session.exit_code = session.process.returncode
+            self._move_to_finished(session)
 
     def _env_poller_loop(
         self, session: ProcessSession, env: Any, log_path: str, pid_path: str


### PR DESCRIPTION
## Summary

- **process_registry.py — zombie process leak**: `_reader_loop()` places `process.wait()` after the `try-except` block (line 380). If the reader thread exits via an unexpected exception path (e.g., `MemoryError`), `wait()` is skipped and the child process becomes a zombie. Moved `wait()` and cleanup into a `finally` block so the child is always reaped regardless of how the reader exits.

- **cron/scheduler.py — stderr not redacted on failure**: `_run_job_script()` only redacts secrets in stdout on the **success** path (lines 417-421). When a script fails (non-zero exit), both stdout and stderr are returned **without redaction** (lines 407-413). A cron script that accidentally prints an API key to stderr during failure would leak it into the LLM prompt context. Moved redaction before the success/failure branch.

- **skill_commands.py — symlink enumeration bypass**: `_build_skill_message()` enumerates supporting files with `rglob("*")` and `is_file()` (line 171) but doesn't filter symlinks. PR #6693 added symlink protection to `scan_skill_commands()` but missed this function. A malicious skill with symlinks in `references/` can expose arbitrary file paths to the LLM. Added `not f.is_symlink()` check.

## Test plan

- [ ] Kill a reader thread mid-execution and verify the child process is reaped (no zombie in `ps aux`)
- [ ] Run a cron script that prints `sk-test1234567890` to stderr and exits with code 1 → verify output is redacted
- [ ] Place a symlink in a skill's `references/` directory → verify it's excluded from the file listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)