### PR TITLE
fix(install): prefer HTTPS clone in public installer

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -735,18 +735,21 @@ clone_repo() {
             exit 1
         fi
     else
-        # Try SSH first (for private repo access), fall back to HTTPS
-        # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
-        # so SSH fails fast instead of hanging when no key is configured.
-        log_info "Trying SSH clone..."
-        if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
-            log_success "Cloned via SSH"
+        # Prefer HTTPS for the public install path. This avoids hanging on SSH
+        # auth / host-key prompts in non-interactive curl|bash installs.
+        log_info "Trying HTTPS clone..."
+        if GIT_TERMINAL_PROMPT=0 \
+           git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR" 2>/dev/null; then
+            log_success "Cloned via HTTPS"
         else
-            rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
-            log_info "SSH failed, trying HTTPS..."
-            if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
-                log_success "Cloned via HTTPS"
+            rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial HTTPS clone
+            # SSH remains as a fallback for environments where HTTPS is blocked.
+            # Keep it fully non-interactive so missing keys cannot hang install.
+            log_info "HTTPS failed, trying SSH..."
+            if GIT_TERMINAL_PROMPT=0 \
+               GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new" \
+               git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+                log_success "Cloned via SSH"
             else
                 log_error "Failed to clone repository"
                 exit 1
@@ -1345,4 +1348,6 @@ main() {
     print_success
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/hermes_cli/test_install_script.py
+++ b/tests/hermes_cli/test_install_script.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _write_fake_git(tmp_path: Path) -> tuple[Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "git.log"
+    fake_git = bin_dir / "git"
+    fake_git.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            printf '%s\\n' "$*" >> "$GIT_CALL_LOG"
+
+            if [ "${1:-}" != "clone" ]; then
+                echo "unexpected git command: $*" >&2
+                exit 1
+            fi
+
+            target="${@: -1}"
+            url=""
+            for arg in "$@"; do
+                case "$arg" in
+                    https://github.com/NousResearch/hermes-agent.git|git@github.com:NousResearch/hermes-agent.git)
+                        url="$arg"
+                        ;;
+                esac
+            done
+
+            case "$url" in
+                https://github.com/NousResearch/hermes-agent.git)
+                    if [ "${FAIL_HTTPS_CLONE:-0}" = "1" ]; then
+                        exit 1
+                    fi
+                    ;;
+                git@github.com:NousResearch/hermes-agent.git)
+                    if [ "${FAIL_SSH_CLONE:-0}" = "1" ]; then
+                        exit 1
+                    fi
+                    ;;
+                *)
+                    echo "unexpected clone url: $url" >&2
+                    exit 1
+                    ;;
+            esac
+
+            mkdir -p "$target/.git"
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    return bin_dir, log_path
+
+
+def _run_clone_repo(tmp_path: Path, *, fail_https: bool = False, fail_ssh: bool = False) -> subprocess.CompletedProcess[str]:
+    bin_dir, log_path = _write_fake_git(tmp_path)
+    install_dir = tmp_path / "install"
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["GIT_CALL_LOG"] = str(log_path)
+    env["TEST_INSTALL_DIR"] = str(install_dir)
+    if fail_https:
+        env["FAIL_HTTPS_CLONE"] = "1"
+    if fail_ssh:
+        env["FAIL_SSH_CLONE"] = "1"
+
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'set -euo pipefail; set --; source "$INSTALL_SCRIPT"; INSTALL_DIR="$TEST_INSTALL_DIR"; BRANCH="main"; clone_repo',
+        ],
+        env={**env, "INSTALL_SCRIPT": str(INSTALL_SCRIPT)},
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+
+
+def test_install_script_is_valid_shell():
+    result = subprocess.run(["bash", "-n", str(INSTALL_SCRIPT)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_clone_repo_prefers_https_for_fresh_install(tmp_path: Path):
+    result = _run_clone_repo(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    call_log = (tmp_path / "git.log").read_text(encoding="utf-8").splitlines()
+    assert len(call_log) == 1
+    assert "https://github.com/NousResearch/hermes-agent.git" in call_log[0]
+    assert "git@github.com:NousResearch/hermes-agent.git" not in call_log[0]
+    assert "Cloned via HTTPS" in result.stdout
+
+
+def test_clone_repo_falls_back_to_ssh_when_https_fails(tmp_path: Path):
+    result = _run_clone_repo(tmp_path, fail_https=True)
+
+    assert result.returncode == 0, result.stderr
+    call_log = (tmp_path / "git.log").read_text(encoding="utf-8").splitlines()
+    assert len(call_log) == 2
+    assert "https://github.com/NousResearch/hermes-agent.git" in call_log[0]
+    assert "git@github.com:NousResearch/hermes-agent.git" in call_log[1]
+    assert "HTTPS failed, trying SSH..." in result.stdout
+    assert "Cloned via SSH" in result.stdout


### PR DESCRIPTION
## What does this PR do?

Fixes the public installer path so it no longer tries SSH first during a fresh install.

`scripts/install.sh` currently attempts `git@github.com:...` before `https://github.com/...`, which is the wrong default for a public `curl | bash` installer. In non-interactive environments, the SSH path can stall on auth or host-key handling before users ever reach the HTTPS fallback.

This change makes fresh installs prefer HTTPS first, and keeps SSH as a fully non-interactive fallback only when HTTPS actually fails.

I also added focused installer tests so this behavior is locked down instead of relying on a shell-script comment.

## Related Issue

Fixes #7066

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`scripts/install.sh`](https://github.com/NousResearch/hermes-agent/blob/main/scripts/install.sh) to try HTTPS clone before SSH for new installs
- Kept SSH as a fallback, but forced it to stay non-interactive with `GIT_TERMINAL_PROMPT=0` and bounded SSH options
- Added a standard `BASH_SOURCE` entrypoint guard so the installer can be sourced safely in tests
- Added regression tests in [`tests/hermes_cli/test_install_script.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/hermes_cli/test_install_script.py) covering:
  - HTTPS-first behavior on fresh install
  - SSH fallback when HTTPS clone fails
  - shell syntax validation for `scripts/install.sh`

## How to Test

1. Run:
   ```bash
   uv run --extra dev pytest -q -o addopts='' tests/hermes_cli/test_install_script.py
   ```
2. Confirm the tests show HTTPS is attempted first and SSH is only used after an HTTPS failure.
3. Optionally run the installer manually in a clean shell and confirm the clone step now starts with `Trying HTTPS clone...`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ uv run --extra dev pytest -q -o addopts='' tests/hermes_cli/test_install_script.py
3 passed in 0.77s
```
