### PR TITLE
fix(cli): add missing os and platform imports in uninstall.py

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -6,6 +6,8 @@ Provides options for:
 - Keep data: Remove code but keep ~/.hermes/ (configs, sessions, logs)
 """
 
+import os
+import platform
 import shutil
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Summary

The `hermes uninstall` command crashes with `NameError: name 'os' is not defined` because `os` and `platform` modules are used in `hermes_cli/uninstall.py` but were not imported.

## Fix

Add `import os` and `import platform` to the imports in `hermes_cli/uninstall.py`.

## Test plan

- Run `hermes uninstall` and verify it no longer crashes with NameError
- Verify uninstall functionality still works correctly

Fixes #6983.