### PR TITLE
fix(acp): populate PromptResponse usage from top-level result fields

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -460,6 +460,14 @@ class HermesACPAgent(acp.Agent):
                 thought_tokens=usage_data.get("reasoning_tokens"),
                 cached_read_tokens=usage_data.get("cached_tokens"),
             )
+        elif any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
+            usage = Usage(
+                input_tokens=result.get("prompt_tokens", 0),
+                output_tokens=result.get("completion_tokens", 0),
+                total_tokens=result.get("total_tokens", 0),
+                thought_tokens=result.get("reasoning_tokens"),
+                cached_read_tokens=result.get("cache_read_tokens"),
+            )
 
         stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -451,16 +451,7 @@ class HermesACPAgent(acp.Agent):
             await conn.session_update(session_id, update)
 
         usage = None
-        usage_data = result.get("usage")
-        if usage_data and isinstance(usage_data, dict):
-            usage = Usage(
-                input_tokens=usage_data.get("prompt_tokens", 0),
-                output_tokens=usage_data.get("completion_tokens", 0),
-                total_tokens=usage_data.get("total_tokens", 0),
-                thought_tokens=usage_data.get("reasoning_tokens"),
-                cached_read_tokens=usage_data.get("cached_tokens"),
-            )
-        elif any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
+        if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
             usage = Usage(
                 input_tokens=result.get("prompt_tokens", 0),
                 output_tokens=result.get("completion_tokens", 0),

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -411,6 +411,37 @@ class TestPrompt:
         assert update.session_update == "agent_message_chunk"
 
     @pytest.mark.asyncio
+    async def test_prompt_populates_usage_from_top_level_run_conversation_fields(self, agent):
+        """ACP should map top-level token fields into PromptResponse.usage."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "usage attached",
+            "messages": [],
+            "prompt_tokens": 123,
+            "completion_tokens": 45,
+            "total_tokens": 168,
+            "reasoning_tokens": 7,
+            "cache_read_tokens": 11,
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="show usage")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert isinstance(resp, PromptResponse)
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 123
+        assert resp.usage.output_tokens == 45
+        assert resp.usage.total_tokens == 168
+        assert resp.usage.thought_tokens == 7
+        assert resp.usage.cached_read_tokens == 11
+
+    @pytest.mark.asyncio
     async def test_prompt_cancelled_returns_cancelled_stop_reason(self, agent):
         """If cancel is called during prompt, stop_reason should be 'cancelled'."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## Summary

Salvage of #7047 by @Astro-Han. Fixes #7007.

`run_conversation()` returns token counters (`prompt_tokens`, `completion_tokens`, `total_tokens`, `reasoning_tokens`, `cache_read_tokens`) at the top level of the result dict. The ACP adapter was reading `result.get("usage")` expecting a nested dict that never existed, so ACP clients always received `usage=None`.

### Changes
- **Cherry-picked** contributor's fix: read usage from top-level result fields
- **Follow-up**: removed the dead nested `result["usage"]` code path (also had wrong key name `cached_tokens` vs `cache_read_tokens`)
- Includes regression test covering the actual `run_conversation()` return shape

### Test results
```
52 passed in 1.10s
```