### PR TITLE
feat(agent): add native image attachments for multimodal runtimes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3946,63 +3946,48 @@ class HermesCLI:
             print(f"(x_x) Failed to save: {e}")
     
     def retry_last(self):
-        """Retry the last user message by removing the last exchange and re-sending.
-        
-        Removes the last assistant response (and any tool-call messages) and
-        the last user message, then re-sends that user message to the agent.
-        Returns the message to re-send, or None if there's nothing to retry.
-        """
+        """Retry the last visible user message by removing its trailing turn."""
         if not self.conversation_history:
             print("(._.) No messages to retry.")
             return None
-        
-        # Walk backwards to find the last user message
-        last_user_idx = None
-        for i in range(len(self.conversation_history) - 1, -1, -1):
-            if self.conversation_history[i].get("role") == "user":
-                last_user_idx = i
-                break
-        
-        if last_user_idx is None:
+
+        from run_agent import message_content_to_text, summarize_last_user_turn
+
+        summary = summarize_last_user_turn(self.conversation_history, preview_limit=60)
+        if not summary:
             print("(._.) No user message found to retry.")
             return None
-        
-        # Extract the message text and remove everything from that point forward
-        last_message = self.conversation_history[last_user_idx].get("content", "")
-        self.conversation_history = self.conversation_history[:last_user_idx]
-        
-        print(f"(^_^)b Retrying: \"{last_message[:60]}{'...' if len(last_message) > 60 else ''}\"")
+
+        last_message = summary["original_content"]
+        self.conversation_history = summary["truncated_history"]
+        preview = message_content_to_text(last_message)
+        preview = " ".join(preview.split()) or "[empty message]"
+        print(f"(^_^)b Retrying: \"{preview[:60]}{'...' if len(preview) > 60 else ''}\"")
         return last_message
-    
+
     def undo_last(self):
-        """Remove the last user/assistant exchange from conversation history.
-        
-        Walks backwards and removes all messages from the last user message
-        onward (including assistant responses, tool calls, etc.).
-        """
+        """Remove the last visible user turn from conversation history."""
         if not self.conversation_history:
             print("(._.) No messages to undo.")
             return
-        
-        # Walk backwards to find the last user message
-        last_user_idx = None
-        for i in range(len(self.conversation_history) - 1, -1, -1):
-            if self.conversation_history[i].get("role") == "user":
-                last_user_idx = i
-                break
-        
-        if last_user_idx is None:
+
+        from run_agent import (
+            format_internal_transcript_message_count,
+            summarize_last_user_turn,
+        )
+
+        summary = summarize_last_user_turn(self.conversation_history, preview_limit=60)
+        if not summary:
             print("(._.) No user message found to undo.")
             return
-        
-        # Count how many messages we're removing
-        removed_count = len(self.conversation_history) - last_user_idx
-        removed_msg = self.conversation_history[last_user_idx].get("content", "")
-        
-        # Truncate history to before the last user message
-        self.conversation_history = self.conversation_history[:last_user_idx]
-        
-        print(f"(^_^)b Undid {removed_count} message(s). Removed: \"{removed_msg[:60]}{'...' if len(removed_msg) > 60 else ''}\"")
+
+        self.conversation_history = summary["truncated_history"]
+        removed_count = int(summary["removed_count"])
+        preview = summary["preview"]
+        print(
+            f"(^_^)b Undid 1 turn ({format_internal_transcript_message_count(removed_count)}). "
+            f"Removed your last message: \"{preview}\""
+        )
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2756,8 +2756,8 @@ class GatewayRunner:
         if _is_shared_thread and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
+        image_paths = []
         if event.media_urls:
-            image_paths = []
             for i, path in enumerate(event.media_urls):
                 # Check media_types if available; otherwise infer from message type
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
@@ -2767,10 +2767,6 @@ class GatewayRunner:
                 )
                 if is_image:
                     image_paths.append(path)
-            if image_paths:
-                message_text = await self._enrich_message_with_vision(
-                    message_text, image_paths
-                )
         
         # -----------------------------------------------------------------
         # Auto-transcribe voice/audio messages sent by the user
@@ -2925,6 +2921,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                image_paths=image_paths,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -3994,29 +3991,33 @@ class GatewayRunner:
         return await self._handle_message(retry_event)
     
     async def _handle_undo_command(self, event: MessageEvent) -> str:
-        """Handle /undo command - remove the last user/assistant exchange."""
+        """Handle /undo command - remove the last visible user turn."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         history = self.session_store.load_transcript(session_entry.session_id)
-        
-        # Find the last user message and remove everything from it onward
-        last_user_idx = None
-        for i in range(len(history) - 1, -1, -1):
-            if history[i].get("role") == "user":
-                last_user_idx = i
-                break
-        
-        if last_user_idx is None:
+
+        from run_agent import (
+            format_internal_transcript_message_count,
+            summarize_last_user_turn,
+        )
+
+        summary = summarize_last_user_turn(history, preview_limit=40)
+        if not summary:
             return "Nothing to undo."
-        
-        removed_msg = history[last_user_idx].get("content", "")
-        removed_count = len(history) - last_user_idx
-        self.session_store.rewrite_transcript(session_entry.session_id, history[:last_user_idx])
+
+        self.session_store.rewrite_transcript(
+            session_entry.session_id,
+            summary["truncated_history"],
+        )
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0
-        
-        preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
-        return f"↩️ Undid {removed_count} message(s).\nRemoved: \"{preview}\""
+
+        removed_count = int(summary["removed_count"])
+        preview = summary["preview"]
+        return (
+            f"↩️ Undid 1 turn ({format_internal_transcript_message_count(removed_count)}).\n"
+            f"Removed your last message: \"{preview}\""
+        )
     
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""
@@ -5946,6 +5947,27 @@ class GatewayRunner:
             if var in os.environ:
                 del os.environ[var]
     
+    async def _prepare_user_message_with_images(
+        self,
+        user_text,
+        image_paths: List[str],
+        turn_route: dict,
+    ):
+        if not image_paths:
+            return user_text
+
+        from run_agent import build_native_multimodal_user_content, supports_native_multimodal_input
+
+        runtime = (turn_route or {}).get("runtime") or {}
+        if supports_native_multimodal_input(
+            provider=runtime.get("provider"),
+            api_mode=runtime.get("api_mode"),
+            base_url=runtime.get("base_url"),
+        ):
+            return build_native_multimodal_user_content(user_text or "", image_paths)
+
+        return await self._enrich_message_with_vision(user_text or "", image_paths)
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,
@@ -6300,6 +6322,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        image_paths: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -6318,6 +6341,7 @@ class GatewayRunner:
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
+        image_paths = list(image_paths or [])
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -6693,6 +6717,8 @@ class GatewayRunner:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            if image_paths:
+                message = asyncio.run(self._prepare_user_message_with_images(message, image_paths, turn_route))
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -6916,7 +6942,9 @@ class GatewayRunner:
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                from run_agent import prepend_text_to_message_content
+
+                message = prepend_text_to_message_content(message, _msn)
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)

--- a/model_tools.py
+++ b/model_tools.py
@@ -140,6 +140,7 @@ def _discover_tools():
         "tools.terminal_tool",
         "tools.file_tools",
         "tools.vision_tools",
+        "tools.native_image_tool",
         "tools.mixture_of_agents_tool",
         "tools.image_generation_tool",
         "tools.skills_tool",
@@ -235,6 +236,7 @@ def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    excluded_tool_names: Optional[List[str] | set[str] | tuple[str, ...]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -245,6 +247,10 @@ def get_tool_definitions(
         enabled_toolsets: Only include tools from these toolsets.
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
+        excluded_tool_names: Tool names to remove after toolset resolution,
+            regardless of which toolsets are enabled. Useful for runtime-aware
+            capability filtering (for example, hiding vision_analyze when the
+            active model already accepts native image input).
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -292,6 +298,10 @@ def get_tool_definitions(
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
+    excluded_tool_names = {str(name) for name in (excluded_tool_names or []) if str(name)}
+    if excluded_tool_names:
+        tools_to_include.difference_update(excluded_tool_names)
+
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()
     # all check the tool registry for plugin-provided toolsets.  No bypass
@@ -300,6 +310,11 @@ def get_tool_definitions(
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    if excluded_tool_names:
+        filtered_tools = [
+            tool for tool in filtered_tools
+            if tool.get("function", {}).get("name") not in excluded_tool_names
+        ]
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
@@ -340,6 +355,20 @@ def get_tool_definitions(
                     }
                     break
 
+    if "read_file" in available_tool_names and "vision_analyze" not in available_tool_names:
+        for i, td in enumerate(filtered_tools):
+            if td.get("function", {}).get("name") == "read_file":
+                desc = td["function"].get("description", "")
+                desc = desc.replace(
+                    " NOTE: Cannot read images or binary files — use vision_analyze for images.",
+                    " NOTE: Cannot read images or binary files.",
+                )
+                filtered_tools[i] = {
+                    "type": "function",
+                    "function": {**td["function"], "description": desc},
+                }
+                break
+
     if not quiet_mode:
         if filtered_tools:
             tool_names = [t["function"]["name"] for t in filtered_tools]
@@ -361,7 +390,7 @@ def get_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "attach_image"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -27,7 +27,7 @@ import copy
 import hashlib
 import json
 import logging
-logger = logging.getLogger(__name__)
+import mimetypes
 import os
 import random
 import re
@@ -38,12 +38,173 @@ import threading
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
-from openai import OpenAI
-import fire
 from datetime import datetime
 from pathlib import Path
+from openai import OpenAI
+import fire
+
+logger = logging.getLogger(__name__)
+
+
+def supports_native_multimodal_input(*, provider: Any = None, api_mode: Any = None, base_url: Any = None) -> bool:
+    """True when the active runtime should receive native image input.
+
+    Today this is intentionally narrow: Codex/OpenAI-style Responses routes,
+    excluding GitHub/Copilot's Responses endpoint.
+    """
+    normalized_mode = str(api_mode or "").strip().lower()
+    if normalized_mode != "codex_responses":
+        return False
+
+    provider_name = str(provider or "").strip().lower()
+    base = str(base_url or "").strip().lower()
+    if provider_name == "copilot":
+        return False
+    if "models.github.ai" in base or "api.githubcopilot.com" in base:
+        return False
+    return True
+
+
+def message_content_to_text(content: Any) -> str:
+    """Best-effort text rendering for logs, memory hooks, and previews."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            if part:
+                parts.append(part)
+            continue
+        if not isinstance(part, dict):
+            continue
+        ptype = str(part.get("type", "") or "")
+        if ptype in {"text", "input_text"}:
+            text = str(part.get("text", "") or "")
+            if text:
+                parts.append(text)
+        elif ptype in {"image_url", "input_image"}:
+            parts.append("[image]")
+
+    return " ".join(p for p in parts if p).strip()
+
+
+def summarize_last_user_turn(messages: List[Dict[str, Any]], *, preview_limit: int = 60) -> Optional[Dict[str, Any]]:
+    """Return metadata for the last visible user turn in a transcript/history.
+
+    Hermes stores full internal agent loops (assistant tool-call messages, tool
+    results, intermediate assistant messages) after each user turn.  Commands
+    like /undo operate on the whole trailing slice, but the UX should still talk
+    in terms of one visible user turn.
+    """
+    if not isinstance(messages, list) or not messages:
+        return None
+
+    last_user_idx = None
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "user":
+            continue
+        if msg.get("_native_image_attachment"):
+            continue
+        last_user_idx = i
+        break
+
+    if last_user_idx is None:
+        return None
+
+    removed = messages[last_user_idx:]
+    preview_text = message_content_to_text(messages[last_user_idx].get("content", ""))
+    preview_text = " ".join(preview_text.split()) or "[empty message]"
+    if len(preview_text) > preview_limit:
+        preview_text = preview_text[:preview_limit] + "..."
+
+    return {
+        "start_idx": last_user_idx,
+        "removed_count": len(removed),
+        "removed_messages": removed,
+        "truncated_history": messages[:last_user_idx],
+        "preview": preview_text,
+        "original_content": messages[last_user_idx].get("content", ""),
+    }
+
+
+def format_internal_transcript_message_count(count: int) -> str:
+    noun = "message" if count == 1 else "messages"
+    return f"{count} internal transcript {noun}"
+
+
+def _content_text_part_type(content: Any) -> str:
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and str(part.get("type", "")).startswith("input_"):
+                return "input_text"
+    return "text"
+
+
+def prepend_text_to_message_content(content: Any, text: str) -> Any:
+    text = str(text or "").strip()
+    if not text:
+        return content
+    if isinstance(content, list):
+        return [{"type": _content_text_part_type(content), "text": text}, *content]
+    base = message_content_to_text(content)
+    return f"{text}\n\n{base}" if base else text
+
+
+def append_text_to_message_content(content: Any, text: str) -> Any:
+    text = str(text or "").strip()
+    if not text:
+        return content
+    if isinstance(content, list):
+        return [*content, {"type": _content_text_part_type(content), "text": text}]
+    base = message_content_to_text(content)
+    return f"{base}\n\n{text}" if base else text
+
+
+def _coerce_image_reference_to_data_url(image_ref: Any) -> str:
+    raw = str(image_ref or "").strip()
+    if not raw or raw.startswith("data:") or re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", raw):
+        return raw
+
+    path = Path(os.path.expanduser(raw))
+    if not path.exists() or not path.is_file():
+        return raw
+
+    from tools.vision_tools import _image_to_base64_data_url
+
+    return _image_to_base64_data_url(path)
+
+
+def build_native_multimodal_user_content(text: str, image_paths: List[Any]) -> List[Dict[str, Any]]:
+    content: List[Dict[str, Any]] = []
+    if isinstance(text, str) and text:
+        content.append({"type": "text", "text": text})
+    for image_path in image_paths or []:
+        image_url = _coerce_image_reference_to_data_url(image_path)
+        if image_url:
+            content.append({"type": "image_url", "image_url": {"url": image_url}})
+    return content
+
+
+_NATIVE_IMAGE_EXTENSIONS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".ico"
+}
+_MAX_NATIVE_IMAGE_BYTES = 20 * 1024 * 1024
+_NATIVE_IMAGE_ATTACH_PROMPT = (
+    "[Internal: Inspect the attached image and continue the current task. "
+    "Treat it as fresh visual context from a previous tool step.]"
+)
+
 
 from hermes_constants import get_hermes_home
