### PR TITLE
feat(cron): run independent cron jobs in parallel with safe non-overlap

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4643,22 +4643,23 @@ class HermesCLI:
             print("  Usage: /snapshot [list|create [label]|restore <id>|prune [N]]")
 
     def _handle_stop_command(self):
-        """Handle /stop — kill all running background processes.
+        """Handle /stop — kill this session's running background processes.
 
         Inspired by OpenAI Codex's separation of interrupt (stop current turn)
         from /stop (clean up background processes). See openai/codex#14602.
         """
         from tools.process_registry import process_registry
 
-        processes = process_registry.list_sessions()
+        task_id = getattr(self, "session_id", None) or None
+        processes = process_registry.list_sessions(task_id=task_id)
         running = [p for p in processes if p.get("status") == "running"]
 
         if not running:
-            print("  No running background processes.")
+            print("  No running background processes for this session.")
             return
 
-        print(f"  Stopping {len(running)} background process(es)...")
-        killed = process_registry.kill_all()
+        print(f"  Stopping {len(running)} background process(es) for this session...")
+        killed = process_registry.kill_all(task_id=task_id)
         print(f"  ✅ Stopped {killed} process(es).")
 
     def _handle_agents_command(self):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1193,7 +1193,13 @@ def remove_job(job_id: str) -> bool:
 
 
 def recover_stale_inflight(now: Optional[datetime] = None) -> int:
-    """Recover timed-out or clearly orphaned in-flight runs."""
+    """Recover timed-out or clearly orphaned in-flight runs.
+
+    Recovery is intentionally recorded as a failed run attempt: it clears the
+    in-flight claim, stores an error status, and increments repeat accounting.
+    This is conservative for operators because a claimed job may have performed
+    partial side effects before the owner wedged or disappeared.
+    """
     now_dt = now or _hermes_now()
     now_iso = now_dt.isoformat()
     with _jobs_file_lock:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -6,6 +6,7 @@ Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 """
 
 import copy
+import errno
 import json
 import logging
 import shutil
@@ -13,11 +14,13 @@ import tempfile
 import threading
 import os
 import re
