### PR TITLE
fix: Skip 'tags' parameter for Fireworks vision API

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1948,7 +1948,14 @@ def _build_call_kwargs(
 
     # Provider-specific extra_body
     merged_extra = dict(extra_body or {})
-    if provider == "nous" or auxiliary_is_nous:
+    # Add Nous Portal tags, but skip for Fireworks (custom provider with fireworks.ai base_url)
+    # which rejects the "tags" parameter as an extra input
+    is_fireworks = (
+        provider == "custom" and 
+        base_url and 
+        "fireworks.ai" in str(base_url).lower()
+    )
+    if (provider == "nous" or auxiliary_is_nous) and not is_fireworks:
         merged_extra.setdefault("tags", []).extend(["product=hermes-agent"])
     if merged_extra:
         kwargs["extra_body"] = merged_extra


### PR DESCRIPTION
## Problem
When using Fireworks AI (e.g., Kimi K2.5 Turbo) as the auxiliary vision model via the `custom` provider, the vision API calls fail with:
```
Extra inputs are not permitted, field: 'tags', value: ['product=hermes-agent']
```

This happens because Fireworks rejects the `tags` parameter that Hermes adds for Nous Portal attribution.

## Solution
Detect Fireworks by checking:
1. Provider is `"custom"`
2. Base URL contains `"fireworks.ai"`

If both conditions are true, skip adding the `tags` parameter while preserving it for all other providers (including Nous Portal).

## Changes
- Modified `agent/auxiliary_client.py` line ~1951
- Added `is_fireworks` detection logic
- Updated condition to skip tags when Fireworks is detected

## Testing
- Verified vision analysis works with Fireworks-hosted Kimi
- Confirmed Nous Portal still receives tags when used
- No breaking changes for other providers

## Related
Fixes vision analysis failures when using Fireworks AI models like Kimi K2.5 Turbo as auxiliary vision models.