### PR TITLE
fix(slack): validate downloaded media before caching as image

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1579,8 +1579,62 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:
             return False
 
+    # Magic-byte signatures used to verify downloaded media is genuine.
+    _IMAGE_SIGNATURES: list[tuple[bytes, int]] = [
+        (b"\x89PNG", 0),    # PNG
+        (b"\xff\xd8", 0),   # JPEG
+        (b"GIF8", 0),       # GIF87a / GIF89a
+        (b"RIFF", 0),       # WEBP (RIFF....WEBP) – first 4 bytes
+        (b"BM", 0),         # BMP
+    ]
+    _AUDIO_SIGNATURES: list[tuple[bytes, int]] = [
+        (b"OggS", 0),       # OGG / Opus
+        (b"ID3", 0),        # MP3 with ID3v2 tag
+        (b"fLaC", 0),       # FLAC
+        (b"RIFF", 0),       # WAV (RIFF....WAVE)
+    ]
+
+    @staticmethod
+    def _looks_like_media(data: bytes, *, audio: bool = False) -> bool:
+        """Return *True* if *data* starts with a recognised media magic-byte
+        signature.  When *audio* is ``True`` the check uses audio signatures;
+        otherwise it uses image signatures.
+
+        An MP3 frame sync (``0xFF 0xE0+``) is also accepted for audio because
+        many MP3 files lack an ID3 header.
+        """
+        if len(data) < 4:
+            return False
+        sigs = SlackAdapter._AUDIO_SIGNATURES if audio else SlackAdapter._IMAGE_SIGNATURES
+        for magic, offset in sigs:
+            if data[offset:offset + len(magic)] == magic:
+                return True
+        # WEBP: RIFF____WEBP  (already matched RIFF above, but refine)
+        if not audio and len(data) >= 12 and data[8:12] == b"WEBP":
+            return True
+        # MP3 frame sync without ID3 header
+        if audio and len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
+            return True
+        return False
+
+    @staticmethod
+    def _content_type_is_html(response_headers) -> bool:
+        """Return *True* when the response Content-Type indicates HTML."""
+        ct = str(response_headers.get("content-type", "")).lower()
+        return "text/html" in ct or "text/xml" in ct
+
     async def _download_slack_file(self, url: str, ext: str, audio: bool = False, team_id: str = "") -> str:
-        """Download a Slack file using the bot token for auth, with retry."""
+        """Download a Slack file using the bot token for auth, with retry.
+
+        After a successful HTTP response the payload is validated:
+        * The ``Content-Type`` header must **not** indicate HTML (a common
+          symptom of Slack returning a sign-in redirect).
+        * The first bytes of the body must match a known image/audio magic-byte
+          signature.
+
+        If validation fails a ``ValueError`` is raised so that the caller's
+        ``except`` block can log a clear warning instead of caching garbage.
+        """
         import asyncio
         import httpx
 
@@ -1595,6 +1649,22 @@ class SlackAdapter(BasePlatformAdapter):
                         headers={"Authorization": f"Bearer {bot_token}"},
                     )
                     response.raise_for_status()
+
+                    # --- Validate the payload before caching ----------------
+                    if self._content_type_is_html(response.headers):
+                        raise ValueError(
+                            f"Expected media but received HTML response "
+                            f"(Content-Type: {response.headers.get('content-type', 'unknown')}); "
+                            f"Slack may require re-authentication"
+                        )
+
+                    if not self._looks_like_media(response.content, audio=audio):
+                        raise ValueError(
+                            f"Downloaded content does not match any known "
+                            f"{'audio' if audio else 'image'} signature "
+                            f"(first bytes: {response.content[:16]!r}); refusing to cache"
+                        )
+                    # -------------------------------------------------------
 
                     if audio:
                         from gateway.platforms.base import cache_audio_from_bytes

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1580,18 +1580,20 @@ class SlackAdapter(BasePlatformAdapter):
             return False
 
     # Magic-byte signatures used to verify downloaded media is genuine.
+    # Each entry is (magic_bytes, offset).  For RIFF-based formats the
+    # check requires 12 bytes so the container sub-type (WEBP / WAVE) is
+    # verified — a bare "RIFF" prefix is NOT enough.
     _IMAGE_SIGNATURES: list[tuple[bytes, int]] = [
         (b"\x89PNG", 0),    # PNG
         (b"\xff\xd8", 0),   # JPEG
         (b"GIF8", 0),       # GIF87a / GIF89a
-        (b"RIFF", 0),       # WEBP (RIFF....WEBP) – first 4 bytes
         (b"BM", 0),         # BMP
     ]
     _AUDIO_SIGNATURES: list[tuple[bytes, int]] = [
-        (b"OggS", 0),       # OGG / Opus
-        (b"ID3", 0),        # MP3 with ID3v2 tag
-        (b"fLaC", 0),       # FLAC
-        (b"RIFF", 0),       # WAV (RIFF....WAVE)
+        (b"OggS", 0),           # OGG / Opus
+        (b"ID3", 0),            # MP3 with ID3v2 tag
+        (b"fLaC", 0),           # FLAC
+        (b"\x1a\x45\xdf\xa3", 0),  # WebM / Matroska (EBML header)
     ]
 
     @staticmethod
