### PR TITLE
fix(agent): set retryable=False for auth errors in _classify_by_message

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -728,7 +728,7 @@ def _classify_by_message(
     if any(p in error_msg for p in _AUTH_PATTERNS):
         return result_fn(
             FailoverReason.auth,
-            retryable=True,
+            retryable=False,
             should_rotate_credential=True,
         )
 


### PR DESCRIPTION
## Summary

In `agent/error_classifier.py`, the `_classify_by_message()` function (the fallback path when no HTTP status code is available) marks auth errors as `retryable=True`. This is inconsistent with the `_classify_by_status()` path which correctly uses `retryable=False` for 401/403 auth errors.

## Fix

Change `retryable=True` → `retryable=False` in the auth pattern branch of `_classify_by_message()`. Auth errors indicate the credential is invalid; retrying with the same key will always fail. The `should_rotate_credential=True` already signals the correct recovery action.

## Impact

When an API response lacks an HTTP status code but contains an auth-related message, the classifier previously returned `retryable=True` for auth failures. This caused:
1. The caller retries with the **same invalid credential** instead of rotating
2. Creates an unnecessary retry loop before eventually hitting max retries
3. Wastes time and potentially burns rate-limit quota with doomed requests

Fixing this aligns the message-based path with the status-code path behavior.

## Test plan

- Run existing error classifier tests: `pytest tests/agent/test_error_classifier.py -v`
- Verify auth error classification returns `retryable=False`

Fixes #7026.