+
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -213,7 +374,7 @@ class IterationBudget:
 
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.
-_NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
+_NEVER_PARALLEL_TOOLS = frozenset({"clarify", "attach_image"})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
@@ -891,16 +1052,13 @@ class AIAgent:
                       " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain))
 
         # Get available tools with filtering
-        self.tools = get_tool_definitions(
-            enabled_toolsets=enabled_toolsets,
-            disabled_toolsets=disabled_toolsets,
-            quiet_mode=self.quiet_mode,
-        )
+        self.tools = []
+        self.valid_tool_names = set()
+        self._pending_native_images: list[dict[str, str]] = []
+        self.refresh_tool_surface(quiet_mode=self.quiet_mode, invalidate_prompt=False)
         
         # Show tool configuration and store valid tool names for validation
-        self.valid_tool_names = set()
         if self.tools:
-            self.valid_tool_names = {tool["function"]["name"] for tool in self.tools}
             tool_names = sorted(self.valid_tool_names)
             if not self.quiet_mode:
                 print(f"🛠️  Loaded {len(self.tools)} tools: {', '.join(tool_names)}")
@@ -1394,8 +1552,7 @@ class AIAgent:
                 new_context_length * self.context_compressor.threshold_percent
             )
 
-        # ── Invalidate cached system prompt so it rebuilds next turn ──
-        self._cached_system_prompt = None
+        self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
 
         # ── Update _primary_runtime so the change persists across turns ──
         _cc = self.context_compressor if hasattr(self, "context_compressor") and self.context_compressor else None
@@ -2994,6 +3151,128 @@ class AIAgent:
 
         return None
 
