### PR TITLE
feat: auto-discover models for custom/user-defined providers via /v1/models

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -48,6 +48,37 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+# ── Custom providers ─────────────────────────────────────────────────────
+#
+# Saved custom endpoints. Created automatically by `hermes model` → Custom,
+# or add manually here. Each entry appears in the provider picker.
+#
+# custom_providers:
+#   - name: "My vLLM"
+#     base_url: "https://my-vllm.example.com/v1"
+#     api_key: "sk-..."
+#     model: "meta-llama/Llama-3.3-70B-Instruct"  # last-used model
+#     # models_url: optional override for the model list endpoint.
+#     # By default, hermes probes <base_url>/models (OpenAI-compatible).
+#     # Set this when the endpoint uses a non-standard path or a
+#     # separate management API for listing models.
+#     # models_url: "https://my-vllm.example.com/admin/models"
+#
+# ── User-defined providers (config.yaml providers: section) ──────────────
+#
+# Named providers with a fixed URL and env var for the API key.
+# Useful for LiteLLM proxies, cloud providers not yet built into Hermes, etc.
+#
+# providers:
+#   bedrock:
+#     name: "AWS Bedrock (via LiteLLM)"
+#     api: "http://localhost:4000/v1"
+#     key_env: "LITELLM_PROXY_KEY"
+#     transport: "openai_chat"        # or "anthropic_messages"
+#     default_model: "anthropic/claude-sonnet-4.6"
+#     # models_url: optional override for the model list endpoint.
+#     # models_url: "http://localhost:4000/v1/models"
+
   # ── Token limits — two settings, easy to confuse ──────────────────────────
   #
   # context_length: TOTAL context window (input + output tokens combined).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1453,7 +1453,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "models",
-    "context_length", "rate_limit_delay",
+    "context_length", "rate_limit_delay", "models_url",
 }
 
 # Fields that look like they should be inside custom_providers, not at root

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -985,6 +985,7 @@ def select_provider_and_model(args=None):
                 "base_url": base_url,
                 "api_key": entry.get("api_key", ""),
                 "model": entry.get("model", ""),
+                "models_url": entry.get("models_url", ""),
             }
         return custom_provider_map
 
@@ -1697,8 +1698,9 @@ def _remove_custom_provider(config):
 def _model_flow_named_custom(config, provider_info):
     """Handle a named custom provider from config.yaml custom_providers list.
 
-    If the entry has a saved model name, activates it immediately.
-    Otherwise probes the endpoint's /models API to let the user pick one.
+    Probes the endpoint's /models API to show available models for selection.
+    If a model is already saved, it appears as the default with an option to
+    keep it (avoiding the probe delay when the user just wants to re-activate).
     """
     from hermes_cli.auth import _save_model_choice, deactivate_provider
     from hermes_cli.config import load_config, save_config
@@ -1708,41 +1710,37 @@ def _model_flow_named_custom(config, provider_info):
     base_url = provider_info["base_url"]
     api_key = provider_info.get("api_key", "")
     saved_model = provider_info.get("model", "")
+    models_url = provider_info.get("models_url", "")
 
-    # If a model is saved, just activate immediately — no probing needed
-    if saved_model:
-        _save_model_choice(saved_model)
-
-        cfg = load_config()
-        model = cfg.get("model")
-        if not isinstance(model, dict):
-            model = {"default": model} if model else {}
-            cfg["model"] = model
-        model["provider"] = "custom"
-        model["base_url"] = base_url
-        if api_key:
-            model["api_key"] = api_key
-        save_config(cfg)
-        deactivate_provider()
-
-        print(f"✅ Switched to: {saved_model}")
-        print(f"   Provider: {name} ({base_url})")
-        return
-
-    # No saved model — probe endpoint and let user pick
     print(f"  Provider: {name}")
     print(f"  URL:      {base_url}")
+    if saved_model:
+        print(f"  Current:  {saved_model}")
     print()
-    print("No model saved for this provider. Fetching available models...")
-    models = fetch_api_models(api_key, base_url, timeout=8.0)
+
+    # Probe for available models (models_url override, then standard /models)
+    print("Fetching available models...")
+    if models_url:
+        from hermes_cli.model_switch import _probe_endpoint_models
+        models = _probe_endpoint_models(base_url, api_key=api_key, models_url=models_url, timeout=8.0)
+    else:
+        models = fetch_api_models(api_key, base_url, timeout=8.0)
+
+    # Ensure saved model appears in the list (even if probe missed it)
+    if saved_model and models and saved_model not in models:
+        models.insert(0, saved_model)
 
     if models:
         print(f"Found {len(models)} model(s):\n")
