### PR TITLE
feat(prompt_builder): add GROK_EXECUTION_GUIDANCE to suppress narration without tool calls

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -275,6 +275,61 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
     "Don't stop with a plan — execute it.\n"
 )
 
+# xAI Grok-specific execution discipline. Injected alongside
+# TOOL_USE_ENFORCEMENT_GUIDANCE when the model name contains "grok".
+#
+# Addresses a failure mode specific to Grok's reasoning architecture: because
+# reasoning is internal and the final response is a separate pass, Grok tends
+# to output intent phrases ("I will check X", "Let me verify Y") describing
+# planned actions without actually calling the corresponding tools. The
+# existing TOOL_USE_ENFORCEMENT_GUIDANCE is interpreted by Grok as "use tools
+# when taking an action" rather than "don't describe actions, execute them" —
+# a subtle but critical difference for multi-turn agent workloads.
+#
+# This block explicitly forbids intent phrases and mandates that the first
+# response to any work-implying request contain a tool call, not a plan.
+# Based on observed failure modes from production sessions where Grok
+# produced structured analyses and recommendations without ever calling a
+# single tool to verify the underlying claims.
+GROK_EXECUTION_GUIDANCE = """# Execution discipline (Grok-specific)
+<no_intent_phrases>
+NEVER write phrases that describe an action you are about to take:
+- 'I will check / fetch / run / install / fix / look / investigate...'
+- 'Let me first / next / now...'
+- 'I am going to / I am about to / I am now...'
+- 'Je vais / je lance / je fais / je verifie / je m occupe de...' (French)
+
+If you need to take an action, call the tool NOW in this turn. Do NOT
+announce the action in text. Do NOT narrate your plan before executing.
+The user cannot execute on your behalf. Only tool calls make things happen.
+</no_intent_phrases>
+
+<execute_first>
+For any request implying work (audit, debug, check, investigate, fix,
+install, ssh, read_file, grep, count, analyse, etc.):
+1. Your FIRST response MUST contain a tool call if information is needed.
+2. Only produce text when you have a concrete result to report or a
+   blocking question to ask that the tools cannot answer.
+3. 'I am going to verify X' without calling the verify tool is a failure.
+   Call the tool first, narrate the result after.
+4. Chain multiple tool calls in the same turn without intermediate prose.
+   Only speak when there is something concrete to show.
+</execute_first>
+
+<no_analysis_hallucination>
+Do NOT produce analyses, diagnoses, lists of 'possible causes', or
+structured recommendations from pure reasoning. If you have not called
+a tool to gather evidence, you cannot have a grounded analysis to report.
+Internal reasoning is not grounding.
+
+When asked 'why does X fail' or 'what's wrong with Y':
+- Your FIRST response must be a tool call that inspects X or Y directly.
+- NOT a structured list of 'possible causes' from memory.
+- NOT a plan of what you 'would check'.
+- An actual tool call that reads, greps, or inspects the target.
+Only after receiving the tool result may you produce an analysis.
+</no_analysis_hallucination>"""
+
 # Model name substrings that should use the 'developer' role instead of
 # 'system' for the system prompt.  OpenAI's newer models (GPT-5, Codex)
 # give stronger instruction-following weight to the 'developer' role.

--- a/run_agent.py
+++ b/run_agent.py
@@ -92,7 +92,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, GROK_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -2654,6 +2654,12 @@ class AIAgent:
                 # prerequisite checks, verification, anti-hallucination).
                 if "gpt" in _model_lower or "codex" in _model_lower:
                     prompt_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+                # xAI Grok execution discipline (anti-narration, execute-first,
+                # no-analysis-hallucination). Grok's reasoning architecture tends
+                # to produce intent phrases without tool calls — this block
+                # explicitly forbids that pattern.
+                if "grok" in _model_lower:
+                    prompt_parts.append(GROK_EXECUTION_GUIDANCE)
 
         # so it can refer the user to them rather than reinventing answers.
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -24,6 +24,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    GROK_EXECUTION_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -1058,6 +1059,48 @@ class TestOpenAIModelExecutionGuidance:
     def test_guidance_is_string(self):
         assert isinstance(OPENAI_MODEL_EXECUTION_GUIDANCE, str)
         assert len(OPENAI_MODEL_EXECUTION_GUIDANCE) > 100
