### PR TITLE
feat: add named delegation routing profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -595,15 +595,20 @@ DEFAULT_CONFIG = {
         "provider": "",
     },
 
-    # Subagent delegation — override the provider:model used by delegate_task
-    # so child agents can run on a different (cheaper/faster) provider and model.
-    # Uses the same runtime provider resolution as CLI/gateway startup, so all
-    # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
+    # Subagent delegation — choose named routes for delegated tasks so child
+    # agents can run on a different provider/model pair than the parent.
+    # Routes are selected explicitly by delegate_task(routing_profile=...) or
+    # fall back to delegation.route / delegation.routes.default.
     "delegation": {
-        "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
-        "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
-        "base_url": "",    # direct OpenAI-compatible endpoint for subagents
-        "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "route": "default",
+        "routes": {
+            "default": {
+                "model": "",
+                "provider": "",
+                "base_url": "",
+                "api_key": "",
+            },
+        },
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
@@ -1916,6 +1921,82 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "    base_url: https://...",
         ))
 
+    # ── delegation routes should be well-formed ──────────────────────────
+    delegation = config.get("delegation")
+    if delegation is not None:
+        if not isinstance(delegation, dict):
+            issues.append(ConfigIssue(
+                "error",
+                f"delegation should be a dict, got {type(delegation).__name__}",
+                "Change to:\n  delegation:\n    route: default\n    routes:\n      default:\n        provider: openai-codex\n        model: gpt-5.3-codex",
+            ))
+        else:
+            routes = delegation.get("routes")
+            if routes is not None and not isinstance(routes, dict):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.routes should be a dict of named routes, got {type(routes).__name__}",
+                    "Change to:\n  delegation:\n    routes:\n      default:\n        provider: openai-codex\n        model: gpt-5.3-codex",
+                ))
+            elif isinstance(routes, dict):
+                if "default" not in routes:
+                    issues.append(ConfigIssue(
+                        "warning",
+                        "delegation.routes does not define a 'default' route — Hermes will synthesize one at runtime",
+                        "Add delegation.routes.default to make the fallback route explicit",
+                    ))
+                for route_name, route_cfg in routes.items():
+                    if not isinstance(route_name, str):
+                        issues.append(ConfigIssue(
+                            "error",
+                            f"delegation.routes contains non-string route key {route_name!r}",
+                            "Use string route names like 'default', 'coding', 'research', or 'fast'",
+                        ))
+                        continue
+                    if not isinstance(route_cfg, dict):
+                        issues.append(ConfigIssue(
+                            "error",
+                            f"delegation.routes.{route_name} should be a dict with model/provider/base_url/api_key",
+                            f"Change delegation.routes.{route_name} to a mapping, not {type(route_cfg).__name__}",
+                        ))
+                        continue
+                    for field in ("model", "provider", "base_url", "api_key"):
+                        value = route_cfg.get(field)
+                        if value is not None and not isinstance(value, str):
+                            issues.append(ConfigIssue(
+                                "error",
+                                f"delegation.routes.{route_name}.{field} should be a string, got {type(value).__name__}",
+                                f"Change delegation.routes.{route_name}.{field} to a string value",
+                            ))
+            max_iterations = delegation.get("max_iterations")
+            if max_iterations is not None and (not isinstance(max_iterations, int) or isinstance(max_iterations, bool) or max_iterations <= 0):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.max_iterations should be a positive integer, got {type(max_iterations).__name__ if max_iterations is not None else 'None'}",
+                    "Change delegation.max_iterations to a positive integer like 50",
+                ))
+            route_name = delegation.get("route")
+            if route_name is not None and not isinstance(route_name, str):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.route should be a string, got {type(route_name).__name__}",
+                    "Change delegation.route to a route name like 'default', 'coding', 'research', or 'fast'",
+                ))
+            elif route_name and isinstance(routes, dict):
+                selected_route = str(route_name).strip()
+                if selected_route.lower() == "auto":
+                    issues.append(ConfigIssue(
+                        "warning",
+                        "delegation.route='auto' is deprecated for delegation routing and will be treated as 'default'",
+                        "Change delegation.route to 'default' (or another explicit route name)",
+                    ))
+                elif selected_route not in routes:
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"delegation.route points to '{selected_route}' but that route is not defined",
+                        f"Add delegation.routes.{selected_route} or change delegation.route to one of: {', '.join(sorted(routes.keys()))}",
+                    ))
+
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:
         if key.startswith("_"):
