### PR TITLE
fix(gateway): validate user access to paths before generating systemd service

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -668,6 +668,31 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
         path_entries.extend(common_bin_paths)
         sane_path = ":".join(path_entries)
+
+        # Validate: target user must be able to access key paths
+        if username != "root":
+            inaccessible = []
+            for label, path in [("WorkingDirectory", working_dir),
+                                ("Python", python_path),
+                                ("HERMES_HOME", hermes_home)]:
+                try:
+                    test = subprocess.run(
+                        ["sudo", "-u", username, "test", "-r", path],
+                        capture_output=True, timeout=5,
+                    )
+                    if test.returncode != 0:
+                        inaccessible.append(f"  {label}: {path}")
+                except Exception:
+                    inaccessible.append(f"  {label}: {path}")
+            if inaccessible:
+                detail = "\n".join(inaccessible)
+                raise SystemExit(
+                    f"User '{username}' cannot access required paths:\n{detail}\n\n"
+                    f"Fix options:\n"
+                    f"  1. Install files under {home_dir}/ instead of /root/\n"
+                    f"  2. Run as root: hermes gateway install --system --run-as-user root"
+                )
+
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target


### PR DESCRIPTION
## Problem

`hermes gateway install --system --run-as-user <user>` silently generates a systemd service that fails with `CHDIR: Permission denied` when the target user cannot access the hermes installation paths.

This happens when hermes-agent is installed under `/root/` but the system service is configured to run as a non-root user — common in LXC/VM setups.

## Root Cause

`generate_systemd_unit()` generates the service file without checking if the `run_as_user` can actually access `WorkingDirectory`, the Python binary, or `HERMES_HOME`. The service fails at startup with:

```
Changing to the requested working directory failed: Permission denied
Failed at step CHDIR spawning ... Permission denied
```

## Fix

Add a validation check in `generate_systemd_unit()` that verifies the target user can read the three critical paths before generating the unit file. If any path is inaccessible, raises a clear error with fix suggestions:

1. Install files under the target user's home directory
2. Use `--run-as-user root` for container/VM environments

## Testing

```bash
# Before: silently broken service
hermes gateway install --system --run-as-user pxnji
# → generates service that fails on start

# After: clear error message
hermes gateway install --system --run-as-user pxnji
# → User 'pxnji' cannot access required paths:
#     WorkingDirectory: /root/.hermes/hermes-agent
#     Python: /root/.hermes/hermes-agent/.venv/bin/python
#   Fix options:
#     1. Install files under /home/pxnji/ instead of /root/
#     2. Run as root: hermes gateway install --system --run-as-user root
```

`run_as_user=root` continues to work without validation (skipped for root user, as intended for container environments).