### PR TITLE
fix(slack): reject HTML file payloads before caching media

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -46,6 +46,31 @@ from gateway.platforms.base import (
 logger = logging.getLogger(__name__)
 
 
+def _looks_like_html_document(data: bytes) -> bool:
+    """Best-effort sniff for HTML payloads accidentally returned as media."""
+    if not data:
+        return False
+    prefix = data[:512].lstrip().lower()
+    return (
+        prefix.startswith(b"<!doctype html")
+        or prefix.startswith(b"<html")
+        or prefix.startswith(b"<head")
+        or prefix.startswith(b"<body")
+    )
+
+
+def _validate_slack_download_payload(response: Any, data: bytes, *, kind: str) -> None:
+    """Reject obvious auth/login HTML pages returned from Slack file URLs."""
+    content_type = str(getattr(response, "headers", {}).get("content-type", "") or "")
+    normalized_ct = content_type.split(";", 1)[0].strip().lower()
+
+    if normalized_ct == "text/html" or _looks_like_html_document(data):
+        raise ValueError(
+            f"Slack returned HTML instead of {kind} payload"
+            + (f" (content-type={normalized_ct})" if normalized_ct else "")
+        )
+
+
 @dataclass
 class _ThreadContextCache:
     """Cache entry for fetched thread context."""
@@ -1595,6 +1620,11 @@ class SlackAdapter(BasePlatformAdapter):
                         headers={"Authorization": f"Bearer {bot_token}"},
                     )
                     response.raise_for_status()
+                    _validate_slack_download_payload(
+                        response,
+                        response.content,
+                        kind="audio" if audio else "image",
+                    )
 
                     if audio:
                         from gateway.platforms.base import cache_audio_from_bytes
@@ -1630,6 +1660,7 @@ class SlackAdapter(BasePlatformAdapter):
                         headers={"Authorization": f"Bearer {bot_token}"},
                     )
                     response.raise_for_status()
+                    _validate_slack_download_payload(response, response.content, kind="file")
                     return response.content
                 except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
                     last_exc = exc

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -489,6 +489,35 @@ class TestSlackDownloadSlackFile:
         assert mock_client.get.call_count == 1
         mock_sleep.assert_not_called()
 
+    def test_rejects_html_login_page_even_with_200(self, tmp_path, monkeypatch):
+        """A 200 HTML login page must not be cached as an image."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        adapter = _make_slack_adapter()
+
+        fake_response = MagicMock()
+        fake_response.content = (
+            b"<!DOCTYPE html><html><head><title>Slack</title></head>"
+            b"<body>Please sign in</body></html>"
+        )
+        fake_response.headers = {"content-type": "text/html; charset=utf-8"}
+        fake_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=fake_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                await adapter._download_slack_file(
+                    "https://files.slack.com/img.jpg", ext=".jpg"
+                )
+
+        with pytest.raises(ValueError, match="HTML instead of image"):
+            asyncio.run(run())
+
+        assert not (tmp_path / "img").exists() or not any((tmp_path / "img").iterdir())
+
 
 # ---------------------------------------------------------------------------
 # SlackAdapter._download_slack_file_bytes
@@ -518,6 +547,29 @@ class TestSlackDownloadSlackFileBytes:
 
         result = asyncio.run(run())
         assert result == b"raw bytes here"
+
+    def test_rejects_html_login_page_for_raw_file_downloads(self):
+        """A 200 HTML login page must not be treated as a real file download."""
+        adapter = _make_slack_adapter()
+
+        fake_response = MagicMock()
+        fake_response.content = b"<!DOCTYPE html><html><body>Sign in</body></html>"
+        fake_response.headers = {"content-type": "text/html"}
+        fake_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=fake_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        async def run():
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                await adapter._download_slack_file_bytes(
+                    "https://files.slack.com/file.bin"
+                )
+
+        with pytest.raises(ValueError, match="HTML instead of file"):
+            asyncio.run(run())
 
     def test_retries_on_429_then_succeeds(self):
         """429 on first attempt is retried; raw bytes returned on second."""


### PR DESCRIPTION
## Summary
- reject obvious HTML sign-in/redirect payloads returned from Slack file URLs before caching them as media
- validate both image/audio and raw file download paths in the Slack adapter
- add regression coverage for `HTTP 200 + HTML body` so bogus local image paths never reach vision

## Test Plan
- `source /Users/peteradams/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/gateway/test_media_download_retry.py -q -o addopts=''`
- manual Slack repro: attach an image in Slack and verify Hermes either caches real media or fails at the Slack download boundary instead of creating HTML-as-image cache files

## Related Issues
- Closes #7015
- Related: #6829

Carried patch: patch-fix-func-pr7017

Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.
