### PR TITLE
feat(config): support model.extra_body passthrough

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2606,6 +2606,7 @@ class HermesCLI:
         self.acp_args = resolved_acp_args
         self._credential_pool = resolved_credential_pool
         self._provider_source = runtime.get("source")
+        self._runtime_request_overrides = runtime.get("request_overrides")
         self.api_key = api_key
         self.base_url = base_url
 
@@ -2638,19 +2639,23 @@ class HermesCLI:
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
                 "credential_pool": getattr(self, "_credential_pool", None),
+                "request_overrides": getattr(self, "_runtime_request_overrides", None),
             },
         )
 
+        merged_overrides = dict(route["runtime"].get("request_overrides") or {})
         service_tier = getattr(self, "service_tier", None)
         if not service_tier:
-            route["request_overrides"] = None
+            route["request_overrides"] = merged_overrides or None
             return route
 
         try:
             overrides = resolve_fast_mode_overrides(route.get("model"))
         except Exception:
             overrides = None
-        route["request_overrides"] = overrides
+        if overrides:
+            merged_overrides.update(overrides)
+        route["request_overrides"] = merged_overrides or None
         return route
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, route_label: str = None, request_overrides: dict | None = None) -> bool:
@@ -2722,8 +2727,10 @@ class HermesCLI:
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
                 "credential_pool": getattr(self, "_credential_pool", None),
+                "request_overrides": getattr(self, "_runtime_request_overrides", None),
             }
             effective_model = model_override or self.model
+            effective_request_overrides = request_overrides if request_overrides is not None else runtime.get("request_overrides")
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -2741,7 +2748,7 @@ class HermesCLI:
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
                 service_tier=self.service_tier,
-                request_overrides=request_overrides,
+                request_overrides=effective_request_overrides,
                 providers_allowed=self._providers_only,
                 providers_ignored=self._providers_ignore,
                 providers_order=self._providers_order,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -311,6 +311,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "request_overrides": runtime.get("request_overrides"),
     }
 
 
@@ -792,6 +793,7 @@ class GatewayRunner:
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
+            "request_overrides": runtime_kwargs.get("request_overrides"),
         }
         return resolve_turn_route(user_message, getattr(self, "_smart_model_routing", {}), primary)
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -87,6 +88,30 @@ def _get_model_config() -> Dict[str, Any]:
     if isinstance(model_cfg, str) and model_cfg.strip():
         return {"default": model_cfg.strip()}
     return {}
