### PR TITLE
fix(gateway): preserve Discord reply text context

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2412,6 +2412,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if not event_text or not event_text.strip():
             event_text = "(The user sent a message with no text content)"
 
+        reply_to_message_id = str(message.reference.message_id) if message.reference else None
+        reply_to_text = None
+        if message.reference:
+            resolved = getattr(message.reference, "resolved", None)
+            if resolved is not None:
+                reply_to_text = getattr(resolved, "content", None) or getattr(resolved, "system_content", None)
+
         event = MessageEvent(
             text=event_text,
             message_type=msg_type,
@@ -2420,7 +2427,8 @@ class DiscordAdapter(BasePlatformAdapter):
             message_id=str(message.id),
             media_urls=media_urls,
             media_types=media_types,
-            reply_to_message_id=str(message.reference.message_id) if message.reference else None,
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
             timestamp=message.created_at,
         )
 

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -85,14 +85,14 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None):
+def make_message(*, channel, content: str, mentions=None, reference=None):
     author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser")
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
         attachments=[],
-        reference=None,
+        reference=reference,
         created_at=datetime.now(timezone.utc),
         channel=channel,
         author=author,
@@ -197,6 +197,27 @@ async def test_dms_unaffected_by_ignored_channels(adapter, monkeypatch):
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reply_context_includes_referenced_message_text(adapter, monkeypatch):
+    """Discord replies should carry replied-to text into MessageEvent.reply_to_text."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    referenced = SimpleNamespace(content="Original quiz question")
+    reference = SimpleNamespace(message_id=999, resolved=referenced)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content="my answer",
+        reference=reference,
+    )
+
+    await adapter._handle_message(message)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.reply_to_message_id == "999"
+    assert event.reply_to_text == "Original quiz question"
 
 
 # ── no_thread_channels ───────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

This PR fixes Discord reply context so Hermes can see the text of the message a user is directly replying to. This is especially important when the replied-to message is not already present in the current session history, such as after scheduler-delivered messages, because the Discord adapter populated the replied message ID but not the replied message text. 

Before this change, the Discord adapter populated `reply_to_message_id` but not `reply_to_text`. The gateway already knows how to inject reply text into the prompt when `reply_to_text` is present, so Discord replies were missing useful quoted context even though the downstream plumbing already existed.

This PR updates the Discord adapter to populate `reply_to_text` from `message.reference.resolved`, while keeping the existing `reply_to_message_id` behavior unchanged. It also adds a regression test covering the reply-context path.

## Related Issue

No tracked issue for this change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/discord.py` to populate `MessageEvent.reply_to_text` for Discord replies using `message.reference.resolved`
- Preserved existing `reply_to_message_id` behavior for Discord replies
- Added a regression test in `tests/gateway/test_discord_channel_controls.py` to verify replied-to text is carried through into the normalized `MessageEvent`
- Manually verified in Discord that Hermes now receives replied-to content in context

## How to Test

1. Run the targeted regression test:
   - `pytest tests/gateway/test_discord_channel_controls.py::test_reply_context_includes_referenced_message_text -q`
2. Run the related Discord tests:
   - `pytest tests/gateway/test_discord_channel_controls.py -q`
   - `pytest tests/gateway/test_discord_send.py -q`
3. Manually test in Discord:
   - send a message
   - reply to that message
   - confirm Hermes receives the replied-to content in injected reply context

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test results:

- `pytest tests/gateway/test_discord_channel_controls.py::test_reply_context_includes_referenced_message_text -q` → passed
- `pytest tests/gateway/test_discord_channel_controls.py -q` → 15 passed
- `pytest tests/gateway/test_discord_send.py -q` → 1 passed

## Note on Character limit
Hermes is intentionally truncating the replied-to text before injecting it into the prompt. The relevant code is in gateway/run.py:

reply_snippet = event.reply_to_text[:500]
then it injects:
[Replying to: "..."]

So even if Discord gives the full original message, Hermes currently only passes the first 500 characters to the agent.

Why that likely exists:
- keeps prompts smaller
- avoids dumping huge quoted messages into context
- reduces token usage/noise

IMO that limit is too small but perhaps the user should have a way to configure this. 