@@ -2230,6 +2311,67 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
+
+    # ── Legacy delegation cleanup: flat keys → named routes ──
+    config = load_config()
+    delegation = config.get("delegation")
+    legacy_delegation_keys = ("model", "provider", "base_url", "api_key")
+    needs_delegation_route_migration = False
+    if isinstance(delegation, dict):
+        if any(key in delegation for key in legacy_delegation_keys):
+            needs_delegation_route_migration = True
+        if not isinstance(delegation.get("routes"), dict):
+            needs_delegation_route_migration = True
+        route_name = delegation.get("route")
+        if not route_name or (isinstance(route_name, str) and route_name.strip().lower() == "auto"):
+            needs_delegation_route_migration = True
+
+    if needs_delegation_route_migration and isinstance(delegation, dict):
+        changed = False
+        migrated_legacy_keys = False
+
+        routes = delegation.get("routes")
+        if not isinstance(routes, dict):
+            routes = {}
+            delegation["routes"] = routes
+            changed = True
+
+        default_route = routes.get("default")
+        if not isinstance(default_route, dict):
+            default_route = {}
+            routes["default"] = default_route
+            changed = True
+
+        for key in legacy_delegation_keys:
+            if key in delegation:
+                legacy_value = delegation.get(key)
+                if not default_route.get(key):
+                    if isinstance(legacy_value, str):
+                        default_route[key] = legacy_value
+                    elif legacy_value is None:
+                        default_route[key] = ""
+                    else:
+                        default_route[key] = str(legacy_value)
+                    changed = True
+                del delegation[key]
+                changed = True
+                migrated_legacy_keys = True
+
+        for key in legacy_delegation_keys:
+            default_route.setdefault(key, "")
+
+        route_name = delegation.get("route")
+        if not route_name or (isinstance(route_name, str) and route_name.strip().lower() == "auto"):
+            delegation["route"] = "default"
+            changed = True
+
+        if changed:
+            config["delegation"] = delegation
+            save_config(config)
+            if migrated_legacy_keys:
+                results["config_added"].append("delegation.routes.default (migrated from legacy delegation.model/provider/base_url/api_key)")
+            if not quiet:
+                print("  ✓ Migrated delegation config to named routes")
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2313,6 +2313,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print("  ✓ Removed unused compression.summary_* keys")
 
     # ── Legacy delegation cleanup: flat keys → named routes ──
