### PR TITLE
fix(acp): populate PromptResponse usage from top-level result fields

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -460,6 +460,14 @@ class HermesACPAgent(acp.Agent):
                 thought_tokens=usage_data.get("reasoning_tokens"),
                 cached_read_tokens=usage_data.get("cached_tokens"),
             )
+        elif any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
+            usage = Usage(
+                input_tokens=result.get("prompt_tokens", 0),
+                output_tokens=result.get("completion_tokens", 0),
+                total_tokens=result.get("total_tokens", 0),
+                thought_tokens=result.get("reasoning_tokens"),
+                cached_read_tokens=result.get("cache_read_tokens"),
+            )
 
         stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -411,6 +411,37 @@ class TestPrompt:
         assert update.session_update == "agent_message_chunk"
 
     @pytest.mark.asyncio
+    async def test_prompt_populates_usage_from_top_level_run_conversation_fields(self, agent):
+        """ACP should map top-level token fields into PromptResponse.usage."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "usage attached",
+            "messages": [],
+            "prompt_tokens": 123,
+            "completion_tokens": 45,
+            "total_tokens": 168,
+            "reasoning_tokens": 7,
+            "cache_read_tokens": 11,
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="show usage")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert isinstance(resp, PromptResponse)
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 123
+        assert resp.usage.output_tokens == 45
+        assert resp.usage.total_tokens == 168
+        assert resp.usage.thought_tokens == 7
+        assert resp.usage.cached_read_tokens == 11
+
+    @pytest.mark.asyncio
     async def test_prompt_cancelled_returns_cancelled_stop_reason(self, agent):
         """If cancel is called during prompt, stop_reason should be 'cancelled'."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## What does this PR do?

Fixes ACP usage reporting when `HermesACPAgent.prompt()` receives the current `AIAgent.run_conversation()` result shape.

`acp_adapter/server.py` only read usage from `result["usage"]`, but `run_conversation()` returns token counters at the top level (`prompt_tokens`, `completion_tokens`, `total_tokens`, `reasoning_tokens`, `cache_read_tokens`). As a result, ACP clients received `PromptResponse.usage=None` even when usage data was available.

This change keeps the existing nested `result["usage"]` path, and adds a fallback to the top-level fields when that dict is absent.

## Related Issue

Fixes #7007

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`
  - preserve the existing nested `result["usage"]` mapping
  - fall back to top-level token fields when `result["usage"]` is absent
- `tests/acp/test_server.py`
  - add a regression test covering the current `run_conversation()` return shape

## How to Test

1. Run `uv run --extra dev --extra acp python -m pytest tests/acp/test_server.py -q`
2. Confirm the ACP server tests pass
3. Confirm `TestPrompt::test_prompt_populates_usage_from_top_level_run_conversation_fields` passes, proving `PromptResponse.usage` is populated from top-level token fields

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verification run:

```bash
uv run --extra dev --extra acp python -m pytest tests/acp/test_server.py -q
52 passed in 1.92s
```