+import subprocess
+import sys
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any, Union, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +47,7 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+IN_FLIGHT_TIMEOUT_GRACE_SECONDS = 5
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -394,6 +398,433 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     return None
 
 
+def _cron_timeout_seconds() -> float:
+    """Return configured cron timeout in seconds, clamped to a sane minimum."""
+    try:
+        timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
+    except (TypeError, ValueError):
+        timeout = 600.0
+    return max(timeout, 1.0)
+
+
+def _orphan_recovery_grace_seconds() -> float:
+    """Return the orphan-recovery grace window in seconds."""
+    try:
+        value = float(os.getenv("HERMES_CRON_ORPHAN_GRACE_SECONDS", 60))
+    except (TypeError, ValueError):
+        value = 60.0
+    return max(value, 0.0)
+
+
+def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return _ensure_aware(datetime.fromisoformat(value))
+    except Exception:
+        return None
+
+
+def _parse_legacy_owner_pid(owner_instance_id: Optional[str]) -> Optional[int]:
+    if not owner_instance_id:
+        return None
+    match = re.match(r"^(\d+)-", str(owner_instance_id).strip())
+    if not match:
+        return None
+    try:
+        pid = int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def _linux_boot_id() -> Optional[str]:
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        value = Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    return value or None
+
+
+def _darwin_boot_fingerprint() -> Optional[str]:
+    if sys.platform != "darwin":
+        return None
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "kern.boottime"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    output = (result.stdout or "").strip()
+    match = re.search(r"sec\s*=\s*(\d+)\s*,\s*usec\s*=\s*(\d+)", output)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}"
+    compact = re.sub(r"\s+", " ", output)
+    return compact or None
+
+
+def _boot_fingerprint() -> Optional[str]:
+    if sys.platform.startswith("linux"):
+        return _linux_boot_id()
+    if sys.platform == "darwin":
+        return _darwin_boot_fingerprint()
+    return None
+
+
+def _linux_process_state(pid: int) -> Optional[str]:
+    if not sys.platform.startswith("linux") or pid <= 0:
+        return None
+    try:
+        stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    end_idx = stat_text.rfind(")")
+    if end_idx == -1 or len(stat_text) <= end_idx + 2:
+        return None
+    state = stat_text[end_idx + 2 : end_idx + 3]
+    return state or None
+
+
+def _linux_process_start_fingerprint(pid: int) -> Optional[str]:
+    if not sys.platform.startswith("linux") or pid <= 0:
+        return None
+    try:
+        stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    end_idx = stat_text.rfind(")")
+    if end_idx == -1:
+        return None
+
+    fields = stat_text[end_idx + 2 :].split()
+    if len(fields) <= 19:
+        return None
+    return fields[19] or None
+
+
+def _darwin_process_start_fingerprint(pid: int) -> Optional[str]:
+    if sys.platform != "darwin" or pid <= 0:
+        return None
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    output = re.sub(r"\s+", " ", (result.stdout or "").strip())
+    return output or None
+
+
+def _process_start_fingerprint(pid: int) -> Optional[str]:
+    if sys.platform.startswith("linux"):
+        return _linux_process_start_fingerprint(pid)
+    if sys.platform == "darwin":
+        return _darwin_process_start_fingerprint(pid)
+    return None
+
+
+def _pid_is_alive(pid: int) -> Optional[bool]:
+    if pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        alive = True
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
+        if exc.errno == errno.EPERM:
+            alive = True
+        else:
+            return None
+    else:
+        alive = True
+
+    if alive and sys.platform.startswith("linux"):
+        state = _linux_process_state(pid)
+        if state in {"Z", "X", "x"}:
+            return False
+    return alive
+
+
+def _process_identity_matches(
+    pid: int,
+    *,
+    boot_id: Optional[str],
+    process_start: Optional[str],
+) -> Optional[bool]:
+    checked = False
+
+    if boot_id:
+        current_boot_id = _boot_fingerprint()
+        if not current_boot_id:
+            return None
+        checked = True
+        if current_boot_id != boot_id:
+            return False
+
+    if process_start:
+        current_process_start = _process_start_fingerprint(pid)
+        if not current_process_start:
+            return None
+        checked = True
+        if current_process_start != process_start:
+            return False
+
+    if checked and process_start:
+        return True
+    return None
+
+
+def _legacy_owner_pid_is_dead(pid: int) -> bool:
+    return _pid_is_alive(pid) is False
+
+
+def _get_inflight_owner_state(
+    in_flight: Dict[str, Any],
+    now_dt: Optional[datetime] = None,
+) -> Tuple[str, str]:
+    del now_dt
+
+    owner_pid_raw = in_flight.get("owner_pid")
+    try:
+        owner_pid = int(owner_pid_raw) if owner_pid_raw is not None else None
+    except (TypeError, ValueError):
+        owner_pid = None
+
+    if owner_pid and owner_pid > 0:
+        alive = _pid_is_alive(owner_pid)
+        if alive is False:
+            return "dead", f"owner pid {owner_pid} not alive"
+        if alive is True:
+            identity = _process_identity_matches(
+                owner_pid,
+                boot_id=in_flight.get("owner_boot_id"),
+                process_start=in_flight.get("owner_process_start"),
+            )
+            if identity is True:
+                return "alive", f"owner pid {owner_pid} alive and fingerprint matches"
+            if identity is False:
+                return "mismatch", f"owner pid {owner_pid} fingerprint mismatch"
+            return "unknown", f"owner pid {owner_pid} alive but identity could not be confirmed"
+        return "unknown", f"owner pid {owner_pid} liveness unavailable"
+
+    legacy_pid = _parse_legacy_owner_pid(in_flight.get("owner_instance_id"))
+    if legacy_pid is not None:
+        if _legacy_owner_pid_is_dead(legacy_pid):
+            return "dead", f"legacy owner pid {legacy_pid} not alive"
+        return "unknown", f"legacy owner pid {legacy_pid} could not be verified"
+
+    return "unknown", "owner metadata missing or unsupported"
+
+
+def _find_job_index(jobs: List[Dict[str, Any]], job_id: str) -> Optional[int]:
+    for i, job in enumerate(jobs):
+        if job.get("id") == job_id:
+            return i
+    return None
+
+
+def _build_jobs_index(jobs: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {str(job.get("id")): job for job in jobs if job.get("id")}
+
+
+def _apply_run_outcome(
+    job: Dict[str, Any],
+    *,
+    success: bool,
+    error: Optional[str],
+    run_at: str,
+    recompute_next_run: bool,
+    delivery_error: Optional[str] = None,
+) -> bool:
+    """Apply run outcome to a job in-place.
+
+    Returns True when the job should be removed because a repeat limit was hit.
+    """
+    was_paused = job.get("state") == "paused" or not job.get("enabled", True)
+
+    job["last_run_at"] = run_at
+    job["last_status"] = "ok" if success else "error"
+    job["last_error"] = None if success else error
+    job["last_delivery_error"] = delivery_error
+
+    if job.get("repeat"):
+        job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1
+        times = job["repeat"].get("times")
+        completed = job["repeat"]["completed"]
+        if times is not None and times > 0 and completed >= times:
+            return True
+
+    schedule = job.get("schedule", {})
+    kind = schedule.get("kind")
+    if recompute_next_run:
+        next_run = compute_next_run(schedule, run_at)
+    elif kind == "once":
+        next_run = None
+    else:
+        next_run = job.get("next_run_at") or compute_next_run(schedule, run_at)
+
+    job["next_run_at"] = next_run
+    if was_paused:
+        job["enabled"] = False
+        job["state"] = "paused"
+    elif next_run is None:
+        # No next run is expected for completed one-shot jobs, but for
+        # recurring schedules it means next-run computation failed (for
+        # example croniter missing). Do not silently disable recurring jobs.
+        if kind in ("cron", "interval"):
+            job["state"] = "error"
+            job["last_status"] = "error"
+            if not job.get("last_error"):
+                job["last_error"] = (
+                    "Failed to compute next run for recurring schedule "
+                    "(is the 'croniter' package installed in the gateway's Python env?)"
+                )
+            logger.error(
+                "Job '%s' (%s) could not compute next_run_at; leaving enabled "
+                "and marking state=error so the job is not silently disabled.",
+                job.get("name", job.get("id")),
+                kind,
+            )
+        else:
+            job["enabled"] = False
+            job["state"] = "completed"
+    else:
+        job["state"] = "scheduled"
+
+    return False
+
+
+def _restore_recoverable_next_run(job: Dict[str, Any], in_flight: Dict[str, Any], *, now_iso: str) -> None:
+    """Undo claim-time recurring schedule advancement so recovery can requeue the job."""
+    kind = job.get("schedule", {}).get("kind")
+    if kind not in ("cron", "interval"):
+        return
+
+    claimed_at = in_flight.get("claimed_at")
+    recovered_due = claimed_at if _parse_iso_datetime(claimed_at) else now_iso
+    job["next_run_at"] = recovered_due
+
+
+def _collect_due_jobs(
+    raw_jobs: List[Dict[str, Any]],
+    now: datetime,
+    *,
+    skip_in_flight: bool = True,
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Collect due jobs from raw storage records."""
+    jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
+    due: List[Dict[str, Any]] = []
+    needs_save = False
+    raw_by_id = _build_jobs_index(raw_jobs)
+
+    for job in jobs:
+        manual_trigger_at = job.get("trigger_once_at")
+        manual_trigger_dt = _parse_iso_datetime(manual_trigger_at) if manual_trigger_at else None
+        manual_trigger_due = manual_trigger_dt is not None and manual_trigger_dt <= now
+
+        if not job.get("enabled", True) and not manual_trigger_due:
+            continue
+        if skip_in_flight and job.get("in_flight"):
+            continue
+
+        if manual_trigger_due:
+            raw = raw_by_id.get(job["id"])
+            if raw is not None:
+                raw["trigger_once_at"] = None
+                needs_save = True
+            job["trigger_once_at"] = None
+            due.append(job)
+            continue
+
+        next_run = job.get("next_run_at")
+        if not next_run:
+            schedule = job.get("schedule", {})
+            kind = schedule.get("kind")
+
+            # One-shot jobs use a small grace window via the dedicated helper.
+            recovered_next = _recoverable_oneshot_run_at(
+                schedule,
+                now,
+                last_run_at=job.get("last_run_at"),
+            )
+            recovery_kind = "one-shot" if recovered_next else None
+
+            # Recurring jobs can reach here after hand edits or legacy records.
+            # Recompute from the schedule so they do not silently disappear.
+            if not recovered_next and kind in ("cron", "interval"):
+                recovered_next = compute_next_run(schedule, now.isoformat())
+                if recovered_next:
+                    recovery_kind = kind
+
+            if not recovered_next:
+                continue
+
+            job["next_run_at"] = recovered_next
+            next_run = recovered_next
+            logger.info(
+                "Job '%s' had no next_run_at; recovering %s run at %s",
+                job.get("name", job["id"]),
+                recovery_kind,
+                recovered_next,
+            )
+            raw = raw_by_id.get(job["id"])
+            if raw is not None:
+                raw["next_run_at"] = recovered_next
+                needs_save = True
+
+        next_run_dt = _parse_iso_datetime(next_run)
+        if not next_run_dt:
+            continue
+
+        if next_run_dt <= now:
+            schedule = job.get("schedule", {})
+            kind = schedule.get("kind")
+
+            grace = _compute_grace_seconds(schedule)
+            if kind in ("cron", "interval") and (now - next_run_dt).total_seconds() > grace:
+                new_next = compute_next_run(schedule, now.isoformat())
+                if new_next:
+                    logger.info(
+                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
+                        "Fast-forwarding to next run: %s",
+                        job.get("name", job["id"]),
+                        next_run,
+                        grace,
+                        new_next,
+                    )
+                    raw = raw_by_id.get(job["id"])
+                    if raw is not None:
+                        raw["next_run_at"] = new_next
+                        needs_save = True
+                    continue
+
+            due.append(job)
+
+    return due, needs_save
+
+
 # =============================================================================
 # Job CRUD Operations
 # =============================================================================
@@ -734,18 +1165,14 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 
 def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
-    """Schedule a job to run on the next scheduler tick."""
+    """Trigger exactly one run on the next scheduler tick without changing pause/resume state."""
     job = get_job(job_id)
     if not job:
         return None
     return update_job(
         job_id,
         {
-            "enabled": True,
-            "state": "scheduled",
-            "paused_at": None,
-            "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
+            "trigger_once_at": _hermes_now().isoformat(),
         },
     )
 
@@ -765,6 +1192,320 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
+def recover_stale_inflight(now: Optional[datetime] = None) -> int:
+    """Recover timed-out or clearly orphaned in-flight runs."""
+    now_dt = now or _hermes_now()
+    now_iso = now_dt.isoformat()
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        recovered = 0
+        needs_save = False
+
+        for idx in range(len(jobs) - 1, -1, -1):
+            job = jobs[idx]
+            in_flight = job.get("in_flight")
+            if not isinstance(in_flight, dict):
+                continue
+
+            timeout_dt = _parse_iso_datetime(in_flight.get("timeout_at"))
+            run_id = in_flight.get("run_id", "unknown")
+            claimed_at_dt = _parse_iso_datetime(in_flight.get("claimed_at"))
+            grace_seconds = _orphan_recovery_grace_seconds()
+            within_grace = (
+                claimed_at_dt is not None
+                and (now_dt - claimed_at_dt).total_seconds() < grace_seconds
+            )
+
+            reason: Optional[str] = None
+            log_message: Optional[str] = None
+            owner_state = "unknown"
+            owner_reason = "owner state not evaluated"
+
+            if timeout_dt is None:
+                owner_state, owner_reason = _get_inflight_owner_state(in_flight, now_dt=now_dt)
+                if owner_state in ("dead", "mismatch") and not within_grace:
+                    reason = f"orphan_recovered: {owner_reason}; run_id={run_id}"
+                    log_message = "Recovering malformed orphaned in-flight run for job '%s' (run_id=%s): %s"
+                elif owner_state == "alive":
+                    logger.warning(
+                        "Keeping malformed in-flight owner for job '%s' (run_id=%s): %s",
+                        job.get("id"),
+                        run_id,
+                        owner_reason,
+                    )
+                elif owner_state == "unknown":
+                    malformed_age_seconds = None
+                    if claimed_at_dt is not None:
+                        malformed_age_seconds = (now_dt - claimed_at_dt).total_seconds()
+                    malformed_stale = (
+                        claimed_at_dt is None
+                        or malformed_age_seconds is None
+                        or malformed_age_seconds >= (_cron_timeout_seconds() + grace_seconds)
+                    )
+                    if malformed_stale:
+                        reason = f"stale_recovered: invalid_timeout_at; run_id={run_id}"
+                        log_message = "Recovering malformed in-flight run for job '%s' (run_id=%s): missing/invalid timeout_at"
+                    else:
+                        logger.warning(
+                            "Deferring malformed in-flight recovery for job '%s' (run_id=%s): %s",
+                            job.get("id"),
+                            run_id,
+                            owner_reason,
+                        )
+                elif within_grace:
+                    logger.debug(
+                        "Malformed owner for job '%s' (run_id=%s) appears %s but remains within grace window",
+                        job.get("id"),
+                        run_id,
+                        owner_state,
+                    )
+            elif timeout_dt <= now_dt:
+                reason = f"stale_recovered: run_id={run_id}"
+                log_message = "Recovering timed-out in-flight run for job '%s' (run_id=%s)"
+            else:
+                owner_state, owner_reason = _get_inflight_owner_state(in_flight, now_dt=now_dt)
+                if owner_state in ("dead", "mismatch") and not within_grace:
+                    reason = f"orphan_recovered: {owner_reason}; run_id={run_id}"
+                    log_message = "Recovering orphaned in-flight run for job '%s' (run_id=%s): %s"
+                elif owner_state == "unknown":
+                    logger.debug(
+                        "Deferring early recovery for job '%s' (run_id=%s): %s",
+                        job.get("id"),
+                        run_id,
+                        owner_reason,
+                    )
+                elif owner_state == "alive":
+                    logger.debug(
+                        "Keeping live in-flight owner for job '%s' (run_id=%s): %s",
+                        job.get("id"),
+                        run_id,
+                        owner_reason,
+                    )
+                elif within_grace:
+                    logger.debug(
+                        "Owner for job '%s' (run_id=%s) appears %s but remains within grace window",
+                        job.get("id"),
+                        run_id,
+                        owner_state,
+                    )
+
+            if reason is None:
+                continue
+
+            if log_message:
+                if log_message.count("%s") >= 3:
+                    logger.warning(log_message, job.get("id"), run_id, reason)
+                else:
+                    logger.warning(log_message, job.get("id"), run_id)
+
+            _restore_recoverable_next_run(job, in_flight, now_iso=now_iso)
+            should_remove = _apply_run_outcome(
+                job,
+                success=False,
+                error=reason,
+                run_at=now_iso,
+                recompute_next_run=False,
+                delivery_error=None,
+            )
+            job["in_flight"] = None
+
+            if should_remove:
+                jobs.pop(idx)
+            else:
+                jobs[idx] = job
+
+            recovered += 1
+            needs_save = True
+
+        if needs_save:
+            save_jobs(jobs)
+
+        return recovered
+
+
+def claim_due_jobs(
+    now: Optional[datetime] = None,
+    owner_instance_id: str = "",
+    max_parallel: int = 1,
+    owner_pid: Optional[int] = None,
+    owner_boot_id: Optional[str] = None,
+    owner_process_start: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Claim due jobs by writing durable in-flight ownership metadata."""
+    now_dt = now or _hermes_now()
+    now_iso = now_dt.isoformat()
+
+    with _jobs_file_lock:
+        raw_jobs = load_jobs()
+        due_jobs, needs_save = _collect_due_jobs(raw_jobs, now_dt, skip_in_flight=True)
+        claimed: List[Dict[str, Any]] = []
+        raw_by_id = _build_jobs_index(raw_jobs)
+
+        try:
+            claim_budget = max(0, int(max_parallel))
+        except (TypeError, ValueError):
+            claim_budget = 1
+
+        if claim_budget <= 0:
+            if needs_save:
+                save_jobs(raw_jobs)
+            return []
+
+        claim_owner_pid = owner_pid if owner_pid is not None else os.getpid()
+        if claim_owner_pid is not None and claim_owner_pid <= 0:
+            claim_owner_pid = None
+        claim_owner_boot_id = owner_boot_id if owner_boot_id is not None else _boot_fingerprint()
+        claim_owner_process_start = owner_process_start
+        if claim_owner_process_start is None and claim_owner_pid is not None:
+            claim_owner_process_start = _process_start_fingerprint(claim_owner_pid)
+
+        timeout_at = (
+            now_dt
+            + timedelta(seconds=_cron_timeout_seconds() + IN_FLIGHT_TIMEOUT_GRACE_SECONDS)
+        ).isoformat()
+
+        for due in due_jobs:
+            if len(claimed) >= claim_budget:
+                break
+            raw = raw_by_id.get(due["id"])
+            if raw is None or raw.get("in_flight"):
+                continue
+
+            run_id = uuid.uuid4().hex
+            raw["in_flight"] = {
+                "run_id": run_id,
+                "owner_instance_id": owner_instance_id,
+                "owner_pid": claim_owner_pid,
+                "owner_boot_id": claim_owner_boot_id,
+                "owner_process_start": claim_owner_process_start,
+                "claimed_at": now_iso,
+                "timeout_at": timeout_at,
+                "started_at": None,
+                "status": "claimed",
+            }
+
+            kind = raw.get("schedule", {}).get("kind")
+            if kind in ("cron", "interval"):
+                advanced_next = compute_next_run(raw["schedule"], now_iso)
+                if advanced_next:
+                    raw["next_run_at"] = advanced_next
+
+            claimed.append(_apply_skill_fields(copy.deepcopy(raw)))
+            needs_save = True
+
+        if needs_save:
+            save_jobs(raw_jobs)
+
+        return claimed
+
+
+def mark_job_started(job_id: str, run_id: str, started_at: Optional[str] = None) -> bool:
+    """Mark an owned in-flight run as actively running."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        in_flight = job.get("in_flight")
+        if not isinstance(in_flight, dict) or in_flight.get("run_id") != run_id:
+            return False
+
+        in_flight["started_at"] = started_at or _hermes_now().isoformat()
+        in_flight["status"] = "running"
+        job["in_flight"] = in_flight
+        save_jobs(jobs)
+        return True
+
+
+def clear_inflight_if_owned(job_id: str, run_id: str, reason: Optional[str] = None) -> bool:
+    """Clear in_flight only when the provided run_id still owns the claim."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        in_flight = job.get("in_flight")
+        if not isinstance(in_flight, dict) or in_flight.get("run_id") != run_id:
+            return False
+
+        job["in_flight"] = None
+        if reason:
+            now_iso = _hermes_now().isoformat()
+            job["last_run_at"] = now_iso
+            job["last_status"] = "error"
+            job["last_error"] = reason
+            job["last_delivery_error"] = None
+            if job.get("schedule", {}).get("kind") == "once":
+                job["next_run_at"] = None
+                job["enabled"] = False
+                if job.get("state") != "paused":
+                    job["state"] = "completed"
+
+        save_jobs(jobs)
+        return True
+
+
+def finalize_job_run(
+    job_id: str,
+    run_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    finished_at: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+) -> bool:
+    """Finalize a run only when run_id still matches the stored owner."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        in_flight = job.get("in_flight")
+        if not isinstance(in_flight, dict) or in_flight.get("run_id") != run_id:
+            return False
+
+        run_at = finished_at or _hermes_now().isoformat()
+        should_remove = _apply_run_outcome(
+            job,
+            success=success,
+            error=error,
+            run_at=run_at,
+            recompute_next_run=False,
+            delivery_error=delivery_error,
+        )
+        job["in_flight"] = None
+
+        if should_remove:
+            jobs.pop(idx)
+        else:
+            jobs[idx] = job
+        save_jobs(jobs)
+        return True
+
+
+def update_delivery_error_if_latest(job_id: str, run_at: str, delivery_error: Optional[str]) -> bool:
+    """Update delivery status only if the recorded run still matches ``run_at``."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        if job.get("last_run_at") != run_at:
+            return False
+
+        job["last_delivery_error"] = delivery_error
+        jobs[idx] = job
+        save_jobs(jobs)
+        return True
+
+
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None):
     """
@@ -778,64 +1519,27 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
     """
     with _jobs_file_lock:
         jobs = load_jobs()
-        for i, job in enumerate(jobs):
-            if job["id"] == job_id:
-                now = _hermes_now().isoformat()
-                job["last_run_at"] = now
-                job["last_status"] = "ok" if success else "error"
-                job["last_error"] = error if not success else None
-                # Track delivery failures separately — cleared on successful delivery
-                job["last_delivery_error"] = delivery_error
-                
-                # Increment completed count
-                if job.get("repeat"):
-                    job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1
-                    
-                    # Check if we've hit the repeat limit
-                    times = job["repeat"].get("times")
-                    completed = job["repeat"]["completed"]
-                    if times is not None and times > 0 and completed >= times:
-                        # Remove the job (limit reached)
-                        jobs.pop(i)
-                        save_jobs(jobs)
-                        return
-                
-                # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+            return
 
-                # If no next run, decide whether this is terminal completion
-                # (one-shot) or a transient failure (recurring schedule couldn't
-                # compute — e.g. 'croniter' missing from the runtime env).
-                # Recurring jobs must NEVER be silently disabled: that turns a
-                # missing runtime dep into "job completed" and the user's
-                # schedule quietly goes off. See issue #16265.
-                if job["next_run_at"] is None:
-                    kind = job.get("schedule", {}).get("kind")
-                    if kind in ("cron", "interval"):
-                        job["state"] = "error"
-                        if not job.get("last_error"):
-                            job["last_error"] = (
-                                "Failed to compute next run for recurring "
-                                "schedule (is the 'croniter' package "
-                                "installed in the gateway's Python env?)"
-                            )
-                        logger.error(
-                            "Job '%s' (%s) could not compute next_run_at; "
-                            "leaving enabled and marking state=error so the "
-                            "job is not silently disabled.",
-                            job.get("name", job["id"]),
-                            kind,
-                        )
-                    else:
-                        job["enabled"] = False
-                        job["state"] = "completed"
-                elif job.get("state") != "paused":
-                    job["state"] = "scheduled"
+        job = jobs[idx]
+        run_at = _hermes_now().isoformat()
+        should_remove = _apply_run_outcome(
+            job,
+            success=success,
+            error=error,
+            run_at=run_at,
+            recompute_next_run=True,
+            delivery_error=delivery_error,
+        )
 
-                save_jobs(jobs)
-                return
-
-        logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+        if should_remove:
+            jobs.pop(idx)
+        else:
+            jobs[idx] = job
+        save_jobs(jobs)
 
 
 def advance_next_run(job_id: str) -> bool:
@@ -876,97 +1580,12 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     immediately.  This prevents a burst of missed jobs on gateway restart.
     """
     with _jobs_file_lock:
-        return _get_due_jobs_locked()
-
-
-def _get_due_jobs_locked() -> List[Dict[str, Any]]:
-    """Inner implementation of get_due_jobs(); must be called with _jobs_file_lock held."""
-    now = _hermes_now()
-    raw_jobs = load_jobs()
-    jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
-    due = []
-    needs_save = False
-
-    for job in jobs:
-        if not job.get("enabled", True):
-            continue
-
-        next_run = job.get("next_run_at")
-        if not next_run:
-            schedule = job.get("schedule", {})
-            kind = schedule.get("kind")
-
-            # One-shot jobs use a small grace window via the dedicated helper.
-            recovered_next = _recoverable_oneshot_run_at(
-                schedule,
-                now,
-                last_run_at=job.get("last_run_at"),
-            )
-            recovery_kind = "one-shot" if recovered_next else None
-
-            # Recurring jobs reach here only when something — typically a
-            # direct jobs.json edit that bypassed add_job() — left
-            # next_run_at unset.  Without this branch, such jobs are
-            # silently skipped forever; recompute next_run_at from the
-            # schedule so they pick up at their next scheduled tick.
-            if not recovered_next and kind in ("cron", "interval"):
-                recovered_next = compute_next_run(schedule, now.isoformat())
-                if recovered_next:
-                    recovery_kind = kind
-
-            if not recovered_next:
-                continue
-
-            job["next_run_at"] = recovered_next
-            next_run = recovered_next
-            logger.info(
-                "Job '%s' had no next_run_at; recovering %s run at %s",
-                job.get("name", job["id"]),
-                recovery_kind,
-                recovered_next,
-            )
-            for rj in raw_jobs:
-                if rj["id"] == job["id"]:
-                    rj["next_run_at"] = recovered_next
-                    needs_save = True
-                    break
-
-        next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
-        if next_run_dt <= now:
-            schedule = job.get("schedule", {})
-            kind = schedule.get("kind")
-
-            # For recurring jobs, check if the scheduled time is stale
-            # (gateway was down and missed the window). Fast-forward to
-            # the next future occurrence instead of firing a stale run.
-            grace = _compute_grace_seconds(schedule)
-            if kind in ("cron", "interval") and (now - next_run_dt).total_seconds() > grace:
-                # Job is past its catch-up grace window — this is a stale missed run.
-                # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
-                new_next = compute_next_run(schedule, now.isoformat())
-                if new_next:
-                    logger.info(
-                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
-                        "Fast-forwarding to next run: %s",
-                        job.get("name", job["id"]),
-                        next_run,
-                        grace,
-                        new_next,
-                    )
-                    # Update the job in storage
-                    for rj in raw_jobs:
-                        if rj["id"] == job["id"]:
-                            rj["next_run_at"] = new_next
-                            needs_save = True
-                            break
-                    continue  # Skip this run
-
-            due.append(job)
-
-    if needs_save:
-        save_jobs(raw_jobs)
-
-    return due
+        now = _hermes_now()
+        raw_jobs = load_jobs()
+        due, needs_save = _collect_due_jobs(raw_jobs, now, skip_in_flight=True)
+        if needs_save:
+            save_jobs(raw_jobs)
+        return due
 
 
 def save_job_output(job_id: str, output: str):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -6,17 +6,20 @@ Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 """
 
 import copy
+import errno
 import json
 import logging
 import tempfile
 import threading
 import os
 import re
+import subprocess
+import sys
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any, Union, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +45,7 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+IN_FLIGHT_TIMEOUT_GRACE_SECONDS = 5
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -317,6 +321,401 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         return next_run.isoformat()
 
     return None
+
+
+def _cron_timeout_seconds() -> float:
+    """Return configured cron timeout in seconds, clamped to a sane minimum."""
+    try:
+        timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
+    except (TypeError, ValueError):
+        timeout = 600.0
+    return max(timeout, 1.0)
+
+
+def _orphan_recovery_grace_seconds() -> float:
+    """Return the orphan-recovery grace window in seconds."""
+    try:
+        value = float(os.getenv("HERMES_CRON_ORPHAN_GRACE_SECONDS", 60))
+    except (TypeError, ValueError):
+        value = 60.0
+    return max(value, 0.0)
+
+
+def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return _ensure_aware(datetime.fromisoformat(value))
+    except Exception:
+        return None
+
+
+def _parse_legacy_owner_pid(owner_instance_id: Optional[str]) -> Optional[int]:
+    if not owner_instance_id:
+        return None
+    match = re.match(r"^(\d+)-", str(owner_instance_id).strip())
+    if not match:
+        return None
+    try:
+        pid = int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def _linux_boot_id() -> Optional[str]:
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        value = Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    return value or None
+
+
+def _darwin_boot_fingerprint() -> Optional[str]:
+    if sys.platform != "darwin":
+        return None
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "kern.boottime"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    output = (result.stdout or "").strip()
+    match = re.search(r"sec\s*=\s*(\d+)\s*,\s*usec\s*=\s*(\d+)", output)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}"
+    compact = re.sub(r"\s+", " ", output)
+    return compact or None
+
+
+def _boot_fingerprint() -> Optional[str]:
+    if sys.platform.startswith("linux"):
+        return _linux_boot_id()
+    if sys.platform == "darwin":
+        return _darwin_boot_fingerprint()
+    return None
+
+
+def _linux_process_state(pid: int) -> Optional[str]:
+    if not sys.platform.startswith("linux") or pid <= 0:
+        return None
+    try:
+        stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    end_idx = stat_text.rfind(")")
+    if end_idx == -1 or len(stat_text) <= end_idx + 2:
+        return None
+    state = stat_text[end_idx + 2 : end_idx + 3]
+    return state or None
+
+
+def _linux_process_start_fingerprint(pid: int) -> Optional[str]:
+    if not sys.platform.startswith("linux") or pid <= 0:
+        return None
+    try:
+        stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    end_idx = stat_text.rfind(")")
+    if end_idx == -1:
+        return None
+
+    fields = stat_text[end_idx + 2 :].split()
+    if len(fields) <= 19:
+        return None
+    return fields[19] or None
+
+
+def _darwin_process_start_fingerprint(pid: int) -> Optional[str]:
+    if sys.platform != "darwin" or pid <= 0:
+        return None
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    output = re.sub(r"\s+", " ", (result.stdout or "").strip())
+    return output or None
+
+
+def _process_start_fingerprint(pid: int) -> Optional[str]:
+    if sys.platform.startswith("linux"):
+        return _linux_process_start_fingerprint(pid)
+    if sys.platform == "darwin":
+        return _darwin_process_start_fingerprint(pid)
+    return None
+
+
+def _pid_is_alive(pid: int) -> Optional[bool]:
+    if pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        alive = True
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
+        if exc.errno == errno.EPERM:
+            alive = True
+        else:
+            return None
+    else:
+        alive = True
+
+    if alive and sys.platform.startswith("linux"):
+        state = _linux_process_state(pid)
+        if state in {"Z", "X", "x"}:
+            return False
+    return alive
+
+
+def _process_identity_matches(
+    pid: int,
+    *,
+    boot_id: Optional[str],
+    process_start: Optional[str],
+) -> Optional[bool]:
+    checked = False
+
+    if boot_id:
+        current_boot_id = _boot_fingerprint()
+        if not current_boot_id:
+            return None
+        checked = True
+        if current_boot_id != boot_id:
+            return False
+
+    if process_start:
+        current_process_start = _process_start_fingerprint(pid)
+        if not current_process_start:
+            return None
+        checked = True
+        if current_process_start != process_start:
+            return False
+
+    if checked and process_start:
+        return True
+    return None
+
+
+def _legacy_owner_pid_is_dead(pid: int) -> bool:
+    return _pid_is_alive(pid) is False
+
+
+def _get_inflight_owner_state(
+    in_flight: Dict[str, Any],
+    now_dt: Optional[datetime] = None,
+) -> Tuple[str, str]:
+    del now_dt
+
+    owner_pid_raw = in_flight.get("owner_pid")
+    try:
+        owner_pid = int(owner_pid_raw) if owner_pid_raw is not None else None
+    except (TypeError, ValueError):
+        owner_pid = None
+
+    if owner_pid and owner_pid > 0:
+        alive = _pid_is_alive(owner_pid)
+        if alive is False:
+            return "dead", f"owner pid {owner_pid} not alive"
+        if alive is True:
+            identity = _process_identity_matches(
+                owner_pid,
+                boot_id=in_flight.get("owner_boot_id"),
+                process_start=in_flight.get("owner_process_start"),
+            )
+            if identity is True:
+                return "alive", f"owner pid {owner_pid} alive and fingerprint matches"
+            if identity is False:
+                return "mismatch", f"owner pid {owner_pid} fingerprint mismatch"
+            return "unknown", f"owner pid {owner_pid} alive but identity could not be confirmed"
+        return "unknown", f"owner pid {owner_pid} liveness unavailable"
+
+    legacy_pid = _parse_legacy_owner_pid(in_flight.get("owner_instance_id"))
+    if legacy_pid is not None:
+        if _legacy_owner_pid_is_dead(legacy_pid):
+            return "dead", f"legacy owner pid {legacy_pid} not alive"
+        return "unknown", f"legacy owner pid {legacy_pid} could not be verified"
+
+    return "unknown", "owner metadata missing or unsupported"
+
+
+def _find_job_index(jobs: List[Dict[str, Any]], job_id: str) -> Optional[int]:
+    for i, job in enumerate(jobs):
+        if job.get("id") == job_id:
+            return i
+    return None
+
+
+def _build_jobs_index(jobs: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {str(job.get("id")): job for job in jobs if job.get("id")}
+
+
+def _apply_run_outcome(
+    job: Dict[str, Any],
+    *,
+    success: bool,
+    error: Optional[str],
+    run_at: str,
+    recompute_next_run: bool,
+    delivery_error: Optional[str] = None,
+) -> bool:
+    """Apply run outcome to a job in-place.
+
+    Returns True when the job should be removed because a repeat limit was hit.
+    """
+    was_paused = job.get("state") == "paused" or not job.get("enabled", True)
+
+    job["last_run_at"] = run_at
+    job["last_status"] = "ok" if success else "error"
+    job["last_error"] = None if success else error
+    job["last_delivery_error"] = delivery_error
+
+    if job.get("repeat"):
+        job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1
+        times = job["repeat"].get("times")
+        completed = job["repeat"]["completed"]
+        if times is not None and times > 0 and completed >= times:
+            return True
+
+    schedule = job.get("schedule", {})
+    kind = schedule.get("kind")
+    if recompute_next_run:
+        next_run = compute_next_run(schedule, run_at)
+    elif kind == "once":
+        next_run = None
+    else:
+        next_run = job.get("next_run_at") or compute_next_run(schedule, run_at)
+
+    job["next_run_at"] = next_run
+    if was_paused:
+        job["enabled"] = False
+        job["state"] = "paused"
+    elif next_run is None:
+        job["enabled"] = False
+        job["state"] = "completed"
+    else:
+        job["state"] = "scheduled"
+
+    return False
+
+
+def _restore_recoverable_next_run(job: Dict[str, Any], in_flight: Dict[str, Any], *, now_iso: str) -> None:
+    """Undo claim-time recurring schedule advancement so recovery can requeue the job."""
+    kind = job.get("schedule", {}).get("kind")
+    if kind not in ("cron", "interval"):
+        return
+
+    claimed_at = in_flight.get("claimed_at")
+    recovered_due = claimed_at if _parse_iso_datetime(claimed_at) else now_iso
+    job["next_run_at"] = recovered_due
+
+
+def _collect_due_jobs(
+    raw_jobs: List[Dict[str, Any]],
+    now: datetime,
+    *,
+    skip_in_flight: bool = True,
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Collect due jobs from raw storage records."""
+    jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
+    due: List[Dict[str, Any]] = []
+    needs_save = False
+    raw_by_id = _build_jobs_index(raw_jobs)
+
+    for job in jobs:
+        manual_trigger_at = job.get("trigger_once_at")
+        manual_trigger_dt = _parse_iso_datetime(manual_trigger_at) if manual_trigger_at else None
+        manual_trigger_due = manual_trigger_dt is not None and manual_trigger_dt <= now
+
+        if not job.get("enabled", True) and not manual_trigger_due:
+            continue
+        if skip_in_flight and job.get("in_flight"):
+            continue
+
+        if manual_trigger_due:
+            raw = raw_by_id.get(job["id"])
+            if raw is not None:
+                raw["trigger_once_at"] = None
+                needs_save = True
+            job["trigger_once_at"] = None
+            due.append(job)
+            continue
+
+        next_run = job.get("next_run_at")
+        if not next_run:
+            recovered_next = _recoverable_oneshot_run_at(
+                job.get("schedule", {}),
+                now,
+                last_run_at=job.get("last_run_at"),
+            )
+            if not recovered_next:
+                continue
+
+            job["next_run_at"] = recovered_next
+            next_run = recovered_next
+            logger.info(
+                "Job '%s' had no next_run_at; recovering one-shot run at %s",
+                job.get("name", job["id"]),
+                recovered_next,
+            )
+            raw = raw_by_id.get(job["id"])
+            if raw is not None:
+                raw["next_run_at"] = recovered_next
+                needs_save = True
+
+        next_run_dt = _parse_iso_datetime(next_run)
+        if not next_run_dt:
+            continue
+
+        if next_run_dt <= now:
+            schedule = job.get("schedule", {})
+            kind = schedule.get("kind")
+
+            grace = _compute_grace_seconds(schedule)
+            if kind in ("cron", "interval") and (now - next_run_dt).total_seconds() > grace:
+                new_next = compute_next_run(schedule, now.isoformat())
+                if new_next:
+                    logger.info(
+                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
+                        "Fast-forwarding to next run: %s",
+                        job.get("name", job["id"]),
+                        next_run,
+                        grace,
+                        new_next,
+                    )
+                    raw = raw_by_id.get(job["id"])
+                    if raw is not None:
+                        raw["next_run_at"] = new_next
+                        needs_save = True
+                    continue
+
+            due.append(job)
+
+    return due, needs_save
 
 
 # =============================================================================
@@ -633,18 +1032,14 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 
 def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
-    """Schedule a job to run on the next scheduler tick."""
+    """Trigger exactly one run on the next scheduler tick without changing pause/resume state."""
     job = get_job(job_id)
     if not job:
         return None
     return update_job(
         job_id,
         {
-            "enabled": True,
-            "state": "scheduled",
-            "paused_at": None,
-            "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
+            "trigger_once_at": _hermes_now().isoformat(),
         },
     )
 
@@ -660,6 +1055,320 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
+def recover_stale_inflight(now: Optional[datetime] = None) -> int:
+    """Recover timed-out or clearly orphaned in-flight runs."""
+    now_dt = now or _hermes_now()
+    now_iso = now_dt.isoformat()
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        recovered = 0
+        needs_save = False
+
+        for idx in range(len(jobs) - 1, -1, -1):
+            job = jobs[idx]
+            in_flight = job.get("in_flight")
+            if not isinstance(in_flight, dict):
+                continue
+
+            timeout_dt = _parse_iso_datetime(in_flight.get("timeout_at"))
+            run_id = in_flight.get("run_id", "unknown")
+            claimed_at_dt = _parse_iso_datetime(in_flight.get("claimed_at"))
+            grace_seconds = _orphan_recovery_grace_seconds()
+            within_grace = (
+                claimed_at_dt is not None
+                and (now_dt - claimed_at_dt).total_seconds() < grace_seconds
+            )
+
+            reason: Optional[str] = None
+            log_message: Optional[str] = None
+            owner_state = "unknown"
+            owner_reason = "owner state not evaluated"
+
+            if timeout_dt is None:
+                owner_state, owner_reason = _get_inflight_owner_state(in_flight, now_dt=now_dt)
+                if owner_state in ("dead", "mismatch") and not within_grace:
+                    reason = f"orphan_recovered: {owner_reason}; run_id={run_id}"
+                    log_message = "Recovering malformed orphaned in-flight run for job '%s' (run_id=%s): %s"
+                elif owner_state == "alive":
+                    logger.warning(
+                        "Keeping malformed in-flight owner for job '%s' (run_id=%s): %s",
+                        job.get("id"),
+                        run_id,
+                        owner_reason,
+                    )
+                elif owner_state == "unknown":
+                    malformed_age_seconds = None
+                    if claimed_at_dt is not None:
+                        malformed_age_seconds = (now_dt - claimed_at_dt).total_seconds()
+                    malformed_stale = (
+                        claimed_at_dt is None
+                        or malformed_age_seconds is None
+                        or malformed_age_seconds >= (_cron_timeout_seconds() + grace_seconds)
+                    )
+                    if malformed_stale:
+                        reason = f"stale_recovered: invalid_timeout_at; run_id={run_id}"
+                        log_message = "Recovering malformed in-flight run for job '%s' (run_id=%s): missing/invalid timeout_at"
+                    else:
+                        logger.warning(
+                            "Deferring malformed in-flight recovery for job '%s' (run_id=%s): %s",
+                            job.get("id"),
+                            run_id,
+                            owner_reason,
+                        )
+                elif within_grace:
+                    logger.debug(
+                        "Malformed owner for job '%s' (run_id=%s) appears %s but remains within grace window",
+                        job.get("id"),
+                        run_id,
+                        owner_state,
+                    )
+            elif timeout_dt <= now_dt:
+                reason = f"stale_recovered: run_id={run_id}"
+                log_message = "Recovering timed-out in-flight run for job '%s' (run_id=%s)"
+            else:
+                owner_state, owner_reason = _get_inflight_owner_state(in_flight, now_dt=now_dt)
+                if owner_state in ("dead", "mismatch") and not within_grace:
+                    reason = f"orphan_recovered: {owner_reason}; run_id={run_id}"
+                    log_message = "Recovering orphaned in-flight run for job '%s' (run_id=%s): %s"
+                elif owner_state == "unknown":
+                    logger.debug(
+                        "Deferring early recovery for job '%s' (run_id=%s): %s",
+                        job.get("id"),
+                        run_id,
+                        owner_reason,
+                    )
+                elif owner_state == "alive":
+                    logger.debug(
+                        "Keeping live in-flight owner for job '%s' (run_id=%s): %s",
+                        job.get("id"),
+                        run_id,
+                        owner_reason,
+                    )
+                elif within_grace:
+                    logger.debug(
+                        "Owner for job '%s' (run_id=%s) appears %s but remains within grace window",
+                        job.get("id"),
+                        run_id,
+                        owner_state,
+                    )
+
+            if reason is None:
+                continue
+
+            if log_message:
+                if log_message.count("%s") >= 3:
+                    logger.warning(log_message, job.get("id"), run_id, reason)
+                else:
+                    logger.warning(log_message, job.get("id"), run_id)
+
+            _restore_recoverable_next_run(job, in_flight, now_iso=now_iso)
+            should_remove = _apply_run_outcome(
+                job,
+                success=False,
+                error=reason,
+                run_at=now_iso,
+                recompute_next_run=False,
+                delivery_error=None,
+            )
+            job["in_flight"] = None
+
+            if should_remove:
+                jobs.pop(idx)
+            else:
+                jobs[idx] = job
+
+            recovered += 1
+            needs_save = True
+
+        if needs_save:
+            save_jobs(jobs)
+
+        return recovered
+
+
+def claim_due_jobs(
+    now: Optional[datetime] = None,
+    owner_instance_id: str = "",
+    max_parallel: int = 1,
+    owner_pid: Optional[int] = None,
+    owner_boot_id: Optional[str] = None,
+    owner_process_start: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Claim due jobs by writing durable in-flight ownership metadata."""
+    now_dt = now or _hermes_now()
+    now_iso = now_dt.isoformat()
+
+    with _jobs_file_lock:
+        raw_jobs = load_jobs()
+        due_jobs, needs_save = _collect_due_jobs(raw_jobs, now_dt, skip_in_flight=True)
+        claimed: List[Dict[str, Any]] = []
+        raw_by_id = _build_jobs_index(raw_jobs)
+
+        try:
+            claim_budget = max(0, int(max_parallel))
+        except (TypeError, ValueError):
+            claim_budget = 1
+
+        if claim_budget <= 0:
+            if needs_save:
+                save_jobs(raw_jobs)
+            return []
+
+        claim_owner_pid = owner_pid if owner_pid is not None else os.getpid()
+        if claim_owner_pid is not None and claim_owner_pid <= 0:
+            claim_owner_pid = None
+        claim_owner_boot_id = owner_boot_id if owner_boot_id is not None else _boot_fingerprint()
+        claim_owner_process_start = owner_process_start
+        if claim_owner_process_start is None and claim_owner_pid is not None:
+            claim_owner_process_start = _process_start_fingerprint(claim_owner_pid)
+
+        timeout_at = (
+            now_dt
+            + timedelta(seconds=_cron_timeout_seconds() + IN_FLIGHT_TIMEOUT_GRACE_SECONDS)
+        ).isoformat()
+
+        for due in due_jobs:
+            if len(claimed) >= claim_budget:
+                break
+            raw = raw_by_id.get(due["id"])
+            if raw is None or raw.get("in_flight"):
+                continue
+
+            run_id = uuid.uuid4().hex
+            raw["in_flight"] = {
+                "run_id": run_id,
+                "owner_instance_id": owner_instance_id,
+                "owner_pid": claim_owner_pid,
+                "owner_boot_id": claim_owner_boot_id,
+                "owner_process_start": claim_owner_process_start,
+                "claimed_at": now_iso,
+                "timeout_at": timeout_at,
+                "started_at": None,
+                "status": "claimed",
+            }
+
+            kind = raw.get("schedule", {}).get("kind")
+            if kind in ("cron", "interval"):
+                advanced_next = compute_next_run(raw["schedule"], now_iso)
+                if advanced_next:
+                    raw["next_run_at"] = advanced_next
+
+            claimed.append(_apply_skill_fields(copy.deepcopy(raw)))
+            needs_save = True
+
+        if needs_save:
+            save_jobs(raw_jobs)
+
+        return claimed
+
+
+def mark_job_started(job_id: str, run_id: str, started_at: Optional[str] = None) -> bool:
+    """Mark an owned in-flight run as actively running."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        in_flight = job.get("in_flight")
+        if not isinstance(in_flight, dict) or in_flight.get("run_id") != run_id:
+            return False
+
+        in_flight["started_at"] = started_at or _hermes_now().isoformat()
+        in_flight["status"] = "running"
+        job["in_flight"] = in_flight
+        save_jobs(jobs)
+        return True
+
+
+def clear_inflight_if_owned(job_id: str, run_id: str, reason: Optional[str] = None) -> bool:
+    """Clear in_flight only when the provided run_id still owns the claim."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        in_flight = job.get("in_flight")
+        if not isinstance(in_flight, dict) or in_flight.get("run_id") != run_id:
+            return False
+
+        job["in_flight"] = None
+        if reason:
+            now_iso = _hermes_now().isoformat()
+            job["last_run_at"] = now_iso
+            job["last_status"] = "error"
+            job["last_error"] = reason
+            job["last_delivery_error"] = None
+            if job.get("schedule", {}).get("kind") == "once":
+                job["next_run_at"] = None
+                job["enabled"] = False
+                if job.get("state") != "paused":
+                    job["state"] = "completed"
+
+        save_jobs(jobs)
+        return True
+
+
+def finalize_job_run(
+    job_id: str,
+    run_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    finished_at: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+) -> bool:
+    """Finalize a run only when run_id still matches the stored owner."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        in_flight = job.get("in_flight")
+        if not isinstance(in_flight, dict) or in_flight.get("run_id") != run_id:
+            return False
+
+        run_at = finished_at or _hermes_now().isoformat()
+        should_remove = _apply_run_outcome(
+            job,
+            success=success,
+            error=error,
+            run_at=run_at,
+            recompute_next_run=False,
+            delivery_error=delivery_error,
+        )
+        job["in_flight"] = None
+
+        if should_remove:
+            jobs.pop(idx)
+        else:
+            jobs[idx] = job
+        save_jobs(jobs)
+        return True
+
+
+def update_delivery_error_if_latest(job_id: str, run_at: str, delivery_error: Optional[str]) -> bool:
+    """Update delivery status only if the recorded run still matches ``run_at``."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            return False
+
+        job = jobs[idx]
+        if job.get("last_run_at") != run_at:
+            return False
+
+        job["last_delivery_error"] = delivery_error
+        jobs[idx] = job
+        save_jobs(jobs)
+        return True
+
+
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None):
     """
@@ -673,42 +1382,27 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
     """
     with _jobs_file_lock:
         jobs = load_jobs()
-        for i, job in enumerate(jobs):
-            if job["id"] == job_id:
-                now = _hermes_now().isoformat()
-                job["last_run_at"] = now
-                job["last_status"] = "ok" if success else "error"
-                job["last_error"] = error if not success else None
-                # Track delivery failures separately — cleared on successful delivery
-                job["last_delivery_error"] = delivery_error
-                
-                # Increment completed count
-                if job.get("repeat"):
-                    job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1
-                    
-                    # Check if we've hit the repeat limit
-                    times = job["repeat"].get("times")
-                    completed = job["repeat"]["completed"]
-                    if times is not None and times > 0 and completed >= times:
-                        # Remove the job (limit reached)
-                        jobs.pop(i)
-                        save_jobs(jobs)
-                        return
-                
-                # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+        idx = _find_job_index(jobs, job_id)
+        if idx is None:
+            logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+            return
 
-                # If no next run (one-shot completed), disable
-                if job["next_run_at"] is None:
-                    job["enabled"] = False
-                    job["state"] = "completed"
-                elif job.get("state") != "paused":
-                    job["state"] = "scheduled"
+        job = jobs[idx]
+        run_at = _hermes_now().isoformat()
+        should_remove = _apply_run_outcome(
+            job,
+            success=success,
+            error=error,
+            run_at=run_at,
+            recompute_next_run=True,
+            delivery_error=delivery_error,
+        )
 
-                save_jobs(jobs)
-                return
-
-        logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+        if should_remove:
+            jobs.pop(idx)
+        else:
+            jobs[idx] = job
+        save_jobs(jobs)
 
 
 def advance_next_run(job_id: str) -> bool:
@@ -748,75 +1442,13 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     the job is fast-forwarded to the next future run instead of firing
     immediately.  This prevents a burst of missed jobs on gateway restart.
     """
-    now = _hermes_now()
-    raw_jobs = load_jobs()
-    jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
-    due = []
-    needs_save = False
-
-    for job in jobs:
-        if not job.get("enabled", True):
-            continue
-
-        next_run = job.get("next_run_at")
-        if not next_run:
-            recovered_next = _recoverable_oneshot_run_at(
-                job.get("schedule", {}),
-                now,
-                last_run_at=job.get("last_run_at"),
-            )
-            if not recovered_next:
-                continue
-
-            job["next_run_at"] = recovered_next
-            next_run = recovered_next
-            logger.info(
-                "Job '%s' had no next_run_at; recovering one-shot run at %s",
-                job.get("name", job["id"]),
-                recovered_next,
-            )
-            for rj in raw_jobs:
-                if rj["id"] == job["id"]:
-                    rj["next_run_at"] = recovered_next
-                    needs_save = True
-                    break
-
-        next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
-        if next_run_dt <= now:
-            schedule = job.get("schedule", {})
-            kind = schedule.get("kind")
-
-            # For recurring jobs, check if the scheduled time is stale
-            # (gateway was down and missed the window). Fast-forward to
-            # the next future occurrence instead of firing a stale run.
-            grace = _compute_grace_seconds(schedule)
-            if kind in ("cron", "interval") and (now - next_run_dt).total_seconds() > grace:
-                # Job is past its catch-up grace window — this is a stale missed run.
-                # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
-                new_next = compute_next_run(schedule, now.isoformat())
-                if new_next:
-                    logger.info(
-                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
-                        "Fast-forwarding to next run: %s",
-                        job.get("name", job["id"]),
-                        next_run,
-                        grace,
-                        new_next,
-                    )
-                    # Update the job in storage
-                    for rj in raw_jobs:
-                        if rj["id"] == job["id"]:
-                            rj["next_run_at"] = new_next
-                            needs_save = True
-                            break
-                    continue  # Skip this run
-
-            due.append(job)
-
-    if needs_save:
-        save_jobs(raw_jobs)
-
-    return due
+    with _jobs_file_lock:
+        now = _hermes_now()
+        raw_jobs = load_jobs()
+        due, needs_save = _collect_due_jobs(raw_jobs, now, skip_in_flight=True)
+        if needs_save:
+            save_jobs(raw_jobs)
+        return due
 
 
 def save_job_output(job_id: str, output: str):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1056,7 +1056,13 @@ def remove_job(job_id: str) -> bool:
 
 
 def recover_stale_inflight(now: Optional[datetime] = None) -> int:
-    """Recover timed-out or clearly orphaned in-flight runs."""
+    """Recover timed-out or clearly orphaned in-flight runs.
+
+    Recovery is intentionally recorded as a failed run attempt: it clears the
+    in-flight claim, stores an error status, and increments repeat accounting.
+    This is conservative for operators because a claimed job may have performed
+    partial side effects before the owner wedged or disappeared.
+    """
     now_dt = now or _hermes_now()
     now_iso = now_dt.isoformat()
     with _jobs_file_lock:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -139,8 +139,11 @@ from cron.jobs import (
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
 
-# Backward-compatible module override used by tests and emergency monkeypatches.
+# Backward-compatible module overrides used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
+_LOCK_DIR: Path | None = None
+_LOCK_FILE: Path | None = None
+_JOB_LOCK_DIR: Path | None = None
 
 def _get_hermes_home() -> Path:
     """Resolve Hermes home dynamically while preserving test monkeypatch hooks."""
@@ -149,12 +152,18 @@ def _get_hermes_home() -> Path:
 
 def _get_lock_paths() -> tuple[Path, Path]:
     """Resolve cron scheduler lock paths at call time so profile/env changes are honored."""
+    if _LOCK_DIR is not None or _LOCK_FILE is not None:
+        lock_dir = _LOCK_DIR or (_LOCK_FILE.parent if _LOCK_FILE is not None else _get_hermes_home() / "cron")
+        lock_file = _LOCK_FILE or lock_dir / ".tick.lock"
+        return lock_dir, lock_file
     lock_dir = _get_hermes_home() / "cron"
     return lock_dir, lock_dir / ".tick.lock"
 
 
 def _get_job_lock_dir() -> Path:
     """Resolve per-job lock directory at call time."""
+    if _JOB_LOCK_DIR is not None:
+        return _JOB_LOCK_DIR
     return _get_hermes_home() / "cron" / "locks"
 
 
@@ -1393,17 +1402,17 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         chat_id="",
         chat_name="",
     )
-    _fallback_cron_env: dict[str, Optional[str]] = {}
-
     def _set_job_context_env(name: str, value: str) -> None:
-        """Set a per-job context var, falling back to env for hot-upgrade safety.
+        """Set a per-job cron delivery ContextVar if the running module has it.
 
-        The parallel scheduler originally reached into session_context._VAR_MAP
-        directly. A long-lived gateway can already have imported an older
-        gateway.session_context module whose _VAR_MAP lacks the newer cron
-        auto-delivery keys. Prefer ContextVars when present; if the running
-        module is older, temporarily use os.environ and restore it in finally
-        so the job works instead of crashing.
+        Cron jobs can run concurrently inside the gateway process. Per-job
+        delivery state must therefore be task/thread-local. If a long-lived
+        gateway has an older already-imported gateway.session_context module
+        that lacks these newer ContextVars, do not fall back to os.environ:
+        process-global env state is exactly what caused cross-job clobbering
+        and cleanup KeyErrors. In that hot-upgrade state, in-run auto-delivery
+        context is unavailable, but final cron delivery still resolves from the
+        concrete job deliver target.
         """
         from gateway import session_context as _session_context
 
@@ -1411,10 +1420,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         if var is not None:
             var.set(value)
             return
-
-        if name not in _fallback_cron_env:
-            _fallback_cron_env[name] = os.environ.get(name)
-        os.environ[name] = value
+        logger.warning(
+            "Job '%s': session_context lacks %s; skipping in-run cron auto-delivery context",
+            job_id,
+            name,
+        )
 
     def _clear_job_context_envs(*names: str) -> None:
         from gateway import session_context as _session_context
@@ -1423,15 +1433,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             var = getattr(_session_context, "_VAR_MAP", {}).get(name)
             if var is not None:
                 var.set("")
-                continue
-            if name in _fallback_cron_env:
-                previous = _fallback_cron_env[name]
-                if previous is None:
-                    os.environ.pop(name, None)
-                else:
-                    os.environ[name] = previous
-            else:
-                os.environ.pop(name, None)
 
 
     # Per-job working directory.  When set (and validated at create/update
@@ -1828,8 +1829,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
         )
         clear_session_vars(_ctx_tokens)
