### PR TITLE
fix(gateway): preserve failed turns outside context overflow

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3854,6 +3854,9 @@ class GatewayRunner:
                 pass
 
             response = agent_result.get("final_response") or ""
+            _has_direct_response = agent_result.get("has_direct_response")
+            if _has_direct_response is None:
+                _has_direct_response = bool(response)
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
@@ -3875,7 +3878,7 @@ class GatewayRunner:
             # Surface error details when the agent produced no direct reply.
             # This covers failed turns and context-overflow partials, where
             # run_agent returns structured error metadata without text.
-            if not response and (agent_result.get("failed") or _failed_reason):
+            if (not _has_direct_response) and (agent_result.get("failed") or _failed_reason):
                 error_detail = agent_result.get("error", "unknown error")
                 error_str = str(error_detail).lower()
 
@@ -3991,7 +3994,7 @@ class GatewayRunner:
             # Persisting it would make the session even larger, causing the
             # same failure on the next attempt — an infinite loop. (#1630)
             agent_failed_due_to_context = (
-                not agent_result.get("final_response")
+                not _has_direct_response
                 and _failed_reason == "context_overflow"
             )
             if agent_failed_due_to_context:
@@ -8759,8 +8762,9 @@ class GatewayRunner:
             _effective_history_offset = 0 if _session_was_split else len(agent_history)
 
             if not final_response:
+                error_msg = f"⚠️ {result['error']}" if result.get("error") else "(No response generated)"
                 return {
-                    "final_response": None,
+                    "final_response": error_msg,
                     "last_reasoning": result.get("last_reasoning"),
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
@@ -8779,6 +8783,7 @@ class GatewayRunner:
                     "error": result.get("error"),
                     "error_reason": result.get("error_reason"),
                     "interrupted": result.get("interrupted"),
+                    "has_direct_response": False,
                 }
 
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -8849,6 +8854,7 @@ class GatewayRunner:
                 "error": result.get("error"),
                 "error_reason": result.get("error_reason"),
                 "interrupted": result.get("interrupted"),
+                "has_direct_response": True,
                 "response_previewed": result.get("response_previewed", False),
             }
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3870,21 +3870,31 @@ class GatewayRunner:
             if session_key:
                 self._clear_restart_failure_count(session_key)
 
-            # Surface error details when the agent failed silently (final_response=None)
-            if not response and agent_result.get("failed"):
+            _failed_reason = str(agent_result.get("error_reason") or "").strip().lower()
+
+            # Surface error details when the agent produced no direct reply.
+            # This covers failed turns and context-overflow partials, where
+            # run_agent returns structured error metadata without text.
+            if not response and (agent_result.get("failed") or _failed_reason):
                 error_detail = agent_result.get("error", "unknown error")
                 error_str = str(error_detail).lower()
 
