### PR TITLE
fix(model-switch): normalize Unicode dashes from Telegram/iOS input

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5387,6 +5387,11 @@ class GatewayRunner:
         import asyncio as _asyncio
 
         args = event.get_command_args().strip()
+
+        # Normalize Unicode dashes (Telegram/iOS auto-converts -- to em/en dash)
+        import re as _re
+        args = _re.sub(r'[\u2012\u2013\u2014\u2015](days|source)', r'--\1', args)
+
         days = 30
         source = None
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -248,6 +248,11 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool]:
     is_global = False
     explicit_provider = ""
 
+    # Normalize Unicode dashes (Telegram/iOS auto-converts -- to em/en dash)
+    # A single Unicode dash before a flag keyword becomes "--"
+    import re as _re
+    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global)', r'--\1', raw_args)
+
     # Extract --global
     if "--global" in raw_args:
         is_global = True

--- a/tests/gateway/test_insights_unicode_flags.py
+++ b/tests/gateway/test_insights_unicode_flags.py
@@ -1,0 +1,54 @@
+"""Tests for Unicode dash normalization in /insights command flag parsing.
+
+Telegram on iOS auto-converts -- to em/en dashes. The /insights handler
+normalizes these before parsing --days and --source flags.
+"""
+import re
+import pytest
+
+
+# The regex from gateway/run.py insights handler
+_UNICODE_DASH_RE = re.compile(r'[\u2012\u2013\u2014\u2015](days|source)')
+
+
+def _normalize_insights_args(raw: str) -> str:
+    """Apply the same normalization as the /insights handler."""
+    return _UNICODE_DASH_RE.sub(r'--\1', raw)
+
+
+class TestInsightsUnicodeDashFlags:
+    """--days and --source must survive iOS Unicode dash conversion."""
+
+    @pytest.mark.parametrize("input_str,expected", [
+        # Standard double hyphen (baseline)
+        ("--days 7", "--days 7"),
+        ("--source telegram", "--source telegram"),
+        # Em dash (U+2014)
+        ("\u2014days 7", "--days 7"),
+        ("\u2014source telegram", "--source telegram"),
+        # En dash (U+2013)
+        ("\u2013days 7", "--days 7"),
+        ("\u2013source telegram", "--source telegram"),
+        # Figure dash (U+2012)
+        ("\u2012days 7", "--days 7"),
+        # Horizontal bar (U+2015)
+        ("\u2015days 7", "--days 7"),
+        # Combined flags with em dashes
+        ("\u2014days 30 \u2014source cli", "--days 30 --source cli"),
+    ])
+    def test_unicode_dash_normalized(self, input_str, expected):
+        result = _normalize_insights_args(input_str)
+        assert result == expected
+
+    def test_regular_hyphens_unaffected(self):
+        """Normal --days/--source must pass through unchanged."""
+        assert _normalize_insights_args("--days 7 --source discord") == "--days 7 --source discord"
+
+    def test_bare_number_still_works(self):
+        """Shorthand /insights 7 (no flag) must not be mangled."""
+        assert _normalize_insights_args("7") == "7"
+
+    def test_no_flags_unchanged(self):
+        """Input with no flags passes through as-is."""
+        assert _normalize_insights_args("") == ""
+        assert _normalize_insights_args("30") == "30"


### PR DESCRIPTION
## What does this PR do?

Fixes slash command flag parsing when Telegram on iOS autocorrects `--` to Unicode dashes (em dash `—`, en dash `–`, figure dash `‒`, horizontal bar `―`).

When a user types `--flag` on iOS Telegram, autocorrect converts it to a Unicode dash, producing e.g. `glm-5.1 —provider zai`. Flag parsers that only recognize literal `--` either treat the entire string as the model name (error: "Model names cannot contain spaces") or silently ignore the flags.

**Fix:** Normalize Unicode dashes (U+2012–U+2015) to `--` when they precede flag keywords, before flag extraction runs.

**Affected commands:**
- `/model glm-5.1 --provider zai` → `parse_model_flags()` in `model_switch.py`
- `/model glm-5.1 --global` → same function
- `/insights --days 7 --source telegram` → inline parsing in `gateway/run.py`

## Related Issue

Part of the broader model-switch provider routing issues. This PR addresses the input sanitization half; companion PR #7188 addresses provider resolution order (direct providers vs aggregator catalog).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py` — `parse_model_flags()`: added `re.sub()` to normalize Unicode dashes before `--global` extraction (flags: `provider`, `global`)
- `gateway/run.py` — `/insights` handler: same `re.sub()` before flag parsing (flags: `days`, `source`)

## How to Test

1. `pytest tests/hermes_cli/test_model_switch_provider_routing.py::TestParseModelFlagsUnicodeDashes -v` — all 8 tests pass (6 previously failing)
2. `pytest tests/gateway/test_model_switch_persistence.py tests/gateway/test_model_command_custom_providers.py -v` — no regressions
3. Manual: on iOS Telegram, send `/model glm-5.1 —provider zai` (em dash) — should parse correctly as model=`glm-5.1` provider=`zai`
4. Manual: on iOS Telegram, send `/insights —days 7 —source telegram` (em dashes) — should parse `days=7 source=telegram`

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I have run `pytest tests/ -q` — all model + gateway tests pass
- [x] I have added tests for my changes (tests already existed in `test_model_switch_provider_routing.py`, this commit adds the code that makes them pass)
- [x] I have tested on my platform: Linux (Ubuntu)

### Documentation and Housekeeping

- [x] N/A — no config changes, no architecture changes, no new tools