-        for _var_name in _cron_delivery_vars:
-            _VAR_MAP[_var_name].set("")
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1365,7 +1365,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
-    from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
+    from gateway.session_context import set_session_vars, clear_session_vars
 
     # Cron execution is an internal scheduler context, not a live inbound
     # gateway message. Do not seed HERMES_SESSION_* contextvars from the
@@ -1393,13 +1393,46 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         chat_id="",
         chat_name="",
     )
-    _cron_delivery_vars = (
-        "HERMES_CRON_AUTO_DELIVER_PLATFORM",
-        "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
-        "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
-    )
-    for _var_name in _cron_delivery_vars:
-        _VAR_MAP[_var_name].set("")
+    _fallback_cron_env: dict[str, Optional[str]] = {}
+
+    def _set_job_context_env(name: str, value: str) -> None:
+        """Set a per-job context var, falling back to env for hot-upgrade safety.
+
+        The parallel scheduler originally reached into session_context._VAR_MAP
+        directly. A long-lived gateway can already have imported an older
+        gateway.session_context module whose _VAR_MAP lacks the newer cron
+        auto-delivery keys. Prefer ContextVars when present; if the running
+        module is older, temporarily use os.environ and restore it in finally
+        so the job works instead of crashing.
+        """
+        from gateway import session_context as _session_context
+
+        var = getattr(_session_context, "_VAR_MAP", {}).get(name)
+        if var is not None:
+            var.set(value)
+            return
+
+        if name not in _fallback_cron_env:
+            _fallback_cron_env[name] = os.environ.get(name)
+        os.environ[name] = value
+
+    def _clear_job_context_envs(*names: str) -> None:
+        from gateway import session_context as _session_context
+
+        for name in names:
+            var = getattr(_session_context, "_VAR_MAP", {}).get(name)
+            if var is not None:
+                var.set("")
+                continue
+            if name in _fallback_cron_env:
+                previous = _fallback_cron_env[name]
+                if previous is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = previous
+            else:
+                os.environ.pop(name, None)
+
 
     # Per-job working directory.  When set (and validated at create/update
     # time), we point TERMINAL_CWD at it so:
@@ -1434,14 +1467,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except UnicodeDecodeError:
             load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
 
+        _cron_delivery_env_names = (
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        )
+        _clear_job_context_envs(*_cron_delivery_env_names)
+
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
-            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])
-            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"].set(str(delivery_target["chat_id"]))
-            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"].set(
-                ""
-                if delivery_target.get("thread_id") is None
-                else str(delivery_target["thread_id"])
+            _set_job_context_env("HERMES_CRON_AUTO_DELIVER_PLATFORM", delivery_target["platform"])
+            _set_job_context_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID", str(delivery_target["chat_id"]))
+            _set_job_context_env(
+                "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+                str(delivery_target["thread_id"]) if delivery_target.get("thread_id") is not None else "",
             )
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
@@ -1783,6 +1822,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
         # Clean up ContextVar session/delivery state for this job.
