### PR TITLE
feat(auxiliary): add xAI backend for text and vision tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -108,9 +108,10 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
-    # grok-4-1-fast-non-reasoning: vision-capable, fast (~3-5s), cheap
-    # ($0.20/$0.50 per M tokens), and skips reasoning — ideal for side
-    # tasks like compression, session_search, and vision analysis.
+    # grok-4-1-fast-non-reasoning: fast, cheap (~$0.20/$0.50 per M),
+    # no reasoning overhead — ideal for text auxiliary tasks.  Vision
+    # tasks route through _try_xai(vision=True) and pick up grok-4.20
+    # instead for nuanced image judgments.
     "xai": "grok-4-1-fast-non-reasoning",
 }
 
@@ -137,9 +138,16 @@ _NOUS_FREE_TIER_AUX_MODEL = "xiaomi/mimo-v2-pro"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
-# grok-4-1-fast-non-reasoning is vision-capable (text+image input), fast,
-# and cheap — the right default for side tasks that include vision analysis.
-_XAI_AUX_MODEL = "grok-4-1-fast-non-reasoning"
+# Text auxiliary tasks (compression, session_search, skills_hub, etc.):
+# grok-4-1-fast-non-reasoning is fast, cheap (~$0.20/$0.50 per M),
+# and perfectly adequate for short text processing side tasks.
+_XAI_TEXT_AUX_MODEL = "grok-4-1-fast-non-reasoning"
+# Vision auxiliary task: use the more capable grok-4.20 for nuanced image
+# judgments (e.g. "is this photo suitable for a professional LinkedIn
+# post?"), but stay on the non-reasoning variant to keep per-call latency
+# and cost sensible. Reasoning adds 15-30s and significant output tokens
+# for marginal vision gains — bounded tasks don't need chain-of-thought.
+_XAI_VISION_MODEL = "grok-4.20-0309-non-reasoning"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 
 # Codex fallback: uses the Responses API (the only endpoint the Codex
@@ -780,28 +788,31 @@ def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
                    default_headers=_OR_HEADERS), _OPENROUTER_MODEL
 
 
