### PR TITLE
feat(discord): add mention-required channel overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -579,6 +579,11 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
+                mrc = discord_cfg.get("mention_required_channels")
+                if mrc is not None and not os.getenv("DISCORD_MENTION_REQUIRED_CHANNELS"):
+                    if isinstance(mrc, list):
+                        mrc = ",".join(str(v) for v in mrc)
+                    os.environ["DISCORD_MENTION_REQUIRED_CHANNELS"] = str(mrc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2280,6 +2280,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Config (all settable via discord.* in config.yaml or DISCORD_* env vars):
         #   discord.require_mention: Require @mention in server channels (default: true)
         #   discord.free_response_channels: Channel IDs where bot responds without mention
+        #   discord.mention_required_channels: Channel IDs that require @mention even when global require_mention is false
         #   discord.ignored_channels: Channel IDs where bot NEVER responds (even when mentioned)
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
@@ -2314,11 +2315,15 @@ class DiscordAdapter(BasePlatformAdapter):
 
             free_channels_raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
+            mention_required_channels_raw = os.getenv("DISCORD_MENTION_REQUIRED_CHANNELS", "")
+            mention_required_channels = {ch.strip() for ch in mention_required_channels_raw.split(",") if ch.strip()}
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
             require_mention = os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
-            is_free_channel = bool(channel_ids & free_channels)
+            is_explicit_mention_required_channel = bool(channel_ids & mention_required_channels)
+            is_free_channel = bool(channel_ids & free_channels) and not is_explicit_mention_required_channel
+            require_mention = require_mention or is_explicit_mention_required_channel
 
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -553,11 +553,12 @@ DEFAULT_CONFIG = {
 
     # Discord platform settings (gateway mode)
     "discord": {
-        "require_mention": True,       # Require @mention to respond in server channels
-        "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
-        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
-        "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
-        "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "require_mention": True,          # Require @mention to respond in server channels
+        "free_response_channels": "",     # Comma-separated channel IDs where bot responds without mention
+        "mention_required_channels": "",  # Comma-separated channel IDs that still require mention when global gating is off
+        "allowed_channels": "",           # If set, bot ONLY responds in these channel IDs (whitelist)
+        "auto_thread": True,              # Auto-create threads on @mention in channels (like Slack)
+        "reactions": True,                # Add 👀/✅/❌ reactions to messages during processing
     },
 
     # WhatsApp platform settings (gateway mode)

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -324,6 +324,31 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
 
 
+def test_config_bridges_mention_required_channels(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.mention_required_channels to env var."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "mention_required_channels": ["444", "555"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_MENTION_REQUIRED_CHANNELS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_MENTION_REQUIRED_CHANNELS") == "444,555"
+
+
+def test_default_config_includes_mention_required_channels():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["discord"]["mention_required_channels"] == ""
+
+
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     """Env vars should take precedence over config.yaml values."""
     import yaml
@@ -331,14 +356,17 @@ def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     config_file.write_text(yaml.dump({
         "discord": {
             "ignored_channels": ["111"],
+            "mention_required_channels": ["222"],
         },
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "999")
+    monkeypatch.setenv("DISCORD_MENTION_REQUIRED_CHANNELS", "888")
 
     from gateway.config import load_gateway_config
     load_gateway_config()
 
     import os
-    # Env var should NOT be overwritten
+    # Env vars should NOT be overwritten
     assert os.getenv("DISCORD_IGNORED_CHANNELS") == "999"
+    assert os.getenv("DISCORD_MENTION_REQUIRED_CHANNELS") == "888"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -205,6 +205,52 @@ async def test_discord_free_response_channel_overrides_mention_requirement(adapt
 
 
 @pytest.mark.asyncio
+async def test_discord_mention_required_channel_overrides_global_free_response(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_MENTION_REQUIRED_CHANNELS", "789,999")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(channel=FakeTextChannel(channel_id=789), content="should require mention here")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_mention_required_channel_still_accepts_bot_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_MENTION_REQUIRED_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content=f"<@{bot_user.id}> stock update",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "stock update"
+
+
+@pytest.mark.asyncio
+async def test_discord_mention_required_channel_beats_free_response_override(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_MENTION_REQUIRED_CHANNELS", "789")
+
+    message = make_message(channel=FakeTextChannel(channel_id=789), content="explicit lock wins")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_discord_forum_parent_in_free_response_list_allows_forum_thread(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "222")

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -170,6 +170,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_HOME_CHANNEL_NAME` | Display name for the Discord home channel |
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
+| `DISCORD_MENTION_REQUIRED_CHANNELS` | Comma-separated channel IDs where mention is still required even when global gating is off |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |
 | `DISCORD_IGNORED_CHANNELS` | Comma-separated channel IDs where the bot never responds |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1087,13 +1087,15 @@ Configure Discord-specific behavior for the messaging gateway:
 
 ```yaml
 discord:
-  require_mention: true          # Require @mention to respond in server channels
-  free_response_channels: ""     # Comma-separated channel IDs where bot responds without @mention
-  auto_thread: true              # Auto-create threads on @mention in channels
+  require_mention: true           # Require @mention to respond in server channels
+  free_response_channels: ""      # Comma-separated channel IDs where bot responds without @mention
+  mention_required_channels: ""   # Comma-separated channel IDs that still require @mention when global gating is off
+  auto_thread: true               # Auto-create threads on @mention in channels
 ```
 
 - `require_mention` — when `true` (default), the bot only responds in server channels when mentioned with `@BotName`. DMs always work without mention.
 - `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
+- `mention_required_channels` — comma-separated list of channel IDs that require `@BotName` even when `require_mention: false`. If a channel appears in both `free_response_channels` and `mention_required_channels`, the mention-required rule wins.
 - `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
 
 ## Security

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -17,6 +17,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
 | **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. |
+| **Mention-required exceptions** | If you mostly want free-response but need a few channels to stay explicit, use `DISCORD_MENTION_REQUIRED_CHANNELS` to require `@mentions` only in those channels. |
 | **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
@@ -274,8 +275,9 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_ALLOWED_USERS` | **Yes** | — | Comma-separated Discord user IDs allowed to interact with the bot. Without this, the gateway denies all users. |
 | `DISCORD_HOME_CHANNEL` | No | — | Channel ID where the bot sends proactive messages (cron output, reminders, notifications). |
 | `DISCORD_HOME_CHANNEL_NAME` | No | `"Home"` | Display name for the home channel in logs and status output. |
-| `DISCORD_REQUIRE_MENTION` | No | `true` | When `true`, the bot only responds in server channels when `@mentioned`. Set to `false` to respond to all messages in every channel. |
+| `DISCORD_REQUIRE_MENTION` | No | `true` | When `true`, the bot only responds in server channels when `@mentioned`. Set to `false` to respond to all messages in every channel by default. |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
+| `DISCORD_MENTION_REQUIRED_CHANNELS` | No | — | Comma-separated channel IDs where the bot still requires an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `false`. If a channel appears in both Discord channel lists, mention-required wins. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
@@ -291,12 +293,13 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 ```yaml
 # Discord-specific settings
 discord:
-  require_mention: true           # Require @mention in server channels
-  free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
-  auto_thread: true               # Auto-create threads on @mention
-  reactions: true                 # Add emoji reactions during processing
-  ignored_channels: []            # Channel IDs where bot never responds
-  no_thread_channels: []          # Channel IDs where bot responds without threading
+  require_mention: true            # Require @mention in server channels
+  free_response_channels: ""       # Comma-separated channel IDs (or YAML list)
+  mention_required_channels: ""    # Comma-separated channel IDs (or YAML list)
+  auto_thread: true                # Auto-create threads on @mention
+  reactions: true                  # Add emoji reactions during processing
+  ignored_channels: []             # Channel IDs where bot never responds
+  no_thread_channels: []           # Channel IDs where bot responds without threading
 
 # Session isolation (applies to all gateway platforms, not just Discord)
 group_sessions_per_user: true     # Isolate sessions per user in shared channels
@@ -327,6 +330,26 @@ discord:
 ```
 
 If a thread's parent channel is in this list, the thread also becomes mention-free.
+
+#### `discord.mention_required_channels`
+
+**Type:** string or list — **Default:** `""`
+
+Channel IDs where the bot still requires an `@mention` even when `require_mention` is globally disabled. Accepts either a comma-separated string or a YAML list:
+
+```yaml
+# String format
+discord:
+  mention_required_channels: "1234567890,9876543210"
+
+# List format
+discord:
+  mention_required_channels:
+    - 1234567890
+    - 9876543210
+```
+
+If a thread's parent channel is in this list, that thread also requires a mention. If a channel appears in both `free_response_channels` and `mention_required_channels`, the mention-required rule wins.
 
 #### `discord.auto_thread`
 


### PR DESCRIPTION
## Summary
- add `discord.mention_required_channels` / `DISCORD_MENTION_REQUIRED_CHANNELS`
- let Discord run in globally free-response mode while keeping specific channels mention-gated
- bridge the new config key from `config.yaml`, add docs, and add regression tests

## Why
Some Discord setups want the inverse of today's model: most channels should be free-response, while a small set (for example stock-alert channels) should still require an explicit `@mention`. Today this requires constantly updating `free_response_channels` as new channels are added.

## Behavior
- `require_mention: false` opens all server channels by default
- `mention_required_channels` re-enables mention gating only for listed channels
- if a channel appears in both `free_response_channels` and `mention_required_channels`, mention-required wins
- thread children inherit the parent channel override

## Test Plan
- `./venv/bin/python -m pytest tests/gateway/test_discord_free_response.py tests/gateway/test_discord_channel_controls.py -q`
- `./venv/bin/python -m pytest tests/gateway/test_discord_*.py -q`