-                # Detect context-overflow failures and give specific guidance.
-                # Generic 400 "Error" from Anthropic with large sessions is the
-                # most common cause of this (#1630).
-                _is_ctx_fail = any(p in error_str for p in (
-                    "context", "token", "too large", "too long",
-                    "exceed", "payload",
-                )) or (
-                    "400" in error_str
-                    and len(history) > 50
-                )
+                # Fall back to a narrow text heuristic only when the agent
+                # did not propagate a structured failure reason.
+                _is_ctx_fail = _failed_reason == "context_overflow"
+                if not _is_ctx_fail and not _failed_reason:
+                    _is_ctx_fail = any(p in error_str for p in (
+                        "context",
+                        "token",
+                        "too large",
+                        "too long",
+                        "payload",
+                        "prompt is too long",
+                        "context window",
+                    )) or (
+                        "400" in error_str
+                        and len(history) > 50
+                    )
 
                 if _is_ctx_fail:
                     response = (
@@ -3976,15 +3986,18 @@ class GatewayRunner:
             # intermediate reasoning) so sessions can be resumed with full context
             # and transcripts are useful for debugging and training data.
             #
-            # IMPORTANT: When the agent failed (e.g. context-overflow 400,
-            # compression exhausted), do NOT persist the user's message.
+            # IMPORTANT: When the agent failed due to context overflow, do NOT
+            # persist the user's message.
             # Persisting it would make the session even larger, causing the
-            # same failure on the next attempt — an infinite loop. (#1630, #9893)
-            agent_failed_early = bool(agent_result.get("failed"))
-            if agent_failed_early:
+            # same failure on the next attempt — an infinite loop. (#1630)
+            agent_failed_due_to_context = (
+                not agent_result.get("final_response")
+                and _failed_reason == "context_overflow"
+            )
+            if agent_failed_due_to_context:
                 logger.info(
-                    "Skipping transcript persistence for failed request in "
-                    "session %s to prevent session growth loop.",
+                    "Skipping transcript persistence for context-overflow "
+                    "failure in session %s to prevent session growth loop.",
                     session_entry.session_id,
                 )
 
@@ -4011,7 +4024,7 @@ class GatewayRunner:
             # If this is a fresh session (no history), write the full tool
             # definitions as the first entry so the transcript is self-describing
             # -- the same list of dicts sent as tools=[...] in the API request.
-            if agent_failed_early:
+            if agent_failed_due_to_context:
                 pass  # Skip all transcript writes — don't grow a broken session
             elif not history:
                 tool_defs = agent_result.get("tools", [])
@@ -4030,7 +4043,7 @@ class GatewayRunner:
             # Use the filtered history length (history_offset) that was actually
             # passed to the agent, not len(history) which includes session_meta
             # entries that were stripped before the agent saw them.
-            if not agent_failed_early:
+            if not agent_failed_due_to_context:
                 history_len = agent_result.get("history_offset", len(history))
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
                 
@@ -8719,22 +8732,55 @@ class GatewayRunner:
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
+            # Sync session_id: the agent may have created a new session during
+            # mid-run context compression (_compress_context splits sessions).
+            # If so, update the session store entry so the NEXT message loads
+            # the compressed transcript, not the stale pre-compression one.
+            agent = agent_holder[0]
+            _session_was_split = False
+            if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
+                _session_was_split = True
+                logger.info(
+                    "Session split detected: %s → %s (compression)",
+                    session_id, agent.session_id,
+                )
+                entry = self.session_store._entries.get(session_key)
+                if entry:
+                    entry.session_id = agent.session_id
+                    self.session_store._save()
+
+            effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
+
+            # When compression created a new session, the messages list was
+            # shortened.  Using the original history offset would produce an
+            # empty new_messages slice, causing the gateway to write only a
+            # user/assistant pair — losing the compressed summary and tail.
+            # Reset to 0 so the gateway writes ALL compressed messages.
+            _effective_history_offset = 0 if _session_was_split else len(agent_history)
+
             if not final_response:
-                error_msg = f"⚠️ {result['error']}" if result.get("error") else "(No response generated)"
                 return {
-                    "final_response": error_msg,
+                    "final_response": None,
+                    "last_reasoning": result.get("last_reasoning"),
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
                     "failed": result.get("failed", False),
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
-                    "history_offset": len(agent_history),
+                    "history_offset": _effective_history_offset,
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "session_id": effective_session_id,
+                    "completed": result.get("completed"),
+                    "failed": result.get("failed"),
+                    "partial": result.get("partial"),
+                    "error": result.get("error"),
+                    "error_reason": result.get("error_reason"),
+                    "interrupted": result.get("interrupted"),
                 }
-            
+
             # Scan tool results for MEDIA:<path> tags that need to be delivered
             # as native audio/file attachments.  The TTS tool embeds MEDIA: tags
             # in its JSON response, but the model's final text reply usually
@@ -8770,32 +8816,6 @@ class GatewayRunner:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
             
-            # Sync session_id: the agent may have created a new session during
-            # mid-run context compression (_compress_context splits sessions).
-            # If so, update the session store entry so the NEXT message loads
-            # the compressed transcript, not the stale pre-compression one.
-            agent = agent_holder[0]
-            _session_was_split = False
-            if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
-                _session_was_split = True
-                logger.info(
-                    "Session split detected: %s → %s (compression)",
-                    session_id, agent.session_id,
-                )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
-
-            effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
-
-            # When compression created a new session, the messages list was
-            # shortened.  Using the original history offset would produce an
-            # empty new_messages slice, causing the gateway to write only a
-            # user/assistant pair — losing the compressed summary and tail.
-            # Reset to 0 so the gateway writes ALL compressed messages.
-            _effective_history_offset = 0 if _session_was_split else len(agent_history)
-
             # Auto-generate session title after first exchange (non-blocking)
             if final_response and self._session_db:
                 try:
@@ -8823,6 +8843,12 @@ class GatewayRunner:
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
                 "session_id": effective_session_id,
+                "completed": result.get("completed"),
+                "failed": result.get("failed"),
+                "partial": result.get("partial"),
+                "error": result.get("error"),
+                "error_reason": result.get("error_reason"),
+                "interrupted": result.get("interrupted"),
                 "response_previewed": result.get("response_previewed", False),
             }
         

