### PR TITLE
fix(security): block redirect-based SSRF in Slack image uploads

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -39,6 +39,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
+    _safe_url_for_log,
     cache_document_from_bytes,
 )
 
@@ -656,8 +657,19 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             import httpx
 
+            async def _ssrf_redirect_guard(response):
+                """Re-check redirect targets so public URLs cannot bounce into private IPs."""
+                if response.is_redirect and response.next_request:
+                    redirect_url = str(response.next_request.url)
+                    if not is_safe_url(redirect_url):
+                        raise ValueError("Blocked redirect to private/internal address")
+
             # Download the image first
-            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            async with httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=True,
+                event_hooks={"response": [_ssrf_redirect_guard]},
+            ) as client:
                 response = await client.get(image_url)
                 response.raise_for_status()
 
@@ -674,7 +686,7 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.warning(
                 "[Slack] Failed to upload image from URL %s, falling back to text: %s",
-                image_url,
+                _safe_url_for_log(image_url),
                 e,
                 exc_info=True,
             )

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1587,6 +1587,61 @@ class TestFallbackPreservesThreadContext:
 
 
 # ---------------------------------------------------------------------------
+# TestSendImageSSRFGuards
+# ---------------------------------------------------------------------------
+
+class TestSendImageSSRFGuards:
+    """send_image should reject redirects that land on private/internal hosts."""
+
+    @pytest.mark.asyncio
+    async def test_send_image_blocks_private_redirect_target(self, adapter):
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.next_request = MagicMock(
+            url="http://169.254.169.254/latest/meta-data"
+        )
+
+        client_kwargs = {}
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        async def fake_get(_url):
+            for hook in client_kwargs["event_hooks"]["response"]:
+                await hook(redirect_response)
+
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        adapter._app.client.files_upload_v2 = AsyncMock(return_value={"ok": True})
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
+
+        def fake_async_client(*args, **kwargs):
+            client_kwargs.update(kwargs)
+            return mock_client
+
+        def fake_is_safe_url(url):
+            return url == "https://public.example/image.png"
+
+        with (
+            patch("tools.url_safety.is_safe_url", side_effect=fake_is_safe_url),
+            patch("httpx.AsyncClient", side_effect=fake_async_client),
+        ):
+            result = await adapter.send_image(
+                chat_id="C123",
+                image_url="https://public.example/image.png",
+                caption="see this",
+            )
+
+        assert result.success
+        assert client_kwargs["follow_redirects"] is True
+        assert client_kwargs["event_hooks"]["response"]
+        adapter._app.client.files_upload_v2.assert_not_awaited()
+        adapter._app.client.chat_postMessage.assert_awaited_once()
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert "see this" in call_kwargs["text"]
+        assert "https://public.example/image.png" in call_kwargs["text"]
+
+
+# ---------------------------------------------------------------------------
 # TestProgressMessageThread
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
- Re-validates every redirect target in `SlackAdapter.send_image()` before following it.
- Preserves the existing fallback behavior: if image download is blocked or fails, the adapter sends the URL as text instead of uploading it.
- Adds a regression test for the case where a public image URL redirects to a private/internal address.

## Why
`send_image()` already checked the initial URL with `is_safe_url()`, but then downloaded it with `httpx.AsyncClient(..., follow_redirects=True)`.

That allowed a redirect-based SSRF bypass: an attacker-controlled public URL could return a redirect to a private/internal endpoint such as `169.254.169.254`, and Hermes would fetch that resource before uploading it to Slack.

This patch closes that gap by validating each redirect target before the client follows it.

## How To Test
1. Run:
   `python -m pytest tests/gateway/test_slack.py -q`
2. Verify the new regression test passes:
   `test_send_image_blocks_private_redirect_target`
3. Optionally confirm a normal public image URL still uploads successfully.
4. Optionally confirm a URL that redirects to a private/internal host no longer uploads and falls back to text send.

## Platforms Tested
- Change is limited to Slack adapter HTTP redirect handling and is platform-agnostic.

## Files Changed
- `gateway/platforms/slack.py`
- `tests/gateway/test_slack.py`