+        # Pre-select saved model so user can press Enter to keep it
+        default_idx = 0
+        if saved_model and saved_model in models:
+            default_idx = models.index(saved_model)
         try:
             from simple_term_menu import TerminalMenu
             menu_items = [f"  {m}" for m in models] + ["  Cancel"]
             menu = TerminalMenu(
-                menu_items, cursor_index=0,
+                menu_items, cursor_index=default_idx,
                 menu_cursor="-> ", menu_cursor_style=("fg_green", "bold"),
                 menu_highlight_style=("fg_green",),
                 cycle_cursor=True, clear_screen=False,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -21,6 +21,7 @@ OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import List, NamedTuple, Optional
 
@@ -720,6 +721,64 @@ def switch_model(
 
 
 # ---------------------------------------------------------------------------
+# Lightweight /v1/models probe for user-defined endpoints
+# ---------------------------------------------------------------------------
+
+def _probe_endpoint_models(
+    api_url: str,
+    api_key: str = "",
+    models_url: str = "",
+    timeout: float = 2.0,
+) -> List[str]:
+    """Probe an OpenAI-compatible endpoint for available model IDs.
+
+    Uses *models_url* if provided (custom override), otherwise delegates to
+    ``probe_api_models()`` from ``hermes_cli.models`` which handles URL
+    fallback logic (with/without ``/v1`` suffix).
+
+    Returns a list of model ID strings, or an empty list on any failure
+    (timeout, 4xx, connection error).  Short timeout by default — this is
+    called from the ``/model`` picker where speed matters more than completeness.
+    """
+    if not api_url and not models_url:
+        return []
+
+    if models_url:
+        # Custom override — probe the explicit URL directly
+        import json
+        import urllib.request
+
+        headers = {"Accept": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        try:
+            req = urllib.request.Request(models_url.rstrip("/"), headers=headers)
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+                return [
+                    m.get("id", "") for m in data.get("data", [])
+                    if isinstance(m, dict) and m.get("id")
+                ]
+        except Exception:
+            return []
+
+    # Standard path — reuse probe_api_models() from models.py
+    # Rewrite /anthropic → /v1 before probing (the /anthropic endpoint
+    # doesn't support /models).
+    effective_url = api_url.rstrip("/")
+    if effective_url.endswith("/anthropic"):
+        effective_url = effective_url[: -len("/anthropic")] + "/v1"
+
+    try:
+        from hermes_cli.models import probe_api_models
+        result = probe_api_models(api_key, effective_url, timeout=timeout)
+        models = result.get("models") if result else None
+        return [m for m in (models or []) if m] or []
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
 # Authenticated providers listing (for /model no-args display)
 # ---------------------------------------------------------------------------
 
@@ -854,20 +913,27 @@ def list_authenticated_providers(
             display_name = ep_cfg.get("name", "") or ep_name
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
+            models_url = ep_cfg.get("models_url", "")
+            key_env = ep_cfg.get("key_env", "")
 
-            models_list = []
-            if default_model:
-                models_list.append(default_model)
+            # Probe endpoint for live model list (short timeout, best-effort)
+            probe_key = os.getenv(key_env, "") if key_env else ""
+            probed = _probe_endpoint_models(
+                api_url, api_key=probe_key, models_url=models_url, timeout=2.0,
+            )
 
-            # Try to probe /v1/models if URL is set (but don't block on it)
-            # For now just show what we know from config
+            # Merge: probed models first, then static default if not already present
+            models_list = list(probed)
+            if default_model and default_model not in models_list:
+                models_list.insert(0, default_model)
+
             results.append({
                 "slug": ep_name,
                 "name": display_name,
                 "is_current": ep_name == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
-                "total_models": len(models_list) if models_list else 0,
+                "models": models_list[:max_models],
+                "total_models": len(models_list),
                 "source": "user-config",
                 "api_url": api_url,
             })
@@ -892,17 +958,26 @@ def list_authenticated_providers(
             if slug in seen_slugs:
                 continue
 
-            models_list = []
+            api_key = (entry.get("api_key") or "").strip()
+            models_url = (entry.get("models_url") or "").strip()
             default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
+
+            # Probe endpoint for live model list (short timeout, best-effort)
+            probed = _probe_endpoint_models(
+                api_url, api_key=api_key, models_url=models_url, timeout=2.0,
+            )
+
+            # Merge: probed models first, then saved model if not already present
+            models_list = list(probed)
+            if default_model and default_model not in models_list:
+                models_list.insert(0, default_model)
 
             results.append({
                 "slug": slug,
                 "name": display_name,
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
+                "models": models_list[:max_models],
                 "total_models": len(models_list),
                 "source": "user-config",
                 "api_url": api_url,

--- a/tests/hermes_cli/test_custom_provider_models.py
+++ b/tests/hermes_cli/test_custom_provider_models.py
@@ -1,0 +1,177 @@
+"""Tests for custom/user-defined provider model discovery via /v1/models probe."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestProbeEndpointModels:
+    """Unit tests for _probe_endpoint_models()."""
+
+    def _make_response(self, model_ids):
+        """Build a mock urllib response with OpenAI /models format."""
+        data = {"data": [{"id": mid, "object": "model"} for mid in model_ids]}
+        body = json.dumps(data).encode()
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_returns_models_from_standard_endpoint(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+
+        resp = self._make_response(["llama-3.3-70b", "qwen-2.5-72b"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = _probe_endpoint_models("http://localhost:1234/v1")
+        assert result == ["llama-3.3-70b", "qwen-2.5-72b"]
+
+    def test_returns_empty_on_timeout(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+        import urllib.error
+
+        with patch("urllib.request.urlopen", side_effect=TimeoutError):
+            result = _probe_endpoint_models("http://localhost:1234/v1")
+        assert result == []
+
+    def test_returns_empty_on_404(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+        import urllib.error
+
+        with patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError(
+            "http://x/models", 404, "Not Found", {}, None
+        )):
+            result = _probe_endpoint_models("http://localhost:1234/v1")
+        assert result == []
+
+    def test_returns_empty_for_empty_url(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+        assert _probe_endpoint_models("") == []
+
+    def test_uses_models_url_override(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+
+        resp = self._make_response(["custom-model-1"])
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            result = _probe_endpoint_models(
+                "http://localhost:1234/v1",
+                models_url="http://admin.example.com/api/models",
+            )
+        assert result == ["custom-model-1"]
+        # Should have called the models_url, not the base_url
+        called_url = mock_open.call_args[0][0].full_url
+        assert "admin.example.com" in called_url
+
+    def test_sends_bearer_auth(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+
+        resp = self._make_response(["model-1"])
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            _probe_endpoint_models("http://localhost/v1", api_key="sk-test-123")
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer sk-test-123"
+
+    def test_rewrites_anthropic_suffix_to_v1(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+
+        resp = self._make_response(["model-1"])
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            result = _probe_endpoint_models("https://api.minimax.io/anthropic")
+        assert result == ["model-1"]
+        # Should have probed /v1/models, not /anthropic/models
+        called_url = mock_open.call_args[0][0].full_url
+        assert "/v1/models" in called_url
+        assert "/anthropic/models" not in called_url
+
+    def test_filters_empty_ids(self):
+        from hermes_cli.model_switch import _probe_endpoint_models
+
+        data = {"data": [{"id": "good"}, {"id": ""}, {"object": "model"}, {"id": "also-good"}]}
+        body = json.dumps(data).encode()
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = _probe_endpoint_models("http://localhost/v1")
+        assert result == ["good", "also-good"]
+
+
+class TestListAuthenticatedProvidersCustomModels:
+    """Verify that list_authenticated_providers() probes custom endpoints."""
+
+    def test_custom_provider_shows_probed_models(self):
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        with patch("hermes_cli.model_switch._probe_endpoint_models", return_value=["model-a", "model-b"]):
+            results = list_authenticated_providers(
+                custom_providers=[{
+                    "name": "My Server",
+                    "base_url": "http://localhost:1234/v1",
+                    "model": "model-a",
+                }],
+            )
+        custom = [r for r in results if r.get("source") == "user-config"]
+        assert len(custom) == 1
+        assert "model-a" in custom[0]["models"]
+        assert "model-b" in custom[0]["models"]
+        assert custom[0]["total_models"] == 2
+
+    def test_custom_provider_preserves_saved_model_on_probe_failure(self):
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        with patch("hermes_cli.model_switch._probe_endpoint_models", return_value=[]):
+            results = list_authenticated_providers(
+                custom_providers=[{
+                    "name": "Offline Server",
+                    "base_url": "http://localhost:9999/v1",
+                    "model": "saved-model",
+                }],
+            )
+        custom = [r for r in results if r.get("source") == "user-config"]
+        assert len(custom) == 1
+        assert custom[0]["models"] == ["saved-model"]
+
+    def test_user_provider_shows_probed_models(self):
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        with patch("hermes_cli.model_switch._probe_endpoint_models", return_value=["llama-70b", "mistral-7b"]):
+            results = list_authenticated_providers(
+                user_providers={
+                    "litellm": {
+                        "name": "LiteLLM Proxy",
+                        "api": "http://localhost:4000/v1",
+                        "default_model": "llama-70b",
+                    }
+                },
+            )
+        user_defined = [r for r in results if r.get("source") == "user-config"]
+        assert len(user_defined) == 1
+        assert user_defined[0]["total_models"] == 2
+
+    def test_custom_provider_passes_models_url(self):
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        with patch("hermes_cli.model_switch._probe_endpoint_models") as mock_probe:
+            mock_probe.return_value = ["m1"]
+            list_authenticated_providers(
+                custom_providers=[{
+                    "name": "Custom",
+                    "base_url": "http://x/v1",
+                    "models_url": "http://x/admin/models",
+                }],
+            )
+        mock_probe.assert_called_once()
+        call_kwargs = mock_probe.call_args
+        assert call_kwargs[1].get("models_url") == "http://x/admin/models" or \
+               (len(call_kwargs[0]) >= 3 and call_kwargs[0][2] == "http://x/admin/models")
+
+
+class TestModelsUrlConfigValidation:
+    """Verify models_url is accepted in custom_providers config validation."""
+
+    def test_models_url_is_valid_field(self):
+        from hermes_cli.config import _VALID_CUSTOM_PROVIDER_FIELDS
+        assert "models_url" in _VALID_CUSTOM_PROVIDER_FIELDS


### PR DESCRIPTION
## Summary

Auto-discover available models for custom and user-defined providers by probing their `/v1/models` endpoint. Previously, the `/model` picker only showed the saved model name for custom endpoints — now it dynamically fetches the full model list.

Closes #7103, closes #6862

## Problem

When a user configures a custom OpenAI-compatible endpoint (e.g. vLLM, LiteLLM proxy, Ollama), the `/model` listing only shows models explicitly saved in config. Users had to manually keep their config in sync with whatever models the endpoint serves.

Additionally, `_model_flow_named_custom()` locked to the first model picked (#6862) — once a model was saved, `hermes model` silently reactivated it without showing the selection menu.

## Changes

### New: `_probe_endpoint_models()` helper

Lightweight probe function in `model_switch.py` that:
- GETs `<base_url>/models` (OpenAI `/v1/models` format)
- Tries multiple URL candidates (with/without `/v1` suffix)
- Rewrites `/anthropic` → `/v1` for Anthropic-compat endpoints
- 2-second timeout — fast enough for the `/model` picker
- Accepts optional `models_url` override for non-standard endpoints
- Returns `[]` on any failure (timeout, 4xx, connection error)

### Wired into `list_authenticated_providers()`

Both the `providers:` (user-defined) and `custom_providers:` sections now probe for models. Results are merged: probed models first, then the saved/default model if not already present.

### Fix: model-lock bug (#6862)

`_model_flow_named_custom()` now always shows the model picker with probed results instead of silently reactivating the saved model. The current model is displayed as context.

### New config field: `models_url`

Optional field on `custom_providers` entries for endpoints that use a non-standard path for their model list API (e.g. `http://admin.example.com/api/models`). When set, the probe uses this URL instead of deriving from `base_url`.

### Documentation

Added `custom_providers` and `providers:` sections with `models_url` examples to `cli-config.yaml.example`.

## Files changed (5)

| File | Change |
|------|--------|
| `hermes_cli/model_switch.py` | `_probe_endpoint_models()` helper + wire into `list_authenticated_providers()` |
| `hermes_cli/main.py` | Fix model-lock in `_model_flow_named_custom()`; pass `models_url` |
| `hermes_cli/config.py` | Add `models_url` to `_VALID_CUSTOM_PROVIDER_FIELDS` |
| `cli-config.yaml.example` | Document `custom_providers`, `providers:`, and `models_url` |
| `tests/hermes_cli/test_custom_provider_models.py` | 13 tests: probe, auth, fallback, config validation |

## Test results

```
13 passed — tests/hermes_cli/test_custom_provider_models.py
```
