### PR TITLE
fix(terminal): accept platform-native workdir paths without weakening shell guards

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,5 +1,9 @@
-"""Regression tests for sudo detection and sudo password handling."""
+"""Regression tests for terminal tool helpers."""
 
+import json
+from types import SimpleNamespace
+
+import pytest
 import tools.terminal_tool as terminal_tool
 
 
@@ -9,6 +13,113 @@ def setup_function():
 
 def teardown_function():
     terminal_tool._cached_sudo_password = ""
+
+
+@pytest.mark.parametrize(
+    "workdir",
+    [
+        r"C:\hermes_workspace\project",
+        r"D:\dev\agent_test",
+        r"..\repo",
+        "/tmp/project (old)",
+        r"C:\hermes_workspace\O'Brien\repo",
+    ],
+)
+def test_validate_workdir_accepts_platform_native_paths(workdir):
+    assert terminal_tool._validate_workdir(workdir) is None
+
+
+@pytest.mark.parametrize(
+    "workdir",
+    [
+        r"C:\hermes_workspace\project; whoami",
+        r"D:\dev\agent_test && whoami",
+        "/tmp/project | cat",
+        "/tmp/project`whoami`",
+        "/tmp/project\nwhoami",
+    ],
+)
+def test_validate_workdir_rejects_shell_metacharacters(workdir):
+    error = terminal_tool._validate_workdir(workdir)
+
+    assert error is not None
+    assert "Blocked: workdir contains disallowed character" in error
+
+
+def test_terminal_tool_passes_valid_workdir_to_environment(monkeypatch):
+    captured = {}
+    dummy_env = SimpleNamespace(
+        env={},
+        execute=lambda command, **kwargs: (
+            captured.update({"command": command, "cwd": kwargs.get("cwd")})
+            or {"output": "ok", "returncode": 0}
+        ),
+    )
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {"env_type": "local", "cwd": ".", "timeout": 30},
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setitem(terminal_tool._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                command="pwd",
+                workdir=r"C:\hermes_workspace\project",
+            )
+        )
+    finally:
+        terminal_tool._active_environments.pop("default", None)
+        terminal_tool._last_activity.pop("default", None)
+
+    assert result["exit_code"] == 0
+    assert captured["cwd"] == r"C:\hermes_workspace\project"
+
+
+def test_terminal_tool_blocks_dangerous_workdir_before_execution(monkeypatch):
+    dummy_env = SimpleNamespace(
+        env={},
+        execute=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("dangerous workdir should be blocked before execute()")
+        ),
+    )
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {"env_type": "local", "cwd": ".", "timeout": 30},
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setitem(terminal_tool._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                command="pwd",
+                workdir=r"C:\hermes_workspace\project; whoami",
+            )
+        )
+    finally:
+        terminal_tool._active_environments.pop("default", None)
+        terminal_tool._last_activity.pop("default", None)
+
+    assert result["status"] == "blocked"
+    assert "disallowed character" in result["error"]
 
 
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -151,31 +151,36 @@ def _check_all_guards(command: str, env_type: str) -> dict:
                                   approval_callback=_approval_callback)
 
 
-# Allowlist: characters that can legitimately appear in directory paths.
-# Covers alphanumeric, path separators, tilde, dot, hyphen, underscore, space,
-# plus, at, equals, and comma.  Everything else is rejected.
-_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/_\-.~ +@=,]+$')
+# Reject only characters that can still change shell meaning even when a path
+# would otherwise look platform-native. The actual cwd is shell-quoted later in
+# BaseEnvironment._wrap_command(), so valid Windows drive prefixes, backslashes,
+# apostrophes, and common punctuation should pass here.
+_WORKDIR_BLOCKED_CHARS = frozenset({
+    "\x00",  # NUL terminator
+    "\n",
+    "\r",
+    ";",
+    "|",
+    "&",
+    "<",
+    ">",
+    "$",
+    "`",
+})
 
 
 def _validate_workdir(workdir: str) -> str | None:
-    """Reject workdir values that don't look like a filesystem path.
-
-    Uses an allowlist of safe characters rather than a deny-list, so novel
-    shell metacharacters can't slip through.
-
-    Returns None if safe, or an error message string if dangerous.
-    """
+    """Reject workdir values containing shell metacharacters or control chars."""
     if not workdir:
         return None
-    if not _WORKDIR_SAFE_RE.match(workdir):
-        # Find the first offending character for a helpful message.
-        for ch in workdir:
-            if not _WORKDIR_SAFE_RE.match(ch):
-                return (
-                    f"Blocked: workdir contains disallowed character {repr(ch)}. "
-                    "Use a simple filesystem path without shell metacharacters."
-                )
-        return "Blocked: workdir contains disallowed characters."
+
+    for ch in workdir:
+        if ch in _WORKDIR_BLOCKED_CHARS or ord(ch) < 32 or ord(ch) == 127:
+            return (
+                f"Blocked: workdir contains disallowed character {repr(ch)}. "
+                "Use a simple filesystem path without shell metacharacters."
+            )
+
     return None
 
 


### PR DESCRIPTION
Summary
This fixes a workdir validation regression in the terminal tool.

The current sanitizer only accepts a narrow POSIX-style character set, which causes valid filesystem paths to be rejected before execution. That includes common Windows paths, backslash-based relative paths, and directory names with normal punctuation.

This change:

allows platform-native workdir values such as C:\hermes_workspace\project, D:\dev\agent_test, ..\repo, and /tmp/project (old)
continues to block shell metacharacters and control characters
adds regression tests for both helper-level validation and terminal_tool() behavior
Why
The terminal backend already shell-quotes cwd before running cd, so the previous allowlist was stricter than the actual execution path required.

In practice, the old validator produced false positives for valid paths and could break terminal calls on Windows or cause commands to run from the wrong directory when workdir was dropped or retried.

Implementation
replaced the POSIX-only workdir allowlist with a narrow blocklist for actual shell/control characters
kept blocking characters that can still change shell meaning, including ;, |, &, <, >, $, backticks, newlines, carriage returns, and NUL
added regression coverage for accepted and rejected workdir values
added small integration-style tests to verify:
valid workdir values are passed through to the execution environment
dangerous workdir values are blocked before execute() is called
Backward Compatibility / Risk
Low risk.

This is a targeted validation fix with no change to backend execution flow. The intended behavior change is only that previously false-positive, valid paths are now accepted. Existing shell guard behavior is preserved for dangerous characters.

Testing
Added coverage for:

valid platform-native paths
rejected shell metacharacters
terminal_tool() passing valid workdir through
terminal_tool() blocking dangerous workdir before execution