### PR TITLE
docs: document explicit api_mode for custom endpoints

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -229,11 +229,28 @@ model:
   api_key: your-key-or-leave-empty-for-local
 ```
 
+If your endpoint supports a non-default API surface, set `model.api_mode` explicitly instead of relying on URL heuristics:
+
+```yaml
+model:
+  default: gpt-5.4
+  provider: custom
+  base_url: https://example.com/my-relay
+  api_mode: codex_responses
+```
+
+Supported values are:
+- `chat_completions` — standard OpenAI-compatible `/v1/chat/completions`
+- `codex_responses` — OpenAI Responses API / Codex-style backends
+- `anthropic_messages` — Anthropic-compatible `/v1/messages`
+
+When `model.api_mode` is set, Hermes uses it as the source of truth for that endpoint. If you leave it unset, Hermes falls back to its existing provider- and URL-based auto-detection.
+
 :::warning Legacy env vars
 `OPENAI_BASE_URL` and `LLM_MODEL` in `.env` are **removed**. Neither is read by any part of Hermes — `config.yaml` is the single source of truth for model and endpoint configuration. If you have stale entries in your `.env`, they are automatically cleared on the next `hermes setup` or config migration. Use `hermes model` or edit `config.yaml` directly.
 :::
 
-Both approaches persist to `config.yaml`, which is the source of truth for model, provider, and base URL.
+Both approaches persist to `config.yaml`, which is the source of truth for model, provider, base URL, and optional `api_mode`.
 
 ### Switching Models with `/model`
 


### PR DESCRIPTION
## Summary
- document `model.api_mode` for custom endpoints in the providers guide
- show an explicit `codex_responses` config example for OpenAI Responses-backed relays
- clarify that explicit `api_mode` wins when set, while existing auto-detection remains the fallback

## Why
Hermes already supports explicit `model.api_mode` for custom endpoints, but the custom endpoint docs only showed `provider`, `base_url`, and `api_key`. That makes Responses-backed relays easy to misconfigure and encourages brittle URL heuristics.

This PR makes the preferred path explicit in the docs without changing runtime behavior.

## Test plan
- documentation-only change
- manually verified the new example matches Hermes' supported `api_mode` values (`chat_completions`, `codex_responses`, `anthropic_messages`)
