### PR TITLE
fix(copilot): add missing Copilot-Integration-Id header

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -285,6 +285,7 @@ def copilot_request_headers(
     headers: dict[str, str] = {
         "Editor-Version": "vscode/1.104.1",
         "User-Agent": "HermesAgent/1.0",
+        "Copilot-Integration-Id": "vscode-chat",
         "Openai-Intent": "conversation-edits",
         "x-initiator": "agent" if is_agent_turn else "user",
     }


### PR DESCRIPTION
## Summary

Salvage of #6806 by @kamil-gwozdz onto current main.

Adds the required `Copilot-Integration-Id: vscode-chat` header to `copilot_request_headers()` in `hermes_cli/copilot_auth.py`. Without this header, all Copilot API calls fail with HTTP 400 (`missing required Copilot-Integration-Id header`).

Confirmed required by OpenCode, LiteLLM, OpenHands, and copilot-to-api — standard header for all `api.githubcopilot.com` requests.

## Changes
- +1 line in `hermes_cli/copilot_auth.py`

## Tests
- 26/26 copilot auth tests pass

Closes #6806