### PR TITLE
fix: harden empty background process completions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6133,7 +6133,9 @@ class GatewayRunner:
                 # --- Agent-triggered completion: inject synthetic message ---
                 if agent_notify:
                     from tools.ansi_strip import strip_ansi
-                    _out = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+                    from tools.process_registry import format_completion_output
+                    _raw_out = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+                    _out = format_completion_output(_raw_out, for_agent=True)
                     synth_text = (
                         f"[SYSTEM: Background process {session_id} completed "
                         f"(exit code {session.exit_code}).\n"
@@ -6177,7 +6179,9 @@ class GatewayRunner:
                     or (notify_mode == "error" and session.exit_code not in (0, None))
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
+                    from tools.process_registry import format_completion_output
+                    _raw_output = session.output_buffer[-1000:] if session.output_buffer else ""
+                    new_output = format_completion_output(_raw_output, for_agent=False)
                     message_text = (
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 from tools.process_registry import (
     ProcessRegistry,
     ProcessSession,
+    format_completion_output,
 )
 
 
@@ -73,6 +74,16 @@ class TestCompletionQueue:
         assert hasattr(registry, "completion_queue")
         assert registry.completion_queue.empty()
 
+    def test_format_completion_output_empty_for_agent(self):
+        text = format_completion_output("", for_agent=True)
+        assert "No buffered stdout captured" in text
+        assert "process(action=\"log\"" in text
+
+    def test_format_completion_output_empty_for_user(self):
+        text = format_completion_output("", for_agent=False)
+        assert "No buffered stdout captured" in text
+        assert "results to files or logs" in text
+
     def test_move_to_finished_no_notify(self, registry):
         """Processes without notify_on_complete don't enqueue."""
         s = _make_session(notify_on_complete=False, output="done")
@@ -119,6 +130,23 @@ class TestCompletionQueue:
         completion = registry.completion_queue.get_nowait()
         assert completion["exit_code"] == 1
         assert "FAILED" in completion["output"]
+
+    def test_move_to_finished_empty_output_gets_hint(self, registry):
+        s = _make_session(
+            notify_on_complete=True,
+            output="",
+            exit_code=0,
+        )
+        s.exited = True
+        s.exit_code = 0
+        registry._running[s.id] = s
+        with patch.object(registry, "_write_checkpoint"):
+            registry._move_to_finished(s)
+
+        completion = registry.completion_queue.get_nowait()
+        assert completion["exit_code"] == 0
+        assert "No buffered stdout captured" in completion["output"]
+        assert "process(action=\"log\"" in completion["output"]
 
     def test_output_truncated_to_2000(self, registry):
         """Long output is truncated to last 2000 chars."""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -59,6 +59,23 @@ FINISHED_TTL_SECONDS = 1800     # Keep finished processes for 30 minutes
 MAX_PROCESSES = 64              # Max concurrent tracked processes (LRU pruning)
 
 
+def format_completion_output(output: str, *, for_agent: bool = False) -> str:
+    """Normalize completion output so empty stdout doesn't look like a missing result."""
+    text = (output or "").strip()
+    if text:
+        return text
+    if for_agent:
+        return (
+            "(No buffered stdout captured. Do not assume the job produced no result — "
+            "inspect process(action=\"log\", session_id=...) and any known output files "
+            "or artifact paths before replying.)"
+        )
+    return (
+        "(No buffered stdout captured. The process may have written results to files "
+        "or logs instead of stdout.)"
+    )
+
+
 @dataclass
 class ProcessSession:
     """A tracked background process with output buffering."""
@@ -470,12 +487,12 @@ class ProcessRegistry:
         # so the CLI/gateway can auto-trigger a new agent turn.
         if session.notify_on_complete:
             from tools.ansi_strip import strip_ansi
-            output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+            raw_output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
             self.completion_queue.put({
                 "session_id": session.id,
                 "command": session.command,
                 "exit_code": session.exit_code,
-                "output": output_tail,
+                "output": format_completion_output(raw_output_tail, for_agent=True),
             })
 
     # ----- Query Methods -----


### PR DESCRIPTION
Summary:
- normalize empty background-process completion output instead of emitting a blank final-output message
- tell the agent to inspect process logs/artifacts before replying when stdout is empty
- add regression tests for the empty-output completion case

Why:
- empty stdout currently produces misleading completion messages like "Here's the final output:" with nothing after it
- this makes agents falsely treat the result as missing rather than checking logs or artifact files
- the fix hardens Hermes for Codex and other models without changing normal non-empty completion behavior

Testing:
- python -m pytest tests/tools/test_notify_on_complete.py -q