### PR TITLE
fix(gateway): remap python/venv/workdir to target user when installing system service as root

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -301,7 +301,10 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         if cmd.cli_only:
             continue
         tg_name = cmd.name.replace("-", "_")
-        result.append((tg_name, cmd.description))
+        # Telegram BotFather rejects command descriptions containing Unicode dashes.
+        # Normalize em dash (U+2014) and en dash (U+2013) to ASCII hyphen-minus.
+        desc = cmd.description.replace("\u2014", "-").replace("\u2013", "-")
+        result.append((tg_name, desc))
     return result
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -397,25 +397,42 @@ def get_hermes_cli_path() -> str:
 # =============================================================================
 
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
-    python_path = get_python_path()
-    working_dir = str(PROJECT_ROOT)
-    venv_dir = str(PROJECT_ROOT / "venv")
-    venv_bin = str(PROJECT_ROOT / "venv" / "bin")
-    node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
-
-    path_entries = [venv_bin, node_bin]
     resolved_node = shutil.which("node")
-    if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
-        if resolved_node_dir not in path_entries:
-            path_entries.append(resolved_node_dir)
-    path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
-    sane_path = ":".join(path_entries)
-
-    hermes_home = str(Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")).resolve())
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
+        hermes_home = str(Path(home_dir) / ".hermes")
+
+        # Remap python/venv/workdir to the target user's home, not root's.
+        target_home = Path(home_dir)
+        target_project = target_home / ".hermes" / "hermes-agent"
+        target_venv_bin = target_project / "venv" / "bin"
+
+        if target_project.exists():
+            working_dir = str(target_project)
+            python_path = (
+                str(target_venv_bin / "python")
+                if (target_venv_bin / "python").exists()
+                else get_python_path()
+            )
+            venv_dir = str(target_project / "venv")
+            venv_bin = str(target_venv_bin)
+        else:
+            # Non-standard install: keep current paths as fallback.
+            working_dir = str(PROJECT_ROOT)
+            python_path = get_python_path()
+            venv_dir = str(PROJECT_ROOT / "venv")
+            venv_bin = str(PROJECT_ROOT / "venv" / "bin")
+
+        node_bin = str(target_project / "node_modules" / ".bin")
+        path_entries = [venv_bin, node_bin]
+        if resolved_node:
+            resolved_node_dir = str(Path(resolved_node).resolve().parent)
+            if resolved_node_dir not in path_entries:
+                path_entries.append(resolved_node_dir)
+        path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
+        sane_path = ":".join(path_entries)
+
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
@@ -446,6 +463,22 @@ StandardError=journal
 [Install]
 WantedBy=multi-user.target
 """
+
+    # User service: use current process paths as before.
+    python_path = get_python_path()
+    working_dir = str(PROJECT_ROOT)
+    venv_dir = str(PROJECT_ROOT / "venv")
+    venv_bin = str(PROJECT_ROOT / "venv" / "bin")
+    node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
+    hermes_home = str(Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")).resolve())
+
+    path_entries = [venv_bin, node_bin]
+    if resolved_node:
+        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        if resolved_node_dir not in path_entries:
+            path_entries.append(resolved_node_dir)
+    path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
+    sane_path = ":".join(path_entries)
 
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}


### PR DESCRIPTION
## Problem

When `hermes gateway install --system` is run as root, the generated systemd unit file has contradictory paths:

- `User=ubuntu` (correctly detected via `SUDO_USER`)
- `WorkingDirectory=/root/.hermes/hermes-agent` (root path — ubuntu cannot access this)
- `ExecStart=/root/.hermes/hermes-agent/venv/bin/python ...` (same)

The `ubuntu` user cannot access `/root/` (permission `drwx------`), so systemd fails immediately with `status=200/CHDIR` and enters a restart loop.

## Root Cause

In `generate_systemd_unit()`, `python_path`, `working_dir`, and `venv_dir` were resolved at function entry from the current process (root), **before** the target user was determined. Only `HERMES_HOME` was remapped to the target user via `_hermes_home_for_target_user()`.

## Fix

When `system=True`, detect the target user first, then derive all paths from that user's home directory:

- `WorkingDirectory` → `~ubuntu/.hermes/hermes-agent`
- `ExecStart` python → `~ubuntu/.hermes/hermes-agent/venv/bin/python`
- `VIRTUAL_ENV` → `~ubuntu/.hermes/hermes-agent/venv`

Falls back to current (root) paths if the target user's install directory does not exist (non-standard installs under `/opt/` etc.).

## Testing

- Fresh Ubuntu 24.04, installed as root, non-root `ubuntu` user present
- `sudo hermes gateway install --system --run-as-user ubuntu`
- Generated unit file now has all paths under `/home/ubuntu/`
- `sudo systemctl start hermes-gateway` starts without CHDIR error

Fixes #6989