@@ -1600,8 +1602,12 @@ class SlackAdapter(BasePlatformAdapter):
         signature.  When *audio* is ``True`` the check uses audio signatures;
         otherwise it uses image signatures.
 
-        An MP3 frame sync (``0xFF 0xE0+``) is also accepted for audio because
-        many MP3 files lack an ID3 header.
+        Additional heuristics:
+        * RIFF containers are matched with their sub-type (``WEBP`` for images,
+          ``WAVE`` for audio) to avoid accepting arbitrary RIFF files.
+        * MP4/M4A (``ftyp`` at offset 4) is accepted for audio.
+        * An MP3 frame sync (``0xFF 0xE0+``) is accepted for audio because
+          many MP3 files lack an ID3 header.
         """
         if len(data) < 4:
             return False
@@ -1609,8 +1615,15 @@ class SlackAdapter(BasePlatformAdapter):
         for magic, offset in sigs:
             if data[offset:offset + len(magic)] == magic:
                 return True
-        # WEBP: RIFF____WEBP  (already matched RIFF above, but refine)
-        if not audio and len(data) >= 12 and data[8:12] == b"WEBP":
+        # RIFF containers: require 12 bytes and verify the sub-type
+        if len(data) >= 12 and data[:4] == b"RIFF":
+            subtype = data[8:12]
+            if not audio and subtype == b"WEBP":
+                return True
+            if audio and subtype == b"WAVE":
+                return True
+        # MP4 / M4A: "ftyp" at offset 4
+        if audio and len(data) >= 8 and data[4:8] == b"ftyp":
             return True
         # MP3 frame sync without ID3 header
         if audio and len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -395,7 +395,8 @@ class TestSlackDownloadSlackFile:
         adapter = _make_slack_adapter()
 
         fake_response = MagicMock()
-        fake_response.content = b"fake image bytes"
+        fake_response.content = b"\xff\xd8\xff\xe0" + b"\x00" * 32  # valid JPEG magic
+        fake_response.headers = {"content-type": "image/jpeg"}
         fake_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
@@ -419,7 +420,8 @@ class TestSlackDownloadSlackFile:
         adapter = _make_slack_adapter()
 
         fake_response = MagicMock()
-        fake_response.content = b"image bytes"
+        fake_response.content = b"\xff\xd8\xff\xe0" + b"\x00" * 32  # valid JPEG magic
+        fake_response.headers = {"content-type": "image/jpeg"}
         fake_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()

--- a/tests/gateway/test_slack_image_cache.py
+++ b/tests/gateway/test_slack_image_cache.py
@@ -1,0 +1,390 @@
+"""
+Tests for Slack image/audio download content validation.
+
+Covers: SlackAdapter._download_slack_file content-type and magic-byte
+        validation added to prevent caching HTML sign-in pages as media.
+
+See: https://github.com/NousResearch/hermes-agent/issues/6829
+"""
+
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import httpx
+
+from gateway.config import Platform, PlatformConfig
+
+# ---------------------------------------------------------------------------
+# Mock the slack-bolt package if it's not installed
+# ---------------------------------------------------------------------------
+
+
+def _ensure_slack_mock():
+    """Install mock slack modules so SlackAdapter can be imported."""
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import gateway.platforms.slack as _slack_mod
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from gateway.platforms.slack import SlackAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app.client = AsyncMock()
+    a._bot_user_id = "U_BOT"
+    a._running = True
+    a.handle_message = AsyncMock()
+    return a
+
+
+@pytest.fixture(autouse=True)
+def _redirect_caches(tmp_path, monkeypatch):
+    """Point image and audio caches to tmp_path so tests don't touch ~/.hermes."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img_cache"
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Minimal valid media payloads (just enough for magic-byte detection).
+FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+FAKE_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+FAKE_GIF = b"GIF89a" + b"\x00" * 32
+FAKE_WEBP = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 32
+FAKE_OGG = b"OggS" + b"\x00" * 32
+FAKE_MP3_ID3 = b"ID3" + b"\x00" * 32
+FAKE_MP3_SYNC = bytes([0xFF, 0xFB, 0x90, 0x00]) + b"\x00" * 32
+
+# A typical HTML sign-in page payload that Slack returns on auth failure.
+HTML_SIGN_IN = (
+    b"<!DOCTYPE html><html><head><title>Slack</title></head>"
+    b"<body>You need to sign in to see this page.</body></html>"
+)
+
+
+def _make_response(content: bytes, content_type: str = "image/png", status_code: int = 200):
+    """Build a mock httpx.Response with the given content and headers."""
+    resp = MagicMock()
+    resp.content = content
+    resp.status_code = status_code
+    resp.headers = {"content-type": content_type}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_client(response):
+    """Wrap a mock response in an AsyncClient context manager."""
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_media – unit tests for the static helper
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeMedia:
+    """Unit tests for SlackAdapter._looks_like_media."""
+
+    def test_png_recognised(self):
+        assert SlackAdapter._looks_like_media(FAKE_PNG) is True
+
+    def test_jpeg_recognised(self):
+        assert SlackAdapter._looks_like_media(FAKE_JPEG) is True
+
+    def test_gif_recognised(self):
+        assert SlackAdapter._looks_like_media(FAKE_GIF) is True
+
+    def test_webp_recognised(self):
+        assert SlackAdapter._looks_like_media(FAKE_WEBP) is True
+
+    def test_ogg_recognised_as_audio(self):
+        assert SlackAdapter._looks_like_media(FAKE_OGG, audio=True) is True
+
+    def test_mp3_id3_recognised_as_audio(self):
+        assert SlackAdapter._looks_like_media(FAKE_MP3_ID3, audio=True) is True
+
+    def test_mp3_sync_recognised_as_audio(self):
+        assert SlackAdapter._looks_like_media(FAKE_MP3_SYNC, audio=True) is True
+
+    def test_html_rejected_as_image(self):
+        assert SlackAdapter._looks_like_media(HTML_SIGN_IN) is False
+
+    def test_html_rejected_as_audio(self):
+        assert SlackAdapter._looks_like_media(HTML_SIGN_IN, audio=True) is False
+
+    def test_empty_bytes_rejected(self):
+        assert SlackAdapter._looks_like_media(b"") is False
+
+    def test_short_bytes_rejected(self):
+        assert SlackAdapter._looks_like_media(b"AB") is False
+
+    def test_random_bytes_rejected(self):
+        assert SlackAdapter._looks_like_media(b"\x00\x01\x02\x03\x04\x05") is False
+
+    def test_ogg_not_recognised_as_image(self):
+        """OGG magic bytes should not pass image validation."""
+        assert SlackAdapter._looks_like_media(FAKE_OGG, audio=False) is False
+
+
+# ---------------------------------------------------------------------------
+# _content_type_is_html – unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestContentTypeIsHtml:
+    def test_text_html(self):
+        assert SlackAdapter._content_type_is_html({"content-type": "text/html"}) is True
+
+    def test_text_html_charset(self):
+        assert SlackAdapter._content_type_is_html(
+            {"content-type": "text/html; charset=utf-8"}
+        ) is True
+
+    def test_text_xml(self):
+        assert SlackAdapter._content_type_is_html({"content-type": "text/xml"}) is True
+
+    def test_image_png(self):
+        assert SlackAdapter._content_type_is_html({"content-type": "image/png"}) is False
+
+    def test_missing_header(self):
+        assert SlackAdapter._content_type_is_html({}) is False
+
+
+# ---------------------------------------------------------------------------
+# _download_slack_file – integration tests with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadSlackFileValidation:
+    """Verify that _download_slack_file rejects non-media payloads."""
+
+    def test_valid_image_cached_successfully(self, adapter, tmp_path):
+        """A genuine PNG payload should be cached without error."""
+        response = _make_response(FAKE_PNG, content_type="image/png")
+        client = _make_client(response)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=client):
+                return await adapter._download_slack_file(
+                    "https://files.slack.com/img.png", ".png"
+                )
+
+        path = asyncio.run(run())
+        assert path.endswith(".png")
+        assert os.path.exists(path)
+        # Verify the cached content matches
+        with open(path, "rb") as f:
+            assert f.read() == FAKE_PNG
+
+    def test_valid_audio_cached_successfully(self, adapter, tmp_path):
+        """A genuine OGG payload should be cached when audio=True."""
+        response = _make_response(FAKE_OGG, content_type="audio/ogg")
+        client = _make_client(response)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=client):
+                return await adapter._download_slack_file(
+                    "https://files.slack.com/voice.ogg", ".ogg", audio=True
+                )
+
+        path = asyncio.run(run())
+        assert path.endswith(".ogg")
+        assert os.path.exists(path)
+
+    def test_html_content_type_rejected(self, adapter):
+        """An HTML Content-Type should raise ValueError before caching."""
+        response = _make_response(HTML_SIGN_IN, content_type="text/html; charset=utf-8")
+        client = _make_client(response)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=client):
+                await adapter._download_slack_file(
+                    "https://files.slack.com/img.png", ".png"
+                )
+
+        with pytest.raises(ValueError, match="HTML response"):
+            asyncio.run(run())
+
+    def test_html_body_with_image_content_type_rejected(self, adapter):
+        """HTML body masquerading with image/png Content-Type should be
+        rejected by magic-byte validation."""
+        response = _make_response(HTML_SIGN_IN, content_type="image/png")
+        client = _make_client(response)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=client):
+                await adapter._download_slack_file(
+                    "https://files.slack.com/img.png", ".png"
+                )
+
+        with pytest.raises(ValueError, match="does not match any known"):
+            asyncio.run(run())
+
+    def test_html_audio_content_type_rejected(self, adapter):
+        """An HTML Content-Type should be rejected for audio downloads too."""
+        response = _make_response(HTML_SIGN_IN, content_type="text/html")
+        client = _make_client(response)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=client):
+                await adapter._download_slack_file(
+                    "https://files.slack.com/voice.ogg", ".ogg", audio=True
+                )
+
+        with pytest.raises(ValueError, match="HTML response"):
+            asyncio.run(run())
+
+    def test_garbage_bytes_rejected(self, adapter):
+        """Random non-media bytes with a valid Content-Type should still be
+        rejected by the magic-byte check."""
+        garbage = b"\x00\x01\x02\x03garbage data that is not an image"
+        response = _make_response(garbage, content_type="application/octet-stream")
+        client = _make_client(response)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=client):
+                await adapter._download_slack_file(
+                    "https://files.slack.com/img.png", ".png"
+                )
+
+        with pytest.raises(ValueError, match="does not match"):
+            asyncio.run(run())
+
+    def test_jpeg_with_octet_stream_content_type_accepted(self, adapter, tmp_path):
+        """A valid JPEG payload should be accepted even if the Content-Type
+        is generic (Slack sometimes returns application/octet-stream)."""
+        response = _make_response(FAKE_JPEG, content_type="application/octet-stream")
+        client = _make_client(response)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=client):
+                return await adapter._download_slack_file(
+                    "https://files.slack.com/photo.jpg", ".jpg"
+                )
+
+        path = asyncio.run(run())
+        assert path.endswith(".jpg")
+        assert os.path.exists(path)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: _handle_slack_message with image validation
+# ---------------------------------------------------------------------------
+
+
+class TestSlackImageAttachmentValidation:
+    """Verify that HTML-as-image is gracefully skipped in message handling."""
+
+    def _make_event(self, files=None, text="hello"):
+        return {
+            "text": text,
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+            "files": files or [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_html_image_skipped_gracefully(self, adapter):
+        """When _download_slack_file raises ValueError (invalid media),
+        the handler should still be called with no media attached."""
+        with patch.object(
+            adapter,
+            "_download_slack_file",
+            new_callable=AsyncMock,
+            side_effect=ValueError("HTML response"),
+        ):
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "image/png",
+                        "name": "screenshot.png",
+                        "url_private_download": "https://files.slack.com/screenshot.png",
+                        "size": 1024,
+                    }
+                ]
+            )
+            await adapter._handle_slack_message(event)
+
+        # Handler should still be called (error is caught)
+        adapter.handle_message.assert_called_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        # No media should be attached since the download was invalid
+        assert len(msg_event.media_urls) == 0
+
+    @pytest.mark.asyncio
+    async def test_valid_image_still_works(self, adapter):
+        """A valid image download should still produce a PHOTO message."""
+        with patch.object(
+            adapter,
+            "_download_slack_file",
+            new_callable=AsyncMock,
+            return_value="/tmp/cached_valid.png",
+        ):
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "image/jpeg",
+                        "name": "photo.jpg",
+                        "url_private_download": "https://files.slack.com/photo.jpg",
+                        "size": 2048,
+                    }
+                ]
+            )
+            await adapter._handle_slack_message(event)
+
+        from gateway.platforms.base import MessageType
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.PHOTO
+        assert len(msg_event.media_urls) == 1

