### PR TITLE
feat: validate learning case saves

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,9 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,6 +80,7 @@ class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")
     def test_writes_content(self, mock_get):
         mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/out.txt", "bytes": 13}
         mock_ops.write_file.return_value = result_obj
@@ -86,6 +90,78 @@ class TestWriteFileHandler:
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
         mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+
+    @patch("tools.file_tools._validate_case_json_targets")
+    @patch("tools.file_tools._get_file_ops")
+    def test_non_case_write_keeps_success_behavior(self, mock_get, mock_validate):
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/out.txt", "bytes": 13}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        mock_validate.return_value = None
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
+
+        assert result["status"] == "ok"
+        mock_validate.assert_called_once_with(["/tmp/out.txt"], task_cwd="/tmp")
+
+    @patch("tools.file_tools._validate_case_json_targets")
+    @patch("tools.file_tools._get_file_ops")
+    def test_case_write_runs_validator_and_returns_success(self, mock_get, mock_validate):
+        case_path = "/Users/maxmcair/.hermes/learning/cases/2026-04-10/example.json"
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": case_path, "bytes": 42}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        mock_validate.return_value = None
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool(case_path, "{\"id\": 1}\n"))
+
+        assert result["status"] == "ok"
+        mock_validate.assert_called_once_with([case_path], task_cwd="/tmp")
+
+    @patch("tools.file_tools._update_read_timestamp")
+    @patch("tools.file_tools._validate_case_json_targets")
+    @patch("tools.file_tools._get_file_ops")
+    def test_case_write_validation_failure_returns_error(self, mock_get, mock_validate, mock_update_timestamp):
+        case_path = "/Users/maxmcair/.hermes/learning/cases/2026-04-10/example.json"
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": case_path, "bytes": 42}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        mock_validate.return_value = "Case JSON validation failed for example.json: missing field"
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool(case_path, "{\"id\": 1}\n"))
+
+        assert result["error"] == "Case JSON validation failed for example.json: missing field"
+        mock_validate.assert_called_once_with([case_path], task_cwd="/tmp")
+        mock_update_timestamp.assert_not_called()
+
+    @patch("tools.file_tools._validate_case_json_targets")
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_error_skips_case_validator(self, mock_get, mock_validate):
+        case_path = "/Users/maxmcair/.hermes/learning/cases/2026-04-10/example.json"
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"error": "disk full"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool(case_path, "{\"id\": 1}\n"))
+
+        assert result["error"] == "disk full"
+        mock_validate.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -111,13 +187,16 @@ class TestWriteFileHandler:
 
 
 class TestPatchHandler:
+    @patch("tools.file_tools._validate_case_json_targets")
     @patch("tools.file_tools._get_file_ops")
-    def test_replace_mode_calls_patch_replace(self, mock_get):
+    def test_replace_mode_calls_patch_replace(self, mock_get, mock_validate):
         mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "replacements": 1}
         mock_ops.patch_replace.return_value = result_obj
         mock_get.return_value = mock_ops
+        mock_validate.return_value = None
 
         from tools.file_tools import patch_tool
         result = json.loads(patch_tool(
@@ -126,10 +205,35 @@ class TestPatchHandler:
         ))
         assert result["status"] == "ok"
         mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_validate.assert_called_once_with(["/tmp/f.py"], task_cwd="/tmp")
+
+    @patch("tools.file_tools._update_read_timestamp")
+    @patch("tools.file_tools._validate_case_json_targets")
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_case_validation_failure_returns_error(self, mock_get, mock_validate, mock_update_timestamp):
+        case_path = "/Users/maxmcair/.hermes/learning/cases/2026-04-10/example.json"
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "replacements": 1}
+        mock_ops.patch_replace.return_value = result_obj
+        mock_get.return_value = mock_ops
+        mock_validate.return_value = "Case JSON validation failed for example.json: missing field"
+
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="replace", path=case_path,
+            old_string="foo", new_string="bar"
+        ))
+
+        assert result["error"] == "Case JSON validation failed for example.json: missing field"
+        mock_validate.assert_called_once_with([case_path], task_cwd="/tmp")
+        mock_update_timestamp.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
         mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "replacements": 5}
         mock_ops.patch_replace.return_value = result_obj
