### PR TITLE
[codex] Batch split inbound messages across gateway adapters

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -422,6 +422,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Discord message limits
     MAX_MESSAGE_LENGTH = 2000
+    _SPLIT_THRESHOLD = 1900
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
@@ -431,6 +432,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
+        self._text_batch_delay_seconds = float(
+            os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6")
+        )
+        self._text_batch_split_delay_seconds = float(
+            os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        )
+        self._pending_text_batches: Dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
@@ -698,6 +707,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._client.close()
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.warning("[%s] Error during disconnect: %s", self.name, e, exc_info=True)
+
+        if self._pending_text_batch_tasks:
+            for task in self._pending_text_batch_tasks.values():
+                task.cancel()
+            await asyncio.gather(*self._pending_text_batch_tasks.values(), return_exceptions=True)
+            self._pending_text_batch_tasks.clear()
+            self._pending_text_batches.clear()
 
         self._running = False
         self._client = None
@@ -2466,7 +2482,86 @@ class DiscordAdapter(BasePlatformAdapter):
         if thread_id:
             self._track_thread(thread_id)
 
+        if self._should_batch_text_event(event):
+            await self._handle_text_event(event)
+            return
+
         await self.handle_message(event)
+
+    def _should_batch_text_event(self, event: MessageEvent) -> bool:
+        """Return True when a plain text Discord event is eligible for batching."""
+        return (
+            event.message_type == MessageType.TEXT
+            and not event.is_command()
+            and not event.media_urls
+        )
+
+    def _text_batch_key(self, event: MessageEvent) -> str:
+        """Return the session-scoped key used for Discord text aggregation."""
+        from gateway.session import build_session_key
+
+        session_key = build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+        return f"{session_key}:reply:{event.reply_to_message_id or ''}"
+
+    async def _handle_text_event(self, event: MessageEvent) -> None:
+        """Dispatch short Discord text immediately and batch likely split chunks."""
+        key = self._text_batch_key(event)
+        if key in self._pending_text_batches or len(event.text or "") >= self._SPLIT_THRESHOLD:
+            self._enqueue_text_event(event, key=key)
+            return
+        await self.handle_message(event)
+
+    def _enqueue_text_event(self, event: MessageEvent, *, key: Optional[str] = None) -> None:
+        """Buffer a text event and reset the flush timer."""
+        batch_key = key or self._text_batch_key(event)
+        existing = self._pending_text_batches.get(batch_key)
+        chunk_len = len(event.text or "")
+        if existing is None:
+            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            self._pending_text_batches[batch_key] = event
+        else:
+            if event.text:
+                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            existing.timestamp = event.timestamp
+            if event.message_id:
+                existing.message_id = event.message_id
+
+        prior_task = self._pending_text_batch_tasks.get(batch_key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_text_batch_tasks[batch_key] = asyncio.create_task(
+            self._flush_text_batch(batch_key)
+        )
+
+    async def _flush_text_batch(self, key: str) -> None:
+        """Wait for the quiet period then dispatch the aggregated text."""
+        current_task = asyncio.current_task()
+        try:
+            pending = self._pending_text_batches.get(key)
+            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+            delay = (
+                self._text_batch_split_delay_seconds
+                if last_len >= self._SPLIT_THRESHOLD
+                else self._text_batch_delay_seconds
+            )
+            await asyncio.sleep(delay)
+            event = self._pending_text_batches.pop(key, None)
+            if not event:
+                return
+            logger.info(
+                "[Discord] Flushing text batch %s (%d chars)",
+                key,
+                len(event.text or ""),
+            )
+            await self.handle_message(event)
+        finally:
+            if self._pending_text_batch_tasks.get(key) is current_task:
+                self._pending_text_batch_tasks.pop(key, None)
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -145,9 +145,11 @@ _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
+_DEFAULT_TEXT_BATCH_SPLIT_DELAY_SECONDS = 2.0
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
 _DEFAULT_TEXT_BATCH_MAX_CHARS = 4000
 _DEFAULT_MEDIA_BATCH_DELAY_SECONDS = 0.8
+_TEXT_BATCH_SPLIT_THRESHOLD = 3900
 _DEFAULT_DEDUP_CACHE_SIZE = 2048
 _DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 _DEFAULT_WEBHOOK_PORT = 8765
@@ -264,6 +266,7 @@ class FeishuAdapterSettings:
     bot_name: str
     dedup_cache_size: int
     text_batch_delay_seconds: float
+    text_batch_split_delay_seconds: float
     text_batch_max_messages: int
     text_batch_max_chars: int
     media_batch_delay_seconds: float
@@ -1105,6 +1108,12 @@ class FeishuAdapter(BasePlatformAdapter):
             text_batch_delay_seconds=float(
                 os.getenv("HERMES_FEISHU_TEXT_BATCH_DELAY_SECONDS", str(_DEFAULT_TEXT_BATCH_DELAY_SECONDS))
             ),
+            text_batch_split_delay_seconds=float(
+                os.getenv(
+                    "HERMES_FEISHU_TEXT_BATCH_SPLIT_DELAY_SECONDS",
+                    str(_DEFAULT_TEXT_BATCH_SPLIT_DELAY_SECONDS),
+                )
+            ),
             text_batch_max_messages=max(
                 1,
                 int(os.getenv("HERMES_FEISHU_TEXT_BATCH_MAX_MESSAGES", str(_DEFAULT_TEXT_BATCH_MAX_MESSAGES))),
@@ -1152,6 +1161,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._bot_name = settings.bot_name
         self._dedup_cache_size = settings.dedup_cache_size
         self._text_batch_delay_seconds = settings.text_batch_delay_seconds
+        self._text_batch_split_delay_seconds = settings.text_batch_split_delay_seconds
         self._text_batch_max_messages = settings.text_batch_max_messages
         self._text_batch_max_chars = settings.text_batch_max_chars
         self._media_batch_delay_seconds = settings.media_batch_delay_seconds
@@ -2479,7 +2489,9 @@ class FeishuAdapter(BasePlatformAdapter):
         """Debounce rapid Feishu text bursts into a single MessageEvent."""
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
+        chunk_len = len(event.text or "")
         if existing is None:
+            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event
             self._pending_text_batch_counts[key] = 1
             self._schedule_text_batch_flush(key)
@@ -2504,6 +2516,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
 
         existing.text = next_text
+        existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
@@ -2533,7 +2546,14 @@ class FeishuAdapter(BasePlatformAdapter):
         """Flush a pending text batch after the quiet period."""
         current_task = asyncio.current_task()
         try:
-            await asyncio.sleep(self._text_batch_delay_seconds)
+            pending = self._pending_text_batches.get(key)
+            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+            delay = (
+                self._text_batch_split_delay_seconds
+                if last_len >= _TEXT_BATCH_SPLIT_THRESHOLD
+                else self._text_batch_delay_seconds
+            )
+            await asyncio.sleep(delay)
             await self._flush_text_batch_now(key)
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -120,6 +120,8 @@ def check_matrix_requirements() -> bool:
 class MatrixAdapter(BasePlatformAdapter):
     """Gateway adapter for Matrix (any homeserver)."""
 
+    _SPLIT_THRESHOLD = 3900
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MATRIX)
 
@@ -171,6 +173,14 @@ class MatrixAdapter(BasePlatformAdapter):
         self._reactions_enabled: bool = os.getenv(
             "MATRIX_REACTIONS", "true"
         ).lower() not in ("false", "0", "no")
+        self._text_batch_delay_seconds = float(
+            os.getenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "0.6")
+        )
+        self._text_batch_split_delay_seconds = float(
+            os.getenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        )
+        self._pending_text_batches: Dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
@@ -416,6 +426,13 @@ class MatrixAdapter(BasePlatformAdapter):
         if self._client:
             await self._client.close()
             self._client = None
