### PR TITLE
feat(cli): show path in hermes update stash restore messages

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3007,7 +3007,7 @@ def _restore_stashed_changes(
             print(f"Restore manually with: git stash apply {stash_ref}")
             return False
 
-    print("→ Restoring local changes...")
+    print(f"→ Restoring local changes at {cwd}...")
     restore = subprocess.run(
         git_cmd + ["stash", "apply", stash_ref],
         cwd=cwd,
@@ -3078,7 +3078,7 @@ def _restore_stashed_changes(
             _print_stash_cleanup_guidance(stash_ref, stash_selector)
 
     print("⚠ Local changes were restored on top of the updated codebase.")
-    print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
+    print(f"  Review `git diff` / `git status` at {cwd} if Hermes behaves unexpectedly.")
     return True
 
 # =========================================================================


### PR DESCRIPTION
## What improved

When `hermes update` restores stashed local changes, the output now shows the exact path where the changes are being restored, making it clear where users should run `git diff` / `git status`.

## Before

```
→ Restoring local changes...
⚠ Local changes were restored on top of the updated codebase.
  Review `git diff` / `git status` if Hermes behaves unexpectedly.
```

## After

```
→ Restoring local changes at /home/user/hermes-agent...
⚠ Local changes were restored on top of the updated codebase.
  Review `git diff` / `git status` at /home/user/hermes-agent if Hermes behaves unexpectedly.
```

## Why this is minimal

- Only 2 print statements changed
- No logic changes
- Uses existing `cwd` parameter

## What I tested

- Python syntax validation (`py_compile`)

## What I intentionally did not change

- No changes to stash restore logic
- No changes to error handling
- No opportunistic refactoring

Fixes #6357