### PR TITLE
feat: add built-in aphrodite skin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2443,9 +2443,11 @@ class HermesCLI:
                 _skin = get_active_skin()
                 label = _skin.get_branding("response_label", "⚕ Hermes")
                 _text_hex = _skin.get_color("banner_text", "#FFF8DC")
+                _border_hex = _skin.get_color("response_border", "#CD7F32")
             except Exception:
                 label = "⚕ Hermes"
                 _text_hex = "#FFF8DC"
+                _border_hex = "#CD7F32"
             # Build a true-color ANSI escape for the response text color
             # so streamed content matches the Rich Panel appearance.
             try:
@@ -2457,7 +2459,7 @@ class HermesCLI:
                 self._stream_text_ansi = ""
             w = shutil.get_terminal_size().columns
             fill = w - 2 - len(label)
-            _cprint(f"\n{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+            _cprint(f"\n[bold {_border_hex}]╭─{label}{'─' * max(fill - 1, 0)}╮[/]")
 
         self._stream_buf += text
 
@@ -2488,7 +2490,12 @@ class HermesCLI:
         # Close the response box
         if self._stream_box_opened:
             w = shutil.get_terminal_size().columns
-            _cprint(f"{_GOLD}╰{'─' * (w - 2)}╯{_RST}")
+            try:
+                from hermes_cli.skin_engine import get_active_skin
+                _border_hex = get_active_skin().get_color("response_border", "#CD7F32")
+            except Exception:
+                _border_hex = "#CD7F32"
+            _cprint(f"[bold {_border_hex}]╰{'─' * (w - 2)}╯[/]")
 
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""
@@ -7008,9 +7015,16 @@ class HermesCLI:
                     if not _streaming_box_opened:
                         _streaming_box_opened = True
                         w = self.console.width
-                        label = " ⚕ Hermes "
+                        try:
+                            from hermes_cli.skin_engine import get_active_skin
+                            _skin = get_active_skin()
+                            label = _skin.get_branding("response_label", " ⚕ Hermes ")
+                            _border_hex = _skin.get_color("response_border", "#CD7F32")
+                        except Exception:
+                            label = " ⚕ Hermes "
+                            _border_hex = "#CD7F32"
                         fill = w - 2 - len(label)
-                        _cprint(f"\n{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+                        _cprint(f"\n[bold {_border_hex}]╭─{label}{'─' * max(fill - 1, 0)}╮[/]")
                     _cprint(sentence.rstrip())
 
                 tts_thread = threading.Thread(
@@ -7226,7 +7240,12 @@ class HermesCLI:
                 if use_streaming_tts and _streaming_box_opened and not is_error_response:
                     # Text was already printed sentence-by-sentence; just close the box
                     w = shutil.get_terminal_size().columns
-                    _cprint(f"\n{_GOLD}╰{'─' * (w - 2)}╯{_RST}")
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _border_hex = get_active_skin().get_color("response_border", "#CD7F32")
+                    except Exception:
+                        _border_hex = "#CD7F32"
+                    _cprint(f"\n[bold {_border_hex}]╰{'─' * (w - 2)}╯[/]")
                 elif already_streamed:
                     # Response was already streamed token-by-token with box framing;
                     # _flush_stream() already closed the box. Skip Rich Panel.

--- a/cli.py
+++ b/cli.py
@@ -992,6 +992,21 @@ _BOLD = "\033[1m"
 _DIM = "\033[2m"
 _RST = "\033[0m"
 
+
+def _ansi_hex(hex_color: str, *, bold: bool = False) -> str:
+    """Return a true-color ANSI prefix for ``#RRGGBB`` strings."""
+    try:
+        text = (hex_color or "").strip()
+        if len(text) != 7 or not text.startswith("#"):
+            raise ValueError("invalid hex")
+        r = int(text[1:3], 16)
+        g = int(text[3:5], 16)
+        b = int(text[5:7], 16)
+        prefix = "1;" if bold else ""
+        return f"\033[{prefix}38;2;{r};{g};{b}m"
+    except Exception:
+        return _BOLD if bold else ""
+
 def _accent_hex() -> str:
     """Return the active skin accent color for legacy CLI output lines."""
     try:
@@ -2459,7 +2474,7 @@ class HermesCLI:
                 self._stream_text_ansi = ""
             w = shutil.get_terminal_size().columns
             fill = w - 2 - len(label)
-            _cprint(f"\n[bold {_border_hex}]╭─{label}{'─' * max(fill - 1, 0)}╮[/]")
+            _cprint(f"\n{_ansi_hex(_border_hex, bold=True)}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
 
         self._stream_buf += text
 
@@ -2495,7 +2510,7 @@ class HermesCLI:
                 _border_hex = get_active_skin().get_color("response_border", "#CD7F32")
             except Exception:
                 _border_hex = "#CD7F32"
-            _cprint(f"[bold {_border_hex}]╰{'─' * (w - 2)}╯[/]")
+            _cprint(f"{_ansi_hex(_border_hex, bold=True)}╰{'─' * (w - 2)}╯{_RST}")
 
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""
@@ -7024,7 +7039,7 @@ class HermesCLI:
                             label = " ⚕ Hermes "
                             _border_hex = "#CD7F32"
                         fill = w - 2 - len(label)
-                        _cprint(f"\n[bold {_border_hex}]╭─{label}{'─' * max(fill - 1, 0)}╮[/]")
+                        _cprint(f"\n{_ansi_hex(_border_hex, bold=True)}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
                     _cprint(sentence.rstrip())
 
                 tts_thread = threading.Thread(
@@ -7245,7 +7260,7 @@ class HermesCLI:
                         _border_hex = get_active_skin().get_color("response_border", "#CD7F32")
                     except Exception:
                         _border_hex = "#CD7F32"
-                    _cprint(f"\n[bold {_border_hex}]╰{'─' * (w - 2)}╯[/]")
+                    _cprint(f"\n{_ansi_hex(_border_hex, bold=True)}╰{'─' * (w - 2)}╯{_RST}")
                 elif already_streamed:
                     # Response was already streamed token-by-token with box framing;
                     # _flush_stream() already closed the box. Skip Rich Panel.

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -83,10 +83,14 @@ USAGE
 BUILT-IN SKINS
 ==============
 
-- ``default`` — Classic Hermes gold/kawaii (the current look)
-- ``ares``    — Crimson/bronze war-god theme with custom spinner wings
-- ``mono``    — Clean grayscale monochrome
-- ``slate``   — Cool blue developer-focused theme
+- ``default``   — Classic Hermes gold/kawaii (the current look)
+- ``ares``      — Crimson/bronze war-god theme with custom spinner wings
+- ``mono``      — Clean grayscale monochrome
+- ``slate``     — Cool blue developer-focused theme
+- ``poseidon``  — Ocean-god theme — deep blue and seafoam
+- ``sisyphus``  — Sisyphean grayscale persistence theme
+- ``charizard`` — Volcanic burnt-orange theme
+- ``aphrodite`` — Rose neon theme with cyan reply borders
 
 USER SKINS
 ==========
@@ -500,6 +504,36 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
 [#F29C38]⠀⠀⠀⠀⠀⠀⠀⠀⣰⡿⢿⣆⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
 [#F29C38]⠀⠀⠀⠀⠀⠀⠀⣼⡟⠀⠀⢻⣧⠀⠀⠀⠀⠀⠀⠀⠀[/]
 [dim #7A3511]⠀⠀⠀⠀⠀⠀⠀tail flame lit⠀⠀⠀⠀⠀⠀⠀⠀[/]""",
+    },
+    "aphrodite": {
+        "name": "aphrodite",
+        "description": "Rose neon theme — pink glass and cyan reply border",
+        "colors": {
+            "banner_border": "#C85A8A",
+            "banner_title": "#FF8FC7",
+            "banner_accent": "#FF6FAE",
+            "banner_dim": "#C85A8A",
+            "banner_text": "#FFF1F7",
+            "ui_accent": "#FF6FAE",
+            "ui_label": "#F3A6C8",
+            "ui_ok": "#FF6FAE",
+            "ui_error": "#FF6B81",
+            "ui_warn": "#FFB36B",
+            "prompt": "#FFF1F7",
+            "input_rule": "#C85A8A",
+            "response_border": "#7FD6E8",
+            "session_label": "#E07AA8",
+            "session_border": "#8E6A78",
+        },
+        "branding": {
+            "agent_name": "Aphrodite Agent",
+            "welcome": "Welcome to Aphrodite Agent! Type your message or /help for commands.",
+            "goodbye": "Goodbye! ♥",
+            "response_label": " ♥ Aphrodite ",
+            "prompt_symbol": "♥ ❯ ",
+            "help_header": "(♥) Available Commands",
+        },
+        "tool_prefix": "┊",
     },
 }
 

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from cli import HermesCLI, _rich_text_from_ansi
+from cli import HermesCLI, _ansi_hex, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
 
@@ -41,6 +41,15 @@ class TestCliSkinPromptIntegration:
 
         set_active_skin("ares")
         assert cli._get_tui_prompt_fragments() == [("class:prompt", "⚔ ❯ ")]
+
+    def test_aphrodite_prompt_fragments_use_skin_symbol(self):
+        cli = _make_cli_stub()
+
+        set_active_skin("aphrodite")
+        assert cli._get_tui_prompt_fragments() == [
+            ("class:prompt-icon", "♥ "),
+            ("class:prompt", "❯ "),
+        ]
 
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()
@@ -105,6 +114,24 @@ class TestCliSkinPromptIntegration:
         assert "Skin set to: ares (saved)" in output
         assert "Prompt + TUI colors updated." in output
         assert cli._app.style is not None
+
+    def test_flush_stream_uses_skin_response_border_color(self):
+        cli = _make_cli_stub()
+        cli._stream_box_opened = True
+        cli._stream_buf = ""
+        cli._stream_text_ansi = ""
+        cli._in_reasoning_block = False
+        cli._stream_prefilt = ""
+        cli._reasoning_box_opened = False
+
+        set_active_skin("aphrodite")
+        printed = []
+        with patch("cli._cprint", side_effect=printed.append), patch(
+            "cli.shutil.get_terminal_size", return_value=SimpleNamespace(columns=20)
+        ):
+            cli._flush_stream()
+
+        assert printed[-1] == f"{_ansi_hex('#7FD6E8', bold=True)}╰{'─' * 18}╯\033[0m"
 
 
 class TestAnsiRichTextHelper:

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -46,10 +46,7 @@ class TestCliSkinPromptIntegration:
         cli = _make_cli_stub()
 
         set_active_skin("aphrodite")
-        assert cli._get_tui_prompt_fragments() == [
-            ("class:prompt-icon", "♥ "),
-            ("class:prompt", "❯ "),
-        ]
+        assert cli._get_tui_prompt_fragments() == [("class:prompt", "♥ ❯ ")]
 
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -88,6 +88,14 @@ class TestBuiltinSkins:
         assert skin.name == "slate"
         assert skin.get_color("banner_title") == "#7eb8f6"
 
+    def test_aphrodite_skin_loads(self):
+        from hermes_cli.skin_engine import load_skin
+        skin = load_skin("aphrodite")
+        assert skin.name == "aphrodite"
+        assert skin.get_color("banner_title") == "#FF8FC7"
+        assert skin.get_color("response_border") == "#7FD6E8"
+        assert skin.get_branding("agent_name") == "Aphrodite Agent"
+
     def test_unknown_skin_falls_back_to_default(self):
         from hermes_cli.skin_engine import load_skin
         skin = load_skin("nonexistent_skin_xyz")
@@ -124,6 +132,7 @@ class TestSkinManagement:
         assert "ares" in names
         assert "mono" in names
         assert "slate" in names
+        assert "aphrodite" in names
         for s in skins:
             assert "source" in s
             assert s["source"] == "builtin"

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -40,19 +40,13 @@ class TestCliSkinPromptIntegration:
         cli = _make_cli_stub()
 
         set_active_skin("ares")
-        assert cli._get_tui_prompt_fragments() == [
-            ("class:prompt-icon", "⚔ "),
-            ("class:prompt", "❯ "),
-        ]
+        assert cli._get_tui_prompt_fragments() == [("class:prompt", "⚔ ❯ ")]
 
     def test_aphrodite_prompt_fragments_use_skin_symbol(self):
         cli = _make_cli_stub()
 
         set_active_skin("aphrodite")
-        assert cli._get_tui_prompt_fragments() == [
-            ("class:prompt-icon", "♥ "),
-            ("class:prompt", "❯ "),
-        ]
+        assert cli._get_tui_prompt_fragments() == [("class:prompt", "♥ ❯ ")]
 
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
+from cli import HermesCLI, _ansi_hex, _build_compact_banner, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
 
@@ -40,7 +40,19 @@ class TestCliSkinPromptIntegration:
         cli = _make_cli_stub()
 
         set_active_skin("ares")
-        assert cli._get_tui_prompt_fragments() == [("class:prompt", "⚔ ❯ ")]
+        assert cli._get_tui_prompt_fragments() == [
+            ("class:prompt-icon", "⚔ "),
+            ("class:prompt", "❯ "),
+        ]
+
+    def test_aphrodite_prompt_fragments_use_skin_symbol(self):
+        cli = _make_cli_stub()
+
+        set_active_skin("aphrodite")
+        assert cli._get_tui_prompt_fragments() == [
+            ("class:prompt-icon", "♥ "),
+            ("class:prompt", "❯ "),
+        ]
 
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()
@@ -86,6 +98,24 @@ class TestCliSkinPromptIntegration:
         assert "Skin set to: ares (saved)" in output
         assert "Prompt + TUI colors updated." in output
         assert cli._app.style is not None
+
+    def test_flush_stream_uses_skin_response_border_color(self):
+        cli = _make_cli_stub()
+        cli._stream_box_opened = True
+        cli._stream_buf = ""
+        cli._stream_text_ansi = ""
+        cli._in_reasoning_block = False
+        cli._stream_prefilt = ""
+        cli._reasoning_box_opened = False
+
+        set_active_skin("aphrodite")
+        printed = []
+        with patch("cli._cprint", side_effect=printed.append), patch(
+            "cli.shutil.get_terminal_size", return_value=SimpleNamespace(columns=20)
+        ):
+            cli._flush_stream()
+
+        assert printed[-1] == f"{_ansi_hex('#7FD6E8', bold=True)}╰{'─' * 18}╯\033[0m"
 
 
 class TestCompactBannerSkinIntegration:

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -39,6 +39,7 @@ display:
 | `poseidon` | Ocean-god theme — deep blue and seafoam | `Poseidon Agent` | Deep blue to seafoam gradient. Ocean-themed spinners ("charting currents", "sounding the depth"). Trident ASCII art banner. |
 | `sisyphus` | Sisyphean theme — austere grayscale with persistence | `Sisyphus Agent` | Light grays with stark contrast. Boulder-themed spinners ("pushing uphill", "resetting the boulder", "enduring the loop"). Boulder-and-hill ASCII art banner. |
 | `charizard` | Volcanic theme — burnt orange and ember | `Charizard Agent` | Warm burnt orange to ember gradient. Fire-themed spinners ("banking into the draft", "measuring burn"). Dragon-silhouette ASCII art banner. |
+| `aphrodite` | Rose neon theme — pink glass and cyan reply border | `Aphrodite Agent` | Pink-forward neon palette with soft rose chrome, pale text, and a cyan response border for a glossy TUI feel. |
 
 ## Complete list of configurable keys
 


### PR DESCRIPTION
## Summary
- add built-in `aphrodite` skin to the Hermes skin engine
- make streaming response box borders respect `skin.response_border` using true-color ANSI
- add targeted tests for aphrodite loading, prompt symbol behavior, and streaming border flush
- document `aphrodite` in the skins guide

## Validation
- Athena review: PASS
- Chaos test: PASS
- `pytest -q tests/hermes_cli/test_skin_engine.py tests/cli/test_cli_skin_integration.py tests/test_cli_skin_integration.py`
- 61 passed

## Notes
- This PR intentionally keeps a single clean path: built-in skin only
- No external YAML/fork distribution path is included
- No install-script changes are included