### PR TITLE
fix: guard against None request_overrides in _build_api_kwargs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":


### PR DESCRIPTION
## Summary

Fix  in  line 5522 when  is , causing  on  and breaking all messaging platform integrations (Weixin, Telegram, etc.).

## Root Cause

 can be  in gateway mode even though  initializes it as . The code at line 5522 called  directly without null-checking:



## Impact

All gateway platform integrations (Weixin, Telegram, Discord, etc.) fail with  when processing messages.

## Testing

Verified fix by running gateway with Weixin platform - messages now process correctly without errors.