### PR TITLE
fix(skills): replace string prefix check with strict path containment

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1128,6 +1128,23 @@ class TestOptionalSkillSourceBinaryAssets:
         assert bundle.files["assets/neutts-cli/samples/jo.txt"] == b"hello\n"
         assert "assets/neutts-cli/src/neutts_cli/__pycache__/cli.cpython-312.pyc" not in bundle.files
 
+    def test_fetch_rejects_sibling_directory_traversal(self, tmp_path):
+        optional_root = tmp_path / "optional-skills"
+        sibling_skill_dir = tmp_path / "optional-skills-escape" / "pwned"
+        optional_root.mkdir()
+        sibling_skill_dir.mkdir(parents=True)
+        (sibling_skill_dir / "SKILL.md").write_text(
+            "---\nname: pwned\ndescription: traversal\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        bundle = src.fetch("official/../optional-skills-escape/pwned")
+
+        assert bundle is None
+
 
 class TestQuarantineBundleBinaryAssets:
     def test_quarantine_bundle_writes_binary_files(self, tmp_path):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2151,7 +2151,8 @@ class OptionalSkillSource(SkillSource):
         # Guard against path traversal (e.g. "official/../../etc")
         try:
             resolved = skill_dir.resolve()
-            if not str(resolved).startswith(str(self._optional_dir.resolve())):
+            optional_root = self._optional_dir.resolve()
+            if not resolved.is_relative_to(optional_root):
                 return None
         except (OSError, ValueError):
             return None


### PR DESCRIPTION
## What

Fixes a path-boundary check in `tools/skills_hub.py` for official optional skill fetches.

`OptionalSkillSource.fetch()` was validating resolved paths with a string-prefix check:

- `str(resolved).startswith(str(self._optional_dir.resolve()))`

That check is not safe for containment. A sibling directory such as `optional-skills-escape/` can still match the `optional-skills` prefix and bypass the guard.

This PR replaces that logic with a real path containment check using `Path.is_relative_to(...)`.

## Why

The previous guard could allow identifiers like:

- `official/../optional-skills-escape/pwned`

to resolve outside `optional-skills/` while still passing validation. That creates a path traversal / directory boundary bypass in the official optional skill source.

## Changes

- Updated `tools/skills_hub.py` to validate fetched skill paths with `is_relative_to(...)`
- Added a regression test in `tests/tools/test_skills_hub.py` covering sibling-directory traversal

## How To Test

1. Run:
   - `pytest tests/tools/test_skills_hub.py -q`
2. Verify the new traversal test passes.
3. Optionally confirm that normal official skill fetches still work for valid paths under `optional-skills/`.


