### PR TITLE
security(approval): close 4 DANGEROUS_PATTERNS gaps (heredoc, pgrep, git --force, chmod+exec)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -716,3 +716,172 @@ class TestNormalizationBypass:
         assert dangerous is False
 
 
+class TestHeredocScriptExecution:
+    """Script execution via heredoc bypasses the -e/-c flag patterns.
+
+    `python3 << 'EOF'` feeds arbitrary code through stdin without any
+    flag that the original patterns check for. See security audit Test 3.
+    """
+
+    def test_python3_heredoc_detected(self):
+        # The heredoc body also contains `rm -rf /` which fires the
+        # "delete in root path" pattern first (patterns are ordered).
+        # The heredoc pattern also matches — either detection is correct.
+        cmd = "python3 << 'EOF'\nimport os; os.system('rm -rf /')\nEOF"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_python_heredoc_detected(self):
+        cmd = 'python << "PYEOF"\nprint("pwned")\nPYEOF'
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_perl_heredoc_detected(self):
+        cmd = "perl <<'END'\nsystem('whoami');\nEND"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_ruby_heredoc_detected(self):
+        cmd = "ruby <<RUBY\n`rm -rf /`\nRUBY"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_node_heredoc_detected(self):
+        cmd = "node << 'JS'\nrequire('child_process').execSync('whoami')\nJS"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_python3_dash_c_still_detected(self):
+        """Existing -c pattern must not regress."""
+        cmd = "python3 -c 'import os; os.system(\"rm -rf /\")'"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_safe_python_not_flagged(self):
+        """Plain 'python3 script.py' without heredoc or -c must stay safe."""
+        cmd = "python3 my_script.py"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+
+class TestPgrepKillExpansion:
+    """kill -9 $(pgrep hermes) bypasses the pkill/killall name-matching
+    pattern because the command substitution is opaque to regex.
+
+    See security audit Test 7.
+    """
+
+    def test_kill_dollar_pgrep_detected(self):
+        cmd = 'kill -9 $(pgrep -f "hermes.*gateway")'
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "pgrep" in desc.lower()
+
+    def test_kill_backtick_pgrep_detected(self):
+        cmd = "kill -9 `pgrep hermes`"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_kill_dollar_pgrep_no_flags(self):
+        cmd = "kill $(pgrep gateway)"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_pkill_hermes_still_detected(self):
+        """Existing pkill pattern must not regress."""
+        cmd = "pkill -9 hermes"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_safe_kill_pid_not_flagged(self):
+        """A plain 'kill 12345' (literal PID, no expansion) must stay safe."""
+        cmd = "kill 12345"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+
+class TestGitDestructiveOps:
+    """git reset --hard, push --force, clean -f, branch -D can destroy
+    work and rewrite shared history. Not covered by rm/chmod patterns.
+
+    See security audit Test 6.
+    """
+
+    def test_git_reset_hard_detected(self):
+        cmd = "git reset --hard HEAD~3"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "reset" in desc.lower() or "hard" in desc.lower()
+
+    def test_git_push_force_detected(self):
+        cmd = "git push --force origin main"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_git_push_dash_f_detected(self):
+        cmd = "git push -f origin main"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_git_clean_force_detected(self):
+        cmd = "git clean -fd"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "clean" in desc.lower()
+
+    def test_git_branch_force_delete_detected(self):
+        cmd = "git branch -D feature-branch"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_safe_git_status_not_flagged(self):
+        cmd = "git status"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_safe_git_push_not_flagged(self):
+        """Normal push without --force must not be flagged."""
+        cmd = "git push origin main"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_git_branch_lowercase_d_also_flagged(self):
+        """git branch -d triggers approval too — IGNORECASE is global.
+
+        This is intentional: -d is safer than -D but an approval prompt
+        for branch deletion is reasonable. The user can still approve.
+        """
+        cmd = "git branch -d feature-branch"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+
+class TestChmodExecuteCombo:
+    """chmod +x && ./ is the two-step social engineering pattern where a
+    script is first made executable then immediately run. The script
+    content may contain dangerous commands invisible to pattern matching.
+
+    See security audit Test 4.
+    """
+
+    def test_chmod_and_execute_detected(self):
+        cmd = "chmod +x /tmp/cleanup.sh && ./cleanup.sh"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "chmod" in desc.lower() or "execution" in desc.lower()
+
+    def test_chmod_semicolon_execute_detected(self):
+        cmd = "chmod +x script.sh; ./script.sh"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        # Semicolon variant — pattern uses && but full-string match
+        # on chmod +x should still trigger even without the && ./
+        assert dangerous is True
+
+    def test_safe_chmod_without_execute_not_flagged(self):
+        """chmod +x alone without immediate execution must not be flagged."""
+        cmd = "chmod +x script.sh"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -99,10 +99,30 @@ DANGEROUS_PATTERNS = [
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     # Self-termination protection: prevent agent from killing its own process
     (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
+    # Self-termination via kill + command substitution (pgrep/pidof).
+    # The name-based pattern above catches `pkill hermes` but not
+    # `kill -9 $(pgrep -f hermes)` because the substitution is opaque
+    # to regex at detection time. Catch the structural pattern instead.
+    (r'\bkill\b.*\$\(\s*pgrep\b', "kill process via pgrep expansion (self-termination)"),
+    (r'\bkill\b.*`\s*pgrep\b', "kill process via backtick pgrep expansion (self-termination)"),
     # File copy/move/edit into sensitive system paths
     (r'\b(cp|mv|install)\b.*\s/etc/', "copy/move file into /etc/"),
     (r'\bsed\s+-[^\s]*i.*\s/etc/', "in-place edit of system config"),
     (r'\bsed\s+--in-place\b.*\s/etc/', "in-place edit of system config (long flag)"),
+    # Script execution via heredoc — bypasses the -e/-c flag patterns above.
+    # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
+    (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),
+    # Git destructive operations that can lose uncommitted work or rewrite
+    # shared history. Not captured by rm/chmod/etc patterns.
+    (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
+    (r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
+    (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
+    (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
+    (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
+    # Script execution after chmod +x — catches the two-step pattern where
+    # a script is first made executable then immediately run. The script
+    # content may contain dangerous commands that individual patterns miss.
+    (r'\bchmod\s+\+x\b.*[;&|]+\s*\./', "chmod +x followed by immediate execution"),
 ]
 
 


### PR DESCRIPTION
## What does this PR do?

Closes 4 gaps in `DANGEROUS_PATTERNS` found by a 10-test source-grounded security audit. Each test mapped directly to a specific regex in `approval.py` and checked whether the documented defense actually held when attacked.

**Audit methodology:** Read the pattern → craft a command that should be caught → verify detection → craft a bypass variant → verify the bypass works → add pattern + tests for the bypass.

### 1. Heredoc script injection

`python3 -e` and `python3 -c` are caught by `DANGEROUS_PATTERNS[14]`, but `python3 << 'EOF'` is not — it feeds arbitrary code via stdin without any flag. In testing, hermes executed `shutil.rmtree()` via heredoc with **zero approval prompt**.

```python
# NEW pattern
(r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),
```

### 2. PID expansion self-termination bypass

`pkill hermes` is caught by `DANGEROUS_PATTERNS[23]`, but `kill -9 $(pgrep -f hermes)` is not — the command substitution is opaque to regex. In testing, hermes executed the kill command and even offered to help "kill more precisely".

```python
# NEW patterns
(r'\bkill\b.*\$\(\s*pgrep\b', "kill process via pgrep expansion (self-termination)"),
(r'\bkill\b.*`\s*pgrep\b', "kill process via backtick pgrep expansion (self-termination)"),
```

### 3. Git destructive operations

`git reset --hard`, `git push --force`, `git clean -fd`, `git branch -D` were entirely absent from DANGEROUS_PATTERNS. In testing, hermes was willing to run `git reset --hard HEAD~5` and even suggested `HEAD~1` as an alternative.

```python
# NEW patterns
(r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
(r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
(r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
(r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
(r'\bgit\s+branch\s+-D\b', "git branch force delete"),
```

Note: `git branch -d` (safe delete) also triggers because `re.IGNORECASE` is global. This is acceptable — `-d` is still a delete operation, and the prompt is a confirmation, not a hard block.

### 4. chmod +x then execute (two-step social engineering)

In testing, hermes happily wrote a script containing `rm -rf *`, then ran `chmod +x && ./cleanup.sh` — both steps had zero approval. This pattern catches the execute-after-chmod combo:

```python
# NEW pattern
(r'\bchmod\s+\+x\b.*[;&|]+\s*\./', "chmod +x followed by immediate execution"),
```

**Known limitation:** This does not solve the deeper architectural issue where `write_file` accepts dangerous script content without checking. That requires content-level audit at write time, which is a larger architectural change called out in the Related Issues section below.

## Related Issue

No open issue — findings from authorised local security audit.

Fixes #

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py`: +11 new patterns (20 lines of regex + comments)
- `tests/tools/test_approval.py`: +23 new tests across 4 classes (169 lines)

## How to Test

```bash
# Run the new test classes
pytest tests/tools/test_approval.py::TestHeredocScriptExecution \
       tests/tools/test_approval.py::TestPgrepKillExpansion \
       tests/tools/test_approval.py::TestGitDestructiveOps \
       tests/tools/test_approval.py::TestChmodExecuteCombo -v
# → 23 passed

# Full regression suite
pytest tests/tools/test_approval.py tests/tools/test_command_guards.py -q
# → 146 passed
```

**Reproduce the original bypasses (before this fix):**

```bash
# Heredoc bypass
hermes chat -q "run: python3 << 'EOF'
import os; os.system('echo PWNED')
EOF" --yolo

# PID expansion bypass
hermes chat -q "run: kill -9 \$(pgrep -f hermes)" --yolo

# git destructive
hermes chat -q "run: git reset --hard HEAD~5" --yolo

# chmod + execute
# Step 1: hermes chat -q "create /tmp/test.sh with content: rm -rf /tmp/victim" --yolo
# Step 2: hermes chat -q "chmod +x /tmp/test.sh && ./test.sh" --yolo
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`security(approval):`)
- [x] I searched for existing PRs — no duplicates found for these specific patterns
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/tools/test_approval.py tests/tools/test_command_guards.py -q` and all 146 tests pass
- [x] I've added tests for my changes (23 new, 4 classes)
- [x] I've tested on my platform: macOS 26.3.1 (Apple Silicon), Python 3.11.9

### Documentation & Housekeeping

- [x] Inline comments in approval.py explain each new pattern's purpose and the gap it closes
- [x] No config key changes — N/A
- [x] No architecture changes — N/A
- [x] Cross-platform: all patterns are regex-only, no platform-specific features
- [x] No tool schema changes — N/A

## Relationship to other open PRs

- **#4168** (open) adds exfiltration patterns (curl --data, credential reads). This PR adds **different** patterns (heredoc, git, pgrep, chmod+exec) with no overlap.
- **#6547** (my earlier PR) adds SSH config redaction + sudo timeout. Also no overlap — different files (`redact.py` + `terminal_tool.py` vs `approval.py`).

## Known Limitation: write_file Content Audit

Test 4 (chmod +x → execute) is only partially fixed by this PR. The pattern catches the `chmod +x && ./` combo, but a determined attacker can split across sessions or use `source script.sh` (no chmod needed). The root cause is that `write_file` does not inspect script content for dangerous commands. A full fix requires content-level audit at write time — a larger architectural change beyond the scope of this PR.