### PR TITLE
fix: prevent duplicate completion notifications on process kill

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -120,6 +120,26 @@ class TestCompletionQueue:
         assert completion["exit_code"] == 1
         assert "FAILED" in completion["output"]
 
+    def test_move_to_finished_idempotent_no_duplicate(self, registry):
+        """Calling _move_to_finished twice must NOT enqueue two notifications.
+
+        Regression test: kill_process() and the reader thread can both call
+        _move_to_finished() for the same session, producing duplicate
+        [SYSTEM: Background process ...] messages.
+        """
+        s = _make_session(notify_on_complete=True, output="done", exit_code=-15)
+        s.exited = True
+        s.exit_code = -15
+        registry._running[s.id] = s
+        with patch.object(registry, "_write_checkpoint"):
+            registry._move_to_finished(s)  # first call — should enqueue
+            s.exit_code = 143  # reader thread updates exit code
+            registry._move_to_finished(s)  # second call — should be no-op
+
+        assert registry.completion_queue.qsize() == 1
+        completion = registry.completion_queue.get_nowait()
+        assert completion["exit_code"] == -15  # from the first (kill) call
+
     def test_output_truncated_to_2000(self, registry):
         """Long output is truncated to last 2000 chars."""
         long_output = "x" * 5000

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -484,15 +484,21 @@ class ProcessRegistry:
         self._move_to_finished(session)
 
     def _move_to_finished(self, session: ProcessSession):
-        """Move a session from running to finished."""
+        """Move a session from running to finished.
+
+        Idempotent: if the session was already moved (e.g. kill_process raced
+        with the reader thread), the second call is a no-op — no duplicate
+        completion notification is enqueued.
+        """
         with self._lock:
-            self._running.pop(session.id, None)
+            was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
         self._write_checkpoint()
 
-        # If the caller requested agent notification, enqueue the completion
-        # so the CLI/gateway can auto-trigger a new agent turn.
-        if session.notify_on_complete:
+        # Only enqueue completion notification on the FIRST move.  Without
+        # this guard, kill_process() and the reader thread can both call
+        # _move_to_finished(), producing duplicate [SYSTEM: ...] messages.
+        if was_running and session.notify_on_complete:
             from tools.ansi_strip import strip_ansi
             output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
             self.completion_queue.put({


### PR DESCRIPTION
## Summary

When a background process with `notify_on_complete=True` is killed via `process(action="kill")`, two `[SYSTEM: Background process ... completed]` messages are delivered to the agent instead of one.

### Root cause

Race condition between `kill_process()` and the reader thread:

1. `kill_process()` sends SIGTERM → sets `exit_code = -15` → calls `_move_to_finished()` → enqueues notification
2. Reader thread's `process.wait()` returns → sets `exit_code = 143` (128+SIGTERM) → calls `_move_to_finished()` → enqueues **second** notification

### Fix

Make `_move_to_finished()` idempotent: track whether the session was actually removed from `_running`. On the second call, `_running.pop()` returns `None` (already moved), so the completion notification is skipped.

### Test plan
- New regression test: `test_move_to_finished_idempotent_no_duplicate`
- All 17 notify_on_complete tests pass