### PR TITLE
fix: four small CLI/config fixes (Bucket K salvage)

### DIFF
--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -97,8 +97,12 @@ def parse_rate_limit_headers(
 
     Returns None if no rate limit headers are present.
     """
+    # Normalize to lowercase so lookups work regardless of how the server
+    # capitalises headers (HTTP header names are case-insensitive per RFC 7230).
+    lowered = {k.lower(): v for k, v in headers.items()}
+
     # Quick check: at least one rate limit header must exist
-    has_any = any(k.lower().startswith("x-ratelimit-") for k in headers)
+    has_any = any(k.startswith("x-ratelimit-") for k in lowered)
     if not has_any:
         return None
 
@@ -109,9 +113,9 @@ def parse_rate_limit_headers(
         #      resource="tokens", suffix="-1h" -> per-hour
         tag = f"{resource}{suffix}"
         return RateLimitBucket(
-            limit=_safe_int(headers.get(f"x-ratelimit-limit-{tag}")),
-            remaining=_safe_int(headers.get(f"x-ratelimit-remaining-{tag}")),
-            reset_seconds=_safe_float(headers.get(f"x-ratelimit-reset-{tag}")),
+            limit=_safe_int(lowered.get(f"x-ratelimit-limit-{tag}")),
+            remaining=_safe_int(lowered.get(f"x-ratelimit-remaining-{tag}")),
+            reset_seconds=_safe_float(lowered.get(f"x-ratelimit-reset-{tag}")),
             captured_at=now,
         )
 

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -181,6 +181,7 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             "api_mode": runtime.get("api_mode"),
             "command": runtime.get("command"),
             "args": list(runtime.get("args") or []),
+            "credential_pool": runtime.get("credential_pool"),
         },
         "label": f"smart route → {route.get('model')} ({runtime.get('provider')})",
         "signature": (

--- a/cli.py
+++ b/cli.py
@@ -319,7 +319,7 @@ def load_cli_config() -> Dict[str, Any]:
     # Load from file if exists
     if config_path.exists():
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 file_config = yaml.safe_load(f) or {}
             
             _file_has_terminal_config = "terminal" in file_config

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1799,7 +1799,7 @@ def _setup_standard_platform(platform: dict):
                     print_warning("  Open access enabled — anyone can use your bot!")
                 elif access_idx == 1:
                     print_success("  DM pairing mode — users will receive a code to request access.")
-                    print_info("  Approve with: hermes pairing approve {platform} {code}")
+                    print_info("  Approve with: hermes pairing approve <platform> <code>")
                 else:
                     print_info("  Skipped — configure later with 'hermes gateway setup'")
             continue


### PR DESCRIPTION
## Summary
Four small verified fixes salvaged from PRs #7063, #7057, #7025, #7019.

| Fix | File | Contributor |
|-----|------|-------------|
| UTF-8 encoding for config file open | cli.py | @zhangchn |
| Pairing approve hint: `{platform}` → `<platform>` | hermes_cli/gateway.py | @konsisumer |
| Missing `credential_pool` key in cheap route dict | agent/smart_model_routing.py | @kuishou68 |
| Normalize rate limit headers to lowercase (RFC 7230) | agent/rate_limit_tracker.py | @kuishou68 |

## Verification
- All 4 bugs confirmed on current main
- py_compile passes on all 4 files
- 50 targeted tests pass (cli_init + rate_limit_tracker)
- E2E: title-cased rate limit headers now parse correctly (previously returned 0/None)