### PR TITLE
fix(gateway): apply /model session override in _run_agent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6614,6 +6614,21 @@ class GatewayRunner:
                     "tools": [],
                 }
 
+            # Apply /model session override (non-global switch).
+            # _session_model_overrides is set by _handle_model_command on every
+            # /model call but was never consumed during agent creation.  The
+            # in-place switch via agent.switch_model() only worked when a cached
+            # agent already existed from a prior message; for fresh sessions or
+            # after /new the override was silently dropped and the config-file
+            # model was used instead.
+            if session_key:
+                _model_override = self._session_model_overrides.get(session_key, {})
+                if _model_override:
+                    model = _model_override.get("model", model)
+                    for _k in ("api_key", "base_url", "provider", "api_mode"):
+                        if _model_override.get(_k):
+                            runtime_kwargs[_k] = _model_override[_k]
+
             pr = self._provider_routing
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config


### PR DESCRIPTION
## Problem

`/model` (session-only switch, without `--global`) was unreliable.

`_handle_model_command` correctly stores the chosen model in `self._session_model_overrides[session_key]` and tries to swap it in the live cached agent via `agent.switch_model()`. But `_session_model_overrides` was **never read during agent creation** in `_run_agent`.

This meant the switch only worked by coincidence — when a cached agent already existed from a previous message and `switch_model()` succeeded in-place. For fresh sessions (first message) or after `/new`, the override was silently dropped and `_resolve_gateway_model(user_config)` always returned the config-file model.

## Fix

Read `_session_model_overrides[session_key]` immediately after credential resolution, before `_resolve_turn_agent_config`, and apply any active override to both `model` and the relevant `runtime_kwargs` fields (`api_key`, `base_url`, `provider`, `api_mode`).

This ensures the correct model reaches both the agent-cache signature check and any new `AIAgent()` instantiation, regardless of whether a cached agent exists.

## Reproduction

1. Start a fresh session (no prior messages)
2. Send `/model <name> --provider <slug>`
3. Send any message — the agent responds using the config-file model, not the switched one

After this fix the switched model is used from the very first message.