+        _clear_job_context_envs(
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        )
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -125,8 +125,6 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 }
 
 from cron.jobs import (
-    _boot_fingerprint,
-    _process_start_fingerprint,
     claim_due_jobs,
     clear_inflight_if_owned,
     finalize_job_run,
@@ -173,8 +171,6 @@ def _current_owner_metadata() -> dict:
     return {
         "owner_instance_id": _INSTANCE_ID,
         "owner_pid": pid,
-        "owner_boot_id": _boot_fingerprint(),
-        "owner_process_start": _process_start_fingerprint(pid),
     }
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -17,6 +17,9 @@ import os
 import shutil
 import subprocess
 import sys
+import threading
+import uuid
+from contextlib import contextmanager
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -121,7 +124,17 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    _boot_fingerprint,
+    _process_start_fingerprint,
+    claim_due_jobs,
+    clear_inflight_if_owned,
+    finalize_job_run,
+    mark_job_started,
+    recover_stale_inflight,
+    save_job_output,
+    update_delivery_error_if_latest,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -131,17 +144,169 @@ SILENT_MARKER = "[SILENT]"
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
 
-
 def _get_hermes_home() -> Path:
     """Resolve Hermes home dynamically while preserving test monkeypatch hooks."""
     return _hermes_home or get_hermes_home()
 
 
 def _get_lock_paths() -> tuple[Path, Path]:
-    """Resolve cron lock paths at call time so profile/env changes are honored."""
-    hermes_home = _get_hermes_home()
-    lock_dir = hermes_home / "cron"
+    """Resolve cron scheduler lock paths at call time so profile/env changes are honored."""
+    lock_dir = _get_hermes_home() / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+def _get_job_lock_dir() -> Path:
+    """Resolve per-job lock directory at call time."""
+    return _get_hermes_home() / "cron" / "locks"
+
+
+_INSTANCE_ID = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
+
+_EXECUTOR_LOCK = threading.Lock()
+_EXECUTOR: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_EXECUTOR_MAX_WORKERS: Optional[int] = 0
+_ACTIVE_FUTURES: set[concurrent.futures.Future] = set()
+
+
+def _current_owner_metadata() -> dict:
+    pid = os.getpid()
+    return {
+        "owner_instance_id": _INSTANCE_ID,
+        "owner_pid": pid,
+        "owner_boot_id": _boot_fingerprint(),
+        "owner_process_start": _process_start_fingerprint(pid),
+    }
+
+
+def _try_acquire_lock_file(path: Path, *, non_blocking: bool) -> Optional[object]:
+    """Acquire a cross-platform file lock, returning an open file handle on success."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fd = open(path, "w", encoding="utf-8")
+    try:
+        if fcntl:
+            mode = fcntl.LOCK_EX | (fcntl.LOCK_NB if non_blocking else 0)
+            fcntl.flock(lock_fd, mode)
+            return lock_fd
+        if msvcrt:
+            mode = msvcrt.LK_NBLCK if non_blocking else msvcrt.LK_LOCK
+            msvcrt.locking(lock_fd.fileno(), mode, 1)
+            return lock_fd
+        return lock_fd
+    except (OSError, IOError):
+        lock_fd.close()
+        return None
+
+
+def _release_lock_file(lock_fd: object) -> None:
+    try:
+        if fcntl:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        elif msvcrt:
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+    finally:
+        lock_fd.close()
+
+
+@contextmanager
+def _scheduler_lock(*, non_blocking: bool):
+    """Context manager for the short global scheduler metadata lock."""
+    _lock_dir, lock_file = _get_lock_paths()
+    _lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_fd = _try_acquire_lock_file(lock_file, non_blocking=non_blocking)
+    if lock_fd is None:
+        yield None
+        return
+    try:
+        yield lock_fd
+    finally:
+        _release_lock_file(lock_fd)
+
+
+def _try_acquire_job_lock(job_id: str) -> Optional[object]:
+    return _try_acquire_lock_file(_get_job_lock_dir() / f"job.{job_id}.lock", non_blocking=True)
+
+
+def _cleanup_done_futures_locked() -> None:
+    done = [future for future in _ACTIVE_FUTURES if future.done()]
+    for future in done:
+        _ACTIVE_FUTURES.discard(future)
+        try:
+            future.result()
+        except Exception as e:
+            logger.error("Cron worker crashed: %s", e)
+
+
+def _active_worker_count() -> int:
+    with _EXECUTOR_LOCK:
+        _cleanup_done_futures_locked()
+        return len(_ACTIVE_FUTURES)
+
+
+def shutdown_worker_pool(*, wait: bool, cancel_futures: bool) -> None:
+    """Shut down the shared cron worker executor safely."""
+    global _EXECUTOR, _EXECUTOR_MAX_WORKERS
+    with _EXECUTOR_LOCK:
+        executor = _EXECUTOR
+        _EXECUTOR = None
+        _EXECUTOR_MAX_WORKERS = 0
+        _ACTIVE_FUTURES.clear()
+    if executor is not None:
+        executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+
+def _get_executor(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
+    global _EXECUTOR, _EXECUTOR_MAX_WORKERS
+    old = None
+    with _EXECUTOR_LOCK:
+        target_workers = None if max_workers is None else max(1, int(max_workers))
+        if _EXECUTOR is None or _EXECUTOR_MAX_WORKERS != target_workers:
+            old = _EXECUTOR
+            if target_workers is None:
+                _EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+                    thread_name_prefix="hermes-cron",
+                )
+            else:
+                _EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=target_workers,
+                    thread_name_prefix="hermes-cron",
+                )
+            _EXECUTOR_MAX_WORKERS = target_workers
+        executor = _EXECUTOR
+    if old is not None:
+        old.shutdown(wait=False, cancel_futures=False)
+    return executor
+
+
+def _register_future(future: concurrent.futures.Future) -> None:
+    with _EXECUTOR_LOCK:
+        _cleanup_done_futures_locked()
+        _ACTIVE_FUTURES.add(future)
+
+
+def _resolve_max_parallel_jobs() -> Optional[int]:
+    """Resolve max parallel workers: env var > config.yaml > unbounded."""
+    raw = None
+    env_value = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
+    if env_value:
+        raw = env_value
+    else:
+        try:
+            cfg = load_config() or {}
+            cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+            raw = cron_cfg.get("max_parallel_jobs")
+        except Exception:
+            raw = None
+
+    if raw in (None, "", 0, "0"):
+        return None
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        logger.warning("Invalid cron.max_parallel_jobs value %r; defaulting to unbounded", raw)
+        return None
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -1654,12 +1819,138 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _save_job_output(job: dict, output: str, verbose: bool) -> Path:
+    """Persist full cron output before finalizing run ownership."""
+    output_file = save_job_output(job["id"], output)
+    if verbose:
+        logger.info("Output saved to: %s", output_file)
+    return output_file
+
+
+def _deliver_job_result(
+    job: dict,
+    success: bool,
+    final_response: str,
+    error: Optional[str],
+    *,
+    adapters=None,
+    loop=None,
+    run_at: Optional[str] = None,
+) -> None:
+    """Best-effort delivery of the final cron response."""
+    deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+    should_deliver = bool(deliver_content)
+    if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+        logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+        should_deliver = False
+
+    delivery_error = None
+    if should_deliver:
+        try:
+            delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+        except Exception as de:
+            delivery_error = str(de)
+            logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+    if run_at is not None:
+        try:
+            update_delivery_error_if_latest(job["id"], run_at, delivery_error)
+        except Exception as exc:
+            logger.warning("Job '%s': failed to persist delivery status: %s", job["id"], exc)
+
+
+def _run_claimed_job(job: dict, verbose: bool, adapters=None, loop=None) -> bool:
+    """Run a previously claimed job with per-job non-overlap and run_id-safe finalization."""
+    job_id = job.get("id")
+    run_id = str((job.get("in_flight") or {}).get("run_id") or "")
+    if not job_id or not run_id:
+        logger.error("Skipping claimed job with missing id/run_id: %s", job)
+        return False
+
+    job_lock_fd = _try_acquire_job_lock(job_id)
+    if job_lock_fd is None:
+        reason = f"aborted: job execution lock busy for {job_id}"
+        logger.error("Job '%s' could not acquire per-job lock; clearing claim if still owned", job_id)
+        with _scheduler_lock(non_blocking=False):
+            clear_inflight_if_owned(job_id, run_id, reason=reason)
+        return False
+
+    try:
+        with _scheduler_lock(non_blocking=False):
+            started = mark_job_started(job_id, run_id, started_at=_hermes_now().isoformat())
+        if not started:
+            logger.warning("Job '%s' run_id=%s lost ownership before start; skipping", job_id, run_id)
+            return False
+
+        success, output, final_response, error = run_job(job)
+
+        if success and not final_response:
+            success = False
+            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+        _save_job_output(job, output, verbose)
+        finished_at = _hermes_now().isoformat()
+
+        with _scheduler_lock(non_blocking=False):
+            finalized = finalize_job_run(job_id, run_id, success, error, finished_at=finished_at)
+
+        if not finalized:
+            logger.warning(
+                "Discarding stale cron completion for job '%s' run_id=%s (ownership changed)",
+                job_id,
+                run_id,
+            )
+            return False
+
+        _deliver_job_result(job, success, final_response, error, adapters=adapters, loop=loop, run_at=finished_at)
+        return True
+
+    except Exception as e:
+        logger.error("Error processing claimed job %s: %s", job_id, e)
+        finished_at = _hermes_now().isoformat()
+        with _scheduler_lock(non_blocking=False):
+            finalize_job_run(job_id, run_id, False, str(e), finished_at=finished_at)
+        return False
+    finally:
+        _release_lock_file(job_lock_fd)
+
+
+def _dispatch_claimed_jobs(
+    claimed_jobs: List[dict],
+    max_parallel_jobs: Optional[int],
+    verbose: bool,
+    adapters=None,
+    loop=None,
+) -> int:
+    if not claimed_jobs:
+        return 0
+
+    # Jobs with a per-job workdir mutate TERMINAL_CWD inside run_job, which is
+    # process-global. Preserve upstream behavior by executing them serially.
+    workdir_jobs = [j for j in claimed_jobs if (j.get("workdir") or "").strip()]
+    parallel_jobs = [j for j in claimed_jobs if not (j.get("workdir") or "").strip()]
+
+    submitted = 0
+    for job in workdir_jobs:
+        contextvars.copy_context().run(_run_claimed_job, job, verbose, adapters, loop)
+        submitted += 1
+
+    if not parallel_jobs:
+        return submitted
+
+    executor = _get_executor(max_parallel_jobs)
+    for job in parallel_jobs:
+        future = executor.submit(_run_claimed_job, job, verbose, adapters, loop)
+        _register_future(future)
+        submitted += 1
+    return submitted
+
+
 def tick(verbose: bool = True, adapters=None, loop=None) -> int:
-    """
-    Check and run all due jobs.
-    
-    Uses a file lock so only one tick runs at a time, even if the gateway's
-    in-process ticker and a standalone daemon or manual tick overlap.
+    """Claim due jobs and dispatch execution workers.
+
+    Uses a short global metadata lock for stale recovery, claiming, and
+    run-state transitions. Job execution happens outside the global lock.
     
     Args:
         verbose: Whether to print status messages
@@ -1667,152 +1958,57 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         loop: Optional asyncio event loop (from gateway) for live adapter sends
     
     Returns:
-        Number of jobs executed (0 if another tick is already running)
+        Number of jobs dispatched (0 if none claimed or lock busy)
     """
-    lock_dir, lock_file = _get_lock_paths()
-    lock_dir.mkdir(parents=True, exist_ok=True)
+    configured_max_parallel = _resolve_max_parallel_jobs()
+    active_workers = _active_worker_count()
 
-    # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
-    lock_fd = None
-    try:
-        lock_fd = open(lock_file, "w", encoding="utf-8")
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        elif msvcrt:
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-    except (OSError, IOError):
-        logger.debug("Tick skipped — another instance holds the lock")
-        if lock_fd is not None:
-            lock_fd.close()
-        return 0
-
-    try:
-        due_jobs = get_due_jobs()
-
-        if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+    if configured_max_parallel is None:
+        available_slots = 1_000_000
+        executor_workers = None
+    else:
+        available_slots = configured_max_parallel - active_workers
+        executor_workers = configured_max_parallel
+        if available_slots <= 0:
+            logger.debug(
+                "Tick skipped — worker pool at capacity (%s/%s active)",
+                active_workers,
+                configured_max_parallel,
+            )
             return 0
 
+    with _scheduler_lock(non_blocking=True) as lock_fd:
+        if lock_fd is None:
+            logger.debug("Tick skipped — another instance holds the scheduler lock")
+            return 0
+
+        now = _hermes_now()
+        recovered = recover_stale_inflight(now=now)
+        owner_metadata = _current_owner_metadata()
+        claimed_jobs = claim_due_jobs(
+            now=now,
+            max_parallel=available_slots,
+            **owner_metadata,
+        )
+
+    if recovered and verbose:
+        logger.info("%s - recovered %s stale in-flight run(s)", _hermes_now().strftime('%H:%M:%S'), recovered)
+
+    if not claimed_jobs:
         if verbose:
-            logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
+            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+        return 0
 
-        # Advance next_run_at for all recurring jobs FIRST, under the file lock,
-        # before any execution begins.  This preserves at-most-once semantics.
-        for job in due_jobs:
-            advance_next_run(job["id"])
-
-        # Resolve max parallel workers: env var > config.yaml > unbounded.
-        # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
-        _max_workers: Optional[int] = None
-        try:
-            _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
-            if _env_par:
-                _max_workers = int(_env_par) or None
-        except (ValueError, TypeError):
-            logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
-        if _max_workers is None:
-            try:
-                _ucfg = load_config() or {}
-                _cfg_par = (
-                    _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
-                ).get("max_parallel_jobs")
-                if _cfg_par is not None:
-                    _max_workers = int(_cfg_par) or None
-            except Exception:
-                pass
-
-        if verbose:
-            logger.info(
-                "Running %d job(s) in parallel (max_workers=%s)",
-                len(due_jobs),
-                _max_workers if _max_workers else "unbounded",
-            )
-
-        def _process_job(job: dict) -> bool:
-            """Run one due job end-to-end: execute, save, deliver, mark."""
-            try:
-                success, output, final_response, error = run_job(job)
-
-                output_file = save_job_output(job["id"], output)
-                if verbose:
-                    logger.info("Output saved to: %s", output_file)
-
-                # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
-                should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                    should_deliver = False
-
-                delivery_error = None
-                if should_deliver:
-                    try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
-                    except Exception as de:
-                        delivery_error = str(de)
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
-
-                # Treat empty final_response as a soft failure so last_status
-                # is not "ok" — the agent ran but produced nothing useful.
-                # (issue #8585)
-                if success and not final_response:
-                    success = False
-                    error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
-
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-                return True
-
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
-                return False
-
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
-        # so they MUST run sequentially to avoid corrupting each other.  Jobs
-        # without a workdir leave env untouched and stay parallel-safe.
-        workdir_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
-
-        _results: list = []
-
-        # Sequential pass for workdir jobs.
-        for job in workdir_jobs:
-            _ctx = contextvars.copy_context()
-            _results.append(_ctx.run(_process_job, job))
-
-        # Parallel pass for the rest — same behaviour as before.
-        if parallel_jobs:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=_max_workers) as _tick_pool:
-                _futures = []
-                for job in parallel_jobs:
-                    _ctx = contextvars.copy_context()
-                    _futures.append(_tick_pool.submit(_ctx.run, _process_job, job))
-                _results.extend(f.result() for f in _futures)
-
-        # Best-effort sweep of MCP stdio subprocesses that survived their
-        # session teardown during this tick.  Runs AFTER every job has
-        # finished so active sessions (including live user chats) are
-        # never touched — only PIDs explicitly detected as orphans in
-        # tools.mcp_tool._run_stdio's finally block are reaped.
-        try:
-            from tools.mcp_tool import _kill_orphaned_mcp_children
-            _kill_orphaned_mcp_children()
-        except Exception as _e:
-            logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
-
-        return sum(_results)
-    finally:
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+    submitted = _dispatch_claimed_jobs(
+        claimed_jobs,
+        executor_workers,
+        verbose,
+        adapters=adapters,
+        loop=loop,
+    )
+    if verbose:
+        logger.info("%s - dispatched %s job(s)", _hermes_now().strftime('%H:%M:%S'), submitted)
+    return submitted
 
 
 if __name__ == "__main__":

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -16,6 +16,9 @@ import logging
 import os
 import subprocess
 import sys
+import threading
+import uuid
+from contextlib import contextmanager
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -107,7 +110,17 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    _boot_fingerprint,
+    _process_start_fingerprint,
+    claim_due_jobs,
+    clear_inflight_if_owned,
+    finalize_job_run,
+    mark_job_started,
+    recover_stale_inflight,
+    save_job_output,
+    update_delivery_error_if_latest,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -120,6 +133,153 @@ _hermes_home = get_hermes_home()
 # File-based lock prevents concurrent ticks from gateway + daemon + systemd timer
 _LOCK_DIR = _hermes_home / "cron"
 _LOCK_FILE = _LOCK_DIR / ".tick.lock"
