### PR TITLE
feat(api-server): add media_urls vision enrichment to /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1519,9 +1519,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
         session_id = body.get("session_id") or run_id
         ephemeral_system_prompt = instructions
+        media_urls = [u for u in (body.get("media_urls") or []) if isinstance(u, str)]
 
         async def _run_and_close():
+            nonlocal user_message
             try:
+                if media_urls:
+                    from gateway.vision import enrich_message_with_vision
+                    user_message = await enrich_message_with_vision(user_message, media_urls)
+
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6009,68 +6009,8 @@ class GatewayRunner:
         user_text: str,
         image_paths: List[str],
     ) -> str:
-        """
-        Auto-analyze user-attached images with the vision tool and prepend
-        the descriptions to the message text.
-
-        Each image is analyzed with a general-purpose prompt.  The resulting
-        description *and* the local cache path are injected so the model can:
-          1. Immediately understand what the user sent (no extra tool call).
-          2. Re-examine the image with vision_analyze if it needs more detail.
-
-        Args:
-            user_text:   The user's original caption / message text.
-            image_paths: List of local file paths to cached images.
-
-        Returns:
-            The enriched message string with vision descriptions prepended.
-        """
-        from tools.vision_tools import vision_analyze_tool
-        import json as _json
-
-        analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
-        )
-
-        enriched_parts = []
-        for path in image_paths:
-            try:
-                logger.debug("Auto-analyzing user image: %s", path)
-                result_json = await vision_analyze_tool(
-                    image_url=path,
-                    user_prompt=analysis_prompt,
-                )
-                result = _json.loads(result_json)
-                if result.get("success"):
-                    description = result.get("analysis", "")
-                    enriched_parts.append(
-                        f"[The user sent an image~ Here's what I can see:\n{description}]\n"
-                        f"[If you need a closer look, use vision_analyze with "
-                        f"image_url: {path} ~]"
-                    )
-                else:
-                    enriched_parts.append(
-                        "[The user sent an image but I couldn't quite see it "
-                        "this time (>_<) You can try looking at it yourself "
-                        f"with vision_analyze using image_url: {path}]"
-                    )
-            except Exception as e:
-                logger.error("Vision auto-analysis error: %s", e)
-                enriched_parts.append(
-                    f"[The user sent an image but something went wrong when I "
-                    f"tried to look at it~ You can try examining it yourself "
-                    f"with vision_analyze using image_url: {path}]"
-                )
-
-        # Combine: vision descriptions first, then the user's original text
-        if enriched_parts:
-            prefix = "\n\n".join(enriched_parts)
-            if user_text:
-                return f"{prefix}\n\n{user_text}"
-            return prefix
-        return user_text
+        from gateway.vision import enrich_message_with_vision
+        return await enrich_message_with_vision(user_text, image_paths)
 
     async def _enrich_message_with_transcription(
         self,

--- a/gateway/vision.py
+++ b/gateway/vision.py
@@ -1,0 +1,70 @@
+"""
+Shared vision-enrichment helper for gateway adapters.
+
+Converts a list of image paths/URLs into text descriptions using the
+vision_analyze tool, then prepends them to the user's message text.
+This is used by platform adapters (Telegram, WhatsApp, etc.) and the
+API server to give the conversation model image context without requiring
+multimodal LLM support.
+"""
+
+import logging
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+_ANALYSIS_PROMPT = (
+    "Describe everything visible in this image in thorough detail. "
+    "Include any text, code, data, objects, people, layout, colors, "
+    "and any other notable visual information."
+)
+
+
+async def enrich_message_with_vision(user_text: str, media_urls: List[str]) -> str:
+    """Analyze images and prepend descriptions to *user_text*.
+
+    Args:
+        user_text:  The user's original caption / message text.
+        media_urls: Local file paths or HTTP URLs to images.
+
+    Returns:
+        Enriched message string with vision descriptions prepended,
+        or the original *user_text* if no images could be processed.
+    """
+    if not media_urls:
+        return user_text
+
+    from tools.vision_tools import vision_analyze_tool
+    import json as _json
+
+    enriched_parts: List[str] = []
+    for url in media_urls:
+        try:
+            logger.debug("Auto-analyzing user image: %s", url)
+            result_json = await vision_analyze_tool(image_url=url, user_prompt=_ANALYSIS_PROMPT)
+            result = _json.loads(result_json)
+            if result.get("success"):
+                description = result.get("analysis", "")
+                enriched_parts.append(
+                    f"[The user sent an image~ Here's what I can see:\n{description}]\n"
+                    f"[If you need a closer look, use vision_analyze with image_url: {url} ~]"
+                )
+            else:
+                enriched_parts.append(
+                    "[The user sent an image but I couldn't quite see it "
+                    f"this time (>_<) You can try looking at it yourself "
+                    f"with vision_analyze using image_url: {url}]"
+                )
+        except Exception as exc:
+            logger.error("Vision auto-analysis error for %s: %s", url, exc)
+            enriched_parts.append(
+                f"[The user sent an image but something went wrong when I "
+                f"tried to look at it~ You can try examining it yourself "
+                f"with vision_analyze using image_url: {url}]"
+            )
+
+    if not enriched_parts:
+        return user_text
+
+    prefix = "\n\n".join(enriched_parts)
+    return f"{prefix}\n\n{user_text}" if user_text else prefix


### PR DESCRIPTION
## Summary

- Extracts `GatewayRunner._enrich_message_with_vision` into a new `gateway/vision.py` module as a standalone async function, removing class coupling so any adapter can use it
- Delegates `GatewayRunner._enrich_message_with_vision` to the shared function (no behaviour change for existing platforms)
- Adds `media_urls` field to `POST /v1/runs` — when provided, runs vision analysis before `run_conversation`, prepending image descriptions to the user message

This gives the REST API the same image understanding that Telegram/WhatsApp/etc. already have via `_enrich_message_with_vision`.

## Test plan

- [ ] Send a request to `POST /v1/runs` with `media_urls: ["/path/to/image.png"]` — confirm vision description is prepended to the message and the agent responds with image context
- [ ] Send without `media_urls` — confirm no behaviour change
- [ ] Confirm existing platform adapters (Telegram image attachments) still work via the delegated `_enrich_message_with_vision`

🤖 Generated with [Claude Code](https://claude.com/claude-code)