### PR TITLE
fix: set retryable=False for message-based auth errors in _classify_by_message()

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -725,10 +725,14 @@ def _classify_by_message(
         )
 
     # Auth patterns
+    # Auth errors should NOT be retried directly — the credential is invalid and
+    # retrying with the same key will always fail.  Set retryable=False so the
+    # caller triggers credential rotation (should_rotate_credential=True) or
+    # provider fallback rather than an immediate retry loop.
     if any(p in error_msg for p in _AUTH_PATTERNS):
         return result_fn(
             FailoverReason.auth,
-            retryable=True,
+            retryable=False,
             should_rotate_credential=True,
         )
 


### PR DESCRIPTION
## Problem

`_classify_by_message()` in `agent/error_classifier.py` was returning `retryable=True` for auth-pattern errors — inconsistent with `_classify_by_status()` which correctly sets `retryable=False` for 401/403 responses.

Closes #7026

## Root Cause

```python
# BEFORE — _classify_by_message()
if any(p in error_msg for p in _AUTH_PATTERNS):
    return result_fn(
        FailoverReason.auth,
        retryable=True,   # ← wrong: causes retry loop with invalid credential
        should_rotate_credential=True,
    )
```

```python
# _classify_by_status() — correct for 401 and 403
return result_fn(
    FailoverReason.auth,
    retryable=False,   # ← caller rotates credential, doesn't retry same key
    should_rotate_credential=True,
)
```

## Fix

```python
# AFTER
if any(p in error_msg for p in _AUTH_PATTERNS):
    return result_fn(
        FailoverReason.auth,
        retryable=False,   # ← don't retry with invalid credential
        should_rotate_credential=True,
    )
```

## Why retryable=False is correct

Auth errors mean the API key/credential is **invalid or expired**. Retrying the exact same request with the same credential will always fail. The correct action is:
- Rotate to a new credential (`should_rotate_credential=True`)
- Or fall back to another provider

`retryable=True` creates an unnecessary retry loop, wastes quota on doomed requests, and delays the credential rotation that would actually recover the situation.

The `_classify_by_status()` path already has this right for 401/403; this PR brings the message-based path into parity.