### PR TITLE
fix(cron): inherit delegated child activity in watchdog

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2503,9 +2503,13 @@ class AIAgent:
 
         Called by the gateway timeout handler to report what the agent was doing
         when it was killed, and by the periodic "still working" notifications.
+
+        When this agent is delegating to active subagents, prefer the freshest
+        child activity so parent-level inactivity monitors (cron/gateway) do not
+        mistake ongoing delegated work for an idle parent.
         """
         elapsed = time.time() - self._last_activity_ts
-        return {
+        summary = {
             "last_activity_ts": self._last_activity_ts,
             "last_activity_desc": self._last_activity_desc,
             "seconds_since_activity": round(elapsed, 1),
@@ -2515,6 +2519,50 @@ class AIAgent:
             "budget_used": self.iteration_budget.used,
             "budget_max": self.iteration_budget.max_total,
         }
+
+        freshest_child = None
+        freshest_child_ts = self._last_activity_ts
+        with self._active_children_lock:
+            children_copy = list(self._active_children)
+
+        for child in children_copy:
+            if not hasattr(child, "get_activity_summary"):
+                continue
+            try:
+                child_summary = child.get_activity_summary()
+            except Exception:
+                continue
+            child_ts = child_summary.get("last_activity_ts")
+            if child_ts is None:
+                continue
+            try:
+                child_ts = float(child_ts)
+            except (TypeError, ValueError):
+                continue
+            if child_ts > freshest_child_ts:
+                freshest_child_ts = child_ts
+                freshest_child = child_summary
+
+        if freshest_child is not None:
+            child_desc = freshest_child.get("last_activity_desc", "unknown")
+            summary["last_activity_ts"] = freshest_child.get(
+                "last_activity_ts", summary["last_activity_ts"]
+            )
+            child_idle = freshest_child.get(
+                "seconds_since_activity", summary["seconds_since_activity"]
+            )
+            try:
+                summary["seconds_since_activity"] = round(float(child_idle), 1)
+            except (TypeError, ValueError):
+                pass
+            if self._current_tool == "delegate_task":
+                summary["last_activity_desc"] = f"delegate_task child active: {child_desc}"
+            else:
+                summary["last_activity_desc"] = f"child active: {child_desc}"
+            if summary["current_tool"] is None:
+                summary["current_tool"] = freshest_child.get("current_tool")
+
+        return summary
 
     def shutdown_memory_provider(self, messages: list = None) -> None:
         """Shut down the memory provider — call at actual session boundaries.

--- a/tests/run_agent/test_activity_summary_delegation.py
+++ b/tests/run_agent/test_activity_summary_delegation.py
@@ -1,0 +1,65 @@
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(*, last_activity_ts: float, last_activity_desc: str, current_tool: str | None):
+    agent = AIAgent.__new__(AIAgent)
+    agent._last_activity_ts = last_activity_ts
+    agent._last_activity_desc = last_activity_desc
+    agent._current_tool = current_tool
+    agent._api_call_count = 6
+    agent.max_iterations = 90
+    agent.iteration_budget = MagicMock(used=4, max_total=90)
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    return agent
+
+
+def test_get_activity_summary_uses_parent_state_without_children():
+    now = time.time()
+    agent = _make_agent(
+        last_activity_ts=now - 12,
+        last_activity_desc="executing tool: delegate_task",
+        current_tool="delegate_task",
+    )
+
+    summary = agent.get_activity_summary()
+
+    assert summary["last_activity_desc"] == "executing tool: delegate_task"
+    assert summary["current_tool"] == "delegate_task"
+    assert summary["seconds_since_activity"] == pytest.approx(12, abs=0.5)
+
+
+def test_get_activity_summary_prefers_more_recent_child_activity():
+    now = time.time()
+    parent = _make_agent(
+        last_activity_ts=now - 610,
+        last_activity_desc="executing tool: delegate_task",
+        current_tool="delegate_task",
+    )
+
+    child = MagicMock()
+    child.get_activity_summary.return_value = {
+        "last_activity_ts": now - 3,
+        "last_activity_desc": "executing tool: read_file",
+        "seconds_since_activity": 3.0,
+        "current_tool": "read_file",
+        "api_call_count": 2,
+        "max_iterations": 50,
+        "budget_used": 1,
+        "budget_max": 50,
+    }
+
+    with parent._active_children_lock:
+        parent._active_children.append(child)
+
+    summary = parent.get_activity_summary()
+
+    assert summary["seconds_since_activity"] == pytest.approx(3.0, abs=0.1)
+    assert "read_file" in summary["last_activity_desc"]
+    assert summary["current_tool"] == "delegate_task"


### PR DESCRIPTION
## Summary
- make parent activity summaries prefer the freshest active subagent activity during delegate_task
- prevent cron/gateway inactivity monitors from treating active delegated work as an idle parent
- add a regression test covering delegated child activity in get_activity_summary

## Test Plan
- source /home/dev/.hermes/hermes-agent/venv/bin/activate && pytest tests/run_agent/test_activity_summary_delegation.py -q
- source /home/dev/.hermes/hermes-agent/venv/bin/activate && pytest tests/cron/test_cron_inactivity_timeout.py -q
- source /home/dev/.hermes/hermes-agent/venv/bin/activate && pytest tests/agent/test_subagent_progress.py -q
- source /home/dev/.hermes/hermes-agent/venv/bin/activate && pytest tests/run_agent/test_real_interrupt_subagent.py -q
- source /home/dev/.hermes/hermes-agent/venv/bin/activate && pytest tests/run_agent/test_activity_summary_delegation.py tests/cron/test_cron_inactivity_timeout.py tests/agent/test_subagent_progress.py tests/run_agent/test_real_interrupt_subagent.py -q