### PR TITLE
fix: correct _camofox_eval argument types for _ensure_tab and _post

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1607,11 +1607,10 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
 
 def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
     """Evaluate JS via Camofox's /tabs/{tab_id}/eval endpoint (if available)."""
-    from tools.browser_camofox import _get_session, _ensure_tab, _post
+    from tools.browser_camofox import _ensure_tab, _post
     try:
-        session = _get_session(task_id or "default")
-        tab_id = _ensure_tab(session)
-        resp = _post(f"/tabs/{tab_id}/eval", json_data={"expression": expression})
+        session = _ensure_tab(task_id or "default")
+        resp = _post(f"/tabs/{session['tab_id']}/eval", body={"expression": expression})
 
         # Camofox returns the result in a JSON envelope
         raw_result = resp.get("result") if isinstance(resp, dict) else resp


### PR DESCRIPTION
## Summary

- Fix two guaranteed `TypeError`s in `_camofox_eval()` that made Camofox JS eval silently non-functional
- `_ensure_tab(session)` passed a `dict` but the function expects `task_id: str`
- `_post(..., json_data={...})` used wrong keyword; the parameter is named `body`
- Remove unused `_get_session` import (already called internally by `_ensure_tab`)

## Related Issue

Fixes #7168

## Test Plan

- Verify `_camofox_eval()` no longer raises `TypeError` on the two corrected call sites
- Confirm existing browser tool tests still pass