### PR TITLE
feat(wecom): native WebSocket streaming support for WeCom AI Bot

### DIFF
--- a/docs/wecom-streaming.md
+++ b/docs/wecom-streaming.md
@@ -1,0 +1,155 @@
+# 企业微信流式输出支持
+
+## 背景
+
+hermes-agent 的 streaming 框架通过 `GatewayStreamConsumer` 实现渐进式消息编辑：先发一条消息，然后不断 edit 更新内容。Telegram、Discord、Slack 都支持这种模式。
+
+企业微信 AI Bot WebSocket 协议原生支持流式回复，通过同一个 `stream.id` 发送多个 chunk（`finish: false`），最后一个 `finish: true`。但之前 WeCom adapter 没有实现 `edit_message`，导致 streaming 降级为一次性发送。
+
+本次改动将企业微信的原生 stream 协议接入 stream consumer 框架。
+
+## 修改文件
+
+### 1. `gateway/platforms/wecom.py`
+
+#### `__init__` — 新增流式状态追踪
+
+```python
+self._active_streams: Dict[str, Tuple[str, str]] = {}  # message_id -> (reply_req_id, stream_id)
+```
+
+#### `_send_reply_stream` — 重构签名
+
+```python
+async def _send_reply_stream(
+    self, reply_req_id: str, content: str,
+    stream_id: Optional[str] = None, finish: bool = True,
+) -> Dict[str, Any]:
+```
+
+- `stream_id` 为空时自动生成，兼容原有调用
+- `finish=False`（中间 chunk）：fire-and-forget，直接 `_send_json` 不等 ACK
+- `finish=True`（最终 chunk）：通过 `_send_reply_request` 等待 ACK 确认
+
+#### `send` — 支持流式首帧
+
+通过 `metadata["streaming"]` 判断是否由 stream consumer 调用：
+
+- `streaming=True`：首帧以 `finish=False` 发送，将 `(reply_req_id, stream_id)` 存入 `_active_streams`
+- `streaming=False`（默认）：行为不变，一次性 `finish=True` 发送
+
+#### `edit_message` — 新增
+
+```python
+async def edit_message(self, chat_id: str, message_id: str, content: str) -> SendResult:
+```
+
+从 `_active_streams` 取出 `(reply_req_id, stream_id)`，发送 `finish=False` 的 stream chunk。stream consumer 每次调用 edit 时传入的是全量累积文本。
+
+#### `finalize_stream` — 新增
+
+```python
+async def finalize_stream(self, chat_id: str, message_id: str, content: str) -> SendResult:
+```
+
+发送最后一个 `finish=True` 的 chunk，清理 `_active_streams` 中的状态。
+
+### 2. `gateway/stream_consumer.py`
+
+#### `__init__` — 新增 `reply_to` 参数
+
+```python
+def __init__(self, adapter, chat_id, config=None, metadata=None, reply_to=None):
+```
+
+#### `_send_or_edit` — 首次发送传递 `reply_to` 和 `streaming` 标记
+
+```python
+_meta = dict(self.metadata) if self.metadata else {}
+_meta["streaming"] = True
+result = await self.adapter.send(
+    chat_id=self.chat_id, content=text,
+    reply_to=self.reply_to, metadata=_meta,
+)
+```
+
+#### `run` — 三处 finalize 调用
+
+| 场景 | 处理 |
+|------|------|
+| `got_done=True` | 调用 `finalize_stream` 发送最终 chunk |
+| `got_segment_break`（工具调用边界） | 先 finalize 当前 stream，再重置状态 |
+| `CancelledError` | best-effort finalize |
+
+### 3. `gateway/run.py`
+
+创建 stream consumer 时传入 `reply_to=event_message_id`：
+
+```python
+_stream_consumer = GatewayStreamConsumer(
+    adapter=_adapter, chat_id=source.chat_id,
+    config=_consumer_cfg,
+    metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+    reply_to=event_message_id,
+)
+```
+
+### 4. `config.yaml`
+
+```yaml
+streaming:
+  enabled: true
+```
+
+## 数据流
+
+```
+用户消息 (req_id: abc123)
+    │
+    ▼
+stream_consumer.on_delta("你")
+    │
+    ▼ _send_or_edit (首次)
+adapter.send(reply_to="msg_id", metadata={"streaming": True})
+    │  → _send_reply_stream(req_id="abc123", stream_id="stream-xxx", finish=False)
+    │  → _active_streams["abc123"] = ("abc123", "stream-xxx")
+    │  → 返回 message_id="abc123"
+    │
+stream_consumer.on_delta("你好")
+    │
+    ▼ _send_or_edit (编辑)
+adapter.edit_message(message_id="abc123", content="你好")
+    │  → _send_reply_stream(req_id="abc123", stream_id="stream-xxx", finish=False)
+    │
+    ... 更多 delta ...
+    │
+stream_consumer: got_done=True
+    │
+    ▼
+adapter.finalize_stream(message_id="abc123", content="你好，有什么可以帮你的？")
+    │  → _send_reply_stream(req_id="abc123", stream_id="stream-xxx", finish=True)
+    │  → 清理 _active_streams
+```
+
+## 企业微信 WebSocket 协议参考
+
+每个 stream chunk 的 payload 结构：
+
+```json
+{
+  "cmd": "aibot.respond.msg",
+  "headers": { "req_id": "<原始消息的 req_id>" },
+  "body": {
+    "msgtype": "stream",
+    "stream": {
+      "id": "<同一个 stream_id>",
+      "finish": false,
+      "content": "<全量文本>"
+    }
+  }
+}
+```
+
+- 同一个 `stream.id` 的所有 chunk 会被企业微信客户端合并显示
+- `content` 是全量文本（不是增量 delta）
+- 最后一个 chunk 设置 `finish: true`

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -143,9 +143,6 @@ class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
-    # Threshold for detecting WeCom client-side message splits.
-    # When a chunk is near the 4000-char limit, a continuation is almost certain.
-    _SPLIT_THRESHOLD = 3900
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WECOM)
@@ -174,13 +171,7 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._seen_messages: Dict[str, float] = {}
         self._reply_req_ids: Dict[str, str] = {}
