### PR TITLE
feat(skills): add optional skill human-like-memory

### DIFF
--- a/optional-skills/productivity/human-like-memory/SKILL.md
+++ b/optional-skills/productivity/human-like-memory/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: human-like-memory
+description: Smart-trigger long-term memory recall, search, and save for continuity across sessions.
+version: 1.0.0
+author: hanlaomo
+license: Apache-2.0
+category: productivity
+triggers:
+  - remember this
+  - recall previous discussion
+  - search memory
+  - save preference
+toolsets:
+  - terminal
+  - file
+  - delegation
+metadata:
+  hermes:
+    tags: [productivity, memory, long-term-memory, personalization]
+required_environment_variables:
+  - name: HUMAN_LIKE_MEM_API_KEY
+    prompt: Human-Like Memory API key (mp_xxx)
+    help: Get a key from https://plugin.human-like.me
+    required_for: Remote memory read/write API access
+  - name: HUMAN_LIKE_MEM_BASE_URL
+    prompt: Memory API base URL
+    help: Default is https://plugin.human-like.me
+    required_for: Custom/self-hosted endpoint
+  - name: HUMAN_LIKE_MEM_USER_ID
+    prompt: Memory user id
+    help: Logical user identifier for memory retrieval
+    required_for: Cross-session memory identity
+  - name: HUMAN_LIKE_MEM_AGENT_ID
+    prompt: Memory agent id
+    help: Logical agent identifier for memory partitioning
+    required_for: Agent-scoped memory partition
+---
+
+# Human-Like Memory
+
+Use this skill when durable user context improves response quality and continuity.
+
+## When To Use
+
+- User asks to remember a preference, profile fact, or decision.
+- User asks to continue prior work and context is needed.
+- Multi-turn sessions produce summaries worth keeping.
+
+## Quick Reference
+
+```bash
+node {baseDir}/scripts/memory.mjs config
+node {baseDir}/scripts/memory.mjs recall "<query>"
+node {baseDir}/scripts/memory.mjs search "<query>"
+node {baseDir}/scripts/memory.mjs save "<user_message>" "<assistant_response>"
+node {baseDir}/scripts/memory.mjs save-batch < {baseDir}/examples/messages.json
+```
+
+## Procedure
+
+1. Verify configuration with `config` command.
+2. Use `recall` or `search` before answering continuity-sensitive prompts.
+3. Use `save` for explicit memory-worthy statements.
+4. Use `save-batch` only after meaningful multi-turn context.
+
+## Safety Rules
+
+- Do not send passwords, tokens, or private secrets.
+- Do not perform hidden/automatic memory writes.
+- Treat remote failures as non-fatal and continue with local reasoning.
+
+## Network Disclosure
+
+- API calls occur only when a memory command is executed.
+- Endpoint defaults to `https://plugin.human-like.me`.
+- Sent fields include query/messages plus `user_id` and `agent_id`.
+
+## Verification
+
+- `node {baseDir}/scripts/memory.mjs config` should show `apiKeyConfigured: true`.
+- `recall` or `search` should return JSON with `success: true` when configured.
+

--- a/optional-skills/productivity/human-like-memory/examples/messages.json
+++ b/optional-skills/productivity/human-like-memory/examples/messages.json
@@ -1,0 +1,10 @@
+[
+  {
+    "role": "user",
+    "content": "Hi"
+  },
+  {
+    "role": "assistant",
+    "content": "Hello"
+  }
+]

