### PR TITLE
feat: default gateway tool_progress to off

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -759,12 +759,14 @@ display:
   # Use compact banner mode
   compact: false
 
-  # Tool progress display level (CLI and gateway)
+  # Tool progress display level
   #   off:     Silent — no tool activity shown, just the final response
   #   new:     Show a tool indicator only when the tool changes (skip repeats)
-  #   all:     Show every tool call with a short preview (default)
+  #   all:     Show every tool call with a short preview
   #   verbose: Full args, results, and debug logs (same as /verbose)
-  # Toggle at runtime with /verbose in the CLI
+  # CLI default: "all" (spinner shows tool activity inline)
+  # Gateway default: "off" (messaging users only see the final response)
+  # Toggle at runtime with /verbose in the CLI or gateway
   tool_progress: all
 
   # What Enter does when Hermes is already busy in the CLI.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4979,7 +4979,7 @@ class GatewayRunner:
             "verbose": "⚙️ Tool progress: **VERBOSE** — every tool call with full arguments.",
         }
 
-        raw_progress = user_config.get("display", {}).get("tool_progress", "all")
+        raw_progress = user_config.get("display", {}).get("tool_progress", "off")
         # YAML 1.1 parses bare "off" as boolean False — normalise back
         if raw_progress is False:
             current = "off"
@@ -4988,7 +4988,7 @@ class GatewayRunner:
         else:
             current = str(raw_progress).lower()
         if current not in cycle:
-            current = "all"
+            current = "off"
         idx = (cycle.index(current) + 1) % len(cycle)
         new_mode = cycle[idx]
 
@@ -6420,11 +6420,16 @@ class GatewayRunner:
         # Tool progress mode from config.yaml: "all", "new", "verbose", "off"
         # Falls back to env vars for backward compatibility.
         # YAML 1.1 parses bare `off` as boolean False — normalise before
-        # the `or` chain so it doesn't silently fall through to "all".
+        # the `or` chain so it doesn't silently fall through to the default.
+        #
+        # Gateway default is "off" — messaging users only see the final
+        # response unless they explicitly opt in via config.yaml or
+        # /verbose.  CLI default remains "all" (set in cli.py).
         #
         # Per-platform overrides (display.tool_progress_overrides) take
-        # priority over the global setting — e.g. Signal users can set
-        # tool_progress to "off" while keeping Telegram on "all".
+        # priority over the global setting — e.g. users can set
+        # tool_progress_overrides.telegram to "all" while keeping the
+        # global gateway default "off".
         _display_cfg = user_config.get("display", {})
         _overrides = _display_cfg.get("tool_progress_overrides", {})
         _raw_tp = _overrides.get(platform_key)
@@ -6435,7 +6440,7 @@ class GatewayRunner:
         progress_mode = (
             _raw_tp
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
-            or "all"
+            or "off"
         )
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -103,6 +103,7 @@ def _make_runner(adapter):
     runner._fallback_model = None
     runner._session_db = None
     runner._running_agents = {}
+    runner._session_model_overrides = {}
     runner.hooks = SimpleNamespace(loaded_hooks=False)
     return runner
 
@@ -323,6 +324,66 @@ def test_all_mode_respects_custom_preview_length(monkeypatch, tmp_path):
     assert len(preview_text) > 40, f"Preview suspiciously short ({len(preview_text)}): {preview_text}"
     # But still capped at 120
     assert len(preview_text) <= 120, f"Preview too long ({len(preview_text)}): {preview_text}"