--- a/run_agent.py
+++ b/run_agent.py
@@ -8602,7 +8602,8 @@ class AIAgent:
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
-                                "failed": True  # Mark as failure for filtering
+                                "failed": True,  # Mark as failure for filtering
+                                "error_reason": FailoverReason.unknown.value,
                             }
                         
                         # Backoff before retry — jittered exponential: 5s base, 120s cap
@@ -8828,7 +8829,8 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "failed": True,
-                                "error": "First response truncated due to output length limit"
+                                "error": "First response truncated due to output length limit",
+                                "error_reason": FailoverReason.unknown.value,
                             }
                     
                     # Track actual token usage from response for context management
@@ -9345,6 +9347,7 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "error": f"Request payload too large: max compression attempts ({max_compression_attempts}) reached.",
                                 "partial": True,
+                                "error_reason": FailoverReason.payload_too_large.value,
                                 "failed": True,
                                 "compression_exhausted": True,
                             }
@@ -9376,6 +9379,7 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "error": "Request payload too large (413). Cannot compress further.",
                                 "partial": True,
+                                "error_reason": FailoverReason.payload_too_large.value,
                                 "failed": True,
                                 "compression_exhausted": True,
                             }
@@ -9429,6 +9433,7 @@ class AIAgent:
                                     "api_calls": api_call_count,
                                     "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
                                     "partial": True,
+                                    "error_reason": FailoverReason.context_overflow.value,
                                     "failed": True,
                                     "compression_exhausted": True,
                                 }
@@ -9481,6 +9486,7 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
                                 "partial": True,
+                                "error_reason": FailoverReason.context_overflow.value,
                                 "failed": True,
                                 "compression_exhausted": True,
                             }
@@ -9514,6 +9520,7 @@ class AIAgent:
                                 "api_calls": api_call_count,
                                 "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
                                 "partial": True,
+                                "error_reason": FailoverReason.context_overflow.value,
                                 "failed": True,
                                 "compression_exhausted": True,
                             }
@@ -9599,6 +9606,7 @@ class AIAgent:
                             "completed": False,
                             "failed": True,
                             "error": str(api_error),
+                            "error_reason": classified.reason.value,
                         }
 
                     if retry_count >= max_retries:
@@ -9682,6 +9690,7 @@ class AIAgent:
                             "completed": False,
                             "failed": True,
                             "error": _final_summary,
