### PR TITLE
feat(nix): add overlay and make package overridable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
         ./nix/nixosModules.nix
         ./nix/checks.nix
         ./nix/devShell.nix
+        ./nix/overlays.nix
       ];
     };
 }

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -8,6 +8,7 @@
   openssh,
   ffmpeg,
   tirith,
+  olm,
   stdenv,
   makeWrapper,
 
@@ -15,11 +16,18 @@
   uv2nix,
   pyproject-nix,
   pyproject-build-systems,
+
+  dependency-groups ? [ "all" ],
 }:
 
 let
   hermesVenv = callPackage ./python.nix {
-    inherit uv2nix pyproject-nix pyproject-build-systems;
+    inherit
+      uv2nix
+      pyproject-nix
+      pyproject-build-systems
+      dependency-groups
+      ;
     python = python311;
   };
 
@@ -36,6 +44,8 @@ let
     openssh
     ffmpeg
     tirith
+  ] ++ lib.optionals (lib.elem "matrix" dependency-groups) [
+    olm
   ];
 
   runtimePath = lib.makeBinPath runtimeDeps;

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  python311,
+  callPackage,
+  nodejs_20,
+  ripgrep,
+  git,
+  openssh,
+  ffmpeg,
+  tirith,
+  stdenv,
+  makeWrapper,
+
+  # inputs
+  uv2nix,
+  pyproject-nix,
+  pyproject-build-systems,
+}:
+
+let
+  hermesVenv = callPackage ./python.nix {
+    inherit uv2nix pyproject-nix pyproject-build-systems;
+    python = python311;
+  };
+
+  # Import bundled skills, excluding runtime caches
+  bundledSkills = lib.cleanSourceWith {
+    src = ../skills;
+    filter = path: _type: !(lib.hasInfix "/index-cache/" path);
+  };
+
+  runtimeDeps = [
+    nodejs_20
+    ripgrep
+    git
+    openssh
+    ffmpeg
+    tirith
+  ];
+
+  runtimePath = lib.makeBinPath runtimeDeps;
+in
+stdenv.mkDerivation {
+  pname = "hermes-agent";
+  version = (builtins.fromTOML (builtins.readFile ../pyproject.toml)).project.version;
+
+  dontUnpack = true;
+  dontBuild = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/hermes-agent $out/bin
+    cp -r ${bundledSkills} $out/share/hermes-agent/skills
+
+    ${lib.concatMapStringsSep "\n"
+      (name: ''
+        makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
+          --suffix PATH : "${runtimePath}" \
+          --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills
+      '')
+      [
+        "hermes"
+        "hermes-agent"
+        "hermes-acp"
+      ]
+    }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "AI agent with advanced tool-calling capabilities";
+    homepage = "https://github.com/NousResearch/hermes-agent";
+    mainProgram = "hermes";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,11 @@
+# nix/overlays.nix
+{ inputs, ... }:
+{
+  flake = {
+    overlays.default = final: _: {
+      hermes-agent = final.callPackage ./hermes-agent.nix {
+        inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
+      };
+    };
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,54 +1,11 @@
 # nix/packages.nix — Hermes Agent package built with uv2nix
-{ inputs, ... }: {
-  perSystem = { pkgs, system, ... }:
-    let
-      hermesVenv = pkgs.callPackage ./python.nix {
+{ inputs, ... }:
+{
+  perSystem =
+    { pkgs, system, ... }:
+    {
+      packages.default = pkgs.callPackage ./hermes-agent.nix {
         inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
-      };
-
-      # Import bundled skills, excluding runtime caches
-      bundledSkills = pkgs.lib.cleanSourceWith {
-        src = ../skills;
-        filter = path: _type:
-          !(pkgs.lib.hasInfix "/index-cache/" path);
-      };
-
-      runtimeDeps = with pkgs; [
-        nodejs_20 ripgrep git openssh ffmpeg tirith
-      ];
-
-      runtimePath = pkgs.lib.makeBinPath runtimeDeps;
-    in {
-      packages.default = pkgs.stdenv.mkDerivation {
-        pname = "hermes-agent";
-        version = (builtins.fromTOML (builtins.readFile ../pyproject.toml)).project.version;
-
-        dontUnpack = true;
-        dontBuild = true;
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-
-        installPhase = ''
-          runHook preInstall
-
-          mkdir -p $out/share/hermes-agent $out/bin
-          cp -r ${bundledSkills} $out/share/hermes-agent/skills
-
-          ${pkgs.lib.concatMapStringsSep "\n" (name: ''
-            makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
-              --suffix PATH : "${runtimePath}" \
-              --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills
-          '') [ "hermes" "hermes-agent" "hermes-acp" ]}
-
-          runHook postInstall
-        '';
-
-        meta = with pkgs.lib; {
-          description = "AI agent with advanced tool-calling capabilities";
-          homepage = "https://github.com/NousResearch/hermes-agent";
-          mainProgram = "hermes";
-          license = licenses.mit;
-          platforms = platforms.unix;
-        };
       };
     };
 }

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -7,6 +7,8 @@
   pyproject-nix,
   pyproject-build-systems,
   stdenv,
+
+  dependency-groups ? [ "all" ],
 }:
 let
   workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./..; };
@@ -36,7 +38,11 @@ let
     };
 
   pythonPackageOverrides = final: _prev:
-    if isAarch64Darwin then {
+    {
+      atomicwrites = hacks.nixpkgsPrebuilt{
+        from = python.pkgs.atomicwrites;
+      };
+    } // (if isAarch64Darwin then {
       numpy = mkPrebuiltOverride final python.pkgs.numpy { };
 
       av = mkPrebuiltOverride final python.pkgs.av { };
@@ -66,7 +72,7 @@ let
         tokenizers = [ ];
         tqdm = [ ];
       };
-    } else {};
+    } else {});
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {
@@ -79,5 +85,5 @@ let
       ]);
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {
-  hermes-agent = [ "all" ];
+  hermes-agent = dependency-groups;
 }

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -1,6 +1,6 @@
 # nix/python.nix — uv2nix virtual environment builder
 {
-  python311,
+  python,
   lib,
   callPackage,
   uv2nix,
@@ -37,28 +37,28 @@ let
 
   pythonPackageOverrides = final: _prev:
     if isAarch64Darwin then {
-      numpy = mkPrebuiltOverride final python311.pkgs.numpy { };
+      numpy = mkPrebuiltOverride final python.pkgs.numpy { };
 
-      av = mkPrebuiltOverride final python311.pkgs.av { };
+      av = mkPrebuiltOverride final python.pkgs.av { };
 
-      humanfriendly = mkPrebuiltOverride final python311.pkgs.humanfriendly { };
+      humanfriendly = mkPrebuiltOverride final python.pkgs.humanfriendly { };
 
-      coloredlogs = mkPrebuiltOverride final python311.pkgs.coloredlogs {
+      coloredlogs = mkPrebuiltOverride final python.pkgs.coloredlogs {
         humanfriendly = [ ];
       };
 
-      onnxruntime = mkPrebuiltOverride final python311.pkgs.onnxruntime {
+      onnxruntime = mkPrebuiltOverride final python.pkgs.onnxruntime {
         coloredlogs = [ ];
         numpy = [ ];
         packaging = [ ];
       };
 
-      ctranslate2 = mkPrebuiltOverride final python311.pkgs.ctranslate2 {
+      ctranslate2 = mkPrebuiltOverride final python.pkgs.ctranslate2 {
         numpy = [ ];
         pyyaml = [ ];
       };
 
-      faster-whisper = mkPrebuiltOverride final python311.pkgs.faster-whisper {
+      faster-whisper = mkPrebuiltOverride final python.pkgs.faster-whisper {
         av = [ ];
         ctranslate2 = [ ];
         huggingface-hub = [ ];
@@ -70,7 +70,7 @@ let
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {
-      python = python311;
+      inherit python;
     }).overrideScope
       (lib.composeManyExtensions [
         pyproject-build-systems.overlays.default


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

This PR fixes the Nix experience, especially when overriding the package.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #4594

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

* The package now takes `dependency-groups` as a parameter for more flexible builds.
* Moved the main Hermes Agent package definition from `nix/packages.nix` to a new, modularized `nix/hermes-agent.nix`, improving maintainability and reusability.
* The package now takes `dependency-groups` as a parameter for more flexible builds.
* Added `nix/overlays.nix`, providing a Nix overlay that exposes the Hermes Agent package for easier consumption in external Nix projects.
* Add uv2nix override for matrix-nio

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Set up hermes-agent on NixOS by following [our documentation](https://hermes-agent.nousresearch.com/docs/getting-started/nix-setup)
2. [Add matrix as messaging platform](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/matrix#end-to-end-encryption-e2ee), and switch to the new generation will fall into #4594 
3. Override the package as follows to make it work:
   ```nix
   nixpkgs = {
     overlays = [ inputs.hermes-agent.overlays.default ];
     config.permittedInsecurePackages = [ "olm-3.2.16" ];
   };

   services.hermes-agent = {
     enable = true;
     package = pkgs.hermes-agent.override {
       dependency-groups = [ "matrix" ];
     };
   };
   ```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: x86_64-linux, NixOS with nixpkgs-unstable <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