+_JOB_LOCK_DIR = _LOCK_DIR / "locks"
+_INSTANCE_ID = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
+
+_EXECUTOR_LOCK = threading.Lock()
+_EXECUTOR: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_EXECUTOR_MAX_WORKERS: Optional[int] = 0
+_ACTIVE_FUTURES: set[concurrent.futures.Future] = set()
+
+
+def _current_owner_metadata() -> dict:
+    pid = os.getpid()
+    return {
+        "owner_instance_id": _INSTANCE_ID,
+        "owner_pid": pid,
+        "owner_boot_id": _boot_fingerprint(),
+        "owner_process_start": _process_start_fingerprint(pid),
+    }
+
+
+def _try_acquire_lock_file(path: Path, *, non_blocking: bool) -> Optional[object]:
+    """Acquire a cross-platform file lock, returning an open file handle on success."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fd = open(path, "w")
+    try:
+        if fcntl:
+            mode = fcntl.LOCK_EX | (fcntl.LOCK_NB if non_blocking else 0)
+            fcntl.flock(lock_fd, mode)
+            return lock_fd
+        if msvcrt:
+            mode = msvcrt.LK_NBLCK if non_blocking else msvcrt.LK_LOCK
+            msvcrt.locking(lock_fd.fileno(), mode, 1)
+            return lock_fd
+        return lock_fd
+    except (OSError, IOError):
+        lock_fd.close()
+        return None
+
+
+def _release_lock_file(lock_fd: object) -> None:
+    try:
+        if fcntl:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        elif msvcrt:
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+    finally:
+        lock_fd.close()
+
+
+@contextmanager
+def _scheduler_lock(*, non_blocking: bool):
+    """Context manager for the short global scheduler metadata lock."""
+    _LOCK_DIR.mkdir(parents=True, exist_ok=True)
+    lock_fd = _try_acquire_lock_file(_LOCK_FILE, non_blocking=non_blocking)
+    if lock_fd is None:
+        yield None
+        return
+    try:
+        yield lock_fd
+    finally:
+        _release_lock_file(lock_fd)
+
+
+def _try_acquire_job_lock(job_id: str) -> Optional[object]:
+    return _try_acquire_lock_file(_JOB_LOCK_DIR / f"job.{job_id}.lock", non_blocking=True)
+
+
+def _cleanup_done_futures_locked() -> None:
+    done = [future for future in _ACTIVE_FUTURES if future.done()]
+    for future in done:
+        _ACTIVE_FUTURES.discard(future)
+        try:
+            future.result()
+        except Exception as e:
+            logger.error("Cron worker crashed: %s", e)
+
+
+def _active_worker_count() -> int:
+    with _EXECUTOR_LOCK:
+        _cleanup_done_futures_locked()
+        return len(_ACTIVE_FUTURES)
+
+
+def shutdown_worker_pool(*, wait: bool, cancel_futures: bool) -> None:
+    """Shut down the shared cron worker executor safely."""
+    global _EXECUTOR, _EXECUTOR_MAX_WORKERS
+    with _EXECUTOR_LOCK:
+        executor = _EXECUTOR
+        _EXECUTOR = None
+        _EXECUTOR_MAX_WORKERS = 0
+        _ACTIVE_FUTURES.clear()
+    if executor is not None:
+        executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+
+def _get_executor(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
+    global _EXECUTOR, _EXECUTOR_MAX_WORKERS
+    old = None
+    with _EXECUTOR_LOCK:
+        target_workers = None if max_workers is None else max(1, int(max_workers))
+        if _EXECUTOR is None or _EXECUTOR_MAX_WORKERS != target_workers:
+            old = _EXECUTOR
+            if target_workers is None:
+                _EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+                    thread_name_prefix="hermes-cron",
+                )
+            else:
+                _EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=target_workers,
+                    thread_name_prefix="hermes-cron",
+                )
+            _EXECUTOR_MAX_WORKERS = target_workers
+        executor = _EXECUTOR
+    if old is not None:
+        old.shutdown(wait=False, cancel_futures=False)
+    return executor
+
+
+def _register_future(future: concurrent.futures.Future) -> None:
+    with _EXECUTOR_LOCK:
+        _cleanup_done_futures_locked()
+        _ACTIVE_FUTURES.add(future)
+
+
+def _resolve_max_parallel_jobs() -> Optional[int]:
+    """Resolve max parallel workers: env var > config.yaml > unbounded."""
+    raw = None
+    env_value = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
+    if env_value:
+        raw = env_value
+    else:
+        try:
+            cfg = load_config() or {}
+            cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+            raw = cron_cfg.get("max_parallel_jobs")
+        except Exception:
+            raw = None
+
+    if raw in (None, "", 0, "0"):
+        return None
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        logger.warning("Invalid cron.max_parallel_jobs value %r; defaulting to unbounded", raw)
+        return None
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -1171,12 +1331,138 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
 
 
+def _save_job_output(job: dict, output: str, verbose: bool) -> Path:
+    """Persist full cron output before finalizing run ownership."""
+    output_file = save_job_output(job["id"], output)
+    if verbose:
+        logger.info("Output saved to: %s", output_file)
+    return output_file
+
+
+def _deliver_job_result(
+    job: dict,
+    success: bool,
+    final_response: str,
+    error: Optional[str],
+    *,
+    adapters=None,
+    loop=None,
+    run_at: Optional[str] = None,
+) -> None:
+    """Best-effort delivery of the final cron response."""
+    deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+    should_deliver = bool(deliver_content)
+    if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+        logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+        should_deliver = False
+
+    delivery_error = None
+    if should_deliver:
+        try:
+            delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+        except Exception as de:
+            delivery_error = str(de)
+            logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+    if run_at is not None:
+        try:
+            update_delivery_error_if_latest(job["id"], run_at, delivery_error)
+        except Exception as exc:
+            logger.warning("Job '%s': failed to persist delivery status: %s", job["id"], exc)
+
+
+def _run_claimed_job(job: dict, verbose: bool, adapters=None, loop=None) -> bool:
+    """Run a previously claimed job with per-job non-overlap and run_id-safe finalization."""
+    job_id = job.get("id")
+    run_id = str((job.get("in_flight") or {}).get("run_id") or "")
+    if not job_id or not run_id:
+        logger.error("Skipping claimed job with missing id/run_id: %s", job)
+        return False
+
+    job_lock_fd = _try_acquire_job_lock(job_id)
+    if job_lock_fd is None:
+        reason = f"aborted: job execution lock busy for {job_id}"
+        logger.error("Job '%s' could not acquire per-job lock; clearing claim if still owned", job_id)
+        with _scheduler_lock(non_blocking=False):
+            clear_inflight_if_owned(job_id, run_id, reason=reason)
+        return False
+
+    try:
+        with _scheduler_lock(non_blocking=False):
+            started = mark_job_started(job_id, run_id, started_at=_hermes_now().isoformat())
+        if not started:
+            logger.warning("Job '%s' run_id=%s lost ownership before start; skipping", job_id, run_id)
+            return False
+
+        success, output, final_response, error = run_job(job)
+
+        if success and not final_response:
+            success = False
+            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+        _save_job_output(job, output, verbose)
+        finished_at = _hermes_now().isoformat()
+
+        with _scheduler_lock(non_blocking=False):
+            finalized = finalize_job_run(job_id, run_id, success, error, finished_at=finished_at)
+
+        if not finalized:
+            logger.warning(
+                "Discarding stale cron completion for job '%s' run_id=%s (ownership changed)",
+                job_id,
+                run_id,
+            )
+            return False
+
+        _deliver_job_result(job, success, final_response, error, adapters=adapters, loop=loop, run_at=finished_at)
+        return True
+
+    except Exception as e:
+        logger.error("Error processing claimed job %s: %s", job_id, e)
+        finished_at = _hermes_now().isoformat()
+        with _scheduler_lock(non_blocking=False):
+            finalize_job_run(job_id, run_id, False, str(e), finished_at=finished_at)
+        return False
+    finally:
+        _release_lock_file(job_lock_fd)
+
+
+def _dispatch_claimed_jobs(
+    claimed_jobs: List[dict],
+    max_parallel_jobs: Optional[int],
+    verbose: bool,
+    adapters=None,
+    loop=None,
+) -> int:
+    if not claimed_jobs:
+        return 0
+
+    # Jobs with a per-job workdir mutate TERMINAL_CWD inside run_job, which is
+    # process-global. Preserve upstream behavior by executing them serially.
+    workdir_jobs = [j for j in claimed_jobs if (j.get("workdir") or "").strip()]
+    parallel_jobs = [j for j in claimed_jobs if not (j.get("workdir") or "").strip()]
+
+    submitted = 0
+    for job in workdir_jobs:
+        contextvars.copy_context().run(_run_claimed_job, job, verbose, adapters, loop)
+        submitted += 1
+
+    if not parallel_jobs:
+        return submitted
+
+    executor = _get_executor(max_parallel_jobs)
+    for job in parallel_jobs:
+        future = executor.submit(_run_claimed_job, job, verbose, adapters, loop)
+        _register_future(future)
+        submitted += 1
+    return submitted
+
+
 def tick(verbose: bool = True, adapters=None, loop=None) -> int:
-    """
-    Check and run all due jobs.
-    
-    Uses a file lock so only one tick runs at a time, even if the gateway's
-    in-process ticker and a standalone daemon or manual tick overlap.
+    """Claim due jobs and dispatch execution workers.
+
+    Uses a short global metadata lock for stale recovery, claiming, and
+    run-state transitions. Job execution happens outside the global lock.
     
     Args:
         verbose: Whether to print status messages
@@ -1184,140 +1470,57 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         loop: Optional asyncio event loop (from gateway) for live adapter sends
     
     Returns:
-        Number of jobs executed (0 if another tick is already running)
+        Number of jobs dispatched (0 if none claimed or lock busy)
     """
-    _LOCK_DIR.mkdir(parents=True, exist_ok=True)
+    configured_max_parallel = _resolve_max_parallel_jobs()
+    active_workers = _active_worker_count()
 
-    # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
-    lock_fd = None
-    try:
-        lock_fd = open(_LOCK_FILE, "w")
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        elif msvcrt:
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-    except (OSError, IOError):
-        logger.debug("Tick skipped — another instance holds the lock")
-        if lock_fd is not None:
-            lock_fd.close()
-        return 0
-
-    try:
-        due_jobs = get_due_jobs()
-
-        if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+    if configured_max_parallel is None:
+        available_slots = 1_000_000
+        executor_workers = None
+    else:
+        available_slots = configured_max_parallel - active_workers
+        executor_workers = configured_max_parallel
+        if available_slots <= 0:
+            logger.debug(
+                "Tick skipped — worker pool at capacity (%s/%s active)",
+                active_workers,
+                configured_max_parallel,
+            )
             return 0
 
+    with _scheduler_lock(non_blocking=True) as lock_fd:
+        if lock_fd is None:
+            logger.debug("Tick skipped — another instance holds the scheduler lock")
+            return 0
+
+        now = _hermes_now()
+        recovered = recover_stale_inflight(now=now)
+        owner_metadata = _current_owner_metadata()
+        claimed_jobs = claim_due_jobs(
+            now=now,
+            max_parallel=available_slots,
+            **owner_metadata,
+        )
+
+    if recovered and verbose:
+        logger.info("%s - recovered %s stale in-flight run(s)", _hermes_now().strftime('%H:%M:%S'), recovered)
+
+    if not claimed_jobs:
         if verbose:
-            logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
+            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+        return 0
 
-        # Advance next_run_at for all recurring jobs FIRST, under the file lock,
-        # before any execution begins.  This preserves at-most-once semantics.
-        for job in due_jobs:
-            advance_next_run(job["id"])
-
-        # Resolve max parallel workers: env var > config.yaml > unbounded.
-        # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
-        _max_workers: Optional[int] = None
-        try:
-            _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
-            if _env_par:
-                _max_workers = int(_env_par) or None
-        except (ValueError, TypeError):
-            logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
-        if _max_workers is None:
-            try:
-                _ucfg = load_config() or {}
-                _cfg_par = (
-                    _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
-                ).get("max_parallel_jobs")
-                if _cfg_par is not None:
-                    _max_workers = int(_cfg_par) or None
-            except Exception:
-                pass
-
-        if verbose:
-            logger.info(
-                "Running %d job(s) in parallel (max_workers=%s)",
-                len(due_jobs),
-                _max_workers if _max_workers else "unbounded",
-            )
-
-        def _process_job(job: dict) -> bool:
-            """Run one due job end-to-end: execute, save, deliver, mark."""
-            try:
-                success, output, final_response, error = run_job(job)
-
-                output_file = save_job_output(job["id"], output)
-                if verbose:
-                    logger.info("Output saved to: %s", output_file)
-
-                # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
-                should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                    should_deliver = False
-
-                delivery_error = None
-                if should_deliver:
-                    try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
-                    except Exception as de:
-                        delivery_error = str(de)
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
-
-                # Treat empty final_response as a soft failure so last_status
-                # is not "ok" — the agent ran but produced nothing useful.
-                # (issue #8585)
-                if success and not final_response:
-                    success = False
-                    error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
-
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-                return True
-
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
-                return False
-
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
-        # so they MUST run sequentially to avoid corrupting each other.  Jobs
-        # without a workdir leave env untouched and stay parallel-safe.
-        workdir_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
-
-        _results: list = []
-
-        # Sequential pass for workdir jobs.
-        for job in workdir_jobs:
-            _ctx = contextvars.copy_context()
-            _results.append(_ctx.run(_process_job, job))
-
-        # Parallel pass for the rest — same behaviour as before.
-        if parallel_jobs:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=_max_workers) as _tick_pool:
-                _futures = []
-                for job in parallel_jobs:
-                    _ctx = contextvars.copy_context()
-                    _futures.append(_tick_pool.submit(_ctx.run, _process_job, job))
-                _results.extend(f.result() for f in _futures)
-
-        return sum(_results)
-    finally:
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+    submitted = _dispatch_claimed_jobs(
+        claimed_jobs,
+        executor_workers,
+        verbose,
+        adapters=adapters,
+        loop=loop,
+    )
+    if verbose:
+        logger.info("%s - dispatched %s job(s)", _hermes_now().strftime('%H:%M:%S'), submitted)
+    return submitted
 
 
 if __name__ == "__main__":

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -111,8 +111,6 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 }
 
 from cron.jobs import (
-    _boot_fingerprint,
-    _process_start_fingerprint,
     claim_due_jobs,
     clear_inflight_if_owned,
     finalize_job_run,
@@ -147,8 +145,6 @@ def _current_owner_metadata() -> dict:
     return {
         "owner_instance_id": _INSTANCE_ID,
         "owner_pid": pid,
-        "owner_boot_id": _boot_fingerprint(),
-        "owner_process_start": _process_start_fingerprint(pid),
     }
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -984,13 +984,54 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
-    from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
+    from gateway.session_context import set_session_vars, clear_session_vars
 
     _ctx_tokens = set_session_vars(
         platform=origin["platform"] if origin else "",
         chat_id=str(origin["chat_id"]) if origin else "",
         chat_name=origin.get("chat_name", "") if origin else "",
     )
+    _fallback_cron_env: dict[str, Optional[str]] = {}
+
+    def _set_job_context_env(name: str, value: str) -> None:
+        """Set a per-job context var, falling back to env for hot-upgrade safety.
+
+        The parallel scheduler originally reached into session_context._VAR_MAP
+        directly.  A long-lived gateway can already have imported an older
+        gateway.session_context module whose _VAR_MAP lacks the newer cron
+        auto-delivery keys, while cron.scheduler has been updated on disk.  In
+        that mixed state direct indexing raises KeyError and every affected job
+        fails before the agent starts.  Prefer ContextVars when present; if the
+        running module is older, temporarily use os.environ and restore it in
+        finally so the job works instead of crashing.
+        """
+        from gateway import session_context as _session_context
+
+        var = getattr(_session_context, "_VAR_MAP", {}).get(name)
+        if var is not None:
+            var.set(value)
+            return
+
+        if name not in _fallback_cron_env:
+            _fallback_cron_env[name] = os.environ.get(name)
+        os.environ[name] = value
+
+    def _clear_job_context_envs(*names: str) -> None:
+        from gateway import session_context as _session_context
+
+        for name in names:
+            var = getattr(_session_context, "_VAR_MAP", {}).get(name)
+            if var is not None:
+                var.set("")
+                continue
+            if name in _fallback_cron_env:
+                previous = _fallback_cron_env[name]
+                if previous is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = previous
+            else:
+                os.environ.pop(name, None)
 
     # Per-job working directory.  When set (and validated at create/update
     # time), we point TERMINAL_CWD at it so:
@@ -1025,12 +1066,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except UnicodeDecodeError:
             load_dotenv(str(_hermes_home / ".env"), override=True, encoding="latin-1")
 
+        _cron_delivery_env_names = (
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        )
+        _clear_job_context_envs(*_cron_delivery_env_names)
+
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
-            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])
-            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"].set(str(delivery_target["chat_id"]))
-            if delivery_target.get("thread_id") is not None:
-                _VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"].set(str(delivery_target["thread_id"]))
+            _set_job_context_env("HERMES_CRON_AUTO_DELIVER_PLATFORM", delivery_target["platform"])
+            _set_job_context_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID", str(delivery_target["chat_id"]))
+            _set_job_context_env(
+                "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+                str(delivery_target["thread_id"]) if delivery_target.get("thread_id") is not None else "",
+            )
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
@@ -1315,6 +1365,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
         # Clean up ContextVar session/delivery state for this job.
+        _clear_job_context_envs(
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        )
         clear_session_vars(_ctx_tokens)
         if _session_db:
             try:

--- a/tests/cli/test_cli_stop_command.py
+++ b/tests/cli/test_cli_stop_command.py
@@ -1,0 +1,38 @@
+"""Tests for /stop slash command session scoping."""
+
+from cli import HermesCLI
+
+
+def test_stop_command_stops_only_current_session_processes(monkeypatch, capsys):
+    """Regression: /stop must not kill background jobs from other sessions."""
+    from tools import process_registry as process_registry_module
+
+    calls = {"list": [], "kill": []}
+
+    class _FakeRegistry:
+        def list_sessions(self, task_id=None):
+            calls["list"].append(task_id)
+            # The scoped session has one running process. If the command asks
+            # globally, expose another session too so the old bug is visible.
+            if task_id == "session-a":
+                return [{"status": "running", "session_id": "proc-a"}]
+            return [
+                {"status": "running", "session_id": "proc-a"},
+                {"status": "running", "session_id": "proc-b"},
+            ]
+
+        def kill_all(self, task_id=None):
+            calls["kill"].append(task_id)
+            return 1 if task_id == "session-a" else 2
+
+    monkeypatch.setattr(process_registry_module, "process_registry", _FakeRegistry())
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "session-a"
+
+    cli._handle_stop_command()
+
+    assert calls == {"list": ["session-a"], "kill": ["session-a"]}
+    out = capsys.readouterr().out
+    assert "Stopping 1 background process" in out
+    assert "Stopped 1 process" in out

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -207,41 +207,66 @@ class TestTickWorkdirPartition:
 
     def test_workdir_jobs_run_sequentially(self, tmp_path, monkeypatch):
         import cron.scheduler as sched
-
-        # Two "jobs" — one with workdir, one without.  get_due_jobs returns both.
-        workdir_job = {"id": "a", "name": "A", "workdir": str(tmp_path)}
-        parallel_job = {"id": "b", "name": "B", "workdir": None}
-
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [workdir_job, parallel_job])
-        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
-
-        # Record call order / thread context.
+        import concurrent.futures
         import threading
-        calls: list[tuple[str, bool]] = []
+        from contextlib import contextmanager
+
+        @contextmanager
+        def noop_scheduler_lock(*, non_blocking: bool):
+            yield object()
+
+        workdir_job = {"id": "a", "name": "A", "workdir": str(tmp_path), "in_flight": {"run_id": "run-a"}}
+        parallel_job = {"id": "b", "name": "B", "workdir": None, "in_flight": {"run_id": "run-b"}}
+
+        monkeypatch.setattr(sched, "_scheduler_lock", noop_scheduler_lock)
+        monkeypatch.setattr(sched, "recover_stale_inflight", lambda now=None: 0)
+        monkeypatch.setattr(sched, "claim_due_jobs", lambda **_kw: [workdir_job, parallel_job])
+        monkeypatch.setattr(sched, "_active_worker_count", lambda: 0)
+        monkeypatch.setattr(sched, "_resolve_max_parallel_jobs", lambda: 2)
+        monkeypatch.setattr(sched, "_current_owner_metadata", lambda: {})
+        monkeypatch.setattr(sched, "mark_job_started", lambda *a, **kw: True)
+        monkeypatch.setattr(sched, "finalize_job_run", lambda *a, **kw: True)
+        monkeypatch.setattr(sched, "save_job_output", lambda _jid, _o: None)
+        monkeypatch.setattr(sched, "update_delivery_error_if_latest", lambda *a, **kw: True)
+        monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "_try_acquire_job_lock", lambda _job_id: object())
+        monkeypatch.setattr(sched, "_release_lock_file", lambda _fd: None)
+        monkeypatch.setattr(sched, "_register_future", lambda _future: None)
+
+        calls: list[tuple[str, str]] = []
 
         def fake_run_job(job):
-            # Return a minimal tuple matching run_job's signature.
             calls.append((job["id"], threading.current_thread().name))
             return True, "output", "response", None
 
         monkeypatch.setattr(sched, "run_job", fake_run_job)
-        monkeypatch.setattr(sched, "save_job_output", lambda _jid, _o: None)
-        monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
-        monkeypatch.setattr(
-            sched, "_deliver_result", lambda *_a, **_kw: None
-        )
+
+        class ImmediateExecutor:
+            def submit(self, fn, *args, **kwargs):
+                fut = concurrent.futures.Future()
+                def runner():
+                    try:
+                        fut.set_result(fn(*args, **kwargs))
+                    except BaseException as exc:
+                        fut.set_exception(exc)
+                t = threading.Thread(target=runner, name="parallel-worker")
+                t.start()
+                t.join(timeout=1.0)
+                return fut
+
+        monkeypatch.setattr(sched, "_get_executor", lambda _max_workers: ImmediateExecutor())
 
         n = sched.tick(verbose=False)
         assert n == 2
 
         ids = [c[0] for c in calls]
-        # Workdir jobs always come before parallel jobs.
         assert ids.index("a") < ids.index("b")
 
-        # The workdir job must run on the main thread (sequential pass).
         main_thread_name = threading.current_thread().name
         workdir_thread_name = next(t for jid, t in calls if jid == "a")
+        parallel_thread_name = next(t for jid, t in calls if jid == "b")
         assert workdir_thread_name == main_thread_name
+        assert parallel_thread_name != main_thread_name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -19,11 +19,19 @@ from cron.jobs import (
     update_job,
     pause_job,
     resume_job,
+    trigger_job,
     remove_job,
+    mark_job_started,
+    finalize_job_run,
     mark_job_run,
     advance_next_run,
     get_due_jobs,
+    claim_due_jobs,
+    recover_stale_inflight,
     save_job_output,
+    update_delivery_error_if_latest,
+    _get_inflight_owner_state,
+    _pid_is_alive,
 )
 
 
@@ -319,6 +327,38 @@ class TestPauseResumeJob:
         assert resumed["state"] == "scheduled"
         assert resumed["paused_at"] is None
         assert resumed["paused_reason"] is None
+
+    def test_trigger_job_keeps_paused_state(self, tmp_cron_dir):
+        job = create_job(prompt="Trigger me", schedule="every 1h")
+        pause_job(job["id"], reason="user paused")
+
+        triggered = trigger_job(job["id"])
+
+        assert triggered is not None
+        assert triggered["enabled"] is False
+        assert triggered["state"] == "paused"
+        assert triggered["trigger_once_at"] is not None
+
+    def test_triggered_paused_job_finishes_and_remains_paused(self, tmp_cron_dir):
+        job = create_job(prompt="Trigger me", schedule="every 1h")
+        pause_job(job["id"], reason="user paused")
+        trigger_job(job["id"])
+
+        from cron.jobs import _hermes_now
+        claimed = claim_due_jobs(now=_hermes_now(), owner_instance_id="instance-a", max_parallel=1)
+        assert len(claimed) == 1
+        run_id = claimed[0]["in_flight"]["run_id"]
+        finished_at = _hermes_now().isoformat()
+
+        assert mark_job_started(job["id"], run_id, started_at=finished_at) is True
+        assert finalize_job_run(job["id"], run_id, True, finished_at=finished_at) is True
+
+        completed = get_job(job["id"])
+        assert completed is not None
+        assert completed["state"] == "paused"
+        assert completed["enabled"] is False
+        assert completed["in_flight"] is None
+        assert completed["last_status"] == "ok"
 
 
 class TestMarkJobRun:
@@ -858,6 +898,205 @@ class TestMarkJobRunConcurrency:
             assert updated["repeat"]["completed"] == 1, (
                 f"Job {job['id']} completed count is {updated['repeat']['completed']}, expected 1"
             )
