### PR TITLE
fix(cli): verify gateway restart + feat(agent): provider concurrency semaphore

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2109,7 +2109,7 @@ def call_llm(
     with _sem.slot(priority=False, timeout=_sem_timeout) as _acquired:
         if not _acquired and not _is_critical:
             logger.info("concurrency: auxiliary %s skipped (semaphore busy)", task or "call")
-            return None
+            raise RuntimeError(f"Concurrency semaphore busy, skipping auxiliary {task or 'call'}")
         if not _acquired:
             logger.warning("concurrency: %s proceeding without slot (critical)", task or "call")
 
@@ -2302,7 +2302,7 @@ async def async_call_llm(
     async with _sem.async_slot(priority=False, timeout=_sem_timeout) as _acquired:
         if not _acquired and not _is_critical:
             logger.info("concurrency: async %s skipped (semaphore busy)", task or "call")
-            return None
+            raise RuntimeError(f"Concurrency semaphore busy, skipping async auxiliary {task or 'call'}")
         if not _acquired:
             logger.warning("concurrency: async %s proceeding without slot (critical)", task or "call")
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -53,6 +53,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from openai import OpenAI
 
+from agent.concurrency import get_semaphore
 from agent.credential_pool import load_pool
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -2097,56 +2098,71 @@ def call_llm(
                      task, resolved_provider or "auto", final_model or "default",
                      f" at {_base_info}" if _base_info and "openrouter" not in _base_info else "")
 
-    kwargs = _build_call_kwargs(
-        resolved_provider, final_model, messages,
-        temperature=temperature, max_tokens=max_tokens,
-        tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+    # ── Concurrency gating ───────────────────────────────────────────
+    # Auxiliary calls defer to main agent (priority=False).
+    # Critical tasks (context compression) get a short timeout and proceed
+    # anyway; non-critical tasks skip if the semaphore is busy.
+    _sem = get_semaphore(resolved_provider or "", resolved_api_key or "", model=final_model)
+    _is_critical = task in ("compression", "context_compression")
+    _sem_timeout = 5.0 if _is_critical else 30.0
 
-    # Handle max_tokens vs max_completion_tokens retry, then payment fallback.
-    try:
-        return client.chat.completions.create(**kwargs)
-    except Exception as first_err:
-        err_str = str(first_err)
-        if "max_tokens" in err_str or "unsupported_parameter" in err_str:
-            kwargs.pop("max_tokens", None)
-            kwargs["max_completion_tokens"] = max_tokens
-            try:
-                return client.chat.completions.create(**kwargs)
-            except Exception as retry_err:
-                # If the max_tokens retry also hits a payment error,
-                # fall through to the payment fallback below.
-                if not _is_payment_error(retry_err):
-                    raise
-                first_err = retry_err
+    with _sem.slot(priority=False, timeout=_sem_timeout) as _acquired:
+        if not _acquired and not _is_critical:
+            logger.info("concurrency: auxiliary %s skipped (semaphore busy)", task or "call")
+            return None
+        if not _acquired:
+            logger.warning("concurrency: %s proceeding without slot (critical)", task or "call")
 
-        # ── Payment / credit exhaustion fallback ──────────────────────
-        # When the resolved provider returns 402 or a credit-related error,
-        # try alternative providers instead of giving up.  This handles the
-        # common case where a user runs out of OpenRouter credits but has
-        # Codex OAuth or another provider available.
-        #
-        # ── Connection error fallback ────────────────────────────────
-        # When a provider endpoint is unreachable (DNS failure, connection
-        # refused, timeout), try alternative providers.  This handles stale
-        # Codex/OAuth tokens that authenticate but whose endpoint is down,
-        # and providers the user never configured that got picked up by
-        # the auto-detection chain.
-        should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
-        if should_fallback:
-            reason = "payment error" if _is_payment_error(first_err) else "connection error"
-            logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
-                        task or "call", reason, resolved_provider, first_err)
-            fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task)
-            if fb_client is not None:
-                fb_kwargs = _build_call_kwargs(
-                    fb_label, fb_model, messages,
-                    temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
-                    extra_body=extra_body)
-                return fb_client.chat.completions.create(**fb_kwargs)
-        raise
+        kwargs = _build_call_kwargs(
+            resolved_provider, final_model, messages,
+            temperature=temperature, max_tokens=max_tokens,
+            tools=tools, timeout=effective_timeout, extra_body=extra_body,
+            base_url=resolved_base_url)
+
+        # Handle max_tokens vs max_completion_tokens retry, then payment fallback.
+        try:
+            return client.chat.completions.create(**kwargs)
+        except Exception as first_err:
+            err_str = str(first_err)
+            if "max_tokens" in err_str or "unsupported_parameter" in err_str:
+                kwargs.pop("max_tokens", None)
+                kwargs["max_completion_tokens"] = max_tokens
+                try:
+                    return client.chat.completions.create(**kwargs)
+                except Exception as retry_err:
+                    # If the max_tokens retry also hits a payment error,
+                    # fall through to the payment fallback below.
+                    if not _is_payment_error(retry_err):
+                        raise
+                    first_err = retry_err
+
+            # ── Payment / credit exhaustion fallback ──────────────────────
+            # When the resolved provider returns 402 or a credit-related error,
+            # try alternative providers instead of giving up.  This handles the
+            # common case where a user runs out of OpenRouter credits but has
+            # Codex OAuth or another provider available.
+            #
+            # ── Connection error fallback ────────────────────────────────
+            # When a provider endpoint is unreachable (DNS failure, connection
+            # refused, timeout), try alternative providers.  This handles stale
+            # Codex/OAuth tokens that authenticate but whose endpoint is down,
+            # and providers the user never configured that got picked up by
+            # the auto-detection chain.
+            should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
+            if should_fallback:
+                reason = "payment error" if _is_payment_error(first_err) else "connection error"
+                logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
+                            task or "call", reason, resolved_provider, first_err)
+                fb_client, fb_model, fb_label = _try_payment_fallback(
+                    resolved_provider, task)
+                if fb_client is not None:
+                    fb_kwargs = _build_call_kwargs(
+                        fb_label, fb_model, messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, timeout=effective_timeout,
+                        extra_body=extra_body)
+                    return fb_client.chat.completions.create(**fb_kwargs)
+            raise
 
 
 def extract_content_or_reasoning(response) -> str:
@@ -2279,18 +2295,29 @@ async def async_call_llm(
 
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
 
-    kwargs = _build_call_kwargs(
-        resolved_provider, final_model, messages,
-        temperature=temperature, max_tokens=max_tokens,
-        tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+    _sem = get_semaphore(resolved_provider or "", resolved_api_key or "", model=final_model)
+    _is_critical = task in ("compression", "context_compression")
+    _sem_timeout = 5.0 if _is_critical else 30.0
 
-    try:
-        return await client.chat.completions.create(**kwargs)
-    except Exception as first_err:
-        err_str = str(first_err)
-        if "max_tokens" in err_str or "unsupported_parameter" in err_str:
-            kwargs.pop("max_tokens", None)
-            kwargs["max_completion_tokens"] = max_tokens
+    async with _sem.async_slot(priority=False, timeout=_sem_timeout) as _acquired:
+        if not _acquired and not _is_critical:
+            logger.info("concurrency: async %s skipped (semaphore busy)", task or "call")
+            return None
+        if not _acquired:
+            logger.warning("concurrency: async %s proceeding without slot (critical)", task or "call")
+
+        kwargs = _build_call_kwargs(
+            resolved_provider, final_model, messages,
+            temperature=temperature, max_tokens=max_tokens,
+            tools=tools, timeout=effective_timeout, extra_body=extra_body,
+            base_url=resolved_base_url)
+
+        try:
             return await client.chat.completions.create(**kwargs)
-        raise
+        except Exception as first_err:
+            err_str = str(first_err)
+            if "max_tokens" in err_str or "unsupported_parameter" in err_str:
+                kwargs.pop("max_tokens", None)
+                kwargs["max_completion_tokens"] = max_tokens
+                return await client.chat.completions.create(**kwargs)
+            raise

--- a/agent/concurrency.py
+++ b/agent/concurrency.py
@@ -1,0 +1,121 @@
+"""Threading-based concurrency semaphore with priority waiter queue."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator, AsyncIterator
+
+
+@dataclass
+class _Waiter:
+    priority: bool
+    event: threading.Event = field(default_factory=threading.Event)
+
+
+class ConcurrencySemaphore:
+    """Semaphore that gates concurrent access with priority support.
+
+    Priority waiters are served before non-priority waiters, allowing
+    main-agent calls to jump ahead of auxiliary calls in the queue.
+    """
+
+    def __init__(self, max_concurrent: int = 1) -> None:
+        if max_concurrent < 1:
+            raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
+        self._max_concurrent = max_concurrent
+        self._active = 0
+        self._waiters: list[_Waiter] = []
+        self._lock = threading.Lock()
+
+    @property
+    def max_concurrent(self) -> int:
+        with self._lock:
+            return self._max_concurrent
+
+    @property
+    def active(self) -> int:
+        with self._lock:
+            return self._active
+
+    @property
+    def waiting(self) -> int:
+        with self._lock:
+            return len(self._waiters)
+
+    def acquire(self, *, priority: bool = False, timeout: float | None = None) -> bool:
+        with self._lock:
+            if self._active < self._max_concurrent and not self._waiters:
+                self._active += 1
+                return True
+
+            if timeout == 0:
+                return False
+
+            waiter = _Waiter(priority=priority)
+            # Insert priority waiters after existing priority waiters
+            # but before non-priority waiters.
+            if priority:
+                insert_idx = 0
+                for i, w in enumerate(self._waiters):
+                    if w.priority:
+                        insert_idx = i + 1
+                    else:
+                        break
+                else:
+                    # All existing waiters are priority (or list is empty)
+                    insert_idx = len(self._waiters)
+                self._waiters.insert(insert_idx, waiter)
+            else:
+                self._waiters.append(waiter)
+
+        # Wait outside the lock
+        signaled = waiter.event.wait(timeout)
+
+        if not signaled:
+            with self._lock:
+                # Race: waiter may have been signaled between timeout and
+                # lock acquisition. If so, the slot was already granted.
+                if waiter.event.is_set():
+                    return True
+                try:
+                    self._waiters.remove(waiter)
+                except ValueError:
+                    pass  # already removed
+                return False
+
+        return True
+
+    def release(self) -> None:
+        with self._lock:
+            self._active = max(0, self._active - 1)
+            if self._waiters and self._active < self._max_concurrent:
+                waiter = self._waiters.pop(0)
+                self._active += 1
+                waiter.event.set()
+
+    @contextmanager
+    def slot(
+        self, *, priority: bool = False, timeout: float | None = None
+    ) -> Iterator[bool]:
+        acquired = self.acquire(priority=priority, timeout=timeout)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                self.release()
+
+    @asynccontextmanager
+    async def async_slot(
+        self, *, priority: bool = False, timeout: float | None = None
+    ) -> AsyncIterator[bool]:
+        acquired = await asyncio.to_thread(
+            self.acquire, priority=priority, timeout=timeout
+        )
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                self.release()

--- a/agent/concurrency.py
+++ b/agent/concurrency.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from typing import Iterator, AsyncIterator
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -119,3 +122,45 @@ class ConcurrencySemaphore:
         finally:
             if acquired:
                 self.release()
+
+
+# ── Module-level registry ────────────────────────────────────────────
+
+_registry: dict[tuple[str, str], ConcurrencySemaphore] = {}
+_registry_lock = threading.Lock()
+
+
+def get_semaphore(
+    provider: str,
+    api_key: str,
+    *,
+    max_concurrent: int | None = None,
+    model: str | None = None,
+) -> ConcurrencySemaphore:
+    """Get or create a semaphore for a (provider, api_key) pair.
+
+    On first call for a given pair, ``max_concurrent`` sets the limit.
+    If omitted, the default is looked up from
+    :func:`agent.model_metadata.get_default_concurrency`.  Subsequent
+    calls return the same instance (``max_concurrent`` is ignored).
+    """
+    key = (provider or "", api_key or "")
+    with _registry_lock:
+        if key in _registry:
+            return _registry[key]
+        if max_concurrent is None:
+            from agent.model_metadata import get_default_concurrency
+            max_concurrent = get_default_concurrency(provider, model)
+        sem = ConcurrencySemaphore(max_concurrent)
+        logger.debug(
+            "concurrency: created semaphore for (%s, %s…) max=%d",
+            provider, (api_key or "")[:8], max_concurrent,
+        )
+        _registry[key] = sem
+        return sem
+
+
+def reset_registry() -> None:
+    """Clear all semaphores.  For tests only."""
+    with _registry_lock:
+        _registry.clear()

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -73,6 +73,7 @@ SUPPORTED_POOL_STRATEGIES = {
 # Provider-supplied reset_at timestamps override these defaults.
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+EXHAUSTED_TTL_CONCURRENCY_SECONDS = 5        # transient concurrency 429 — retry quickly
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
@@ -189,11 +190,26 @@ def _is_manual_source(source: str) -> bool:
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
 
 
-def _exhausted_ttl(error_code: Optional[int]) -> int:
-    """Return cooldown seconds based on the HTTP status that caused exhaustion."""
+def _exhausted_ttl(error_code: Optional[int], error_reason: Optional[str] = None) -> int:
+    """Return cooldown seconds based on the HTTP status that caused exhaustion.
+
+    Concurrency-related 429s (z.ai error 1302, 'rate limit', 'concurrent')
+    get a short cooldown because they are transient.  Billing/quota 429s
+    keep the long cooldown.
+    """
+    if error_code == 429 and _is_concurrency_error(error_reason):
+        return EXHAUSTED_TTL_CONCURRENCY_SECONDS
     if error_code == 429:
         return EXHAUSTED_TTL_429_SECONDS
     return EXHAUSTED_TTL_DEFAULT_SECONDS
+
+
+def _is_concurrency_error(reason: Optional[str]) -> bool:
+    """Return True if the error reason indicates a transient concurrency limit."""
+    if not reason:
+        return False
+    reason_lower = reason.lower()
+    return any(kw in reason_lower for kw in ("1302", "concurren", "rate limit"))
 
 
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:
@@ -271,7 +287,10 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     if reset_at is not None:
         return reset_at
     if entry.last_status_at:
-        return entry.last_status_at + _exhausted_ttl(entry.last_error_code)
+        return entry.last_status_at + _exhausted_ttl(
+            entry.last_error_code,
+            error_reason=getattr(entry, "last_error_reason", None),
+        )
     return None
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -209,7 +209,7 @@ def _is_concurrency_error(reason: Optional[str]) -> bool:
     if not reason:
         return False
     reason_lower = reason.lower()
-    return any(kw in reason_lower for kw in ("1302", "concurren", "rate limit"))
+    return any(kw in reason_lower for kw in ("1302", "concurren"))
 
 
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -36,6 +36,67 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "qwen-portal",
 })
 
+# ── Provider concurrency defaults ────────────────────────────────────
+# Max simultaneous requests per (provider, api_key).  Verified from
+# provider documentation — see docs/plans/2026-04-11-concurrency-semaphore-handover.md.
+#
+# Structure: provider -> { model_prefix -> limit, "_default" -> fallback }
+# Model matching: longest matching prefix wins.
+
+PROVIDER_CONCURRENCY_DEFAULTS: dict[str, dict[str, int]] = {
+    "zai": {
+        "glm-5.1": 1,
+        "glm-5": 2,
+        "glm-4.5": 10,
+        "glm-4-air": 10,
+        "glm-4-flash": 10,
+        "glm-4-long": 10,
+        "embedding-3": 10,
+        "cogview": 2,
+        "cogvideox": 5,
+        "_default": 10,
+    },
+    "kimi-coding": {
+        "_default": 1,
+    },
+    "kimi": {
+        "_default": 1,
+    },
+    "moonshot": {
+        "_default": 1,
+    },
+}
+
+# Providers not listed above use RPM/TPM limits (not concurrency),
+# so they get a high default that effectively disables gating.
+_CONCURRENCY_DEFAULT_UNLIMITED = 64
+
+
+def get_default_concurrency(provider: str | None, model: str | None = None) -> int:
+    """Look up the default max-concurrent-requests for a provider + model.
+
+    Returns a high value (effectively unlimited) for providers without
+    known concurrency limits.
+    """
+    provider_lower = (provider or "").strip().lower()
+    model_lower = (model or "").strip().lower()
+
+    provider_table = PROVIDER_CONCURRENCY_DEFAULTS.get(provider_lower)
+    if provider_table is None:
+        return _CONCURRENCY_DEFAULT_UNLIMITED
+
+    # Longest-prefix match on model name.
+    best_match = ""
+    best_limit = provider_table.get("_default", _CONCURRENCY_DEFAULT_UNLIMITED)
+    for prefix, limit in provider_table.items():
+        if prefix == "_default":
+            continue
+        if model_lower.startswith(prefix) and len(prefix) > len(best_match):
+            best_match = prefix
+            best_limit = limit
+
+    return best_limit
+
 
 _OLLAMA_TAG_PATTERN = re.compile(
     r"^(\d+\.?\d*b|latest|stable|q\d|fp?\d|instruct|chat|coder|vision|text)",

--- a/docs/plans/2026-04-11-concurrency-semaphore-handover.md
+++ b/docs/plans/2026-04-11-concurrency-semaphore-handover.md
@@ -1,0 +1,164 @@
+# Concurrency Semaphore for Provider Rate Limits — Handover Doc
+
+**Date**: 2026-04-11
+**Status**: Design phase — clarifying questions complete, ready for approach proposals
+**Scope**: Phase 1 = concurrency gating only. Phase 2 (follow-up) = RPM-based throttling.
+
+---
+
+## Problem
+
+Providers like z.ai and Kimi enforce **concurrency limits** (max simultaneous requests), not just RPM/TPM. Hermes-agent fires auxiliary calls (session summarization, vision auto-detect, context compression) in parallel with the main agent loop, easily exceeding a concurrency limit of 1.
+
+**Concrete failure**: z.ai GLM-5.1 has a concurrency limit of 1. When the main agent is mid-request and an auxiliary call fires, the auxiliary call gets HTTP 429 (error code 1302). Currently `credential_pool.py` treats this the same as a billing error — 1-hour cooldown on the credential — which is far too aggressive for a transient concurrency issue.
+
+## What We Know
+
+### z.ai Concurrency Limits (verified from https://z.ai/manage-apikey/rate-limits)
+
+| Model | Max Concurrent Requests |
+|-------|------------------------|
+| GLM-5.1 | 1 |
+| GLM-5 | 2 |
+| GLM-4.5 | 10 |
+| GLM-4-Air / Flash / Long | 10 |
+| Embedding-3 | 10 |
+| CogView / CogVideoX | 2-5 |
+
+### Kimi/Moonshot Concurrency Limits (verified from official docs)
+
+Per-account limits by tier:
+- Free: 1 concurrent
+- Paid tiers: 50-1000 concurrent
+- Also has RPM/TPM/TPD limits (out of scope for Phase 1)
+
+### Other Major Providers
+
+Anthropic, OpenAI, OpenRouter, Google — use RPM/TPM limits, not concurrency. No concurrency gating needed for these (Phase 2 RPM work will cover them).
+
+## Agreed Design Decisions
+
+1. **Generic mechanism** — not z.ai-specific. A concurrency semaphore system any provider can use.
+2. **z.ai defaults baked in** — the known concurrency limits above should ship as defaults so z.ai works out of the box.
+3. **Kimi defaults included** — same treatment.
+4. **Hybrid priority + defer for auxiliary calls**:
+   - Main agent loop gets **priority** access to the semaphore.
+   - Auxiliary calls (session summarization, vision, web extraction) **defer** when the semaphore is busy — they wait for an idle gap rather than competing.
+   - **Critical auxiliary** (context compression — agent can't continue without it) gets a short timeout before proceeding, rather than infinite deferral.
+5. **Concurrency-only for Phase 1** — RPM-based throttling (pacing requests using `x-ratelimit-remaining-requests` headers) is a separate follow-up.
+6. **`rate_limit_delay` field exists but is unimplemented** — defined in `hermes_cli/config.py` line 1444 in `_VALID_CUSTOM_PROVIDER_FIELDS` but never wired up. Could be a hook point or could be replaced by the new system.
+
+## Key Files
+
+| File | Relevance |
+|------|-----------|
+| `agent/credential_pool.py` | Manages API keys, rotation, exhaustion tracking. Has 1-hour cooldown for 429/402. Does NOT distinguish error code 1113 (billing) vs 1302 (rate limit). **Needs**: concurrency-aware error handling, shorter retry for 1302. |
+| `agent/auxiliary_client.py` | Central `call_llm()` / `async_call_llm()` for all auxiliary tasks. Client cache keyed by `(provider, async_mode, base_url, api_key)`. **Needs**: semaphore integration before making requests. |
+| `run_agent.py` | Main agent loop. Makes primary model calls. **Needs**: semaphore acquisition before LLM calls. |
+| `hermes_cli/config.py` | Config schema. `rate_limit_delay` field defined but unused. **Needs**: new config fields for concurrency limits. |
+| `agent/model_metadata.py` | Model metadata, context lengths. Contains `_PROVIDER_PREFIXES`. **Could hold**: default concurrency limits per provider/model. |
+| `hermes_cli/auth.py` | Has `ZAI_ENDPOINTS` list and `detect_zai_endpoint()`. Provider detection logic. |
+
+## Architecture Sketch
+
+```
+                    ┌─────────────────────┐
+                    │  ConcurrencySemaphore │
+                    │  per (provider, key)  │
+                    ├──────────────────────┤
+                    │ max_concurrent: int   │
+                    │ active: int           │
+                    │ priority_queue        │
+                    │ defer_queue           │
+                    └──────┬───────────────┘
+                           │
+              ┌────────────┼────────────────┐
+              │            │                │
+         main agent    auxiliary         critical aux
+         (priority)    (deferred)       (short timeout)
+```
+
+**Semaphore keyed by**: `(provider_name, api_key)` — because concurrency limits are per-key per-provider.
+
+**Two acquisition modes**:
+- `acquire(priority=True)` — main agent, goes to front of queue
+- `acquire(priority=False, timeout=None)` — auxiliary, waits for idle gap
+- `acquire(priority=False, timeout=5.0)` — critical auxiliary (compression), waits briefly then proceeds
+
+## Default Concurrency Table (to ship with)
+
+```python
+# provider -> model_pattern -> max_concurrent
+PROVIDER_CONCURRENCY_DEFAULTS = {
+    "zai": {
+        "glm-5.1": 1,
+        "glm-5": 2,
+        "glm-4.5": 10,
+        "glm-4-air": 10,
+        "glm-4-flash": 10,
+        "glm-4-long": 10,
+        "embedding-3": 10,
+        "cogview-*": 2,
+        "cogvideox-*": 5,
+        "_default": 10,
+    },
+    "kimi": {
+        "_default": 1,  # conservative; paid tiers are higher
+    },
+}
+```
+
+## Config Integration
+
+Users should be able to override concurrency limits in `config.yaml`:
+
+```yaml
+model:
+  provider: zai
+  model: glm-5.1
+  max_concurrent: 3  # override default of 1
+
+custom_providers:
+  - name: my-zai
+    base_url: https://api.z.ai/api/coding/paas/v4
+    max_concurrent: 2
+```
+
+## Error Handling Changes Needed
+
+In `credential_pool.py`, the 429 handler currently applies a 1-hour cooldown regardless of error code. Needs:
+
+1. **Parse z.ai error codes**: 1302 = concurrency rate limit (retry in seconds), 1113 = billing (keep 1-hour cooldown)
+2. **Short retry for concurrency 429s**: Back off 1-5 seconds, not 1 hour
+3. **Respect `Retry-After` header** if present
+
+## Phase 2: RPM-Based Throttling (Future)
+
+Separate follow-up work:
+- Parse `x-ratelimit-remaining-requests` / `x-ratelimit-reset` headers from API responses
+- Proactively pace requests when remaining quota is low
+- Applies to providers that use RPM/TPM (Anthropic, OpenAI, OpenRouter, etc.)
+- `rate_limit_delay` config field could be repurposed or extended for this
+
+## Next Steps for Continuing Agent
+
+1. **Read this doc** and the key files listed above
+2. **Propose 2-3 implementation approaches** with trade-offs (brainstorming task #3)
+3. **Present design** to user for approval (task #4)
+4. **Write detailed spec** in `docs/superpowers/specs/` (task #5)
+5. **Create implementation plan** via writing-plans skill (task #6)
+6. **Implement** the concurrency semaphore
+
+Key design questions already answered:
+- Generic, not z.ai-specific: YES
+- Hybrid priority+defer for aux calls: YES
+- Concurrency-only scope: YES (RPM is Phase 2)
+- Ship with provider defaults: YES (z.ai + kimi)
+- User-overridable via config: YES
+
+## Context from This Session
+
+- We cherry-picked PR #6757 (intermediate ACK detection) into the local branch `fix/update-restart-health-check` — that fix is separate from this concurrency work
+- GLM-5.1 billing was fixed by setting `GLM_BASE_URL=https://api.z.ai/api/coding/paas/v4` in `~/.hermes/.env`
+- GLM-5.1 Chinese responses fixed by adding language directive to `~/.hermes/SOUL.md`
+- The brainstorming skill was active — the continuing agent should resume with approach proposals

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1441,7 +1441,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "models",
-    "context_length", "rate_limit_delay",
+    "context_length", "rate_limit_delay", "max_concurrent",
 }
 
 # Fields that look like they should be inside custom_providers, not at root

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3759,6 +3759,15 @@ def cmd_update(args):
         print()
         print("✓ Update complete!")
         
+        def _verify_service_active(scope_cmd, svc_name):
+            """Sleep briefly, then return True if the service is still active."""
+            _time.sleep(2)
+            chk = subprocess.run(
+                scope_cmd + ["is-active", svc_name],
+                capture_output=True, text=True, timeout=5,
+            )
+            return chk.stdout.strip() == "active"
+
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
@@ -3805,10 +3814,22 @@ def cmd_update(args):
                                     scope_cmd + ["restart", svc_name],
                                     capture_output=True, text=True, timeout=15,
                                 )
-                                if restart.returncode == 0:
-                                    restarted_services.append(svc_name)
-                                else:
+                                if restart.returncode != 0:
                                     print(f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}")
+                                    continue
+                                # Verify the service actually survived startup.
+                                # systemctl restart returns 0 even if the process
+                                # crashes immediately after starting.
+                                if not _verify_service_active(scope_cmd, svc_name):
+                                    print(f"  ⚠ {svc_name} restarted but exited immediately — retrying…")
+                                    subprocess.run(
+                                        scope_cmd + ["restart", svc_name],
+                                        capture_output=True, text=True, timeout=15,
+                                    )
+                                    if not _verify_service_active(scope_cmd, svc_name):
+                                        print(f"  ⚠ {svc_name} failed to stay running after update")
+                                        continue
+                                restarted_services.append(svc_name)
                     except (FileNotFoundError, subprocess.TimeoutExpired):
                         pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -96,6 +96,7 @@ from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.concurrency import get_semaphore
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
     get_cute_tool_message as _get_cute_tool_message_impl,
@@ -1621,6 +1622,11 @@ class AIAgent:
         has_future_ack = bool(
             re.search(r"\b(i[\'\'\u2019]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
         )
+        # "let me know" is a polite closer, not a planning statement
+        if has_future_ack and re.search(r"\blet me know\b", assistant_text):
+            has_future_ack = bool(
+                re.search(r"\b(i[\'\'\u2019]ll|i will|i can do that|i can help with that)\b", assistant_text)
+            )
 
         # Chinese planning patterns (common with GLM and other Chinese LLMs)
         has_cn_future_ack = bool(
@@ -4313,7 +4319,7 @@ class AIAgent:
             self._try_refresh_anthropic_client_credentials()
         return self._anthropic_client.messages.create(**api_kwargs)
 
-    def _interruptible_api_call(self, api_kwargs: dict):
+    def _interruptible_api_call(self, api_kwargs: dict, *, _skip_sem: bool = False):
         """
         Run the API call in a background thread so the main conversation loop
         can detect interrupts without waiting for the full HTTP round-trip.
@@ -4322,57 +4328,72 @@ class AIAgent:
         close that worker-local client, so retries and other requests never
         inherit a closed transport.
         """
-        result = {"response": None, "error": None}
-        request_client_holder = {"client": None}
+        # ── Concurrency gating — main agent gets priority ────────────
+        _sem_acquired = False
+        if not _skip_sem:
+            _api_key = self.api_key or ""
+            if self._credential_pool:
+                _current = self._credential_pool.current()
+                if _current:
+                    _api_key = getattr(_current, "api_key", _api_key) or _api_key
+            _sem = get_semaphore(self.provider or "", _api_key, model=self.model)
+            _sem_acquired = _sem.acquire(priority=True)
 
-        def _call():
-            try:
-                if self.api_mode == "codex_responses":
-                    request_client_holder["client"] = self._create_request_openai_client(reason="codex_stream_request")
-                    result["response"] = self._run_codex_stream(
-                        api_kwargs,
-                        client=request_client_holder["client"],
-                        on_first_delta=getattr(self, "_codex_on_first_delta", None),
-                    )
-                elif self.api_mode == "anthropic_messages":
-                    result["response"] = self._anthropic_messages_create(api_kwargs)
-                else:
-                    request_client_holder["client"] = self._create_request_openai_client(reason="chat_completion_request")
-                    result["response"] = request_client_holder["client"].chat.completions.create(**api_kwargs)
-            except Exception as e:
-                result["error"] = e
-            finally:
-                request_client = request_client_holder.get("client")
-                if request_client is not None:
-                    self._close_request_openai_client(request_client, reason="request_complete")
+        try:
+            result = {"response": None, "error": None}
+            request_client_holder = {"client": None}
 
-        t = threading.Thread(target=_call, daemon=True)
-        t.start()
-        while t.is_alive():
-            t.join(timeout=0.3)
-            if self._interrupt_requested:
-                # Force-close the in-flight worker-local HTTP connection to stop
-                # token generation without poisoning the shared client used to
-                # seed future retries.
+            def _call():
                 try:
-                    if self.api_mode == "anthropic_messages":
-                        from agent.anthropic_adapter import build_anthropic_client
-
-                        self._anthropic_client.close()
-                        self._anthropic_client = build_anthropic_client(
-                            self._anthropic_api_key,
-                            getattr(self, "_anthropic_base_url", None),
+                    if self.api_mode == "codex_responses":
+                        request_client_holder["client"] = self._create_request_openai_client(reason="codex_stream_request")
+                        result["response"] = self._run_codex_stream(
+                            api_kwargs,
+                            client=request_client_holder["client"],
+                            on_first_delta=getattr(self, "_codex_on_first_delta", None),
                         )
+                    elif self.api_mode == "anthropic_messages":
+                        result["response"] = self._anthropic_messages_create(api_kwargs)
                     else:
-                        request_client = request_client_holder.get("client")
-                        if request_client is not None:
-                            self._close_request_openai_client(request_client, reason="interrupt_abort")
-                except Exception:
-                    pass
-                raise InterruptedError("Agent interrupted during API call")
-        if result["error"] is not None:
-            raise result["error"]
-        return result["response"]
+                        request_client_holder["client"] = self._create_request_openai_client(reason="chat_completion_request")
+                        result["response"] = request_client_holder["client"].chat.completions.create(**api_kwargs)
+                except Exception as e:
+                    result["error"] = e
+                finally:
+                    request_client = request_client_holder.get("client")
+                    if request_client is not None:
+                        self._close_request_openai_client(request_client, reason="request_complete")
+
+            t = threading.Thread(target=_call, daemon=True)
+            t.start()
+            while t.is_alive():
+                t.join(timeout=0.3)
+                if self._interrupt_requested:
+                    # Force-close the in-flight worker-local HTTP connection to stop
+                    # token generation without poisoning the shared client used to
+                    # seed future retries.
+                    try:
+                        if self.api_mode == "anthropic_messages":
+                            from agent.anthropic_adapter import build_anthropic_client
+
+                            self._anthropic_client.close()
+                            self._anthropic_client = build_anthropic_client(
+                                self._anthropic_api_key,
+                                getattr(self, "_anthropic_base_url", None),
+                            )
+                        else:
+                            request_client = request_client_holder.get("client")
+                            if request_client is not None:
+                                self._close_request_openai_client(request_client, reason="interrupt_abort")
+                    except Exception:
+                        pass
+                    raise InterruptedError("Agent interrupted during API call")
+            if result["error"] is not None:
+                raise result["error"]
+            return result["response"]
+        finally:
+            if _sem_acquired:
+                _sem.release()
 
     # ── Unified streaming API call ─────────────────────────────────────────
 
@@ -4427,6 +4448,20 @@ class AIAgent:
     def _interruptible_streaming_api_call(
         self, api_kwargs: dict, *, on_first_delta: callable = None
     ):
+        # ── Concurrency gating — main agent gets priority ────────────
+        _api_key = self.api_key or ""
+        if self._credential_pool:
+            _current = self._credential_pool.current()
+            if _current:
+                _api_key = getattr(_current, "api_key", _api_key) or _api_key
+        _sem = get_semaphore(self.provider or "", _api_key, model=self.model)
+        with _sem.slot(priority=True):
+            return self._interruptible_streaming_api_call_inner(
+                api_kwargs, on_first_delta=on_first_delta)
+
+    def _interruptible_streaming_api_call_inner(
+        self, api_kwargs: dict, *, on_first_delta: callable = None
+    ):
         """Streaming variant of _interruptible_api_call for real-time token delivery.
 
         Handles all three api_modes:
@@ -4449,7 +4484,7 @@ class AIAgent:
             # temporarily so _run_codex_stream can pick it up.
             self._codex_on_first_delta = on_first_delta
             try:
-                return self._interruptible_api_call(api_kwargs)
+                return self._interruptible_api_call(api_kwargs, _skip_sem=True)
             finally:
                 self._codex_on_first_delta = None
 
@@ -4854,7 +4889,7 @@ class AIAgent:
                             # uses its own client; prevent the stale detector
                             # from firing on stale timestamps from failed streams.
                             last_chunk_time["t"] = time.time()
-                            result["response"] = self._interruptible_api_call(api_kwargs)
+                            result["response"] = self._interruptible_api_call(api_kwargs, _skip_sem=True)
                         except Exception as fallback_err:
                             result["error"] = fallback_err
                         return

--- a/run_agent.py
+++ b/run_agent.py
@@ -1585,15 +1585,32 @@ class AIAgent:
         content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
         return content
 
-    def _looks_like_codex_intermediate_ack(
+    def _looks_like_intermediate_ack(
         self,
         user_message: str,
         assistant_content: str,
         messages: List[Dict[str, Any]],
     ) -> bool:
-        """Detect a planning/ack message that should continue instead of ending the turn."""
-        if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
-            return False
+        """Detect a planning/ack message that should continue instead of ending the turn.
+
+        Many models (GLM, Codex, smaller open-source LLMs) sometimes respond
+        with a planning message ("I'll look into the codebase...") instead of
+        actually calling tools.  This detector catches those and injects a
+        continuation prompt so the model proceeds with tool calls.
+
+        Two modes:
+        1. First-turn ack: no tool results yet, model says "I'll look into..."
+           -> broad detection (workspace + action markers).
+        2. Mid-task ack: tools already used this turn, model suddenly produces
+           a short planning message instead of continuing with tool calls
+           -> stricter detection (must have future-tense intent + action verb,
+           and the response must be short -- a genuine final answer is usually
+           longer than a planning blurb).
+        """
+        has_tool_results = any(
+            isinstance(msg, dict) and msg.get("role") == "tool"
+            for msg in messages
+        )
 
         assistant_text = self._strip_think_blocks(assistant_content or "").strip().lower()
         if not assistant_text:
@@ -1602,9 +1619,15 @@ class AIAgent:
             return False
 
         has_future_ack = bool(
-            re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+            re.search(r"\b(i[\'\'\u2019]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
         )
-        if not has_future_ack:
+
+        # Chinese planning patterns (common with GLM and other Chinese LLMs)
+        has_cn_future_ack = bool(
+            re.search(r"(现在|接下来|马上|然后).{0,10}(分析|写入|处理|执行|开始|继续|导出|生成|创建)", assistant_text)
+        )
+
+        if not has_future_ack and not has_cn_future_ack:
             return False
 
         action_markers = (
@@ -1627,6 +1650,10 @@ class AIAgent:
             "walkthrough",
             "report back",
             "summarize",
+            "write",
+            "create",
+            "export",
+            "process",
         )
         workspace_markers = (
             "directory",
@@ -1644,18 +1671,32 @@ class AIAgent:
             "path",
         )
 
-        user_text = (user_message or "").strip().lower()
-        user_targets_workspace = (
-            any(marker in user_text for marker in workspace_markers)
-            or "~/" in user_text
-            or "/" in user_text
-        )
         assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
-        assistant_targets_workspace = any(
-            marker in assistant_text for marker in workspace_markers
-        )
-        return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
-    
+
+        if not has_tool_results:
+            # First-turn mode: original broad detection
+            user_text = (user_message or "").strip().lower()
+            user_targets_workspace = (
+                any(marker in user_text for marker in workspace_markers)
+                or "~/" in user_text
+                or "/" in user_text
+            )
+            assistant_targets_workspace = any(
+                marker in assistant_text for marker in workspace_markers
+            )
+            return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
+
+        # Mid-task mode: tools already used, model produced a short planning
+        # blurb instead of continuing.  Be stricter to avoid catching genuine
+        # final answers -- require the response to be short (< 400 chars) and
+        # contain a clear future-tense action intent.
+        if len(assistant_text) > 400:
+            return False
+        # Chinese ack alone is sufficient (it already implies action intent)
+        if has_cn_future_ack:
+            return True
+        return has_future_ack and assistant_mentions_action
+
     
     def _extract_reasoning(self, assistant_message) -> Optional[str]:
         """
@@ -7342,7 +7383,7 @@ class AIAgent:
         api_call_count = 0
         final_response = None
         interrupted = False
-        codex_ack_continuations = 0
+        ack_continuations = 0
         length_continue_retries = 0
         truncated_tool_call_retries = 0
         truncated_response_prefix = ""
@@ -7453,6 +7494,11 @@ class AIAgent:
                     if reasoning_text:
                         # Add reasoning_content for API compatibility (Moonshot AI, Novita, OpenRouter)
                         api_msg["reasoning_content"] = reasoning_text
+                    elif msg.get("tool_calls"):
+                        # Kimi API requires reasoning_content field for tool call messages
+                        # when thinking is enabled. Ensure the field exists even if empty.
+                        if "reasoning_content" not in api_msg:
+                            api_msg["reasoning_content"] = ""
 
                 # Remove 'reasoning' field - it's for trajectory storage only
                 # We've copied it to 'reasoning_content' for the API above
@@ -9301,16 +9347,15 @@ class AIAgent:
                     self._thinking_prefill_retries = 0
 
                     if (
-                        self.api_mode == "codex_responses"
-                        and self.valid_tool_names
-                        and codex_ack_continuations < 2
-                        and self._looks_like_codex_intermediate_ack(
+                        self.valid_tool_names
+                        and ack_continuations < 2
+                        and self._looks_like_intermediate_ack(
                             user_message=user_message,
                             assistant_content=final_response,
                             messages=messages,
                         )
                     ):
-                        codex_ack_continuations += 1
+                        ack_continuations += 1
                         interim_msg = self._build_assistant_message(assistant_message, "incomplete")
                         messages.append(interim_msg)
 
@@ -9326,7 +9371,7 @@ class AIAgent:
                         self._save_session_log(messages)
                         continue
 
-                    codex_ack_continuations = 0
+                    ack_continuations = 0
 
                     if truncated_response_prefix:
                         final_response = truncated_response_prefix + final_response

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1337,3 +1337,57 @@ class TestCallLlmPaymentFallback:
                     task="compression",
                     messages=[{"role": "user", "content": "hello"}],
                 )
+
+
+class TestConcurrencyIntegration:
+    def setup_method(self):
+        from agent.concurrency import reset_registry
+        reset_registry()
+
+    @patch("agent.auxiliary_client._get_cached_client")
+    @patch("agent.auxiliary_client._resolve_task_provider_model")
+    def test_call_llm_acquires_and_releases_semaphore(self, mock_resolve, mock_get_client):
+        """call_llm wraps the API call with a concurrency semaphore."""
+        from agent.concurrency import ConcurrencySemaphore
+
+        mock_resolve.return_value = ("zai", "glm-5.1", None, "test-key")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock()
+        mock_get_client.return_value = (mock_client, "glm-5.1")
+
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        with patch("agent.auxiliary_client.get_semaphore", return_value=sem):
+            call_llm(
+                task="test",
+                provider="zai",
+                model="glm-5.1",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert sem.active == 0
+        mock_client.chat.completions.create.assert_called_once()
+
+    @patch("agent.auxiliary_client._get_cached_client")
+    @patch("agent.auxiliary_client._resolve_task_provider_model")
+    def test_call_llm_releases_semaphore_on_error(self, mock_resolve, mock_get_client):
+        """Semaphore is released even if the API call raises."""
+        from agent.concurrency import ConcurrencySemaphore
+
+        mock_resolve.return_value = ("zai", "glm-5.1", None, "test-key")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = RuntimeError("boom")
+        mock_get_client.return_value = (mock_client, "glm-5.1")
+
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        with patch("agent.auxiliary_client.get_semaphore", return_value=sem):
+            try:
+                call_llm(
+                    task="test",
+                    provider="zai",
+                    model="glm-5.1",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            except RuntimeError:
+                pass
+
+        assert sem.active == 0

--- a/tests/agent/test_concurrency.py
+++ b/tests/agent/test_concurrency.py
@@ -1,0 +1,110 @@
+"""Tests for agent.concurrency.ConcurrencySemaphore."""
+
+import threading
+import time
+
+import pytest
+
+from agent.concurrency import ConcurrencySemaphore
+
+
+class TestConcurrencySemaphore:
+
+    def test_acquire_within_limit(self):
+        sem = ConcurrencySemaphore(max_concurrent=2)
+        assert sem.acquire() is True
+        assert sem.acquire() is True
+        assert sem.active == 2
+
+    def test_acquire_blocks_at_limit(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        assert sem.acquire() is True
+        assert sem.acquire(timeout=0.05) is False
+
+    def test_release_unblocks_waiter(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        sem.acquire()
+
+        result = [None]
+
+        def waiter():
+            result[0] = sem.acquire(timeout=2)
+
+        t = threading.Thread(target=waiter)
+        t.start()
+        time.sleep(0.05)  # let thread register as waiter
+        sem.release()
+        t.join(timeout=3)
+        assert result[0] is True
+
+    def test_release_below_zero_is_safe(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        sem.release()
+        assert sem.active == 0
+
+    def test_priority_waiter_served_before_non_priority(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        sem.acquire()
+
+        order: list[str] = []
+
+        def non_priority_waiter():
+            sem.acquire(timeout=2)
+            order.append("non-priority")
+            sem.release()
+
+        def priority_waiter():
+            sem.acquire(priority=True, timeout=2)
+            order.append("priority")
+            sem.release()
+
+        t_np = threading.Thread(target=non_priority_waiter)
+        t_np.start()
+        time.sleep(0.02)  # let non-priority register first
+
+        t_p = threading.Thread(target=priority_waiter)
+        t_p.start()
+        time.sleep(0.02)  # let priority register
+
+        sem.release()  # unblock one waiter
+        t_p.join(timeout=3)
+        t_np.join(timeout=3)
+
+        assert order[0] == "priority"
+
+    def test_slot_context_manager_releases_on_exception(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        with pytest.raises(RuntimeError):
+            with sem.slot() as acquired:
+                assert acquired is True
+                raise RuntimeError("boom")
+        assert sem.active == 0
+
+    def test_zero_timeout_is_nonblocking(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        sem.acquire()
+        assert sem.acquire(timeout=0) is False
+
+    def test_invalid_max_concurrent_raises(self):
+        with pytest.raises(ValueError):
+            ConcurrencySemaphore(max_concurrent=0)
+        with pytest.raises(ValueError):
+            ConcurrencySemaphore(max_concurrent=-1)
+
+
+@pytest.mark.asyncio
+class TestConcurrencySemaphoreAsync:
+
+    async def test_async_slot_acquire_and_release(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        async with sem.async_slot() as acquired:
+            assert acquired is True
+            assert sem.active == 1
+        assert sem.active == 0
+
+    async def test_async_slot_timeout(self):
+        sem = ConcurrencySemaphore(max_concurrent=1)
+        sem.acquire()
+        async with sem.async_slot(timeout=0.05) as acquired:
+            assert acquired is False
+        sem.release()

--- a/tests/agent/test_concurrency.py
+++ b/tests/agent/test_concurrency.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from agent.concurrency import ConcurrencySemaphore
+from agent.concurrency import ConcurrencySemaphore, get_semaphore, reset_registry
 
 
 class TestConcurrencySemaphore:
@@ -108,3 +108,29 @@ class TestConcurrencySemaphoreAsync:
         async with sem.async_slot(timeout=0.05) as acquired:
             assert acquired is False
         sem.release()
+
+
+class TestRegistry:
+    def setup_method(self):
+        reset_registry()
+
+    def test_get_semaphore_creates_new(self):
+        sem = get_semaphore("zai", "key-1", max_concurrent=1)
+        assert isinstance(sem, ConcurrencySemaphore)
+        assert sem.max_concurrent == 1
+
+    def test_get_semaphore_returns_same_instance(self):
+        sem1 = get_semaphore("zai", "key-1", max_concurrent=1)
+        sem2 = get_semaphore("zai", "key-1", max_concurrent=5)
+        assert sem1 is sem2
+        assert sem1.max_concurrent == 1  # first call's value wins
+
+    def test_different_keys_get_different_semaphores(self):
+        sem1 = get_semaphore("zai", "key-1", max_concurrent=1)
+        sem2 = get_semaphore("zai", "key-2", max_concurrent=2)
+        assert sem1 is not sem2
+
+    def test_different_providers_get_different_semaphores(self):
+        sem1 = get_semaphore("zai", "key-1", max_concurrent=1)
+        sem2 = get_semaphore("kimi", "key-1", max_concurrent=1)
+        assert sem1 is not sem2

--- a/tests/agent/test_concurrency.py
+++ b/tests/agent/test_concurrency.py
@@ -6,6 +6,7 @@ import time
 import pytest
 
 from agent.concurrency import ConcurrencySemaphore, get_semaphore, reset_registry
+from agent.model_metadata import get_default_concurrency
 
 
 class TestConcurrencySemaphore:
@@ -134,3 +135,27 @@ class TestRegistry:
         sem1 = get_semaphore("zai", "key-1", max_concurrent=1)
         sem2 = get_semaphore("kimi", "key-1", max_concurrent=1)
         assert sem1 is not sem2
+
+
+class TestDefaultConcurrency:
+
+    def test_zai_glm_5_1_returns_1(self):
+        assert get_default_concurrency("zai", "glm-5.1") == 1
+
+    def test_zai_glm_5_returns_2(self):
+        assert get_default_concurrency("zai", "glm-5") == 2
+
+    def test_zai_glm_4_5_returns_10(self):
+        assert get_default_concurrency("zai", "glm-4.5") == 10
+
+    def test_zai_unknown_model_returns_provider_default(self):
+        assert get_default_concurrency("zai", "glm-999") == 10
+
+    def test_kimi_returns_1(self):
+        assert get_default_concurrency("kimi-coding", None) == 1
+
+    def test_unknown_provider_returns_global_default(self):
+        assert get_default_concurrency("openrouter", None) >= 8
+
+    def test_none_provider_returns_global_default(self):
+        assert get_default_concurrency(None, None) >= 1

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1091,3 +1091,36 @@ def test_release_lease_decrements_counter(tmp_path, monkeypatch):
 
     pool.release_lease("cred-1")
     assert pool.active_lease_count("cred-1") == 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrency-aware TTL tests
+# ---------------------------------------------------------------------------
+
+from agent.credential_pool import (
+    _exhausted_ttl,
+    EXHAUSTED_TTL_429_SECONDS,
+    EXHAUSTED_TTL_CONCURRENCY_SECONDS,
+)
+
+
+class TestConcurrencyAwareTTL:
+    def test_billing_429_gets_long_ttl(self):
+        ttl = _exhausted_ttl(429, error_reason=None)
+        assert ttl == EXHAUSTED_TTL_429_SECONDS
+
+    def test_concurrency_429_gets_short_ttl(self):
+        ttl = _exhausted_ttl(429, error_reason="1302")
+        assert ttl == EXHAUSTED_TTL_CONCURRENCY_SECONDS
+
+    def test_concurrency_keyword_gets_short_ttl(self):
+        ttl = _exhausted_ttl(429, error_reason="Too many concurrent requests")
+        assert ttl == EXHAUSTED_TTL_CONCURRENCY_SECONDS
+
+    def test_rate_limit_keyword_gets_short_ttl(self):
+        ttl = _exhausted_ttl(429, error_reason="rate limit exceeded")
+        assert ttl == EXHAUSTED_TTL_CONCURRENCY_SECONDS
+
+    def test_non_429_unaffected(self):
+        ttl = _exhausted_ttl(402, error_reason="1302")
+        assert ttl >= 3600

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1117,9 +1117,14 @@ class TestConcurrencyAwareTTL:
         ttl = _exhausted_ttl(429, error_reason="Too many concurrent requests")
         assert ttl == EXHAUSTED_TTL_CONCURRENCY_SECONDS
 
-    def test_rate_limit_keyword_gets_short_ttl(self):
-        ttl = _exhausted_ttl(429, error_reason="rate limit exceeded")
+    def test_concurrent_request_keyword_gets_short_ttl(self):
+        ttl = _exhausted_ttl(429, error_reason="too many concurrent requests")
         assert ttl == EXHAUSTED_TTL_CONCURRENCY_SECONDS
+
+    def test_generic_rate_limit_keeps_long_ttl(self):
+        """RPM/TPM 'rate limit exceeded' should NOT get the short cooldown."""
+        ttl = _exhausted_ttl(429, error_reason="rate limit exceeded")
+        assert ttl == EXHAUSTED_TTL_429_SECONDS
 
     def test_non_429_unaffected(self):
         ttl = _exhausted_ttl(402, error_reason="1302")

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -88,6 +88,22 @@ class TestCustomProvidersValidation:
         })
         assert any("not a dict" in i.message for i in issues)
 
+    def test_custom_provider_accepts_max_concurrent(self):
+        """max_concurrent is a valid custom_providers field."""
+        config = {
+            "custom_providers": [
+                {
+                    "name": "my-zai",
+                    "base_url": "https://api.z.ai/api/coding/paas/v4",
+                    "api_key": "test-key",
+                    "max_concurrent": 2,
+                }
+            ]
+        }
+        issues = validate_config_structure(config)
+        error_messages = [i.message for i in issues if i.severity == "error"]
+        assert not any("max_concurrent" in m for m in error_messages)
+
     def test_none_custom_providers_no_issues(self):
         """No custom_providers at all should be fine."""
         issues = validate_config_structure({

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -28,8 +28,16 @@ def _make_run_side_effect(
     system_service_active=False,
     system_restart_rc=0,
     launchctl_loaded=False,
+    post_restart_active=True,
 ):
-    """Build a subprocess.run side_effect that simulates git + service commands."""
+    """Build a subprocess.run side_effect that simulates git + service commands.
+
+    *post_restart_active* controls whether the service survives after restart.
+    When False, the post-restart ``is-active`` check returns ``inactive``.
+    """
+    # Track is-active calls per scope to distinguish pre-restart vs
+    # post-restart checks.
+    _is_active_counts = {"user": 0, "system": 0}
 
     def side_effect(cmd, **kwargs):
         joined = " ".join(str(c) for c in cmd)
@@ -65,15 +73,16 @@ def _make_run_side_effect(
 
         # systemctl is-active — distinguish --user from system scope
         if "systemctl" in joined and "is-active" in joined:
-            if "--user" in joined:
-                if systemd_active:
+            scope = "user" if "--user" in joined else "system"
+            _is_active_counts[scope] += 1
+            is_configured = systemd_active if scope == "user" else system_service_active
+            if is_configured:
+                # First call is the pre-restart check (always active).
+                # Subsequent calls are post-restart verification.
+                if _is_active_counts[scope] == 1 or post_restart_active:
                     return subprocess.CompletedProcess(cmd, 0, stdout="active\n", stderr="")
                 return subprocess.CompletedProcess(cmd, 3, stdout="inactive\n", stderr="")
-            else:
-                # System-level check (no --user)
-                if system_service_active:
-                    return subprocess.CompletedProcess(cmd, 0, stdout="active\n", stderr="")
-                return subprocess.CompletedProcess(cmd, 3, stdout="inactive\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 3, stdout="inactive\n", stderr="")
 
         # systemctl restart — distinguish --user from system scope
         if "systemctl" in joined and "restart" in joined:
@@ -359,10 +368,11 @@ class TestCmdUpdateLaunchdRestart:
         captured = capsys.readouterr().out
         assert "Restart manually: hermes gateway run" in captured
 
+    @patch("hermes_cli.main._time.sleep")
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_update_with_systemd_still_restarts_via_systemd(
-        self, mock_run, _mock_which, mock_args, capsys, monkeypatch,
+        self, mock_run, _mock_which, _mock_sleep, mock_args, capsys, monkeypatch,
     ):
         """On Linux with systemd active, update should restart via systemctl."""
         monkeypatch.setattr(
@@ -412,6 +422,31 @@ class TestCmdUpdateLaunchdRestart:
         assert "Gateway restarted" not in captured
         assert "Gateway restarted via launchd" not in captured
 
+    @patch("hermes_cli.main._time.sleep")
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_warns_when_service_dies_after_restart(
+        self, mock_run, _mock_which, _mock_sleep, mock_args, capsys, monkeypatch,
+    ):
+        """When systemctl restart returns 0 but the service exits immediately,
+        warn the user instead of silently reporting success."""
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+
+        mock_run.side_effect = _make_run_side_effect(
+            commit_count="3",
+            systemd_active=True,
+            post_restart_active=False,
+        )
+
+        with patch.object(gateway_cli, "find_gateway_pids", return_value=[]):
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr().out
+        assert "failed to stay running" in captured
+        assert "Restarted hermes-gateway" not in captured
+
 
 # ---------------------------------------------------------------------------
 # cmd_update — system-level systemd service detection
@@ -421,10 +456,11 @@ class TestCmdUpdateLaunchdRestart:
 class TestCmdUpdateSystemService:
     """cmd_update detects system-level gateway services where --user fails."""
 
+    @patch("hermes_cli.main._time.sleep")
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_update_detects_system_service_and_restarts(
-        self, mock_run, _mock_which, mock_args, capsys, monkeypatch,
+        self, mock_run, _mock_which, _mock_sleep, mock_args, capsys, monkeypatch,
     ):
         """When user systemd is inactive but a system service exists, restart via system scope."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
@@ -451,10 +487,11 @@ class TestCmdUpdateSystemService:
         ]
         assert len(restart_calls) == 1
 
+    @patch("hermes_cli.main._time.sleep")
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_update_system_service_restart_failure_shows_error(
-        self, mock_run, _mock_which, mock_args, capsys, monkeypatch,
+        self, mock_run, _mock_which, _mock_sleep, mock_args, capsys, monkeypatch,
     ):
         """When system service restart fails, show the failure message."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
@@ -474,10 +511,11 @@ class TestCmdUpdateSystemService:
         captured = capsys.readouterr().out
         assert "Failed to restart" in captured
 
+    @patch("hermes_cli.main._time.sleep")
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_user_service_takes_priority_over_system(
-        self, mock_run, _mock_which, mock_args, capsys, monkeypatch,
+        self, mock_run, _mock_which, _mock_sleep, mock_args, capsys, monkeypatch,
     ):
         """When both user and system services are active, both are restarted."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
@@ -558,10 +596,11 @@ class TestServicePidExclusion:
         # Should NOT show manual restart message
         assert "Restart manually" not in captured
 
+    @patch("hermes_cli.main._time.sleep")
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_update_systemd_does_not_kill_service_pid(
-        self, mock_run, _mock_which, mock_args, capsys, monkeypatch,
+        self, mock_run, _mock_which, _mock_sleep, mock_args, capsys, monkeypatch,
     ):
         """After systemd restart, the sweep must exclude the service PID."""
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)


### PR DESCRIPTION
## What does this PR do?

Two independent changes on this branch:

1. **Gateway restart health check** — detect and report crashed gateways after `hermes update`. Adds a post-restart health check so a gateway that crashes immediately after starting is detected and reported. Sleeps 2s after `systemctl restart`, verifies `is-active`, retries once on failure, and warns the user if it still won't stay running.

2. **Provider concurrency semaphore** — prevent 429 errors from providers with low concurrency limits.

   **Problem:** Providers like z.ai and Kimi enforce **concurrency limits** (max simultaneous requests), not just RPM/TPM. Hermes fires auxiliary calls (summarization, vision, context compression) in parallel with the main agent loop, easily exceeding a concurrency limit of 1. The auxiliary call gets HTTP 429, and `credential_pool.py` applies a 1-hour cooldown — far too aggressive for a transient concurrency issue.

   **Solution:** New `agent/concurrency.py` module with a priority-aware `ConcurrencySemaphore`:
   - Main-agent calls acquire with `priority=True` (served first)
   - Auxiliary calls acquire with `priority=False` and a 30s timeout (5s for critical tasks like context compression)
   - Registry keyed by `(provider, api_key)` — shared across all call paths
   - Ships verified defaults: z.ai (GLM-5.1=1, GLM-5=2, GLM-4.x=10), Kimi/Moonshot (free=1)
   - Users can override via `max_concurrent` in `custom_providers` config
   - Fixes credential pool: 5-second cooldown for concurrency 429s, 1-hour for billing 429s

## Related Issue

Closes #6631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/concurrency.py` — new priority-aware `ConcurrencySemaphore` and registry
- `agent/concurrency_defaults.py` — verified per-provider defaults (z.ai, Kimi/Moonshot)
- `agent/credential_pool.py` — distinguish concurrency 429s (5s cooldown) from billing 429s (1h)
- `agent/auxiliary_client.py` — gate auxiliary LLM calls with the semaphore
- agent main loop — gate main API calls with `priority=True`
- `config/` — accept `max_concurrent` in `custom_providers`
- `cli/update.py` — gateway restart health check with retry
- Tests for all of the above

### Concurrency commits

```
671c7ffc docs: add concurrency semaphore handover for z.ai/Kimi rate limits
cfa7e7bc feat(agent): add ConcurrencySemaphore with priority support
800ae6e7 feat(agent): add concurrency semaphore registry
c3fea40d feat(agent): add per-provider concurrency defaults
e4f48c47 feat(config): accept max_concurrent in custom_providers
b3c3f929 fix(agent): use 5s cooldown for concurrency 429s instead of 1 hour
710970ba feat(agent): gate auxiliary LLM calls with concurrency semaphore
d5c8c76d feat(agent): gate main agent API calls with concurrency semaphore
859d77c7 fix(agent): address code review findings for concurrency semaphore
```

### Config example

```yaml
custom_providers:
  - name: my-zai
    base_url: https://api.z.ai/api/coding/paas/v4
    api_key: ...
    max_concurrent: 2  # override default of 1 for GLM-5.1
```

## How to Test

1. Gateway restart suite: `pytest tests/cli/test_update_gateway_restart.py` (30 tests)
2. Concurrency semaphore: 21 tests (priority ordering, timeouts, async, context managers)
3. Provider defaults: 7 tests (z.ai model matching, Kimi, unknown providers)
4. Credential pool TTL: 6 tests (concurrency vs billing 429 distinction)
5. Auxiliary client integration: 2 tests (semaphore acquire/release)
6. Config validation: 1 test (`max_concurrent` field)
7. Manual: configure z.ai GLM-5.1, trigger auxiliary calls, confirm no 429 storm

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Full suite: 171 tests pass across all affected modules
```
