### PR TITLE
fix(processes): skip gateway runtime checkpoint recovery

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -17,6 +17,7 @@ from tools.process_registry import (
     MAX_OUTPUT_CHARS,
     FINISHED_TTL_SECONDS,
     MAX_PROCESSES,
+    _is_gateway_runtime_command,
 )
 
 
@@ -407,6 +408,19 @@ class TestSpawnEnvSanitization:
 # =========================================================================
 
 class TestCheckpoint:
+    @pytest.mark.parametrize("command", [
+        "python -m hermes_cli.main gateway run --replace",
+        "source venv/bin/activate && python -m hermes_cli.main gateway run --replace & disown",
+        "/opt/homebrew/bin/python3 -m hermes_cli.main -p coder gateway run",
+        "hermes gateway run --replace",
+    ])
+    def test_detects_gateway_runtime_commands(self, command):
+        assert _is_gateway_runtime_command(command) is True
+
+    def test_does_not_flag_normal_background_commands(self):
+        assert _is_gateway_runtime_command("python -m pytest -q") is False
+        assert _is_gateway_runtime_command("hermes gateway status") is False
+
     def test_write_checkpoint(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
             s = _make_session()
@@ -416,6 +430,23 @@ class TestCheckpoint:
             data = json.loads((tmp_path / "procs.json").read_text())
             assert len(data) == 1
             assert data[0]["session_id"] == s.id
+
+    def test_write_checkpoint_skips_gateway_runtime_commands(self, registry, tmp_path):
+        with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
+            normal = _make_session(sid="proc_normal", command="python -m pytest -q")
+            gateway = _make_session(
+                sid="proc_gateway",
+                command="source venv/bin/activate && python -m hermes_cli.main gateway run --replace",
+            )
+            registry._running[normal.id] = normal
+            registry._running[gateway.id] = gateway
+
+            registry._write_checkpoint()
+
+            data = json.loads((tmp_path / "procs.json").read_text())
+            assert len(data) == 1
+            assert data[0]["session_id"] == normal.id
+            assert data[0]["command"] == normal.command
 
     def test_recover_no_file(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "missing.json"):
@@ -508,6 +539,33 @@ class TestCheckpoint:
             assert data[0]["session_id"] == "proc_live"
             assert data[0]["pid"] == os.getpid()
             assert data != []
+
+    def test_recovery_skips_gateway_runtime_entries(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([
+            {
+                "session_id": "proc_gateway",
+                "command": "python -m hermes_cli.main gateway run --replace",
+                "pid": os.getpid(),
+                "task_id": "t1",
+            },
+            {
+                "session_id": "proc_live",
+                "command": "sleep 999",
+                "pid": os.getpid(),
+                "task_id": "t2",
+            },
+        ]))
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            recovered = registry.recover_from_checkpoint()
+            assert recovered == 1
+            assert registry.get("proc_gateway") is None
+            assert registry.get("proc_live") is not None
+
+            data = json.loads(checkpoint.read_text())
+            assert len(data) == 1
+            assert data[0]["session_id"] == "proc_live"
 
     def test_recovery_skips_explicit_sandbox_backed_entries(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shlex
 import signal
 import subprocess
@@ -57,6 +58,31 @@ CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 MAX_OUTPUT_CHARS = 200_000      # 200KB rolling output buffer
 FINISHED_TTL_SECONDS = 1800     # Keep finished processes for 30 minutes
 MAX_PROCESSES = 64              # Max concurrent tracked processes (LRU pruning)
+
+
+_GATEWAY_RUNTIME_COMMAND_MARKERS = (
+    "python -m hermes_cli.main",
+    "python3 -m hermes_cli.main",
+    "hermes_cli.main gateway run",
+    "hermes gateway run",
+)
+
+
+def _normalize_command_for_match(command: str) -> str:
+    return re.sub(r"\s+", " ", (command or "").strip().lower())
+
+
+def _is_gateway_runtime_command(command: str) -> bool:
+    """Return True for background commands that launch Hermes gateway itself.
+
+    These commands are unsafe to checkpoint and recover from processes.json
+    because the gateway is typically supervised separately (launchd/systemd)
+    and reviving a stale copy can create duplicate live gateways.
+    """
+    normalized = _normalize_command_for_match(command)
+    if " gateway run" not in normalized:
+        return False
+    return any(marker in normalized for marker in _GATEWAY_RUNTIME_COMMAND_MARKERS)
 
 
 @dataclass
@@ -848,22 +874,29 @@ class ProcessRegistry:
             with self._lock:
                 entries = []
                 for s in self._running.values():
-                    if not s.exited:
-                        entries.append({
-                            "session_id": s.id,
-                            "command": s.command,
-                            "pid": s.pid,
-                            "pid_scope": s.pid_scope,
-                            "cwd": s.cwd,
-                            "started_at": s.started_at,
-                            "task_id": s.task_id,
-                            "session_key": s.session_key,
-                            "watcher_platform": s.watcher_platform,
-                            "watcher_chat_id": s.watcher_chat_id,
-                            "watcher_thread_id": s.watcher_thread_id,
-                            "watcher_interval": s.watcher_interval,
-                            "notify_on_complete": s.notify_on_complete,
-                        })
+                    if s.exited:
+                        continue
+                    if _is_gateway_runtime_command(s.command):
+                        logger.info(
+                            "Skipping checkpoint for gateway runtime command: %s",
+                            s.command[:120],
+                        )
+                        continue
+                    entries.append({
+                        "session_id": s.id,
+                        "command": s.command,
+                        "pid": s.pid,
+                        "pid_scope": s.pid_scope,
+                        "cwd": s.cwd,
+                        "started_at": s.started_at,
+                        "task_id": s.task_id,
+                        "session_key": s.session_key,
+                        "watcher_platform": s.watcher_platform,
+                        "watcher_chat_id": s.watcher_chat_id,
+                        "watcher_thread_id": s.watcher_thread_id,
+                        "watcher_interval": s.watcher_interval,
+                        "notify_on_complete": s.notify_on_complete,
+                    })
             
             # Atomic write to avoid corruption on crash
             from utils import atomic_json_write
@@ -889,6 +922,12 @@ class ProcessRegistry:
         for entry in entries:
             pid = entry.get("pid")
             if not pid:
+                continue
+            if _is_gateway_runtime_command(entry.get("command", "")):
+                logger.info(
+                    "Skipping recovery for gateway runtime command: %s",
+                    entry.get("command", "unknown")[:120],
+                )
                 continue
 
             pid_scope = entry.get("pid_scope", "host")


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes gateway self-hosting commands from being checkpointed into `~/.hermes/processes.json` or recovered from it on the next gateway start.

This addresses the confirmed duplicate-gateway path in #7061: if a background command like `python -m hermes_cli.main gateway run --replace` lands in the process registry checkpoint, a later gateway restart can resurrect a stale second gateway process and collide with the real service manager.

This PR intentionally stays scoped to the confirmed checkpoint/recovery issue. It does not try to add a broader single-instance guard for every gateway start path.

## Related Issue

Fixes #7061

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`tools/process_registry.py`](https://github.com/NousResearch/hermes-agent/blob/main/tools/process_registry.py) to detect gateway runtime commands such as:
  - `python -m hermes_cli.main gateway run --replace`
  - `python -m hermes_cli.main -p <profile> gateway run`
  - `hermes gateway run --replace`
- Skipped those commands when writing `processes.json`
- Skipped legacy checkpoint entries for those commands during recovery, so stale gateway runtimes are dropped instead of revived
- Added regression coverage in [`tests/tools/test_process_registry.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/tools/test_process_registry.py) for:
  - command detection
  - checkpoint write filtering
  - recovery filtering while preserving normal background processes

## How to Test

1. Run:
   ```bash
   uv run --extra dev pytest -q -o addopts='' tests/tools/test_process_registry.py tests/tools/test_notify_on_complete.py
   ```
2. Confirm the checkpoint tests pass and normal process recovery still works.
3. Optionally inspect `~/.hermes/processes.json` after spawning a background gateway self-hosting command and confirm it is not persisted there.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ uv run --extra dev pytest -q -o addopts='' tests/tools/test_process_registry.py tests/tools/test_notify_on_complete.py
65 passed in 1.38s
```