@@ -152,18 +256,43 @@ class TestPatchHandler:
         result = json.loads(patch_tool(mode="replace", path="/tmp/f.py", old_string=None, new_string="b"))
         assert "error" in result
 
+    @patch("tools.file_tools._validate_case_json_targets")
     @patch("tools.file_tools._get_file_ops")
-    def test_patch_mode_calls_patch_v4a(self, mock_get):
+    def test_patch_mode_calls_patch_v4a(self, mock_get, mock_validate):
         mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
         result_obj = MagicMock()
-        result_obj.to_dict.return_value = {"status": "ok", "operations": 1}
+        case_path = "/Users/maxmcair/.hermes/learning/cases/2026-04-10/example.json"
+        result_obj.to_dict.return_value = {"status": "ok", "operations": 1, "files_modified": [case_path]}
         mock_ops.patch_v4a.return_value = result_obj
         mock_get.return_value = mock_ops
+        mock_validate.return_value = None
 
         from tools.file_tools import patch_tool
         result = json.loads(patch_tool(mode="patch", patch="*** Begin Patch\n..."))
         assert result["status"] == "ok"
         mock_ops.patch_v4a.assert_called_once()
+        mock_validate.assert_called_once_with([case_path], task_cwd="/tmp")
+
+    @patch("tools.file_tools._update_read_timestamp")
+    @patch("tools.file_tools._validate_case_json_targets")
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_mode_case_validation_failure_returns_error(self, mock_get, mock_validate, mock_update_timestamp):
+        mock_ops = MagicMock()
+        mock_ops.cwd = "/tmp"
+        case_path = "/Users/maxmcair/.hermes/learning/cases/2026-04-10/example.json"
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "operations": 1, "files_modified": [case_path]}
+        mock_ops.patch_v4a.return_value = result_obj
+        mock_get.return_value = mock_ops
+        mock_validate.return_value = "Case JSON validation failed for example.json: missing field"
+
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(mode="patch", patch="*** Begin Patch\n..."))
+
+        assert result["error"] == "Case JSON validation failed for example.json: missing field"
+        mock_validate.assert_called_once_with([case_path], task_cwd="/tmp")
+        mock_update_timestamp.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
     def test_patch_mode_missing_content_errors(self, mock_get):
@@ -216,6 +345,48 @@ class TestSearchHandler:
         from tools.file_tools import search_tool
         result = json.loads(search_tool(pattern="x"))
         assert "error" in result
+
+
+class TestCaseValidationHelpers:
+    def test_collect_targets_resolves_relative_paths_from_task_cwd(self, monkeypatch):
+        temp_root = tempfile.mkdtemp()
+        hermes_home = os.path.join(temp_root, ".hermes")
+        case_root = os.path.join(hermes_home, "learning", "cases", "2026-04-10")
+        os.makedirs(case_root, exist_ok=True)
+
+        from tools.file_tools import _collect_case_json_validation_targets
+
+        monkeypatch.setenv("HERMES_HOME", hermes_home)
+        targets = _collect_case_json_validation_targets(
+            ["example.json"],
+            task_cwd=case_root,
+        )
+
+        assert len(targets) == 1
+        assert targets[0] == Path(case_root, "example.json").resolve(strict=False)
+
+    def test_validate_targets_reports_missing_node(self, monkeypatch):
+        temp_root = tempfile.mkdtemp()
+        hermes_home = os.path.join(temp_root, ".hermes")
+        case_root = os.path.join(hermes_home, "learning", "cases", "2026-04-10")
+        script_root = os.path.join(hermes_home, "learning", "scripts")
+        os.makedirs(case_root, exist_ok=True)
+        os.makedirs(script_root, exist_ok=True)
+        case_path = os.path.join(case_root, "example.json")
+        validator_path = os.path.join(script_root, "validate-case.mjs")
+
+        with open(case_path, "w", encoding="utf-8") as f:
+            f.write("{}\n")
+        with open(validator_path, "w", encoding="utf-8") as f:
+            f.write("console.log('ok')\n")
+
+        from tools.file_tools import _validate_case_json_targets
+
+        monkeypatch.setenv("HERMES_HOME", hermes_home)
+        with patch("tools.file_tools.subprocess.run", side_effect=FileNotFoundError):
+            error = _validate_case_json_targets([case_path], task_cwd=case_root)
+
+        assert error == "Case JSON validation failed: 'node' executable not found"
 
 
 # ---------------------------------------------------------------------------
