### PR TITLE
fix(api): remove tool progress markers from chat completions SSE stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -587,17 +587,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
-            def _on_tool_progress(event_type, name, preview, args, **kwargs):
-                """Inject tool progress into the SSE stream for Open WebUI."""
-                if event_type != "tool.started":
-                    return  # Only show tool start events in chat stream
-                if name.startswith("_"):
-                    return  # Skip internal events (_thinking)
-                from agent.display import get_tool_emoji
-                emoji = get_tool_emoji(name)
-                label = preview or name
-                _stream_q.put(f"\n`{emoji} {label}`\n")
-
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             agent_ref = [None]
@@ -607,7 +596,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
+                # Do not inject tool progress markers into delta.content.
+                # OpenAI-compatible clients may persist streamed content as
+                # assistant text, which can corrupt subsequent model behavior.
+                tool_progress_callback=None,
                 agent_ref=agent_ref,
             ))
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -462,8 +462,8 @@ class TestChatCompletionsEndpoint:
                 assert " about it..." in body
 
     @pytest.mark.asyncio
-    async def test_stream_includes_tool_progress(self, adapter):
-        """tool_progress_callback fires → progress appears in the SSE stream."""
+    async def test_stream_passes_no_tool_progress_callback(self, adapter):
+        """Streaming chat completions must not wire tool progress into content deltas."""
         import asyncio
 
         app = _create_app(adapter)
@@ -471,9 +471,8 @@ class TestChatCompletionsEndpoint:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 tp_cb = kwargs.get("tool_progress_callback")
-                # Simulate tool progress before streaming content
-                if tp_cb:
-                    tp_cb("tool.started", "terminal", "ls -la", {"command": "ls -la"})
+                # Regression guard: no tool progress callback should be passed.
+                assert tp_cb is None
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Here are the files.")
@@ -494,14 +493,12 @@ class TestChatCompletionsEndpoint:
                 assert resp.status == 200
                 body = await resp.text()
                 assert "[DONE]" in body
-                # Tool progress message must appear in the stream
-                assert "ls -la" in body
                 # Final content must also be present
                 assert "Here are the files." in body
 
     @pytest.mark.asyncio
-    async def test_stream_tool_progress_skips_internal_events(self, adapter):
-        """Internal events (name starting with _) are not streamed."""
+    async def test_stream_does_not_render_tool_progress_text(self, adapter):
+        """Even if tool events fire, SSE content should only contain assistant text."""
         import asyncio
 
         app = _create_app(adapter)
@@ -531,10 +528,9 @@ class TestChatCompletionsEndpoint:
                 )
                 assert resp.status == 200
                 body = await resp.text()
-                # Internal _thinking event should NOT appear
                 assert "some internal state" not in body
-                # Real tool progress should appear
-                assert "Python docs" in body
+                assert "Python docs" not in body
+                assert "Found it." in body
 
     @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Removes tool progress markers from the `/v1/chat/completions` SSE streaming response. These markers (backtick-wrapped emoji + tool name like `` `clock list` ``) were being injected into `delta.content`, which OpenAI-compatible frontends like Open WebUI persist as the assistant's literal response text.

Over enough turns, smaller models (particularly local models via llama.cpp/Ollama) learn to generate these markers as plain text instead of issuing real tool calls. The model effectively imitates the marker pattern from its own conversation history, causing silent tool execution failures where it reports success without any tool actually running.

## Related Issue

Fixes #6972

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: Removed the `_on_tool_progress` callback definition and passed `tool_progress_callback=None` to `_run_agent()` for streaming chat completions. Tool progress remains active on interactive platforms (CLI, Telegram, Discord) where messages are ephemeral.
- `tests/gateway/test_api_server.py`: Updated two existing tests: `test_stream_passes_no_tool_progress_callback` now asserts `tp_cb is None`, and `test_stream_does_not_render_tool_progress_text` asserts progress text does not appear in the SSE output.

The Responses API path (line 1362) was checked and uses a separate structured event mechanism that doesn't inject into `delta.content`, so no change was needed there.

## How to Test

1. Configure Hermes with the API server adapter (`/v1/chat/completions`)
2. Connect Open WebUI (or any OpenAI-compatible frontend)
3. Use a tool-heavy conversation (e.g., cron operations) for 10+ turns
4. Verify no `` `clock list` `` or similar markers appear in stored assistant messages
5. Verify the model continues to issue real tool calls rather than generating marker text

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3

### Documentation & Housekeeping

- [x] N/A - no config or doc changes needed

This contribution was developed with AI assistance (Codex).