### PR TITLE
Fix OpenCode Go support in doctor, chat CLI, and curated models

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -728,7 +728,7 @@ def run_doctor(args):
         ("AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),
-        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         "https://opencode.ai/zen/go/v1/models", "OPENCODE_GO_BASE_URL", True),
+        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         None,                                  "OPENCODE_GO_BASE_URL", False),
     ]
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:
         _key = ""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4298,7 +4298,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "opencode-go"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -213,6 +213,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "big-pickle",
     ],
     "opencode-go": [
+        "glm-5.1",
         "glm-5",
         "kimi-k2.5",
         "mimo-v2-pro",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -110,7 +110,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
-    "opencode-go": ["glm-5", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7"],
+    "opencode-go": ["glm-5.1", "glm-5", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",

--- a/tests/hermes_cli/test_chat_skills_flag.py
+++ b/tests/hermes_cli/test_chat_skills_flag.py
@@ -73,6 +73,32 @@ def test_chat_subcommand_accepts_image_flag(monkeypatch):
     }
 
 
+def test_chat_subcommand_accepts_opencode_go_provider(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_chat(args):
+        captured["provider"] = args.provider
+        captured["model"] = args.model
+        captured["query"] = args.query
+
+    monkeypatch.setattr(main_mod, "cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "chat", "-q", "hello", "--provider", "opencode-go", "-m", "opencode-go/mimo-v2-pro"],
+    )
+
+    main_mod.main()
+
+    assert captured == {
+        "provider": "opencode-go",
+        "model": "opencode-go/mimo-v2-pro",
+        "query": "hello",
+    }
+
+
 def test_continue_worktree_and_skills_flags_work_together(monkeypatch):
     import hermes_cli.main as main_mod
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -292,3 +292,49 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "system dependency not met" in out
     assert "agent-browser is not installed (expected in the tested Termux path)" in out
     assert "npm install -g agent-browser && agent-browser install" in out
+
+
+def test_run_doctor_opencode_go_reports_key_configured_without_models_probe(monkeypatch, tmp_path):
+    helper = TestDoctorMemoryProviderSection()
+
+    for env_var in (
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "GLM_API_KEY",
+        "ZAI_API_KEY",
+        "Z_AI_API_KEY",
+        "KIMI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "HF_TOKEN",
+        "DASHSCOPE_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
+        "AI_GATEWAY_API_KEY",
+        "KILOCODE_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_BASE_URL",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-opencode-go")
+
+    import httpx
+
+    calls: list[str] = []
+
+    class _FakeResponse:
+        status_code = 200
+
+    def fake_get(url, *args, **kwargs):
+        calls.append(str(url))
+        return _FakeResponse()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+
+    opencode_lines = [line for line in out.splitlines() if "OpenCode Go" in line]
+    assert opencode_lines
+    assert any("(key configured)" in line for line in opencode_lines)
+    assert not any("opencode.ai/zen/go/v1/models" in url for url in calls)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -356,6 +356,8 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-zen", "minimax-m2.5") == "chat_completions"
 
     def test_opencode_go_api_modes_match_docs(self):
+        assert opencode_model_api_mode("opencode-go", "glm-5.1") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/glm-5.1") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "glm-5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "opencode-go/glm-5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "kimi-k2.5") == "chat_completions"

--- a/tests/hermes_cli/test_setup_model_selection.py
+++ b/tests/hermes_cli/test_setup_model_selection.py
@@ -37,7 +37,7 @@ class TestSetupProviderModelSelection:
         ("minimax", ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"]),
         ("minimax-cn", ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"]),
         ("opencode-zen", ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash"]),
-        ("opencode-go", ["glm-5", "kimi-k2.5", "minimax-m2.5", "minimax-m2.7"]),
+        ("opencode-go", ["glm-5.1", "glm-5", "kimi-k2.5", "minimax-m2.5", "minimax-m2.7"]),
     ])
     @patch("hermes_cli.models.fetch_api_models", return_value=[])
     @patch("hermes_cli.config.get_env_value", return_value="fake-key")


### PR DESCRIPTION
## Summary
This PR fixes the OpenCode Go integration issues that were reproducible from the CLI:
- `hermes doctor` no longer probes `GET /zen/go/v1/models` for OpenCode Go
- `hermes chat --provider opencode-go` now parses correctly and reaches the runtime provider
- the curated `opencode-go` model list now includes `glm-5.1`, matching the official OpenCode Go docs

## Why
The original user-facing failure was not just `doctor`.

Official OpenCode sources show that Go models are documented on:
- https://opencode.ai/docs/go/
- https://github.com/anomalyco/opencode/blob/dev/packages/web/src/content/docs/go.mdx

Those docs map:
- GLM / Kimi / MiMo -> `/chat/completions`
- MiniMax -> `/messages`

What was reproducible before this patch:
- `GET https://opencode.ai/zen/go/v1/models` returned `404`
- documented Go inference endpoints returned `200` with the same key
- `hermes chat --provider opencode-go ...` failed at argparse with `invalid choice: 'opencode-go'`
- Hermes also omitted `glm-5.1` from its curated `opencode-go` defaults

This PR fixes those three concrete mismatches.

Closes #7074.

## Validation
- `uv run --extra dev pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_setup_model_selection.py -q`
- `uv run --extra dev pytest tests/hermes_cli/test_chat_skills_flag.py -q`
- `/Users/gustavo/.local/bin/hermes doctor | rg 'OpenCode Go|HTTP 404|key configured'`
- `curl -H "Authorization: Bearer $OPENCODE_GO_API_KEY" https://opencode.ai/zen/go/v1/models` -> `404`
- `curl -H "Authorization: Bearer $OPENCODE_GO_API_KEY" -H "Content-Type: application/json" https://opencode.ai/zen/go/v1/chat/completions ...` -> `200`
- `curl -H "x-api-key: $OPENCODE_GO_API_KEY" -H "Content-Type: application/json" https://opencode.ai/zen/go/v1/messages ...` -> `200`
- `/Users/gustavo/.local/bin/hermes chat -q 'Reply with OK only' --provider opencode-go -m opencode-go/mimo-v2-pro -Q` -> `OK`
