### PR TITLE
[codex] Stop streaming tool progress in chat completions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -24,8 +24,10 @@ import hmac
 import json
 import logging
 import os
+import re
 import sqlite3
 import time
+import unicodedata
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -280,6 +282,63 @@ def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
     return sha256(repr(subset).encode("utf-8")).hexdigest()
+
+
+def _is_tool_progress_marker(text: str) -> bool:
+    """Detect the chat-completions tool progress marker format injected by Hermes SSE."""
+    stripped = text.strip()
+    if not stripped.startswith("`") or not stripped.endswith("`"):
+        return False
+
+    inner = stripped[1:-1].strip()
+    if not inner or "`" in inner or "\n" in inner:
+        return False
+
+    marker, _, label = inner.partition(" ")
+    if not marker or not label.strip():
+        return False
+    if any(ch.isalnum() or ch == "_" for ch in marker):
+        return False
+
+    # Hermes emits emoji/symbol prefixes such as `⚡ terminal` or `🔍 search`.
+    return any(ord(ch) > 127 and unicodedata.category(ch).startswith("S") for ch in marker)
+
+
+def _strip_tool_progress_markers(content: Any) -> Any:
+    """Remove persisted Hermes tool-progress marker paragraphs from assistant history."""
+    if not isinstance(content, str) or "`" not in content:
+        return content
+
+    cleaned_lines = []
+    removed_marker = False
+    for line in content.splitlines():
+        if _is_tool_progress_marker(line):
+            removed_marker = True
+            continue
+        cleaned_lines.append(line)
+
+    if not removed_marker:
+        return content
+
+    cleaned = "\n".join(cleaned_lines)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip("\n")
+
+
+def _sanitize_assistant_history(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Strip stale tool-progress markers from assistant messages before reusing history."""
+    sanitized: List[Dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            sanitized.append(msg)
+            continue
+
+        updated = dict(msg)
+        updated["content"] = _strip_tool_progress_markers(updated.get("content", ""))
+        if updated["content"] == "":
+            continue
+        sanitized.append(updated)
+    return sanitized
 
 
 class APIServerAdapter(BasePlatformAdapter):
@@ -537,6 +596,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 else:
                     system_prompt = system_prompt + "\n" + content
             elif role in ("user", "assistant"):
+                if role == "assistant":
+                    content = _strip_tool_progress_markers(content)
+                    if content == "":
+                        continue
                 conversation_messages.append({"role": role, "content": content})
 
         # Extract the last user message as the primary input
@@ -560,7 +623,7 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 db = self._ensure_session_db()
                 if db is not None:
-                    history = db.get_messages_as_conversation(session_id)
+                    history = _sanitize_assistant_history(db.get_messages_as_conversation(session_id))
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []
@@ -587,17 +650,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
-            def _on_tool_progress(event_type, name, preview, args, **kwargs):
-                """Inject tool progress into the SSE stream for Open WebUI."""
-                if event_type != "tool.started":
-                    return  # Only show tool start events in chat stream
-                if name.startswith("_"):
-                    return  # Skip internal events (_thinking)
-                from agent.display import get_tool_emoji
-                emoji = get_tool_emoji(name)
-                label = preview or name
-                _stream_q.put(f"\n`{emoji} {label}`\n")
-
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             agent_ref = [None]
@@ -607,7 +659,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
             ))
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -462,8 +462,8 @@ class TestChatCompletionsEndpoint:
                 assert " about it..." in body
 
     @pytest.mark.asyncio
-    async def test_stream_includes_tool_progress(self, adapter):
-        """tool_progress_callback fires → progress appears in the SSE stream."""
+    async def test_stream_omits_tool_progress_from_chat_content(self, adapter):
+        """Tool progress must not be injected into chat-completions delta.content."""
         import asyncio
 
         app = _create_app(adapter)
@@ -494,14 +494,14 @@ class TestChatCompletionsEndpoint:
                 assert resp.status == 200
                 body = await resp.text()
                 assert "[DONE]" in body
-                # Tool progress message must appear in the stream
-                assert "ls -la" in body
+                # Tool progress must not be exposed as assistant content
+                assert "ls -la" not in body
                 # Final content must also be present
                 assert "Here are the files." in body
 
     @pytest.mark.asyncio
-    async def test_stream_tool_progress_skips_internal_events(self, adapter):
-        """Internal events (name starting with _) are not streamed."""
+    async def test_stream_omits_all_tool_progress_events(self, adapter):
+        """Neither internal nor visible tool progress should reach delta.content."""
         import asyncio
 
         app = _create_app(adapter)
@@ -531,10 +531,63 @@ class TestChatCompletionsEndpoint:
                 )
                 assert resp.status == 200
                 body = await resp.text()
-                # Internal _thinking event should NOT appear
+                # Tool progress should not be serialized into assistant content
                 assert "some internal state" not in body
-                # Real tool progress should appear
-                assert "Python docs" in body
+                assert "Python docs" not in body
+                assert "Found it." in body
+
+    @pytest.mark.asyncio
+    async def test_assistant_history_strips_persisted_tool_progress_markers(self, adapter):
+        """Stateless chat history should drop persisted SSE-only tool markers."""
+        mock_result = {"final_response": "Next step", "messages": [], "api_calls": 1}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {"role": "assistant", "content": "`⏰ ls -la`\n\nI found the files you asked for."},
+                            {"role": "user", "content": "What should I open next?"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"] == [
+                {"role": "assistant", "content": "I found the files you asked for."}
+            ]
+
+    @pytest.mark.asyncio
+    async def test_assistant_history_drops_marker_only_messages(self, adapter):
+        """Marker-only assistant turns should not be replayed back into model history."""
+        mock_result = {"final_response": "Next step", "messages": [], "api_calls": 1}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {"role": "user", "content": "List the files"},
+                            {"role": "assistant", "content": "`⏰ ls -la`"},
+                            {"role": "user", "content": "What should I open next?"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"] == [
+                {"role": "user", "content": "List the files"}
+            ]
 
     @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
@@ -1694,6 +1747,34 @@ class TestSessionIdHeader:
             # History must come from DB, not from the request body
             assert call_kwargs["conversation_history"] == db_history
             assert call_kwargs["user_message"] == "new question"
+
+    @pytest.mark.asyncio
+    async def test_provided_session_id_sanitizes_persisted_assistant_markers(self, adapter):
+        """Stored assistant history should be cleaned before it is sent back to the agent."""
+        mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "stored message 1"},
+            {"role": "assistant", "content": "`🔍 Python docs`\n\nStored reply 1"},
+        ]
+        adapter._session_db = mock_db
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "existing-session"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "new question"}]},
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"] == [
+                {"role": "user", "content": "stored message 1"},
+                {"role": "assistant", "content": "Stored reply 1"},
+            ]
 
     @pytest.mark.asyncio
     async def test_db_failure_falls_back_to_empty_history(self, adapter):


### PR DESCRIPTION
## Summary
- stop injecting Hermes tool-progress markers into `/v1/chat/completions` SSE `delta.content`
- strip persisted marker-only paragraphs from assistant history before replaying chat-completions context
- add regression coverage for clean streaming output and polluted-history recovery

## Root Cause
The API server adapter was serializing tool progress into the same assistant content stream used for OpenAI-compatible chat completions. Frontends such as Open WebUI can persist that streamed content into assistant history and send it back on later turns, which teaches the model to imitate the markers as plain text instead of making tool calls.

## Validation
- `source /Users/jerome.xu/Desktop/codex/hermes-agent/.codex-runtime/venv311/bin/activate && pytest -n 0 tests/gateway/test_api_server.py`
