### PR TITLE
feat(tinfoil): add Tinfoil confidential inference provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -106,6 +106,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    "tinfoil": "llama3-3-70b",
 }
 
 # OpenRouter app attribution headers
@@ -676,6 +677,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
     Returns (client, model) for the first provider with usable runtime
     credentials, or (None, None) if none are configured.
+
+    Tinfoil is intentionally excluded from this generic auto chain. It must
+    only be selected explicitly so confidential-mode routing stays auditable.
     """
     try:
         from hermes_cli.auth import PROVIDER_REGISTRY, resolve_api_key_provider_credentials
@@ -685,6 +689,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
     for provider_id, pconfig in PROVIDER_REGISTRY.items():
         if pconfig.auth_type != "api_key":
+            continue
+        if provider_id == "tinfoil":
             continue
         if provider_id == "anthropic":
             return _try_anthropic()
@@ -967,6 +973,24 @@ def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     return AnthropicAuxiliaryClient(real_client, model, token, base_url, is_oauth=is_oauth), model
 
 
+def _try_tinfoil(*, suppress_errors: bool = True) -> Tuple[Optional[Any], Optional[str]]:
+    """Try to build a Tinfoil auxiliary client from env credentials."""
+    api_key = os.getenv("TINFOIL_API_KEY") or os.getenv("TINFOIL_TOKEN")
+    if not api_key:
+        return None, None
+    try:
+        from agent.tinfoil_adapter import build_client as _tinfoil_build
+        client = _tinfoil_build(api_key.strip())
+        model = _API_KEY_PROVIDER_AUX_MODELS.get("tinfoil", "llama3-3-70b")
+        logger.debug("Auxiliary client: Tinfoil confidential (%s)", model)
+        return client, model
+    except Exception as exc:
+        if not suppress_errors:
+            raise
+        logger.debug("Tinfoil auxiliary client build failed: %s", exc)
+        return None, None
+
+
 def _resolve_forced_provider(forced: str) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Resolve a specific forced provider.  Returns (None, None) if creds missing."""
     if forced == "openrouter":
