### PR TITLE
fix(bluebubbles): remove invalid 'message' event from webhook registration

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -53,7 +53,7 @@ _TAPBACK_REMOVED = {
 }
 
 # Webhook event types that carry user messages
-_MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_MESSAGE_EVENTS = {"new-message", "updated-message"}
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -267,7 +267,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message", "message"],
+            "events": ["new-message", "updated-message"],
         }
 
         try:


### PR DESCRIPTION
## Summary

Salvage of PR #7178 by @mehmoodosman onto current main.

Removes the invalid `"message"` event from BlueBubbles webhook registration. `"message"` is not a valid BlueBubbles server event type — only `"new-message"` and `"updated-message"` are. The invalid event caused a 400 Bad Request, preventing webhook registration entirely (no incoming messages received).

Also cleans up the `_MESSAGE_EVENTS` filter set to remove the same dead entry for consistency.

## Changes
- `gateway/platforms/bluebubbles.py`: Remove `"message"` from webhook registration payload and `_MESSAGE_EVENTS` set

## Tests
- 45/45 BlueBubbles tests pass

Closes #7178