+    def _runtime_excluded_tool_names(self) -> set[str]:
+        """Tool names to hide for the current runtime's native capabilities."""
+        excluded: set[str] = set()
+        if supports_native_multimodal_input(
+            provider=self.provider,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        ):
+            excluded.add("vision_analyze")
+        else:
+            excluded.add("attach_image")
+        return excluded
+
+    @staticmethod
+    def _native_image_attachment_prompt(entries: List[Dict[str, str]]) -> str:
+        notes = [str(entry.get("note") or "").strip() for entry in entries if str(entry.get("note") or "").strip()]
+        if not notes:
+            return _NATIVE_IMAGE_ATTACH_PROMPT
+        lines = [_NATIVE_IMAGE_ATTACH_PROMPT, "Notes:"]
+        lines.extend(f"- {note}" for note in notes[:6])
+        return "\n".join(lines)
+
+    def _queue_native_image_attachment(self, image_path: str, *, note: str | None = None) -> Dict[str, Any]:
+        if not supports_native_multimodal_input(
+            provider=self.provider,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        ):
+            return {
+                "success": False,
+                "error": "Current runtime does not support native image input.",
+            }
+
+        raw_path = str(image_path or "").strip()
+        if not raw_path:
+            return {"success": False, "error": "Image path is required."}
+
+        resolved = Path(os.path.expanduser(raw_path))
+        if not resolved.exists() or not resolved.is_file():
+            return {"success": False, "error": f"Image file not found: {raw_path}"}
+
+        suffix = resolved.suffix.lower()
+        if suffix == ".svg":
+            return {
+                "success": False,
+                "error": "SVG files are not supported for native image attachments. Rasterize them first or use vision_analyze.",
+            }
+
+        mime_type, _ = mimetypes.guess_type(str(resolved))
+        is_image = bool(mime_type and mime_type.startswith("image/")) or suffix in _NATIVE_IMAGE_EXTENSIONS
+        if not is_image:
+            return {"success": False, "error": f"File is not a supported image: {resolved.name}"}
+
+        try:
+            file_size = resolved.stat().st_size
+        except OSError as exc:
+            return {"success": False, "error": f"Could not inspect image file: {exc}"}
+        if file_size > _MAX_NATIVE_IMAGE_BYTES:
+            limit_mb = _MAX_NATIVE_IMAGE_BYTES // (1024 * 1024)
+            return {
+                "success": False,
+                "error": f"Image file is too large for native attachment ({file_size} bytes > {limit_mb} MB limit).",
+            }
+
+        entry = {"path": str(resolved), "note": str(note or "").strip()}
+        self._pending_native_images.append(entry)
+        return {
+            "success": True,
+            "queued": len(self._pending_native_images),
+            "image_path": str(resolved),
+            "note": entry["note"] or None,
+        }
+
+    def _flush_pending_native_images(self, messages: List[Dict[str, Any]]) -> bool:
+        if not self._pending_native_images:
+            return False
+        if not supports_native_multimodal_input(
+            provider=self.provider,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        ):
+            logger.debug("Pending native images exist but current runtime is not native-multimodal; leaving queue untouched")
+            return False
+
+        entries = list(self._pending_native_images)
+        self._pending_native_images.clear()
+        message = {
+            "role": "user",
+            "content": build_native_multimodal_user_content(
+                self._native_image_attachment_prompt(entries),
+                [entry["path"] for entry in entries],
+            ),
+            "_native_image_attachment": True,
+        }
+        messages.append(message)
+        return True
+
+    def refresh_tool_surface(
+        self,
+        *,
+        quiet_mode: Optional[bool] = None,
+        invalidate_prompt: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Rebuild the current tool surface, applying runtime-aware exclusions."""
+        quiet = getattr(self, "quiet_mode", False) if quiet_mode is None else quiet_mode
+        previous_names = set(getattr(self, "valid_tool_names", set()) or set())
+        tools = get_tool_definitions(
+            enabled_toolsets=getattr(self, "enabled_toolsets", None),
+            disabled_toolsets=getattr(self, "disabled_toolsets", None),
+            quiet_mode=quiet,
+            excluded_tool_names=self._runtime_excluded_tool_names(),
+        )
+        self.tools = tools
+        self.valid_tool_names = {
+            tool["function"]["name"] for tool in tools or []
+        }
+        if invalidate_prompt and previous_names != self.valid_tool_names:
+            invalidate = getattr(self, "_invalidate_system_prompt", None)
+            if callable(invalidate):
+                invalidate()
+        return self.tools
+
     def _invalidate_system_prompt(self):
         """
         Invalidate the cached system prompt, forcing a rebuild on the next turn.
@@ -3002,8 +3281,9 @@ class AIAgent:
         so the rebuilt prompt captures any writes from this session.
         """
         self._cached_system_prompt = None
-        if self._memory_store:
-            self._memory_store.load_from_disk()
+        memory_store = getattr(self, "_memory_store", None)
+        if memory_store:
+            memory_store.load_from_disk()
 
     def _responses_tools(self, tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
         """Convert chat-completions tool schemas to Responses function-tool schemas."""
@@ -3098,7 +3378,8 @@ class AIAgent:
 
             if role in {"user", "assistant"}:
                 content = msg.get("content", "")
-                content_text = str(content) if content is not None else ""
+                normalized_content = self._normalize_codex_content(content)
+                content_text = message_content_to_text(normalized_content)
 
                 if role == "assistant":
                     # Replay encrypted reasoning items from previous turns
@@ -3111,8 +3392,8 @@ class AIAgent:
                                 items.append(ri)
                                 has_codex_reasoning = True
 
-                    if content_text.strip():
-                        items.append({"role": "assistant", "content": content_text})
+                    if (isinstance(normalized_content, list) and normalized_content) or content_text.strip():
+                        items.append({"role": "assistant", "content": normalized_content})
                     elif has_codex_reasoning:
                         # The Responses API requires a following item after each
                         # reasoning item (otherwise: missing_following_item error).
@@ -3164,7 +3445,7 @@ class AIAgent:
                             })
                     continue
 
-                items.append({"role": role, "content": content_text})
+                items.append({"role": role, "content": normalized_content})
                 continue
 
             if role == "tool":
@@ -3255,6 +3536,11 @@ class AIAgent:
             role = item.get("role")
             if role in {"user", "assistant"}:
                 content = item.get("content", "")
+                if isinstance(content, list):
+                    normalized_content = self._normalize_codex_content(content)
+                    normalized.append({"role": role, "content": normalized_content})
+                    continue
+
                 if content is None:
                     content = ""
                 if not isinstance(content, str):
@@ -5042,6 +5328,8 @@ class AIAgent:
                     fb_context_length * self.context_compressor.threshold_percent
                 )
 
+            self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
+
             self._emit_status(
                 f"🔄 Primary model failed — switching to fallback: "
                 f"{fb_model} via {fb_provider}"
@@ -5107,6 +5395,8 @@ class AIAgent:
             cc.provider = rt["compressor_provider"]
             cc.context_length = rt["compressor_context_length"]
             cc.threshold_tokens = rt["compressor_threshold_tokens"]
+
+            self.refresh_tool_surface(quiet_mode=True, invalidate_prompt=True)
 
             # ── Reset fallback chain for the new turn ──
             self._fallback_activated = False
@@ -5215,6 +5505,38 @@ class AIAgent:
             if isinstance(part, dict) and part.get("type") in {"image_url", "input_image"}:
                 return True
         return False
+
+    @staticmethod
+    def _normalize_codex_content(content: Any) -> Any:
+        from agent.auxiliary_client import _convert_content_for_responses
+
+        if isinstance(content, list):
+            normalized_parts: List[Dict[str, Any]] = []
+            for part in content:
+                if isinstance(part, str):
+                    if part:
+                        normalized_parts.append({"type": "text", "text": part})
+                    continue
+                if not isinstance(part, dict):
+                    continue
+                normalized_part = dict(part)
+                ptype = str(normalized_part.get("type", "") or "")
+                if ptype == "image_url":
+                    image_data = normalized_part.get("image_url", {})
+                    if isinstance(image_data, dict):
+                        url = _coerce_image_reference_to_data_url(image_data.get("url"))
+                        normalized_part["image_url"] = {**image_data, "url": url}
+                    else:
+                        normalized_part["image_url"] = {"url": _coerce_image_reference_to_data_url(image_data)}
+                elif ptype == "input_image":
+                    normalized_part["image_url"] = _coerce_image_reference_to_data_url(
+                        normalized_part.get("image_url")
+                    )
+                normalized_parts.append(normalized_part)
+
+            return _convert_content_for_responses(normalized_parts)
+
+        return content if isinstance(content, str) else (str(content) if content is not None else "")
 
     @staticmethod
     def _materialize_data_url_for_vision(image_url: str) -> tuple[str, Optional[Path]]:
@@ -6257,6 +6579,14 @@ class AIAgent:
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
             )
+        elif function_name == "attach_image":
+            return json.dumps(
+                self._queue_native_image_attachment(
+                    function_args.get("path", ""),
+                    note=function_args.get("note"),
+                ),
+                ensure_ascii=False,
+            )
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -6489,6 +6819,8 @@ class AIAgent:
                 tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
                 print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
 
+        self._flush_pending_native_images(messages)
+
     def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
@@ -6657,6 +6989,17 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+            elif function_name == "attach_image":
+                function_result = json.dumps(
+                    self._queue_native_image_attachment(
+                        function_args.get("path", ""),
+                        note=function_args.get("note"),
+                    ),
+                    ensure_ascii=False,
+                )
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('attach_image', function_args, tool_duration, result=function_result)}")
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.
@@ -6823,6 +7166,8 @@ class AIAgent:
                 remaining = self.max_iterations - api_call_count
                 tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
                 print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
+
+        self._flush_pending_native_images(messages)
 
     def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
         """Return a budget pressure string, or None if not yet needed.
@@ -7121,7 +7466,8 @@ class AIAgent:
         self.iteration_budget = IterationBudget(self.max_iterations)
 
         # Log conversation turn start for debugging/observability
-        _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
+        _user_message_text = message_content_to_text(user_message)
+        _msg_preview = (_user_message_text[:80] + "...") if len(_user_message_text) > 80 else _user_message_text
         _msg_preview = _msg_preview.replace("\n", " ")
         logger.info(
             "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
@@ -7157,6 +7503,7 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+        original_user_message_text = message_content_to_text(original_user_message)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
@@ -7177,7 +7524,9 @@ class AIAgent:
         self._persist_user_message_idx = current_turn_user_idx
         
         if not self.quiet_mode:
-            self._safe_print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
+            self._safe_print(
+                f"💬 Starting conversation: '{_user_message_text[:60]}{'...' if len(_user_message_text) > 60 else ''}'"
+            )
         
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.
@@ -7346,8 +7695,7 @@ class AIAgent:
         _ext_prefetch_cache = ""
         if self._memory_manager:
             try:
-                _query = original_user_message if isinstance(original_user_message, str) else ""
-                _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
+                _ext_prefetch_cache = self._memory_manager.prefetch_all(original_user_message_text) or ""
             except Exception:
                 pass
 
@@ -7429,8 +7777,10 @@ class AIAgent:
                         _injections.append(_plugin_user_context)
                     if _injections:
                         _base = api_msg.get("content", "")
-                        if isinstance(_base, str):
-                            api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                        api_msg["content"] = append_text_to_message_content(
+                            _base,
+                            "\n\n".join(_injections),
+                        )
 
                 # For ALL assistant messages, pass reasoning back to the API
                 # This ensures multi-turn reasoning context is preserved
@@ -7447,8 +7797,9 @@ class AIAgent:
                 # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
                 if "finish_reason" in api_msg:
                     api_msg.pop("finish_reason")
-                # Strip internal thinking-prefill marker
+                # Strip internal-only markers
                 api_msg.pop("_thinking_prefill", None)
+                api_msg.pop("_native_image_attachment", None)
                 # Strip Codex Responses API fields (call_id, response_item_id) for
                 # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
                 # Uses new dicts so the internal messages list retains the fields
@@ -9534,10 +9885,10 @@ class AIAgent:
         # External memory provider: sync the completed turn + queue next prefetch.
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
-        if self._memory_manager and final_response and original_user_message:
+        if self._memory_manager and final_response and original_user_message_text:
             try:
-                self._memory_manager.sync_all(original_user_message, final_response)
-                self._memory_manager.queue_prefetch_all(original_user_message)
+                self._memory_manager.sync_all(original_user_message_text, final_response)
+                self._memory_manager.queue_prefetch_all(original_user_message_text)
             except Exception:
                 pass
 

--- a/tests/cli/test_cli_retry.py
+++ b/tests/cli/test_cli_retry.py
@@ -1,4 +1,4 @@
-"""Regression tests for CLI /retry history replacement semantics."""
+"""Regression tests for CLI /retry and /undo history replacement semantics."""
 
 from tests.cli.test_cli_init import _make_cli
 
@@ -47,3 +47,42 @@ def test_process_command_retry_requeues_original_message_not_retry_command():
 
     assert queued == ["retry me"]
     assert cli.conversation_history == []
+
+
+def test_undo_last_reports_one_turn_and_internal_transcript_count(capsys):
+    cli = _make_cli()
+    cli.conversation_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "one"},
+        {"role": "user", "content": "fix /undo"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "search_files", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"success": true}'},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "[Internal: inspect the attached image and continue.]"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "_native_image_attachment": True,
+        },
+        {"role": "assistant", "content": "intermediate note"},
+        {"role": "assistant", "content": "final answer"},
+    ]
+
+    cli.undo_last()
+
+    out = capsys.readouterr().out
+    assert cli.conversation_history == [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "one"},
+    ]
+    assert "Undid 1 turn" in out
+    assert "6 internal transcript messages" in out
+    assert 'Removed your last message: "fix /undo"' in out
+    assert "Undid 5 message(s)" not in out

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -28,7 +28,7 @@ class TestHermesApiServerToolset:
         expected = [
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
-            "vision_analyze", "image_generate",
+            "vision_analyze", "attach_image", "image_generate",
             "execute_code", "delegate_task",
             "todo", "memory", "session_search", "cronjob",
         ]

