### PR TITLE
[codex] Remove broken Matrix package extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "py
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
-matrix = ["matrix-nio[e2e]>=0.24.0,<1", "Markdown>=3.6,<4"]
 cli = ["simple-term-menu>=1.0,<2"]
 tts-premium = ["elevenlabs>=1.0,<2"]
 voice = [
@@ -88,10 +87,10 @@ all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
   "hermes-agent[messaging]",
-  # matrix excluded: python-olm (required by matrix-nio[e2e]) is upstream-broken
-  # on modern macOS (archived libolm, C++ errors with Clang 21+). Including it
-  # here causes the entire [all] install to fail, dropping all other extras.
-  # Users who need Matrix can install manually: pip install 'hermes-agent[matrix]'
+  # Matrix extras are intentionally omitted from packaging metadata for now.
+  # Current matrix-nio wheels still pin h11~=0.14, which conflicts with the
+  # httpcore==1.x stack required by Hermes core deps. Users who need Matrix can
+  # still install matrix-nio manually until a compatible dependency set exists.
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[dev]",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -11,12 +11,21 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
-def test_matrix_extra_exists_but_excluded_from_all():
-    """matrix-nio[e2e] depends on python-olm which is upstream-broken on modern
-    macOS (archived libolm, C++ errors with Clang 21+).  The [matrix] extra is
-    kept for opt-in install but deliberately excluded from [all] so one broken
-    upstream dep doesn't nuke every other extra during ``hermes update``."""
+def test_broken_matrix_extra_not_advertised():
+    """Do not publish a Matrix extra until its dependency stack is compatible.
+
+    Current matrix-nio wheels still require h11~=0.14, which conflicts with the
+    httpcore==1.x stack pulled in by Hermes core dependencies. Advertising a
+    ``hermes-agent[matrix]`` install path would therefore publish a broken
+    dependency set in packaging metadata.
+    """
     optional_dependencies = _load_optional_dependencies()
 
-    assert "matrix" in optional_dependencies
-    assert "hermes-agent[matrix]" not in optional_dependencies["all"]
+    assert "matrix" not in optional_dependencies
+
+
+def test_all_extra_does_not_pull_matrix_dependencies():
+    """The catch-all extra must stay installable even while Matrix is guarded."""
+    optional_dependencies = _load_optional_dependencies()
+
+    assert all("matrix" not in dep for dep in optional_dependencies["all"])


### PR DESCRIPTION
## Summary
- remove the packaged `matrix` extra from `pyproject.toml`
- keep `all` free of Matrix dependency paths until a compatible stack exists
- add packaging metadata regression coverage so the broken extra does not get republished by accident

## Root Cause
Current `matrix-nio` wheels still publish `Requires-Dist: h11 ~=0.14`, which conflicts with the `httpcore==1.x` / `h11>=0.16` stack required by Hermes core dependencies. Advertising `hermes-agent[matrix]` therefore publishes a dependency set that is not packaging-consistent.

## Validation
- `source /Users/jerome.xu/Desktop/codex/hermes-agent/.codex-runtime/venv311/bin/activate && pytest -n 0 tests/test_project_metadata.py tests/test_packaging_metadata.py`
- built a local wheel and inspected `METADATA` to confirm `Provides-Extra: matrix` is no longer exported
- confirmed upstream `matrix-nio==0.25.2` wheel metadata still declares `Requires-Dist: h11 ~=0.14`

Fixes #6931.
