### PR TITLE
feat: add Astraflow as a first-class provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -73,6 +73,11 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "astra-flow": "astraflow",
+    "astra_flow": "astraflow",
+    "modelverse": "astraflow",
+    "astraflow-china": "astraflow-cn",
+    "astraflow_cn": "astraflow-cn",
 }
 
 
@@ -106,6 +111,8 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    "astraflow": "claude-haiku-4-5-20251001",
+    "astraflow-cn": "deepseek-ai/DeepSeek-V3.2",
 }
 
 # OpenRouter app attribution headers

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -26,7 +26,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
-    "qwen-oauth",
+    "qwen-oauth", "astraflow", "astraflow-cn",
     "custom", "local",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
@@ -34,6 +34,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
     "qwen-portal",
+    "astra-flow", "astra_flow", "modelverse", "astraflow-china", "astraflow_cn",
 })
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -98,6 +98,8 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # Optional URL where users can get an API key
+    key_url: str = ""
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -242,6 +244,24 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://router.huggingface.co/v1",
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
+    ),
+    "astraflow": ProviderConfig(
+        id="astraflow",
+        name="Astraflow",
+        auth_type="api_key",
+        inference_base_url="https://api-us-ca.umodelverse.ai/v1",
+        api_key_env_vars=("ASTRAFLOW_API_KEY",),
+        base_url_env_var="ASTRAFLOW_BASE_URL",
+        key_url="https://astraflow.ucloud-global.com/en-us/modelverse/api-keys",
+    ),
+    "astraflow-cn": ProviderConfig(
+        id="astraflow-cn",
+        name="Astraflow (China)",
+        auth_type="api_key",
+        inference_base_url="https://api.modelverse.cn/v1",
+        api_key_env_vars=("ASTRAFLOW_CN_API_KEY",),
+        base_url_env_var="ASTRAFLOW_CN_BASE_URL",
+        key_url="https://astraflow.ucloud.cn/modelverse/api-keys",
     ),
 }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -966,6 +966,8 @@ def select_provider_and_model(args=None):
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
         ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
+        ("astraflow", "Astraflow (200+ curated models, pay-as-you-go)"),
+        ("astraflow-cn", "Astraflow China (100+ curated models, domestic direct API)"),
     ]
 
     # Add user-defined custom providers from config.yaml
@@ -1062,7 +1064,7 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
+    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "astraflow", "astraflow-cn"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -2287,6 +2289,9 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
 
     if not existing_key:
         print(f"No {pconfig.name} API key configured.")
+        if getattr(pconfig, "key_url", ""):
+            print(f"Get one at: {pconfig.key_url}")
+            print()
         if key_env:
             try:
                 import getpass
@@ -4312,7 +4317,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "astraflow", "astraflow-cn"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -485,6 +485,8 @@ _PROVIDER_LABELS = {
     "alibaba": "Alibaba Cloud (DashScope)",
     "qwen-oauth": "Qwen OAuth (Portal)",
     "huggingface": "Hugging Face",
+    "astraflow": "Astraflow",
+    "astraflow-cn": "Astraflow (China)",
     "custom": "Custom endpoint",
 }
 
@@ -527,6 +529,11 @@ _PROVIDER_ALIASES = {
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
+    "astra-flow": "astraflow",
+    "astra_flow": "astraflow",
+    "modelverse": "astraflow",
+    "astraflow-china": "astraflow-cn",
+    "astraflow_cn": "astraflow-cn",
 }
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -129,11 +129,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "astraflow": HermesOverlay(
         transport="openai_chat",
+        extra_env_vars=("ASTRAFLOW_API_KEY",),
         base_url_override="https://api-us-ca.umodelverse.ai/v1",
         base_url_env_var="ASTRAFLOW_BASE_URL",
     ),
     "astraflow-cn": HermesOverlay(
         transport="openai_chat",
+        extra_env_vars=("ASTRAFLOW_CN_API_KEY",),
         base_url_override="https://api.modelverse.cn/v1",
         base_url_env_var="ASTRAFLOW_CN_BASE_URL",
     ),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -127,6 +127,16 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="HF_BASE_URL",
     ),
+    "astraflow": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="https://api-us-ca.umodelverse.ai/v1",
+        base_url_env_var="ASTRAFLOW_BASE_URL",
+    ),
+    "astraflow-cn": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="https://api.modelverse.cn/v1",
+        base_url_env_var="ASTRAFLOW_CN_BASE_URL",
+    ),
 }
 
 