--- a/tests/gateway/test_gateway_multimodal.py
+++ b/tests/gateway/test_gateway_multimodal.py
@@ -1,0 +1,135 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_prepare_user_message_with_images_uses_native_multimodal_for_codex(tmp_path):
+    runner = object.__new__(GatewayRunner)
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = await runner._prepare_user_message_with_images(
+        "Describe this",
+        [str(img)],
+        {
+            "runtime": {
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            }
+        },
+    )
+
+    assert isinstance(result, list)
+    assert result[0]["type"] == "text"
+    assert result[1]["type"] == "image_url"
+    assert result[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_prepare_user_message_with_images_uses_vision_fallback_for_text_only_route(tmp_path):
+    runner = object.__new__(GatewayRunner)
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    async def _fake_enrich(message_text, image_paths):
+        assert message_text == "Describe this"
+        assert image_paths == [str(img)]
+        return "fallback text"
+
+    runner._enrich_message_with_vision = _fake_enrich
+
+    result = await runner._prepare_user_message_with_images(
+        "Describe this",
+        [str(img)],
+        {
+            "runtime": {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        },
+    )
+
+    assert result == "fallback text"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_awaits_image_preparation(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.tools = []
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            assert message == "native-ready"
+            return {"final_response": "done", "messages": [], "api_calls": 1}
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner._prepare_user_message_with_images = AsyncMock(return_value="native-ready")
+    runner._resolve_turn_agent_config = lambda message, model, runtime_kwargs: {
+        "model": "gpt-5.4",
+        "runtime": {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+        "api_key": "***",
+    }
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:telegram:dm:123",
+        image_paths=[str(tmp_path / "shot.png")],
+    )
+
+    assert result["final_response"] == "done"
+    runner._prepare_user_message_with_images.assert_awaited_once()

--- a/tests/gateway/test_undo_command.py
+++ b/tests/gateway/test_undo_command.py
@@ -1,0 +1,68 @@
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_event(text="/undo"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        user_name="tester",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+@pytest.mark.asyncio
+async def test_handle_undo_command_reports_one_turn_and_internal_transcript_count():
+    runner = object.__new__(GatewayRunner)
+    entry = SimpleNamespace(session_id="sess-1", last_prompt_tokens=42)
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "one"},
+        {"role": "user", "content": "fix /undo"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "search_files", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"success": true}'},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "[Internal: inspect the attached image and continue.]"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "_native_image_attachment": True,
+        },
+        {"role": "assistant", "content": "intermediate note"},
+        {"role": "assistant", "content": "final answer"},
+    ]
+
+    store = MagicMock()
+    store.get_or_create_session.return_value = entry
+    store.load_transcript.return_value = history
+    runner.session_store = store
+
+    result = await runner._handle_undo_command(_make_event())
+
+    store.rewrite_transcript.assert_called_once_with("sess-1", history[:2])
+    assert entry.last_prompt_tokens == 0
+    assert "Undid 1 turn" in result
+    assert "6 internal transcript messages" in result
+    assert 'Removed your last message: "fix /undo"' in result
+    assert "Undid 5 message(s)" not in result

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -457,6 +457,27 @@ class TestChatMessagesToResponsesInput:
         reasoning_items = [i for i in items if i.get("type") == "reasoning"]
         assert len(reasoning_items) == 0
 
+    def test_user_multimodal_content_becomes_responses_parts(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUFB"}},
+            ],
+        }]
+
+        items = agent._chat_messages_to_responses_input(messages)
+
+        assert items == [{
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "What is in this image?"},
+                {"type": "input_image", "image_url": "data:image/png;base64,QUFB"},
+            ],
+        }]
+
 
 # ── Response normalization tests ─────────────────────────────────────────────
 