+
+        if self._pending_text_batch_tasks:
+            for task in self._pending_text_batch_tasks.values():
+                task.cancel()
+            await asyncio.gather(*self._pending_text_batch_tasks.values(), return_exceptions=True)
+            self._pending_text_batch_tasks.clear()
+            self._pending_text_batches.clear()
 
         logger.info("Matrix: disconnected")
 
@@ -1088,7 +1105,78 @@ class MatrixAdapter(BasePlatformAdapter):
         # Acknowledge receipt so the room shows as read (fire-and-forget).
         self._background_read_receipt(room.room_id, event.event_id)
 
+        if self._should_batch_text_event(msg_event):
+            await self._handle_text_event(msg_event)
+            return
+
         await self.handle_message(msg_event)
+
+    def _should_batch_text_event(self, event: MessageEvent) -> bool:
+        """Return True when a Matrix text event is eligible for split batching."""
+        return event.message_type == MessageType.TEXT and not event.is_command()
+
+    def _text_batch_key(self, event: MessageEvent) -> str:
+        """Return the session-scoped key used for Matrix text aggregation."""
+        from gateway.session import build_session_key
+
+        session_key = build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+        return f"{session_key}:reply:{event.reply_to_message_id or ''}"
+
+    async def _handle_text_event(self, event: MessageEvent) -> None:
+        """Dispatch short Matrix text immediately and batch likely split chunks."""
+        key = self._text_batch_key(event)
+        if key in self._pending_text_batches or len(event.text or "") >= self._SPLIT_THRESHOLD:
+            self._enqueue_text_event(event, key=key)
+            return
+        await self.handle_message(event)
+
+    def _enqueue_text_event(self, event: MessageEvent, *, key: Optional[str] = None) -> None:
+        """Buffer a text event and reset the flush timer."""
+        batch_key = key or self._text_batch_key(event)
+        existing = self._pending_text_batches.get(batch_key)
+        chunk_len = len(event.text or "")
+        if existing is None:
+            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            self._pending_text_batches[batch_key] = event
+        else:
+            if event.text:
+                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            existing.timestamp = event.timestamp
+            if event.message_id:
+                existing.message_id = event.message_id
+
+        prior_task = self._pending_text_batch_tasks.get(batch_key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_text_batch_tasks[batch_key] = asyncio.create_task(
+            self._flush_text_batch(batch_key)
+        )
+
+    async def _flush_text_batch(self, key: str) -> None:
+        """Wait for the quiet period then dispatch the aggregated text."""
+        current_task = asyncio.current_task()
+        try:
+            pending = self._pending_text_batches.get(key)
+            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+            delay = (
+                self._text_batch_split_delay_seconds
+                if last_len >= self._SPLIT_THRESHOLD
+                else self._text_batch_delay_seconds
+            )
+            await asyncio.sleep(delay)
+            event = self._pending_text_batches.pop(key, None)
+            if not event:
+                return
+            logger.info("Matrix: flushing text batch %s (%d chars)", key, len(event.text or ""))
+            await self.handle_message(event)
+        finally:
+            if self._pending_text_batch_tasks.get(key) is current_task:
+                self._pending_text_batch_tasks.pop(key, None)
 
     async def _on_room_message_media(self, room: Any, event: Any) -> None:
         """Handle incoming media messages (images, audio, video, files)."""

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -143,6 +143,7 @@ class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    _SPLIT_THRESHOLD = 3900
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WECOM)
@@ -171,6 +172,14 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._seen_messages: Dict[str, float] = {}
         self._reply_req_ids: Dict[str, str] = {}
