### PR TITLE
mattermost added as deliver target to webhook gateway

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -193,6 +193,7 @@ class WebhookAdapter(BasePlatformAdapter):
             "slack",
             "signal",
             "sms",
+            "mattermost",
         ):
             return await self._deliver_cross_platform(
                 deliver_type, content, delivery


### PR DESCRIPTION
## What does this PR do?

The webhook gateway did not deliver to the route mattermost because "mattermost" was missing from the list in webhook.py. But the [documentation ](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks#route-properties) mentions "mattermost" as possible delivery target. I only included mattermost in webhook.py as I tested that it works. Other delivery targets are mentioned docs, but are not included in the code are:

- matrix
- email
- dingtalk
- feishu
- wecom

Maybe future work?