+    # Keep this persistent migration aligned with
+    # tools.delegate_tool._normalize_delegation_config(), which performs the
+    # runtime-only normalization for already-loaded config objects.
     config = load_config()
     delegation = config.get("delegation")
     legacy_delegation_keys = ("model", "provider", "base_url", "api_key")

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -609,3 +609,119 @@ class TestInterimAssistantMessageConfig:
         assert raw["_config_version"] == 17
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True
+
+
+class TestDelegationRouteConfig:
+    def _write_config(self, tmp_path, payload):
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    def test_load_config_includes_default_delegation_routes(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            assert config["delegation"]["route"] == "default"
+            assert "default" in config["delegation"]["routes"]
+
+    def test_migrate_config_moves_legacy_delegation_fields_into_routes(self, tmp_path):
+        self._write_config(tmp_path, {
+            "_config_version": 17,
+            "delegation": {
+                "model": "gpt-5.3-codex",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "",
+                "max_iterations": 44,
+                "reasoning_effort": "high",
+            },
+        })
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            config = load_config()
+            assert config["delegation"]["route"] == "default"
+            assert config["delegation"]["routes"]["default"]["model"] == "gpt-5.3-codex"
+            assert config["delegation"]["routes"]["default"]["provider"] == "openai-codex"
+            assert config["delegation"]["reasoning_effort"] == "high"
+            assert "model" not in config["delegation"]
+            assert "provider" not in config["delegation"]
+
+    def test_load_config_preserves_named_delegation_routes(self, tmp_path):
+        self._write_config(tmp_path, {
+            "delegation": {
+                "route": "research",
+                "routes": {
+                    "default": {"model": "gpt-5.3-codex", "provider": "openai-codex"},
+                    "research": {"model": "gpt-5.4", "provider": "openai-codex"},
+                    "fast": {"model": "gpt-5.3-codex-spark", "provider": "openai-codex"},
+                },
+                "reasoning_effort": "medium",
+            },
+        })
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            assert config["delegation"]["route"] == "research"
+            assert config["delegation"]["routes"]["fast"]["model"] == "gpt-5.3-codex-spark"
+            assert config["delegation"]["reasoning_effort"] == "medium"
+
+    def test_validate_config_structure_flags_non_string_delegation_route(self, tmp_path):
+        self._write_config(tmp_path, {
+            "delegation": {
+                "route": 123,
+                "routes": {"default": {"model": "gpt-5.3-codex", "provider": "openai-codex"}},
+            },
+        })
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            from hermes_cli.config import validate_config_structure
+            issues = validate_config_structure()
+            assert any("delegation.route should be a string" in issue.message for issue in issues)
+
+    def test_validate_config_structure_flags_invalid_delegation_route_field_types(self, tmp_path):
+        self._write_config(tmp_path, {
+            "delegation": {
+                "max_iterations": "bad",
+                "routes": {"default": {"model": 123, "provider": "openai-codex"}},
+            },
+        })
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            from hermes_cli.config import validate_config_structure
+            issues = validate_config_structure()
+            assert any("delegation.max_iterations should be a positive integer" in issue.message for issue in issues)
+            assert any("delegation.routes.default.model should be a string" in issue.message for issue in issues)
+
+    def test_validate_config_structure_warns_on_delegation_route_auto(self, tmp_path):
+        self._write_config(tmp_path, {
+            "delegation": {
+                "route": "auto",
+                "routes": {"default": {"model": "gpt-5.3-codex", "provider": "openai-codex"}},
+            },
+        })
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            from hermes_cli.config import validate_config_structure
+            issues = validate_config_structure()
+            assert any("treated as 'default'" in issue.message for issue in issues)
+
+    def test_migrate_config_preserves_explicit_empty_legacy_delegation_fields(self, tmp_path):
+        self._write_config(tmp_path, {
+            "_config_version": 17,
+            "delegation": {
+                "model": "gpt-5.3-codex",
+                "provider": "openai-codex",
+                "api_key": "",
+                "base_url": "",
+            },
+        })
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            config = load_config()
+            assert "api_key" in config["delegation"]["routes"]["default"]
+            assert config["delegation"]["routes"]["default"]["api_key"] == ""
+            assert config["delegation"]["routes"]["default"]["base_url"] == ""
+
+    def test_validate_config_structure_flags_non_string_delegation_route_keys(self, tmp_path):
+        self._write_config(tmp_path, {
+            "delegation": {
+                "routes": {1: {"model": "gpt-5.3-codex", "provider": "openai-codex"}},
+            },
+        })
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            from hermes_cli.config import validate_config_structure
+            issues = validate_config_structure()
+            assert any("non-string route key" in issue.message for issue in issues)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -17,6 +17,8 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import hermes_cli.runtime_provider  # ensure patch("hermes_cli.runtime_provider...") resolves
+
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
@@ -29,6 +31,8 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _normalize_delegation_config,
+    _resolve_delegation_route,
 )
 
 
@@ -67,7 +71,10 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
         self.assertIn("max_iterations", props)
-        self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
+        self.assertIn("routing_profile", props)
+        self.assertIn("routing_profile", props["tasks"]["items"]["properties"])
+        self.assertIn("acp_command", props)
+        self.assertNotIn("maxItems", props["tasks"])  # runtime-configured limit
 
 
 class TestChildSystemPrompt(unittest.TestCase):
@@ -128,6 +135,12 @@ class TestDelegateTask(unittest.TestCase):
         parent = _make_mock_parent()
         result = json.loads(delegate_task(tasks=[{"context": "no goal here"}], parent_agent=parent))
         self.assertIn("error", result)