@@ -807,6 +828,23 @@ class TestCodexReasoningPreflight:
         reasoning_items = [i for i in items if isinstance(i, dict) and i.get("type") == "reasoning"]
         assert len(reasoning_items) == 1
         assert reasoning_items[0]["encrypted_content"] == "enc123"
+
+    def test_multimodal_content_list_passes_preflight(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        raw_input = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe it"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                ],
+            }
+        ]
+
+        normalized = agent._preflight_codex_input_items(raw_input)
+
+        assert normalized == raw_input
 
 
 # ── Reasoning effort consistency tests ───────────────────────────────────────

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -513,6 +513,137 @@ class TestInit:
             )
 
 
+class TestNativeMultimodalToolFiltering:
+    @staticmethod
+    def _fake_tool_loader(**kwargs):
+        names = ["web_search", "vision_analyze", "attach_image"]
+        excluded = set(kwargs.get("excluded_tool_names") or set())
+        return _make_tool_defs(*[name for name in names if name not in excluded])
+
+    def test_codex_runtime_excludes_vision_tool_on_init(self):
+        with (
+            patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                provider="openai-codex",
+                api_mode="codex_responses",
+                base_url="https://chatgpt.com/backend-api/codex",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent.valid_tool_names == {"web_search", "attach_image"}
+        assert "vision_analyze" not in agent.valid_tool_names
+
+    def test_switch_model_refreshes_runtime_filtered_tool_surface(self, agent):
+        with (
+            patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader),
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        ):
+            agent.refresh_tool_surface(invalidate_prompt=False)
+            assert agent.valid_tool_names == {"web_search", "vision_analyze"}
+
+            agent.switch_model(
+                new_model="gpt-5",
+                new_provider="openai-codex",
+                api_key="test-key-1234567890",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_mode="codex_responses",
+            )
+
+        assert agent.valid_tool_names == {"web_search", "attach_image"}
+
+    def test_fallback_restore_refreshes_runtime_filtered_tool_surface(self, agent):
+        with patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader):
+            agent.refresh_tool_surface(invalidate_prompt=False)
+            assert agent.valid_tool_names == {"web_search", "vision_analyze"}
+
+        agent._fallback_activated = False
+        agent._fallback_chain = [{"provider": "openai-codex", "model": "gpt-5"}]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://chatgpt.com/backend-api/codex"
+        mock_client.api_key = "test-key-1234567890"
+
+        with (
+            patch("run_agent.get_tool_definitions", side_effect=self._fake_tool_loader),
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.valid_tool_names == {"web_search", "attach_image"}
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.valid_tool_names == {"web_search", "vision_analyze"}
+
+
+class TestNativeImageQueue:
+    def test_flush_pending_native_images_appends_internal_multimodal_user_message(self, agent, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        agent.provider = "openai-codex"
+        agent.api_mode = "codex_responses"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+
+        result = agent._queue_native_image_attachment(str(img), note="inspect this screenshot")
+        assert result["success"] is True
+        assert result["queued"] == 1
+
+        messages = [{"role": "user", "content": "do the task"}]
+        assert agent._flush_pending_native_images(messages) is True
+        assert len(messages) == 2
+        queued_message = messages[-1]
+        assert queued_message["role"] == "user"
+        assert queued_message["_native_image_attachment"] is True
+        assert queued_message["content"][0]["type"] == "text"
+        assert "inspect this screenshot" in queued_message["content"][0]["text"]
+        assert queued_message["content"][1]["type"] == "image_url"
+        assert queued_message["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert agent._pending_native_images == []
+
+    def test_queue_native_image_attachment_rejects_text_only_runtime(self, agent, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        agent.provider = "openrouter"
+        agent.api_mode = "chat_completions"
+        agent.base_url = "https://openrouter.ai/api/v1"
+
+        result = agent._queue_native_image_attachment(str(img))
+        assert result["success"] is False
+        assert "does not support native image input" in result["error"]
+        assert agent._pending_native_images == []
+
+    def test_queue_native_image_attachment_rejects_svg(self, agent, tmp_path):
+        img = tmp_path / "vector.svg"
+        img.write_text("<svg xmlns='http://www.w3.org/2000/svg'></svg>", encoding="utf-8")
+        agent.provider = "openai-codex"
+        agent.api_mode = "codex_responses"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+
+        result = agent._queue_native_image_attachment(str(img))
+        assert result["success"] is False
+        assert "SVG files are not supported" in result["error"]
+        assert agent._pending_native_images == []
+
+    def test_queue_native_image_attachment_rejects_oversized_file(self, agent, tmp_path):
+        img = tmp_path / "huge.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        agent.provider = "openai-codex"
+        agent.api_mode = "codex_responses"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+
+        with patch("pathlib.Path.stat", return_value=SimpleNamespace(st_size=21 * 1024 * 1024, st_mode=0o100644)):
+            result = agent._queue_native_image_attachment(str(img))
+
+        assert result["success"] is False
+        assert "too large for native attachment" in result["error"]
+        assert agent._pending_native_images == []
+
+
 class TestInterrupt:
     def test_interrupt_sets_flag(self, agent):
         with patch("run_agent._set_interrupt"):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -24,7 +25,15 @@ def _patch_agent_bootstrap(monkeypatch):
                     "description": "Run shell commands.",
                     "parameters": {"type": "object", "properties": {}},
                 },
-            }
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "attach_image",
+                    "description": "Attach a local image for native multimodal inspection.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
         ],
     )
     monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
