### PR TITLE
fix(acp): declare session resume capability in initialize response

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -36,6 +36,7 @@ from acp.schema import (
     SessionCapabilities,
     SessionForkCapabilities,
     SessionListCapabilities,
+    SessionResumeCapabilities,
     SessionInfo,
     TextContentBlock,
     UnstructuredCommandInput,
@@ -248,6 +249,7 @@ class HermesACPAgent(acp.Agent):
                 session_capabilities=SessionCapabilities(
                     fork=SessionForkCapabilities(),
                     list=SessionListCapabilities(),
+                    resume=SessionResumeCapabilities(),
                 ),
             ),
             auth_methods=auth_methods,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -71,6 +71,7 @@ class TestInitialize:
         assert caps.session_capabilities is not None
         assert caps.session_capabilities.fork is not None
         assert caps.session_capabilities.list is not None
+        assert caps.session_capabilities.resume is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `SessionResumeCapabilities` to the ACP `initialize` response so clients (e.g. Zed Editor) can discover and use session resumption
- The `resume_session` method is already fully implemented but clients couldn't call it because the capability wasn't declared per the [ACP spec](https://agentclientprotocol.com/protocol/session-setup#checking-support)

## Changes

- `acp_adapter/server.py`: Import `SessionResumeCapabilities`, add `resume=SessionResumeCapabilities()` to `SessionCapabilities`
- `tests/acp/test_server.py`: Assert `resume` capability is present in initialize response

## Test plan

- [x] `pytest tests/acp/test_server.py::TestInitialize` — 3 tests pass

Closes #6633