### PR TITLE
fix(telegram): use valid reaction emojis for processing completion

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2802,5 +2802,5 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._set_reaction(
                 chat_id,
                 message_id,
-                "\u2705" if outcome == ProcessingOutcome.SUCCESS else "\u274c",
+                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
             )

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -175,7 +175,7 @@ async def test_on_processing_start_handles_missing_ids(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_success(monkeypatch):
-    """Successful processing should set check mark reaction."""
+    """Successful processing should set thumbs-up reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
@@ -185,13 +185,13 @@ async def test_on_processing_complete_success(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\u2705",
+        reaction="\U0001f44d",
     )
 
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_failure(monkeypatch):
-    """Failed processing should set cross mark reaction."""
+    """Failed processing should set thumbs-down reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
@@ -201,7 +201,7 @@ async def test_on_processing_complete_failure(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\u274c",
+        reaction="\U0001f44e",
     )
 
 


### PR DESCRIPTION
## Summary

Telegram's Bot API only allows a [specific set of emoji](https://core.telegram.org/bots/api#reactiontypeemoji) for bot reactions. `✅` (U+2705) and `❌` (U+274C) are **not** in that set, causing `on_processing_complete` reactions to silently fail with `REACTION_INVALID` (caught at debug log level by the existing try/except in `_set_reaction`).

### Changes

- **`gateway/platforms/telegram.py`**: Replace ✅/❌ with 👍/👎 in `on_processing_complete`
- **`tests/gateway/test_telegram_reactions.py`**: Update assertions + docstrings to match

The 👀 (eyes) reaction used by `on_processing_start` was already valid — no change needed.

### Credit

Based on the fix identified by @ppdng in #6685 and @r266-tech in #6097. Root cause discovered by @willy-scr in #6068.

Fixes #6068
Supersedes #6685, #6097, #5222, #2595