### PR TITLE
[codex] Install procps in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev && \
+        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/hermes


### PR DESCRIPTION
## Summary
- install `procps` in the Docker image so `ps` is available in container runs
- restore `hermes gateway status`, `hermes cron status`, and `hermes cron list` in the packaged image

## Root Cause
The Debian-based Docker image did not include `procps`, but the CLI's gateway/cron status flow calls `find_gateway_pids()`, which shells out to `ps aux` on non-Windows platforms. Inside the container image that meant the status commands could not inspect running gateway processes correctly.

## Validation
- `source /Users/jerome.xu/Desktop/codex/hermes-agent/.codex-runtime/venv311/bin/activate && pytest -n 0 tests/hermes_cli/test_update_gateway_restart.py`
- Docker image build could not be run in this environment because `docker` is not installed locally.

Fixes #7020.
