### PR TITLE
fix(gateway): use yaml.safe_load instead of json.load when parsing gateway config file

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7889,10 +7889,10 @@ def main():
     
     config = None
     if args.config:
-        import json
-        with open(args.config, encoding="utf-8") as f:
-            data = json.load(f)
-            config = GatewayConfig.from_dict(data)
+    import yaml
+    with open(args.config, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+        config = GatewayConfig.from_dict(data)
     
     # Run the gateway - exit with code 1 if no platforms connected,
     # so systemd Restart=on-failure will retry on transient errors (e.g. DNS)


### PR DESCRIPTION
## Root cause

In gateway/run.py, the main() function loads the gateway config file (--config / -c) using json.load(), but the documented config format is YAML (config.yaml). This causes a json.JSONDecodeError whenever a user passes a YAML config file via the CLI.

The rest of the codebase consistently uses yaml.safe_load to read config files (e.g. ~/.hermes/config.yaml), but this one code path was accidentally left as json.load.
Impact: Any user who starts the gateway with hermes gateway start or python -m gateway.run --config config.yaml will get a parse error and the gateway will fail to start with a non-default config.

## Related Issue
https://github.com/NousResearch/hermes-agent/issues/10216

## Fixes

### Type of Change

- [ ✅] 🐛 Bug fix (non-breaking change that fixes an issue)

### Changes Made

Bug location: gateway/run.py, function main()

#### Before (broken)
```
if args.config:
    import json
    with open(args.config, encoding="utf-8") as f:
        data = json.load(f)
        config = GatewayConfig.from_dict(data)
```

#### After (fix)
```
if args.config:
    import yaml
    with open(args.config, encoding="utf-8") as f:
        data = yaml.safe_load(f)
        config = GatewayConfig.from_dict(data)
```


