### PR TITLE
fix(agent): wire up on_turn_start memory provider hook

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7238,6 +7238,19 @@ class AIAgent:
         # Track user turns for memory flush and periodic nudge logic
         self._user_turn_count += 1
 
+        # Notify memory providers of the new turn
+        if self._memory_manager:
+            try:
+                self._memory_manager.on_turn_start(
+                    self._user_turn_count,
+                    user_message if isinstance(user_message, str) else str(user_message),
+                    platform=getattr(self, '_platform', None),
+                    model=self._current_model if hasattr(self, '_current_model') else self.model,
+                    tool_count=len(self.valid_tool_names) if hasattr(self, 'valid_tool_names') else 0,
+                )
+            except Exception:
+                pass
+
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
 


### PR DESCRIPTION
## What does this PR do?

Wires up the `MemoryProvider.on_turn_start()` hook that was defined in the ABC and fully implemented in the memory manager dispatcher but never called from `run_agent.py`. This fixes turn tracking for all memory plugins, most notably Honcho's `dialectic_cadence` and `injection_frequency` logic which depend on accurate turn counts.

## Related Issue

Fixes #7193

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` after line ~7156: Add `self._memory_manager.on_turn_start()` call after `_user_turn_count` is incremented, passing `platform`, `model`, and `tool_count` as kwargs per the ABC docstring contract

## How to Test

1. Enable Honcho with `dialectic_cadence: 3` (or any value > 1)
2. Start a multi-turn conversation
3. Verify via DEBUG logs that `on_turn_start` is called each turn with incrementing turn numbers
4. Verify that Honcho's cadence gating now activates at the correct turn intervals

For code review only:
1. `grep -n "on_turn_start" run_agent.py` — confirm the call now exists
2. Verify the call passes `turn_number`, `message`, and kwargs consistent with the ABC docstring
3. Verify the call is wrapped in try/except consistent with other memory hook call sites

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A