### PR TITLE
fix(model): support context_length and max_tokens in model_aliases

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -71,6 +71,47 @@ def _ensure_ssl_certs() -> None:
 
 _ensure_ssl_certs()
 
+
+def _append_model_switch_details(
+    lines: List[str],
+    result,
+    *,
+    current_base_url: str = "",
+    current_api_key: str = "",
+) -> None:
+    """Append context/output metadata for a /model switch confirmation."""
+    mi = result.model_info
+
+    context_tokens = result.context_length
+    if context_tokens is None and mi and mi.context_window:
+        context_tokens = mi.context_window
+    if context_tokens is None:
+        try:
+            from agent.model_metadata import get_model_context_length
+
+            context_tokens = get_model_context_length(
+                result.new_model,
+                base_url=result.base_url or current_base_url,
+                api_key=result.api_key or current_api_key,
+                provider=result.target_provider,
+            )
+        except Exception:
+            context_tokens = None
+    if context_tokens:
+        lines.append(f"Context: {context_tokens:,} tokens")
+
+    max_output_tokens = result.max_tokens
+    if max_output_tokens is None and mi and mi.max_output:
+        max_output_tokens = mi.max_output
+    if max_output_tokens:
+        lines.append(f"Max output: {max_output_tokens:,} tokens")
+
+    if mi:
+        if mi.has_cost_data():
+            lines.append(f"Cost: {mi.format_cost()}")
+        lines.append(f"Capabilities: {mi.format_capabilities()}")
+
+
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -517,7 +558,7 @@ class GatewayRunner:
 
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
-        self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        self._session_model_overrides: Dict[str, Dict[str, Any]] = {}
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
@@ -3749,6 +3790,8 @@ class GatewayRunner:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
+                                    context_length=result.context_length,
+                                    max_tokens=result.max_tokens,
                                 )
                             except Exception as exc:
                                 logger.warning("Picker model switch failed for cached agent: %s", exc)
@@ -3769,21 +3812,20 @@ class GatewayRunner:
                             "api_key": result.api_key,
                             "base_url": result.base_url,
                             "api_mode": result.api_mode,
+                            "context_length": result.context_length,
+                            "max_tokens": result.max_tokens,
                         }
 
                         # Build confirmation text
                         plabel = result.provider_label or result.target_provider
                         lines = [f"Model switched to `{result.new_model}`"]
                         lines.append(f"Provider: {plabel}")
-                        mi = result.model_info
-                        if mi:
-                            if mi.context_window:
-                                lines.append(f"Context: {mi.context_window:,} tokens")
-                            if mi.max_output:
-                                lines.append(f"Max output: {mi.max_output:,} tokens")
-                            if mi.has_cost_data():
-                                lines.append(f"Cost: {mi.format_cost()}")
-                            lines.append(f"Capabilities: {mi.format_capabilities()}")
+                        _append_model_switch_details(
+                            lines,
+                            result,
+                            current_base_url=_cur_base_url,
+                            current_api_key=_cur_api_key,
+                        )
                         lines.append("_(session only — use `/model <name> --global` to persist)_")
                         return "\n".join(lines)
 
@@ -3861,6 +3903,8 @@ class GatewayRunner:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    context_length=result.context_length,
+                    max_tokens=result.max_tokens,
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
@@ -3884,6 +3928,8 @@ class GatewayRunner:
             "api_key": result.api_key,
             "base_url": result.base_url,
             "api_mode": result.api_mode,
+            "context_length": result.context_length,
+            "max_tokens": result.max_tokens,
         }
 
         # Persist to config if --global
@@ -3899,6 +3945,10 @@ class GatewayRunner:
                 model_cfg["provider"] = result.target_provider
                 if result.base_url:
                     model_cfg["base_url"] = result.base_url
+                if result.context_length is not None:
+                    model_cfg["context_length"] = result.context_length
+                if result.max_tokens is not None:
+                    model_cfg["max_tokens"] = result.max_tokens
                 from hermes_cli.config import save_config
                 save_config(cfg)
             except Exception as e:
@@ -3908,29 +3958,12 @@ class GatewayRunner:
         provider_label = result.provider_label or result.target_provider
         lines = [f"Model switched to `{result.new_model}`"]
         lines.append(f"Provider: {provider_label}")