@@ -434,6 +443,73 @@ def test_run_conversation_codex_empty_output_no_output_text_retries(monkeypatch)
     assert calls["api"] >= 2
     assert result["completed"] is True
     assert result["final_response"] == "Recovered"
+
+
+def test_run_conversation_codex_multimodal_user_content(monkeypatch, tmp_path):
+    agent = _build_agent(monkeypatch)
+    image_path = tmp_path / "screenshot.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    seen = {}
+
+    def _fake_api_call(api_kwargs):
+        seen["api_kwargs"] = api_kwargs
+        return _codex_message_response("looks good")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation([
+        {"type": "text", "text": "What is in this screenshot?"},
+        {"type": "image_url", "image_url": {"url": str(image_path)}},
+    ])
+
+    assert result["completed"] is True
+    assert result["final_response"] == "looks good"
+    assert seen["api_kwargs"]["input"][0]["role"] == "user"
+    assert seen["api_kwargs"]["input"][0]["content"][0]["type"] == "input_text"
+    assert seen["api_kwargs"]["input"][0]["content"][1]["type"] == "input_image"
+    assert seen["api_kwargs"]["input"][0]["content"][1]["image_url"].startswith("data:image/png;base64,")
+
+
+def test_run_conversation_codex_attach_image_tool_queues_native_image_for_next_step(monkeypatch, tmp_path):
+    agent = _build_agent(monkeypatch)
+    image_path = tmp_path / "screenshot.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    seen_calls = []
+
+    attach_response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="function_call",
+                id="fc_attach_1",
+                call_id="call_attach_1",
+                name="attach_image",
+                arguments=json.dumps({"path": str(image_path), "note": "inspect this screenshot"}),
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+    responses = [attach_response, _codex_message_response("looks good")]
+
+    def _fake_api_call(api_kwargs):
+        seen_calls.append(api_kwargs)
+        return responses[len(seen_calls) - 1]
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("Inspect the screenshot you just created")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "looks good"
+    assert len(seen_calls) == 2
+    second_input = seen_calls[1]["input"]
+    assert second_input[-1]["role"] == "user"
+    assert second_input[-1]["content"][0]["type"] == "input_text"
+    assert "inspect this screenshot" in second_input[-1]["content"][0]["text"]
+    assert second_input[-1]["content"][1]["type"] == "input_image"
+    assert second_input[-1]["content"][1]["image_url"].startswith("data:image/png;base64,")
 
 
 def test_run_conversation_codex_refreshes_after_401_and_retries(monkeypatch):

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -8,6 +8,7 @@ import pytest
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
@@ -137,3 +138,50 @@ class TestBackwardCompat:
     def test_tool_to_toolset_map(self):
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
+
+    def test_attach_image_registered_in_vision_toolset(self):
+        assert get_toolset_for_tool("attach_image") == "vision"
+
+
+class TestGetToolDefinitionsRuntimeFiltering:
+    def test_excluded_tool_names_remove_tool_and_strip_stale_read_file_hint(self):
+        read_file_tool = {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": (
+                    "Read a text file. NOTE: Cannot read images or binary files — "
+                    "use vision_analyze for images."
+                ),
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        vision_tool = {
+            "type": "function",
+            "function": {
+                "name": "vision_analyze",
+                "description": "Analyze images using AI vision.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        def _resolve(toolset_name):
+            return {
+                "file": ["read_file"],
+                "vision": ["vision_analyze"],
+            }[toolset_name]
+
+        with (
+            patch("model_tools.validate_toolset", return_value=True),
+            patch("model_tools.resolve_toolset", side_effect=_resolve),
+            patch("model_tools.registry.get_definitions", return_value=[read_file_tool, vision_tool]),
+        ):
+            tools = get_tool_definitions(
+                enabled_toolsets=["file", "vision"],
+                quiet_mode=True,
+                excluded_tool_names={"vision_analyze"},
+            )
+
+        tool_names = [tool["function"]["name"] for tool in tools]
+        assert tool_names == ["read_file"]
+        assert "vision_analyze" not in tools[0]["function"]["description"]

--- a/tools/native_image_tool.py
+++ b/tools/native_image_tool.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Native image attachment tool schema.
+
+This tool does not analyze images itself. Instead, it tells the agent loop to
+queue a local image file for native multimodal input on the next model call.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tools.registry import registry
+
+
+def check_attach_image_requirements() -> bool:
+    return True
+
+
+ATTACH_IMAGE_SCHEMA = {
+    "name": "attach_image",
+    "description": (
+        "Attach a local image file so the current model can inspect it natively on the next step. "
+        "Use this instead of vision analysis when the active runtime already supports native multimodal input. "
+        "Pass a filesystem path to an image and an optional note describing what to inspect."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Absolute or relative filesystem path to a local image file.",
+            },
+            "note": {
+                "type": "string",
+                "description": "Optional short note describing what to inspect in the image.",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+def _attach_image_stub(args, **kwargs) -> str:
+    return json.dumps({"error": "attach_image must be handled by the agent loop"})
+
+
+registry.register(
+    name="attach_image",
+    toolset="vision",
+    schema=ATTACH_IMAGE_SCHEMA,
+    handler=_attach_image_stub,
+    check_fn=check_attach_image_requirements,
+    emoji="📎",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -36,7 +36,7 @@ _HERMES_CORE_TOOLS = [
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "attach_image", "image_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -80,8 +80,8 @@ TOOLSETS = {
     },
     
     "vision": {
-        "description": "Image analysis and vision tools",
-        "tools": ["vision_analyze"],
+        "description": "Image analysis and native multimodal image attachment tools",
+        "tools": ["vision_analyze", "attach_image"],
         "includes": []
     },
     
@@ -252,7 +252,7 @@ TOOLSETS = {
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation
-            "vision_analyze", "image_generate",
+            "vision_analyze", "attach_image", "image_generate",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation


### PR DESCRIPTION
Related: #6916

## Summary
Hermes currently pre-processes user images into text with `vision_analyze` before the main model sees them. That works for text-only routes, but it prevents Codex/OpenAI-style Responses runtimes from using native image input and leaves some CLI/gateway flows assuming user messages are always plain strings.

This PR adds a native image-attachment path for runtimes that can already accept multimodal user input directly. CLI `--image`, gateway image ingress, and the new `attach_image` tool now pass list-shaped image content straight through on those runtimes, while text-only routes keep the existing vision fallback.

## Changes
- add `attach_image` as an agent-loop tool and apply runtime-aware tool filtering so native-multimodal runtimes expose `attach_image` while text-only runtimes keep `vision_analyze`
- build native multimodal user content for Codex/OpenAI-style Responses routes in CLI and gateway flows instead of eagerly converting images to text
- make `/retry`, `/undo`, and preview text operate on visible user turns even when the underlying user message is list-shaped multimodal content
- reject SVGs and oversized files for native attachments before sending them to the provider
- add regression coverage for runtime-aware tool filtering, gateway native/fallback routing, multimodal undo/retry behavior, and queued native attachments

## Testing
- `venv/bin/python -m pytest tests/gateway/test_gateway_multimodal.py tests/run_agent/test_run_agent.py tests/run_agent/test_compressor_fallback_update.py tests/cli/test_cli_retry.py tests/gateway/test_undo_command.py tests/run_agent/test_provider_parity.py tests/run_agent/test_run_agent_codex_responses.py tests/test_model_tools.py tests/gateway/test_api_server_toolset.py -q -n 0` (392 passed)
- manual validation: `PYTHONPATH=. venv/bin/python -m hermes_cli.main chat -q "One word only: what website is shown in this screenshot?" --image <github-screenshot.png> --provider openai-codex -m gpt-5.4 -Q` returned `GitHub`
- `venv/bin/python -m pytest tests/ -q` still reports unrelated red tests on current `origin/main`; representative approval/transcription failures reproduce on a clean `origin/main` worktree
