### PR TITLE
fix(config): use 0o701 for HERMES_HOME to allow web server traversal

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -212,7 +212,10 @@ def ensure_hermes_home():
             os.umask(old_umask)
     else:
         home.mkdir(parents=True, exist_ok=True)
-        _secure_dir(home)
+        try:
+            os.chmod(home, 0o701)
+        except (OSError, NotImplementedError):
+            pass
         for subdir in ("cron", "sessions", "logs", "memories"):
             d = home / subdir
             d.mkdir(parents=True, exist_ok=True)

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -105,14 +105,14 @@ class TestConfigFilePermissions(unittest.TestCase):
             file_mode = stat.S_IMODE(os.stat(env_path).st_mode)
             self.assertEqual(file_mode, 0o600)
 
-    def test_ensure_hermes_home_sets_0700(self):
+    def test_ensure_hermes_home_sets_permissions(self):
         home = Path(self.tmpdir) / ".hermes"
         with patch("hermes_cli.config.get_hermes_home", return_value=home):
             from hermes_cli.config import ensure_hermes_home
             ensure_hermes_home()
 
             home_mode = stat.S_IMODE(os.stat(home).st_mode)
-            self.assertEqual(home_mode, 0o700)
+            self.assertEqual(home_mode, 0o701)
 
             for subdir in ("cron", "sessions", "logs", "memories"):
                 subdir_mode = stat.S_IMODE(os.stat(home / subdir).st_mode)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -58,6 +58,20 @@ class TestEnsureHermesHome:
             ensure_hermes_home()
             assert soul_path.read_text(encoding="utf-8") == "custom soul"
 
+    def test_permissions_home_701_and_subdirs_700(self, tmp_path):
+        if os.name == "nt":
+            return
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+
+            home_mode = os.stat(tmp_path).st_mode & 0o777
+            assert home_mode == 0o701
+
+            for subdir in ("cron", "sessions", "logs", "memories"):
+                subdir_mode = os.stat(tmp_path / subdir).st_mode & 0o777
+                assert subdir_mode == 0o700
+
 
 class TestLoadConfigDefaults:
     def test_returns_defaults_when_no_file(self, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Changes `ensure_hermes_home()` to set HERMES_HOME to `0o701` instead of `0o700`. This preserves owner-only read/write on the directory while allowing other users (like `www-data`) to traverse it. Subdirectories (`cron`, `sessions`, `logs`, `memories`) remain at `0o700`.

## Related Issue

Fixes #6991

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Replaced `_secure_dir(home)` call in `ensure_hermes_home()` with direct `os.chmod(home, 0o701)`, using the same `try/except` pattern. Subdirectories still use `_secure_dir()` (0o700).
- `tests/hermes_cli/test_config.py`: Added `test_permissions_home_701_and_subdirs_700` verifying the permission split.
- `tests/cron/test_file_permissions.py`: Updated existing permission test to expect 0o701 for home.

## How to Test

1. Configure nginx to serve from a subdirectory of `~/.hermes/` (e.g., `alias /home/user/.hermes/reports/;`)
2. Restart hermes-gateway
3. Verify `ls -lad ~/.hermes` shows `drwx-----x` (0o701)
4. Verify `ls -lad ~/.hermes/sessions` shows `drwx------` (0o700)
5. Verify nginx can serve content from the subdirectory (HTTP 200, not 403)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A

---

Aware of related PRs #6993 and #6994 which take a different approach (env var override). This PR takes the simpler path of changing the default, since `0o701` (execute-only for others) is the standard Unix pattern for web-serving parent directories and doesn't require configuration.

This contribution was developed with AI assistance (Codex).