+        self._text_batch_delay_seconds = float(
+            os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6")
+        )
+        self._text_batch_split_delay_seconds = float(
+            os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        )
+        self._pending_text_batches: Dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -239,6 +248,13 @@ class WeComAdapter(BasePlatformAdapter):
         if self._http_client:
             await self._http_client.aclose()
             self._http_client = None
+
+        if self._pending_text_batch_tasks:
+            for task in self._pending_text_batch_tasks.values():
+                task.cancel()
+            await asyncio.gather(*self._pending_text_batch_tasks.values(), return_exceptions=True)
+            self._pending_text_batch_tasks.clear()
+            self._pending_text_batches.clear()
 
         self._seen_messages.clear()
         logger.info("[%s] Disconnected", self.name)
@@ -519,7 +535,82 @@ class WeComAdapter(BasePlatformAdapter):
             timestamp=datetime.now(tz=timezone.utc),
         )
 
+        if self._should_batch_text_event(event):
+            await self._handle_text_event(event)
+            return
+
         await self.handle_message(event)
+
+    def _should_batch_text_event(self, event: MessageEvent) -> bool:
+        """Return True when a WeCom text event is eligible for split batching."""
+        return (
+            event.message_type == MessageType.TEXT
+            and not event.is_command()
+            and not event.media_urls
+        )
+
+    def _text_batch_key(self, event: MessageEvent) -> str:
+        """Return the session-scoped key used for WeCom text aggregation."""
+        from gateway.session import build_session_key
+
+        session_key = build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+        return f"{session_key}:reply:{event.reply_to_message_id or ''}"
+
+    async def _handle_text_event(self, event: MessageEvent) -> None:
+        """Dispatch short WeCom text immediately and batch likely split chunks."""
+        key = self._text_batch_key(event)
+        if key in self._pending_text_batches or len(event.text or "") >= self._SPLIT_THRESHOLD:
+            self._enqueue_text_event(event, key=key)
+            return
+        await self.handle_message(event)
+
+    def _enqueue_text_event(self, event: MessageEvent, *, key: Optional[str] = None) -> None:
+        """Buffer a text event and reset the flush timer."""
+        batch_key = key or self._text_batch_key(event)
+        existing = self._pending_text_batches.get(batch_key)
+        chunk_len = len(event.text or "")
+        if existing is None:
+            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            self._pending_text_batches[batch_key] = event
+        else:
+            if event.text:
+                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            existing.timestamp = event.timestamp
+            if event.message_id:
+                existing.message_id = event.message_id
+
+        prior_task = self._pending_text_batch_tasks.get(batch_key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_text_batch_tasks[batch_key] = asyncio.create_task(
+            self._flush_text_batch(batch_key)
+        )
+
+    async def _flush_text_batch(self, key: str) -> None:
+        """Wait for the quiet period then dispatch the aggregated text."""
+        current_task = asyncio.current_task()
+        try:
+            pending = self._pending_text_batches.get(key)
+            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+            delay = (
+                self._text_batch_split_delay_seconds
+                if last_len >= self._SPLIT_THRESHOLD
+                else self._text_batch_delay_seconds
+            )
+            await asyncio.sleep(delay)
+            event = self._pending_text_batches.pop(key, None)
+            if not event:
+                return
+            logger.info("[%s] Flushing text batch %s (%d chars)", self.name, key, len(event.text or ""))
+            await self.handle_message(event)
+        finally:
+            if self._pending_text_batch_tasks.get(key) is current_task:
+                self._pending_text_batch_tasks.pop(key, None)
 
     @staticmethod
     def _extract_text(body: Dict[str, Any]) -> Tuple[str, Optional[str]]:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1699,6 +1699,78 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(second.text, "C")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_text_batch_uses_split_delay_for_near_limit_chunk(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.session import SessionSource
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter.handle_message = AsyncMock()
+        source = SessionSource(
+            platform=adapter.platform,
+            chat_id="oc_chat",
+            chat_name="Feishu DM",
+            chat_type="dm",
+            user_id="ou_user",
+            user_name="张三",
+        )
+        event = MessageEvent(text="x" * 3950, message_type=MessageType.TEXT, source=source, message_id="om_1")
+        event._last_chunk_len = len(event.text)  # type: ignore[attr-defined]
+        key = adapter._text_batch_key(event)
+        adapter._pending_text_batches[key] = event
+        observed_delays = []
+
+        async def _sleep(delay):
+            observed_delays.append(delay)
+            return None
+
+        async def _run() -> None:
+            with patch("gateway.platforms.feishu.asyncio.sleep", side_effect=_sleep):
+                await adapter._flush_text_batch(key)
+
+        asyncio.run(_run())
+
+        self.assertEqual(observed_delays, [adapter._text_batch_split_delay_seconds])
+        adapter.handle_message.assert_awaited_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_text_batch_uses_normal_delay_for_short_tail_chunk(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.session import SessionSource
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter.handle_message = AsyncMock()
+        source = SessionSource(
+            platform=adapter.platform,
+            chat_id="oc_chat",
+            chat_name="Feishu DM",
+            chat_type="dm",
+            user_id="ou_user",
+            user_name="张三",
+        )
+        event = MessageEvent(text="tail", message_type=MessageType.TEXT, source=source, message_id="om_2")
+        event._last_chunk_len = len(event.text)  # type: ignore[attr-defined]
+        key = adapter._text_batch_key(event)
+        adapter._pending_text_batches[key] = event
+        observed_delays = []
+
+        async def _sleep(delay):
+            observed_delays.append(delay)
+            return None
+
+        async def _run() -> None:
+            with patch("gateway.platforms.feishu.asyncio.sleep", side_effect=_sleep):
+                await adapter._flush_text_batch(key)
+
+        asyncio.run(_run())
+
+        self.assertEqual(observed_delays, [adapter._text_batch_delay_seconds])
+        adapter.handle_message.assert_awaited_once()
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_media_batch_merges_rapid_photo_messages(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.base import MessageEvent, MessageType

--- a/tests/gateway/test_split_message_batching.py
+++ b/tests/gateway/test_split_message_batching.py
@@ -1,0 +1,158 @@
+"""Cross-platform tests for inbound split-message batching."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+
+class _DummyTask:
+    def done(self) -> bool:
+        return False
+
+    def cancel(self) -> None:
+        return None
+
+
+def _capture_task(coro):
+    coro.close()
+    return _DummyTask()
+
+
+def _make_discord_adapter():
+    from gateway.platforms.discord import DiscordAdapter
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True))
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _make_matrix_adapter():
+    from gateway.platforms.matrix import MatrixAdapter
+
+    adapter = MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="matrix-token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+    )
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _make_wecom_adapter():
+    from gateway.platforms.wecom import WeComAdapter
+
+    adapter = WeComAdapter(PlatformConfig(enabled=True))
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _make_event(platform: Platform, *, text: str, reply_to: str | None = None) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=platform,
+            chat_id="chat-1",
+            chat_name="Test Chat",
+            chat_type="group",
+            user_id="user-1",
+            user_name="User One",
+        ),
+        message_id=f"msg-{len(text)}",
+        reply_to_message_id=reply_to,
+    )
+
+
+@pytest.mark.parametrize(
+    ("factory", "module_path", "platform"),
+    [
+        (_make_discord_adapter, "gateway.platforms.discord", Platform.DISCORD),
+        (_make_matrix_adapter, "gateway.platforms.matrix", Platform.MATRIX),
+        (_make_wecom_adapter, "gateway.platforms.wecom", Platform.WECOM),
+    ],
+)
+@pytest.mark.asyncio
+async def test_short_text_dispatches_immediately(factory, module_path, platform):
+    adapter = factory()
+    event = _make_event(platform, text="hello")
+
+    with patch(f"{module_path}.asyncio.create_task", side_effect=_capture_task):
+        await adapter._handle_text_event(event)
+
+    adapter.handle_message.assert_awaited_once_with(event)
+    assert adapter._pending_text_batches == {}
+
+
+@pytest.mark.parametrize(
+    ("factory", "module_path", "platform"),
+    [
+        (_make_discord_adapter, "gateway.platforms.discord", Platform.DISCORD),
+        (_make_matrix_adapter, "gateway.platforms.matrix", Platform.MATRIX),
+        (_make_wecom_adapter, "gateway.platforms.wecom", Platform.WECOM),
+    ],
+)
+@pytest.mark.asyncio
+async def test_near_limit_text_batches_and_merges_tail(factory, module_path, platform):
+    adapter = factory()
+    head = _make_event(platform, text="x" * adapter._SPLIT_THRESHOLD)
+    tail = _make_event(platform, text="tail")
+    head_text = head.text
+    tail_text = tail.text
+
+    with patch(f"{module_path}.asyncio.create_task", side_effect=_capture_task):
+        await adapter._handle_text_event(head)
+        await adapter._handle_text_event(tail)
+
+    adapter.handle_message.assert_not_awaited()
+    assert len(adapter._pending_text_batches) == 1
+    pending = next(iter(adapter._pending_text_batches.values()))
+    assert pending.text == f"{head_text}\n{tail_text}"
+    assert getattr(pending, "_last_chunk_len") == len(tail_text)
+
+
+@pytest.mark.parametrize(
+    ("factory", "module_path", "platform", "use_split_delay"),
+    [
+        (_make_discord_adapter, "gateway.platforms.discord", Platform.DISCORD, True),
+        (_make_matrix_adapter, "gateway.platforms.matrix", Platform.MATRIX, True),
+        (_make_wecom_adapter, "gateway.platforms.wecom", Platform.WECOM, True),
+        (_make_discord_adapter, "gateway.platforms.discord", Platform.DISCORD, False),
+        (_make_matrix_adapter, "gateway.platforms.matrix", Platform.MATRIX, False),
+        (_make_wecom_adapter, "gateway.platforms.wecom", Platform.WECOM, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_flush_uses_expected_delay(factory, module_path, platform, use_split_delay):
+    adapter = factory()
+    text = "x" * adapter._SPLIT_THRESHOLD if use_split_delay else "tail"
+    event = _make_event(platform, text=text)
+    event._last_chunk_len = len(text)  # type: ignore[attr-defined]
+    key = adapter._text_batch_key(event)
+    adapter._pending_text_batches[key] = event
+
+    observed_delays = []
+
+    async def _sleep(delay):
+        observed_delays.append(delay)
+        return None
+
+    with patch(f"{module_path}.asyncio.sleep", side_effect=_sleep):
+        await adapter._flush_text_batch(key)
+
+    expected = (
+        adapter._text_batch_split_delay_seconds
+        if use_split_delay
+        else adapter._text_batch_delay_seconds
+    )
+    assert observed_delays == [expected]
+    adapter.handle_message.assert_awaited_once()
+    assert key not in adapter._pending_text_batches


### PR DESCRIPTION
## Summary
- add near-limit text batching for Discord, Matrix, and WeCom so client-side split messages stay in a single inbound turn
- add adaptive split-delay handling to Feishu's existing text batching so near-limit chunks wait longer for continuation
- cover the new batching behavior with cross-platform regression tests plus Feishu delay-selection tests

## Root Cause
Several gateway adapters were still treating each inbound text callback as a standalone user turn. When a client auto-split a long paste at the platform character limit, Hermes processed only the first chunk immediately and the continuation either arrived too late to merge or got handled as a second, unrelated turn.

## Testing
- `source /Users/jerome.xu/Desktop/codex/hermes-agent/.codex-runtime/venv311/bin/activate && pytest -n 0 tests/gateway/test_split_message_batching.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_matrix_mention.py tests/gateway/test_matrix.py tests/gateway/test_wecom.py tests/gateway/test_feishu.py`

Fixes #6892
