### PR TITLE
fix: normalize numeric MCP server names to str (fixes #6901)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -506,6 +506,10 @@ def _get_platform_tools(
         default_ts = PLATFORMS[platform]["default_toolset"]
         toolset_names = [default_ts]
 
+    # YAML may parse bare numeric names (e.g. ``12306:``) as int.
+    # Normalise to str so downstream sorted() never mixes types.
+    toolset_names = [str(ts) for ts in toolset_names]
+
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
 
     # If the saved list contains any configurable keys directly, the user
@@ -563,7 +567,7 @@ def _get_platform_tools(
     # as an allowlist. Otherwise include every globally enabled MCP server.
     mcp_servers = config.get("mcp_servers", {})
     enabled_mcp_servers = {
-        name
+        str(name)
         for name, server_cfg in mcp_servers.items()
         if isinstance(server_cfg, dict)
         and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -381,3 +381,31 @@ class TestPlatformToolsetConsistency:
                 f"Platform {platform!r} in tools_config but missing from "
                 f"skills_config PLATFORMS"
             )
+
+
+def test_numeric_mcp_server_name_does_not_crash_sorted():
+    """YAML parses bare numeric keys (e.g. ``12306:``) as int.
+
+    _get_platform_tools must normalise them to str so that sorted()
+    on the returned set never raises TypeError on mixed int/str.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/6901
+    """
+    config = {
+        "platform_toolsets": {"cli": ["web", 12306]},
+        "mcp_servers": {
+            12306: {"url": "https://example.com/mcp"},
+            "normal-server": {"url": "https://example.com/mcp2"},
+        },
+    }
+
+    enabled = _get_platform_tools(config, "cli")
+
+    # All names must be str — no int leaking through
+    assert all(isinstance(name, str) for name in enabled), (
+        f"Non-string toolset names found: {enabled}"
+    )
+    assert "12306" in enabled
+
+    # sorted() must not raise TypeError
+    sorted(enabled)


### PR DESCRIPTION
## Problem

When an MCP server is configured with a purely numeric name in `config.yaml` (e.g. `12306:` without quotes), YAML parses the key as `int`. This causes `TypeError: '<' not supported between instances of 'int' and 'str'` when `sorted()` is called on the enabled toolsets collection.

## Root Cause

`_get_platform_tools()` in `hermes_cli/tools_config.py` returns a `Set[str]` but could contain `int` values from two sources:
1. `toolset_names` list from `platform_toolsets` config (YAML int keys)
2. `enabled_mcp_servers` set built from `mcp_servers.items()` (YAML int keys)

## Fix

- Normalize `toolset_names` entries to `str` early: `[str(ts) for ts in toolset_names]`
- Cast MCP server names: `str(name)` when building `enabled_mcp_servers`

## Testing

- Added regression test `test_numeric_mcp_server_name_does_not_crash_sorted` that reproduces the exact scenario with int keys
- All 19 existing tests in `test_tools_config.py` pass (1 pre-existing failure unrelated)

Closes #6901