### PR TITLE
fix(gateway): bypass text batching when delay is 0

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2474,7 +2474,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         # Only batch plain text messages — commands, media, etc. dispatch
         # immediately since they won't be split by the Discord client.
-        if msg_type == MessageType.TEXT:
+        if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
             self._enqueue_text_event(event)
         else:
             await self.handle_message(event)

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1101,7 +1101,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._background_read_receipt(room.room_id, event.event_id)
 
         # Only batch plain text messages — commands dispatch immediately.
-        if msg_type == MessageType.TEXT:
+        if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
             self._enqueue_text_event(msg_event)
         else:
             await self.handle_message(msg_event)

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -531,7 +531,7 @@ class WeComAdapter(BasePlatformAdapter):
 
         # Only batch plain text messages — commands, media, etc. dispatch
         # immediately since they won't be split by the WeCom client.
-        if message_type == MessageType.TEXT:
+        if message_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
             self._enqueue_text_event(event)
         else:
             await self.handle_message(event)


### PR DESCRIPTION
## Summary

The text batching commits (50757179..8104f400) broke 33 gateway tests on CI by routing TEXT messages through `asyncio.create_task()`. Even with `_text_batch_delay_seconds = 0` (set by the test fixture commit 8104f400), the async task doesn't complete before synchronous test assertions fire.

**Fix:** Check `_text_batch_delay_seconds > 0` at the dispatch point — when delay is 0, call `handle_message()` directly instead of going through the batching path. One-line change in each of 3 adapters (discord, matrix, wecom).

**Affected tests:** All 33 failures from CI run 24229759373
- `test_discord_channel_controls.py` (6 tests)
- `test_discord_free_response.py` (10 tests)
- `test_discord_slash_commands.py` (3 tests)
- `test_matrix_mention.py` (12 tests)
- `test_wecom.py` (2 tests)

**Verified:** All 108 previously-failing tests pass. Text batching tests (22 tests) still pass — production behavior unchanged since default delay is 0.6s.