--- a/tests/gateway/test_slack_image_cache.py
+++ b/tests/gateway/test_slack_image_cache.py
@@ -99,6 +99,12 @@ FAKE_WEBP = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 32
 FAKE_OGG = b"OggS" + b"\x00" * 32
 FAKE_MP3_ID3 = b"ID3" + b"\x00" * 32
 FAKE_MP3_SYNC = bytes([0xFF, 0xFB, 0x90, 0x00]) + b"\x00" * 32
+FAKE_WAV = b"RIFF\x00\x00\x00\x00WAVE" + b"\x00" * 32
+FAKE_WEBM = b"\x1a\x45\xdf\xa3" + b"\x00" * 32
+FAKE_M4A = b"\x00\x00\x00\x20ftyp" + b"M4A " + b"\x00" * 24
+FAKE_FLAC = b"fLaC" + b"\x00" * 32
+# A RIFF container that is neither WEBP nor WAVE (e.g. AVI).
+FAKE_RIFF_AVI = b"RIFF\x00\x00\x00\x00AVI " + b"\x00" * 32
 
 # A typical HTML sign-in page payload that Slack returns on auth failure.
 HTML_SIGN_IN = (
@@ -173,6 +179,38 @@ class TestLooksLikeMedia:
     def test_ogg_not_recognised_as_image(self):
         """OGG magic bytes should not pass image validation."""
         assert SlackAdapter._looks_like_media(FAKE_OGG, audio=False) is False
+
+    # -- New formats: WAV, WebM, M4A, FLAC --
+
+    def test_wav_recognised_as_audio(self):
+        assert SlackAdapter._looks_like_media(FAKE_WAV, audio=True) is True
+
+    def test_webm_recognised_as_audio(self):
+        assert SlackAdapter._looks_like_media(FAKE_WEBM, audio=True) is True
+
+    def test_m4a_recognised_as_audio(self):
+        assert SlackAdapter._looks_like_media(FAKE_M4A, audio=True) is True
+
+    def test_flac_recognised_as_audio(self):
+        assert SlackAdapter._looks_like_media(FAKE_FLAC, audio=True) is True
+
+    # -- RIFF sub-type gating --
+
+    def test_riff_avi_rejected_as_image(self):
+        """An AVI RIFF container should NOT pass image validation."""
+        assert SlackAdapter._looks_like_media(FAKE_RIFF_AVI, audio=False) is False
+
+    def test_riff_avi_rejected_as_audio(self):
+        """An AVI RIFF container should NOT pass audio validation."""
+        assert SlackAdapter._looks_like_media(FAKE_RIFF_AVI, audio=True) is False
+
+    def test_webp_not_recognised_as_audio(self):
+        """A WEBP RIFF container should NOT pass audio validation."""
+        assert SlackAdapter._looks_like_media(FAKE_WEBP, audio=True) is False
+
+    def test_wav_not_recognised_as_image(self):
+        """A WAV RIFF container should NOT pass image validation."""
+        assert SlackAdapter._looks_like_media(FAKE_WAV, audio=False) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Prevents Slack image/audio downloads from silently caching HTML sign-in pages as media files. When Slack returns an HTML response instead of actual media (e.g. due to expired bot tokens), the raw HTML bytes were written to the image cache as `.png`/`.jpg` files, causing downstream `vision_analyze` to fail with confusing errors.

This PR adds two-layer content validation to `_download_slack_file()` **before** writing to cache:
1. **Content-Type check** — reject responses with `text/html` or `text/xml` headers
2. **Magic-byte check** — verify the payload starts with a known image or audio file signature (PNG, JPEG, GIF, WEBP, BMP, OGG, MP3, FLAC, WAV)

If either check fails, a clear `ValueError` is raised, which the caller's existing `except` block logs as a descriptive warning — no silent corruption.

## Related Issue

Fixes #6829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/slack.py` — Added `_looks_like_media()` (magic-byte validator), `_content_type_is_html()` (header check), and integrated both into `_download_slack_file()` between `raise_for_status()` and the cache write
- `tests/gateway/test_slack_image_cache.py` — **New**: 27 tests covering magic-byte recognition, Content-Type detection, download validation (HTML rejected, valid media accepted, garbage bytes rejected), and end-to-end message handling with invalid media
- `tests/gateway/test_media_download_retry.py` — Updated 2 existing tests to use valid JPEG magic bytes (they previously used `b"fake image bytes"` which now correctly fails validation)

## How to Test

1. `pytest tests/gateway/test_slack_image_cache.py -v` — all 27 new tests pass
2. `pytest tests/gateway/test_media_download_retry.py -v` — all existing retry tests still pass
3. `pytest tests/gateway/test_slack.py -v` — all existing Slack adapter tests still pass
4. `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e` — full test suite passes (no new failures)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A