@@ -216,6 +226,15 @@ ALIASES: Dict[str, str] = {
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
+
+    # astraflow
+    "astra-flow": "astraflow",
+    "astra_flow": "astraflow",
+    "modelverse": "astraflow",
+
+    # astraflow-cn
+    "astraflow-china": "astraflow-cn",
+    "astraflow_cn": "astraflow-cn",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",
@@ -371,6 +390,8 @@ LABELS: Dict[str, str] = {
     "opencode-go": "OpenCode Go",
     "kilo": "Kilo Gateway",
     "huggingface": "Hugging Face",
+    "astraflow": "Astraflow",
+    "astraflow-cn": "Astraflow (China)",
     "local": "Local endpoint",
     "custom": "Custom endpoint",
     # Legacy Hermes IDs (point to same providers)

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -25,6 +25,8 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
+| **Astraflow** | `ASTRAFLOW_API_KEY` in `~/.hermes/.env` (provider: `astraflow`) |
+| **Astraflow China** | `ASTRAFLOW_CN_API_KEY` in `~/.hermes/.env` (provider: `astraflow-cn`) |
 | **Alibaba Cloud** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`, aliases: `dashscope`, `qwen`) |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
@@ -154,6 +156,14 @@ hermes chat --provider minimax --model MiniMax-M2.7
 hermes chat --provider minimax-cn --model MiniMax-M2.7
 # Requires: MINIMAX_CN_API_KEY in ~/.hermes/.env
 
+# Astraflow (global endpoint)
+hermes chat --provider astraflow --model <model-name>
+# Requires: ASTRAFLOW_API_KEY in ~/.hermes/.env
+
+# Astraflow (China endpoint)
+hermes chat --provider astraflow-cn --model <model-name>
+# Requires: ASTRAFLOW_CN_API_KEY in ~/.hermes/.env
+
 # Alibaba Cloud / DashScope (Qwen models)
 hermes chat --provider alibaba --model qwen3.5-plus
 # Requires: DASHSCOPE_API_KEY in ~/.hermes/.env
@@ -162,11 +172,11 @@ hermes chat --provider alibaba --model qwen3.5-plus
 Or set the provider permanently in `config.yaml`:
 ```yaml
 model:
-  provider: "zai"       # or: kimi-coding, minimax, minimax-cn, alibaba
+  provider: "zai"       # or: kimi-coding, minimax, minimax-cn, astraflow, astraflow-cn, alibaba
   default: "glm-5"
 ```
 
-Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, or `DASHSCOPE_BASE_URL` environment variables.
+Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `ASTRAFLOW_BASE_URL`, `ASTRAFLOW_CN_BASE_URL`, or `DASHSCOPE_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -849,7 +859,7 @@ You can also select named custom providers from the interactive `hermes model` m
 | **Cost optimization** | ClawRouter or OpenRouter with `sort: "price"` |
 | **Maximum privacy** | Ollama, vLLM, or llama.cpp (fully local) |
 | **Enterprise / Azure** | Azure OpenAI with custom endpoint |
-| **Chinese AI models** | z.ai (GLM), Kimi/Moonshot, or MiniMax (first-class providers) |
+| **Chinese AI models** | z.ai (GLM), Kimi/Moonshot, MiniMax, or Astraflow (first-class providers) |
 
 :::tip
 You can switch between providers at any time with `hermes model` — no restart required. Your conversation history, memory, and skills carry over regardless of which provider you use.
@@ -923,7 +933,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. It fires **at most once** per session.
 
-Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `deepseek`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `alibaba`, `custom`.
+Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `deepseek`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `alibaba`, `astraflow`, `astraflow-cn`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — there are no environment variables for it. For full details on when it triggers, supported providers, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/docs/user-guide/features/fallback-providers).

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -35,6 +35,10 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/v1`) |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)) |
 | `MINIMAX_CN_BASE_URL` | Override MiniMax China base URL (default: `https://api.minimaxi.com/v1`) |
+| `ASTRAFLOW_API_KEY` | Astraflow API key — global endpoint ([astraflow.ucloud-global.com](https://astraflow.ucloud-global.com/en-us/modelverse/api-keys)) |
+| `ASTRAFLOW_BASE_URL` | Override Astraflow base URL (default: `https://api-us-ca.umodelverse.ai/v1`) |
+| `ASTRAFLOW_CN_API_KEY` | Astraflow API key — China endpoint ([astraflow.ucloud.cn](https://astraflow.ucloud.cn/modelverse/api-keys)) |
+| `ASTRAFLOW_CN_BASE_URL` | Override Astraflow China base URL (default: `https://api.modelverse.cn/v1`) |
 | `KILOCODE_API_KEY` | Kilo Code API key ([kilo.ai](https://kilo.ai)) |
 | `KILOCODE_BASE_URL` | Override Kilo Code base URL (default: `https://api.kilo.ai/api/gateway`) |
 | `HF_TOKEN` | Hugging Face token for Inference Providers ([huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)) |
@@ -65,7 +69,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway`, `astraflow`, `astraflow-cn` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -46,6 +46,8 @@ Both `provider` and `model` are **required**. If either is missing, the fallback
 | Kimi / Moonshot | `kimi-coding` | `KIMI_API_KEY` |
 | MiniMax | `minimax` | `MINIMAX_API_KEY` |
 | MiniMax (China) | `minimax-cn` | `MINIMAX_CN_API_KEY` |
+| Astraflow | `astraflow` | `ASTRAFLOW_API_KEY` |
+| Astraflow (China) | `astraflow-cn` | `ASTRAFLOW_CN_API_KEY` |
 | DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` |
 | OpenCode Zen | `opencode-zen` | `OPENCODE_ZEN_API_KEY` |
 | OpenCode Go | `opencode-go` | `OPENCODE_GO_API_KEY` |


### PR DESCRIPTION
## What does this PR do?

Adds **Astraflow** as a first-class built-in provider with two regional endpoints.

- **Astraflow** (global): `https://api-us-ca.umodelverse.ai/v1`
- **Astraflow China** (domestic): `https://api.modelverse.cn/v1`

Astraflow is an LLM aggregation platform offering 200+ curated models with pay-as-you-go pricing. It uses the standard OpenAI Chat Completions protocol, so no new adapter or `api_mode` is needed.

Website: [astraflow.ucloud-global.com](https://astraflow.ucloud-global.com/en-us/modelverse/playground#all)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/providers.py` — Added `astraflow` and `astraflow-cn` to `HERMES_OVERLAYS`, `ALIASES`, and `LABELS`
- `hermes_cli/auth.py` — Added `ProviderConfig` entries with API key auth, env vars, and key-acquisition URLs; added `key_url` field to `ProviderConfig` dataclass
- `hermes_cli/models.py` — Added `_PROVIDER_LABELS` and `_PROVIDER_ALIASES` entries
- `hermes_cli/main.py` — Added to `extended_providers` menu, `--provider` CLI choices, and generic API-key flow dispatch; generic flow now prints `key_url` when prompting for missing API key
- `agent/auxiliary_client.py` — Added aux model defaults (`claude-haiku-4-5-20251001` for global, `deepseek-ai/DeepSeek-V3.2` for China) and provider aliases
- `agent/model_metadata.py` — Added provider prefixes and aliases to `_PROVIDER_PREFIXES`
- `website/docs/integrations/providers.md` — Updated provider table, CLI examples, config examples, base URL list, recommendation table, and fallback provider list
- `website/docs/reference/environment-variables.md` — Documented `ASTRAFLOW_API_KEY`, `ASTRAFLOW_BASE_URL`, `ASTRAFLOW_CN_API_KEY`, `ASTRAFLOW_CN_BASE_URL`
- `website/docs/user-guide/features/fallback-providers.md` — Added Astraflow entries to the supported providers table

## How to Test

1. Install: `uv pip install -e ".[all,dev]"`
2. Verify CLI accepts the provider:
   ```bash
   hermes chat --provider astraflow --help
   ```
3. Run the interactive model flow:
   ```bash
   hermes model
   # → "More providers..." → Astraflow / Astraflow China should appear
   ```
4. With a valid API key:
   ```bash
   export ASTRAFLOW_API_KEY="your-key"
   hermes chat --provider astraflow --model claude-sonnet-4-6 -q "Say hello"
   ```
5. Run existing tests: `python -m pytest tests/ -q` (all 4441 tests pass, no regressions)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — existing generic provider tests cover the new entries via `PROVIDER_REGISTRY` and runtime resolution
- [x] I've tested on my platform: macOS (Darwin 25.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/`)
- [x] N/A — no new config keys beyond env vars
- [x] N/A — no architecture changes
- [x] N/A — standard OpenAI-compatible provider, no platform-specific code
- [x] N/A — no tool changes