-
-        # Rich metadata from models.dev
-        mi = result.model_info
-        if mi:
-            if mi.context_window:
-                lines.append(f"Context: {mi.context_window:,} tokens")
-            if mi.max_output:
-                lines.append(f"Max output: {mi.max_output:,} tokens")
-            if mi.has_cost_data():
-                lines.append(f"Cost: {mi.format_cost()}")
-            lines.append(f"Capabilities: {mi.format_capabilities()}")
-        else:
-            try:
-                from agent.model_metadata import get_model_context_length
-                ctx = get_model_context_length(
-                    result.new_model,
-                    base_url=result.base_url or current_base_url,
-                    api_key=result.api_key or current_api_key,
-                    provider=result.target_provider,
-                )
-                lines.append(f"Context: {ctx:,} tokens")
-            except Exception:
-                pass
+        _append_model_switch_details(
+            lines,
+            result,
+            current_base_url=current_base_url,
+            current_api_key=current_api_key,
+        )
 
         # Cache notice
         cache_enabled = (

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -140,7 +140,9 @@ class DirectAlias(NamedTuple):
     """Exact model mapping that bypasses catalog resolution."""
     model: str
     provider: str
-    base_url: str
+    base_url: str = ""
+    context_length: Optional[int] = None
+    max_tokens: Optional[int] = None
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
@@ -165,6 +167,15 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
             provider: custom
             base_url: "https://ollama.com/v1"
     """
+    def _optional_int(value: object) -> Optional[int]:
+        if value in (None, ""):
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
     merged = dict(_BUILTIN_DIRECT_ALIASES)
     try:
         from hermes_cli.config import load_config
@@ -177,9 +188,15 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 model = entry.get("model", "")
                 provider = entry.get("provider", "custom")
                 base_url = entry.get("base_url", "")
+                context_length = _optional_int(entry.get("context_length"))
+                max_tokens = _optional_int(entry.get("max_tokens"))
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
-                        model=model, provider=provider, base_url=base_url,
+                        model=model,
+                        provider=provider,
+                        base_url=base_url,
+                        context_length=context_length,
+                        max_tokens=max_tokens,
                     )
     except Exception:
         pass
@@ -214,6 +231,8 @@ class ModelSwitchResult:
     resolved_via_alias: str = ""
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
+    context_length: Optional[int] = None
+    max_tokens: Optional[int] = None
     is_global: bool = False
 
 
@@ -435,6 +454,8 @@ def switch_model(
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
+    alias_context_length = None
+    alias_max_tokens = None
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -648,6 +669,9 @@ def switch_model(
             base_url = _da.base_url
             if not api_key:
                 api_key = "no-key-required"
+        if _da is not None:
+            alias_context_length = _da.context_length
+            alias_max_tokens = _da.max_tokens
 
     # --- Normalize model name for target provider ---
     new_model = normalize_model_for_provider(new_model, target_provider)
@@ -715,6 +739,8 @@ def switch_model(
         resolved_via_alias=resolved_alias,
         capabilities=capabilities,
         model_info=model_info,
+        context_length=alias_context_length,
+        max_tokens=alias_max_tokens,
         is_global=is_global,
     )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1345,6 +1345,7 @@ class AIAgent:
             "base_url": self.base_url,
             "api_mode": self.api_mode,
             "api_key": getattr(self, "api_key", ""),
+            "max_tokens": self.max_tokens,
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             # Compressor state that _try_activate_fallback() overwrites
@@ -1407,7 +1408,16 @@ class AIAgent:
             # Iterative summary from previous session must not bleed into new one (#2635)
             self.context_compressor._previous_summary = None
     
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(
+        self,
+        new_model,
+        new_provider,
+        api_key='',
+        base_url='',
+        api_mode='',
+        context_length=None,
+        max_tokens=None,
+    ):
         """Switch the model/provider in-place for a live agent.
 
         Called by the /model command handlers (CLI and gateway) after
@@ -1438,6 +1448,8 @@ class AIAgent:
         self.api_mode = api_mode
         if api_key:
             self.api_key = api_key
+        if max_tokens is not None:
+            self.max_tokens = max_tokens
 
         # ── Build new client ──
         if api_mode == "anthropic_messages":
@@ -1478,14 +1490,18 @@ class AIAgent:
 
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
-            from agent.model_metadata import get_model_context_length
-            new_context_length = get_model_context_length(
-                self.model,
-                base_url=self.base_url,
-                api_key=self.api_key,
-                provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
-            )
+            if context_length is None:
+                from agent.model_metadata import get_model_context_length
+
+                new_context_length = get_model_context_length(
+                    self.model,
+                    base_url=self.base_url,
+                    api_key=self.api_key,
+                    provider=self.provider,
+                    config_context_length=getattr(self, "_config_context_length", None),
+                )
+            else:
+                new_context_length = context_length
             self.context_compressor.model = self.model
             self.context_compressor.base_url = self.base_url
             self.context_compressor.api_key = self.api_key
@@ -1506,6 +1522,7 @@ class AIAgent:
             "base_url": self.base_url,
             "api_mode": self.api_mode,
             "api_key": getattr(self, "api_key", ""),
+            "max_tokens": self.max_tokens,
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "compressor_model": _cc.model if _cc else self.model,
@@ -5286,6 +5303,7 @@ class AIAgent:
             self.base_url = rt["base_url"]           # setter updates _base_url_lower
             self.api_mode = rt["api_mode"]
             self.api_key = rt["api_key"]
+            self.max_tokens = rt.get("max_tokens")
             self._client_kwargs = dict(rt["client_kwargs"])
             self._use_prompt_caching = rt["use_prompt_caching"]
 

--- a/tests/gateway/test_model_switch_details.py
+++ b/tests/gateway/test_model_switch_details.py
@@ -1,0 +1,38 @@
+"""Tests for /model switch confirmation details."""
+
+from hermes_cli.model_switch import ModelSwitchResult
+
+from gateway.run import _append_model_switch_details
+
+
+class _FakeModelInfo:
+    context_window = 128000
+    max_output = 8192
+
+    def has_cost_data(self):
+        return False
+
+    def format_capabilities(self):
+        return "tools"
+
+
+def test_alias_overrides_beat_model_info_defaults():
+    """Alias-specific context/max output should be shown ahead of catalog defaults."""
+    lines = []
+    result = ModelSwitchResult(
+        success=True,
+        new_model="custom-model:latest",
+        target_provider="custom",
+        provider_changed=True,
+        base_url="https://example.com/v1",
+        api_mode="openai_compat",
+        model_info=_FakeModelInfo(),
+        context_length=204800,
+        max_tokens=131072,
+    )
+
+    _append_model_switch_details(lines, result)
+
+    assert "Context: 204,800 tokens" in lines
+    assert "Max output: 131,072 tokens" in lines
+    assert "Capabilities: tools" in lines

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -86,6 +86,8 @@ class TestDirectAliases:
                     "model": "custom-model:latest",
                     "provider": "custom",
                     "base_url": "https://example.com/v1",
+                    "context_length": 204800,
+                    "max_tokens": 131072,
                 }
             }
         }
