### PR TITLE
fix(config): allow HERMES_HOME permissions override via HERMES_HOME_M…

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -167,8 +167,9 @@ def _secure_dir(path):
     if is_managed():
         return
     try:
-        os.chmod(path, 0o700)
-    except (OSError, NotImplementedError):
+        mode_str = os.environ.get("HERMES_HOME_MODE", "0700")
+        os.chmod(path, int(mode_str, 8))
+    except (OSError, ValueError, NotImplementedError):
         pass
 
 


### PR DESCRIPTION
…ODE (#6991)

## What does this PR do?


Fixes #6991

### The Bug
`_secure_dir()` in `config.py` unconditionally applies `0o700` permissions to directories on every gateway startup. This removes the other-execute bit (`o+x`), preventing web servers (like nginx) from traversing into `HERMES_HOME` subdirectories to serve content, resulting in persistent 403 Forbidden errors.

### The Fix
Introduced the `HERMES_HOME_MODE` environment variable to `_secure_dir()`.
- Defaults to `0700` to maintain strict owner-only access for standard installations.
- Deployments requiring directory traversal can now explicitly opt-in by setting `HERMES_HOME_MODE=0701` (or similar).
- Preserved the existing `is_managed()` carve-out for NixOS setups.
- Included graceful handling of `ValueError` if an invalid octal string is provided.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

