### PR TITLE
fix(run_agent): recover primary client on openai transport errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5143,6 +5143,7 @@ class AIAgent:
     _TRANSIENT_TRANSPORT_ERRORS = frozenset({
         "ReadTimeout", "ConnectTimeout", "PoolTimeout",
         "ConnectError", "RemoteProtocolError",
+        "APIConnectionError", "APITimeoutError",
     })
 
     def _try_recover_primary_transport(

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -262,6 +262,30 @@ class TestTryRecoverPrimaryTransport:
 
         assert result is True
 
+    def test_recovers_on_openai_api_connection_error(self):
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error("APIConnectionError")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+
+    def test_recovers_on_openai_api_timeout_error(self):
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error("APITimeoutError")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+
     def test_skipped_when_already_on_fallback(self):
         agent = _make_agent(provider="custom")
         agent._fallback_activated = True


### PR DESCRIPTION
## Summary

Salvage of #6795 by @helix4u (cherry-picked onto current main).

Adds `APIConnectionError` and `APITimeoutError` to `_TRANSIENT_TRANSPORT_ERRORS` so the primary client rebuild path fires for OpenAI SDK transport errors — the most common error types from local LLM endpoints (LM Studio, Ollama, llama.cpp, vLLM).

**The gap:** The error classifier already classified these as transient transport errors (retries work), but when retries exhausted, `_try_recover_primary_transport()` only checked for raw httpx types (`ReadTimeout`, `ConnectTimeout`, etc.). The OpenAI SDK wraps httpx errors into `APIConnectionError`/`APITimeoutError` before they reach our code, so the recovery path never triggered. Sessions would get stuck until `/new`.

Complements #6967 (stream read timeout increase): that PR reduces how often timeouts occur, this PR fixes what happens when they do.

## Changes
- +2 entries in `_TRANSIENT_TRANSPORT_ERRORS` frozenset (run_agent.py)
- +2 regression tests (test_primary_runtime_restore.py)

## Test plan
- `pytest tests/run_agent/test_primary_runtime_restore.py -n0 -q` → 27 passed
- `pytest tests/run_agent/test_openai_client_lifecycle.py -n0 -q` → 4 passed
- E2E: verified APIConnectionError/APITimeoutError trigger recovery for local providers, OpenRouter correctly skips, existing httpx types still work, non-transport errors still skip