### PR TITLE
fix: sync telegram codex model picker with cli discovery

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -723,6 +723,59 @@ def switch_model(
 # Authenticated providers listing (for /model no-args display)
 # ---------------------------------------------------------------------------
 
+
+def _slice_provider_models(model_ids: list[str], max_models: int) -> tuple[list[str], int]:
+    """Return (display_models, total_models) with max_models<=0 meaning no limit."""
+    ordered = list(model_ids or [])
+    total = len(ordered)
+    if max_models <= 0:
+        return ordered, total
+    return ordered[:max_models], total
+
+
+def _get_display_models_for_provider(
+    provider_id: str,
+    curated: dict[str, list[str]],
+    max_models: int,
+) -> tuple[list[str], int]:
+    """Return display models for a provider, preferring live discovery when useful.
+
+    Today only OpenAI Codex needs provider-specific discovery so that Telegram /
+    model pickers can show the same dynamically discovered models as the CLI
+    `hermes model` flow. If discovery fails, fall back to the curated static
+    list instead of returning nothing.
+    """
+    fallback = list(curated.get(provider_id, []))
+
+    if provider_id == "openai-codex":
+        try:
+            from hermes_cli.auth import get_codex_auth_status, resolve_codex_runtime_credentials
+            from hermes_cli.codex_models import get_codex_model_ids
+
+            access_token = None
+            try:
+                status = get_codex_auth_status()
+                if status.get("logged_in"):
+                    access_token = status.get("api_key")
+            except Exception as exc:
+                logger.debug("Could not read Codex auth status for picker model list: %s", exc)
+
+            if not access_token:
+                try:
+                    creds = resolve_codex_runtime_credentials()
+                    access_token = creds.get("api_key")
+                except Exception as exc:
+                    logger.debug("Could not resolve Codex runtime credentials for picker model list: %s", exc)
+
+            discovered = get_codex_model_ids(access_token=access_token)
+            if discovered:
+                return _slice_provider_models(discovered, max_models)
+        except Exception as exc:
+            logger.debug("Could not dynamically discover Codex picker models: %s", exc)
+
+    return _slice_provider_models(fallback, max_models)
+
+
 def list_authenticated_providers(
     current_provider: str = "",
     user_providers: dict = None,
@@ -789,10 +842,9 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list, falling back to models.dev if no curated list
-        model_ids = curated.get(hermes_id, [])
-        total = len(model_ids)
-        top = model_ids[:max_models]
+        # Use curated list by default, with provider-specific discovery hooks
+        # for pickers that should mirror richer CLI model discovery.
+        top, total = _get_display_models_for_provider(hermes_id, curated, max_models)
 
         slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
@@ -836,10 +888,9 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list
-        model_ids = curated.get(pid, [])
-        total = len(model_ids)
-        top = model_ids[:max_models]
+        # Use curated list by default, with provider-specific discovery hooks
+        # for pickers that should mirror richer CLI model discovery.
+        top, total = _get_display_models_for_provider(pid, curated, max_models)
 
         results.append({
             "slug": pid,

--- a/tests/hermes_cli/test_model_switch_codex_picker_models.py
+++ b/tests/hermes_cli/test_model_switch_codex_picker_models.py
@@ -1,0 +1,69 @@
+"""Tests for Codex model discovery in shared /model provider listings."""
+
+import hermes_cli.providers as providers_mod
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.models import _PROVIDER_MODELS
+
+
+def test_list_authenticated_providers_uses_dynamic_codex_models(monkeypatch):
+    """Gateway/Telegram /model should reuse the richer Codex discovery path."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        providers_mod,
+        "HERMES_OVERLAYS",
+        {"openai-codex": providers_mod.HERMES_OVERLAYS["openai-codex"]},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {"openai-codex": {"tokens": {"access_token": "abc"}}}, "credential_pool": {}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": True, "api_key": "codex-live-token"},
+    )
+
+    captured = {}
+
+    def _fake_get_codex_model_ids(access_token=None):
+        captured["access_token"] = access_token
+        return ["gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2", "gpt-5.3-codex-spark"]
+
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        _fake_get_codex_model_ids,
+    )
+
+    providers = list_authenticated_providers(current_provider="openai-codex", max_models=50)
+    codex = next(p for p in providers if p["slug"] == "openai-codex")
+
+    assert captured["access_token"] == "codex-live-token"
+    assert codex["models"] == ["gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2", "gpt-5.3-codex-spark"]
+    assert codex["total_models"] == 5
+
+
+def test_list_authenticated_providers_falls_back_to_curated_codex_models(monkeypatch):
+    """If dynamic Codex discovery fails, keep the old curated picker list."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        providers_mod,
+        "HERMES_OVERLAYS",
+        {"openai-codex": providers_mod.HERMES_OVERLAYS["openai-codex"]},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {"openai-codex": {"tokens": {"access_token": "abc"}}}, "credential_pool": {}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": True, "api_key": "codex-live-token"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: [],
+    )
+
+    providers = list_authenticated_providers(current_provider="openai-codex", max_models=50)
+    codex = next(p for p in providers if p["slug"] == "openai-codex")
+
+    assert codex["models"] == _PROVIDER_MODELS["openai-codex"]
+    assert codex["total_models"] == len(_PROVIDER_MODELS["openai-codex"])


### PR DESCRIPTION
## Summary
- make shared /model provider listings use dynamic OpenAI Codex model discovery
- keep the previous curated Codex list as a fallback when live discovery fails
- add regression tests covering dynamic picker results and fallback behavior

## Why
Telegram /model was using the static provider list from hermes_cli/models.py, while the CLI hermes model flow already used Codex-specific dynamic discovery via get_codex_model_ids(...). This made Telegram miss newer Codex models like gpt-5.4.

## Test Plan
- python -m pytest tests/hermes_cli/test_model_switch_codex_picker_models.py tests/hermes_cli/test_codex_models.py -q
- manually verified Telegram /model now shows gpt-5.4 for OpenAI Codex
