### PR TITLE
fix(model-switch): prefer direct providers over aggregator catalog

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -402,8 +402,8 @@ def switch_model(
         a. Try alias resolution on current provider
         b. If alias exists but not on current provider -> fallback
         c. On aggregator, try vendor/model slug conversion
-        d. Aggregator catalog search
-        e. detect_provider_for_model() as last resort
+        d. detect_provider_for_model() — direct providers before aggregator
+        e. Aggregator catalog search (fallback when no direct provider)
         f. Resolve credentials
         g. Normalize model name for target provider
 
@@ -562,7 +562,25 @@ def switch_model(
                             raw_input, new_model,
                         )
 
-        # --- Step d: Aggregator catalog search ---
+        # --- Step d: detect_provider_for_model() ---
+        # Check direct providers BEFORE aggregator catalog so that a
+        # native provider with credentials wins over OpenRouter.
+        _base = current_base_url or ""
+        is_custom = current_provider in ("custom", "local") or (
+            "localhost" in _base or "127.0.0.1" in _base
+        )
+
+        if (
+            target_provider == current_provider
+            and not is_custom
+            and not resolved_alias
+        ):
+            detected = detect_provider_for_model(new_model, current_provider)
+            if detected:
+                target_provider, new_model = detected
+
+        # --- Step e: Aggregator catalog search ---
+        # Only runs if detect didn't find a direct provider (still on aggregator).
         if is_aggregator(target_provider) and not resolved_alias:
             catalog = list_provider_models(target_provider)
             if catalog:
@@ -578,21 +596,6 @@ def switch_model(
                             if bare.lower() == new_model_lower:
                                 new_model = mid
                                 break
-
-        # --- Step e: detect_provider_for_model() as last resort ---
-        _base = current_base_url or ""
-        is_custom = current_provider in ("custom", "local") or (
-            "localhost" in _base or "127.0.0.1" in _base
-        )
-
-        if (
-            target_provider == current_provider
-            and not is_custom
-            and not resolved_alias
-        ):
-            detected = detect_provider_for_model(new_model, current_provider)
-            if detected:
-                target_provider, new_model = detected
 
     # =================================================================
     # COMMON PATH: Resolve credentials, normalize, get metadata

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -123,6 +123,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemma-4-26b-it",
     ],
     "zai": [
+        "glm-5.1",
         "glm-5",
         "glm-5-turbo",
         "glm-4.7",
@@ -915,6 +916,19 @@ def curated_models_for_provider(
     return [(m, "") for m in models]
 
 
+def _provider_has_credentials(provider_id: str) -> bool:
+    """Check whether any API key env var is set for *provider_id*."""
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        import os
+        pconfig = PROVIDER_REGISTRY.get(provider_id)
+        if pconfig:
+            return any(os.getenv(ev, "").strip() for ev in pconfig.api_key_env_vars)
+    except Exception:
+        pass
+    return False
+
+
 def detect_provider_for_model(
     model_name: str,
     current_provider: str,
@@ -971,18 +985,7 @@ def detect_provider_for_model(
 
     if direct_match:
         # Check if we have credentials for this provider
-        has_creds = False
-        try:
-            from hermes_cli.auth import PROVIDER_REGISTRY
-            pconfig = PROVIDER_REGISTRY.get(direct_match)
-            if pconfig:
-                import os
-                for env_var in pconfig.api_key_env_vars:
-                    if os.getenv(env_var, "").strip():
-                        has_creds = True
-                        break
-        except Exception:
-            pass
+        has_creds = _provider_has_credentials(direct_match)
 
         if has_creds:
             return (direct_match, name)
@@ -994,6 +997,18 @@ def detect_provider_for_model(
         # Still return the direct provider — credential resolution will
         # give a clear error rather than silently using the wrong provider
         return (direct_match, name)
+
+    # --- Step 1.5: family prefix matching ---
+    # Handles new model versions not yet in the static catalog.
+    # E.g. glm-5.2 matches ZAI because ZAI has glm-5, glm-4.7, etc.
+    name_family = name_lower.split("-")[0]  # e.g. "glm" from "glm-5.1"
+    if name_family:
+        for pid, models in _PROVIDER_MODELS.items():
+            if pid == current_provider or pid in _AGGREGATORS:
+                continue
+            if any(m.lower().split("-")[0] == name_family for m in models):
+                if _provider_has_credentials(pid):
+                    return (pid, name)
 
     # --- Step 2: check OpenRouter catalog ---
     # First try exact match (handles provider/model format)


### PR DESCRIPTION
## What does this PR do?

Fixes model provider routing so that `/model glm-5.1` on OpenRouter switches to the direct ZAI provider when `GLM_API_KEY` is configured, instead of staying on OpenRouter.

**Root cause:** Two issues in the resolution chain:

1. **Resolution order:** `switch_model()` PATH B ran the aggregator catalog search (step d) before `detect_provider_for_model()` (step e). The aggregator rewrites `glm-5.1` → `z-ai/glm-5.1`, which then doesn't match ZAI's bare-name catalog.

2. **Exact-only matching:** `detect_provider_for_model()` only did exact matching against static catalogs. Models not yet in the catalog (like `glm-5.1`) fell through to OpenRouter.

## Related Issue

Companion to #7177 (Unicode dash normalization). That PR fixes input parsing; this PR fixes provider resolution logic.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_cli/model_switch.py`** — Reordered PATH B steps (d)/(e): `detect_provider_for_model()` now runs BEFORE aggregator catalog search. Direct providers with credentials get priority; aggregator is the fallback.
- **`hermes_cli/models.py`** — Three changes:
  - Added `_provider_has_credentials()` helper (extracted from inline credential check)
  - Added family prefix matching in `detect_provider_for_model()` after exact match (Step 1.5): new model versions route to the correct provider even before static catalog updates
  - Updated ZAI static catalog to include `glm-5.1`

## How to Test

1. `pytest tests/hermes_cli/test_model_switch_provider_routing.py::TestDirectProviderPreferred -v` — direct provider detection
2. `pytest tests/hermes_cli/test_model_switch_provider_routing.py::TestSwitchModelProviderRouting -v` — end-to-end switch_model routing
3. `pytest tests/hermes_cli/test_models.py -v` — all existing model tests pass

All 4 previously-failing provider routing tests now pass. 136 model-related tests pass with zero regressions.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I have run `pytest tests/ -q` — all model tests pass (4 previously-failing routing tests now pass, 136 existing tests green)
- [x] I have added tests for my changes (tests already existed in `test_model_switch_provider_routing.py`, this commit adds the code that makes them pass)
- [x] I have tested on my platform: Linux (Ubuntu)

### Documentation and Housekeeping

- [x] Updated docstrings for changed functions — or N/A
- [x] N/A — no config changes, no new tools, no architecture changes affecting docs