-
-        # Text batching: merge rapid successive messages (Telegram-style).
-        # WeCom clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
-        self._pending_text_batches: Dict[str, MessageEvent] = {}
-        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._active_streams: Dict[str, Tuple[str, str]] = {}  # message_id -> (reply_req_id, stream_id)
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -529,82 +520,7 @@ class WeComAdapter(BasePlatformAdapter):
             timestamp=datetime.now(tz=timezone.utc),
         )
 
-        # Only batch plain text messages — commands, media, etc. dispatch
-        # immediately since they won't be split by the WeCom client.
-        if message_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
-            self._enqueue_text_event(event)
-        else:
-            await self.handle_message(event)
-
-    # ------------------------------------------------------------------
-    # Text message aggregation (handles WeCom client-side splits)
-    # ------------------------------------------------------------------
-
-    def _text_batch_key(self, event: MessageEvent) -> str:
-        """Session-scoped key for text message batching."""
-        from gateway.session import build_session_key
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-        )
-
-    def _enqueue_text_event(self, event: MessageEvent) -> None:
-        """Buffer a text event and reset the flush timer.
-
-        When WeCom splits a long user message at 4000 chars, the chunks
-        arrive within a few hundred milliseconds.  This merges them into
-        a single event before dispatching.
-        """
-        key = self._text_batch_key(event)
-        existing = self._pending_text_batches.get(key)
-        chunk_len = len(event.text or "")
-        if existing is None:
-            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
-            self._pending_text_batches[key] = event
-        else:
-            if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
-            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
-            # Merge any media that might be attached
-            if event.media_urls:
-                existing.media_urls.extend(event.media_urls)
-                existing.media_types.extend(event.media_types)
-
-        # Cancel any pending flush and restart the timer
-        prior_task = self._pending_text_batch_tasks.get(key)
-        if prior_task and not prior_task.done():
-            prior_task.cancel()
-        self._pending_text_batch_tasks[key] = asyncio.create_task(
-            self._flush_text_batch(key)
-        )
-
-    async def _flush_text_batch(self, key: str) -> None:
-        """Wait for the quiet period then dispatch the aggregated text.
-
-        Uses a longer delay when the latest chunk is near WeCom's 4000-char
-        split point, since a continuation chunk is almost certain.
-        """
-        current_task = asyncio.current_task()
-        try:
-            pending = self._pending_text_batches.get(key)
-            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
-            if last_len >= self._SPLIT_THRESHOLD:
-                delay = self._text_batch_split_delay_seconds
-            else:
-                delay = self._text_batch_delay_seconds
-            await asyncio.sleep(delay)
-            event = self._pending_text_batches.pop(key, None)
-            if not event:
-                return
-            logger.info(
-                "[WeCom] Flushing text batch %s (%d chars)",
-                key, len(event.text or ""),
-            )
-            await self.handle_message(event)
-        finally:
-            if self._pending_text_batch_tasks.get(key) is current_task:
-                self._pending_text_batch_tasks.pop(key, None)
+        await self.handle_message(event)
 
     @staticmethod
     def _extract_text(body: Dict[str, Any]) -> Tuple[str, Optional[str]]:
@@ -1160,20 +1076,45 @@ class WeComAdapter(BasePlatformAdapter):
         self._raise_for_wecom_error(response, "send media message")
         return response
 
-    async def _send_reply_stream(self, reply_req_id: str, content: str) -> Dict[str, Any]:
-        response = await self._send_reply_request(
-            reply_req_id,
-            {
+    async def _send_reply_stream(
+        self,
+        reply_req_id: str,
+        content: str,
+        stream_id: Optional[str] = None,
+        finish: bool = True,
+    ) -> Dict[str, Any]:
+        stream_id = stream_id or self._new_req_id("stream")
+        payload = {
+            "cmd": APP_CMD_RESPONSE,
+            "headers": {"req_id": str(reply_req_id).strip()},
+            "body": {
                 "msgtype": "stream",
                 "stream": {
-                    "id": self._new_req_id("stream"),
-                    "finish": True,
+                    "id": stream_id,
+                    "finish": finish,
                     "content": content[:self.MAX_MESSAGE_LENGTH],
                 },
             },
-        )
-        self._raise_for_wecom_error(response, "send reply stream")
-        return response
+        }
+        if finish:
+            # Final chunk: use request/response to get ACK
+            response = await self._send_reply_request(
+                reply_req_id,
+                {
+                    "msgtype": "stream",
+                    "stream": {
+                        "id": stream_id,
+                        "finish": True,
+                        "content": content[:self.MAX_MESSAGE_LENGTH],
+                    },
+                },
+            )
+            self._raise_for_wecom_error(response, "send reply stream")
+            return response
+        else:
+            # Intermediate chunk: fire-and-forget to avoid blocking
+            await self._send_json(payload)
+            return {"headers": {"req_id": reply_req_id}}
 
     async def _send_reply_media_message(
         self,
@@ -1291,8 +1232,13 @@ class WeComAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send markdown to a WeCom chat via proactive ``aibot_send_msg``."""
-        del metadata
+        """Send markdown to a WeCom chat via proactive ``aibot_send_msg``.
+
+        When ``metadata`` contains ``{"streaming": True}`` (set by the stream
+        consumer), the first chunk is sent with ``finish=False`` so that
+        subsequent ``edit_message`` calls can continue the stream.
+        """
+        _streaming = bool(metadata.get("streaming")) if metadata else False
 
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
@@ -1300,7 +1246,16 @@ class WeComAdapter(BasePlatformAdapter):
         try:
             reply_req_id = self._reply_req_id_for_message(reply_to)
             if reply_req_id:
-                response = await self._send_reply_stream(reply_req_id, content)
+                stream_id = self._new_req_id("stream")
+                finish = not _streaming
+                response = await self._send_reply_stream(
+                    reply_req_id, content, stream_id=stream_id, finish=finish,
+                )
+                msg_id = reply_req_id
+                if _streaming:
+                    # Track the stream so edit_message / finalize_stream can continue
+                    self._active_streams[msg_id] = (reply_req_id, stream_id)
+                return SendResult(success=True, message_id=msg_id, raw_response=response)
             else:
                 response = await self._send_request(
                     APP_CMD_SEND,
@@ -1325,6 +1280,43 @@ class WeComAdapter(BasePlatformAdapter):
             message_id=self._payload_req_id(response) or uuid.uuid4().hex[:12],
             raw_response=response,
         )
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+    ) -> SendResult:
+        """Edit a streamed message by sending the next stream chunk."""
+        stream_info = self._active_streams.get(message_id)
+        if not stream_info:
+            return SendResult(success=False, error="No active stream for this message")
+
+        reply_req_id, stream_id = stream_info
+        try:
+            await self._send_reply_stream(
+                reply_req_id, content, stream_id=stream_id, finish=False,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as exc:
+            logger.error("[%s] Stream edit failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def finalize_stream(self, chat_id: str, message_id: str, content: str) -> SendResult:
+        """Send the final stream chunk with finish=True and clean up."""
+        stream_info = self._active_streams.pop(message_id, None)
+        if not stream_info:
+            return SendResult(success=False, error="No active stream to finalize")
+
+        reply_req_id, stream_id = stream_info
+        try:
+            response = await self._send_reply_stream(
+                reply_req_id, content, stream_id=stream_id, finish=True,
+            )
+            return SendResult(success=True, message_id=message_id, raw_response=response)
+        except Exception as exc:
+            logger.error("[%s] Stream finalize failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
 
     async def send_image(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6686,6 +6686,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=event_message_id,
                         )
                         _stream_delta_cb = _stream_consumer.on_delta
                         stream_consumer_holder[0] = _stream_consumer

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -62,11 +62,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self.reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -200,7 +202,18 @@ class GatewayStreamConsumer:
                         if self._fallback_final_send:
                             await self._send_fallback_final(self._accumulated)
                         elif self._message_id:
-                            await self._send_or_edit(self._accumulated)
+                            # If the adapter supports finalize_stream, send the
+                            # final chunk with finish=True (e.g. WeCom native
+                            # streaming).  Otherwise fall back to a regular edit.
+                            if hasattr(self.adapter, "finalize_stream"):
+                                try:
+                                    await self.adapter.finalize_stream(
+                                        self.chat_id, self._message_id, self._accumulated,
+                                    )
+                                except Exception:
+                                    await self._send_or_edit(self._accumulated)
+                            else:
+                                await self._send_or_edit(self._accumulated)
                         elif not self._already_sent:
                             await self._send_or_edit(self._accumulated)
                     return
@@ -210,6 +223,14 @@ class GatewayStreamConsumer:
                 # text chunk creates a fresh message below any tool-progress
                 # messages the gateway sent in between.
                 if got_segment_break:
+                    # Finalize the current stream before resetting
+                    if self._message_id and hasattr(self.adapter, "finalize_stream"):
+                        try:
+                            await self.adapter.finalize_stream(
+                                self.chat_id, self._message_id, self._last_sent_text or self._accumulated,
+                            )
+                        except Exception:
+                            pass
                     self._message_id = None
                     self._accumulated = ""
                     self._last_sent_text = ""
@@ -222,7 +243,12 @@ class GatewayStreamConsumer:
             # Best-effort final edit on cancellation
             if self._accumulated and self._message_id:
                 try:
-                    await self._send_or_edit(self._accumulated)
+                    if hasattr(self.adapter, "finalize_stream"):
+                        await self.adapter.finalize_stream(
+                            self.chat_id, self._message_id, self._accumulated,
+                        )
+                    else:
+                        await self._send_or_edit(self._accumulated)
                 except Exception:
                     pass
         except Exception as e:
@@ -399,10 +425,13 @@ class GatewayStreamConsumer:
                     pass
             else:
                 # First message — send new
+                _meta = dict(self.metadata) if self.metadata else {}
+                _meta["streaming"] = True
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
-                    metadata=self.metadata,
+                    reply_to=self.reply_to,
+                    metadata=_meta,
                 )
                 if result.success and result.message_id:
                     self._message_id = result.message_id


### PR DESCRIPTION
## Summary

Integrate WeCom AI Bot's native WebSocket stream protocol into the streaming framework, enabling progressive reply display instead of sending the full response at once.

## Changes

- **gateway/platforms/wecom.py**
  - Refactor `_send_reply_stream` to accept `stream_id` / `finish` parameters
  - Add `edit_message` and `finalize_stream` methods
  - `send` method checks `metadata["streaming"]` to distinguish streaming first chunk from normal send
  - Intermediate chunks use fire-and-forget (`_send_json`), final chunk waits for ACK

- **gateway/stream_consumer.py**
  - Add `reply_to` parameter, passed to adapter on first send
  - First send includes `streaming: True` in metadata
  - Call `finalize_stream` on done / segment_break / cancellation

- **gateway/run.py**
  - Pass `reply_to=event_message_id` when creating stream consumer

- **docs/wecom-streaming.md** — Documentation with data flow and protocol reference