--- a/optional-skills/productivity/human-like-memory/scripts/memory.mjs
+++ b/optional-skills/productivity/human-like-memory/scripts/memory.mjs
@@ -1,0 +1,625 @@
+#!/usr/bin/env node
+/**
+ * Human-Like Memory CLI for Hermes Skill
+ *
+ * Usage:
+ *   node memory.mjs recall "query"
+ *   node memory.mjs save "user message" "assistant response"
+ *   node memory.mjs save-batch                    # reads JSON from stdin
+ *   node memory.mjs search "query"
+ *   node memory.mjs config
+ */
+
+import { createInterface } from 'readline';
+
+const SKILL_VERSION = '1.0.0';
+
+/**
+ * Parse boolean from string/boolean value
+ */
+function parseBoolean(value, defaultValue) {
+  if (value === undefined || value === null) return defaultValue;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    return value.toLowerCase() === 'true' || value === '1';
+  }
+  return defaultValue;
+}
+
+/**
+ * Build configuration from environment variables
+ */
+async function buildConfig() {
+  const rawLimit = parseInt(process.env.HUMAN_LIKE_MEM_LIMIT_NUMBER || '', 10);
+  const rawMinScore = parseFloat(process.env.HUMAN_LIKE_MEM_MIN_SCORE || '');
+  const rawTimeoutMs = parseInt(process.env.HUMAN_LIKE_MEM_TIMEOUT_MS || '', 10);
+  const rawSaveTriggerTurns = parseInt(process.env.HUMAN_LIKE_MEM_SAVE_TRIGGER_TURNS || '', 10);
+  const rawSaveMaxMessages = parseInt(process.env.HUMAN_LIKE_MEM_SAVE_MAX_MESSAGES || '', 10);
+  return {
+    baseUrl: process.env.HUMAN_LIKE_MEM_BASE_URL || 'https://plugin.human-like.me',
+    apiKey: process.env.HUMAN_LIKE_MEM_API_KEY,
+    userId: process.env.HUMAN_LIKE_MEM_USER_ID || 'hermes-user',
+    agentId: process.env.HUMAN_LIKE_MEM_AGENT_ID || 'main',
+    memoryLimitNumber: Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 6,
+    minScore: Number.isFinite(rawMinScore) ? rawMinScore : 0.1,
+    timeoutMs: Number.isFinite(rawTimeoutMs) && rawTimeoutMs > 0 ? rawTimeoutMs : 30000,
+    scenario: process.env.HUMAN_LIKE_MEM_SCENARIO || 'humanlike-memory-skill-smart',
+    recallEnabled: parseBoolean(process.env.HUMAN_LIKE_MEM_RECALL_ENABLED, true),
+    addEnabled: parseBoolean(process.env.HUMAN_LIKE_MEM_ADD_ENABLED, true),
+    autoSaveEnabled: parseBoolean(process.env.HUMAN_LIKE_MEM_AUTO_SAVE_ENABLED, true),
+    saveTriggerTurns: Number.isFinite(rawSaveTriggerTurns) && rawSaveTriggerTurns > 0 ? rawSaveTriggerTurns : 5,
+    saveMaxMessages: Number.isFinite(rawSaveMaxMessages) && rawSaveMaxMessages > 0 ? rawSaveMaxMessages : 20,
+  };
+}
+
+/**
+ * Build actionable guidance when API key is missing
+ */
+function buildMissingApiKeyError() {
+  return {
+    success: false,
+    error: 'API Key not configured. HUMAN_LIKE_MEM_API_KEY is required.',
+    nextSteps: [
+      'Set environment variable: export HUMAN_LIKE_MEM_API_KEY="mp_xxx"',
+      'Optional: export HUMAN_LIKE_MEM_BASE_URL="https://plugin.human-like.me"',
+      'Optional: export HUMAN_LIKE_MEM_USER_ID="hermes-user"',
+      'Then verify with: node ./scripts/memory.mjs config',
+    ],
+    helpUrl: 'https://plugin.human-like.me',
+  };
+}
+
+/**
+ * Make HTTP request with timeout
+ */
+async function httpRequest(url, options, timeoutMs = 5000) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText.substring(0, 200)}`);
+    }
+    return await response.json();
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error.name === 'AbortError') {
+      throw new Error(`Request timeout after ${timeoutMs}ms`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Recall memories based on query
+ */
+async function recallMemory(query) {
+  const cfg = await buildConfig();
+
+  if (!cfg.apiKey) {
+    console.error(JSON.stringify(buildMissingApiKeyError()));
+    process.exit(1);
+  }
+
+  if (!cfg.recallEnabled) {
+    console.log(JSON.stringify({
+      success: true,
+      count: 0,
+      memories: [],
+      message: 'Memory recall is disabled via HUMAN_LIKE_MEM_RECALL_ENABLED=false',
+    }, null, 2));
+    return;
+  }
+
+  const url = `${cfg.baseUrl}/api/plugin/v1/search/memory`;
+  const payload = {
+    query: query,
+    user_id: cfg.userId,
+    agent_id: cfg.agentId,
+    memory_limit_number: cfg.memoryLimitNumber,
+    min_score: cfg.minScore,
+  };
+
+  try {
+    const result = await httpRequest(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': cfg.apiKey,
+        'x-request-id': `humanlike-memory-skill-${Date.now()}`,
+        'x-plugin-version': SKILL_VERSION,
+        'x-client-type': 'skill',
+      },
+      body: JSON.stringify(payload),
+    }, cfg.timeoutMs);
+
+    if (!result.success) {
+      console.error(JSON.stringify({
+        success: false,
+        error: result.error || 'Memory retrieval failed',
+      }));
+      process.exit(1);
+    }
+
+    const memories = result.memories || [];
+
+    // Format output for agent consumption
+    const output = {
+      success: true,
+      count: memories.length,
+      memories: memories.map(m => ({
+        content: m.description || m.event || '',
+        timestamp: m.timestamp,
+        score: m.score,
+      })),
+    };
+
+    // Also output human-readable format for context injection
+    if (memories.length > 0) {
+      output.context = formatMemoriesForContext(memories);
+    }
+
+    console.log(JSON.stringify(output, null, 2));
+  } catch (error) {
+    console.error(JSON.stringify({
+      success: false,
+      error: error.message,
+    }));
+    process.exit(1);
+  }
+}
+
+/**
+ * Save messages to memory
+ */
+async function saveMemory(userMessage, assistantResponse) {
+  const cfg = await buildConfig();
+
+  if (!cfg.apiKey) {
+    console.error(JSON.stringify(buildMissingApiKeyError()));
+    process.exit(1);
+  }
+
+  if (!cfg.addEnabled) {
+    console.log(JSON.stringify({
+      success: true,
+      message: 'Memory storage is disabled via HUMAN_LIKE_MEM_ADD_ENABLED=false',
+    }));
+    return;
+  }
+
+  const url = `${cfg.baseUrl}/api/plugin/v1/add/message`;
+  const sessionId = `session-${Date.now()}`;
+  const agentId = cfg.agentId || 'main';
+  const messages = [];
+
+  if (userMessage) {
+    messages.push({ role: 'user', content: userMessage });
+  }
+  if (assistantResponse) {
+    messages.push({ role: 'assistant', content: assistantResponse });
+  }
+
+  if (messages.length === 0) {
+    console.error(JSON.stringify({
+      success: false,
+      error: 'No messages to save',
+    }));
+    process.exit(1);
+  }
+
+  const payload = {
+    user_id: cfg.userId,
+    conversation_id: sessionId,
+    messages: messages,
+    agent_id: agentId,
+    tags: ['humanlike-memory-skill'],
+    async_mode: true,
+    custom_workflows: {
+      stream_params: {
+        metadata: JSON.stringify({
+          user_ids: [cfg.userId],
+          agent_ids: [agentId],
+          session_id: sessionId,
+          scenario: cfg.scenario || 'humanlike-memory-skill',
+        }),
+      },
+    },
+  };
+
+  try {
+    const result = await httpRequest(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': cfg.apiKey,
+        'x-request-id': `humanlike-memory-skill-${Date.now()}`,
+        'x-plugin-version': SKILL_VERSION,
+        'x-client-type': 'skill',
+      },
+      body: JSON.stringify(payload),
+    }, cfg.timeoutMs);
+
+    const output = {
+      success: true,
+      message: 'Memory saved successfully',
+      memoriesCount: result.memories_count || 0,
+    };
+
+    console.log(JSON.stringify(output));
+  } catch (error) {
+    console.error(JSON.stringify({
+      success: false,
+      error: error.message,
+    }));
+    process.exit(1);
+  }
+}
+
+/**
+ * Search memories (alias for recall with different output format)
+ */
+async function searchMemory(query) {
+  await recallMemory(query);
+}
+
+/**
+ * Read JSON from stdin
+ */
+async function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    const rl = createInterface({
+      input: process.stdin,
+      terminal: false,
+    });
+
+    rl.on('line', (line) => {
+      data += line;
+    });
+
+    rl.on('close', () => {
+      resolve(data.trim());
+    });
+
+    rl.on('error', reject);
+
+    // Timeout after 5 seconds if no input
+    setTimeout(() => {
+      rl.close();
+      if (!data) {
+        reject(new Error('No input received from stdin'));
+      }
+    }, 5000);
+  });
+}
+
+/**
+ * Save batch messages to memory (from stdin JSON)
+ */
+async function saveBatchMemory() {
+  const cfg = await buildConfig();
+
+  if (!cfg.apiKey) {
+    console.error(JSON.stringify(buildMissingApiKeyError()));
+    process.exit(1);
+  }
+
+  if (!cfg.addEnabled) {
+    console.log(JSON.stringify({
+      success: true,
+      message: 'Memory storage is disabled via HUMAN_LIKE_MEM_ADD_ENABLED=false',
+    }));
+    return;
+  }
+
+  let inputData;
+  try {
+    inputData = await readStdin();
+  } catch (error) {
+    console.error(JSON.stringify({
+      success: false,
+      error: `Failed to read stdin: ${error.message}`,
+      usage: 'echo \'[{"role":"user","content":"..."}, {"role":"assistant","content":"..."}]\' | node memory.mjs save-batch',
+    }));
+    process.exit(1);
+  }
+
+  let messages;
+  try {
+    messages = JSON.parse(inputData);
+  } catch (error) {
+    console.error(JSON.stringify({
+      success: false,
+      error: `Invalid JSON: ${error.message}`,
+      received: inputData.substring(0, 200),
+    }));
+    process.exit(1);
+  }
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    console.error(JSON.stringify({
+      success: false,
+      error: 'Messages must be a non-empty array',
+    }));
+    process.exit(1);
+  }
+
+  // Validate message format
+  for (const msg of messages) {
+    if (!msg.role || !msg.content) {
+      console.error(JSON.stringify({
+        success: false,
+        error: 'Each message must have "role" and "content" fields',
+        invalid: msg,
+      }));
+      process.exit(1);
+    }
+    if (!['user', 'assistant'].includes(msg.role)) {
+      console.error(JSON.stringify({
+        success: false,
+        error: 'Role must be "user" or "assistant"',
+        invalid: msg.role,
+      }));
+      process.exit(1);
+    }
+  }
+
+  const maxMessages = cfg.saveMaxMessages;
+  const messagesToSave = messages.slice(-maxMessages);
+
+  const url = `${cfg.baseUrl}/api/plugin/v1/add/message`;
+  const sessionId = `session-${Date.now()}`;
+  const agentId = cfg.agentId || 'main';
+
+  const payload = {
+    user_id: cfg.userId,
+    conversation_id: sessionId,
+    messages: messagesToSave.map(m => ({
+      role: m.role,
+      content: m.content.substring(0, 20000), // Truncate if too long
+    })),
+    agent_id: agentId,
+    tags: ['humanlike-memory-skill'],
+    async_mode: true,
+    custom_workflows: {
+      stream_params: {
+        metadata: JSON.stringify({
+          user_ids: [cfg.userId],
+          agent_ids: [agentId],
+          session_id: sessionId,
+          scenario: cfg.scenario || 'humanlike-memory-skill',
+        }),
+      },
+    },
+  };
+
+  try {
+    const result = await httpRequest(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': cfg.apiKey,
+        'x-request-id': `humanlike-memory-skill-${Date.now()}`,
+        'x-plugin-version': SKILL_VERSION,
+        'x-client-type': 'skill',
+      },
+      body: JSON.stringify(payload),
+    }, cfg.timeoutMs);
+
+    const turnCount = Math.floor(messagesToSave.length / 2);
+    const output = {
+      success: true,
+      message: `Saved ${turnCount} turns (${messagesToSave.length} messages) to memory`,
+      memoriesCount: result.memories_count || 0,
+      config: {
+        saveMaxMessages: cfg.saveMaxMessages,
+      },
+    };
+
+    console.log(JSON.stringify(output));
+  } catch (error) {
+    console.error(JSON.stringify({
+      success: false,
+      error: error.message,
+    }));
+    process.exit(1);
+  }
+}
+
+/**
+ * Show current configuration (without sensitive data)
+ */
+async function showConfig() {
+  const cfg = await buildConfig();
+
+  console.log(JSON.stringify({
+    baseUrl: cfg.baseUrl,
+    userId: cfg.userId,
+    agentId: cfg.agentId,
+    apiKeyConfigured: !!cfg.apiKey,
+    memoryLimitNumber: cfg.memoryLimitNumber,
+    minScore: cfg.minScore,
+    recallEnabled: cfg.recallEnabled,
+    addEnabled: cfg.addEnabled,
+    autoSaveEnabled: cfg.autoSaveEnabled,
+    saveTriggerTurns: cfg.saveTriggerTurns,
+    saveMaxMessages: cfg.saveMaxMessages,
+    mode: 'agent-smart',
+  }, null, 2));
+}
+
+/**
+ * Format memories for context injection (aligned with plugin format)
+ */
+function formatMemoriesForContext(memories) {
+  if (!memories || memories.length === 0) return '';
+
+  const now = Date.now();
+  const nowText = formatTime(now);
+
+  const memoryLines = memories
+    .map(m => {
+      const date = formatTime(m.timestamp);
+      const content = m.description || m.event || '';
+      const score = m.score ? ` (${(m.score * 100).toFixed(0)}%)` : '';
+      if (!content) return '';
+      if (date) return `   -[${date}] ${content}${score}`;
+      return `   - ${content}${score}`;
+    })
+    .filter(Boolean);
+
+  if (memoryLines.length === 0) return '';
+
+  const lines = [
+    '# Role',
+    '',
+    'You are an intelligent assistant with long-term memory capabilities. Your goal is to combine retrieved memory fragments to provide highly personalized, accurate, and logically rigorous responses.',
+    '',
+    '# System Context',
+    '',
+    `* Current Time: ${nowText} (Use this as the baseline for freshness checks)`,
+    '',
+    '# Memory Data',
+    '',
+    'Below are **episodic memory summaries** retrieved from long-term memory.',
+    '',
+    '* **Memory Type**: All memories are episodic summaries - they represent contextual information from past conversations.',
+    '* **Special Note**: If content is tagged with \'[assistant_opinion]\' or \'[model_summary]\', it represents **past AI inference**, **not** direct user statements.',
+    '',
+    '```text',
+    '<memories>',
+    ...memoryLines,
+    '</memories>',
+    '```',
+    '',
+    '# Critical Protocol: Memory Safety',
+    '',
+    '1. **Source Verification**: Distinguish direct user statements from AI inference. AI summaries are reference-only.',
+    '2. **Attribution Check**: Never attribute third-party info to the user.',
+    '3. **Strong Relevance Check**: Only use memories that directly help answer the current query.',
+    '4. **Freshness Check**: Prioritize the current query over conflicting memories.',
+    '',
+    '# Instructions',
+    '',
+    '1. **Review**: Read the episodic memory summaries and apply the protocol above to remove noise.',
+    '2. **Execute**: Use only memories that pass filtering as context.',
+    '3. **Output**: Answer directly. Never mention internal terms such as "memory store", "retrieval", or "AI opinions".',
+  ];
+
+  return lines.join('\n');
+}
+
+/**
+ * Format timestamp for display
+ */
+function formatTime(value) {
+  if (!value) return '';
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    if (isNaN(date.getTime())) return '';
+    const pad = (v) => String(v).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+  }
+  return String(value);
+}
+
+/**
+ * Print usage information
+ */
+function printUsage() {
+  console.log(`
+Human-Like Memory CLI for Hermes
+
+Usage:
+  node memory.mjs <command> [arguments]
+
+Commands:
+  recall <query>                    Retrieve relevant memories for a query
+  save <user_msg> [assistant_msg]   Save single conversation turn to memory
+  save-batch                        Save multiple turns from stdin (JSON array)
+  search <query>                    Search memories (alias for recall)
+  config                            Show current configuration
+
+Examples:
+  node memory.mjs recall "What projects am I working on?"
+  node memory.mjs save "I'm working on Project X" "Great, I'll remember that."
+  node memory.mjs search "meeting notes"
+  node memory.mjs config
+
+  # Save batch (read JSON array from file):
+  node memory.mjs save-batch < ./examples/messages.json
+
+Configuration:
+  Configure via Hermes secure env or environment variables:
+  - HUMAN_LIKE_MEM_API_KEY (required)
+  - HUMAN_LIKE_MEM_BASE_URL (optional, default: https://plugin.human-like.me)
+  - HUMAN_LIKE_MEM_USER_ID (optional, default: hermes-user)
+  - HUMAN_LIKE_MEM_AGENT_ID (optional, default: main)
+  - HUMAN_LIKE_MEM_LIMIT_NUMBER (optional, default: 6)
+  - HUMAN_LIKE_MEM_MIN_SCORE (optional, default: 0.1)
+  - HUMAN_LIKE_MEM_RECALL_ENABLED (optional, default: true)
+  - HUMAN_LIKE_MEM_ADD_ENABLED (optional, default: true)
+  - HUMAN_LIKE_MEM_AUTO_SAVE_ENABLED (optional, default: true)
+  - HUMAN_LIKE_MEM_SAVE_TRIGGER_TURNS (optional, default: 5)
+  - HUMAN_LIKE_MEM_SAVE_MAX_MESSAGES (optional, default: 20)
+`);
+}
+
+// Main entry point
+const [,, command, ...args] = process.argv;
+
+switch (command) {
+  case 'recall':
+    if (!args[0]) {
+      console.error('Error: Query is required for recall command');
+      process.exit(1);
+    }
+    await recallMemory(args.join(' '));
+    break;
+
+  case 'save':
+    if (!args[0]) {
+      console.error('Error: At least one message is required for save command');
+      process.exit(1);
+    }
+    await saveMemory(args[0], args[1]);
+    break;
+
+  case 'save-batch':
+    await saveBatchMemory();
+    break;
+
+  case 'search':
+    if (!args[0]) {
+      console.error('Error: Query is required for search command');
+      process.exit(1);
+    }
+    await searchMemory(args.join(' '));
+    break;
+
+  case 'config':
+    await showConfig();
+    break;
+
+  case 'help':
+  case '--help':
+  case '-h':
+    printUsage();
+    break;
+
+  default:
+    if (command) {
+      console.error(`Unknown command: ${command}`);
+    }
+    printUsage();
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

Add a new official optional skill: `human-like-memory`.

This PR adds the skill under `optional-skills/productivity/human-like-memory/` with:
- `SKILL.md`
- `scripts/memory.mjs`
- `examples/messages.json`

## Why

- Provides explicit, smart-trigger long-term memory recall/search/save workflow.
- Uses environment-variable based secret handling (`HUMAN_LIKE_MEM_API_KEY`).
- Keeps behavior predictable: no always-on background save/recall.

## Security Notes

- Network access only on explicit skill invocation.
- No local secret-file reads.
- No destructive shell commands in skill instructions.

## Test Plan

1. `hermes skills install ./optional-skills/productivity/human-like-memory`
2. `node optional-skills/productivity/human-like-memory/scripts/memory.mjs config`
3. `node optional-skills/productivity/human-like-memory/scripts/memory.mjs recall "test query"` with API key set
4. `node optional-skills/productivity/human-like-memory/scripts/memory.mjs save "u" "a"` with API key set
5. Verify `required_environment_variables` prompt/registration behavior

## Checklist

- [x] Skill path follows `optional-skills/<category>/<skill-name>/`
- [x] Frontmatter includes `name`, `description`, `version`, `author`, `license`
- [x] `required_environment_variables` documented and minimal
- [x] No `.git`, build artifacts, or unrelated files included
- [x] Security scan passes
- [x] Docs are concise and aligned with Hermes conventions

