### PR TITLE
feat(signal): per-group require_mention overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -532,6 +532,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                # Per-group require_mention overrides: {group_id: bool}
+                _rmo = platform_cfg.get("require_mention_overrides")
+                if isinstance(_rmo, dict):
+                    bridged["require_mention_overrides"] = _rmo
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -468,6 +468,40 @@ class SignalAdapter(BasePlatformAdapter):
                 logger.debug("Signal: group %s not in allowlist", group_id[:8] if group_id else "?")
                 return
 
+        # Require mention in groups (per-group overrides supported).
+        # Requires @mention before responding in group chats.
+        # Priority: per-group override > global require_mention > SIGNAL_REQUIRE_MENTION env var.
+        if is_group:
+            require_mention = False
+            # Check per-group override first
+            overrides = self.config.extra.get("require_mention_overrides", {})
+            group_key = f"group:{group_id}"
+            if group_key in overrides:
+                rm_value = overrides[group_key]
+                if isinstance(rm_value, str):
+                    require_mention = rm_value.lower() in ("true", "1", "yes")
+                else:
+                    require_mention = bool(rm_value)
+            else:
+                # Fall back to global config, then env var
+                configured = self.config.extra.get("require_mention")
+                if configured is not None:
+                    if isinstance(configured, str):
+                        require_mention = configured.lower() in ("true", "1", "yes")
+                    else:
+                        require_mention = bool(configured)
+                else:
+                    require_mention = os.getenv("SIGNAL_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes")
+
+            if require_mention:
+                mentions = data_message.get("mentions", [])
+                mentioned_uuids = [m.get("uuid", "") for m in mentions]
+                mentioned_numbers = [m.get("number", "") for m in mentions]
+                bot_account = self._account_normalized
+                if bot_account and bot_account not in mentioned_numbers and bot_account not in mentioned_uuids:
+                    logger.debug("Signal: ignoring group message (require_mention enabled, bot not mentioned)")
+                    return
+
         # Build chat info
         chat_id = sender if not is_group else f"group:{group_id}"
         chat_type = "group" if is_group else "dm"

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -770,3 +770,148 @@ class TestSignalStopTyping:
         await adapter.stop_typing("+155****4567")
 
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
+
+
+# ---------------------------------------------------------------------------
+# require_mention (per-group overrides)
+# ---------------------------------------------------------------------------
+
+class TestSignalRequireMention:
+    """Test require_mention logic for group messages."""
+
+    def _make_envelope(self, group_id="grp123", sender="+155****9999", message="hello", mentions=None):
+        """Create a minimal Signal message envelope."""
+        return {
+            "envelope": {
+                "source": {"number": sender, "uuid": "uuid-sender"},
+                "dataMessage": {
+                    "message": message,
+                    "groupInfo": {"groupId": group_id, "groupName": "Test Group"},
+                    "mentions": mentions or [],
+                    "timestamp": 1234567890,
+                },
+            }
+        }
+
+    def test_require_mention_false_responds_to_all(self, monkeypatch):
+        """With require_mention=False (default), bot responds to all group messages."""
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="grp123",
+            require_mention=False,
+        )
+        # require_mention should not be set in config, so default behavior
+        assert adapter.config.extra.get("require_mention") is False
+
+    def test_require_mention_true_config(self, monkeypatch):
+        """require_mention=True is passed through config."""
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="grp123",
+            require_mention=True,
+        )
+        assert adapter.config.extra.get("require_mention") is True
+
+    def test_require_mention_overrides_passed_through(self, monkeypatch):
+        """require_mention_overrides dict is available in config.extra."""
+        overrides = {"group:grp123": False, "group:grp456": True}
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="grp123,grp456",
+            require_mention=True,
+            require_mention_overrides=overrides,
+        )
+        assert adapter.config.extra.get("require_mention_overrides") == overrides
+
+    def test_require_mention_string_true(self, monkeypatch):
+        """String 'true' is recognized as True."""
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="grp123",
+            require_mention="true",
+        )
+        assert adapter.config.extra.get("require_mention") == "true"
+        # The adapter code checks: str.lower() in ("true", "1", "yes")
+
+    def test_require_mention_string_false(self, monkeypatch):
+        """String 'false' is recognized as False."""
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="grp123",
+            require_mention="false",
+        )
+        assert adapter.config.extra.get("require_mention") == "false"
+
+    def test_override_disables_mention_for_group(self, monkeypatch):
+        """Per-group override false means bot responds without mention."""
+        overrides = {"group:grp123": False}
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="grp123",
+            require_mention=True,
+            require_mention_overrides=overrides,
+        )
+        # The override says False for grp123, so even with global True,
+        # the bot should process the message
+        rm = adapter.config.extra.get("require_mention_overrides", {}).get("group:grp123")
+        assert rm is False
+
+    def test_override_enables_mention_for_group(self, monkeypatch):
+        """Per-group override true means bot requires mention."""
+        overrides = {"group:grp123": True}
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="grp123",
+            require_mention=False,
+            require_mention_overrides=overrides,
+        )
+        rm = adapter.config.extra.get("require_mention_overrides", {}).get("group:grp123")
+        assert rm is True
+
+    def test_env_var_fallback(self, monkeypatch):
+        """SIGNAL_REQUIRE_MENTION env var works as fallback."""
+        monkeypatch.setenv("SIGNAL_REQUIRE_MENTION", "true")
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="grp123")
+        # No require_mention in config.extra, so code falls back to env var
+        env_val = adapter.config.extra.get("require_mention")
+        assert env_val is None  # Not set in config, will use env var in handler
+
+    def test_config_passes_overrides_to_adapter(self, monkeypatch):
+        """load_gateway_config should bridge require_mention_overrides."""
+        from gateway.config import load_gateway_config, Platform
+        import yaml
+        import os
+
+        # Create a temporary config with signal overrides
+        cfg = {
+            "signal": {
+                "require_mention": True,
+                "require_mention_overrides": {
+                    "group:abc123": False,
+                    "group:xyz789": True,
+                },
+            }
+        }
+
+        # Test the bridged config directly
+        bridged = {}
+        platform_cfg = cfg["signal"]
+        if "require_mention" in platform_cfg:
+            bridged["require_mention"] = platform_cfg["require_mention"]
+        _rmo = platform_cfg.get("require_mention_overrides")
+        if isinstance(_rmo, dict):
+            bridged["require_mention_overrides"] = _rmo
+
+        assert bridged["require_mention"] is True
+        assert bridged["require_mention_overrides"]["group:abc123"] is False
+        assert bridged["require_mention_overrides"]["group:xyz789"] is True
+
+    def test_overrides_non_dict_ignored(self):
+        """Non-dict require_mention_overrides should be skipped."""
+        bridged = {}
+        platform_cfg = {"require_mention_overrides": "not a dict"}
+        _rmo = platform_cfg.get("require_mention_overrides")
+        if isinstance(_rmo, dict):
+            bridged["require_mention_overrides"] = _rmo
+
+        assert "require_mention_overrides" not in bridged

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -141,6 +141,45 @@ Group access is controlled by the `SIGNAL_GROUP_ALLOWED_USERS` env var:
 | Set with group IDs | Only listed groups are monitored (e.g., `groupId1,groupId2`). |
 | Set to `*` | The bot responds in any group it's a member of. |
 