@@ -309,6 +480,3 @@ class TestSearchHints:
         raw = search_tool(pattern="foo", offset=50, limit=50)
         assert "[Hint:" in raw
         assert "offset=100" in raw
-
-
-

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import subprocess
 import threading
 from pathlib import Path
 from tools.binary_extensions import has_binary_extension
@@ -123,6 +124,81 @@ def _is_expected_write_exception(exc: Exception) -> bool:
     if isinstance(exc, OSError) and exc.errno in _EXPECTED_WRITE_ERRNOS:
         return True
     return False
+
+
+def _get_case_validation_root() -> Path:
+    """Return the profile-aware Hermes learning case root."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home().expanduser() / "learning" / "cases"
+
+
+def _get_case_validator_script() -> Path:
+    """Return the profile-aware Hermes case validator script path."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home().expanduser() / "learning" / "scripts" / "validate-case.mjs"
+
+
+def _resolve_case_json_target(filepath: str | None, task_cwd: str | None = None) -> Path | None:
+    """Return a resolved case JSON path when the target is under learning/cases."""
+    if not filepath:
+        return None
+    try:
+        candidate = Path(os.path.expandvars(filepath)).expanduser()
+        if not candidate.is_absolute() and task_cwd:
+            candidate = Path(os.path.expandvars(task_cwd)).expanduser() / candidate
+        candidate = candidate.resolve(strict=False)
+        if candidate.suffix.lower() != ".json":
+            return None
+        candidate.relative_to(_get_case_validation_root().resolve(strict=False))
+        return candidate
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _collect_case_json_validation_targets(paths: list[str], task_cwd: str | None = None) -> list[Path]:
+    """Return de-duplicated case JSON targets that require validation."""
+    targets: list[Path] = []
+    seen: set[Path] = set()
+    for raw_path in paths:
+        resolved = _resolve_case_json_target(raw_path, task_cwd=task_cwd)
+        if resolved is None or resolved in seen:
+            continue
+        seen.add(resolved)
+        targets.append(resolved)
+    return targets
+
+
+def _validate_case_json_targets(paths: list[str], task_cwd: str | None = None) -> str | None:
+    """Validate case JSON files and return an error string on failure."""
+    targets = _collect_case_json_validation_targets(paths, task_cwd=task_cwd)
+    if not targets:
+        return None
+
+    validator_script = _get_case_validator_script()
+    if not validator_script.exists():
+        return f"Case JSON validator script not found: {validator_script}"
+
+    for target in targets:
+        try:
+            result = subprocess.run(
+                ["node", str(validator_script), str(target)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except FileNotFoundError:
+            return "Case JSON validation failed: 'node' executable not found"
+        except Exception as exc:
+            return f"Case JSON validation failed for {target}: {exc}"
+
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout or "").strip() or "validation failed"
+            return f"Case JSON validation failed for {target}: {details}"
+
+    return None
 
 
 _file_ops_lock = threading.Lock()
@@ -578,11 +654,17 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
         file_ops = _get_file_ops(task_id)
         result = file_ops.write_file(path, content)
         result_dict = result.to_dict()
+        validation_error = None
+        if not result_dict.get("error"):
+            validation_error = _validate_case_json_targets([path], task_cwd=file_ops.cwd)
         if stale_warning:
             result_dict["_warning"] = stale_warning
+        if validation_error:
+            return tool_error(validation_error)
         # Refresh the stored timestamp so consecutive writes by this
         # task don't trigger false staleness warnings.
-        _update_read_timestamp(path, task_id)
+        if not result_dict.get("error"):
+            _update_read_timestamp(path, task_id)
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -630,10 +712,23 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             result = file_ops.patch_v4a(patch)
         else:
             return tool_error(f"Unknown mode: {mode}")
-        
+
         result_dict = result.to_dict()
+        validation_paths = []
+        if mode == "replace":
+            validation_paths = [path] if path else []
+        elif not result_dict.get("error"):
+            validation_paths = [
+                *result_dict.get("files_modified", []),
+                *result_dict.get("files_created", []),
+            ]
+        validation_error = None
+        if not result_dict.get("error"):
+            validation_error = _validate_case_json_targets(validation_paths, task_cwd=file_ops.cwd)
         if stale_warnings:
             result_dict["_warning"] = stale_warnings[0] if len(stale_warnings) == 1 else " | ".join(stale_warnings)
+        if validation_error:
+            return tool_error(validation_error)
         # Refresh stored timestamps for all successfully-patched paths so
         # consecutive edits by this task don't trigger false warnings.
         if not result_dict.get("error"):


### PR DESCRIPTION
   ## What does this PR do?

  Automatically validates learning case JSON files after successful
  `write_file` and `patch` operations when the target is under
  `HERMES_HOME/learning/cases/*.json`.

  This prevents invalid reviewed case saves from being treated as
  successful tool results. Validation failures now surface as tool
  errors instead of success payloads, and relative case JSON paths
  are also resolved from the task cwd.

  ## Related Issue

  N/A

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - add automatic case JSON validation in `tools/file_tools.py` after
  successful `write_file` and `patch` operations targeting
  `HERMES_HOME/learning/cases/*.json`
  - return a tool error instead of a success payload when validation
  fails
  - skip `_update_read_timestamp()` on validation failure so failed
  saves do not look successful internally
  - resolve relative case JSON targets from the task cwd before
  deciding whether validation is required
  - add targeted tests in `tests/tools/test_file_tools.py` for:
    - case write success and failure
    - patch success and failure
    - relative path resolution
    - missing `node`
    - timestamp behavior on validation failure

  ## How to Test

  1. Run `pytest tests/tools/test_file_tools.py tests/tools/
  test_file_staleness.py`
  2. Start Hermes with an isolated `HERMES_HOME` and write a valid
  case JSON file under `learning/cases/...`
  3. Repeat with an invalid case JSON file missing `privacy_class`
  and confirm the tool returns an error instead of a success payload

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/
  NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://
  www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/
  NousResearch/hermes-agent/pulls) to make sure this isn't a
  duplicate
  - [x] My PR contains **only** changes related to this fix/feature
  (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes,
  strongly encouraged for features)
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [ ] I've updated relevant documentation (README, `docs/`,
  docstrings) — or N/A
  - [ ] I've updated `cli-config.yaml.example` if I added/changed
  config keys — or N/A
  - [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed
  architecture or workflows — or N/A
  - [ ] I've considered cross-platform impact (Windows, macOS) per
  the [compatibility guide](https://github.com/NousResearch/hermes-
  agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or
  N/A
  - [x] I've updated tool descriptions/schemas if I changed tool
  behavior — or N/A

  ## Screenshots / Logs

  - `pytest tests/tools/test_file_tools.py tests/tools/
  test_file_staleness.py` -> `42 passed`
  - live Hermes CLI validation in isolated `HERMES_HOME`:
    - valid case save -> success
    - invalid case save missing `privacy_class` -> `write_file
  failed: ... missing required field privacy_class`

