### PR TITLE
fix(config): allow HERMES_HOME_MODE env var to override _secure_dir() permissions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -158,16 +158,27 @@ def get_project_root() -> Path:
     return Path(__file__).parent.parent.resolve()
 
 def _secure_dir(path):
-    """Set directory to owner-only access (0700). No-op on Windows.
+    """Set directory to owner-only access (0700 by default). No-op on Windows.
 
     Skipped in managed mode — the NixOS module sets group-readable
     permissions (0750) so interactive users in the hermes group can
     share state with the gateway service.
+
+    The mode can be overridden via the HERMES_HOME_MODE environment variable
+    (e.g. HERMES_HOME_MODE=0701) for deployments where a web server (nginx,
+    caddy, etc.) needs to traverse HERMES_HOME to reach a served subdirectory.
+    The execute-only bit on a directory permits cd-through without exposing
+    directory listings.
     """
     if is_managed():
         return
     try:
-        os.chmod(path, 0o700)
+        mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
+        mode = int(mode_str, 8) if mode_str else 0o700
+    except ValueError:
+        mode = 0o700
+    try:
+        os.chmod(path, mode)
     except (OSError, NotImplementedError):
         pass
 


### PR DESCRIPTION
## Problem

`_secure_dir()` unconditionally applied `0o700` to `HERMES_HOME` on every gateway start, removing the other-execute bit. Any web server (nginx, caddy) configured to serve from a subdirectory of `~/.hermes/` would get 403 Forbidden after a gateway restart.

## Root Cause

`_secure_dir()` in `hermes_cli/config.py` had no mechanism for non-managed installs to preserve permissions set by the operator.

## Fix

Add `HERMES_HOME_MODE` environment variable support. When set (e.g. `HERMES_HOME_MODE=0701`), `_secure_dir()` uses that mode instead of the hardcoded `0o700`.

- `0o701` allows other users to traverse (execute) but not list or read
- Default behavior (`0700`) is completely unchanged for all existing installs
- Invalid values fall back silently to `0700`

## Usage

```bash
HERMES_HOME_MODE=0701
```

Fixes #6991