+
+    def test_resolve_effective_max_iterations_rejects_invalid_values(self):
+        parent = _make_mock_parent(depth=0)
+        result = json.loads(delegate_task(goal="bad", max_iterations=0, parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("positive integer", result["error"])
 
     @patch("tools.delegate_tool._run_single_child")
     def test_single_task_mode(self, mock_run):
@@ -570,13 +583,14 @@ class TestBlockedTools(unittest.TestCase):
 
 
 class TestDelegationCredentialResolution(unittest.TestCase):
-    """Tests for provider:model credential resolution in delegation config."""
+    """Test provider/base_url credential resolution for subagents."""
 
-    def test_no_provider_returns_none_credentials(self):
-        """When delegation.provider is empty, all credentials are None (inherit parent)."""
+    def test_empty_config_inherits_parent(self):
+        """When delegation config is empty, child inherits parent's model/provider."""
         parent = _make_mock_parent(depth=0)
-        cfg = {"model": "", "provider": ""}
+        cfg = {}
         creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertIsNone(creds["model"])
         self.assertIsNone(creds["provider"])
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
@@ -599,7 +613,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         mock_resolve.return_value = {
             "provider": "openrouter",
             "base_url": "https://openrouter.ai/api/v1",
-            "api_key": "sk-or-test-key",
+            "api_key": "***",
             "api_mode": "chat_completions",
         }
         parent = _make_mock_parent(depth=0)
@@ -608,7 +622,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["model"], "google/gemini-3-flash-preview")
         self.assertEqual(creds["provider"], "openrouter")
         self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
-        self.assertEqual(creds["api_key"], "sk-or-test-key")
+        self.assertEqual(creds["api_key"], "***")
         self.assertEqual(creds["api_mode"], "chat_completions")
         mock_resolve.assert_called_once_with(requested="openrouter")
 
@@ -708,8 +722,53 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
 
 
+class TestDelegationRouteResolution(unittest.TestCase):
+    def test_normalize_delegation_config_folds_legacy_keys_into_default_route(self):
+        cfg = {
+            "model": "gpt-5.3-codex",
+            "provider": "openai-codex",
+            "max_iterations": 33,
+        }
+        normalized = _normalize_delegation_config(cfg)
+        self.assertEqual(normalized["route"], "default")
+        self.assertEqual(normalized["routes"]["default"]["model"], "gpt-5.3-codex")
+        self.assertEqual(normalized["routes"]["default"]["provider"], "openai-codex")
+        self.assertEqual(normalized["max_iterations"], 33)
+
+    def test_resolve_delegation_route_uses_requested_profile(self):
+        cfg = {
+            "route": "default",
+            "routes": {
+                "default": {"model": "gpt-5.3-codex", "provider": "openai-codex"},
+                "research": {"model": "gpt-5.4", "provider": "openai-codex"},
+            },
+        }
+        route_name, route_cfg, normalized = _resolve_delegation_route(cfg, "research")
+        self.assertEqual(route_name, "research")
+        self.assertEqual(route_cfg["model"], "gpt-5.4")
+        self.assertIn("default", normalized["routes"])
+
+    def test_resolve_delegation_route_rejects_unknown_profile(self):
+        cfg = {
+            "routes": {
+                "default": {"model": "gpt-5.3-codex", "provider": "openai-codex"},
+            },
+        }
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_delegation_route(cfg, "missing")
+        self.assertIn("routing_profile 'missing'", str(ctx.exception))
+
+    def test_model_only_route_rejects_incompatible_parent_provider(self):
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "openai-codex"
+        cfg = {"model": "anthropic/claude-sonnet-4-6"}
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_delegation_credentials(cfg, parent, route_name="research")
+        self.assertIn("research", str(ctx.exception))
+        self.assertIn("openai-codex", str(ctx.exception))
+
+
 class TestDelegationProviderIntegration(unittest.TestCase):
-    """Integration tests: delegation config → _run_single_child → AIAgent construction."""
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
@@ -899,6 +958,66 @@ class TestDelegationProviderIntegration(unittest.TestCase):
                 self.assertEqual(call.kwargs.get("override_base_url"), "https://openrouter.ai/api/v1")
                 self.assertEqual(call.kwargs.get("override_api_key"), "sk-or-batch")
                 self.assertEqual(call.kwargs.get("override_api_mode"), "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_batch_mode_unknown_routing_profile_fails_whole_call(self, mock_cfg):
+        mock_cfg.return_value = {
+            "route": "default",
+            "routes": {
+                "default": {"model": "gpt-5.3-codex", "provider": "openai-codex"},
+            },
+        }
+        parent = _make_mock_parent(depth=0)
+        result = json.loads(delegate_task(tasks=[{"goal": "A"}, {"goal": "B", "routing_profile": "missing"}], parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("routing_profile 'missing'", result["error"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_uses_per_task_routing_profiles(self, mock_run, mock_creds, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "route": "default",
+            "routes": {
+                "default": {"model": "gpt-5.3-codex", "provider": "openai-codex"},
+                "research": {"model": "gpt-5.4", "provider": "openai-codex"},
+            },
+        }
+        mock_creds.side_effect = [
+            {
+                "model": "gpt-5.3-codex",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "***",
+                "api_mode": "codex_responses",
+            },
+            {
+                "model": "gpt-5.4",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "***",
+                "api_mode": "codex_responses",
+            },
+        ]
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "A", "api_calls": 1, "duration_seconds": 1.0},
+            {"task_index": 1, "status": "completed", "summary": "B", "api_calls": 1, "duration_seconds": 1.0},
+        ]
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.return_value = MagicMock()
+            tasks = [
+                {"goal": "Task A"},
+                {"goal": "Task B", "routing_profile": "research"},
+            ]
+            delegate_task(tasks=tasks, parent_agent=parent)
+
+        self.assertEqual(mock_build.call_args_list[0].kwargs["model"], "gpt-5.3-codex")
+        self.assertEqual(mock_build.call_args_list[1].kwargs["model"], "gpt-5.4")
+        self.assertEqual(mock_creds.call_args_list[0].kwargs["route_name"], "default")
+        self.assertEqual(mock_creds.call_args_list[1].kwargs["route_name"], "research")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -703,6 +703,15 @@ def delegate_task(
     # Track goal labels for progress display (truncated for readability)
     task_labels = [t["goal"][:40] for t in task_list]
 
+    prepared_tasks = []
+    for i, t in enumerate(task_list):
+        selected_route = t.get("routing_profile") or routing_profile
+        try:
+            route_name, route_cfg, _ = _resolve_delegation_route(normalized_cfg, selected_route)
+        except ValueError as exc:
+            return tool_error(str(exc))
+        prepared_tasks.append((i, t, route_name, route_cfg))
+
     # Save parent tool names BEFORE any child construction mutates the global.
     # _build_child_agent() calls AIAgent() which calls get_tool_definitions(),
     # which overwrites model_tools._last_resolved_tool_names with child's toolset.
@@ -714,10 +723,8 @@ def delegate_task(
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
     try:
-        for i, t in enumerate(task_list):
-            selected_route = t.get("routing_profile") or routing_profile
+        for i, t, route_name, route_cfg in prepared_tasks:
             try:
-                route_name, route_cfg, _ = _resolve_delegation_route(normalized_cfg, selected_route)
                 creds = _resolve_delegation_credentials(route_cfg, parent_agent, route_name=route_name)
             except ValueError as exc:
                 return tool_error(str(exc))
@@ -861,7 +868,12 @@ def _empty_delegation_route() -> dict:
 
 
 def _normalize_delegation_config(cfg: Optional[dict]) -> dict:
-    """Return delegation config in canonical routing form."""
+    """Return delegation config in canonical routing form.
+
+    Keep this normalization aligned with hermes_cli.config.migrate_config(), which
+    performs the persistent on-disk migration of legacy flat delegation keys into
+    delegation.routes.default.
+    """
     cfg = cfg if isinstance(cfg, dict) else {}
     normalized_routes: Dict[str, Dict[str, str]] = {}
 
@@ -925,7 +937,14 @@ def _resolve_delegation_route(cfg: Optional[dict], requested_route: Optional[str
 
 
 def _validate_inherited_route_model(configured_model: Optional[str], parent_agent, route_name: str) -> None:
-    """Fail fast on provider/model mismatches when inheriting the parent provider."""
+    """Fail fast on provider/model mismatches when inheriting the parent provider.
+
+    This guard is intentionally narrow: it only protects the known bad case where
+    a route inherits the parent openai-codex provider but specifies a provider-
+    qualified model name (contains '/'). In that situation the delegated child
+    would otherwise inherit Codex transport settings and fail later with a less
+    obvious provider/model mismatch.
+    """
     if not configured_model:
         return
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -78,6 +78,8 @@ def _get_max_concurrent_children() -> int:
             pass
     return _DEFAULT_MAX_CONCURRENT_CHILDREN
 DEFAULT_MAX_ITERATIONS = 50
+DEFAULT_DELEGATION_ROUTE = "default"
+DELEGATION_ROUTE_FIELDS = ("model", "provider", "base_url", "api_key")
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
 
@@ -626,6 +628,7 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    routing_profile: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     parent_agent=None,
@@ -654,16 +657,12 @@ def delegate_task(
 
     # Load config
     cfg = _load_config()
-    default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
-    effective_max_iter = max_iterations or default_max_iter
-
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
+    normalized_cfg = _normalize_delegation_config(cfg)
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        effective_max_iter = _resolve_effective_max_iterations(
+            normalized_cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS),
+            max_iterations,
+        )
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -680,7 +679,12 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{
+            "goal": goal,
+            "context": context,
+            "toolsets": toolsets,
+            "routing_profile": routing_profile,
+        }]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -711,6 +715,13 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            selected_route = t.get("routing_profile") or routing_profile
+            try:
+                route_name, route_cfg, _ = _resolve_delegation_route(normalized_cfg, selected_route)
+                creds = _resolve_delegation_credentials(route_cfg, parent_agent, route_name=route_name)
+            except ValueError as exc:
+                return tool_error(str(exc))
+
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets, model=creds["model"],
@@ -845,21 +856,103 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     return None
 
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
-    """Resolve credentials for subagent delegation.
+def _empty_delegation_route() -> dict:
+    return {key: "" for key in DELEGATION_ROUTE_FIELDS}
 
-    If ``delegation.base_url`` is configured, subagents use that direct
-    OpenAI-compatible endpoint. Otherwise, if ``delegation.provider`` is
-    configured, the full credential bundle (base_url, api_key, api_mode,
-    provider) is resolved via the runtime provider system — the same path used
-    by CLI/gateway startup. This lets subagents run on a completely different
-    provider:model pair.
 
-    If neither base_url nor provider is configured, returns None values so the
-    child inherits everything from the parent agent.
+def _normalize_delegation_config(cfg: Optional[dict]) -> dict:
+    """Return delegation config in canonical routing form."""
+    cfg = cfg if isinstance(cfg, dict) else {}
+    normalized_routes: Dict[str, Dict[str, str]] = {}
 
-    Raises ValueError with a user-friendly message on credential failure.
-    """
+    raw_routes = cfg.get("routes")
+    if isinstance(raw_routes, dict):
+        for raw_name, raw_route in raw_routes.items():
+            name = str(raw_name or "").strip()
+            if not name or not isinstance(raw_route, dict):
+                continue
+            normalized_routes[name] = {
+                key: (raw_route.get(key).strip() if isinstance(raw_route.get(key), str) else "")
+                for key in DELEGATION_ROUTE_FIELDS
+            }
+
+    legacy_route = {
+        key: (cfg.get(key).strip() if isinstance(cfg.get(key), str) else "")
+        for key in DELEGATION_ROUTE_FIELDS
+    }
+    if any(legacy_route.values()):
+        default_route = normalized_routes.setdefault(
+            DEFAULT_DELEGATION_ROUTE,
+            _empty_delegation_route(),
+        )
+        for key, value in legacy_route.items():
+            if value and not default_route.get(key):
+                default_route[key] = value
+
+    normalized_routes.setdefault(DEFAULT_DELEGATION_ROUTE, _empty_delegation_route())
+
+    route_name = cfg.get("route") if isinstance(cfg.get("route"), str) else ""
+    route_name = route_name.strip() or DEFAULT_DELEGATION_ROUTE
+    if route_name.lower() == "auto":
+        route_name = DEFAULT_DELEGATION_ROUTE
+
+    return {
+        "route": route_name,
+        "routes": normalized_routes,
+        "max_iterations": cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS),
+        "reasoning_effort": cfg.get("reasoning_effort", ""),
+        "max_concurrent_children": cfg.get("max_concurrent_children"),
+    }
+
+
+def _resolve_delegation_route(cfg: Optional[dict], requested_route: Optional[str] = None) -> tuple[str, dict, dict]:
+    """Resolve a named delegation route from config."""
+    normalized = _normalize_delegation_config(cfg)
+    route_name = requested_route if isinstance(requested_route, str) else normalized.get("route")
+    route_name = str(route_name or DEFAULT_DELEGATION_ROUTE).strip()
+    if not route_name or route_name.lower() == "auto":
+        route_name = DEFAULT_DELEGATION_ROUTE
+
+    routes = normalized.get("routes") or {}
+    route_cfg = routes.get(route_name)
+    if route_cfg is None:
+        available = ", ".join(sorted(routes.keys())) or DEFAULT_DELEGATION_ROUTE
+        raise ValueError(
+            f"Unknown delegation routing_profile '{route_name}'. "
+            f"Available routes: {available}."
+        )
+    return route_name, route_cfg, normalized
+
+
+def _validate_inherited_route_model(configured_model: Optional[str], parent_agent, route_name: str) -> None:
+    """Fail fast on provider/model mismatches when inheriting the parent provider."""
+    if not configured_model:
+        return
+
+    parent_provider = str(getattr(parent_agent, "provider", "") or "").strip().lower()
+    if parent_provider == "openai-codex" and "/" in configured_model:
+        raise ValueError(
+            f"Delegation route '{route_name}' sets model '{configured_model}' but no provider/base_url. "
+            "That would inherit the parent openai-codex provider, which only supports Codex model slugs here. "
+            f"Set delegation.routes.{route_name}.provider explicitly or use a Codex-compatible model slug."
+        )
+
+
+def _resolve_effective_max_iterations(configured_value: Any, override_value: Optional[int]) -> int:
+    if override_value is not None:
+        if not isinstance(override_value, int) or isinstance(override_value, bool) or override_value <= 0:
+            raise ValueError("delegate_task max_iterations must be a positive integer.")
+        return override_value
+
+    if configured_value is None:
+        return DEFAULT_MAX_ITERATIONS
+    if not isinstance(configured_value, int) or isinstance(configured_value, bool) or configured_value <= 0:
+        raise ValueError("delegation.max_iterations must be a positive integer.")
+    return configured_value
+
+
+def _resolve_delegation_credentials(cfg: dict, parent_agent, *, route_name: str = DEFAULT_DELEGATION_ROUTE) -> dict:
+    """Resolve credentials for one selected subagent delegation route."""
     configured_model = str(cfg.get("model") or "").strip() or None
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
@@ -872,8 +965,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         )
         if not api_key:
             raise ValueError(
-                "Delegation base_url is configured but no API key was found. "
-                "Set delegation.api_key or OPENAI_API_KEY."
+                f"Delegation route '{route_name}' configures base_url but no API key was found. "
+                "Set delegation.routes.<name>.api_key or OPENAI_API_KEY."
             )
 
         base_lower = configured_base_url.lower()
@@ -895,7 +988,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         }
 
     if not configured_provider:
-        # No provider override — child inherits everything from parent
+        _validate_inherited_route_model(configured_model, parent_agent, route_name)
         return {
             "model": configured_model,
             "provider": None,
@@ -904,22 +997,21 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "api_mode": None,
         }
 
-    # Provider is configured — resolve full credentials
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
         runtime = resolve_runtime_provider(requested=configured_provider)
     except Exception as exc:
         raise ValueError(
-            f"Cannot resolve delegation provider '{configured_provider}': {exc}. "
+            f"Cannot resolve delegation provider '{configured_provider}' for route '{route_name}': {exc}. "
             f"Check that the provider is configured (API key set, valid provider name), "
-            f"or set delegation.base_url/delegation.api_key for a direct endpoint. "
+            f"or set delegation.routes.{route_name}.base_url/delegation.routes.{route_name}.api_key for a direct endpoint. "
             f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
         ) from exc
 
     api_key = runtime.get("api_key", "")
     if not api_key:
         raise ValueError(
-            f"Delegation provider '{configured_provider}' resolved but has no API key. "
+            f"Delegation provider '{configured_provider}' for route '{route_name}' resolved but has no API key. "
             f"Set the appropriate environment variable or run 'hermes auth'."
         )
 
@@ -938,9 +1030,9 @@ def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
     Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    to the persistent config (hermes_cli/config.py load_config()) so routing,
+    legacy delegation.model/provider, and related settings are picked up
+    regardless of the entry point (CLI, gateway, cron).
     """
     try:
         from cli import CLI_CONFIG
@@ -1031,6 +1123,10 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
                         },
+                        "routing_profile": {
+                            "type": "string",
+                            "description": "Per-task delegation route override, e.g. 'coding', 'research', or 'fast'.",
+                        },
                         "acp_command": {
                             "type": "string",
                             "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
@@ -1057,6 +1153,14 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Max tool-calling turns per subagent (default: 50). "
                     "Only set lower for simple tasks."
+                ),
+            },
+            "routing_profile": {
+                "type": "string",
+                "description": (
+                    "Select a named delegation route from config, e.g. 'coding', "
+                    "'research', or 'fast'. When omitted, Hermes uses delegation.route "
+                    "or delegation.routes.default."
                 ),
             },
             "acp_command": {
@@ -1095,6 +1199,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        routing_profile=args.get("routing_profile"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         parent_agent=kw.get("parent_agent")),


### PR DESCRIPTION
Description
===========

Refreshes PR #7201 onto the current `main` line and keeps the scope limited to **named delegation routing profiles** only.

This PR now contains **ONLY** these files:
- `tools/delegate_tool.py`
- `hermes_cli/config.py`
- `tests/tools/test_delegate.py`
- `tests/hermes_cli/test_config.py`

The earlier accidental Matrix history has been removed from the branch.

What this adds
==============

- named delegation routes under `delegation.routes`
- default route selection via `delegation.route`
- explicit per-call route selection via `delegate_task(..., routing_profile=...)`
- per-task route overrides in batch delegation
- runtime normalization of legacy flat delegation config into `delegation.routes.default`
- validation for delegation route structure and iteration limits
- fail-fast guard for invalid inherited provider/model combinations

Config shape
============

```yaml
delegation:
  route: default
  routes:
    default:
      provider: openai-codex
      model: gpt-5.3-codex
    coding:
      provider: openai-codex
      model: gpt-5.3-codex
    research:
      provider: openai-codex
      model: gpt-5.4
    fast:
      provider: openai-codex
      model: gpt-5.3-codex-spark
  max_iterations: 50
  reasoning_effort: high
```

Behavior
========

Route precedence is:
- per-task `routing_profile`
- top-level `routing_profile`
- `delegation.route`
- fallback to `default`

Legacy configs like:

```yaml
delegation:
  model: gpt-5.4
  provider: openai-codex
  base_url: ''
  api_key: ''
```

are normalized/migrated to:

```yaml
delegation:
  route: default
  routes:
    default:
      model: gpt-5.4
      provider: openai-codex
      base_url: ''
      api_key: ''
```

Validation
==========

This PR adds validation for:
- `delegation` being a dict
- `delegation.routes` being a dict
- route entry values being mappings
- route field types (`model`, `provider`, `base_url`, `api_key`)
- non-string route keys
- `delegation.route` type and missing-route warnings
- deprecated `delegation.route: auto`
- `delegation.max_iterations` being a positive integer

How to test
===========

Targeted:

```bash
~/.hermes/hermes-agent/venv/bin/python -m pytest -q -o 'addopts=' \
  tests/tools/test_delegate.py \
  tests/hermes_cli/test_config.py
```

Additional relevant slice:

```bash
~/.hermes/hermes-agent/venv/bin/python -m pytest -q -o 'addopts=' \
  tests/tools/test_delegate_toolset_scope.py
```

Local results
=============

- `tests/tools/test_delegate.py tests/hermes_cli/test_config.py` → **128 passed**
- `tests/tools/test_delegate_toolset_scope.py` → **5 passed**

Note on current upstream baseline
================================

`tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_providers_dict_when_list_missing`
currently fails on clean `origin/main` as well, so it is not introduced by this PR refresh.