+class TestDeliveryStatusUpdates:
+    def test_update_delivery_error_if_latest_updates_matching_run(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True, delivery_error=None)
+        run_at = get_job(job["id"])["last_run_at"]
+
+        assert update_delivery_error_if_latest(job["id"], run_at, "telegram down") is True
+        assert get_job(job["id"])["last_delivery_error"] == "telegram down"
+
+    def test_update_delivery_error_if_latest_rejects_stale_run(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True, delivery_error=None)
+        first_run_at = get_job(job["id"])["last_run_at"]
+
+        mark_job_run(job["id"], success=True, delivery_error="current failure")
+
+        assert update_delivery_error_if_latest(job["id"], first_run_at, "stale overwrite") is False
+        assert get_job(job["id"])["last_delivery_error"] == "current failure"
+
+
+class TestInFlightOwnership:
+    def _make_due_job(self, now, prompt="Due", repeat=None):
+        job = create_job(prompt=prompt, schedule="every 1h", repeat=repeat)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (now - timedelta(minutes=5)).isoformat()
+        save_jobs(jobs)
+        return job
+
+    def test_claim_due_jobs_records_owner_and_prevents_second_claim(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+
+        claimed = claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+        assert [entry["id"] for entry in claimed] == [job["id"]]
+
+        persisted = get_job(job["id"])
+        assert persisted["in_flight"]["run_id"]
+        assert persisted["in_flight"]["owner_instance_id"] == "instance-a"
+        assert persisted["in_flight"]["owner_pid"] > 0
+        assert persisted["in_flight"]["status"] == "claimed"
+
+        assert claim_due_jobs(now=now, owner_instance_id="instance-b", max_parallel=1) == []
+
+    def test_finalize_rejects_stale_run_id(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+
+        claimed = claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+        run_id = claimed[0]["in_flight"]["run_id"]
+
+        assert finalize_job_run(job["id"], "old-run", True, finished_at=now.isoformat()) is False
+        still_owned = get_job(job["id"])
+        assert still_owned["in_flight"]["run_id"] == run_id
+        assert still_owned["last_status"] is None
+
+        assert finalize_job_run(job["id"], run_id, True, finished_at=now.isoformat()) is True
+        assert get_job(job["id"])["in_flight"] is None
+
+    def test_timeout_recovery_restores_recurring_slot_to_claim_time(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+
+        claimed = claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+        claimed_at = claimed[0]["in_flight"]["claimed_at"]
+        timeout_at = datetime.fromisoformat(get_job(job["id"])["in_flight"]["timeout_at"])
+
+        assert recover_stale_inflight(now=timeout_at + timedelta(seconds=1)) == 1
+
+        updated = get_job(job["id"])
+        assert updated["in_flight"] is None
+        assert updated["last_status"] == "error"
+        assert updated["next_run_at"] == claimed_at
+        assert "stale_recovered" in updated["last_error"]
+
+    def test_orphan_recovery_waits_for_grace_window(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+
+        monkeypatch.setattr(
+            "cron.jobs._get_inflight_owner_state",
+            lambda inflight, now_dt=None: ("dead", "owner pid not alive"),
+        )
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 60.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=30)) == 0
+        assert get_job(job["id"])["in_flight"] is not None
+        assert recover_stale_inflight(now=now + timedelta(seconds=61)) == 1
+        assert get_job(job["id"])["in_flight"] is None
+
+    def test_legacy_owner_instance_id_pid_can_be_recovered_early(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="43210-legacyaa", max_parallel=1)
+
+        jobs = load_jobs()
+        jobs[0]["in_flight"] = {
+            "run_id": jobs[0]["in_flight"]["run_id"],
+            "owner_instance_id": "43210-legacyaa",
+            "claimed_at": jobs[0]["in_flight"]["claimed_at"],
+            "timeout_at": jobs[0]["in_flight"]["timeout_at"],
+            "started_at": jobs[0]["in_flight"]["started_at"],
+            "status": jobs[0]["in_flight"]["status"],
+        }
+        save_jobs(jobs)
+
+        monkeypatch.setattr("cron.jobs._legacy_owner_pid_is_dead", lambda pid: True)
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 30.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=90)) == 1
+        assert get_job(job["id"])["in_flight"] is None
+
+    def test_malformed_owner_does_not_guess_before_timeout(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+
+        jobs = load_jobs()
+        jobs[0]["in_flight"] = {
+            "run_id": jobs[0]["in_flight"]["run_id"],
+            "owner_instance_id": "weird-format",
+            "claimed_at": jobs[0]["in_flight"]["claimed_at"],
+            "timeout_at": jobs[0]["in_flight"]["timeout_at"],
+            "started_at": jobs[0]["in_flight"]["started_at"],
+            "status": jobs[0]["in_flight"]["status"],
+        }
+        save_jobs(jobs)
+
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 30.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=90)) == 0
+        timeout_at = datetime.fromisoformat(get_job(job["id"])["in_flight"]["timeout_at"])
+        assert recover_stale_inflight(now=timeout_at + timedelta(seconds=1)) == 1
+
+    def test_owner_fingerprint_mismatch_is_recovered_before_timeout(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+
+        monkeypatch.setattr(
+            "cron.jobs._get_inflight_owner_state",
+            lambda inflight, now_dt=None: ("mismatch", "owner pid fingerprint mismatch"),
+        )
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 30.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=90)) == 1
+        updated = get_job(job["id"])
+        assert updated["in_flight"] is None
+        assert "orphan_recovered" in updated["last_error"]
+
+
+class TestOwnerLivenessHelpers:
+    def test_pid_is_alive_treats_linux_zombie_as_dead(self, monkeypatch):
+        monkeypatch.setattr("cron.jobs.sys.platform", "linux")
+        monkeypatch.setattr("cron.jobs.os.kill", lambda pid, sig: None)
+        monkeypatch.setattr("cron.jobs._linux_process_state", lambda pid: "Z")
+
+        assert _pid_is_alive(12345) is False
+
+    def test_get_inflight_owner_state_on_darwin_confirms_matching_identity(self, monkeypatch):
+        monkeypatch.setattr("cron.jobs.sys.platform", "darwin")
+        monkeypatch.setattr("cron.jobs.os.kill", lambda pid, sig: None)
+        monkeypatch.setattr("cron.jobs._darwin_boot_fingerprint", lambda: "boot-1")
+        monkeypatch.setattr("cron.jobs._darwin_process_start_fingerprint", lambda pid: "start-1")
+
+        state, reason = _get_inflight_owner_state(
+            {
+                "owner_pid": 12345,
+                "owner_boot_id": "boot-1",
+                "owner_process_start": "start-1",
+            }
+        )
+
+        assert state == "alive"
+        assert "fingerprint matches" in reason
+
+    def test_get_inflight_owner_state_on_darwin_detects_pid_reuse(self, monkeypatch):
+        monkeypatch.setattr("cron.jobs.sys.platform", "darwin")
+        monkeypatch.setattr("cron.jobs.os.kill", lambda pid, sig: None)
+        monkeypatch.setattr("cron.jobs._darwin_boot_fingerprint", lambda: "boot-1")
+        monkeypatch.setattr("cron.jobs._darwin_process_start_fingerprint", lambda pid: "start-2")
+
+        state, reason = _get_inflight_owner_state(
+            {
+                "owner_pid": 12345,
+                "owner_boot_id": "boot-1",
+                "owner_process_start": "start-1",
+            }
+        )
+
+        assert state == "mismatch"
+        assert "fingerprint mismatch" in reason
 
 
 class TestSaveJobOutput:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -18,11 +18,19 @@ from cron.jobs import (
     update_job,
     pause_job,
     resume_job,
+    trigger_job,
     remove_job,
+    mark_job_started,
+    finalize_job_run,
     mark_job_run,
     advance_next_run,
     get_due_jobs,
+    claim_due_jobs,
+    recover_stale_inflight,
     save_job_output,
+    update_delivery_error_if_latest,
+    _get_inflight_owner_state,
+    _pid_is_alive,
 )
 
 
@@ -298,6 +306,38 @@ class TestPauseResumeJob:
         assert resumed["state"] == "scheduled"
         assert resumed["paused_at"] is None
         assert resumed["paused_reason"] is None
+
+    def test_trigger_job_keeps_paused_state(self, tmp_cron_dir):
+        job = create_job(prompt="Trigger me", schedule="every 1h")
+        pause_job(job["id"], reason="user paused")
+
+        triggered = trigger_job(job["id"])
+
+        assert triggered is not None
+        assert triggered["enabled"] is False
+        assert triggered["state"] == "paused"
+        assert triggered["trigger_once_at"] is not None
+
+    def test_triggered_paused_job_finishes_and_remains_paused(self, tmp_cron_dir):
+        job = create_job(prompt="Trigger me", schedule="every 1h")
+        pause_job(job["id"], reason="user paused")
+        trigger_job(job["id"])
+
+        from cron.jobs import _hermes_now
+        claimed = claim_due_jobs(now=_hermes_now(), owner_instance_id="instance-a", max_parallel=1)
+        assert len(claimed) == 1
+        run_id = claimed[0]["in_flight"]["run_id"]
+        finished_at = _hermes_now().isoformat()
+
+        assert mark_job_started(job["id"], run_id, started_at=finished_at) is True
+        assert finalize_job_run(job["id"], run_id, True, finished_at=finished_at) is True
+
+        completed = get_job(job["id"])
+        assert completed is not None
+        assert completed["state"] == "paused"
+        assert completed["enabled"] is False
+        assert completed["in_flight"] is None
+        assert completed["last_status"] == "ok"
 
 
 class TestMarkJobRun:
@@ -593,6 +633,207 @@ class TestEnabledToolsets:
         update_job(job["id"], {"enabled_toolsets": ["web", "delegation"]})
         fetched = get_job(job["id"])
         assert fetched["enabled_toolsets"] == ["web", "delegation"]
+
+
+class TestDeliveryStatusUpdates:
+    def test_update_delivery_error_if_latest_updates_matching_run(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True, delivery_error=None)
+        run_at = get_job(job["id"])["last_run_at"]
+
+        assert update_delivery_error_if_latest(job["id"], run_at, "telegram down") is True
+        assert get_job(job["id"])["last_delivery_error"] == "telegram down"
+
+    def test_update_delivery_error_if_latest_rejects_stale_run(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True, delivery_error=None)
+        first_run_at = get_job(job["id"])["last_run_at"]
+
+        mark_job_run(job["id"], success=True, delivery_error="current failure")
+
+        assert update_delivery_error_if_latest(job["id"], first_run_at, "stale overwrite") is False
+        assert get_job(job["id"])["last_delivery_error"] == "current failure"
+
+
+class TestInFlightOwnership:
+    def _make_due_job(self, now, prompt="Due", repeat=None):
+        job = create_job(prompt=prompt, schedule="every 1h", repeat=repeat)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (now - timedelta(minutes=5)).isoformat()
+        save_jobs(jobs)
+        return job
+
+    def test_claim_due_jobs_records_owner_and_prevents_second_claim(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+
+        claimed = claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+        assert [entry["id"] for entry in claimed] == [job["id"]]
+
+        persisted = get_job(job["id"])
+        assert persisted["in_flight"]["run_id"]
+        assert persisted["in_flight"]["owner_instance_id"] == "instance-a"
+        assert persisted["in_flight"]["owner_pid"] > 0
+        assert persisted["in_flight"]["status"] == "claimed"
+
+        assert claim_due_jobs(now=now, owner_instance_id="instance-b", max_parallel=1) == []
+
+    def test_finalize_rejects_stale_run_id(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+
+        claimed = claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+        run_id = claimed[0]["in_flight"]["run_id"]
+
+        assert finalize_job_run(job["id"], "old-run", True, finished_at=now.isoformat()) is False
+        still_owned = get_job(job["id"])
+        assert still_owned["in_flight"]["run_id"] == run_id
+        assert still_owned["last_status"] is None
+
+        assert finalize_job_run(job["id"], run_id, True, finished_at=now.isoformat()) is True
+        assert get_job(job["id"])["in_flight"] is None
+
+    def test_timeout_recovery_restores_recurring_slot_to_claim_time(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+
+        claimed = claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+        claimed_at = claimed[0]["in_flight"]["claimed_at"]
+        timeout_at = datetime.fromisoformat(get_job(job["id"])["in_flight"]["timeout_at"])
+
+        assert recover_stale_inflight(now=timeout_at + timedelta(seconds=1)) == 1
+
+        updated = get_job(job["id"])
+        assert updated["in_flight"] is None
+        assert updated["last_status"] == "error"
+        assert updated["next_run_at"] == claimed_at
+        assert "stale_recovered" in updated["last_error"]
+
+    def test_orphan_recovery_waits_for_grace_window(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+
+        monkeypatch.setattr(
+            "cron.jobs._get_inflight_owner_state",
+            lambda inflight, now_dt=None: ("dead", "owner pid not alive"),
+        )
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 60.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=30)) == 0
+        assert get_job(job["id"])["in_flight"] is not None
+        assert recover_stale_inflight(now=now + timedelta(seconds=61)) == 1
+        assert get_job(job["id"])["in_flight"] is None
+
+    def test_legacy_owner_instance_id_pid_can_be_recovered_early(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="43210-legacyaa", max_parallel=1)
+
+        jobs = load_jobs()
+        jobs[0]["in_flight"] = {
+            "run_id": jobs[0]["in_flight"]["run_id"],
+            "owner_instance_id": "43210-legacyaa",
+            "claimed_at": jobs[0]["in_flight"]["claimed_at"],
+            "timeout_at": jobs[0]["in_flight"]["timeout_at"],
+            "started_at": jobs[0]["in_flight"]["started_at"],
+            "status": jobs[0]["in_flight"]["status"],
+        }
+        save_jobs(jobs)
+
+        monkeypatch.setattr("cron.jobs._legacy_owner_pid_is_dead", lambda pid: True)
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 30.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=90)) == 1
+        assert get_job(job["id"])["in_flight"] is None
+
+    def test_malformed_owner_does_not_guess_before_timeout(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+
+        jobs = load_jobs()
+        jobs[0]["in_flight"] = {
+            "run_id": jobs[0]["in_flight"]["run_id"],
+            "owner_instance_id": "weird-format",
+            "claimed_at": jobs[0]["in_flight"]["claimed_at"],
+            "timeout_at": jobs[0]["in_flight"]["timeout_at"],
+            "started_at": jobs[0]["in_flight"]["started_at"],
+            "status": jobs[0]["in_flight"]["status"],
+        }
+        save_jobs(jobs)
+
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 30.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=90)) == 0
+        timeout_at = datetime.fromisoformat(get_job(job["id"])["in_flight"]["timeout_at"])
+        assert recover_stale_inflight(now=timeout_at + timedelta(seconds=1)) == 1
+
+    def test_owner_fingerprint_mismatch_is_recovered_before_timeout(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = self._make_due_job(now)
+        claim_due_jobs(now=now, owner_instance_id="instance-a", max_parallel=1)
+
+        monkeypatch.setattr(
+            "cron.jobs._get_inflight_owner_state",
+            lambda inflight, now_dt=None: ("mismatch", "owner pid fingerprint mismatch"),
+        )
+        monkeypatch.setattr("cron.jobs._orphan_recovery_grace_seconds", lambda: 30.0)
+
+        assert recover_stale_inflight(now=now + timedelta(seconds=90)) == 1
+        updated = get_job(job["id"])
+        assert updated["in_flight"] is None
+        assert "orphan_recovered" in updated["last_error"]
+
+
+class TestOwnerLivenessHelpers:
+    def test_pid_is_alive_treats_linux_zombie_as_dead(self, monkeypatch):
+        monkeypatch.setattr("cron.jobs.sys.platform", "linux")
+        monkeypatch.setattr("cron.jobs.os.kill", lambda pid, sig: None)
+        monkeypatch.setattr("cron.jobs._linux_process_state", lambda pid: "Z")
+
+        assert _pid_is_alive(12345) is False
+
+    def test_get_inflight_owner_state_on_darwin_confirms_matching_identity(self, monkeypatch):
+        monkeypatch.setattr("cron.jobs.sys.platform", "darwin")
+        monkeypatch.setattr("cron.jobs.os.kill", lambda pid, sig: None)
+        monkeypatch.setattr("cron.jobs._darwin_boot_fingerprint", lambda: "boot-1")
+        monkeypatch.setattr("cron.jobs._darwin_process_start_fingerprint", lambda pid: "start-1")
+
+        state, reason = _get_inflight_owner_state(
+            {
+                "owner_pid": 12345,
+                "owner_boot_id": "boot-1",
+                "owner_process_start": "start-1",
+            }
+        )
+
+        assert state == "alive"
+        assert "fingerprint matches" in reason
+
+    def test_get_inflight_owner_state_on_darwin_detects_pid_reuse(self, monkeypatch):
+        monkeypatch.setattr("cron.jobs.sys.platform", "darwin")
+        monkeypatch.setattr("cron.jobs.os.kill", lambda pid, sig: None)
+        monkeypatch.setattr("cron.jobs._darwin_boot_fingerprint", lambda: "boot-1")
+        monkeypatch.setattr("cron.jobs._darwin_process_start_fingerprint", lambda pid: "start-2")
+
+        state, reason = _get_inflight_owner_state(
+            {
+                "owner_pid": 12345,
+                "owner_boot_id": "boot-1",
+                "owner_process_start": "start-1",
+            }
+        )
+
+        assert state == "mismatch"
+        assert "fingerprint mismatch" in reason
 
 
 class TestSaveJobOutput:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1439,13 +1439,90 @@ class TestRunJobSessionPersistence:
         assert final_response == "ok"
         assert "ok" in output
         assert seen == {
-            "platform": "telegram",
-            "chat_id": "-2002",
+            "platform": None,
+            "chat_id": None,
             "thread_id": None,
         }
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        fake_db.close.assert_called_once()
+
+    def test_run_job_does_not_clobber_process_env_when_auto_delivery_contextvars_missing(self, tmp_path, monkeypatch):
+        """Hot-upgraded cron must not use process-global env as per-job delivery state.
+
+        In the gateway, cron jobs run in a shared process.  If the imported
+        session_context module is old and lacks the cron ContextVars, falling
+        back to os.environ both leaks per-job state across jobs and lets cleanup
+        race with other jobs.  The safe behavior is to skip in-run auto-delivery
+        context for that mixed import state, while still allowing final cron
+        delivery to use the concrete job target.
+        """
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "deliver": "telegram",
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        (tmp_path / ".env").write_text("TELEGRAM_HOME_CHANNEL=-2002\n")
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", "sibling-platform")
+        monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "sibling-chat")
+        monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "sibling-thread")
+
+        from gateway import session_context
+
+        removed = {}
+        for name in (
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        ):
+            removed[name] = session_context._VAR_MAP.pop(name)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+                seen["platform"] = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None
+                seen["chat_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None
+                seen["thread_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None
+                return {"final_response": "ok"}
+
+        try:
+            with patch("cron.scheduler._hermes_home", tmp_path), \
+                 patch("hermes_state.SessionDB", return_value=fake_db), \
+                 patch(
+                     "hermes_cli.runtime_provider.resolve_runtime_provider",
+                     return_value={
+                         "api_key": "***",
+                         "base_url": "https://example.invalid/v1",
+                         "provider": "openrouter",
+                         "api_mode": "chat_completions",
+                     },
+                 ), \
+                 patch("run_agent.AIAgent", FakeAgent):
+                success, output, final_response, error = run_job(job)
+        finally:
+            session_context._VAR_MAP.update(removed)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {
+            "platform": "sibling-platform",
+            "chat_id": "sibling-chat",
+            "thread_id": "sibling-thread",
+        }
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") == "sibling-platform"
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") == "sibling-chat"
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") == "sibling-thread"
         fake_db.close.assert_called_once()
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,13 +3,70 @@
 import json
 import logging
 import os
+import threading
+import time
+from contextlib import contextmanager
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
+import cron.scheduler as scheduler
+from cron.jobs import create_job, load_jobs, save_jobs
 from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+@pytest.fixture()
+def cron_runtime(tmp_path, monkeypatch):
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr("cron.jobs.CRON_DIR", cron_dir)
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr("cron.scheduler._LOCK_DIR", cron_dir)
+    monkeypatch.setattr("cron.scheduler._LOCK_FILE", cron_dir / ".tick.lock")
+    monkeypatch.setattr("cron.scheduler._JOB_LOCK_DIR", cron_dir / "locks")
+
+    scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
+    yield cron_dir
+    scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
+
+
+def _wait_for_cron_workers(timeout_s: float = 2.5) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if scheduler._active_worker_count() == 0:
+            return
+        time.sleep(0.01)
+    raise AssertionError("Timed out waiting for cron workers to finish")
+
+
+@contextmanager
+def _noop_scheduler_lock(*, non_blocking: bool):
+    yield object()
+
+
+class TestSchedulerOwnershipMetadata:
+    def test_current_owner_metadata_uses_generic_fingerprints(self, monkeypatch):
+        monkeypatch.setattr("cron.scheduler.os.getpid", lambda: 4242)
+        monkeypatch.setattr("cron.scheduler._boot_fingerprint", lambda: "boot-generic")
+        monkeypatch.setattr("cron.scheduler._process_start_fingerprint", lambda pid: f"start-{pid}")
+
+        assert scheduler._current_owner_metadata() == {
+            "owner_instance_id": scheduler._INSTANCE_ID,
+            "owner_pid": 4242,
+            "owner_boot_id": "boot-generic",
+            "owner_process_start": "start-4242",
+        }
+
+    def test_get_executor_none_uses_default_pool_size(self, cron_runtime):
+        executor = scheduler._get_executor(None)
+        try:
+            assert executor is not None
+            assert scheduler._EXECUTOR_MAX_WORKERS is None
+        finally:
+            scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
 
 
 class TestResolveOrigin:
@@ -1173,40 +1230,30 @@ class TestRunJobSessionPersistence:
 
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
-        tick() should mark the job as error so last_status != 'ok'.
+        claimed-run finalization should mark the job as error so last_status != 'ok'.
         (issue #8585)
         """
-        from cron.scheduler import tick
-        from cron.jobs import load_jobs, save_jobs
-
         job = {
             "id": "empty-job",
             "name": "empty-test",
             "prompt": "do something",
-            "schedule": "every 1h",
-            "enabled": True,
-            "next_run_at": "2020-01-01T00:00:00",
             "deliver": "local",
-            "last_status": None,
+            "in_flight": {"run_id": "run-empty"},
         }
 
-        fake_db = MagicMock()
-
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
-             patch("cron.scheduler.advance_next_run"), \
-             patch("cron.scheduler.mark_job_run") as mock_mark, \
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.finalize_job_run") as finalize_mock, \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
-            tick(verbose=False)
+            assert scheduler._run_claimed_job(job, verbose=False) is True
 
-        # Should be called with success=False because final_response is empty
-        mock_mark.assert_called_once()
-        call_args = mock_mark.call_args
-        assert call_args[0][0] == "empty-job"
-        assert call_args[0][1] is False  # success should be False
-        assert "empty" in call_args[0][2].lower()  # error should mention empty
+        finalize_mock.assert_called_once()
+        args = finalize_mock.call_args.args
+        assert args[:3] == ("empty-job", "run-empty", False)
+        assert "empty" in args[3].lower()
 
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {
@@ -1706,72 +1753,87 @@ class TestSilentDelivery:
             "origin": {"platform": "telegram", "chat_id": "123"},
         }
 
+    def test_normal_response_delivers(self):
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(self._make_job(), True, "Results here", None)
+        deliver_mock.assert_called_once()
+
     def test_silent_response_suppresses_delivery(self, caplog):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
             with caplog.at_level(logging.INFO, logger="cron.scheduler"):
-                tick(verbose=False)
+                scheduler._deliver_job_result(self._make_job(), True, "[SILENT]", None)
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
     def test_silent_with_note_suppresses_delivery(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "[SILENT] No changes detected",
+                None,
+            )
         deliver_mock.assert_not_called()
 
     def test_silent_trailing_suppresses_delivery(self):
         """Agent appended [SILENT] after explanation text — must still suppress."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(self._make_job(), True, response, None)
         deliver_mock.assert_not_called()
 
     def test_silent_is_case_insensitive(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "[silent] nothing new",
+                None,
+            )
         deliver_mock.assert_not_called()
 
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(self._make_job(), False, "", "some error")
         deliver_mock.assert_called_once()
 
     def test_output_saved_even_when_delivery_suppressed(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \
-             patch("cron.scheduler.save_job_output") as save_mock, \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with patch("cron.scheduler.save_job_output") as save_mock:
             save_mock.return_value = "/tmp/out.md"
-            from cron.scheduler import tick
-            tick(verbose=False)
+            result = scheduler._save_job_output(
+                self._make_job(),
+                "# full output",
+                verbose=False,
+            )
         save_mock.assert_called_once_with("monitor-job", "# full output")
-        deliver_mock.assert_not_called()
+        assert result == "/tmp/out.md"
+
+    def test_delivery_failure_is_recorded_for_latest_run(self):
+        with patch("cron.scheduler._deliver_result", return_value="telegram down") as deliver_mock, \
+             patch("cron.scheduler.update_delivery_error_if_latest") as update_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "Results here",
+                None,
+                run_at="2026-04-09T12:00:00+00:00",
+            )
+        deliver_mock.assert_called_once()
+        update_mock.assert_called_once_with("monitor-job", "2026-04-09T12:00:00+00:00", "telegram down")
+
+    def test_successful_delivery_clears_previous_delivery_error(self):
+        with patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
+             patch("cron.scheduler.update_delivery_error_if_latest") as update_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "Results here",
+                None,
+                run_at="2026-04-09T12:00:00+00:00",
+            )
+        deliver_mock.assert_called_once()
+        update_mock.assert_called_once_with("monitor-job", "2026-04-09T12:00:00+00:00", None)
 
 
 class TestBuildJobPromptSilentHint:
@@ -2109,11 +2171,15 @@ class TestSendMediaViaAdapter:
         t = threading.Thread(target=loop.run_forever, daemon=True)
         t.start()
         try:
+            deadline = time.time() + 1.0
+            while not loop.is_running() and time.time() < deadline:
+                time.sleep(0.01)
             _send_media_via_adapter(adapter, chat_id, media_files, metadata, loop, job)
         finally:
             loop.call_soon_threadsafe(loop.stop)
             t.join(timeout=5)
-            loop.close()
+            if not loop.is_running():
+                loop.close()
 
     def test_video_dispatched_to_send_video(self):
         adapter = MagicMock()
@@ -2150,14 +2216,24 @@ class TestParallelTick:
         lock_dir = tmp_path / "cron"
         lock_dir.mkdir()
         lock_file = lock_dir / ".tick.lock"
-        with patch("cron.scheduler._get_lock_paths", return_value=(lock_dir, lock_file)):
+        with patch("cron.jobs.CRON_DIR", lock_dir), \
+             patch("cron.jobs.JOBS_FILE", lock_dir / "jobs.json"), \
+             patch("cron.jobs.OUTPUT_DIR", lock_dir / "output"), \
+             patch("cron.scheduler._get_lock_paths", return_value=(lock_dir, lock_file)), \
+             patch("cron.scheduler._get_job_lock_dir", return_value=lock_dir / "locks"):
+            scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
             yield
+            scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
+
+    def _set_due(self):
+        due_at = (scheduler._hermes_now() - timedelta(minutes=1)).isoformat()
+        jobs = load_jobs()
+        for job in jobs:
+            job["next_run_at"] = due_at
+        save_jobs(jobs)
 
     def test_parallel_jobs_run_concurrently(self):
         """Two jobs launched in the same tick should overlap in time."""
-        import threading
-        import time
-
         barrier = threading.Barrier(2, timeout=5)
         call_order = []
 
@@ -2168,19 +2244,17 @@ class TestParallelTick:
             call_order.append(("end", job["id"]))
             return (True, "output", "response", None)
 
-        jobs = [
-            {"id": "job-a", "name": "a", "deliver": "local"},
-            {"id": "job-b", "name": "b", "deliver": "local"},
-        ]
+        create_job(prompt="A", schedule="every 1h", name="job-a")
+        create_job(prompt="B", schedule="every 1h", name="job-b")
+        self._set_due()
 
-        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
+        with patch("cron.scheduler.load_config", return_value={"cron": {"max_parallel_jobs": 2, "wrap_response": False}}), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result", return_value=None), \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler._deliver_result", return_value=None):
             from cron.scheduler import tick
             result = tick(verbose=False)
+            _wait_for_cron_workers()
 
         assert result == 2
         # Both starts happened before both ends — proof of concurrency
@@ -2211,24 +2285,32 @@ class TestParallelTick:
             clear_session_vars(tokens)
             return (True, "output", "response", None)
 
-        jobs = [
-            {"id": "tg-job", "name": "tg", "deliver": "local",
-             "origin": {"platform": "telegram", "chat_id": "111"}},
-            {"id": "dc-job", "name": "dc", "deliver": "local",
-             "origin": {"platform": "discord", "chat_id": "222"}},
-        ]
+        create_job(
+            prompt="tg",
+            schedule="every 1h",
+            name="tg-job",
+            origin={"platform": "telegram", "chat_id": "111"},
+        )
+        create_job(
+            prompt="dc",
+            schedule="every 1h",
+            name="dc-job",
+            origin={"platform": "discord", "chat_id": "222"},
+        )
+        self._set_due()
 
-        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
+        with patch("cron.scheduler.load_config", return_value={"cron": {"max_parallel_jobs": 2, "wrap_response": False}}), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result", return_value=None), \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler._deliver_result", return_value=None):
             from cron.scheduler import tick
             tick(verbose=False)
