### PR TITLE
Fix Telegram session model switching

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -47,6 +47,8 @@ import logging
 import os
 import threading
 import time
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
@@ -58,6 +60,11 @@ from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
+
+_MAIN_RUNTIME_OVERRIDE: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "auxiliary_main_runtime_override",
+    default=None,
+)
 
 _PROVIDER_ALIASES = {
     "google": "gemini",
@@ -93,6 +100,36 @@ def _normalize_aux_provider(provider: Optional[str], *, for_vision: bool = False
             return main_prov
         return "custom"
     return _PROVIDER_ALIASES.get(normalized, normalized)
+
+
+def _get_main_runtime_override() -> Dict[str, Any]:
+    override = _MAIN_RUNTIME_OVERRIDE.get()
+    if isinstance(override, dict):
+        return dict(override)
+    return {}
+
+
+@contextmanager
+def override_main_runtime(
+    *,
+    model: Optional[str] = None,
+    runtime: Optional[Dict[str, Any]] = None,
+):
+    """Temporarily override the active main model/runtime for auxiliary routing."""
+
+    override = _get_main_runtime_override()
+    if isinstance(runtime, dict):
+        for key in ("provider", "base_url", "api_key", "api_mode", "credential_pool"):
+            value = runtime.get(key)
+            if value not in (None, ""):
+                override[key] = value
+    if isinstance(model, str) and model.strip():
+        override["model"] = model.strip()
+    token = _MAIN_RUNTIME_OVERRIDE.set(override)
+    try:
+        yield
+    finally:
+        _MAIN_RUNTIME_OVERRIDE.reset(token)
 
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
@@ -814,6 +851,10 @@ def _read_main_model() -> str:
     config.yaml model.default is the single source of truth for the active
     model. Environment variables are no longer consulted.
     """
+    override = _get_main_runtime_override()
+    override_model = override.get("model")
+    if isinstance(override_model, str) and override_model.strip():
+        return override_model.strip()
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
@@ -835,6 +876,10 @@ def _read_main_provider() -> str:
     Returns the lowercase provider id (e.g. "alibaba", "openrouter") or ""
     if not configured.
     """
+    override = _get_main_runtime_override()
+    override_provider = override.get("provider")
+    if isinstance(override_provider, str) and override_provider.strip():
+        return override_provider.strip().lower()
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
@@ -855,6 +900,16 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
     endpoints where the base URL lives in config.yaml instead of the live
     environment.
     """
+    override = _get_main_runtime_override()
+    override_provider = str(override.get("provider") or "").strip().lower()
+    override_base = str(override.get("base_url") or "").strip().rstrip("/")
+    if override_base and (
+        override_provider in {"custom", "local"}
+        or override_provider.startswith("custom:")
+    ):
+        override_key = str(override.get("api_key") or "").strip() or "no-key-required"
+        return override_base, override_key
+
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -1497,17 +1552,9 @@ def _strict_vision_backend_available(provider: str) -> bool:
 
 def _preferred_main_vision_provider() -> Optional[str]:
     """Return the selected main provider when it is also a supported vision backend."""
-    try:
-        from hermes_cli.config import load_config
-
-        config = load_config()
-        model_cfg = config.get("model", {})
-        if isinstance(model_cfg, dict):
-            provider = _normalize_vision_provider(model_cfg.get("provider", ""))
-            if provider in _VISION_AUTO_PROVIDER_ORDER:
-                return provider
-    except Exception:
-        pass
+    provider = _normalize_vision_provider(_read_main_provider())
+    if provider in _VISION_AUTO_PROVIDER_ORDER:
+        return provider
     return None
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -314,6 +314,51 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _resolve_runtime_agent_kwargs_for_override(session_override: dict | None = None) -> dict:
+    """Resolve runtime credentials, honoring a session-scoped /model override."""
+    override = session_override or {}
+    override_provider = str(override.get("provider") or "").strip()
+    override_api_key = str(override.get("api_key") or "").strip() or None
+    override_base_url = str(override.get("base_url") or "").strip() or None
+
+    if not (override_provider or override_api_key or override_base_url):
+        return _resolve_runtime_agent_kwargs()
+
+    from hermes_cli.runtime_provider import (
+        resolve_runtime_provider,
+        format_runtime_provider_error,
+    )
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=override_provider or os.getenv("HERMES_INFERENCE_PROVIDER"),
+            explicit_api_key=override_api_key,
+            explicit_base_url=override_base_url,
+        )
+    except Exception as exc:
+        raise RuntimeError(format_runtime_provider_error(exc)) from exc
+
+    resolved = {
+        "api_key": runtime.get("api_key"),
+        "base_url": runtime.get("base_url"),
+        "provider": runtime.get("provider"),
+        "api_mode": runtime.get("api_mode"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+        "credential_pool": runtime.get("credential_pool"),
+    }
+    if override_provider:
+        resolved["provider"] = override_provider
+    if override_api_key:
+        resolved["api_key"] = override_api_key
+    if override_base_url:
+        resolved["base_url"] = override_base_url
+    override_api_mode = str(override.get("api_mode") or "").strip()
+    if override_api_mode:
+        resolved["api_mode"] = override_api_mode
+    return resolved
+
+
 def _build_media_placeholder(event) -> str:
     """Build a text placeholder for media-only events so they aren't dropped.
 
@@ -6318,9 +6363,9 @@ class GatewayRunner:
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
-
-        from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        session_override = {}
+        if session_key:
+            session_override = getattr(self, "_session_model_overrides", {}).get(session_key, {}) or {}
 
         # Apply tool preview length config (0 = no limit)
         try:
@@ -6648,10 +6693,10 @@ class GatewayRunner:
             except Exception:
                 pass
 
-            model = _resolve_gateway_model(user_config)
+            model = str(session_override.get("model") or "").strip() or _resolve_gateway_model(user_config)
 
             try:
-                runtime_kwargs = _resolve_runtime_agent_kwargs()
+                runtime_kwargs = _resolve_runtime_agent_kwargs_for_override(session_override)
             except Exception as exc:
                 return {
                     "final_response": f"⚠️ Provider authentication failed: {exc}",
@@ -6659,6 +6704,11 @@ class GatewayRunner:
                     "api_calls": 0,
                     "tools": [],
                 }
+
+            from agent.auxiliary_client import override_main_runtime as _override_main_runtime
+            with _override_main_runtime(model=model, runtime=runtime_kwargs):
+                from hermes_cli.tools_config import _get_platform_tools
+                enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
 
             pr = self._provider_routing
             reasoning_config = self._load_reasoning_config()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -11,6 +11,7 @@ from agent.auxiliary_client import (
     get_text_auxiliary_client,
     get_vision_auxiliary_client,
     get_available_vision_backends,
+    override_main_runtime,
     resolve_vision_provider_client,
     resolve_provider_client,
     auxiliary_max_tokens_param,
@@ -19,6 +20,8 @@ from agent.auxiliary_client import (
     _get_auxiliary_provider,
     _get_provider_chain,
     _is_payment_error,
+    _read_main_model,
+    _read_main_provider,
     _try_payment_fallback,
     _resolve_forced_provider,
     _resolve_auto,
@@ -212,6 +215,35 @@ class TestAnthropicOAuthFlag:
             # The adapter inside should have is_oauth=True
             adapter = client.chat.completions
             assert adapter._is_oauth is True
+
+
+class TestMainRuntimeOverride:
+    def test_override_main_runtime_beats_config_for_provider_and_model(self, monkeypatch):
+        mock_config = {
+            "model": {
+                "default": "MiniMax-M2.7",
+                "provider": "minimax",
+            }
+        }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: mock_config)
+
+        assert _read_main_provider() == "minimax"
+        assert _read_main_model() == "MiniMax-M2.7"
+
+        with override_main_runtime(
+            model="gpt-5.4",
+            runtime={
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "codex-key",
+            },
+        ):
+            assert _read_main_provider() == "openai-codex"
+            assert _read_main_model() == "gpt-5.4"
+
+        assert _read_main_provider() == "minimax"
+        assert _read_main_model() == "MiniMax-M2.7"
 
     def test_api_key_no_oauth_flag(self, monkeypatch):
         """Regular API keys (sk-ant-api-*) should create client with is_oauth=False."""

--- a/tests/gateway/test_session_model_override_runtime.py
+++ b/tests/gateway/test_session_model_override_runtime.py
@@ -1,0 +1,194 @@
+"""Tests for gateway session-scoped model/runtime overrides."""
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+class _FreshAgent:
+    """Captures the effective runtime used to build a new agent."""
+
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "fresh",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class _CachedAgent:
+    """Cached agent used to detect stale signature reuse."""
+
+    def __init__(self):
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "cached",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._load_reasoning_config = lambda: {"enabled": True, "effort": "medium"}
+    return runner
+
+
+def _telegram_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fake_agent_module(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _FreshAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def test_run_agent_uses_session_override_runtime_for_new_telegram_turn(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: MiniMax-M2.7\n"
+        "  provider: minimax\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "minimax",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.minimax.io/anthropic",
+            "api_key": "minimax-key",
+            "credential_pool": None,
+        },
+    )
+
+    _FreshAgent.last_init = None
+    runner = _make_runner()
+    runner._session_model_overrides["telegram:dm:12345"] = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "codex-key",
+    }
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=_telegram_source(),
+            session_id="session-1",
+            session_key="telegram:dm:12345",
+        )
+    )
+
+    assert result["final_response"] == "fresh"
+    assert _FreshAgent.last_init is not None
+    assert _FreshAgent.last_init["model"] == "gpt-5.4"
+    assert _FreshAgent.last_init["provider"] == "openai-codex"
+    assert _FreshAgent.last_init["api_mode"] == "codex_responses"
+    assert _FreshAgent.last_init["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert _FreshAgent.last_init["api_key"] == "codex-key"
+
+
+def test_run_agent_cache_signature_uses_session_override_runtime(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: MiniMax-M2.7\n"
+        "  provider: minimax\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "minimax",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.minimax.io/anthropic",
+            "api_key": "minimax-key",
+            "credential_pool": None,
+        },
+    )
+
+    _FreshAgent.last_init = None
+    runner = _make_runner()
+    runner._session_model_overrides["telegram:dm:12345"] = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "codex-key",
+    }
+
+    stale_runtime = {
+        "provider": "minimax",
+        "api_mode": "anthropic_messages",
+        "base_url": "https://api.minimax.io/anthropic",
+        "api_key": "minimax-key",
+        "credential_pool": None,
+    }
+    stale_sig = runner._agent_config_signature("MiniMax-M2.7", stale_runtime, [], "")
+    runner._agent_cache["telegram:dm:12345"] = (_CachedAgent(), stale_sig)
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=_telegram_source(),
+            session_id="session-2",
+            session_key="telegram:dm:12345",
+        )
+    )
+
+    assert result["final_response"] == "fresh"
+    assert _FreshAgent.last_init is not None
+    assert _FreshAgent.last_init["provider"] == "openai-codex"


