### PR TITLE
fix(streaming): update stale-stream timer during Anthropic native streaming

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4644,6 +4644,14 @@ class AIAgent:
             # Use the Anthropic SDK's streaming context manager
             with self._anthropic_client.messages.stream(**api_kwargs) as stream:
                 for event in stream:
+                    # Update stale-stream timer on every event so the
+                    # outer poll loop knows data is flowing.  Without
+                    # this, the detector kills healthy long-running
+                    # Opus streams after 180 s even when events are
+                    # actively arriving (the chat_completions path
+                    # already does this at the top of its chunk loop).
+                    last_chunk_time["t"] = time.time()
+
                     if self._interrupt_requested:
                         break
 
@@ -4667,6 +4675,7 @@ class AIAgent:
                                 if text and not has_tool_use:
                                     _fire_first_delta()
                                     self._fire_stream_delta(text)
+                                    deltas_were_sent["yes"] = True
                             elif delta_type == "thinking_delta":
                                 thinking_text = getattr(delta, "thinking", "")
                                 if thinking_text:


### PR DESCRIPTION
## Summary

The `_call_anthropic()` streaming path never updated `last_chunk_time` during the event loop — only once at stream start. The stale stream detector in the outer poll loop fires after 180s (or 240-300s for large contexts), killing any Anthropic stream that runs longer than the threshold even when events are actively arriving.

This self-inflicts a `RemoteProtocolError` that users see as:
```
⚠️ Connection to provider dropped (RemoteProtocolError). Reconnecting… (attempt 2/3)
```

The `_call_chat_completions()` path already updates `last_chunk_time` on every chunk. This brings `_call_anthropic()` to parity.

**Second fix:** Adds `deltas_were_sent` tracking to the Anthropic `text_delta` path so the retry loop knows not to retry after partial delivery (prevents duplicated output on connection drops mid-stream).

## Impact

Affects all users on native Anthropic (`api_mode == "anthropic_messages"`) whose responses stream for >180s — common with Opus on complex prompts.

## Test plan

- `tests/run_agent/test_streaming.py` — 20 passed
- `tests/run_agent/ -k anthropic` — 37 passed
- `tests/ -k stale` — 48 passed
- py_compile clean

Reported-by: Discord users (Castellani, Codename_11)