+
+
+class NullSafeFakeAgent:
+    """Like FakeAgent but guards callback calls — used when progress is off."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.tool_progress_callback:
+            self.tool_progress_callback("tool.started", "terminal", "pwd", {})
+            time.sleep(0.35)
+            self.tool_progress_callback("tool.started", "browser_navigate", "https://example.com", {})
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+@pytest.mark.asyncio
+async def test_gateway_defaults_to_off_no_progress_messages(monkeypatch, tmp_path):
+    """Without explicit tool_progress config or env var, gateway default is 'off' — no progress messages."""
+    # Deliberately do NOT set HERMES_TOOL_PROGRESS_MODE
+    monkeypatch.delenv("HERMES_TOOL_PROGRESS_MODE", raising=False)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = NullSafeFakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-default",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    # With default "off", no progress messages should be sent
+    assert adapter.sent == [], f"Expected no progress messages, got {adapter.sent}"
+    assert adapter.edits == [], f"Expected no edits, got {adapter.edits}"
 
 
 def test_all_mode_no_truncation_when_preview_fits(monkeypatch, tmp_path):

--- a/tests/gateway/test_verbose_command.py
+++ b/tests/gateway/test_verbose_command.py
@@ -107,8 +107,8 @@ class TestVerboseCommand:
                 f"Expected {mode}, got {saved['display']['tool_progress']}"
 
     @pytest.mark.asyncio
-    async def test_defaults_to_all_when_no_tool_progress_set(self, tmp_path, monkeypatch):
-        """When tool_progress is not in config, defaults to 'all' then cycles to verbose."""
+    async def test_defaults_to_off_when_no_tool_progress_set(self, tmp_path, monkeypatch):
+        """When tool_progress is not in config, gateway defaults to 'off' then cycles to 'new'."""
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
         config_path = hermes_home / "config.yaml"
@@ -122,10 +122,10 @@ class TestVerboseCommand:
         runner = _make_runner()
         result = await runner._handle_verbose_command(_make_event())
 
-        # default "all" -> verbose
-        assert "VERBOSE" in result
+        # gateway default "off" -> new
+        assert "NEW" in result
         saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-        assert saved["display"]["tool_progress"] == "verbose"
+        assert saved["display"]["tool_progress"] == "new"
 
     @pytest.mark.asyncio
     async def test_no_config_file_returns_disabled(self, tmp_path, monkeypatch):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -821,7 +821,7 @@ This controls both the `text_to_speech` tool and spoken replies in voice mode (`
 
 ```yaml
 display:
-  tool_progress: all      # off | new | all | verbose
+  tool_progress: all      # off (gateway default) | new | all (CLI default) | verbose
   tool_progress_command: false  # Enable /verbose slash command in messaging gateway
   tool_progress_overrides: {}  # Per-platform overrides (see below)
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
@@ -839,7 +839,7 @@ display:
 |------|-------------|
 | `off` | Silent — just the final response |
 | `new` | Tool indicator only when the tool changes |
-| `all` | Every tool call with a short preview (default) |
+| `all` | Every tool call with a short preview (CLI default) |
 | `verbose` | Full args, results, and debug logs |
 
 In the CLI, cycle through these modes with `/verbose`. To use `/verbose` in messaging platforms (Telegram, Discord, Slack, etc.), set `tool_progress_command: true` in the `display` section above. The command will then cycle the mode and save to config.
@@ -850,7 +850,7 @@ Different platforms have different verbosity needs. For example, Signal can't ed
 
 ```yaml
 display:
-  tool_progress: all          # global default
+  tool_progress: all          # explicit opt-in for gateway (CLI default is already "all")
   tool_progress_overrides:
     signal: 'off'             # silence progress on Signal
     telegram: verbose         # detailed progress on Telegram

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -397,13 +397,13 @@ See the [Session Model](#session-model-in-discord) section above for the full im
 
 #### `display.tool_progress`
 
-**Type:** string — **Default:** `"all"` — **Values:** `off`, `new`, `all`, `verbose`
+**Type:** string — **Default:** `"off"` (gateway), `"all"` (CLI) — **Values:** `off`, `new`, `all`, `verbose`
 
-Controls whether the bot sends progress messages in the chat while processing (e.g., "Reading file...", "Running terminal command..."). This is a global gateway setting that applies to all platforms.
+Controls whether the bot sends progress messages in the chat while processing (e.g., "Reading file...", "Running terminal command..."). Gateway platforms default to silent (`"off"`) so users only see the final response. Set to `"all"` or `"new"` to see tool activity.
 
 ```yaml
 display:
-  tool_progress: "all"    # off | new | all | verbose
+  tool_progress: "off"    # off | new | all | verbose
 ```
 
 - `off` — no progress messages

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -211,11 +211,11 @@ Control how much tool activity is displayed in `~/.hermes/config.yaml`:
 
 ```yaml
 display:
-  tool_progress: all    # off | new | all | verbose
+  tool_progress: off    # off (default for gateway) | new | all | verbose
   tool_progress_command: false  # set to true to enable /verbose in messaging
 ```
 
-When enabled, the bot sends status messages as it works:
+Gateway platforms default to `off` — only the final response is shown. Set to `all` or `new` to see tool activity. When enabled, the bot sends status messages as it works:
 
 ```text
 💻 `ls -la`...


### PR DESCRIPTION
Closes #7161

## What

Change the gateway `tool_progress` default from `"all"` to `"off"`.

Messaging platform users (Telegram, Discord, Signal, etc.) now only see the final response by default — no intermediate tool progress messages cluttering the chat.

## Why

Users on messaging platforms see every tool call as a separate message (or edited message), which is noisy and unhelpful for most use cases. The CLI's inline spinner is unobtrusive, but gateway progress messages are persistent chat messages.

## Changes

- `gateway/run.py` — fallback default `"all"` → `"off"` in message handler, `/verbose` command, and unrecognized-value fallback
- `cli-config.yaml.example` — updated comments documenting different CLI/gateway defaults
- `tests/gateway/test_verbose_command.py` — updated test to match new gateway default
- `tests/gateway/test_run_progress_topics.py` — added regression test verifying no progress messages with default "off"; fixed pre-existing `_session_model_overrides` AttributeError in `_make_runner()` helper that blocked all progress tests
- `website/docs/` — updated configuration.md, discord.md, and messaging/index.md to document gateway default as "off"

## Opt-in

Users who want tool progress on their gateway can set:
```yaml
display:
  tool_progress: all
```

Or per-platform:
```yaml
display:
  tool_progress_overrides:
    telegram: all
```

## What's unchanged

- CLI default remains `"all"`
- `/verbose` slash command still cycles through all modes
- Explicit config values are always respected
- Per-platform overrides work as before
- `HERMES_TOOL_PROGRESS_MODE` env var override works as before
- Config migration and setup wizard defaults unchanged

## Tests

13 passed (7 progress tests + 6 verbose command tests). The progress tests were previously broken on upstream/main due to a missing `_session_model_overrides` attribute — fixed as part of this PR.
