### PR TITLE
feat(discord): add allowed_channels whitelist config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -581,6 +581,12 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(ic, list):
                         ic = ",".join(str(v) for v in ic)
                     os.environ["DISCORD_IGNORED_CHANNELS"] = str(ic)
+                # allowed_channels: if set, bot ONLY responds in these channels (whitelist)
+                ac = discord_cfg.get("allowed_channels")
+                if ac is not None and not os.getenv("DISCORD_ALLOWED_CHANNELS"):
+                    if isinstance(ac, list):
+                        ac = ",".join(str(v) for v in ac)
+                    os.environ["DISCORD_ALLOWED_CHANNELS"] = str(ac)
                 # no_thread_channels: channels where bot responds directly without creating thread
                 ntc = discord_cfg.get("no_thread_channels")
                 if ntc is not None and not os.getenv("DISCORD_NO_THREAD_CHANNELS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2234,6 +2234,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.require_mention: Require @mention in server channels (default: true)
         #   discord.free_response_channels: Channel IDs where bot responds without mention
         #   discord.ignored_channels: Channel IDs where bot NEVER responds (even when mentioned)
+        #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
 
@@ -2245,12 +2246,21 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_channel_id = self._get_parent_channel_id(message.channel)
 
         if not isinstance(message.channel, discord.DMChannel):
-            # Check ignored channels first - never respond even when mentioned
-            ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
-            ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
+
+            # Check allowed channels - if set, only respond in these channels
+            allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+            if allowed_channels_raw:
+                allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
+                if not (channel_ids & allowed_channels):
+                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
+                    return
+
+            # Check ignored channels - never respond even when mentioned
+            ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
+            ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
             if channel_ids & ignored_channels:
                 logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
                 return

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -541,6 +541,7 @@ DEFAULT_CONFIG = {
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
+        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
     },


### PR DESCRIPTION
## Summary

Add `DISCORD_ALLOWED_CHANNELS` (env var) / `discord.allowed_channels` (config.yaml) support to restrict the Discord bot to only respond in specified channels.

When set, messages from any channel **not** in the allowed list are silently ignored — even if the bot is @mentioned. This provides a secure default-deny posture vs the existing `ignored_channels` which is default-allow.

## Motivation

In servers where other bots dynamically create channels (e.g., project management bots), maintaining `DISCORD_IGNORED_CHANNELS` as a blacklist requires constant updates every time a new channel appears. A whitelist (`allowed_channels`) is set-and-forget — new channels are ignored by default until explicitly added.

This is the same problem space as the existing `ignored_channels` and `free_response_channels` configs, but solves the inverse: "only respond here" instead of "never respond there."

## Changes

- **`gateway/platforms/discord.py`**: Check `allowed_channels` before `ignored_channels` in `_handle_message()`. If the channel (or parent thread channel) is not in the allowed set, log and return early.
- **`gateway/config.py`**: Map `discord.allowed_channels` from config.yaml → `DISCORD_ALLOWED_CHANNELS` env var (same pattern as `ignored_channels` and `free_response_channels`).
- **`hermes_cli/config.py`**: Add `allowed_channels: ""` to `DEFAULT_CONFIG` under the `discord` section.

## Config

```yaml
# config.yaml
discord:
  allowed_channels: "123456789,987654321"  # or as a list: [123456789, 987654321]
```

```bash
# .env
DISCORD_ALLOWED_CHANNELS=123456789,987654321
```

- Empty/unset = no restriction (fully backward compatible)
- Env var takes precedence over config.yaml
- Supports string (comma-separated) or YAML list
- Works with threads: checks both thread ID and parent channel ID

## Testing

The implementation follows the exact same pattern as the existing `ignored_channels` check (lines 2258-2264 in the current code). No new dependencies or breaking changes.

Manual verification: with `DISCORD_ALLOWED_CHANNELS` set to a single channel ID, messages in other channels (including @mentions) are correctly ignored. DMs are unaffected (the check only runs inside the `if not isinstance(message.channel, discord.DMChannel)` block).