-def _try_xai() -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_xai(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Try to build an auxiliary client for xAI (Grok) direct.
 
     Uses the credential pool first, then falls back to the XAI_API_KEY
-    environment variable.  Returns a default vision-capable model so the
-    client works for both text auxiliary tasks (compression, session
-    search, etc.) and vision analysis without reconfiguration.
+    environment variable.  Selects a different default model depending on
+    whether the caller is doing text-only side tasks (compression, session
+    search) or vision analysis — the latter gets the more capable grok-4.20
+    since nuanced image judgments benefit from the larger model.
     """
+    default_model = _XAI_VISION_MODEL if vision else _XAI_TEXT_AUX_MODEL
+
     pool_present, entry = _select_pool_entry("xai")
     if pool_present:
         api_key = _pool_runtime_api_key(entry)
         if not api_key:
             return None, None
         base_url = _pool_runtime_base_url(entry, _XAI_DEFAULT_BASE_URL) or _XAI_DEFAULT_BASE_URL
-        logger.debug("Auxiliary client: xAI via pool")
-        return OpenAI(api_key=api_key, base_url=base_url), _XAI_AUX_MODEL
+        logger.debug("Auxiliary client: xAI via pool (%s)", default_model)
+        return OpenAI(api_key=api_key, base_url=base_url), default_model
 
     api_key = os.getenv("XAI_API_KEY")
     if not api_key:
         return None, None
-    logger.debug("Auxiliary client: xAI")
-    return OpenAI(api_key=api_key, base_url=_XAI_DEFAULT_BASE_URL), _XAI_AUX_MODEL
+    logger.debug("Auxiliary client: xAI (%s)", default_model)
+    return OpenAI(api_key=api_key, base_url=_XAI_DEFAULT_BASE_URL), default_model
 
 
 def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -1485,7 +1496,7 @@ def _resolve_strict_vision_backend(provider: str) -> Tuple[Optional[Any], Option
     if provider == "nous":
         return _try_nous(vision=True)
     if provider == "xai":
-        return _try_xai()
+        return _try_xai(vision=True)
     if provider == "openai-codex":
         return _try_codex()
     if provider == "anthropic":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -67,6 +67,8 @@ _PROVIDER_ALIASES = {
     "z-ai": "zai",
     "z.ai": "zai",
     "zhipu": "zai",
+    "x-ai": "xai",
+    "x.ai": "xai",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
@@ -106,6 +108,10 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    # grok-4-1-fast-non-reasoning: vision-capable, fast (~3-5s), cheap
+    # ($0.20/$0.50 per M tokens), and skips reasoning — ideal for side
+    # tasks like compression, session_search, and vision analysis.
+    "xai": "grok-4-1-fast-non-reasoning",
 }
 
 # OpenRouter app attribution headers
@@ -130,6 +136,10 @@ _NOUS_FREE_TIER_VISION_MODEL = "xiaomi/mimo-v2-omni"
 _NOUS_FREE_TIER_AUX_MODEL = "xiaomi/mimo-v2-pro"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
+_XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
+# grok-4-1-fast-non-reasoning is vision-capable (text+image input), fast,
+# and cheap — the right default for side tasks that include vision analysis.
+_XAI_AUX_MODEL = "grok-4-1-fast-non-reasoning"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 
 # Codex fallback: uses the Responses API (the only endpoint the Codex
@@ -770,6 +780,30 @@ def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
                    default_headers=_OR_HEADERS), _OPENROUTER_MODEL
 
 
+def _try_xai() -> Tuple[Optional[OpenAI], Optional[str]]:
+    """Try to build an auxiliary client for xAI (Grok) direct.
+
+    Uses the credential pool first, then falls back to the XAI_API_KEY
+    environment variable.  Returns a default vision-capable model so the
+    client works for both text auxiliary tasks (compression, session
+    search, etc.) and vision analysis without reconfiguration.
+    """
+    pool_present, entry = _select_pool_entry("xai")
+    if pool_present:
+        api_key = _pool_runtime_api_key(entry)
+        if not api_key:
+            return None, None
+        base_url = _pool_runtime_base_url(entry, _XAI_DEFAULT_BASE_URL) or _XAI_DEFAULT_BASE_URL
+        logger.debug("Auxiliary client: xAI via pool")
+        return OpenAI(api_key=api_key, base_url=base_url), _XAI_AUX_MODEL
+
+    api_key = os.getenv("XAI_API_KEY")
+    if not api_key:
+        return None, None
+    logger.debug("Auxiliary client: xAI")
+    return OpenAI(api_key=api_key, base_url=_XAI_DEFAULT_BASE_URL), _XAI_AUX_MODEL
+
+
 def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     if not nous:
@@ -1238,6 +1272,17 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
 
+    # ── xAI (Grok direct) ────────────────────────────────────────────
+    if provider == "xai":
+        client, default = _try_xai()
+        if client is None:
+            logger.warning("resolve_provider_client: xai requested "
+                           "but XAI_API_KEY not set")
+            return None, None
+        final_model = model or default
+        return (_to_async_client(client, final_model) if async_mode
+                else (client, final_model))
+
     # ── OpenAI Codex (OAuth → Responses API) ─────────────────────────
     if provider == "openai-codex":
         if raw_codex:
@@ -1425,6 +1470,7 @@ def get_async_text_auxiliary_client(task: str = ""):
 _VISION_AUTO_PROVIDER_ORDER = (
     "openrouter",
     "nous",
+    "xai",
 )
 
 
@@ -1438,6 +1484,8 @@ def _resolve_strict_vision_backend(provider: str) -> Tuple[Optional[Any], Option
         return _try_openrouter()
     if provider == "nous":
         return _try_nous(vision=True)
+    if provider == "xai":
+        return _try_xai()
     if provider == "openai-codex":
         return _try_codex()
     if provider == "anthropic":

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -471,6 +471,24 @@ class TestExplicitProviderRouting:
             client, model = resolve_provider_client("zai")
             assert client is not None
 
+    def test_explicit_xai(self, monkeypatch):
+        """provider='xai' should use XAI_API_KEY and return the default aux model."""
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = resolve_provider_client("xai")
+            assert client is not None
+            assert model == "grok-4-1-fast-non-reasoning"
+
+    def test_explicit_xai_alias_x_ai(self, monkeypatch):
+        """provider='x-ai' should normalise to xai via _PROVIDER_ALIASES."""
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = resolve_provider_client("x-ai")
+            assert client is not None
+            assert model == "grok-4-1-fast-non-reasoning"
+
     def test_explicit_google_alias_uses_gemini_credentials(self):
         """provider='google' should route through the gemini API-key provider."""
         with (
@@ -803,6 +821,35 @@ class TestAuxiliaryPoolAwareness:
             client, model = get_vision_auxiliary_client()
         assert model == "google/gemini-3-flash-preview"
         assert client is not None
+
+    def test_vision_uses_xai_when_no_openrouter_no_nous(self, monkeypatch):
+        """When neither OpenRouter nor Nous is available, the vision auto chain
+        must fall back to xAI (grok-4-1-fast-non-reasoning) if XAI_API_KEY is set."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = get_vision_auxiliary_client()
+        assert client is not None
+        assert model == "grok-4-1-fast-non-reasoning"
+
+    def test_vision_forced_xai_uses_xai_backend(self, monkeypatch):
+        """Explicit provider='xai' in config should resolve to the xAI backend
+        even when OpenRouter is also available (no silent fallback)."""
+        monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        config = {"auxiliary": {"vision": {"provider": "xai"}}}
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            resolved_provider, client, model = resolve_vision_provider_client()
+        assert client is not None
+        assert model == "grok-4-1-fast-non-reasoning"
+        assert resolved_provider == "xai"
+        # Verify the xAI base URL was used, not OpenRouter
+        call_base = mock_openai.call_args.kwargs.get("base_url", "")
+        assert "x.ai" in call_base, f"expected x.ai base URL, got {call_base}"
 
     def test_vision_config_google_provider_uses_gemini_credentials(self, monkeypatch):
         config = {

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -600,7 +600,14 @@ class TestGetTextAuxiliaryClient:
         call_kwargs = mock_openai.call_args
         assert call_kwargs.kwargs["base_url"] == "http://localhost:1234/v1"
 
-    def test_codex_fallback_when_nothing_else(self, codex_auth_dir):
+    def test_codex_fallback_when_nothing_else(self, codex_auth_dir, monkeypatch):
+        # Ensure no other api-key providers leak from the environment and
+        # short-circuit the codex fallback path.
+        for env_var in ("OPENROUTER_API_KEY", "XAI_API_KEY", "GLM_API_KEY",
+                        "ZAI_API_KEY", "Z_AI_API_KEY", "KIMI_API_KEY",
+                        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
+                        "DEEPSEEK_API_KEY", "DASHSCOPE_API_KEY"):
+            monkeypatch.delenv(env_var, raising=False)
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = get_text_auxiliary_client()
@@ -1049,6 +1056,13 @@ class TestResolveForcedProvider:
         assert model == "my-local-model"
 
     def test_forced_main_falls_to_codex(self, codex_auth_dir, monkeypatch):
+        # Ensure no other api-key providers leak from the environment and
+        # short-circuit the codex fallback path.
+        for env_var in ("OPENROUTER_API_KEY", "XAI_API_KEY", "GLM_API_KEY",
+                        "ZAI_API_KEY", "Z_AI_API_KEY", "KIMI_API_KEY",
+                        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
+                        "DEEPSEEK_API_KEY", "DASHSCOPE_API_KEY"):
+            monkeypatch.delenv(env_var, raising=False)
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
              patch("agent.auxiliary_client.OpenAI"):
             client, model = _resolve_forced_provider("main")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -831,7 +831,8 @@ class TestAuxiliaryPoolAwareness:
 
     def test_vision_uses_xai_when_no_openrouter_no_nous(self, monkeypatch):
         """When neither OpenRouter nor Nous is available, the vision auto chain
-        must fall back to xAI (grok-4-1-fast-non-reasoning) if XAI_API_KEY is set."""
+        must fall back to xAI. The default vision model is grok-4.20
+        (non-reasoning) — more capable than the cheap text default."""
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
         monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
@@ -839,11 +840,12 @@ class TestAuxiliaryPoolAwareness:
             mock_openai.return_value = MagicMock()
             client, model = get_vision_auxiliary_client()
         assert client is not None
-        assert model == "grok-4-1-fast-non-reasoning"
+        assert model == "grok-4.20-0309-non-reasoning"
 
     def test_vision_forced_xai_uses_xai_backend(self, monkeypatch):
         """Explicit provider='xai' in config should resolve to the xAI backend
-        even when OpenRouter is also available (no silent fallback)."""
+        even when OpenRouter is also available (no silent fallback).
+        Default vision model is grok-4.20-0309-non-reasoning."""
         monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         config = {"auxiliary": {"vision": {"provider": "xai"}}}
@@ -852,7 +854,7 @@ class TestAuxiliaryPoolAwareness:
             mock_openai.return_value = MagicMock()
             resolved_provider, client, model = resolve_vision_provider_client()
         assert client is not None
-        assert model == "grok-4-1-fast-non-reasoning"
+        assert model == "grok-4.20-0309-non-reasoning"
         assert resolved_provider == "xai"
         # Verify the xAI base URL was used, not OpenRouter
         call_base = mock_openai.call_args.kwargs.get("base_url", "")


### PR DESCRIPTION
## Problem

The auxiliary client resolution chain (compression, session_search, vision, web_extract, etc.) had no direct xAI support. Users with `XAI_API_KEY` had to rely on either the main provider fallback (only if they were also on xAI as main) or routing through OpenRouter, which defeats the purpose of using xAI direct for cheap/fast side tasks.

In particular, `_VISION_AUTO_PROVIDER_ORDER` was limited to `("openrouter", "nous")`. Users with both `XAI_API_KEY` **and** `OPENROUTER_API_KEY` saw every vision analysis routed through OpenRouter even when their main chat provider was xai — burning OpenRouter credits and adding latency while ignoring Grok 4's native vision support.

Concrete scenario: on my instance, every invocation of the vision tool in my `content-machine-daily` cron (which analyses candidate photos for LinkedIn posts) was going through OpenRouter → gemini-3-flash-preview instead of staying on xAI, even though Grok 4.20 supports vision natively and the main agent was already on xai.

## Solution

Add xAI as a first-class auxiliary backend, following the exact pattern used by the existing `_try_openrouter` / `_try_nous` helpers, with a text/vision default-model split.

### Changes to `agent/auxiliary_client.py`

1. **New `_try_xai(vision: bool = False)` helper** — reads the credential pool first, then falls back to `XAI_API_KEY` env var. The `vision` flag selects a different default model (same pattern as `_try_nous(vision=True)`).

2. **Text vs vision default models**:
   - `_XAI_TEXT_AUX_MODEL = "grok-4-1-fast-non-reasoning"` — fast, cheap (~$0.20/$0.50 per M), no reasoning overhead. Used for compression, session_search, skills_hub, web_extract, etc.
   - `_XAI_VISION_MODEL = "grok-4.20-0309-non-reasoning"` — the larger/smarter model, used for vision tasks where nuanced image judgments matter (e.g. "is this photo suitable for a professional LinkedIn post?"). Stays on the non-reasoning variant to keep per-call latency and cost sensible — reasoning adds 15-30s and significant output tokens for marginal gains on bounded vision tasks.

3. **`_XAI_DEFAULT_BASE_URL`** constant next to the existing `_NOUS_*` / `_ANTHROPIC_*` constants.

4. **`_PROVIDER_ALIASES`** gains `x-ai` and `x.ai` → `xai` so users can spell the provider any of the three common ways (consistent with the existing `z-ai` / `z.ai` → `zai` aliases).

5. **`_API_KEY_PROVIDER_AUX_MODELS["xai"] = "grok-4-1-fast-non-reasoning"`** so the api-key provider fallback path picks the text model as its default. Vision tasks route through `_try_xai(vision=True)` and pick up grok-4.20 instead.

6. **`resolve_provider_client("xai")`** gets an explicit case so text auxiliary tasks with `provider: xai` work standalone (no dependency on the PROVIDER_REGISTRY lookup — #7050 adds the registry entry too, but this PR stands alone).

7. **`_VISION_AUTO_PROVIDER_ORDER`** gains `"xai"` at the end so users without OpenRouter or Nous get xAI vision automatically. **Back-compat preserved**: users with `OPENROUTER_API_KEY` keep the current behavior.

8. **`_resolve_strict_vision_backend("xai")`** gets the matching case and passes `vision=True` so explicit `auxiliary.vision.provider: xai` in config.yaml resolves to the xAI backend with the grok-4.20 default (no silent OpenRouter fallback when both are available).

### Usage after this change

Zero-config path (works automatically for users on xAI direct without OpenRouter/Nous):

```yaml
auxiliary:
  vision:
    provider: auto   # will now include xAI in the chain
```

Explicit path (force xAI vision even when OpenRouter is present):

```yaml
auxiliary:
  vision:
    provider: xai
    # model: grok-4.20-0309-non-reasoning   # optional, this is the default
```

## Testing

4 new tests in `tests/agent/test_auxiliary_client.py`:

- `test_explicit_xai` — `resolve_provider_client("xai")` picks up `XAI_API_KEY` and returns the default **text** aux model.
- `test_explicit_xai_alias_x_ai` — the `x-ai` alias normalises to `xai`.
- `test_vision_uses_xai_when_no_openrouter_no_nous` — vision auto chain falls back to xAI when nothing else is available, returning the **grok-4.20** vision default.
- `test_vision_forced_xai_uses_xai_backend` — explicit config override routes vision to xAI even when `OPENROUTER_API_KEY` is set. Verifies the `api.x.ai` base URL is used, not OpenRouter, and the grok-4.20 model is selected.

Also hardens `test_codex_fallback_when_nothing_else` and `test_forced_main_falls_to_codex` by explicitly clearing `XAI_API_KEY` and other api-key env vars — they were silently depending on the developer shell having no api-key providers set.

```
$ pytest tests/agent/test_auxiliary_client.py
100 passed in 6.86s
```

## Impact

- **Back-compat**: existing users with `OPENROUTER_API_KEY` see no behavior change
- **New capability**: users on xAI direct get a proper first-class auxiliary backend with a smart text/vision split
- **Cost reduction** for users configured to prefer xAI — vision calls stop leaking to OpenRouter
- **Vision quality**: grok-4.20 (rather than the cheap fast variant) for nuanced image judgments
- **Complements** the existing xAI integration stack:
  - `x-grok-conv-id` prompt caching in `run_agent.py`
  - `"grok"` in `TOOL_USE_ENFORCEMENT_MODELS` in `agent/prompt_builder.py`
  - Native xAI provider registration in #7050
  - `DEFAULT_CONTEXT_LENGTHS` fallbacks in #7039

This PR is **self-contained** and does not depend on #7039 or #7050, though it composes cleanly with them.
