### PR TITLE
fix(prompt): move platform hint before session timestamp

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2808,6 +2808,10 @@ class AIAgent:
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
+        platform_key = (self.platform or "").lower().strip()
+        if platform_key in PLATFORM_HINTS:
+            prompt_parts.append(f"# Platform context\n{PLATFORM_HINTS[platform_key]}")
+
         from hermes_time import now as _hermes_now
         now = _hermes_now()
         timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
@@ -2830,10 +2834,6 @@ class AIAgent:
                 f"When asked what model you are, always answer based on this information, "
                 f"not on any model name returned by the API."
             )
-
-        platform_key = (self.platform or "").lower().strip()
-        if platform_key in PLATFORM_HINTS:
-            prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
 


### PR DESCRIPTION
## Problem

Closes #7114

The platform hint (e.g. `You are a CLI AI Agent. Try not to use markdown...`) was appended **after** the session timestamp marker (`Conversation started: ...`), making it look like the first user message to the model.

This caused spurious memory entries such as `User prefers simple text over markdown` being written to `USER.md`, even though the user never expressed this preference — it came from the system prompt.

**Before (broken order):**
```
...skills...

Conversation started: Friday, April 10, 2026 10:51 AM

You are a CLI AI Agent. Try not to use markdown...
```

**After (fixed order):**
```
...skills...

# Platform context
You are a CLI AI Agent. Try not to use markdown...

Conversation started: Friday, April 10, 2026 10:51 AM
```

## Fix

- Moved `PLATFORM_HINTS` injection to **before** the timestamp block in `run_agent.py`
- Added `# Platform context` header so the model clearly distinguishes it from user input

## Root Cause

In `run_agent.py` `_build_system_prompt()`, `prompt_parts.append(PLATFORM_HINTS[platform_key])` was the last append before `return`, placing it after the session timestamp which acts as a visual boundary between system context and conversation start.