### PR TITLE
feat(gateway): stream reasoning content to messaging platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6755,6 +6755,11 @@ class GatewayRunner:
             pr = self._provider_routing
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
+            
+            # Track reasoning code block state for streaming (must be defined before StreamConsumer)
+            _reasoning_started_holder = [False]  # Track if we've started reasoning
+            _reasoning_block_open = [False]  # Track if reasoning code block is currently open
+            
             # Set up streaming consumer if enabled
             _stream_consumer = None
             _stream_delta_cb = None
@@ -6773,11 +6778,17 @@ class GatewayRunner:
                             buffer_threshold=_scfg.buffer_threshold,
                             cursor=_scfg.cursor,
                         )
+                        
+                        # Callback to notify Gateway when truncate closes a code block
+                        def _on_code_block_split():
+                            _reasoning_block_open[0] = False
+                        
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            code_block_split_callback=_on_code_block_split,
                         )
                         _stream_delta_cb = _stream_consumer.on_delta
                         stream_consumer_holder[0] = _stream_consumer
@@ -6842,7 +6853,7 @@ class GatewayRunner:
 
             # Set up reasoning callback for streaming reasoning display
             # This allows reasoning content to be streamed to the platform in real-time
-            _reasoning_started_holder = [False]  # Track if we've started reasoning
+            # Note: _reasoning_started_holder and _reasoning_block_open defined earlier (before StreamConsumer)
             _reasoning_delta_cb = None
             _wrapped_stream_delta_cb = None
 
@@ -6854,16 +6865,20 @@ class GatewayRunner:
                     # Add reasoning prefix on first chunk
                     if not _reasoning_started_holder[0]:
                         _reasoning_started_holder[0] = True
+                        _reasoning_block_open[0] = True  # Block is now open
                         prefix = "💭 **Reasoning:**\n```\n"
                         _stream_delta_cb(prefix)
+                    # If block was closed (by truncate_message split), reopen it
+                    elif not _reasoning_block_open[0]:
+                        _reasoning_block_open[0] = True
+                        _stream_delta_cb("```\n")
                     _stream_delta_cb(text)
 
                 def _wrapped_stream_delta_cb(text: str) -> None:
                     """Wrap stream delta to close reasoning block before regular content."""
-                    # If reasoning was shown and this is the first regular content,
-                    # close the reasoning code block first
-                    if _reasoning_started_holder[0]:
-                        _reasoning_started_holder[0] = False  # Reset for next turn
+                    # If reasoning block is still open, close it first
+                    if _reasoning_block_open[0]:
+                        _reasoning_block_open[0] = False
                         close_block = "\n```\n\n"
                         _stream_delta_cb(close_block)
                     _stream_delta_cb(text)
@@ -7052,6 +7067,12 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+
+            # Close reasoning block if still open (no regular content followed reasoning)
+            if _reasoning_started_holder and _reasoning_started_holder[0]:
+                _reasoning_started_holder[0] = False
+                if _stream_delta_cb:
+                    _stream_delta_cb("\n```\n\n")
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6838,9 +6838,42 @@ class GatewayRunner:
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
-            agent.stream_delta_callback = _stream_delta_cb
-            agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
+
+            # Set up reasoning callback for streaming reasoning display
+            # This allows reasoning content to be streamed to the platform in real-time
+            _reasoning_started_holder = [False]  # Track if we've started reasoning
+            _reasoning_delta_cb = None
+            _wrapped_stream_delta_cb = None
+
+            if self._show_reasoning and _stream_delta_cb:
+                def _reasoning_delta_cb(text: str) -> None:
+                    """Stream reasoning content with a prefix to distinguish it from regular content."""
+                    if not text:
+                        return
+                    # Add reasoning prefix on first chunk
+                    if not _reasoning_started_holder[0]:
+                        _reasoning_started_holder[0] = True
+                        prefix = "💭 **Reasoning:**\n```\n"
+                        _stream_delta_cb(prefix)
+                    _stream_delta_cb(text)
+
+                def _wrapped_stream_delta_cb(text: str) -> None:
+                    """Wrap stream delta to close reasoning block before regular content."""
+                    # If reasoning was shown and this is the first regular content,
+                    # close the reasoning code block first
+                    if _reasoning_started_holder[0]:
+                        _reasoning_started_holder[0] = False  # Reset for next turn
+                        close_block = "\n```\n\n"
+                        _stream_delta_cb(close_block)
+                    _stream_delta_cb(text)
+
+                agent.reasoning_callback = _reasoning_delta_cb
+                agent.stream_delta_callback = _wrapped_stream_delta_cb
+            else:
+                agent.stream_delta_callback = _stream_delta_cb
+
+            agent.status_callback = _status_callback_sync
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -62,6 +62,7 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        code_block_split_callback: Optional[callable] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
@@ -76,6 +77,8 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        self._code_block_split_callback = code_block_split_callback
+        self._in_code_block = False  # Track if we're inside a code block
 
     @property
     def already_sent(self) -> bool:
@@ -120,6 +123,12 @@ class GatewayStreamConsumer:
                             got_segment_break = True
                             break
                         self._accumulated += item
+                        # Track code block state by counting fence markers
+                        # This is a simple heuristic - count lines starting with ```
+                        for line in item.split('\n'):
+                            stripped = line.strip()
+                            if stripped.startswith('```'):
+                                self._in_code_block = not self._in_code_block
                     except queue.Empty:
                         break
 
@@ -149,8 +158,19 @@ class GatewayStreamConsumer:
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit
                         )
-                        for chunk in chunks:
+                        for i, chunk in enumerate(chunks):
                             await self._send_new_chunk(chunk, self._message_id)
+                            # Check if this chunk closed a code block that was open
+                            # (truncate_message adds closing fence when splitting mid-block)
+                            if self._in_code_block and chunk.rstrip().endswith("```"):
+                                # Code block was closed by truncate
+                                if i < len(chunks) - 1:  # Not the last chunk
+                                    self._in_code_block = False
+                                    if self._code_block_split_callback:
+                                        try:
+                                            self._code_block_split_callback()
+                                        except Exception:
+                                            pass
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
@@ -203,6 +223,12 @@ class GatewayStreamConsumer:
                             await self._send_or_edit(self._accumulated)
                         elif not self._already_sent:
                             await self._send_or_edit(self._accumulated)
+                    # Add completion reaction to the final message
+                    if self._message_id and hasattr(self.adapter, '_add_completion_reaction'):
+                        try:
+                            await self.adapter._add_completion_reaction(self._message_id)
+                        except Exception as e:
+                            logger.debug("Failed to add completion reaction: %s", e)
                     return
 
                 # Tool boundary: reset message state so the next text chunk

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -223,12 +223,6 @@ class GatewayStreamConsumer:
                             await self._send_or_edit(self._accumulated)
                         elif not self._already_sent:
                             await self._send_or_edit(self._accumulated)
-                    # Add completion reaction to the final message
-                    if self._message_id and hasattr(self.adapter, '_add_completion_reaction'):
-                        try:
-                            await self.adapter._add_completion_reaction(self._message_id)
-                        except Exception as e:
-                            logger.debug("Failed to add completion reaction: %s", e)
                     return
 
                 # Tool boundary: reset message state so the next text chunk

--- a/run_agent.py
+++ b/run_agent.py
@@ -1682,6 +1682,16 @@ class AIAgent:
             if assistant_message.reasoning_content not in reasoning_parts:
                 reasoning_parts.append(assistant_message.reasoning_content)
         
+        # Check thinking_content field (Baidu Qianfan, some Chinese providers)
+        if hasattr(assistant_message, 'thinking_content') and assistant_message.thinking_content:
+            if assistant_message.thinking_content not in reasoning_parts:
+                reasoning_parts.append(assistant_message.thinking_content)
+        
+        # Check thinking field (some providers)
+        if hasattr(assistant_message, 'thinking') and assistant_message.thinking:
+            if assistant_message.thinking not in reasoning_parts:
+                reasoning_parts.append(assistant_message.thinking)
+        
         # Check reasoning_details array (OpenRouter unified format)
         # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
@@ -4533,7 +4543,14 @@ class AIAgent:
                     model_name = chunk.model
 
                 # Accumulate reasoning content
-                reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+                # Check multiple fields: reasoning_content (Moonshot, Novita), reasoning (DeepSeek, Qwen),
+                # thinking_content (Baidu Qianfan, some Chinese providers), thinking (some providers)
+                reasoning_text = (
+                    getattr(delta, "reasoning_content", None) or
+                    getattr(delta, "reasoning", None) or
+                    getattr(delta, "thinking_content", None) or
+                    getattr(delta, "thinking", None)
+                )
                 if reasoning_text:
                     reasoning_parts.append(reasoning_text)
                     _fire_first_delta()


### PR DESCRIPTION
## Summary

Enable streaming of reasoning/thinking content to messaging platforms (Feishu, Telegram, Discord, etc.) when `show_reasoning` is enabled, matching the TUI behavior.

## Changes

- Add `reasoning_callback` setup in `GatewayRunner`
- Stream reasoning with `💭 **Reasoning:**` header and code block formatting
- Close reasoning block before regular content begins
- Only enable when `show_reasoning=true` and streaming is active

## Benefits

Users on messaging platforms can now see the model's reasoning process in real-time, consistent with the TUI experience. This is especially useful for models like DeepSeek that expose reasoning tokens.

## Example Output

```
💭 **Reasoning:**
```
Let me analyze this request step by step...
The user wants to...
```

[Actual response content here]
```

## Testing

Tested with DeepSeek model via Feishu gateway with `show_reasoning: true`. Reasoning content streams correctly with proper formatting.