### PR TITLE
Add import statement for os module in uninstall.py

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -6,6 +6,7 @@ Provides options for:
 - Keep data: Remove code but keep ~/.hermes/ (configs, sessions, logs)
 """
 
+import os;
 import shutil
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## What does this PR do?

Add the missing import os;
<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

Fixes #6983

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- import the missing os module in `uninstall.py`

## How to Test

Run `hermes uninstall`

