### PR TITLE
fix(acp): declare session load and resume capabilities in initialize response

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -36,6 +36,7 @@ from acp.schema import (
     SessionCapabilities,
     SessionForkCapabilities,
     SessionListCapabilities,
+    SessionResumeCapabilities,
     SessionInfo,
     TextContentBlock,
     UnstructuredCommandInput,
@@ -245,9 +246,11 @@ class HermesACPAgent(acp.Agent):
             protocol_version=acp.PROTOCOL_VERSION,
             agent_info=Implementation(name="hermes-agent", version=HERMES_VERSION),
             agent_capabilities=AgentCapabilities(
+                load_session=True,
                 session_capabilities=SessionCapabilities(
                     fork=SessionForkCapabilities(),
                     list=SessionListCapabilities(),
+                    resume=SessionResumeCapabilities(),
                 ),
             ),
             auth_methods=auth_methods,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -68,9 +68,22 @@ class TestInitialize:
         resp = await agent.initialize(protocol_version=1)
         caps = resp.agent_capabilities
         assert isinstance(caps, AgentCapabilities)
+        assert caps.load_session is True
         assert caps.session_capabilities is not None
         assert caps.session_capabilities.fork is not None
         assert caps.session_capabilities.list is not None
+        assert caps.session_capabilities.resume is not None
+
+    @pytest.mark.asyncio
+    async def test_initialize_capabilities_wire_format(self, agent):
+        """Verify the JSON wire format uses correct aliases so ACP clients see the right keys."""
+        resp = await agent.initialize(protocol_version=1)
+        payload = resp.agent_capabilities.model_dump(by_alias=True, exclude_none=True)
+        assert payload["loadSession"] is True
+        session_caps = payload["sessionCapabilities"]
+        assert "fork" in session_caps
+        assert "list" in session_caps
+        assert "resume" in session_caps
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

The ACP `initialize` response only advertised `fork` and `list` session capabilities, but `load_session()` and `resume_session()` were already fully implemented. ACP clients (e.g. Zed) check these capability declarations before sending requests, so sessions could not be loaded or resumed despite the handlers being present.

This PR adds the missing capability declarations so ACP clients can discover and use the existing session load/resume functionality.

## Related Issue

Fixes #6633

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py`: Import `SessionResumeCapabilities` and add `load_session=True` + `resume=SessionResumeCapabilities()` to the `initialize` response's `AgentCapabilities`
- `tests/acp/test_server.py`: Add assertions for `load_session` and `resume` capabilities, plus a wire-format serialization test to guard against alias regressions

## How to Test

1. `pytest tests/acp/test_server.py -v` — all 52 tests pass
2. `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e` — full suite passes (pre-existing env-dependent failures in `test_api_key_providers.py` are unrelated)
3. With Zed + ACP: connect to hermes-agent, close Zed, reopen — session load/resume should now work instead of showing "Loading or resuming sessions is not supported by this agent"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A