### PR TITLE
fix(cli): use angle-bracket placeholders in pairing approve hint

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1773,7 +1773,7 @@ def _setup_standard_platform(platform: dict):
                     print_warning("  Open access enabled — anyone can use your bot!")
                 elif access_idx == 1:
                     print_success("  DM pairing mode — users will receive a code to request access.")
-                    print_info("  Approve with: hermes pairing approve {platform} {code}")
+                    print_info("  Approve with: hermes pairing approve <platform> <code>")
                 else:
                     print_info("  Skipped — configure later with 'hermes gateway setup'")
             continue


### PR DESCRIPTION
## Summary

- The gateway setup wizard (`hermes gateway setup`) prints literal `{platform} {code}` in the DM-pairing help text instead of the intended `<platform> <code>` angle-bracket placeholders
- Every other reference to this command (pairing.py docstring, docs, the runtime gateway message) uses `<platform> <code>`
- One-line fix: replace `{platform} {code}` → `<platform> <code>` in `hermes_cli/gateway.py:1776`

## Test plan

- [x] Verify the fix matches the placeholder convention used in `hermes_cli/pairing.py:6` and `website/docs/`
- [x] Run `hermes gateway setup`, select DM pairing mode, confirm the hint reads `hermes pairing approve <platform> <code>`