+
+
+class TestGrokExecutionGuidance:
+    """Tests for Grok-specific execution discipline guidance (anti-narration)."""
+
+    def test_guidance_forbids_intent_phrases(self):
+        text = GROK_EXECUTION_GUIDANCE.lower()
+        assert "no_intent_phrases" in text
+        assert "i will" in text or "'i will" in text
+        assert "je vais" in text
+
+    def test_guidance_mandates_execute_first(self):
+        text = GROK_EXECUTION_GUIDANCE.lower()
+        assert "execute_first" in text
+        assert "tool call" in text
+        assert "first response" in text
+
+    def test_guidance_blocks_analysis_hallucination(self):
+        text = GROK_EXECUTION_GUIDANCE.lower()
+        assert "no_analysis_hallucination" in text
+        assert "hallucination" in text or "grounding" in text
+        assert "possible causes" in text
+
+    def test_guidance_uses_xml_tags(self):
+        assert "<no_intent_phrases>" in GROK_EXECUTION_GUIDANCE
+        assert "</no_intent_phrases>" in GROK_EXECUTION_GUIDANCE
+        assert "<execute_first>" in GROK_EXECUTION_GUIDANCE
+        assert "</execute_first>" in GROK_EXECUTION_GUIDANCE
+        assert "<no_analysis_hallucination>" in GROK_EXECUTION_GUIDANCE
+        assert "</no_analysis_hallucination>" in GROK_EXECUTION_GUIDANCE
+
+    def test_guidance_mentions_french_phrases(self):
+        # Grok is multilingual and the narration failure happens in any
+        # language — French phrases are explicitly listed because the main
+        # production user of this guidance runs a French-language agent.
+        text = GROK_EXECUTION_GUIDANCE.lower()
+        assert "je vais" in text
+        assert "je lance" in text or "je fais" in text
+
+    def test_guidance_is_string(self):
+        assert isinstance(GROK_EXECUTION_GUIDANCE, str)
+        assert len(GROK_EXECUTION_GUIDANCE) > 500
 
 
 # =========================================================================


### PR DESCRIPTION
## Problem