@@ -987,8 +1011,30 @@ def _resolve_forced_provider(forced: str) -> Tuple[Optional[OpenAI], Optional[st
             logger.warning("auxiliary.provider=codex but no Codex OAuth token found (run: hermes model)")
         return client, model
 
+    if forced == "tinfoil":
+        client, model = _try_tinfoil()
+        if client is None:
+            logger.warning("auxiliary.provider=tinfoil but no Tinfoil credentials found (set TINFOIL_API_KEY)")
+        return client, model
+
     if forced == "main":
-        # "main" = skip OpenRouter/Nous, use the main chat model's credentials.
+        # When the main provider is Tinfoil, auxiliary tasks must also use Tinfoil.
+        # Do not silently route to OpenRouter — that would violate confidentiality.
+        try:
+            from hermes_cli.config import load_config as _load_config
+            _cfg = _load_config()
+            _model_cfg = _cfg.get("model", {})
+            _main_provider = str(_model_cfg.get("provider") or "").strip().lower()
+        except Exception:
+            _main_provider = ""
+
+        if _main_provider == "tinfoil":
+            client, model = _try_tinfoil()
+            if client is None:
+                logger.warning("auxiliary.provider=main with tinfoil main provider but TINFOIL_API_KEY not set")
+            return client, model
+
+        # Original "main" fallback chain for non-Tinfoil providers
         for try_fn in (_try_custom_endpoint, _try_codex, _resolve_api_key_provider):
             client, model = try_fn()
             if client is not None:
@@ -1206,6 +1252,7 @@ def resolve_provider_client(
     raw_codex: bool = False,
     explicit_base_url: str = None,
     explicit_api_key: str = None,
+    task: str = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.
@@ -1218,6 +1265,7 @@ def resolve_provider_client(
         provider: Provider identifier.  One of:
             "openrouter", "nous", "openai-codex" (or "codex"),
             "zai", "kimi-coding", "minimax", "minimax-cn",
+            "tinfoil" (Tinfoil confidential AI),
             "custom" (OPENAI_BASE_URL + OPENAI_API_KEY),
             "auto" (full auto-detection chain).
         model: Model slug override.  If None, uses the provider's default
@@ -1229,12 +1277,30 @@ def resolve_provider_client(
             the main agent loop).
         explicit_base_url: Optional direct OpenAI-compatible endpoint.
         explicit_api_key: Optional API key paired with explicit_base_url.
+        task: Optional task hint (e.g. "vision") used for fail-closed guards.
 
     Returns:
         (client, resolved_model) or (None, None) if auth is unavailable.
     """
     # Normalise aliases
     provider = _normalize_aux_provider(provider)
+
+    # Tinfoil confidentiality guard: if the main provider is Tinfoil, vision
+    # auxiliary must not fall back to OpenRouter or other non-confidential providers.
+    # Return None rather than silently leaking data.
+    if task == "vision":
+        try:
+            from hermes_cli.config import load_config as _load_cfg_vision
+            _vcfg = _load_cfg_vision()
+            _vprovider = str((_vcfg.get("model") or {}).get("provider") or "").strip().lower()
+        except Exception:
+            _vprovider = ""
+        if provider == "tinfoil" or (_vprovider == "tinfoil" and provider not in ("tinfoil", "custom")):
+            logger.warning(
+                "Vision auxiliary disabled: Tinfoil is active and vision is not yet "
+                "supported through Tinfoil. Configure a non-Tinfoil main provider to enable vision."
+            )
+            return None, None
 
     # ── Auto: try all providers in priority order ────────────────────
     if provider == "auto":
@@ -1298,6 +1364,17 @@ def resolve_provider_client(
         final_model = model or default
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
+
+    # ── Tinfoil (explicit only, fail closed) ─────────────────────────
+    if provider == "tinfoil":
+        client, default = _try_tinfoil(suppress_errors=False)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: tinfoil requested but TINFOIL_API_KEY is not set"
+            )
+            return None, None
+        final_model = model or default
+        return client, final_model
 
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
@@ -1536,6 +1613,16 @@ def get_available_vision_backends() -> List[str]:
     return available
 
 
+def _vprovider_for_vision() -> str:
+    """Return the configured main provider for use in vision fail-closed checks."""
+    try:
+        from hermes_cli.config import load_config as _lcfg
+        _cfg = _lcfg()
+        return str((_cfg.get("model") or {}).get("provider") or "").strip().lower()
+    except Exception:
+        return ""
+
+
 def resolve_vision_provider_client(
     provider: Optional[str] = None,
     model: Optional[str] = None,
@@ -1555,6 +1642,17 @@ def resolve_vision_provider_client(
         "vision", provider, model, base_url, api_key
     )
     requested = _normalize_vision_provider(requested)
+
+    # Tinfoil fail-closed: vision is not supported through Tinfoil's confidential enclave.
+    # Never fall back to OpenRouter or other providers when Tinfoil is active —
+    # that would silently route potentially-sensitive image data off-enclave.
+    if requested == "tinfoil" or _vprovider_for_vision() == "tinfoil":
+        logger.warning(
+            "Vision auxiliary disabled: Tinfoil is configured as the main provider. "
+            "Vision tasks require a non-Tinfoil provider. "
+            "Configure 'auxiliary.vision' in config.yaml to enable vision separately."
+        )
+        return None, None, None
 
     def _finalize(resolved_provider: str, sync_client: Any, default_model: Optional[str]):
         if sync_client is None:

--- a/agent/tinfoil_adapter.py
+++ b/agent/tinfoil_adapter.py
@@ -1,0 +1,105 @@
+"""Tinfoil confidential inference adapter for Hermes Agent.
+
+Wraps TinfoilAI (the tinfoil-python SDK) for use as a first-class api_mode
+in hermes-agent.  All inference calls in this mode stay on the TinfoilAI
+client, which handles enclave router selection, attestation via GitHub +
+Sigstore, and TLS certificate pinning.  No fallback to generic OpenAI clients.
+
+Public API:
+  build_client(api_key)                          -> TinfoilAI
+  create_chat_completion(client, **kwargs)        -> response
+  stream_chat_completion(client, **kwargs)        -> Iterator[chunk]
+  list_models(api_key)                           -> list[str]
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator, List
+
+logger = logging.getLogger(__name__)
+
+try:
+    from tinfoil import TinfoilAI as _TinfoilAI
+except ImportError:
+    _TinfoilAI = None  # type: ignore[assignment]
+
+
+def build_client(api_key: str) -> Any:
+    """Instantiate a TinfoilAI client with repo-based enclave attestation.
+
+    The SDK auto-selects a verified router via https://atc.tinfoil.sh/routers,
+    fetches a Sigstore-attested digest from GitHub, and pins the TLS certificate
+    to the enclave's public key.  No enclave address needed from the caller.
+
+    Args:
+        api_key: Tinfoil API key (TINFOIL_API_KEY or TINFOIL_TOKEN).
+
+    Returns:
+        A TinfoilAI client instance (OpenAI-compatible interface).
+
+    Raises:
+        ImportError: If the tinfoil package is not installed.
+    """
+    if _TinfoilAI is None:
+        raise ImportError(
+            "The 'tinfoil' package is required for the Tinfoil provider. "
+            "Install it with: pip install 'tinfoil>=0.11.0'"
+        )
+    return _TinfoilAI(api_key=api_key)
+
+
+def create_chat_completion(client: Any, **kwargs: Any) -> Any:
+    """Execute a non-streaming chat completion through the Tinfoil client.
+
+    Accepts the same kwargs as openai.chat.completions.create().
+    The payload is standard OpenAI chat-completions format — no translation needed.
+
+    Args:
+        client: A TinfoilAI client returned by build_client().
+        **kwargs: Standard chat completions parameters (model, messages, tools, etc.).
+
+    Returns:
+        OpenAI-compatible response object with .choices[0].message.content.
+    """
+    return client.chat.completions.create(**kwargs)
+
+
+def stream_chat_completion(client: Any, **kwargs: Any) -> Iterator[Any]:
+    """Execute a streaming chat completion through the Tinfoil client.
+
+    Yields OpenAI-compatible chunks with .choices[0].delta.content.
+
+    Args:
+        client: A TinfoilAI client returned by build_client().
+        **kwargs: Standard chat completions parameters. `stream` is forced True.
+
+    Yields:
+        OpenAI-compatible stream chunks.
+    """
+    kwargs["stream"] = True
+    stream = client.chat.completions.create(**kwargs)
+    yield from stream
+
+
+def list_models(api_key: str) -> List[str]:
+    """Fetch available Tinfoil model IDs through the Tinfoil client.
+
+    Used by setup and model-selection flows.  Returns an empty list on any
+    error so callers can fall back to a default list without crashing.
+
+    Args:
+        api_key: Tinfoil API key.
+
+    Returns:
+        List of model ID strings (e.g. ["llama3-3-70b", "whisper-large-v3-turbo"]).
+    """
+    try:
+        client = build_client(api_key)
+        # TinfoilAI wraps an inner OpenAI client as self.client but does not
+        # proxy the models resource onto itself — access it via client.client.
+        models_page = client.client.models.list()
+        return [m.id for m in models_page.data if getattr(m, "id", None)]
+    except Exception as exc:
+        logger.debug("Tinfoil model listing failed: %s", exc)
+        return []

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -26,6 +26,7 @@ model:
   #   "huggingface"  - Hugging Face Inference (requires: HF_TOKEN)
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
   #   "ai-gateway"   - Vercel AI Gateway (requires: AI_GATEWAY_API_KEY)
+  #   "tinfoil"      - Tinfoil confidential AI (requires: TINFOIL_API_KEY)
   #
   # Local servers (LM Studio, Ollama, vLLM, llama.cpp):
   #   "custom"       - Any OpenAI-compatible endpoint. Set base_url below.
@@ -40,6 +41,12 @@ model:
   #     base_url: "https://ollama.com/v1"
   #   Set OLLAMA_API_KEY in .env — automatically picked up when base_url
   #   points to ollama.com.
+  #
+  # Confidential inference (Tinfoil):
+  #   provider: "tinfoil"
+  #   default: "llama3-3-70b"
+  #   # Set TINFOIL_API_KEY in ~/.hermes/.env
+  #   # All requests are routed through a verified secure enclave.
   #
   # Can also be overridden with --provider flag or HERMES_INFERENCE_PROVIDER env var.
   provider: "auto"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -243,6 +243,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
     ),
+    "tinfoil": ProviderConfig(
+        id="tinfoil",
+        name="Tinfoil (Confidential AI)",
+        auth_type="api_key",
+        inference_base_url="https://inference.tinfoil.sh/v1",
+        api_key_env_vars=("TINFOIL_API_KEY", "TINFOIL_TOKEN"),
+    ),
 }
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -256,6 +256,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2.5",
         "MiniMax-M2.5",
     ],
+    "tinfoil": [],  # Populated dynamically via agent.tinfoil_adapter.list_models()
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B",
@@ -484,6 +485,7 @@ _PROVIDER_LABELS = {
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
     "qwen-oauth": "Qwen OAuth (Portal)",
+    "tinfoil": "Tinfoil (Confidential AI)",
     "huggingface": "Hugging Face",
     "custom": "Custom endpoint",
 }
@@ -771,7 +773,7 @@ def list_available_providers() -> list[dict[str, str]]:
         "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "qwen-oauth",
         "opencode-zen", "opencode-go",
-        "ai-gateway", "deepseek", "custom",
+        "ai-gateway", "deepseek", "tinfoil", "custom",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}
@@ -1031,8 +1033,8 @@ def _resolve_copilot_catalog_api_key() -> str:
 def provider_model_ids(provider: Optional[str]) -> list[str]:
     """Return the best known model catalog for a provider.
 
-    Tries live API endpoints for providers that support them (Codex, Nous),
-    falling back to static lists.
+    Tries live API endpoints for providers that support them (Codex, Nous,
+    Tinfoil), falling back to static lists.
     """
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
@@ -1069,6 +1071,19 @@ def provider_model_ids(provider: Optional[str]) -> list[str]:
         live = _fetch_ai_gateway_models()
         if live:
             return live