+            _wait_for_cron_workers()
 
-        assert seen["tg-job"] == {"platform": "telegram", "chat_id": "111"}
-        assert seen["dc-job"] == {"platform": "discord", "chat_id": "222"}
+        names_by_id = {job["id"]: job["name"] for job in load_jobs()}
+        seen_by_name = {names_by_id[job_id]: value for job_id, value in seen.items()}
+        assert seen_by_name["tg-job"] == {"platform": "telegram", "chat_id": "111"}
+        assert seen_by_name["dc-job"] == {"platform": "discord", "chat_id": "222"}
 
     def test_max_parallel_env_var(self, monkeypatch):
         """HERMES_CRON_MAX_PARALLEL=1 should restore serial behaviour."""
@@ -2242,25 +2324,185 @@ class TestParallelTick:
             call_times.append(("end", job["id"], time.monotonic()))
             return (True, "output", "response", None)
 
-        jobs = [
-            {"id": "s1", "name": "s1", "deliver": "local"},
-            {"id": "s2", "name": "s2", "deliver": "local"},
-        ]
+        create_job(prompt="s1", schedule="every 1h", name="s1")
+        create_job(prompt="s2", schedule="every 1h", name="s2")
+        self._set_due()
 
-        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
-             patch("cron.scheduler.run_job", side_effect=mock_run_job), \
+        with patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result", return_value=None), \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler._deliver_result", return_value=None):
             from cron.scheduler import tick
             result = tick(verbose=False)
+            _wait_for_cron_workers()
 
-        assert result == 2
-        # With max_workers=1, second job starts after first ends
-        end_s1 = [t for action, jid, t in call_times if action == "end" and jid == "s1"][0]
-        start_s2 = [t for action, jid, t in call_times if action == "start" and jid == "s2"][0]
-        assert start_s2 >= end_s1, "Jobs ran concurrently despite max_parallel=1"
+        assert result == 1
+        assert len([entry for entry in call_times if entry[0] == "start"]) == 1
+
+
+class TestParallelCronOwnership:
+    def _set_due_now(self):
+        jobs = load_jobs()
+        due_at = (scheduler._hermes_now() - timedelta(minutes=1)).isoformat()
+        for job in jobs:
+            job["next_run_at"] = due_at
+        save_jobs(jobs)
+
+    def test_same_job_non_overlap(self, cron_runtime, monkeypatch):
+        job = create_job(prompt="single", schedule="every 1h", name="job-single")
+        self._set_due_now()
+        monkeypatch.setattr("cron.scheduler.load_config", lambda: {"cron": {"max_parallel_jobs": 2, "wrap_response": False}})
+
+        started = threading.Event()
+        release = threading.Event()
+        run_count = 0
+
+        def fake_run_job(_job):
+            nonlocal run_count
+            run_count += 1
+            started.set()
+            release.wait(timeout=1.0)
+            return True, "# output", "done", None
+
+        with patch("cron.scheduler.run_job", side_effect=fake_run_job), \
+             patch("cron.scheduler.save_job_output", return_value=cron_runtime / "out.md"), \
+             patch("cron.scheduler._deliver_result"):
+            assert scheduler.tick(verbose=False) == 1
+            assert started.wait(timeout=1.0)
+
+            jobs = load_jobs()
+            for rec in jobs:
+                if rec["id"] == job["id"]:
+                    rec["next_run_at"] = (scheduler._hermes_now() - timedelta(minutes=1)).isoformat()
+            save_jobs(jobs)
+
+            assert scheduler.tick(verbose=False) == 0
+            release.set()
+            _wait_for_cron_workers()
+
+        assert run_count == 1
+
+    def test_capacity_limited_ticks_dispatch_remaining_jobs_in_next_wave(self, cron_runtime, monkeypatch):
+        create_job(prompt="A", schedule="every 1h", name="job-a")
+        create_job(prompt="B", schedule="every 1h", name="job-b")
+        create_job(prompt="C", schedule="every 1h", name="job-c")
+        self._set_due_now()
+        monkeypatch.setattr("cron.scheduler.load_config", lambda: {"cron": {"max_parallel_jobs": 2, "wrap_response": False}})
+
+        invocation_count = 0
+        started_ids = []
+        first_wave_started = threading.Event()
+        release_first_wave = threading.Event()
+        lock = threading.Lock()
+
+        def fake_run_job(job):
+            nonlocal invocation_count
+            with lock:
+                invocation_count += 1
+                current = invocation_count
+                started_ids.append(job["id"])
+                if current >= 2:
+                    first_wave_started.set()
+            if current <= 2:
+                release_first_wave.wait(timeout=1.0)
+            return True, f"# output {job['id']}", f"done-{job['id']}", None
+
+        with patch("cron.scheduler.run_job", side_effect=fake_run_job), \
+             patch("cron.scheduler.save_job_output", return_value=cron_runtime / "out.md"), \
+             patch("cron.scheduler._deliver_result"):
+            assert scheduler.tick(verbose=False) == 2
+            assert first_wave_started.wait(timeout=1.0)
+            assert scheduler.tick(verbose=False) == 0
+
+            release_first_wave.set()
+            _wait_for_cron_workers()
+
+            assert scheduler.tick(verbose=False) == 1
+            _wait_for_cron_workers()
+
+        assert len(started_ids) == 3
+        assert len(set(started_ids)) == 3
+
+    def test_stale_finalize_result_discarded(self):
+        claimed = {
+            "id": "job-1",
+            "name": "Job 1",
+            "deliver": "local",
+            "in_flight": {"run_id": "run-1"},
+        }
+
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "ok", None)), \
+             patch("cron.scheduler.finalize_job_run", return_value=False) as finalize_mock, \
+             patch("cron.scheduler.save_job_output") as save_mock, \
+             patch("cron.scheduler._deliver_result") as deliver_mock:
+            result = scheduler._run_claimed_job(claimed, verbose=False)
+
+        assert result is False
+        finalize_mock.assert_called_once()
+        save_mock.assert_called_once_with("job-1", "# output")
+        deliver_mock.assert_not_called()
+
+    def test_output_is_saved_before_finalize(self):
+        claimed = {
+            "id": "job-1",
+            "name": "Job 1",
+            "deliver": "local",
+            "in_flight": {"run_id": "run-1"},
+        }
+        call_order = []
+
+        def fake_save(job_id, output):
+            call_order.append(("save", job_id, output))
+            return "/tmp/out.md"
+
+        def fake_finalize(job_id, run_id, success, error, **kwargs):
+            call_order.append(("finalize", job_id, run_id, success, error))
+            return True
+
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "ok", None)), \
+             patch("cron.scheduler.save_job_output", side_effect=fake_save), \
+             patch("cron.scheduler.finalize_job_run", side_effect=fake_finalize), \
+             patch("cron.scheduler._deliver_result"):
+            result = scheduler._run_claimed_job(claimed, verbose=False)
+
+        assert result is True
+        assert call_order == [
+            ("save", "job-1", "# output"),
+            ("finalize", "job-1", "run-1", True, None),
+        ]
+
+    def test_save_failure_records_error_before_clearing_ownership(self):
+        claimed = {
+            "id": "job-1",
+            "name": "Job 1",
+            "deliver": "local",
+            "in_flight": {"run_id": "run-1"},
+        }
+
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "ok", None)), \
+             patch("cron.scheduler.save_job_output", side_effect=OSError("disk full")), \
+             patch("cron.scheduler.finalize_job_run", return_value=True) as finalize_mock, \
+             patch("cron.scheduler._deliver_result") as deliver_mock:
+            result = scheduler._run_claimed_job(claimed, verbose=False)
+
+        assert result is False
+        finalize_mock.assert_called_once()
+        args = finalize_mock.call_args.args
+        assert args[:2] == ("job-1", "run-1")
+        assert args[2] is False
+        assert "disk full" in args[3]
+        deliver_mock.assert_not_called()
 
 
 class TestDeliverResultTimeoutCancelsFuture:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -48,16 +48,12 @@ def _noop_scheduler_lock(*, non_blocking: bool):
 
 
 class TestSchedulerOwnershipMetadata:
-    def test_current_owner_metadata_uses_generic_fingerprints(self, monkeypatch):
+    def test_current_owner_metadata_passes_only_stable_identity(self, monkeypatch):
         monkeypatch.setattr("cron.scheduler.os.getpid", lambda: 4242)
-        monkeypatch.setattr("cron.scheduler._boot_fingerprint", lambda: "boot-generic")
-        monkeypatch.setattr("cron.scheduler._process_start_fingerprint", lambda pid: f"start-{pid}")
 
         assert scheduler._current_owner_metadata() == {
             "owner_instance_id": scheduler._INSTANCE_ID,
             "owner_pid": 4242,
-            "owner_boot_id": "boot-generic",
-            "owner_process_start": "start-4242",
         }
 
     def test_get_executor_none_uses_default_pool_size(self, cron_runtime):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1380,6 +1380,74 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         assert fake_db.close.call_count == 2
 