Grok reasoning models (`grok-4.20-*`, `grok-4-1-fast-*`, `grok-4-fast-*`) have a narration-vs-execution failure mode that is **not** addressed by the existing `TOOL_USE_ENFORCEMENT_GUIDANCE` (added to cover Grok in #5595).

Because Grok's reasoning happens internally and the final response is a separate pass, Grok tends to output intent phrases describing planned actions **without actually calling the corresponding tools**:

- *"I will check X"*
- *"Let me verify Y"*
- *"Je vais lancer l'audit"* (French users see this routinely)
- *"I'm going to SSH into the server and look at the logs"*

Then the assistant turn ends. The user sees a plan, no execution. When corrected, Grok says *"You're right, let me do it now"* — and again produces no tool call. I had a 10+ minute session this morning correcting this exact pattern three consecutive times on a remote-audit task before Grok finally chained the real tool calls.

`TOOL_USE_ENFORCEMENT_GUIDANCE` (*"use tools when taking an action"*) is interpreted by Grok as *"use tools **when** you are taking an action"* rather than *"don't describe actions, execute them"* — a subtle but critical difference for multi-turn agent workloads.

A related symptom: Grok produces **structured analyses from pure reasoning** (lists of *"possible causes"*, *"things to check"*, diagnostics) without calling a single tool to verify the underlying claims. The output looks credible because reasoning models are good at structured prose — but the grounding is absent.

## Solution

Add `GROK_EXECUTION_GUIDANCE` — a Grok-specific system prompt block injected alongside `TOOL_USE_ENFORCEMENT_GUIDANCE` when the model name contains "grok". Three XML-tagged sections (same style as the existing `OPENAI_MODEL_EXECUTION_GUIDANCE` added in a prior PR):

```xml
<no_intent_phrases>
NEVER write phrases that describe an action you are about to take:
- 'I will check / fetch / run / install / fix / look / investigate...'
- 'Let me first / next / now...'
- 'I am going to / I am about to / I am now...'
- 'Je vais / je lance / je fais / je verifie / je m occupe de...' (French)

If you need to take an action, call the tool NOW in this turn. Do NOT
announce the action in text. Do NOT narrate your plan before executing.
The user cannot execute on your behalf. Only tool calls make things happen.
</no_intent_phrases>

<execute_first>
For any request implying work (audit, debug, check, investigate, fix,
install, ssh, read_file, grep, count, analyse, etc.):
1. Your FIRST response MUST contain a tool call if information is needed.
2. Only produce text when you have a concrete result to report or a
   blocking question to ask that the tools cannot answer.
3. 'I am going to verify X' without calling the verify tool is a failure.
   Call the tool first, narrate the result after.
4. Chain multiple tool calls in the same turn without intermediate prose.
   Only speak when there is something concrete to show.
</execute_first>

<no_analysis_hallucination>
Do NOT produce analyses, diagnoses, lists of 'possible causes', or
structured recommendations from pure reasoning. If you have not called
a tool to gather evidence, you cannot have a grounded analysis to report.
Internal reasoning is not grounding.

When asked 'why does X fail' or 'what's wrong with Y':
- Your FIRST response must be a tool call that inspects X or Y directly.
- NOT a structured list of 'possible causes' from memory.
- NOT a plan of what you 'would check'.
- An actual tool call that reads, greps, or inspects the target.
Only after receiving the tool result may you produce an analysis.
</no_analysis_hallucination>
```

Injected in `run_agent.py` next to the existing provider-specific guidance blocks (`OPENAI_MODEL_EXECUTION_GUIDANCE`, `GOOGLE_MODEL_OPERATIONAL_GUIDANCE`), behind the same `TOOL_USE_ENFORCEMENT_MODELS` gate.

## Production A/B evidence (same-day, same-session, same task)

This PR was written and tested in response to a production failure. I kept the broken session around and re-ran the exact same task after applying the patch. Result:

### Before the patch (this morning, Grok 4.20-0309-reasoning, session `20260410_102501_800b5bd8.jsonl`)

- Task: *"Audit the Matthieu instance to check there's no trace of the budget_guard installed this morning. Find all scripts, crons, logs, or config files that reference it. Complete report."*
- Turn 1: Grok writes *"I will verify..."* — no tool call. I correct it.
- Turn 2: Grok writes *"I'm going to start the audit right now"* — no tool call. I correct it again.
- Turn 3: Grok writes *"You're right, let me do it"* — still no tool call. Third correction.
- Turns 4–7: chaotic cascade of SSH attempts with broken bash escaping, retries, partial results.
- Total: ~10 minutes, 3 user corrections, 5+ API calls, degraded user trust.

### After the patch (same session, same task, ~2h later)

- Turn 1: Grok emits a single tool call composing crontab listing, directory scan, and reference search into one SSH command, **no preamble text**.
- Turn 2: structured report based on actual tool output, *"Audit complete"* (past tense, grounded in evidence).
- Total: **33.9 seconds, 2 API calls, zero corrections, zero narration**.

**Only variable**: presence of `GROK_EXECUTION_GUIDANCE` in the system prompt. Same session file (assistant had the previous chaotic history in context, yet behaved correctly once the guidance was active — which also validates that the guidance survives session pollution).

The session file is available in the commit history of the author's fork if the maintainers want to inspect the raw JSONL before/after.

## Testing

Added `TestGrokExecutionGuidance` (6 tests) in `tests/agent/test_prompt_builder.py` following the exact pattern of `TestOpenAIModelExecutionGuidance`:

- `test_guidance_forbids_intent_phrases` — asserts the `<no_intent_phrases>` section is present with English and French examples
- `test_guidance_mandates_execute_first` — asserts the execute-first mandate
- `test_guidance_blocks_analysis_hallucination` — asserts the `<no_analysis_hallucination>` section
- `test_guidance_uses_xml_tags` — asserts all three XML blocks are present with open and close tags
- `test_guidance_mentions_french_phrases` — asserts multilingual coverage
- `test_guidance_is_string` — type and size checks

```
$ pytest tests/agent/test_prompt_builder.py
124 passed, 1 skipped in 1.52s
```

No regression on the existing `TestToolUseEnforcementModels` or `TestOpenAIModelExecutionGuidance` classes.

## Why not just extend `TOOL_USE_ENFORCEMENT_GUIDANCE`?

I considered it. Three reasons for a separate block instead:

1. **Provider-specific nuances**: the narration-vs-execution split is peculiar to reasoning architectures (Grok, possibly DeepSeek-R1 family later). GPT-4 / Codex don't have this exact failure mode because they don't separate reasoning from response the same way. Keeping the guidance provider-specific avoids polluting the general enforcement block for models that don't need it.
2. **Consistency with existing pattern**: `OPENAI_MODEL_EXECUTION_GUIDANCE` and `GOOGLE_MODEL_OPERATIONAL_GUIDANCE` already exist as separate provider-specific blocks injected alongside the general enforcement guidance. This PR follows the same pattern — no new architectural precedent.
3. **Additive, not replacement**: `TOOL_USE_ENFORCEMENT_GUIDANCE` still runs for Grok (I'm the author of the PR that added Grok to the tuple, #5595). This block adds on top of it, not instead.

## Impact

- **Back-compat**: zero. Only fires when the model name contains "grok". Other providers are unaffected.
- **Token cost**: adds ~1,800 characters to the system prompt for Grok models only (~450 tokens). Negligible compared to the cost of repeated correction turns in the failure mode.
- **Complements** the existing xAI integration stack:
  - `x-grok-conv-id` prompt caching in `run_agent.py` (#5604)
  - `"grok"` in `TOOL_USE_ENFORCEMENT_MODELS` (#5595)
  - `DEFAULT_CONTEXT_LENGTHS` Grok fallbacks (#7093, merged earlier today)
  - Auxiliary xAI backend with text/vision split (#7076, open)
- **No dependency** on other pending PRs. Self-contained.

## Related

- #7093 (merged earlier today): Grok context length fallbacks
- #7076 (open): auxiliary xAI backend for text and vision
- #5595 (merged): original Grok addition to TOOL_USE_ENFORCEMENT_MODELS