+### Require Mention in Groups
+
+By default, the bot responds to all messages in allowed groups. To require users to @mention the bot before it responds, use the `require_mention` setting in `config.yaml`:
+
+```yaml
+signal:
+  require_mention: true
+```
+
+Or via environment variable:
+
+```
+SIGNAL_REQUIRE_MENTION=true
+```
+
+When enabled, the bot ignores group messages unless it is @mentioned (by phone number or UUID).
+
+#### Per-Group Overrides
+
+Override the global `require_mention` setting for specific groups using `require_mention_overrides` in `config.yaml`:
+
+```yaml
+signal:
+  require_mention: true              # Global default: must @mention
+  group_mappings:
+    group:ABC123...: work             # Mapped to 'work' profile
+    group:XYZ789...: side-business    # Mapped to 'side-business' profile
+  require_mention_overrides:
+    group:ABC123...: false            # Work group: always respond
+    group:XYZ789...: false            # Side-business group: always respond
+    # Other groups inherit global require_mention: true
+```
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | `require_mention_overrides` for the specific group |
+| 2 | Global `require_mention` in `config.yaml` |
+| 3 (lowest) | `SIGNAL_REQUIRE_MENTION` env var (default: `false`) |
+
 ---
 
 ## Features
@@ -237,3 +276,4 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | `SIGNAL_GROUP_ALLOWED_USERS` | No | — | Group IDs to monitor, or `*` for all (omit to disable groups) |
 | `SIGNAL_ALLOW_ALL_USERS` | No | `false` | Allow any user to interact (skip allowlist) |
 | `SIGNAL_HOME_CHANNEL` | No | — | Default delivery target for cron jobs |
+| `SIGNAL_REQUIRE_MENTION` | No | `false` | Require @mention in groups before responding |


### PR DESCRIPTION
 ## What does this PR do?

Signal is the only messaging adapter in Hermes that has no `require_mention` support. Discord and Slack both allow configuring whether the bot must be @mentioned before responding in group chats, but Signal silently responds to every message in allowed groups.

This PR adds `require_mention` support for Signal with per-group overrides, following the same priority pattern as other platforms. This is particularly useful for setups where the bot is in multiple groups with different interaction styles (e.g. a work group where it should only respond when mentioned, vs. a support group where it should always respond).

## Related Issue

N/A, feature gap discovered during production use.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/signal.py`: require_mention logic with per-group overrides, global config fallback, and env var support.
Initializes `require_mention = False` before the override check to prevent undefined variable access.
- `gateway/config.py`: type-safe passthrough of `require_mention_overrides` dict from `config.yaml` signal section to the
adapter's `extra` config, with validation that the value is actually a dict.
- `website/docs/user-guide/messaging/signal.md`: new "Require Mention in Groups" section with config examples, per-group override docs, priority table, and `SIGNAL_REQUIRE_MENTION` added to environment variables reference.

## How to Test

1. In `config.yaml`, set `signal.require_mention: true` and add a group to `require_mention_overrides` with `false`. Send a message in that group without @mentioning the bot. It should respond.
2. Send a message in a different group (not in overrides) without @mentioning. The bot should ignore it.
3. @Mention the bot in the group from step 2. It should respond.
4. Set `SIGNAL_REQUIRE_MENTION=false` via env var and remove the config.yaml settings. The bot should respond to all group messages (default behavior).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (signal-cli 0.14.2, Java 21)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```
# require_mention: false (default) - bot responds to all group messages
2026-04-10 11:04:58 INFO gateway.run: inbound message: platform=signal user=Mirza chat=group:XYZ789 msg='hello'
2026-04-10 11:05:11 INFO gateway.run: response ready: platform=signal chat=group:XYZ789

# require_mention: true with per-group override false - bot responds without mention
signal:
  require_mention: true
  require_mention_overrides:
    group:XYZ789: false

# require_mention: true, no override - bot ignores unmentioned messages
2026-04-10 11:06:10 DEBUG signal: ignoring group message (require_mention enabled, bot not mentioned)
```