+    def test_run_job_tolerates_missing_auto_delivery_contextvars_after_hot_upgrade(self, tmp_path, monkeypatch):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "deliver": "telegram",
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        (tmp_path / ".env").write_text("TELEGRAM_HOME_CHANNEL=-2002\n")
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        from gateway import session_context
+
+        removed = {}
+        for name in (
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        ):
+            removed[name] = session_context._VAR_MAP.pop(name)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+                seen["platform"] = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None
+                seen["chat_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None
+                seen["thread_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None
+                return {"final_response": "ok"}
+
+        try:
+            with patch("cron.scheduler._hermes_home", tmp_path), \
+                 patch("hermes_state.SessionDB", return_value=fake_db), \
+                 patch(
+                     "hermes_cli.runtime_provider.resolve_runtime_provider",
+                     return_value={
+                         "api_key": "***",
+                         "base_url": "https://example.invalid/v1",
+                         "provider": "openrouter",
+                         "api_mode": "chat_completions",
+                     },
+                 ), \
+                 patch("run_agent.AIAgent", FakeAgent):
+                success, output, final_response, error = run_job(job)
+        finally:
+            session_context._VAR_MAP.update(removed)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {
+            "platform": "telegram",
+            "chat_id": "-2002",
+            "thread_id": None,
+        }
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        fake_db.close.assert_called_once()
+
 
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,13 +3,70 @@
 import json
 import logging
 import os
+import threading
+import time
+from contextlib import contextmanager
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
+import cron.scheduler as scheduler
+from cron.jobs import create_job, load_jobs, save_jobs
 from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+@pytest.fixture()
+def cron_runtime(tmp_path, monkeypatch):
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr("cron.jobs.CRON_DIR", cron_dir)
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr("cron.scheduler._LOCK_DIR", cron_dir)
+    monkeypatch.setattr("cron.scheduler._LOCK_FILE", cron_dir / ".tick.lock")
+    monkeypatch.setattr("cron.scheduler._JOB_LOCK_DIR", cron_dir / "locks")
+
+    scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
+    yield cron_dir
+    scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
+
+
+def _wait_for_cron_workers(timeout_s: float = 2.5) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if scheduler._active_worker_count() == 0:
+            return
+        time.sleep(0.01)
+    raise AssertionError("Timed out waiting for cron workers to finish")
+
+
+@contextmanager
+def _noop_scheduler_lock(*, non_blocking: bool):
+    yield object()
+
+
+class TestSchedulerOwnershipMetadata:
+    def test_current_owner_metadata_uses_generic_fingerprints(self, monkeypatch):
+        monkeypatch.setattr("cron.scheduler.os.getpid", lambda: 4242)
+        monkeypatch.setattr("cron.scheduler._boot_fingerprint", lambda: "boot-generic")
+        monkeypatch.setattr("cron.scheduler._process_start_fingerprint", lambda pid: f"start-{pid}")
+
+        assert scheduler._current_owner_metadata() == {
+            "owner_instance_id": scheduler._INSTANCE_ID,
+            "owner_pid": 4242,
+            "owner_boot_id": "boot-generic",
+            "owner_process_start": "start-4242",
+        }
+
+    def test_get_executor_none_uses_default_pool_size(self, cron_runtime):
+        executor = scheduler._get_executor(None)
+        try:
+            assert executor is not None
+            assert scheduler._EXECUTOR_MAX_WORKERS is None
+        finally:
+            scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
 
 
 class TestResolveOrigin:
@@ -810,40 +867,30 @@ class TestRunJobSessionPersistence:
 
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
-        tick() should mark the job as error so last_status != 'ok'.
+        claimed-run finalization should mark the job as error so last_status != 'ok'.
         (issue #8585)
         """
-        from cron.scheduler import tick
-        from cron.jobs import load_jobs, save_jobs
-
         job = {
             "id": "empty-job",
             "name": "empty-test",
             "prompt": "do something",
-            "schedule": "every 1h",
-            "enabled": True,
-            "next_run_at": "2020-01-01T00:00:00",
             "deliver": "local",
-            "last_status": None,
+            "in_flight": {"run_id": "run-empty"},
         }
 
-        fake_db = MagicMock()
-
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
-             patch("cron.scheduler.advance_next_run"), \
-             patch("cron.scheduler.mark_job_run") as mock_mark, \
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.finalize_job_run") as finalize_mock, \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
-            tick(verbose=False)
+            assert scheduler._run_claimed_job(job, verbose=False) is True
 
-        # Should be called with success=False because final_response is empty
-        mock_mark.assert_called_once()
-        call_args = mock_mark.call_args
-        assert call_args[0][0] == "empty-job"
-        assert call_args[0][1] is False  # success should be False
-        assert "empty" in call_args[0][2].lower()  # error should mention empty
+        finalize_mock.assert_called_once()
+        args = finalize_mock.call_args.args
+        assert args[:3] == ("empty-job", "run-empty", False)
+        assert "empty" in args[3].lower()
 
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {
@@ -1172,72 +1219,87 @@ class TestSilentDelivery:
             "origin": {"platform": "telegram", "chat_id": "123"},
         }
 
+    def test_normal_response_delivers(self):
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(self._make_job(), True, "Results here", None)
+        deliver_mock.assert_called_once()
+
     def test_silent_response_suppresses_delivery(self, caplog):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
             with caplog.at_level(logging.INFO, logger="cron.scheduler"):
-                tick(verbose=False)
+                scheduler._deliver_job_result(self._make_job(), True, "[SILENT]", None)
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
     def test_silent_with_note_suppresses_delivery(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "[SILENT] No changes detected",
+                None,
+            )
         deliver_mock.assert_not_called()
 
     def test_silent_trailing_suppresses_delivery(self):
         """Agent appended [SILENT] after explanation text — must still suppress."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(self._make_job(), True, response, None)
         deliver_mock.assert_not_called()
 
     def test_silent_is_case_insensitive(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "[silent] nothing new",
+                None,
+            )
         deliver_mock.assert_not_called()
 
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
-             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
-            from cron.scheduler import tick
-            tick(verbose=False)
+        with patch("cron.scheduler._deliver_result") as deliver_mock:
+            scheduler._deliver_job_result(self._make_job(), False, "", "some error")
         deliver_mock.assert_called_once()
 
     def test_output_saved_even_when_delivery_suppressed(self):
-        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \
-             patch("cron.scheduler.save_job_output") as save_mock, \
-             patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+        with patch("cron.scheduler.save_job_output") as save_mock:
             save_mock.return_value = "/tmp/out.md"
-            from cron.scheduler import tick
-            tick(verbose=False)
+            result = scheduler._save_job_output(
+                self._make_job(),
+                "# full output",
+                verbose=False,
+            )
         save_mock.assert_called_once_with("monitor-job", "# full output")
-        deliver_mock.assert_not_called()
+        assert result == "/tmp/out.md"
+
+    def test_delivery_failure_is_recorded_for_latest_run(self):
+        with patch("cron.scheduler._deliver_result", return_value="telegram down") as deliver_mock, \
+             patch("cron.scheduler.update_delivery_error_if_latest") as update_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "Results here",
+                None,
+                run_at="2026-04-09T12:00:00+00:00",
+            )
+        deliver_mock.assert_called_once()
+        update_mock.assert_called_once_with("monitor-job", "2026-04-09T12:00:00+00:00", "telegram down")
+
+    def test_successful_delivery_clears_previous_delivery_error(self):
+        with patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock, \
+             patch("cron.scheduler.update_delivery_error_if_latest") as update_mock:
+            scheduler._deliver_job_result(
+                self._make_job(),
+                True,
+                "Results here",
+                None,
+                run_at="2026-04-09T12:00:00+00:00",
+            )
+        deliver_mock.assert_called_once()
+        update_mock.assert_called_once_with("monitor-job", "2026-04-09T12:00:00+00:00", None)
 
 
 class TestBuildJobPromptSilentHint:
@@ -1522,11 +1584,15 @@ class TestSendMediaViaAdapter:
         t = threading.Thread(target=loop.run_forever, daemon=True)
         t.start()
         try:
+            deadline = time.time() + 1.0
+            while not loop.is_running() and time.time() < deadline:
+                time.sleep(0.01)
             _send_media_via_adapter(adapter, chat_id, media_files, metadata, loop, job)
         finally:
             loop.call_soon_threadsafe(loop.stop)
             t.join(timeout=5)
-            loop.close()
+            if not loop.is_running():
+                loop.close()
 
     def test_video_dispatched_to_send_video(self):
         adapter = MagicMock()
@@ -1562,15 +1628,25 @@ class TestParallelTick:
         """Point the tick file lock at a per-test temp dir to avoid xdist contention."""
         lock_dir = tmp_path / "cron"
         lock_dir.mkdir()
-        with patch("cron.scheduler._LOCK_DIR", lock_dir), \
-             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"):
+        with patch("cron.jobs.CRON_DIR", lock_dir), \
+             patch("cron.jobs.JOBS_FILE", lock_dir / "jobs.json"), \
+             patch("cron.jobs.OUTPUT_DIR", lock_dir / "output"), \
+             patch("cron.scheduler._LOCK_DIR", lock_dir), \
+             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"), \
+             patch("cron.scheduler._JOB_LOCK_DIR", lock_dir / "locks"):
+            scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
             yield
+            scheduler.shutdown_worker_pool(wait=True, cancel_futures=True)
+
+    def _set_due(self):
+        due_at = (scheduler._hermes_now() - timedelta(minutes=1)).isoformat()
+        jobs = load_jobs()
+        for job in jobs:
+            job["next_run_at"] = due_at
+        save_jobs(jobs)
 
     def test_parallel_jobs_run_concurrently(self):
         """Two jobs launched in the same tick should overlap in time."""
-        import threading
-        import time
-
         barrier = threading.Barrier(2, timeout=5)
         call_order = []
 
@@ -1581,19 +1657,17 @@ class TestParallelTick:
             call_order.append(("end", job["id"]))
             return (True, "output", "response", None)
 
-        jobs = [
-            {"id": "job-a", "name": "a", "deliver": "local"},
-            {"id": "job-b", "name": "b", "deliver": "local"},
-        ]
+        create_job(prompt="A", schedule="every 1h", name="job-a")
+        create_job(prompt="B", schedule="every 1h", name="job-b")
+        self._set_due()
 
-        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
+        with patch("cron.scheduler.load_config", return_value={"cron": {"max_parallel_jobs": 2, "wrap_response": False}}), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result", return_value=None), \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler._deliver_result", return_value=None):
             from cron.scheduler import tick
             result = tick(verbose=False)
+            _wait_for_cron_workers()
 
         assert result == 2
         # Both starts happened before both ends — proof of concurrency
@@ -1624,24 +1698,32 @@ class TestParallelTick:
             clear_session_vars(tokens)
             return (True, "output", "response", None)
 
-        jobs = [
-            {"id": "tg-job", "name": "tg", "deliver": "local",
-             "origin": {"platform": "telegram", "chat_id": "111"}},
-            {"id": "dc-job", "name": "dc", "deliver": "local",
-             "origin": {"platform": "discord", "chat_id": "222"}},
-        ]
+        create_job(
+            prompt="tg",
+            schedule="every 1h",
+            name="tg-job",
+            origin={"platform": "telegram", "chat_id": "111"},
+        )
+        create_job(
+            prompt="dc",
+            schedule="every 1h",
+            name="dc-job",
+            origin={"platform": "discord", "chat_id": "222"},
+        )
+        self._set_due()
 
-        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
+        with patch("cron.scheduler.load_config", return_value={"cron": {"max_parallel_jobs": 2, "wrap_response": False}}), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result", return_value=None), \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler._deliver_result", return_value=None):
             from cron.scheduler import tick
             tick(verbose=False)
+            _wait_for_cron_workers()
 
-        assert seen["tg-job"] == {"platform": "telegram", "chat_id": "111"}
-        assert seen["dc-job"] == {"platform": "discord", "chat_id": "222"}
+        names_by_id = {job["id"]: job["name"] for job in load_jobs()}
+        seen_by_name = {names_by_id[job_id]: value for job_id, value in seen.items()}
+        assert seen_by_name["tg-job"] == {"platform": "telegram", "chat_id": "111"}
+        assert seen_by_name["dc-job"] == {"platform": "discord", "chat_id": "222"}
 
     def test_max_parallel_env_var(self, monkeypatch):
         """HERMES_CRON_MAX_PARALLEL=1 should restore serial behaviour."""
@@ -1655,25 +1737,185 @@ class TestParallelTick:
             call_times.append(("end", job["id"], time.monotonic()))
             return (True, "output", "response", None)
 
-        jobs = [
-            {"id": "s1", "name": "s1", "deliver": "local"},
-            {"id": "s2", "name": "s2", "deliver": "local"},
-        ]
+        create_job(prompt="s1", schedule="every 1h", name="s1")
+        create_job(prompt="s2", schedule="every 1h", name="s2")
+        self._set_due()
 
-        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_run"), \
-             patch("cron.scheduler.run_job", side_effect=mock_run_job), \
+        with patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
-             patch("cron.scheduler._deliver_result", return_value=None), \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler._deliver_result", return_value=None):
             from cron.scheduler import tick
             result = tick(verbose=False)
+            _wait_for_cron_workers()
 
-        assert result == 2
-        # With max_workers=1, second job starts after first ends
-        end_s1 = [t for action, jid, t in call_times if action == "end" and jid == "s1"][0]
-        start_s2 = [t for action, jid, t in call_times if action == "start" and jid == "s2"][0]
-        assert start_s2 >= end_s1, "Jobs ran concurrently despite max_parallel=1"
+        assert result == 1
+        assert len([entry for entry in call_times if entry[0] == "start"]) == 1
+
+
+class TestParallelCronOwnership:
+    def _set_due_now(self):
+        jobs = load_jobs()
+        due_at = (scheduler._hermes_now() - timedelta(minutes=1)).isoformat()
+        for job in jobs:
+            job["next_run_at"] = due_at
+        save_jobs(jobs)
+
+    def test_same_job_non_overlap(self, cron_runtime, monkeypatch):
+        job = create_job(prompt="single", schedule="every 1h", name="job-single")
+        self._set_due_now()
+        monkeypatch.setattr("cron.scheduler.load_config", lambda: {"cron": {"max_parallel_jobs": 2, "wrap_response": False}})
+
+        started = threading.Event()
+        release = threading.Event()
+        run_count = 0
+
+        def fake_run_job(_job):
+            nonlocal run_count
+            run_count += 1
+            started.set()
+            release.wait(timeout=1.0)
+            return True, "# output", "done", None
+
+        with patch("cron.scheduler.run_job", side_effect=fake_run_job), \
+             patch("cron.scheduler.save_job_output", return_value=cron_runtime / "out.md"), \
+             patch("cron.scheduler._deliver_result"):
+            assert scheduler.tick(verbose=False) == 1
+            assert started.wait(timeout=1.0)
+
+            jobs = load_jobs()
+            for rec in jobs:
+                if rec["id"] == job["id"]:
+                    rec["next_run_at"] = (scheduler._hermes_now() - timedelta(minutes=1)).isoformat()
+            save_jobs(jobs)
+
+            assert scheduler.tick(verbose=False) == 0
+            release.set()
+            _wait_for_cron_workers()
+
+        assert run_count == 1
+
+    def test_capacity_limited_ticks_dispatch_remaining_jobs_in_next_wave(self, cron_runtime, monkeypatch):
+        create_job(prompt="A", schedule="every 1h", name="job-a")
+        create_job(prompt="B", schedule="every 1h", name="job-b")
+        create_job(prompt="C", schedule="every 1h", name="job-c")
+        self._set_due_now()
+        monkeypatch.setattr("cron.scheduler.load_config", lambda: {"cron": {"max_parallel_jobs": 2, "wrap_response": False}})
+
+        invocation_count = 0
+        started_ids = []
+        first_wave_started = threading.Event()
+        release_first_wave = threading.Event()
+        lock = threading.Lock()
+
+        def fake_run_job(job):
+            nonlocal invocation_count
+            with lock:
+                invocation_count += 1
+                current = invocation_count
+                started_ids.append(job["id"])
+                if current >= 2:
+                    first_wave_started.set()
+            if current <= 2:
+                release_first_wave.wait(timeout=1.0)
+            return True, f"# output {job['id']}", f"done-{job['id']}", None
+
+        with patch("cron.scheduler.run_job", side_effect=fake_run_job), \
+             patch("cron.scheduler.save_job_output", return_value=cron_runtime / "out.md"), \
+             patch("cron.scheduler._deliver_result"):
+            assert scheduler.tick(verbose=False) == 2
+            assert first_wave_started.wait(timeout=1.0)
+            assert scheduler.tick(verbose=False) == 0
+
+            release_first_wave.set()
+            _wait_for_cron_workers()
+
+            assert scheduler.tick(verbose=False) == 1
+            _wait_for_cron_workers()
+
+        assert len(started_ids) == 3
+        assert len(set(started_ids)) == 3
+
+    def test_stale_finalize_result_discarded(self):
+        claimed = {
+            "id": "job-1",
+            "name": "Job 1",
+            "deliver": "local",
+            "in_flight": {"run_id": "run-1"},
+        }
+
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "ok", None)), \
+             patch("cron.scheduler.finalize_job_run", return_value=False) as finalize_mock, \
+             patch("cron.scheduler.save_job_output") as save_mock, \
+             patch("cron.scheduler._deliver_result") as deliver_mock:
+            result = scheduler._run_claimed_job(claimed, verbose=False)
+
+        assert result is False
+        finalize_mock.assert_called_once()
+        save_mock.assert_called_once_with("job-1", "# output")
+        deliver_mock.assert_not_called()
+
+    def test_output_is_saved_before_finalize(self):
+        claimed = {
+            "id": "job-1",
+            "name": "Job 1",
+            "deliver": "local",
+            "in_flight": {"run_id": "run-1"},
+        }
+        call_order = []
+
+        def fake_save(job_id, output):
+            call_order.append(("save", job_id, output))
+            return "/tmp/out.md"
+
+        def fake_finalize(job_id, run_id, success, error, **kwargs):
+            call_order.append(("finalize", job_id, run_id, success, error))
+            return True
+
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "ok", None)), \
+             patch("cron.scheduler.save_job_output", side_effect=fake_save), \
+             patch("cron.scheduler.finalize_job_run", side_effect=fake_finalize), \
+             patch("cron.scheduler._deliver_result"):
+            result = scheduler._run_claimed_job(claimed, verbose=False)
+
+        assert result is True
+        assert call_order == [
+            ("save", "job-1", "# output"),
+            ("finalize", "job-1", "run-1", True, None),
+        ]
+
+    def test_save_failure_records_error_before_clearing_ownership(self):
+        claimed = {
+            "id": "job-1",
+            "name": "Job 1",
+            "deliver": "local",
+            "in_flight": {"run_id": "run-1"},
+        }
+
+        with patch("cron.scheduler._try_acquire_job_lock", return_value=MagicMock()), \
+             patch("cron.scheduler._scheduler_lock", side_effect=_noop_scheduler_lock), \
+             patch("cron.scheduler._release_lock_file"), \
+             patch("cron.scheduler.mark_job_started", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "ok", None)), \
+             patch("cron.scheduler.save_job_output", side_effect=OSError("disk full")), \
+             patch("cron.scheduler.finalize_job_run", return_value=True) as finalize_mock, \
+             patch("cron.scheduler._deliver_result") as deliver_mock:
+            result = scheduler._run_claimed_job(claimed, verbose=False)
+
+        assert result is False
+        finalize_mock.assert_called_once()
+        args = finalize_mock.call_args.args
+        assert args[:2] == ("job-1", "run-1")
+        assert args[2] is False
+        assert "disk full" in args[3]
+        deliver_mock.assert_not_called()
 
 
 class TestDeliverResultTimeoutCancelsFuture:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -943,6 +943,74 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         fake_db.close.assert_called_once()
 
+    def test_run_job_tolerates_missing_auto_delivery_contextvars_after_hot_upgrade(self, tmp_path, monkeypatch):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "deliver": "telegram",
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        (tmp_path / ".env").write_text("TELEGRAM_HOME_CHANNEL=-2002\n")
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        from gateway import session_context
+
+        removed = {}
+        for name in (
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        ):
+            removed[name] = session_context._VAR_MAP.pop(name)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+                seen["platform"] = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None
+                seen["chat_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None
+                seen["thread_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None
+                return {"final_response": "ok"}
+
+        try:
+            with patch("cron.scheduler._hermes_home", tmp_path), \
+                 patch("hermes_state.SessionDB", return_value=fake_db), \
+                 patch(
+                     "hermes_cli.runtime_provider.resolve_runtime_provider",
+                     return_value={
+                         "api_key": "***",
+                         "base_url": "https://example.invalid/v1",
+                         "provider": "openrouter",
+                         "api_mode": "chat_completions",
+                     },
+                 ), \
+                 patch("run_agent.AIAgent", FakeAgent):
+                success, output, final_response, error = run_job(job)
+        finally:
+            session_context._VAR_MAP.update(removed)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {
+            "platform": "telegram",
+            "chat_id": "-2002",
+            "thread_id": None,
+        }
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        fake_db.close.assert_called_once()
+
 
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1980,9 +1980,10 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             captured["session_key"] = get_current_session_key(default="")
+            captured["task_id"] = task_id
             return {
                 "final_response": "ok",
                 "messages": [{"role": "assistant", "content": "ok"}],
@@ -2011,6 +2012,7 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
 
     assert resp["result"]["status"] == "streaming"
     assert captured["session_key"] == "session-key"
+    assert captured["task_id"] == "session-key"
 
 
 def test_prompt_submit_expands_context_refs(monkeypatch):
@@ -2022,7 +2024,7 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
         api_key = ""
 
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             captured["prompt"] = prompt
             return {
@@ -2617,7 +2619,7 @@ def test_prompt_submit_history_version_mismatch_surfaces_warning(monkeypatch):
 
     class _RacyAgent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             # Simulate: something external bumped history_version
             # while we were running.
@@ -2679,7 +2681,7 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             return {
                 "final_response": "reply",
@@ -3010,6 +3012,27 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     assert seen["compress"]
     assert seen["sync"]
     assert ("session.info", "sid", {"model": "x"}) in emitted
+
+
+def test_mirror_slash_stop_kills_only_current_session_processes(monkeypatch):
+    """Regression: TUI /stop mirror must not kill other sessions' jobs."""
+    from tools import process_registry as process_registry_module
+
+    killed_task_ids = []
+
+    class _FakeRegistry:
+        def kill_all(self, task_id=None):
+            killed_task_ids.append(task_id)
+            return 1
+
+    monkeypatch.setattr(process_registry_module, "process_registry", _FakeRegistry())
+
+    session = _session(running=False, session_key="session-a")
+
+    warning = server._mirror_slash_side_effects("sid", session, "/stop")
+
+    assert warning == ""
+    assert killed_task_ids == ["session-a"]
 
 
 # ---------------------------------------------------------------------------
@@ -3531,7 +3554,7 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             return {
                 "final_response": "Rome was founded in 753 BC.",
@@ -3569,7 +3592,7 @@ def test_prompt_submit_skips_auto_title_when_interrupted(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             return {
                 "final_response": "partial answer",
@@ -3601,7 +3624,7 @@ def test_prompt_submit_skips_auto_title_when_response_empty(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             return {
                 "final_response": "",
@@ -3634,7 +3657,7 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             return {
                 "final_response": None,
@@ -3681,7 +3704,7 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, task_id=None
         ):
             return {
                 "final_response": None,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3148,6 +3148,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 run_message,
                 conversation_history=list(history),
                 stream_callback=_stream,
+                task_id=session["session_key"],
             )
 
             last_reasoning = None
@@ -5436,7 +5437,7 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
         elif name == "stop":
             from tools.process_registry import process_registry
 
-            process_registry.kill_all()
+            process_registry.kill_all(task_id=session.get("session_key") or None)
     except Exception as e:
         return f"live session sync failed: {e}"
     return ""


### PR DESCRIPTION
## Summary
- run independent cron jobs in parallel instead of serializing scheduler execution
- preserve per-job non-overlap with claim-time ownership and job-specific locking
- recover orphaned in-flight jobs conservatively after gateway restarts while preserving timeout fallback and legacy owner compatibility
- keep recovery, claim ordering, and run finalization semantics consistent with the existing cron model

## Design
The scheduler still performs recovery before claim on each tick. Claimed work now carries owner metadata so different jobs can run concurrently while the same job remains protected from overlap. If a gateway instance dies after claiming work, the next instance can recover definitely orphaned claims after a short grace period. When owner liveness is unclear, behavior stays conservative and falls back to timeout-based recovery.

## Safety properties
- different jobs may run concurrently
- the same job cannot overlap with itself
- stale completions are discarded if they no longer own the claim
- repeat accounting and run finalization continue to use the shared outcome path
- legacy persisted owner metadata still falls back safely

## Test Plan
- python -m pytest tests/cron/test_jobs.py tests/cron/test_scheduler.py tests/hermes_cli/test_cron.py tests/tools/test_cronjob_tools.py -q -o addopts=''

## Issue links
- Fixes #3752
- Related to #6702