### PR TITLE
fix(dingtalk): enforce origin validation for session webhooks

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -68,6 +68,11 @@ def check_dingtalk_requirements() -> bool:
     return True
 
 
+def _is_valid_session_webhook(session_webhook: str) -> bool:
+    """Allow only official DingTalk session webhook origins."""
+    return bool(session_webhook and _DINGTALK_WEBHOOK_RE.match(session_webhook))
+
+
 class DingTalkAdapter(BasePlatformAdapter):
     """DingTalk chatbot adapter using Stream Mode.
 
@@ -200,7 +205,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         # Store session webhook for reply routing (validate origin to prevent SSRF)
         session_webhook = getattr(message, "session_webhook", None) or ""
-        if session_webhook and chat_id and _DINGTALK_WEBHOOK_RE.match(session_webhook):
+        if chat_id and _is_valid_session_webhook(session_webhook):
             if len(self._session_webhooks) >= _SESSION_WEBHOOKS_MAX:
                 # Evict oldest entry to cap memory growth
                 try:
@@ -282,7 +287,14 @@ class DingTalkAdapter(BasePlatformAdapter):
         """Send a markdown reply via DingTalk session webhook."""
         metadata = metadata or {}
 
-        session_webhook = metadata.get("session_webhook") or self._session_webhooks.get(chat_id)
+        metadata_webhook = metadata.get("session_webhook") or ""
+        if metadata_webhook and not _is_valid_session_webhook(metadata_webhook):
+            return SendResult(
+                success=False,
+                error="Invalid session_webhook origin. Only DingTalk API webhooks are allowed.",
+            )
+
+        session_webhook = metadata_webhook or self._session_webhooks.get(chat_id)
         if not session_webhook:
             return SendResult(success=False,
                               error="No session_webhook available. Reply must follow an incoming message.")

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -165,12 +165,12 @@ class TestSend:
 
         result = await adapter.send(
             "chat-123", "Hello!",
-            metadata={"session_webhook": "https://dingtalk.example/webhook"}
+            metadata={"session_webhook": "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"}
         )
         assert result.success is True
         mock_client.post.assert_called_once()
         call_args = mock_client.post.call_args
-        assert call_args[0][0] == "https://dingtalk.example/webhook"
+        assert call_args[0][0] == "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
         payload = call_args[1]["json"]
         assert payload["msgtype"] == "markdown"
         assert payload["markdown"]["title"] == "Hermes"
@@ -196,11 +196,26 @@ class TestSend:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         adapter._http_client = mock_client
-        adapter._session_webhooks["chat-123"] = "https://cached.example/webhook"
+        adapter._session_webhooks["chat-123"] = "https://api.dingtalk.com/v1.0/robot/oToMessages/cached"
 
         result = await adapter.send("chat-123", "Hello!")
         assert result.success is True
-        assert mock_client.post.call_args[0][0] == "https://cached.example/webhook"
+        assert mock_client.post.call_args[0][0] == "https://api.dingtalk.com/v1.0/robot/oToMessages/cached"
+
+    @pytest.mark.asyncio
+    async def test_send_rejects_non_dingtalk_metadata_webhook(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+
+        result = await adapter.send(
+            "chat-123", "Hello!",
+            metadata={"session_webhook": "https://evil.example/webhook"}
+        )
+
+        assert result.success is False
+        assert "Invalid session_webhook origin" in result.error
+        adapter._http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_handles_http_error(self):
@@ -216,7 +231,7 @@ class TestSend:
 
         result = await adapter.send(
             "chat-123", "Hello!",
-            metadata={"session_webhook": "https://example/webhook"}
+            metadata={"session_webhook": "https://api.dingtalk.com/v1.0/robot/oToMessages/error"}
         )
         assert result.success is False
         assert "400" in result.error


### PR DESCRIPTION
### Summary
Implemented origin validation for `metadata["session_webhook"]` in `DingTalkAdapter.send()` to prevent potential SSRF vulnerabilities.

### Problem
Previously, the outbound `send()` method used the webhook URL from metadata without validation. While inbound requests had origin checks, an attacker could bypass this by providing a malicious webhook URL in the session metadata, potentially reaching internal network services.

### Changes
- **Validation Logic:** Added a whitelist check in `gateway/platforms/dingtalk.py` to ensure only official DingTalk domains (e.g., `oapi.dingtalk.com`) are targeted.
- **Regression Tests:** Added tests in `tests/gateway/test_dingtalk.py` to verify:
  - Successful delivery to valid DingTalk URLs.
  - Rejection of unauthorized origins (e.g., `evil.example`).

### Impact
Significantly improves security by closing a metadata-based SSRF vector in the DingTalk gateway adapter.