+    if normalized == "tinfoil":
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+            from agent.tinfoil_adapter import list_models as _list_tinfoil_models
+
+            creds = resolve_api_key_provider_credentials("tinfoil")
+            api_key = str(creds.get("api_key") or "").strip()
+            if api_key:
+                live = _list_tinfoil_models(api_key)
+                if live:
+                    return live
+        except Exception:
+            pass
     if normalized == "custom":
         base_url = _get_custom_base_url()
         if base_url:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -124,7 +124,7 @@ def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
         return "chat_completions"
 
 
-_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages"}
+_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages", "tinfoil"}
 
 
 def _parse_api_mode(raw: Any) -> Optional[str]:
@@ -167,6 +167,8 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+    elif provider == "tinfoil":
+        api_mode = "tinfoil"
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider
@@ -558,7 +560,9 @@ def _resolve_explicit_runtime(
                 base_url = creds.get("base_url", "").rstrip("/")
 
         api_mode = "chat_completions"
-        if provider == "copilot":
+        if provider == "tinfoil":
+            api_mode = "tinfoil"
+        elif provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
         else:
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
@@ -769,10 +773,16 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
+    # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN, Tinfoil)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
         creds = resolve_api_key_provider_credentials(provider)
+        # Tinfoil requires an API key — fail early with an actionable message.
+        if provider == "tinfoil" and not creds.get("api_key"):
+            raise AuthError(
+                "No Tinfoil credentials found. Set TINFOIL_API_KEY in your environment. "
+                "Get an API key at https://tinfoil.sh"
+            )
         # Honour model.base_url from config.yaml when the configured provider
         # matches this provider — mirrors the Anthropic path above.  Without
         # this, users who set model.base_url to e.g. api.minimaxi.com/anthropic
@@ -783,7 +793,9 @@ def resolve_runtime_provider(
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
-        if provider == "copilot":
+        if provider == "tinfoil":
+            api_mode = "tinfoil"
+        elif provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -17,7 +17,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from hermes_cli.nous_subscription import (
     apply_nous_provider_defaults,
@@ -31,6 +31,12 @@ logger = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 _DOCS_BASE = "https://hermes-agent.nousresearch.com/docs"
+
+
+# Shim for testing: tests can monkeypatch hermes_cli.setup._tinfoil_list_models
+def _tinfoil_list_models(api_key: str) -> List[str]:
+    from agent.tinfoil_adapter import list_models
+    return list_models(api_key)
 
 
 def _model_config_dict(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -116,6 +122,11 @@ _DEFAULT_PROVIDER_MODELS = {
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",
         "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2.5",
     ],
+    "tinfoil": [
+        "llama3-3-70b",
+        "llama3-1-405b",
+        "mistral-7b-instruct",
+    ],
 }
 
 
@@ -192,6 +203,7 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
 
     pconfig = PROVIDER_REGISTRY[provider_id]
     is_copilot_catalog_provider = provider_id in {"copilot", "copilot-acp"}
+    is_tinfoil = provider_id == "tinfoil"
 
     # Resolve API key and base URL for the probe
     if is_copilot_catalog_provider:
@@ -226,6 +238,12 @@ def _setup_provider_model_selection(config, provider_id, current_model, prompt_c
     # Try live /models endpoint
     if is_copilot_catalog_provider and catalog:
         live_models = [item.get("id", "") for item in catalog if item.get("id")]
+    elif is_tinfoil:
+        # Tinfoil: fetch models through the Tinfoil client (not generic /models probe)
+        tf_api_key = get_env_value("TINFOIL_API_KEY") or os.getenv("TINFOIL_API_KEY", "")
+        if not tf_api_key:
+            tf_api_key = get_env_value("TINFOIL_TOKEN") or os.getenv("TINFOIL_TOKEN", "")
+        live_models = _tinfoil_list_models(tf_api_key) if tf_api_key else []
     else:
         live_models = fetch_api_models(api_key, base_url)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   # Core — pinned to known-good ranges to limit supply chain attack surface
   "openai>=2.21.0,<3",
   "anthropic>=0.39.0,<1",
+  "tinfoil>=0.11.0,<1",
   "python-dotenv>=1.2.1,<2",
   "fire>=0.7.1,<1",
   "httpx>=0.28.1,<1",

--- a/run_agent.py
+++ b/run_agent.py
@@ -586,7 +586,7 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "tinfoil"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
@@ -748,8 +748,22 @@ class AIAgent:
         # access for Codex Responses API streaming.
         self._anthropic_client = None
         self._is_anthropic_oauth = False
+        self._tinfoil_client = None
 
-        if self.api_mode == "anthropic_messages":
+        if self.api_mode == "tinfoil":
+            from agent.tinfoil_adapter import build_client as _tinfoil_build
+            if not api_key:
+                raise RuntimeError(
+                    "Tinfoil mode requires TINFOIL_API_KEY. "
+                    "Set it in your environment or run 'hermes model' to reconfigure."
+                )
+            self.api_key = api_key
+            self._tinfoil_client = _tinfoil_build(api_key)
+            self.client = None
+            self._client_kwargs = {}
+            if not self.quiet_mode:
+                print(f"🤖 AI Agent initialized with model: {self.model} (Tinfoil confidential)")
+        elif self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
             # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
@@ -4288,6 +4302,9 @@ class AIAgent:
                     )
                 elif self.api_mode == "anthropic_messages":
                     result["response"] = self._anthropic_messages_create(api_kwargs)
+                elif self.api_mode == "tinfoil":
+                    from agent.tinfoil_adapter import create_chat_completion
+                    result["response"] = create_chat_completion(self._tinfoil_client, **api_kwargs)
                 else:
                     request_client_holder["client"] = self._create_request_openai_client(reason="chat_completion_request")
                     result["response"] = request_client_holder["client"].chat.completions.create(**api_kwargs)
@@ -4315,6 +4332,11 @@ class AIAgent:
                             self._anthropic_api_key,
                             getattr(self, "_anthropic_base_url", None),
                         )
+                    elif self.api_mode == "tinfoil":
+                        # Rebuild the Tinfoil client to get a fresh connection
+                        # after an interrupt — do not fall back to any other provider.
+                        from agent.tinfoil_adapter import build_client as _tinfoil_rebuild
+                        self._tinfoil_client = _tinfoil_rebuild(self.api_key)
                     else:
                         request_client = request_client_holder.get("client")
                         if request_client is not None:
@@ -4438,19 +4460,28 @@ class AIAgent:
                     pool=30.0,
                 ),
             }