### PR DESCRIPTION
## Summary
- honor Telegram session `/model` overrides when resolving the next turn's model and runtime
- make the next-turn cache signature use the effective session override instead of stale config runtime
- let auxiliary/tool gating read the effective session-switched main provider/model during gateway turns

## Problem
Telegram `/model` switches were being stored in `_session_model_overrides`, but the next turn still rebuilt its runtime from `config.yaml` / default runtime resolution. That meant Hermes could report a successful switch while the next message still initialized the old provider/model or reused a stale cached signature.

This showed up as a generic Telegram model-switching bug, not just a Codex bug:
- fresh switched turns still built the old config model
- cache reuse still keyed off the old runtime
- auxiliary/tool gating still read the old "main" provider/model during switched Telegram turns

## Changes
- add a gateway runtime resolver that honors session-scoped `/model` overrides
- resolve the effective model from the session override before building the next agent turn
- scope auxiliary main-provider/model reads to the effective gateway turn runtime while tool gating runs
- add focused regression tests for fresh switched turns, cache signature behavior, and auxiliary main-runtime override reads

## Testing
- `./venv/bin/pytest tests/gateway/test_session_model_override_runtime.py tests/agent/test_auxiliary_client.py -q -k 'session_model_override_runtime or MainRuntimeOverride'`
- `./venv/bin/pytest tests/gateway/test_reasoning_command.py tests/gateway/test_session_model_reset.py tests/gateway/test_session_info.py -q`

## Notes
One unrelated progress test around a terminal emoji fallback (`💻` vs `⚙️`) failed in a broader sweep and is not part of this PR's scope.
