### PR TITLE
fix(cli): secure external dependency checks and fix early return logic

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import getpass
 import os
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -127,9 +129,56 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
+def _parse_external_check_command(check_cmd: object) -> list[str]:
+    """Convert plugin metadata into argv for shell-free execution."""
+    if isinstance(check_cmd, str):
+        stripped = check_cmd.strip()
+        if not stripped:
+            return []
+        return shlex.split(stripped)
+
+    if isinstance(check_cmd, (list, tuple)):
+        return [part for part in check_cmd if isinstance(part, str) and part]
+
+    return []
+
+
+def _external_dependency_is_available(check_cmd: object) -> bool:
+    """Return True when an external dependency probe exits successfully."""
+    try:
+        argv = _parse_external_check_command(check_cmd)
+    except ValueError:
+        return False
+
+    if not argv:
+        return False
+
+    try:
+        subprocess.run(argv, capture_output=True, timeout=5, check=True)
+        return True
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+        PermissionError,
+    ):
+        return False
+
+
+def _report_missing_external_dependencies(ext_deps: list[dict]) -> None:
+    """Print install hints for external tools that are not available."""
+    for dep in ext_deps:
+        dep_name = dep.get("name", "")
+        check_cmd = dep.get("check")
+        install_cmd = dep.get("install", "")
+        if check_cmd and not _external_dependency_is_available(check_cmd):
+            if install_cmd:
+                print(f"\n  Warning: '{dep_name}' not found. Install with:")
+                print(f"    {install_cmd}")
+
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
-    import subprocess
     from pathlib import Path as _Path
 
     plugin_dir = _Path(__file__).parent.parent / "plugins" / "memory" / provider_name
@@ -146,6 +195,7 @@ def _install_dependencies(provider_name: str) -> None:
 
     pip_deps = meta.get("pip_dependencies", [])
     if not pip_deps:
+        _report_missing_external_dependencies(meta.get("external_dependencies", []))
         return
 
     # pip name → import name mapping for packages where they differ
@@ -166,6 +216,7 @@ def _install_dependencies(provider_name: str) -> None:
             missing.append(dep)
 
     if not missing:
+        _report_missing_external_dependencies(meta.get("external_dependencies", []))
         return
 
     print(f"\n  Installing dependencies: {', '.join(missing)}")
@@ -176,6 +227,7 @@ def _install_dependencies(provider_name: str) -> None:
         print(f"  ⚠ uv not found — cannot install dependencies")
         print(f"  Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh")
         print(f"  Then re-run: hermes memory setup")
+        _report_missing_external_dependencies(meta.get("external_dependencies", []))
         return
 
     try:
@@ -199,17 +251,12 @@ def _install_dependencies(provider_name: str) -> None:
     ext_deps = meta.get("external_dependencies", [])
     for dep in ext_deps:
         dep_name = dep.get("name", "")
-        check_cmd = dep.get("check", "")
+        check_cmd = dep.get("check")
         install_cmd = dep.get("install", "")
-        if check_cmd:
-            try:
-                subprocess.run(
-                    check_cmd, shell=True, capture_output=True, timeout=5
-                )
-            except Exception:
-                if install_cmd:
-                    print(f"\n  ⚠ '{dep_name}' not found. Install with:")
-                    print(f"    {install_cmd}")
+        if check_cmd and not _external_dependency_is_available(check_cmd):
+            if install_cmd:
+                print(f"\n  Warning: '{dep_name}' not found. Install with:")
+                print(f"    {install_cmd}")
 
 
 def _get_available_providers() -> list:

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,0 +1,73 @@
+import subprocess
+from textwrap import dedent
+
+from hermes_cli import memory_setup
+
+
+def _write_memory_plugin(tmp_path, provider_name: str, plugin_yaml: str):
+    fake_module = tmp_path / "repo" / "hermes_cli" / "memory_setup.py"
+    fake_module.parent.mkdir(parents=True, exist_ok=True)
+    fake_module.write_text("# test stub\n")
+
+    plugin_dir = fake_module.parent.parent / "plugins" / "memory" / provider_name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(dedent(plugin_yaml))
+    return fake_module
+
+
+def test_install_dependencies_warns_for_external_only_dependency(monkeypatch, tmp_path, capsys):
+    fake_module = _write_memory_plugin(
+        tmp_path,
+        "demo",
+        """
+        name: demo
+        version: 1.0.0
+        external_dependencies:
+          - name: democtl
+            check: "democtl --version"
+            install: "brew install democtl"
+        """,
+    )
+    monkeypatch.setattr(memory_setup, "__file__", str(fake_module))
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(memory_setup.subprocess, "run", fake_run)
+
+    memory_setup._install_dependencies("demo")
+
+    output = capsys.readouterr().out
+    assert "democtl" in output
+    assert "brew install democtl" in output
+    assert calls == [
+        (
+            ["democtl", "--version"],
+            {"capture_output": True, "timeout": 5, "check": True},
+        )
+    ]
+
+
+def test_external_dependency_check_runs_without_shell(monkeypatch):
+    recorded = {}
+
+    def fake_run(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(memory_setup.subprocess, "run", fake_run)
+
+    assert memory_setup._external_dependency_is_available(
+        'democtl --probe "value with spaces" && whoami'
+    )
+    assert recorded["cmd"] == ["democtl", "--probe", "value with spaces", "&&", "whoami"]
+    assert "shell" not in recorded["kwargs"]
+    assert recorded["kwargs"] == {
+        "capture_output": True,
+        "timeout": 5,
+        "check": True,
+    }


### PR DESCRIPTION
### Summary
Fixed a critical logic bug and security vulnerability in `hermes_cli/memory_setup.py` regarding external dependency validation.

### Problem
1. **Logic Leak:** An early `return` was preventing external dependency checks from executing for external-only plugins.
2. **Security Risk:** Dependency probe commands were executed via `shell=True`, exposing the setup flow to shell injection.
3. **UX Issue:** Setup warnings were not correctly displayed when pip dependencies were absent but external ones were missing.

### Changes
- Fixed the control flow to ensure all plugins undergo dependency probes.
- Migrated from `shell=True` to secure `subprocess.run` calls using `shlex.split`.
- Added `check=True` to properly capture probe failures.
- Implemented regression tests in `tests/hermes_cli/test_memory_setup.py`.