@@ -101,6 +103,8 @@ class TestDirectAliases:
         assert aliases["mymodel"].model == "custom-model:latest"
         assert aliases["mymodel"].provider == "custom"
         assert aliases["mymodel"].base_url == "https://example.com/v1"
+        assert aliases["mymodel"].context_length == 204800
+        assert aliases["mymodel"].max_tokens == 131072
 
     def test_direct_alias_resolved_before_catalog(self, monkeypatch):
         """Direct aliases take priority over models.dev catalog lookup."""
@@ -555,6 +559,50 @@ class TestSwitchModelDirectAliasOverride:
         assert result.success
         assert result.api_key == "no-key-required"
         assert result.base_url == "http://localhost:11434/v1"
+
+    def test_switch_model_carries_alias_context_and_max_tokens(self, monkeypatch):
+        """Direct alias metadata is exposed on the switch result."""
+        from hermes_cli.model_switch import DirectAlias
+        import hermes_cli.model_switch as ms
+
+        test_aliases = {
+            "mymodel": DirectAlias(
+                "custom-model:latest",
+                "custom",
+                "https://example.com/v1",
+                204800,
+                131072,
+            ),
+        }
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(
+            ms,
+            "resolve_alias",
+            lambda raw, prov: ("custom", "custom-model:latest", "mymodel"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested: {
+                "api_key": "",
+                "base_url": "",
+                "api_mode": "openai_compat",
+                "provider": "custom",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.validate_requested_model",
+            lambda *a, **kw: {"accepted": True, "persist": True, "recognized": True, "message": None},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.opencode_model_api_mode",
+            lambda *a, **kw: "openai_compat",
+        )
+
+        result = ms.switch_model("mymodel", "openrouter", "old-model")
+
+        assert result.success
+        assert result.context_length == 204800
+        assert result.max_tokens == 131072
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_switch_model_alias_overrides.py
+++ b/tests/run_agent/test_switch_model_alias_overrides.py
@@ -1,0 +1,56 @@
+"""Tests for AIAgent.switch_model alias-specific overrides."""
+
+from unittest.mock import MagicMock
+
+from agent.context_compressor import ContextCompressor
+from run_agent import AIAgent
+
+
+def _make_agent() -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "old-model"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_key = "sk-old"
+    agent.api_mode = "openai_compat"
+    agent.client = MagicMock()
+    agent._client_kwargs = {"api_key": "sk-old", "base_url": "https://openrouter.ai/api/v1"}
+    agent._use_prompt_caching = False
+    agent._cached_system_prompt = "cached"
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._create_openai_client = lambda kwargs, reason, shared: MagicMock()
+    agent.context_compressor = ContextCompressor(
+        model="old-model",
+        threshold_percent=0.50,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-old",
+        provider="openrouter",
+        quiet_mode=True,
+    )
+    return agent
+
+
+def test_switch_model_applies_alias_context_and_max_tokens():
+    """Explicit alias overrides should update runtime state in-place."""
+    agent = _make_agent()
+
+    agent.switch_model(
+        "custom-model:latest",
+        "custom",
+        api_key="",
+        base_url="https://example.com/v1",
+        api_mode="openai_compat",
+        context_length=204800,
+        max_tokens=131072,
+    )
+
+    assert agent.model == "custom-model:latest"
+    assert agent.provider == "custom"
+    assert agent.base_url == "https://example.com/v1"
+    assert agent.max_tokens == 131072
+    assert agent.context_compressor.context_length == 204800
+    assert agent.context_compressor.threshold_tokens == int(204800 * agent.context_compressor.threshold_percent)
+    assert agent._primary_runtime["max_tokens"] == 131072
+    assert agent._primary_runtime["compressor_context_length"] == 204800
+    assert agent._cached_system_prompt is None


### PR DESCRIPTION
## What does this PR do?

This fixes `model_aliases` entries that define custom `context_length` and `max_tokens` values but currently lose those overrides during `/model <alias>` switches.

The change loads those fields into direct aliases, carries them through `switch_model()`, shows them in gateway `/model` confirmations, and applies them to the live agent runtime so the active session actually uses the alias-specific limits.

## Related Issue

Fixes #6955

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/model_switch.py` to load `context_length` and `max_tokens` from `model_aliases`, add them to `DirectAlias`, and carry them in `ModelSwitchResult`
- Updated `gateway/run.py` so `/model` confirmation messages prefer alias overrides for `Context` and `Max output`, and persist those values on `--global`
- Updated `run_agent.py` so in-place model switches apply alias-specific `context_length` and `max_tokens` to the live runtime
- Added regression coverage in `tests/hermes_cli/test_ollama_cloud_auth.py`, `tests/gateway/test_model_switch_details.py`, and `tests/run_agent/test_switch_model_alias_overrides.py`

## How to Test

1. Add an alias like this to `~/.hermes/config.yaml`:
   ```yaml
   model_aliases:
     mymodel:
       model: "some-model"
       provider: custom:myprovider
       base_url: "https://api.example.com/v1"
       context_length: 204800
       max_tokens: 131072
   ```
2. Run `/model mymodel` in gateway or switch to the alias in a live session.
3. Verify the confirmation shows `Context: 204,800 tokens` and `Max output: 131,072 tokens`, and that the active agent runtime picks up those overrides.
4. Run focused regression tests:
   - `pytest -q tests/hermes_cli/test_ollama_cloud_auth.py tests/gateway/test_model_switch_details.py tests/run_agent/test_switch_model_alias_overrides.py`
   - `pytest -q tests/hermes_cli/test_model_switch_variant_tags.py tests/gateway/test_session_info.py tests/run_agent/test_compressor_fallback_update.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests run locally:

- `pytest -q tests/hermes_cli/test_ollama_cloud_auth.py tests/gateway/test_model_switch_details.py tests/run_agent/test_switch_model_alias_overrides.py` → passed
- `pytest -q tests/hermes_cli/test_model_switch_variant_tags.py tests/gateway/test_session_info.py tests/run_agent/test_compressor_fallback_update.py` → passed
