### PR TITLE
fix: handle None request_overrides in _build_api_kwargs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":


### PR DESCRIPTION
When `request_overrides` is `None`, calling `.get("speed")` raises `AttributeError`. Guard with `(self.request_overrides or {})`.

Fixes regression from #7037 (Anthropic Fast Mode support).