-            request_client_holder["client"] = self._create_request_openai_client(
-                reason="chat_completion_stream_request"
-            )
             # Reset stale-stream timer so the detector measures from this
             # attempt's start, not a previous attempt's last chunk.
             last_chunk_time["t"] = time.time()
             self._touch_activity("waiting for provider response (streaming)")
-            stream = request_client_holder["client"].chat.completions.create(**stream_kwargs)
+            if self.api_mode == "tinfoil":
+                # Do NOT put the shared tinfoil client into the holder — the
+                # holder's cleanup paths call close() which would break all
+                # future requests.  Keep streaming on the dedicated Tinfoil
+                # adapter path instead of the generic OpenAI client path.
+                from agent.tinfoil_adapter import stream_chat_completion
 
-            # Capture rate limit headers from the initial HTTP response.
-            # The OpenAI SDK Stream object exposes the underlying httpx
-            # response via .response before any chunks are consumed.
-            self._capture_rate_limits(getattr(stream, "response", None))
+                stream = stream_chat_completion(self._tinfoil_client, **stream_kwargs)
+            else:
+                request_client_holder["client"] = self._create_request_openai_client(
+                    reason="chat_completion_stream_request"
+                )
+                stream = request_client_holder["client"].chat.completions.create(**stream_kwargs)
+
+                # Capture rate limit headers from the initial HTTP response.
+                # The OpenAI SDK Stream object exposes the underlying httpx
+                # response via .response before any chunks are consumed.
+                self._capture_rate_limits(getattr(stream, "response", None))
 
             content_parts: list = []
             tool_calls_acc: dict = {}
@@ -4885,6 +4916,9 @@ class AIAgent:
                             self._anthropic_api_key,
                             getattr(self, "_anthropic_base_url", None),
                         )
+                    elif self.api_mode == "tinfoil":
+                        from agent.tinfoil_adapter import build_client as _tinfoil_rebuild
+                        self._tinfoil_client = _tinfoil_rebuild(self.api_key)
                     else:
                         request_client = request_client_holder.get("client")
                         if request_client is not None:
@@ -4929,10 +4963,18 @@ class AIAgent:
         can continue with the new backend.  Advances through the chain on
         each call; returns False when exhausted.
 
+        Tinfoil mode refuses all fallback to preserve confidentiality.
+
         Uses the centralized provider router (resolve_provider_client) for
         auth resolution and client construction — no duplicated provider→key
         mappings.
         """
+        if self.api_mode == "tinfoil":
+            logging.warning(
+                "Tinfoil mode is active; refusing provider fallback to preserve confidentiality."
+            )
+            return False
+
         if self._fallback_index >= len(self._fallback_chain):
             return False
 

--- a/tests/agent/test_auxiliary_client_tinfoil.py
+++ b/tests/agent/test_auxiliary_client_tinfoil.py
@@ -1,0 +1,94 @@
+"""Tests for Tinfoil routing in auxiliary_client — fail-closed on vision fallback."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+class TestTryTinfoil:
+    def test_returns_client_and_model_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        mock_client = MagicMock()
+        with patch("agent.tinfoil_adapter.build_client", return_value=mock_client):
+            from agent.auxiliary_client import _try_tinfoil
+            client, model = _try_tinfoil()
+        assert client is not None
+        assert isinstance(model, str) and model
+
+    def test_returns_none_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("TINFOIL_API_KEY", raising=False)
+        monkeypatch.delenv("TINFOIL_TOKEN", raising=False)
+        from agent.auxiliary_client import _try_tinfoil
+        client, model = _try_tinfoil()
+        assert client is None
+        assert model is None
+
+
+class TestResolveForcedProviderTinfoil:
+    def test_forced_tinfoil_resolves(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        mock_client = MagicMock()
+        with patch("agent.tinfoil_adapter.build_client", return_value=mock_client):
+            from agent.auxiliary_client import _resolve_forced_provider
+            client, model = _resolve_forced_provider("tinfoil")
+        assert client is not None
+
+    def test_forced_main_uses_tinfoil_when_configured(self, monkeypatch):
+        """When the main provider is Tinfoil, 'main' auxiliary must use Tinfoil too."""
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        mock_client = MagicMock()
+        # Patch load_config at the source so all imports see the patched version
+        mock_cfg = {"model": {"provider": "tinfoil", "default": "llama3-3-70b"}}
+        with patch("hermes_cli.config.load_config", return_value=mock_cfg), \
+             patch("agent.tinfoil_adapter.build_client", return_value=mock_client):
+            from agent.auxiliary_client import _resolve_forced_provider
+            client, model = _resolve_forced_provider("main")
+        assert client is not None
+
+    def test_vision_fails_when_tinfoil_active(self, monkeypatch):
+        """Vision auxiliary must not fall back to OpenRouter when Tinfoil is the main provider."""
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        mock_cfg = {"model": {"provider": "tinfoil", "default": "llama3-3-70b"}}
+        with patch("hermes_cli.config.load_config", return_value=mock_cfg):
+            from agent.auxiliary_client import resolve_provider_client
+            # Vision task for tinfoil should return None (unsupported), not fall to OpenRouter
+            client, model = resolve_provider_client("tinfoil", task="vision")
+        assert client is None
+
+    def test_explicit_tinfoil_uses_tinfoil_sdk_not_openai(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        mock_client = MagicMock()
+        with patch("agent.tinfoil_adapter.build_client", return_value=mock_client) as mock_build, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("tinfoil", model="llama3-3-70b")
+
+        assert client is mock_client
+        assert model == "llama3-3-70b"
+        mock_build.assert_called_once_with("tf-test-key")
+        mock_openai.assert_not_called()
+
+    def test_auto_mode_never_selects_tinfoil(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        fake_pconfig = SimpleNamespace(
+            auth_type="api_key",
+            name="Tinfoil",
+            inference_base_url="https://inference.tinfoil.sh/v1",
+        )
+        with patch(
+            "hermes_cli.auth.PROVIDER_REGISTRY",
+            {"tinfoil": fake_pconfig},
+        ), patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "tf-test-key"},
+        ), patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            from agent.auxiliary_client import _resolve_api_key_provider
+
+            client, model = _resolve_api_key_provider()
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()

--- a/tests/agent/test_tinfoil_adapter.py
+++ b/tests/agent/test_tinfoil_adapter.py
@@ -1,0 +1,91 @@
+"""Tests for agent.tinfoil_adapter — specifically list_models() correctness.
+
+Regression test for: "No models returned. Check your API key." when verifying
+a Tinfoil API key from the dashboard.
+
+Root cause: TinfoilAI SDK only proxies chat/embeddings/audio onto the wrapper
+object; the models resource lives on the inner `.client` (OpenAI). Calling
+`client.models.list()` raised AttributeError, caught silently, returning [].
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class TestListModels:
+    def _make_fake_tinfoil_client(self, model_ids: list[str]) -> MagicMock:
+        """Build a fake TinfoilAI instance that mirrors the SDK structure.
+
+        The real TinfoilAI stores the OpenAI client as self.client and does NOT
+        expose self.models directly — only self.client.models exists.
+        """
+        fake_model = lambda mid: SimpleNamespace(id=mid)
+        fake_models_page = SimpleNamespace(data=[fake_model(m) for m in model_ids])
+
+        inner_client = MagicMock()
+        inner_client.models.list.return_value = fake_models_page
+
+        outer_client = MagicMock(spec=[])  # no .models attribute on the outer object
+        outer_client.client = inner_client
+        return outer_client
+
+    def test_list_models_returns_ids_from_inner_client(self):
+        """list_models() must return model IDs via client.client.models.list()."""
+        fake_client = self._make_fake_tinfoil_client(["llama3-3-70b", "whisper-large-v3-turbo"])
+
+        with patch("agent.tinfoil_adapter.build_client", return_value=fake_client):
+            from agent.tinfoil_adapter import list_models
+
+            result = list_models("tf-test-key")
+
+        assert result == ["llama3-3-70b", "whisper-large-v3-turbo"]
+
+    def test_list_models_does_not_call_outer_models(self):
+        """Calling client.models must not be attempted — it does not exist on TinfoilAI."""
+        fake_client = self._make_fake_tinfoil_client(["llama3-3-70b"])
+
+        # Verify the outer client has no .models attribute (mirrors real SDK)
+        assert not hasattr(fake_client, "models") or isinstance(
+            getattr(type(fake_client), "models", None), MagicMock
+        )
+
+        with patch("agent.tinfoil_adapter.build_client", return_value=fake_client):
+            from agent.tinfoil_adapter import list_models
+
+            result = list_models("tf-test-key")
+
+        # Should succeed — not return [] due to AttributeError
+        assert result
+
+    def test_list_models_returns_empty_on_real_exception(self):
+        """Genuine errors (network, auth) still return [] without crashing."""
+        fake_client = MagicMock()
+        fake_client.client.models.list.side_effect = RuntimeError("enclave unreachable")
+
+        with patch("agent.tinfoil_adapter.build_client", return_value=fake_client):
+            from agent.tinfoil_adapter import list_models
+
+            result = list_models("tf-bad-key")
+
+        assert result == []
+
+    def test_list_models_filters_entries_without_id(self):
+        """Models without an id field are excluded from results."""
+        inner_client = MagicMock()
+        inner_client.models.list.return_value = SimpleNamespace(
+            data=[
+                SimpleNamespace(id="llama3-3-70b"),
+                SimpleNamespace(),  # no .id attribute
+                SimpleNamespace(id=None),
+            ]
+        )
+        fake_client = MagicMock(spec=[])
+        fake_client.client = inner_client
+
+        with patch("agent.tinfoil_adapter.build_client", return_value=fake_client):
+            from agent.tinfoil_adapter import list_models
+
+            result = list_models("tf-test-key")
+
+        assert result == ["llama3-3-70b"]

--- a/tests/test_run_agent_tinfoil.py
+++ b/tests/test_run_agent_tinfoil.py
@@ -1,0 +1,120 @@
+"""Tests for Tinfoil mode wiring in AIAgent — fail-closed behavior."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def _make_tinfoil_agent():
+    """Build an AIAgent configured for tinfoil mode, with mocked adapter."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(
+            message=SimpleNamespace(content="ok", role="assistant", tool_calls=None),
+            finish_reason="stop",
+            index=0,
+        )],
+        model="llama3-3-70b",
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+    )
+    with patch("agent.tinfoil_adapter.build_client", return_value=mock_client):
+        from run_agent import AIAgent
+        agent = AIAgent(
+            model="llama3-3-70b",
+            api_key="tf-key-123",
+            base_url="https://inference.tinfoil.sh",
+            provider="tinfoil",
+            api_mode="tinfoil",
+            quiet_mode=True,
+        )
+    agent._tinfoil_client = mock_client
+    return agent, mock_client
+
+
+class TestTinfoilAgentInit:
+    def test_api_mode_is_tinfoil(self):
+        agent, _ = _make_tinfoil_agent()
+        assert agent.api_mode == "tinfoil"
+
+    def test_openai_client_is_none(self):
+        agent, _ = _make_tinfoil_agent()
+        # For tinfoil mode, the generic OpenAI client must not be initialized
+        assert agent.client is None
+
+    def test_tinfoil_client_is_set(self):
+        agent, mock_client = _make_tinfoil_agent()
+        assert agent._tinfoil_client is mock_client
+
+
+class TestTinfoilNonStreamingCall:
+    def test_dispatches_to_tinfoil_adapter(self):
+        agent, mock_client = _make_tinfoil_agent()
+        api_kwargs = {
+            "model": "llama3-3-70b",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        with patch("agent.tinfoil_adapter.create_chat_completion",
+                   return_value=mock_client.chat.completions.create.return_value) as mock_call:
+            response = agent._interruptible_api_call(api_kwargs)
+        mock_call.assert_called_once_with(mock_client, **api_kwargs)
+        assert response.choices[0].message.content == "ok"
+
+    def test_does_not_use_openai_client(self):
+        agent, mock_client = _make_tinfoil_agent()
+        with patch("agent.tinfoil_adapter.create_chat_completion",
+                   return_value=mock_client.chat.completions.create.return_value):
+            agent._interruptible_api_call({
+                "model": "llama3-3-70b",
+                "messages": [],
+            })
+        # The generic OpenAI client must never be called
+        assert agent.client is None
+
+
+class TestTinfoilStreamingCall:
+    def test_streaming_dispatches_to_tinfoil_adapter(self):
+        agent, _ = _make_tinfoil_agent()
+        chunk1 = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="hel", tool_calls=None), finish_reason=None)],
+            model="llama3-3-70b",
+        )
+        chunk2 = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="lo", tool_calls=None), finish_reason="stop")],
+            model="llama3-3-70b",
+        )
+
+        with patch(
+            "agent.tinfoil_adapter.stream_chat_completion",
+            return_value=iter([chunk1, chunk2]),
+        ) as mock_stream:
+            response = agent._interruptible_streaming_api_call(
+                {"model": "llama3-3-70b", "messages": []}
+            )
+
+        mock_stream.assert_called_once()
+        assert response.choices[0].message.content == "hello"
+
+
+class TestTinfoilFailClosed:
+    def test_tinfoil_error_does_not_fall_back_to_openrouter(self):
+        """An error in tinfoil mode must not silently route to OpenRouter."""
+        agent, mock_client = _make_tinfoil_agent()
+        with patch("agent.tinfoil_adapter.create_chat_completion",
+                   side_effect=Exception("attestation failed")):
+            with pytest.raises(Exception, match="attestation failed"):
+                agent._interruptible_api_call({
+                    "model": "llama3-3-70b",
+                    "messages": [],
+                })
+        # Verify no OpenAI client was created as a fallback
+        assert agent.client is None
+
+    def test_provider_fallback_is_disabled_when_tinfoil_active(self):
+        agent, _ = _make_tinfoil_agent()
+        agent._fallback_chain = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        agent._fallback_index = 0
+
+        assert agent._try_activate_fallback() is False
+        assert agent.provider == "tinfoil"
+        assert agent.api_mode == "tinfoil"

--- a/tests/test_tinfoil_adapter.py
+++ b/tests/test_tinfoil_adapter.py
@@ -1,0 +1,118 @@
+"""Tests for agent/tinfoil_adapter.py — all tests mock TinfoilAI."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def _make_mock_tinfoil_client(models=None, completion_text="hello"):
+    """Build a mock TinfoilAI client that returns plausible responses."""
+    client = MagicMock()
+
+    # models.list() — TinfoilAI wraps an inner OpenAI client as .client,
+    # and list_models() accesses client.client.models.list().
+    model_objs = [SimpleNamespace(id=m) for m in (models or ["llama3-3-70b"])]
+    client.client.models.list.return_value = SimpleNamespace(data=model_objs)
+
+    # chat.completions.create() non-streaming
+    choice = SimpleNamespace(
+        index=0,
+        message=SimpleNamespace(content=completion_text, role="assistant", tool_calls=None),
+        finish_reason="stop",
+    )
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[choice],
+        model="llama3-3-70b",
+        usage=usage,
+    )
+    return client
+
+
+class TestBuildClient:
+    def test_returns_tinfoil_ai_instance(self):
+        mock_cls = MagicMock()
+        with patch("agent.tinfoil_adapter._TinfoilAI", mock_cls):
+            from agent.tinfoil_adapter import build_client
+            build_client("tf-key-123")
+        mock_cls.assert_called_once_with(api_key="tf-key-123")
+
+    def test_raises_import_error_when_sdk_missing(self):
+        with patch("agent.tinfoil_adapter._TinfoilAI", None):
+            from agent.tinfoil_adapter import build_client
+            with pytest.raises(ImportError, match="tinfoil"):
+                build_client("tf-key-123")
+
+
+class TestCreateChatCompletion:
+    def test_delegates_to_client(self):
+        from agent.tinfoil_adapter import create_chat_completion
+        mock_client = _make_mock_tinfoil_client()
+        result = create_chat_completion(
+            mock_client,
+            model="llama3-3-70b",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        mock_client.chat.completions.create.assert_called_once_with(
+            model="llama3-3-70b",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result.choices[0].message.content == "hello"
+
+    def test_passes_through_kwargs(self):
+        from agent.tinfoil_adapter import create_chat_completion
+        mock_client = _make_mock_tinfoil_client()
+        create_chat_completion(
+            mock_client,
+            model="llama3-3-70b",
+            messages=[],
+            temperature=0.7,
+            max_tokens=512,
+        )
+        _, kwargs = mock_client.chat.completions.create.call_args
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["max_tokens"] == 512
+
+
+class TestStreamChatCompletion:
+    def test_yields_chunks_from_stream(self):
+        from agent.tinfoil_adapter import stream_chat_completion
+        mock_client = MagicMock()
+
+        chunk1 = SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="hel"), finish_reason=None)])
+        chunk2 = SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="lo"), finish_reason="stop")])
+        mock_client.chat.completions.create.return_value = iter([chunk1, chunk2])
+
+        chunks = list(stream_chat_completion(
+            mock_client,
+            model="llama3-3-70b",
+            messages=[{"role": "user", "content": "hi"}],
+        ))
+        assert len(chunks) == 2
+        assert chunks[0].choices[0].delta.content == "hel"
+        assert chunks[1].choices[0].delta.content == "lo"
+
+    def test_sets_stream_true(self):
+        from agent.tinfoil_adapter import stream_chat_completion
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([])
+        list(stream_chat_completion(mock_client, model="m", messages=[]))
+        _, kwargs = mock_client.chat.completions.create.call_args
+        assert kwargs.get("stream") is True
+
+
+class TestListModels:
+    def test_returns_model_ids(self):
+        from agent.tinfoil_adapter import list_models
+        mock_cls = MagicMock(return_value=_make_mock_tinfoil_client(models=["llama3-3-70b", "mistral-7b"]))
+        with patch("agent.tinfoil_adapter._TinfoilAI", mock_cls):
+            result = list_models("tf-key-123")
+        assert result == ["llama3-3-70b", "mistral-7b"]
+
+    def test_returns_empty_list_on_error(self):
+        from agent.tinfoil_adapter import list_models
+        mock_cls = MagicMock(side_effect=Exception("network error"))
+        with patch("agent.tinfoil_adapter._TinfoilAI", mock_cls):
+            result = list_models("tf-key-123")
+        assert result == []

