### PR TITLE
fix(cli): add missing os import in uninstall.py

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -6,6 +6,7 @@ Provides options for:
 - Keep data: Remove code but keep ~/.hermes/ (configs, sessions, logs)
 """
 
+import os
 import shutil
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## What does this PR do?
 Add missing `import os` to `hermes_cli/uninstall.py`. 
The `uninstall_gateway_service()` function calls `os.getenv()` on lines 126-127 but `os` was not imported, causing a `NameError` at runtime.  

## Changes Made
- `hermes_cli/uninstall.py`: Added `import os` to the existing imports section  

### Documentation & Housekeeping  
- [x] N/A