### PR TITLE
fix: preserve dots in model names for custom base URLs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5816,14 +5816,22 @@ class AIAgent:
         return transformed
 
     def _anthropic_preserve_dots(self) -> bool:
-        """True when using an anthropic-compatible endpoint that preserves dots in model names.
-        Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
-        MiniMax keeps dots (e.g. MiniMax-M2.7).
-        OpenCode Go keeps dots (e.g. minimax-m2.7)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go"}:
+        """True when the endpoint expects model names with dots preserved.
+
+        Dot-to-hyphen conversion is only needed for official Anthropic and
+        OpenRouter URLs.  All other custom base_urls (proxies, alternative
+        providers) receive the model name as-is so they aren't broken by
+        the rewrite.
+        """
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
+        if "dashscope" in base or "aliyuncs" in base:
+            return True
+        # Custom base_url that is NOT Anthropic or OpenRouter → preserve dots
+        if base and "anthropic.com" not in base and "openrouter.co" not in base:
+            return True
+        return False
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -483,6 +483,62 @@ class TestNormalizeModelName:
 
 
 # ---------------------------------------------------------------------------
+# _anthropic_preserve_dots (via RunAgent)
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicPreserveDots:
+    """Tests for RunAgent._anthropic_preserve_dots().
+
+    The method lives on RunAgent and reads self.provider / self.base_url,
+    so we use a lightweight SimpleNamespace stub to avoid constructing a
+    full RunAgent.
+    """
+
+    @staticmethod
+    def _make_stub(base_url="", provider=""):
+        from types import SimpleNamespace
+        stub = SimpleNamespace(base_url=base_url, provider=provider)
+        # Bind the unbound method to the stub
+        from run_agent import AIAgent
+        stub._anthropic_preserve_dots = AIAgent._anthropic_preserve_dots.__get__(stub)
+        return stub
+
+    def test_no_base_url_returns_false(self):
+        """Default Anthropic behaviour — dots converted to hyphens."""
+        stub = self._make_stub()
+        assert stub._anthropic_preserve_dots() is False
+
+    def test_anthropic_com_returns_false(self):
+        stub = self._make_stub(base_url="https://api.anthropic.com/v1")
+        assert stub._anthropic_preserve_dots() is False
+
+    def test_openrouter_returns_false(self):
+        stub = self._make_stub(base_url="https://openrouter.co/api/v1")
+        assert stub._anthropic_preserve_dots() is False
+
+    def test_custom_proxy_returns_true(self):
+        stub = self._make_stub(base_url="http://104.43.91.188:8000")
+        assert stub._anthropic_preserve_dots() is True
+
+    def test_custom_domain_returns_true(self):
+        stub = self._make_stub(base_url="https://my-proxy.example.com/v1")
+        assert stub._anthropic_preserve_dots() is True
+
+    def test_dashscope_returns_true(self):
+        stub = self._make_stub(base_url="https://dashscope.aliyuncs.com/compatible-mode/v1")
+        assert stub._anthropic_preserve_dots() is True
+
+    def test_alibaba_provider_returns_true(self):
+        stub = self._make_stub(provider="alibaba")
+        assert stub._anthropic_preserve_dots() is True
+
+    def test_alibaba_provider_case_insensitive(self):
+        stub = self._make_stub(provider="Alibaba")
+        assert stub._anthropic_preserve_dots() is True
+
+
+# ---------------------------------------------------------------------------
 # Tool conversion
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #7164

## Problem

When using a custom `base_url` (proxy, alternative API endpoint), `normalize_model_name()` converts dots to hyphens in model names — e.g. `claude-opus-4.6` → `claude-opus-4-6`. This causes HTTP 400 errors (`model_not_supported`) from endpoints that expect the original model name.

## Context

I deployed a Hermes instance using a custom Anthropic-compatible proxy for LLM calls. The proxy expects model names exactly as configured (e.g. `claude-opus-4.6`), but Hermes's `normalize_model_name()` silently rewrote it to `claude-opus-4-6`, resulting in 400 errors. It took a while to trace through the code to find the root cause.

The dot-to-hyphen conversion exists for good reason — OpenRouter uses dots (e.g. `anthropic/claude-opus-4.6`) while Anthropic's API uses hyphens (`claude-opus-4-6`). But this conversion should only apply to official Anthropic and OpenRouter endpoints, not to arbitrary custom base URLs.

## Changes

**`run_agent.py`**: Updated `_anthropic_preserve_dots()` to return `True` for any custom `base_url` that doesn't contain `anthropic.com` or `openrouter.co`. Existing Alibaba/DashScope behavior is preserved.

**`tests/test_anthropic_adapter.py`**: Added 8 tests covering all cases:
- No base_url / anthropic.com / openrouter.co → `False` (dots converted, existing behavior)
- Custom proxy IP / custom domain → `True` (dots preserved)
- DashScope / Alibaba provider → `True` (existing behavior unchanged)

## Testing

All 115 tests in `test_anthropic_adapter.py` pass. No regressions.