--- a/tests/test_tinfoil_provider.py
+++ b/tests/test_tinfoil_provider.py
@@ -1,0 +1,126 @@
+"""Tests for Tinfoil provider registration and runtime resolution."""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from hermes_cli.auth import PROVIDER_REGISTRY, ProviderConfig
+
+
+class TestTinfoilRegistry:
+    def test_tinfoil_in_registry(self):
+        assert "tinfoil" in PROVIDER_REGISTRY
+
+    def test_tinfoil_is_api_key_provider(self):
+        cfg = PROVIDER_REGISTRY["tinfoil"]
+        assert cfg.auth_type == "api_key"
+
+    def test_tinfoil_has_api_key_env_vars(self):
+        cfg = PROVIDER_REGISTRY["tinfoil"]
+        assert "TINFOIL_API_KEY" in cfg.api_key_env_vars
+        assert "TINFOIL_TOKEN" in cfg.api_key_env_vars
+
+    def test_tinfoil_has_inference_base_url(self):
+        cfg = PROVIDER_REGISTRY["tinfoil"]
+        assert cfg.inference_base_url == "https://inference.tinfoil.sh/v1"
+
+    def test_tinfoil_config_is_provider_config_instance(self):
+        cfg = PROVIDER_REGISTRY["tinfoil"]
+        assert isinstance(cfg, ProviderConfig)
+
+
+class TestTinfoilRuntimeResolution:
+    def test_resolves_api_mode_tinfoil(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="tinfoil")
+        assert result["api_mode"] == "tinfoil"
+
+    def test_resolves_provider_name(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="tinfoil")
+        assert result["provider"] == "tinfoil"
+
+    def test_resolves_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="tinfoil")
+        assert result["api_key"] == "tf-test-key"
+
+    def test_resolves_api_key_from_fallback_env(self, monkeypatch):
+        monkeypatch.delenv("TINFOIL_API_KEY", raising=False)
+        monkeypatch.setenv("TINFOIL_TOKEN", "tf-token-fallback")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="tinfoil")
+        assert result["api_key"] == "tf-token-fallback"
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("TINFOIL_API_KEY", raising=False)
+        monkeypatch.delenv("TINFOIL_TOKEN", raising=False)
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        from hermes_cli.auth import AuthError
+        with pytest.raises(AuthError):
+            resolve_runtime_provider(requested="tinfoil")
+
+    def test_tinfoil_not_in_auto_fallback(self, monkeypatch):
+        """Tinfoil should never be selected via 'auto' provider."""
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="auto")
+        assert result.get("provider") != "tinfoil"
+
+    def test_resolves_base_url(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="tinfoil")
+        assert result["base_url"] == "https://inference.tinfoil.sh/v1"
+
+
+class TestTinfoilModelCatalog:
+    def test_provider_models_has_tinfoil_key(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "tinfoil" in _PROVIDER_MODELS
+
+    def test_setup_default_models_has_tinfoil_fallback(self):
+        from hermes_cli.setup import _DEFAULT_PROVIDER_MODELS
+        assert "tinfoil" in _DEFAULT_PROVIDER_MODELS
+        assert len(_DEFAULT_PROVIDER_MODELS["tinfoil"]) > 0
+
+    def test_tinfoil_model_selection_uses_list_models(self, monkeypatch):
+        """Setup must call list_models (not fetch_api_models) for tinfoil."""
+        monkeypatch.setenv("TINFOIL_API_KEY", "tf-test-key")
+        called_with = {}
+
+        def _fake_list_models(api_key):
+            called_with["api_key"] = api_key
+            return ["llama3-3-70b", "mistral-7b-instruct"]
+
+        import hermes_cli.setup as setup_mod
+        monkeypatch.setattr(
+            "hermes_cli.setup._tinfoil_list_models",
+            _fake_list_models,
+            raising=False,
+        )
+
+        choices = []
+        def _fake_prompt_choice(question, options, default=0):
+            choices.extend(options)
+            return len(options) - 1  # "Keep current"
+
+        def _fake_prompt_fn(q):
+            return ""
+
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        setup_mod._setup_provider_model_selection(
+            cfg, "tinfoil", "llama3-3-70b",
+            _fake_prompt_choice, _fake_prompt_fn,
+        )
+        # list_models should have been called, not fetch_api_models
+        assert called_with.get("api_key") == "tf-test-key"
+        # The model list from list_models should appear in choices
+        assert "llama3-3-70b" in choices


### PR DESCRIPTION




## What does this PR do?
Add Tinfoil as a first-class provider with dedicated api_mode="tinfoil". All inference stays on the TinfoilAI SDK client which handles enclave router selection, Sigstore attestation, and TLS certificate pinning. Despite tinfoil being openai compatible I integrated their SDK due to actual enforcement of attestation and thus ensuring the confidentiality with it. If its only used as openai compatible endpoint then there is no assurance of inference being confidential. 

Key design decisions:
- Fail-closed: errors never silently fall back to other providers
- Vision disabled: image data never leaves the confidential enclave
- Auto-exclusion: tinfoil is never auto-selected, must be explicit
- Thin adapter: agent/tinfoil_adapter.py delegates to tinfoil SDK

## Related Issue

N/A

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Files added:
-  agent/tinfoil_adapter.py — SDK wrapper (build_client, completions, list_models) tests/test_tinfoil_*.py, tests/agent/test_tinfoil_*.py — 42 tests

Files modified:
-  pyproject.toml — add tinfoil>=0.11.0 dependency 
- hermes_cli/auth.py — register in PROVIDER_REGISTRY 
- hermes_cli/runtime_provider.py — api_mode routing + credential resolution 
- hermes_cli/models.py — model catalog, labels, provider order 
- hermes_cli/setup.py — setup wizard with live model fetching 
- agent/auxiliary_client.py — auxiliary routing, fail-closed guards 
- run_agent.py — client init, streaming/non-streaming dispatch, fallback block 
- cli-config.yaml.example — documentation

## How to Test


1.  get api key from tinfoil.sh 
2.  configure tinfoil provider 
3.  profit

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A



