### PR TITLE
fix(model-switch): resolve credentials for user-defined providers instead of failing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5481,7 +5481,14 @@ class HermesCLI:
             )
             return
 
-        # Perform the switch
+        # Perform the switch — pass user_providers so user-defined providers
+        # (from config.yaml providers:) are resolvable.
+        _user_provs = None
+        try:
+            from hermes_cli.config import load_config
+            _user_provs = load_config().get("providers")
+        except Exception:
+            pass
         result = switch_model(
             raw_input=model_input,
             current_provider=self.provider or "",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6224,6 +6224,8 @@ class GatewayRunner:
                     _cur_base_url = current_base_url
                     _cur_api_key = current_api_key
 
+                    _user_provs_for_cb = user_provs
+
                     async def _on_model_selected(
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -638,6 +638,7 @@ def switch_model(
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
+    pdef = None  # set in PATH A when --provider is given
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -803,7 +804,9 @@ def switch_model(
 
     provider_changed = target_provider != current_provider
     provider_label = get_label(target_provider)
-    if target_provider.startswith("custom:"):
+    if pdef is not None:
+        provider_label = pdef.name or provider_label
+    elif target_provider.startswith("custom:"):
         custom_pdef = resolve_provider_full(
             target_provider,
             user_providers,
@@ -818,25 +821,37 @@ def switch_model(
     api_mode = ""
 
     if provider_changed or explicit_provider:
-        try:
-            runtime = resolve_runtime_provider(
-                requested=target_provider,
-                target_model=new_model,
-            )
-            api_key = runtime.get("api_key", "")
-            base_url = runtime.get("base_url", "")
-            api_mode = runtime.get("api_mode", "")
-        except Exception as e:
-            return ModelSwitchResult(
-                success=False,
-                target_provider=target_provider,
-                provider_label=provider_label,
-                is_global=is_global,
-                error_message=(
-                    f"Could not resolve credentials for provider "
-                    f"'{provider_label}': {e}"
-                ),
-            )
+        # User-defined providers carry their own credentials in the ProviderDef;
+        # resolve_runtime_provider only knows about built-in providers.
+        if pdef is not None and getattr(pdef, "source", "") == "user-config":
+            import os as _os
+            for _ev in pdef.api_key_env_vars:
+                _val = _os.environ.get(_ev, "")
+                if _val:
+                    api_key = _val
+                    break
+            if pdef.base_url:
+                base_url = pdef.base_url
+        else:
+            try:
+                runtime = resolve_runtime_provider(
+                    requested=target_provider,
+                    target_model=new_model,
+                )
+                api_key = runtime.get("api_key", "")
+                base_url = runtime.get("base_url", "")
+                api_mode = runtime.get("api_mode", "")
+            except Exception as e:
+                return ModelSwitchResult(
+                    success=False,
+                    target_provider=target_provider,
+                    provider_label=provider_label,
+                    is_global=is_global,
+                    error_message=(
+                        f"Could not resolve credentials for provider "
+                        f"'{provider_label}': {e}"
+                    ),
+                )
     else:
         try:
             runtime = resolve_runtime_provider(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -435,6 +435,7 @@ def switch_model(
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
+    pdef = None  # set in PATH A when --provider is given
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -599,8 +600,8 @@ def switch_model(
     # =================================================================
 
     provider_changed = target_provider != current_provider
-    provider_label = get_label(target_provider)
-    if target_provider.startswith("custom:"):
+    provider_label = (pdef.name if pdef is not None else None) or get_label(target_provider)
+    if provider_label == target_provider and target_provider.startswith("custom:"):
         custom_pdef = resolve_provider_full(
             target_provider,
             user_providers,
@@ -615,22 +616,34 @@ def switch_model(
     api_mode = ""
 
     if provider_changed or explicit_provider:
-        try:
-            runtime = resolve_runtime_provider(requested=target_provider)
-            api_key = runtime.get("api_key", "")
-            base_url = runtime.get("base_url", "")
-            api_mode = runtime.get("api_mode", "")
-        except Exception as e:
-            return ModelSwitchResult(
-                success=False,
-                target_provider=target_provider,
-                provider_label=provider_label,
-                is_global=is_global,
-                error_message=(
-                    f"Could not resolve credentials for provider "
-                    f"'{provider_label}': {e}"
-                ),
-            )
+        # User-defined providers carry their own credentials in the ProviderDef;
+        # resolve_runtime_provider only knows about built-in providers.
+        if pdef is not None and getattr(pdef, "source", "") == "user-config":
+            import os as _os
+            for _ev in pdef.api_key_env_vars:
+                _val = _os.environ.get(_ev, "")
+                if _val:
+                    api_key = _val
+                    break
+            if pdef.base_url:
+                base_url = pdef.base_url
+        else:
+            try:
+                runtime = resolve_runtime_provider(requested=target_provider)
+                api_key = runtime.get("api_key", "")
+                base_url = runtime.get("base_url", "")
+                api_mode = runtime.get("api_mode", "")
+            except Exception as e:
+                return ModelSwitchResult(
+                    success=False,
+                    target_provider=target_provider,
+                    provider_label=provider_label,
+                    is_global=is_global,
+                    error_message=(
+                        f"Could not resolve credentials for provider "
+                        f"'{provider_label}': {e}"
+                    ),
+                )
     else:
         try:
             runtime = resolve_runtime_provider(requested=current_provider)


### PR DESCRIPTION
## Summary

`switch_model()` always calls `resolve_runtime_provider()` for credential resolution, which only knows built-in providers. When a user-defined provider (from `config.yaml` `providers:`) is selected via `--provider`, this causes credential resolution errors like `"Unknown provider 'bedrock'"`.

### Root cause

In the COMMON PATH of `switch_model()`, the `pdef` variable (set in PATH A from `resolve_provider_full()`) is not initialized, so it's unavailable when deciding how to resolve credentials. The code unconditionally calls `resolve_runtime_provider()`, which has no knowledge of user-config providers.

### Changes (single file: `hermes_cli/model_switch.py`)

- Initialize `pdef = None` before PATH A so it's available in the COMMON PATH.
- When `pdef.source == "user-config"`, resolve `api_key` from `pdef.api_key_env_vars` (via `os.environ`) and `base_url` from `pdef.base_url` directly, bypassing `resolve_runtime_provider`.
- Use `pdef.name` for `provider_label` when available, so user-defined provider names display correctly in switch confirmation messages.

## Reproduction

1. Add a custom provider in `~/.hermes/config.yaml`:
   ```yaml
   providers:
     bedrock:
       name: AWS Bedrock (via LiteLLM)
       api: http://localhost:4000/v1
       key_env: LITELLM_PROXY_KEY
       transport: openai_chat
       default_model: anthropic/claude-sonnet-4.6
   ```
2. Set env: `export LITELLM_PROXY_KEY=sk-some-key`
3. Run `/model sonnet --provider bedrock`
4. **Before fix**: `Error: Could not resolve credentials for provider 'bedrock': ...`
5. **After fix**: Model switches correctly, credentials resolved from env.

## Test plan

- [ ] `/model` with no args still lists providers correctly
- [ ] `/model <name> --provider <user-defined-slug>` switches successfully
- [ ] `/model <name> --provider <built-in-slug>` still works via `resolve_runtime_provider`
- [ ] `custom:` prefixed providers still resolve their label correctly