### PR TITLE
fix(gateway): handle provider command without config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3839,6 +3839,7 @@ class GatewayRunner:
 
         # Resolve current provider from config
         current_provider = "openrouter"
+        model_cfg = {}
         config_path = _hermes_home / 'config.yaml'
         try:
             if config_path.exists():

--- a/tests/e2e/test_telegram_commands.py
+++ b/tests/e2e/test_telegram_commands.py
@@ -105,10 +105,6 @@ class TestTelegramSlashCommands:
         send_status.assert_called_once()
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="Bug: _handle_provider_command references unbound model_cfg when config.yaml is absent",
-        strict=False,
-    )
     async def test_provider_shows_current_provider(self, adapter):
         send = await send_and_capture(adapter, "/provider")
 


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway `/provider` command when `config.yaml` is absent.

## Related Issue

Fixes the currently xfailed Telegram E2E case for `/provider` without config.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- initialize `model_cfg` defensively in `gateway/run.py` before reading `config.yaml`
- remove the `xfail` from the Telegram E2E `/provider` test now that the command succeeds without a config file

## How to Test

1. Run `.venv/bin/python -m pytest tests/e2e/test_telegram_commands.py -q`
2. Run `.venv/bin/python -m pytest tests/e2e/test_telegram_commands.py::TestTelegramSlashCommands::test_provider_shows_current_provider -q`
3. Trigger `/provider` in the gateway without a `config.yaml` present and confirm it responds normally

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `.venv/bin/python -m pytest tests/e2e/test_telegram_commands.py -q` → `15 passed`
- `.venv/bin/python -m pytest tests/e2e/test_telegram_commands.py::TestTelegramSlashCommands::test_provider_shows_current_provider -q` → `1 passed`

