### PR TITLE
fix(docker): use uv for dependency resolution to fix resolution-too-deep error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY . /opt/hermes
 WORKDIR /opt/hermes
 
 # Install Python and Node dependencies in one layer, no cache
-RUN pip install --no-cache-dir -e ".[all]" --break-system-packages && \
+RUN pip install --no-cache-dir uv --break-system-packages && \
+    uv pip install --system --break-system-packages --no-cache -e ".[all]" && \
     npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
     cd /opt/hermes/scripts/whatsapp-bridge && \


### PR DESCRIPTION
## Summary
Switches the Docker image from `pip install` to `uv pip install --system` for dependency resolution. pip hits `resolution-too-deep` on Debian 13 / Python 3.13 when resolving the `.[all]` extra set, breaking the Docker Build and Publish CI workflow.

Using `--system --break-system-packages` keeps packages in the same system site-packages location — zero path changes for entrypoint, plugins, or any downstream code.

Salvaged from #6783 by @EnGassa. Cherry-picked with original authorship preserved.

Also closes #6922 (duplicate fix using a venv approach — simpler system install preferred to avoid path changes).

## Verified
- CI run [24221111425](https://github.com/NousResearch/hermes-agent/actions/runs/24221111425) confirms the `resolution-too-deep` failure on main
- Dockerfile change is a drop-in resolver swap with no path or behavior changes