+
+
+def _runtime_request_overrides(model_cfg: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+    """Return config-derived request overrides for runtime agent creation."""
+    model_cfg = model_cfg or _get_model_config()
+    extra_body = model_cfg.get("extra_body")
+    if not isinstance(extra_body, dict) or not extra_body:
+        return None
+    return {"extra_body": copy.deepcopy(extra_body)}
+
+
+def _attach_runtime_request_overrides(
+    runtime: Optional[Dict[str, Any]],
+    model_cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Attach config-derived request overrides to a resolved runtime dict."""
+    if runtime is None:
+        return None
+    request_overrides = _runtime_request_overrides(model_cfg)
+    if not request_overrides:
+        return runtime
+    enriched = dict(runtime)
+    enriched["request_overrides"] = request_overrides
+    return enriched
 
 
 def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:
@@ -595,7 +620,7 @@ def resolve_runtime_provider(
     )
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider
-        return custom_runtime
+        return _attach_runtime_request_overrides(custom_runtime, model_cfg=_get_model_config())
 
     provider = resolve_provider(
         requested_provider,
@@ -611,7 +636,7 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     if explicit_runtime:
-        return explicit_runtime
+        return _attach_runtime_request_overrides(explicit_runtime, model_cfg=model_cfg)
 
     should_use_pool = provider != "openrouter"
     if provider == "openrouter":
@@ -661,12 +686,15 @@ def resolve_runtime_provider(
                 logger.debug("Nous pool entry agent_key expired/missing, falling through to runtime resolution")
                 pool_api_key = ""
         if entry is not None and pool_api_key:
-            return _resolve_runtime_from_pool_entry(
-                provider=provider,
-                entry=entry,
-                requested_provider=requested_provider,
+            return _attach_runtime_request_overrides(
+                _resolve_runtime_from_pool_entry(
+                    provider=provider,
+                    entry=entry,
+                    requested_provider=requested_provider,
+                    model_cfg=model_cfg,
+                    pool=pool,
+                ),
                 model_cfg=model_cfg,
-                pool=pool,
             )
 
     if provider == "nous":
@@ -675,7 +703,7 @@ def resolve_runtime_provider(
                 min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
                 timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
             )
-            return {
+            return _attach_runtime_request_overrides({
                 "provider": "nous",
                 "api_mode": "chat_completions",
                 "base_url": creds.get("base_url", "").rstrip("/"),
@@ -683,7 +711,7 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "portal"),
                 "expires_at": creds.get("expires_at"),
                 "requested_provider": requested_provider,
-            }
+            }, model_cfg=model_cfg)
         except AuthError:
             if requested_provider != "auto":
                 raise
@@ -695,7 +723,7 @@ def resolve_runtime_provider(
     if provider == "openai-codex":
         try:
             creds = resolve_codex_runtime_credentials()
-            return {
+            return _attach_runtime_request_overrides({
                 "provider": "openai-codex",
                 "api_mode": "codex_responses",
                 "base_url": creds.get("base_url", "").rstrip("/"),
@@ -703,7 +731,7 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "hermes-auth-store"),
                 "last_refresh": creds.get("last_refresh"),
                 "requested_provider": requested_provider,
-            }
+            }, model_cfg=model_cfg)
         except AuthError:
             if requested_provider != "auto":
                 raise
@@ -715,7 +743,7 @@ def resolve_runtime_provider(
     if provider == "qwen-oauth":
         try:
             creds = resolve_qwen_runtime_credentials()
-            return {
+            return _attach_runtime_request_overrides({
                 "provider": "qwen-oauth",
                 "api_mode": "chat_completions",
                 "base_url": creds.get("base_url", "").rstrip("/"),
@@ -723,7 +751,7 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "qwen-cli"),
                 "expires_at_ms": creds.get("expires_at_ms"),
                 "requested_provider": requested_provider,
-            }
+            }, model_cfg=model_cfg)
         except AuthError:
             if requested_provider != "auto":
                 raise
@@ -732,7 +760,7 @@ def resolve_runtime_provider(
 
     if provider == "copilot-acp":
         creds = resolve_external_process_provider_credentials(provider)
-        return {
+        return _attach_runtime_request_overrides({
             "provider": "copilot-acp",
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
@@ -741,7 +769,7 @@ def resolve_runtime_provider(
             "args": list(creds.get("args") or []),
             "source": creds.get("source", "process"),
             "requested_provider": requested_provider,
-        }
+        }, model_cfg=model_cfg)
 
     # Anthropic (native Messages API)
     if provider == "anthropic":
@@ -760,14 +788,14 @@ def resolve_runtime_provider(
         if cfg_provider == "anthropic":
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or "https://api.anthropic.com"
-        return {
+        return _attach_runtime_request_overrides({
             "provider": "anthropic",
             "api_mode": "anthropic_messages",
             "base_url": base_url,
             "api_key": token,
             "source": "env",
             "requested_provider": requested_provider,
-        }
+        }, model_cfg=model_cfg)
 
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
@@ -801,14 +829,14 @@ def resolve_runtime_provider(
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
         if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
             base_url = re.sub(r"/v1/?$", "", base_url)
-        return {
+        return _attach_runtime_request_overrides({
             "provider": provider,
             "api_mode": api_mode,
             "base_url": base_url,
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
-        }
+        }, model_cfg=model_cfg)
 
     runtime = _resolve_openrouter_runtime(
         requested_provider=requested_provider,
@@ -816,7 +844,7 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     runtime["requested_provider"] = requested_provider
-    return runtime
+    return _attach_runtime_request_overrides(runtime, model_cfg=model_cfg)
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5440,6 +5440,43 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
+    @staticmethod
+    def _deep_merge_request_dicts(base: dict, overlay: dict) -> dict:
+        """Recursively merge two request dicts, letting overlay win on conflicts."""
+        merged = copy.deepcopy(base)
+        for key, value in overlay.items():
+            if isinstance(merged.get(key), dict) and isinstance(value, dict):
+                merged[key] = AIAgent._deep_merge_request_dicts(merged[key], value)
+            else:
+                merged[key] = copy.deepcopy(value)
+        return merged
+
+    def _apply_request_overrides(self, api_kwargs: dict, *, allow_extra_body: bool) -> dict:
+        """Apply generic request overrides while merging nested request payloads safely."""
+        if not self.request_overrides:
+            return api_kwargs
+
+        merged_kwargs = dict(api_kwargs)
+        for key, value in self.request_overrides.items():
+            if key == "extra_body":
+                if not allow_extra_body or not isinstance(value, dict):
+                    continue
+                existing = merged_kwargs.get("extra_body")
+                if isinstance(existing, dict):
+                    merged_kwargs["extra_body"] = self._deep_merge_request_dicts(value, existing)
+                else:
+                    merged_kwargs["extra_body"] = copy.deepcopy(value)
+                continue
+            if key == "extra_headers" and isinstance(value, dict):
+                existing = merged_kwargs.get("extra_headers")
+                if isinstance(existing, dict):
+                    merged_kwargs["extra_headers"] = self._deep_merge_request_dicts(value, existing)
+                else:
+                    merged_kwargs["extra_headers"] = copy.deepcopy(value)
+                continue
+            merged_kwargs[key] = value
+        return merged_kwargs
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
@@ -5522,8 +5559,7 @@ class AIAgent:
             elif not is_github_responses:
                 kwargs["include"] = []
 
-            if self.request_overrides:
-                kwargs.update(self.request_overrides)
+            kwargs = self._apply_request_overrides(kwargs, allow_extra_body=False)
 
             if self.max_tokens is not None and not is_codex_backend:
                 kwargs["max_output_tokens"] = self.max_tokens
@@ -5697,9 +5733,9 @@ class AIAgent:
             api_kwargs["extra_headers"] = {"x-grok-conv-id": self.session_id}
 
         # Priority Processing / generic request overrides (e.g. service_tier).
-        # Applied last so overrides win over any defaults set above.
-        if self.request_overrides:
-            api_kwargs.update(self.request_overrides)
+        # ``extra_body`` / ``extra_headers`` are merged specially so configured
+        # advanced request payloads can coexist with Hermes-generated fields.
+        api_kwargs = self._apply_request_overrides(api_kwargs, allow_extra_body=True)
 
         return api_kwargs
 

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -211,6 +211,46 @@ class TestFastModeRouting(unittest.TestCase):
         # But request_overrides should be set
         assert route["request_overrides"] == {"service_tier": "priority"}
 
+    def test_turn_route_merges_runtime_request_overrides_with_fast_mode(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="gpt-5.4",
+            api_key="primary-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _smart_model_routing={},
+            _runtime_request_overrides={"extra_body": {"transforms": ["middle-out"]}},
+            service_tier="priority",
+        )
+
+        original_runtime = {
+            "api_key": "***",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+            "request_overrides": {"extra_body": {"transforms": ["middle-out"]}},
+        }
+
+        with patch("agent.smart_model_routing.resolve_turn_route", return_value={
+            "model": "gpt-5.4",
+            "runtime": dict(original_runtime),
+            "label": None,
+            "signature": ("gpt-5.4", "openrouter", "https://openrouter.ai/api/v1", "chat_completions", None, ()),
+        }):
+            route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["request_overrides"] == {
+            "extra_body": {"transforms": ["middle-out"]},
+            "service_tier": "priority",
+        }
+
     def test_turn_route_keeps_primary_runtime_when_model_has_no_fast_backend(self):
         cli_mod = _import_cli()
         stub = SimpleNamespace(

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -127,3 +127,35 @@ class TestApiServerAdapterToolset:
             call_kwargs = mock_agent_cls.call_args
             toolsets = call_kwargs.kwargs.get("enabled_toolsets")
             assert sorted(toolsets) == ["terminal", "web"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_passes_request_overrides_from_runtime(self):
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {
+                "api_key": "***",
+                "base_url": None,
+                "provider": None,
+                "api_mode": None,
+                "command": None,
+                "args": [],
+                "request_overrides": {"extra_body": {"transforms": ["middle-out"]}},
+            }
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {}
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            mock_agent_cls.assert_called_once()
+            assert mock_agent_cls.call_args.kwargs.get("request_overrides") == {
+                "extra_body": {"transforms": ["middle-out"]}
+            }

--- a/tests/hermes_cli/test_runtime_provider_request_overrides.py
+++ b/tests/hermes_cli/test_runtime_provider_request_overrides.py
@@ -1,0 +1,33 @@
+import hermes_cli.runtime_provider as runtime_provider
+
+
+def test_resolve_runtime_provider_attaches_model_extra_body_request_overrides(monkeypatch):
+    monkeypatch.setattr(
+        runtime_provider,
+        "load_config",
+        lambda: {
+            "model": {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "extra_body": {
+                    "transforms": ["middle-out"],
+                    "provider": {"ignore": ["deepinfra"]},
+                },
+            }
+        },
+    )
+    monkeypatch.setattr(runtime_provider, "load_pool", lambda provider: None)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    runtime = runtime_provider.resolve_runtime_provider(requested="openrouter")
+
+    assert runtime["provider"] == "openrouter"
+    assert runtime["request_overrides"] == {
+        "extra_body": {
+            "transforms": ["middle-out"],
+            "provider": {"ignore": ["deepinfra"]},
+        }
+    }

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -244,6 +244,27 @@ class TestBuildApiKwargsChatCompletionsServiceTier:
         kwargs = agent._build_api_kwargs(messages)
         assert "service_tier" not in kwargs
 
+    def test_merges_extra_body_request_overrides_without_clobbering_hermes_fields(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.model = "anthropic/claude-sonnet-4-20250514"
+        agent.providers_allowed = ["anthropic"]
+        agent.request_overrides = {
+            "extra_body": {
+                "provider": {
+                    "ignore": ["deepinfra"],
+                    "only": ["google"],
+                },
+                "transforms": ["middle-out"],
+            }
+        }
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        extra = kwargs["extra_body"]
+        assert extra["provider"]["only"] == ["anthropic"]
+        assert extra["provider"]["ignore"] == ["deepinfra"]
+        assert extra["transforms"] == ["middle-out"]
+        assert extra["reasoning"]["effort"] == "medium"
+
 
 class TestBuildApiKwargsAIGateway:
     def test_uses_chat_completions_format(self, monkeypatch):


### PR DESCRIPTION
## Summary
- support `model.extra_body` passthrough for normal runtime agent requests
- carry config-derived request overrides through CLI and gateway runtime resolution
- merge configured `extra_body` safely with Hermes-generated request payloads
- add regression coverage for runtime provider, CLI routing, gateway wiring, and request merge behavior

## Test Plan
- [x] `../../venv/bin/python -m pytest tests/run_agent/test_provider_parity.py tests/cli/test_fast_command.py tests/gateway/test_api_server_toolset.py tests/hermes_cli/test_runtime_provider_request_overrides.py -q -o addopts=''`

## Why
Users already have an `extra_body` escape hatch in the RL environment stack, but the normal CLI/gateway `AIAgent` path had no `config.yaml` passthrough for provider-specific request payloads. This makes the main interactive runtime less capable than the eval/runtime plumbing.

## Notes
- Hermes-generated request payload fields still win on conflict.
- `extra_body` is merged recursively instead of shallow-overwritten, so nested payloads like `provider` / `options` do not get clobbered.
- Scope is intentionally narrow: this PR only wires `model.extra_body` through the standard runtime path.

## Comparison with #7190
PR #7190 added gateway `/fast` support by routing Priority Processing through `request_overrides`. This PR is not a duplicate of that work.

- **#7190**: product feature for gateway `/fast`
  - introduces/uses `request_overrides` for `service_tier`
  - primarily changes gateway command behavior
- **#7218**: runtime plumbing for `model.extra_body`
  - carries config-derived request overrides from `config.yaml`
  - makes normal CLI/gateway runtime requests accept provider-specific `extra_body`
  - adds safe recursive merge behavior in `run_agent.py`

### Why they overlap
Both PRs touch the same `request_overrides` path:
- #7190 uses it for fast mode / `service_tier`
- #7218 uses it for config-driven `extra_body`

That overlap is why this PR also updates CLI/gateway routing and adds a `/fast` interaction test: once `request_overrides` has more than one source, we need to prove those sources can coexist instead of clobbering each other.

### Why this is still separate work
#7190 is a feature-specific use of request overrides. This PR generalizes the runtime override path so advanced payloads from config can flow through the normal agent stack. In short:
- #7190 = **feature-level use case**
- #7218 = **infrastructure/plumbing for a broader override channel**

Closes #7209

Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.

Carried patch: patch-feat-pr7218
