### PR TITLE
fix: add missing 'import os' in uninstall.py

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -6,6 +6,7 @@ Provides options for:
 - Keep data: Remove code but keep ~/.hermes/ (configs, sessions, logs)
 """
 
+import os
 import shutil
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
`os.getenv()` is called on line 126 of `hermes_cli/uninstall.py` but `os` is never imported, causing a `NameError` when running `hermes uninstall`:

\`\`\`
File "/root/.hermes/hermes-agent/hermes_cli/uninstall.py", line 126, in uninstall_gateway_service
    prefix = os.getenv("PREFIX", "")
             ^^
NameError: name 'os' is not defined
\`\`\`

One-line fix — add \`import os\` to the imports at the top of the file.