### PR TITLE
fix(doctor): skip unsupported OpenCode Go models probe

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -728,7 +728,8 @@ def run_doctor(args):
         ("AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),
-        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         "https://opencode.ai/zen/go/v1/models", "OPENCODE_GO_BASE_URL", True),
+        # OpenCode Go docs expose inference endpoints, but not a documented provider-wide /models listing endpoint.
+        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         None,                                  "OPENCODE_GO_BASE_URL", False),
     ]
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:
         _key = ""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -14,6 +14,43 @@ from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
 
 
+DOCTOR_PROVIDER_BASE_ENVS = (
+    "GLM_BASE_URL",
+    "KIMI_BASE_URL",
+    "DEEPSEEK_BASE_URL",
+    "HF_BASE_URL",
+    "DASHSCOPE_BASE_URL",
+    "MINIMAX_BASE_URL",
+    "MINIMAX_CN_BASE_URL",
+    "AI_GATEWAY_BASE_URL",
+    "KILOCODE_BASE_URL",
+    "OPENCODE_ZEN_BASE_URL",
+    "OPENCODE_GO_BASE_URL",
+)
+
+
+def _run_doctor_with_fake_httpx(monkeypatch, tmp_path, env):
+    helper = TestDoctorMemoryProviderSection()
+    for key in doctor_mod._PROVIDER_ENV_HINTS:
+        monkeypatch.delenv(key, raising=False)
+    for key in DOCTOR_PROVIDER_BASE_ENVS:
+        monkeypatch.delenv(key, raising=False)
+
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return types.SimpleNamespace(status_code=200)
+
+    monkeypatch.setitem(sys.modules, "httpx", types.SimpleNamespace(get=fake_get))
+
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+    return out, calls
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
@@ -292,3 +329,35 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "system dependency not met" in out
     assert "agent-browser is not installed (expected in the tested Termux path)" in out
     assert "npm install -g agent-browser && agent-browser install" in out
+
+
+def test_run_doctor_opencode_go_skips_models_probe(monkeypatch, tmp_path):
+    out, calls = _run_doctor_with_fake_httpx(
+        monkeypatch,
+        tmp_path,
+        {
+            "OPENCODE_GO_API_KEY": "test-opencode-go-key",
+            "OPENCODE_GO_BASE_URL": "https://example.invalid/zen/go/v1",
+        },
+    )
+
+    assert "OpenCode Go" in out
+    assert "(key configured)" in out
+    assert "Checking OpenCode Go API..." not in out
+    assert calls == []
+
+
+def test_run_doctor_opencode_zen_still_probes_models_endpoint(monkeypatch, tmp_path):
+    out, calls = _run_doctor_with_fake_httpx(
+        monkeypatch,
+        tmp_path,
+        {
+            "OPENCODE_ZEN_API_KEY": "test-opencode-zen-key",
+            "OPENCODE_ZEN_BASE_URL": "https://example.invalid/zen/v1",
+        },
+    )
+
+    assert "OpenCode Zen" in out
+    assert "Checking OpenCode Zen API..." in out
+    assert len(calls) == 1
+    assert calls[0][0] == "https://example.invalid/zen/v1/models"


### PR DESCRIPTION
## What does this PR do?

Stops `hermes doctor` from probing the undocumented `OpenCode Go` `/models` endpoint.

`doctor.py` currently treats OpenCode Go like providers that expose a provider-wide `/models` listing, but the issue report shows that `GET /zen/go/v1/models` returns `404` while the documented inference endpoints still work with the same key. This change makes the doctor output match the documented surface area by reporting `OpenCode Go` as `key configured` instead of probing `/models`.

I also added regression tests to make the boundary explicit:
- OpenCode Go skips the HTTP probe even when `OPENCODE_GO_BASE_URL` is set
- OpenCode Zen still probes its `/models` endpoint

## Related Issue

Fixes #7074

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`hermes_cli/doctor.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/doctor.py) so OpenCode Go no longer uses `/zen/go/v1/models` as a health probe target
- Kept OpenCode Zen on the existing `/models` probe path
- Added regression coverage in [`tests/hermes_cli/test_doctor.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/hermes_cli/test_doctor.py) for both behaviors

## How to Test

1. Export a valid `OPENCODE_GO_API_KEY` and run `hermes doctor`.
2. Confirm the `OpenCode Go` line reports `(key configured)` instead of `HTTP 404`.
3. Run:
   ```bash
   uv run --extra dev pytest -q -o addopts='' tests/hermes_cli/test_doctor.py tests/hermes_cli/test_api_key_providers.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ uv run --extra dev pytest -q -o addopts='' tests/hermes_cli/test_doctor.py
19 passed in 1.28s

$ uv run --extra dev pytest -q -o addopts='' tests/hermes_cli/test_api_key_providers.py
125 passed in 8.64s
```
