### PR TITLE
 fix(gateway): replace ss-based TCP watchdog with log-based health check

### DIFF
--- a/scripts/hermes-gateway-watchdog.sh
+++ b/scripts/hermes-gateway-watchdog.sh
@@ -1,0 +1,53 @@
+ #!/bin/bash
+  # Feishu Gateway Watchdog v4
+  # Replaces ss-based TCP check with pure log-based health detection
+  # Fixes: https://github.com/NousResearch/hermes-agent/issues/7213
+
+  GATEWAY_LOG="/root/.hermes/logs/gateway.log"
+
+  # 1. Check gateway process is alive
+  if ! systemctl is-active --quiet hermes-gateway; then
+      echo "$(date '+%Y-%m-%d %H:%M:%S') [WATCHDOG] Gateway not running, starting..."
+      systemctl start hermes-gateway
+      exit 0
+  fi
+
+  # 2. Check if WS disconnected >5min without reconnect (log-based)
+  LAST_DISCONNECT=$(tail -200 "$GATEWAY_LOG" | grep "Feishu.*Disconnected" | tail -1)
+  LAST_CONNECT=$(tail -200 "$GATEWAY_LOG" | grep "Feishu.*Connected in websocket" | tail -1)
+
+  if [ -n "$LAST_DISCONNECT" ]; then
+      DISC_TIME=$(echo "$LAST_DISCONNECT" | awk '{print $1, $2}' | cut -d',' -f1)
+      CONN_TIME=""
+      if [ -n "$LAST_CONNECT" ]; then
+          CONN_TIME=$(echo "$LAST_CONNECT" | awk '{print $1, $2}' | cut -d',' -f1)
+      fi
+
+      DISC_TS=$(date -d "$DISC_TIME" +%s 2>/dev/null || echo 0)
+      CONN_TS=0
+      if [ -n "$CONN_TIME" ]; then
+          CONN_TS=$(date -d "$CONN_TIME" +%s 2>/dev/null || echo 0)
+      fi
+
+      NOW=$(date +%s)
+      if [ "$DISC_TS" -gt "$CONN_TS" ] && [ $((NOW - DISC_TS)) -gt 300 ]; then
+          echo "$(date '+%Y-%m-%d %H:%M:%S') [WATCHDOG] WS disconnected $((NOW - DISC_TS))s without reconnect,
+  restarting..."
+          systemctl restart hermes-gateway
+          exit 0
+      fi
+  fi
+
+  # 3. Startup failure: process alive >60s but never connected
+  PID=$(systemctl show hermes-gateway -p MainPID --value 2>/dev/null)
+  if [ -n "$PID" ] && [ "$PID" -gt 0 ]; then
+      UPTIME_SEC=$(ps -o etimes= -p "$PID" 2>/dev/null | tr -d ' ')
+      if [ -n "$UPTIME_SEC" ] && [ "$UPTIME_SEC" -gt 60 ]; then
+          LAST_CONNECT_LOG=$(tail -50 "$GATEWAY_LOG" | grep "Connected in websocket" | tail -1)
+          if [ -z "$LAST_CONNECT_LOG" ]; then
+              echo "$(date '+%Y-%m-%d %H:%M:%S') [WATCHDOG] No WS connect after ${UPTIME_SEC}s, restarting..."
+              systemctl restart hermes-gateway
+              exit 0
+          fi
+      fi
+  fi


### PR DESCRIPTION
Fixes #7213

  The ss-based TCP check incorrectly restarts the gateway every 3 minutes
  even when the WebSocket connection is healthy. Replace with log-based
  detection that checks Connected/Disconnected timestamps and startup failure.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

The ss-based TCP check restarts the gateway every 3 minutes even when
  the WebSocket is healthy. This adds a log-based watchdog script that
  checks Connected/Disconnected timestamps and startup failure instead.



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #7213

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->
-  Added scripts/hermes-gateway-watchdog.sh with log-based watchdog logic
- Removes dependency on ss command which fails in cron environments
 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.  Deploy Hermes gateway with Feishu platform on CentOS Stream 9 via systemd
2. Run the watchdog script via cron every 3 minutes
3. Confirm gateway stays running without restart loop

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

