### PR TITLE
feat: add context-mode plugin integration with compress hooks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -62,6 +62,8 @@ VALID_HOOKS: Set[str] = {
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",
+    "pre_compress",
+    "post_compress",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
@@ -775,6 +777,51 @@ def get_pre_tool_call_block_message(
         message = result.get("message")
         if isinstance(message, str) and message:
             return message
+
+    return None
+
+
+def get_pre_tool_call_intercept(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Check ``pre_tool_call`` hooks for block or redirect directives.
+
+    Plugins can return:
+
+    * ``{"action": "block", "message": "reason"}`` — prevent execution,
+      return an error to the model.
+    * ``{"action": "redirect", "result": "<json string>"}`` — skip execution,
+      return *result* as the successful tool output (used by context-mode
+      to sandbox large-output commands).
+
+    Returns a dict with ``"kind"`` set to ``"block"`` or ``"redirect"``
+    plus the relevant payload, or ``None`` if no hook intercepted.
+    """
+    hook_results = invoke_hook(
+        "pre_tool_call",
+        tool_name=tool_name,
+        args=args if isinstance(args, dict) else {},
+        task_id=task_id,
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+    )
+
+    for result in hook_results:
+        if not isinstance(result, dict):
+            continue
+        action = result.get("action")
+        if action == "block":
+            message = result.get("message")
+            if isinstance(message, str) and message:
+                return {"kind": "block", "message": message}
+        elif action == "redirect":
+            redirect_result = result.get("result")
+            if isinstance(redirect_result, str) and redirect_result:
+                return {"kind": "redirect", "result": redirect_result}
 
     return None
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -451,14 +451,14 @@ def handle_function_call(
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
 
-        # Check plugin hooks for a block directive (unless caller already
+        # Check plugin hooks for intercept directives (unless caller already
         # checked — e.g. run_agent._invoke_tool passes skip=True to
         # avoid double-firing the hook).
         if not skip_pre_tool_call_hook:
-            block_message: Optional[str] = None
+            intercept: Optional[Dict[str, Any]] = None
             try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
-                block_message = get_pre_tool_call_block_message(
+                from hermes_cli.plugins import get_pre_tool_call_intercept
+                intercept = get_pre_tool_call_intercept(
                     function_name,
                     function_args,
                     task_id=task_id or "",
@@ -468,8 +468,11 @@ def handle_function_call(
             except Exception:
                 pass
 
-            if block_message is not None:
-                return json.dumps({"error": block_message}, ensure_ascii=False)
+            if intercept is not None:
+                if intercept["kind"] == "block":
+                    return json.dumps({"error": intercept["message"]}, ensure_ascii=False)
+                elif intercept["kind"] == "redirect":
+                    return intercept["result"]
         else:
             # Still fire the hook for observers — just don't check for blocking
             # (the caller already did that).

--- a/run_agent.py
+++ b/run_agent.py
@@ -7331,17 +7331,20 @@ class AIAgent:
         tools. Used by the concurrent execution path; the sequential path retains
         its own inline invocation for backward-compatible display handling.
         """
-        # Check plugin hooks for a block directive before executing anything.
-        block_message: Optional[str] = None
+        # Check plugin hooks for intercept directives before executing anything.
+        intercept: Optional[Dict[str, Any]] = None
         try:
-            from hermes_cli.plugins import get_pre_tool_call_block_message
-            block_message = get_pre_tool_call_block_message(
+            from hermes_cli.plugins import get_pre_tool_call_intercept
+            intercept = get_pre_tool_call_intercept(
                 function_name, function_args, task_id=effective_task_id or "",
             )
         except Exception:
             pass
-        if block_message is not None:
-            return json.dumps({"error": block_message}, ensure_ascii=False)
+        if intercept is not None:
+            if intercept["kind"] == "block":
+                return json.dumps({"error": intercept["message"]}, ensure_ascii=False)
+            elif intercept["kind"] == "redirect":
+                return intercept["result"]
 
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
@@ -7732,19 +7735,18 @@ class AIAgent:
             if not isinstance(function_args, dict):
                 function_args = {}
 
-            # Check plugin hooks for a block directive before executing.
-            _block_msg: Optional[str] = None
+            # Check plugin hooks for intercept directives before executing.
+            _intercept: Optional[Dict[str, Any]] = None
             try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
-                _block_msg = get_pre_tool_call_block_message(
+                from hermes_cli.plugins import get_pre_tool_call_intercept
+                _intercept = get_pre_tool_call_intercept(
                     function_name, function_args, task_id=effective_task_id or "",
                 )
             except Exception:
                 pass
 
-            if _block_msg is not None:
-                # Tool blocked by plugin policy — skip counter resets.
-                # Execution is handled below in the tool dispatch chain.
+            if _intercept is not None:
+                # Tool intercepted by plugin — skip counter resets.
                 pass
             else:
                 # Reset nudge counters when the relevant tool is actually used
@@ -7762,35 +7764,35 @@ class AIAgent:
                     args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
                     print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
 
-            if _block_msg is None:
+            if _intercept is None:
                 self._current_tool = function_name
                 self._touch_activity(f"executing tool: {function_name}")
 
             # Set activity callback for long-running tool execution (terminal
             # commands, etc.) so the gateway's inactivity monitor doesn't kill
             # the agent while a command is running.
-            if _block_msg is None:
+            if _intercept is None:
                 try:
                     from tools.environments.base import set_activity_callback
                     set_activity_callback(self._touch_activity)
                 except Exception:
                     pass
 
-            if _block_msg is None and self.tool_progress_callback:
+            if _intercept is None and self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(function_name, function_args)
                     self.tool_progress_callback("tool.started", function_name, preview, function_args)
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
-            if _block_msg is None and self.tool_start_callback:
+            if _intercept is None and self.tool_start_callback:
                 try:
                     self.tool_start_callback(tool_call.id, function_name, function_args)
                 except Exception as cb_err:
                     logging.debug(f"Tool start callback error: {cb_err}")
 
             # Checkpoint: snapshot working dir before file-mutating tools
-            if _block_msg is None and function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
+            if _intercept is None and function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
                 try:
                     file_path = function_args.get("path", "")
                     if file_path:
@@ -7802,7 +7804,7 @@ class AIAgent:
                     pass  # never block tool execution
 
             # Checkpoint before destructive terminal commands
-            if _block_msg is None and function_name == "terminal" and self._checkpoint_mgr.enabled:
+            if _intercept is None and function_name == "terminal" and self._checkpoint_mgr.enabled:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
@@ -7815,9 +7817,13 @@ class AIAgent:
 
             tool_start_time = time.time()
 
-            if _block_msg is not None:
+            if _intercept is not None and _intercept["kind"] == "block":
                 # Tool blocked by plugin policy — return error without executing.
-                function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
+                function_result = json.dumps({"error": _intercept["message"]}, ensure_ascii=False)
+                tool_duration = 0.0
+            elif _intercept is not None and _intercept["kind"] == "redirect":
+                # Tool redirected by plugin — return sandbox result as success.
+                function_result = _intercept["result"]
                 tool_duration = 0.0
             elif function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool


### PR DESCRIPTION
## Summary

This PR extends the plugin system with **tool call interception** and **context compression hooks**, enabling plugins like context-mode to sandbox large-output commands via MCP for ~98% context savings.

### Key Change: `get_pre_tool_call_intercept()`

Extends the existing `get_pre_tool_call_block_message()` with a new **redirect** action alongside the existing **block** action:

- `{"action": "block", "message": "reason"}` — prevent execution, return error to model *(existing)*
- `{"action": "redirect", "result": "<json string>"}` — skip execution, return result as successful output *(new)*

This is fully backward-compatible — existing hooks returning `"block"` continue to work unchanged.

### Changes

**`hermes_cli/plugins.py`**
- Added `pre_compress` and `post_compress` to `VALID_HOOKS`
- Added `get_pre_tool_call_intercept()` — returns `{"kind": "block"|"redirect", ...}` or `None`
- Keeps `get_pre_tool_call_block_message()` intact for existing consumers

**`model_tools.py`**
- Updated `handle_function_call` to use `get_pre_tool_call_intercept()` 
- Handles both `block` (error response) and `redirect` (success response) kinds

**`run_agent.py`**
- Updated `_invoke_tool()` (concurrent path) and sequential dispatch to use intercept pattern
- Both paths consistently handle block + redirect

### How It Works

```
Tool Call → pre_tool_call hook → {"action": "redirect", "result": "..."} 
          → intercept returns {"kind": "redirect", "result": "..."}
          → handle_function_call returns result directly (skips normal dispatch)
          → only sandboxed stdout enters context (~98% savings)
```

### Testing

The integration has been running stably in daily use with the context-mode plugin enabled. The hook pattern is safe — failures silently fall through to normal dispatch.