### PR TITLE
Fix UTF-8 encoding issue when reading config.yaml on Chinese Windows

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -319,7 +319,7 @@ def load_cli_config() -> Dict[str, Any]:
     # Load from file if exists
     if config_path.exists():
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 file_config = yaml.safe_load(f) or {}
             
             _file_has_terminal_config = "terminal" in file_config


### PR DESCRIPTION
## Summary
- **Root cause**: On Chinese Windows, the system default encoding (GBK/GB2312) is used when reading config.yaml, causing UTF-8 encoded content to be misinterpreted
- **Fix**: Added `encoding="utf-8"` to the `open()` call in `cli.py`

## Changes
- `cli.py`: Added `encoding="utf-8"` to `load_cli_config()` function