+                            "error_reason": classified.reason.value,
                         }
 
                     # For rate limits, respect the Retry-After header if present

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -83,6 +83,7 @@ AUTHOR_MAP = {
     "pickett.austin@gmail.com": "austinpickett",
     "jaisehgal11299@gmail.com": "jaisup",
     "percydikec@gmail.com": "PercyDikec",
+    "lei.yuhan@outlook.com": "Astro-Han",
     "dean.kerr@gmail.com": "deankerr",
     "socrates1024@gmail.com": "socrates1024",
     "satelerd@gmail.com": "satelerd",

--- a/tests/gateway/test_failed_turn_persistence.py
+++ b/tests/gateway/test_failed_turn_persistence.py
@@ -195,7 +195,8 @@ async def test_run_agent_wrapper_preserves_no_response_failure_metadata(monkeypa
         session_key=build_session_key(_make_source()),
     )
 
-    assert result["final_response"] is None
+    assert "429 rate limit exceeded" in result["final_response"]
+    assert result["has_direct_response"] is False
     assert result["failed"] is True
     assert result["error"] == "429 rate limit exceeded"
     assert result["error_reason"] == "rate_limit"

--- a/tests/gateway/test_failed_turn_persistence.py
+++ b/tests/gateway/test_failed_turn_persistence.py
@@ -1,0 +1,271 @@
+"""Regression tests for failed gateway turns and transcript persistence."""
+
+import sys
+import threading
+import types
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+class _FakeAgent:
+    next_result = None
+
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+        self.model = kwargs.get("model")
+        self.session_id = kwargs.get("session_id")
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message=None,
+    ):
+        result = dict(type(self).next_result or {})
+        result.setdefault("messages", [])
+        result.setdefault("api_calls", 1)
+        return result
+
+    def interrupt(self, _pending_text=None):
+        return None
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner(*, history):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.config.streaming = SimpleNamespace(enabled=False, transport="off")
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.stop_typing = AsyncMock()
+    adapter.has_pending_interrupt = lambda _session_key: False
+    adapter.get_pending_message = lambda _session_key: None
+    adapter.queue_message = lambda _session_key, _message: None
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = history
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = None
+    runner._smart_model_routing = None
+    runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._pending_model_notes = {}
+    runner._effective_model = None
+    runner._effective_provider = None
+    runner._model = None
+    runner._base_url = None
+    runner._service_tier = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._clear_session_env = lambda _tokens: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+    runner._load_reasoning_config = lambda: None
+    runner._load_service_tier = lambda: None
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "fake-model",
+        {
+            "api_key": "***",
+            "base_url": "https://example.invalid/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+    )
+    runner._resolve_turn_agent_config = (
+        lambda _message, model, runtime: {
+            "model": model,
+            "runtime": runtime,
+            "request_overrides": None,
+        }
+    )
+    runner._agent_config_signature = lambda *_args: ("sig",)
+    runner._is_intentional_model_switch = lambda *_args, **_kwargs: False
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._deliver_media_from_response = AsyncMock()
+    runner._enrich_message_with_vision = AsyncMock(side_effect=lambda text, *_a, **_kw: text)
+    runner._enrich_message_with_transcription = AsyncMock(
+        side_effect=lambda text, *_a, **_kw: text
+    )
+    runner._evict_cached_agent = lambda *_a, **_kw: None
+    return runner
+
+
+def _install_fake_agent(monkeypatch, result):
+    import gateway.run as gateway_run
+
+    _FakeAgent.next_result = dict(result)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"tool_progress": "off"}},
+    )
+
+
+def _persisted_roles(runner):
+    return [
+        call.args[1]["role"]
+        for call in runner.session_store.append_to_transcript.call_args_list
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_wrapper_preserves_no_response_failure_metadata(monkeypatch):
+    runner = _make_runner(history=[{"role": "user", "content": "earlier"}])
+    _install_fake_agent(
+        monkeypatch,
+        {
+            "failed": True,
+            "final_response": None,
+            "messages": [],
+            "api_calls": 1,
+            "error": "429 rate limit exceeded",
+            "error_reason": "rate_limit",
+        },
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=runner.session_store.load_transcript.return_value,
+        source=_make_source(),
+        session_id="sess-1",
+        session_key=build_session_key(_make_source()),
+    )
+
+    assert result["final_response"] is None
+    assert result["failed"] is True
+    assert result["error"] == "429 rate limit exceeded"
+    assert result["error_reason"] == "rate_limit"
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_persists_user_turn_and_surfaces_error(monkeypatch):
+    runner = _make_runner(history=[{"role": "user", "content": "earlier"}])
+    _install_fake_agent(
+        monkeypatch,
+        {
+            "failed": True,
+            "final_response": None,
+            "messages": [],
+            "api_calls": 1,
+            "error": "401 invalid api key",
+            "error_reason": "auth",
+        },
+    )
+
+    result = await runner._handle_message(_make_event("hello"))
+
+    assert result == (
+        "The request failed: 401 invalid api key\n"
+        "Try again or use /reset to start a fresh session."
+    )
+    assert _persisted_roles(runner) == ["user", "assistant"]
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_failure_persists_user_turn_and_does_not_show_compact_guidance(monkeypatch):
+    runner = _make_runner(history=[{"role": "user", "content": "earlier"}] * 60)
+    _install_fake_agent(
+        monkeypatch,
+        {
+            "failed": True,
+            "final_response": None,
+            "messages": [],
+            "api_calls": 1,
+            "error": "429 rate limit exceeded",
+            "error_reason": "rate_limit",
+        },
+    )
+
+    result = await runner._handle_message(_make_event("hello"))
+
+    assert "Session too large for the model's context window." not in result
+    assert "429 rate limit exceeded" in result
+    assert _persisted_roles(runner) == ["user", "assistant"]
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_skips_persistence_and_shows_compact_guidance(monkeypatch):
+    runner = _make_runner(history=[{"role": "user", "content": "earlier"}] * 60)
+    _install_fake_agent(
+        monkeypatch,
+        {
+            "final_response": None,
+            "messages": [],
+            "api_calls": 1,
+            "error": "Context length exceeded: max compression attempts (3) reached.",
+            "partial": True,
+            "error_reason": "context_overflow",
+        },
+    )
+
+    result = await runner._handle_message(_make_event("hello"))
+
+    assert result == (
+        "⚠️ Session too large for the model's context window.\n"
+        "Use /compact to compress the conversation, or /reset to start fresh."
+    )
+    assert runner.session_store.append_to_transcript.call_count == 0


### PR DESCRIPTION
## What does this PR do?

Fixes gateway handling for no-response agent turns so Hermes only skips transcript persistence for real context-overflow failures.

Before this change, the gateway treated any `failed=True` plus `final_response=None` result as a growth-loop case and skipped transcript writes entirely. That dropped user turns for auth and rate-limit failures. The gateway also used a broad string heuristic that could misclassify `429 rate limit exceeded` as a context-overflow failure and incorrectly tell users to use `/compact`.

This change propagates a structured `error_reason` from `run_agent.py` and uses that in `gateway/run.py` for both fallback error rendering and transcript persistence decisions.

## Related Issue

Fixes #7100

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - propagate structured `error_reason` on failed and partial no-response returns
- `gateway/run.py`
  - use `error_reason` to decide when to show `/compact` guidance
  - only skip transcript persistence for real `context_overflow` cases
  - stop relying on the broad `"exceed"` substring heuristic
- `tests/gateway/test_failed_turn_persistence.py`
  - add regression coverage for auth, rate-limit, and context-overflow no-response turns

## How to Test

1. Run:
   ```bash
   uv run --extra dev python -m pytest -q tests/gateway/test_failed_turn_persistence.py
   uv run --extra dev python -m pytest -q tests/run_agent/test_1630_context_overflow_loop.py
   uv run --extra dev python -m pytest -q tests/gateway/test_status_command.py tests/gateway/test_unknown_command.py
   ```
2. Confirm:
   - auth failures persist the user turn and fallback assistant error response
   - rate-limit failures persist the user turn and do not show `/compact`
   - real context-overflow failures still skip transcript persistence and show `/compact`
3. Note:
   - `uv run --extra dev --extra acp python -m pytest tests/ -q -x` is currently baseline-red on clean `main` in this environment, so full-suite failure here is not introduced by this PR

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification:

```bash
uv run --extra dev python -m pytest -q tests/gateway/test_failed_turn_persistence.py
3 passed

uv run --extra dev python -m pytest -q tests/run_agent/test_1630_context_overflow_loop.py
14 passed

uv run --extra dev python -m pytest -q tests/gateway/test_status_command.py tests/gateway/test_unknown_command.py
8 passed
```

Baseline comparison:

```bash
uv run --extra dev --extra acp python -m pytest tests/ -q -x
```

This command is already failing on clean `main` in this environment before reaching branch-specific verification.