### PR TITLE
feat(gateway): separate visible vs spoken voice replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,9 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
 
+
+_VOICE_TTS_BLOCK_RE = re.compile(r"<tts>\s*(.*?)\s*</tts>", re.IGNORECASE | re.DOTALL)
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -2885,6 +2888,8 @@ class GatewayRunner:
             if not found_in_history:
                 message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
+        message_text = self._apply_voice_reply_preferences(event, message_text)
+
         try:
             # Emit agent:start hook
             hook_ctx = {
@@ -2995,6 +3000,10 @@ class GatewayRunner:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
+            spoken_response = response
+            if response:
+                response, spoken_response = self._split_voice_reply_text(response)
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
@@ -3086,8 +3095,11 @@ class GatewayRunner:
                         # Skip system messages (they're rebuilt each run)
                         if msg.get("role") == "system":
                             continue
+                        sanitized_msg = dict(msg)
+                        if sanitized_msg.get("role") == "assistant" and isinstance(sanitized_msg.get("content"), str):
+                            sanitized_msg["content"], _ = self._split_voice_reply_text(sanitized_msg["content"])
                         # Add timestamp to each message for debugging
-                        entry = {**msg, "timestamp": ts}
+                        entry = {**sanitized_msg, "timestamp": ts}
                         self.session_store.append_to_transcript(
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
@@ -3104,7 +3116,7 @@ class GatewayRunner:
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
-                await self._send_voice_reply(event, response)
+                await self._send_voice_reply(event, response, spoken_text=spoken_response)
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -4280,6 +4292,54 @@ class GatewayRunner:
 
         await adapter.handle_message(event)
 
+    def _load_voice_reply_config(self) -> Dict[str, Any]:
+        """Load voice reply preferences from the main Hermes config."""
+        try:
+            from hermes_cli.config import load_config
+            config = load_config() or {}
+        except Exception:
+            logger.debug("Failed to load voice reply config", exc_info=True)
+            return {}
+        return config.get("voice", {}) or {}
+
+    def _apply_voice_reply_preferences(self, event: MessageEvent, message_text: str) -> str:
+        """Append per-user guidance for voice-originated messages only."""
+        if event.message_type not in (MessageType.VOICE, MessageType.AUDIO):
+            return message_text
+
+        voice_config = self._load_voice_reply_config()
+        style_prompt = (voice_config.get("reply_style_prompt") or "").strip()
+        if not style_prompt:
+            return message_text
+
+        guidance = (
+            "[Voice reply preference: Reply in a casual, light, natural tone. "
+            f"Additional style instruction: {style_prompt} "
+            "Keep the visible text clean and natural. If the spoken reply would "
+            "benefit from ElevenLabs v3 expression tags such as [chuckles], "
+            "[softly], or [excited], append a hidden <tts>...</tts> block with "
+            "the spoken-only version. Do not mention the hidden block explicitly.]"
+        )
+        if message_text:
+            return f"{message_text}\n\n{guidance}"
+        return guidance
+
+    def _split_voice_reply_text(self, text: str) -> tuple[str, str]:
+        """Return (visible_text, spoken_text) for auto voice replies.
+
+        Visible text strips a hidden <tts>...</tts> block before the message is
+        shown to the user, while spoken_text prefers the hidden block when
+        present so ElevenLabs v3 tags stay out of the chat transcript.
+        """
+        if not text:
+            return "", ""
+
+        match = _VOICE_TTS_BLOCK_RE.search(text)
+        visible_text = _VOICE_TTS_BLOCK_RE.sub("", text)
+        visible_text = re.sub(r"\n{3,}", "\n\n", visible_text).strip()
+        spoken_text = (match.group(1).strip() if match else visible_text)
+        return visible_text, spoken_text
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -4334,7 +4394,12 @@ class GatewayRunner:
 
         return True
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
+    async def _send_voice_reply(
+        self,
+        event: MessageEvent,
+        text: str,
+        spoken_text: Optional[str] = None,
+    ) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
         import uuid as _uuid
         audio_path = None
@@ -4342,7 +4407,9 @@ class GatewayRunner:
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            if spoken_text is None:
+                _, spoken_text = self._split_voice_reply_text(text)
+            tts_text = _strip_markdown_for_tts((spoken_text or "")[:4000])
             if not tts_text:
                 return
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -493,6 +493,7 @@ DEFAULT_CONFIG = {
         "auto_tts": False,
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "reply_style_prompt": "",    # Extra instruction applied when replying to voice/audio inputs
     },
     
     "human_delay": {
@@ -612,7 +613,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 14,
+    "_config_version": 15,
 }
 
 # =============================================================================

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -339,6 +339,58 @@ class TestAutoVoiceReply:
 # _send_voice_reply
 # =====================================================================
 
+class TestVoiceReplyFormatting:
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        return _make_runner(tmp_path)
+
+    def test_split_voice_reply_text_extracts_hidden_tts_block(self, runner):
+        visible, spoken = runner._split_voice_reply_text(
+            "Hola, aquí va la respuesta visible.\n\n<tts>[chuckles] Hola, aquí va la respuesta hablada.</tts>"
+        )
+
+        assert visible == "Hola, aquí va la respuesta visible."
+        assert spoken == "[chuckles] Hola, aquí va la respuesta hablada."
+
+    def test_split_voice_reply_text_falls_back_to_visible_text(self, runner):
+        visible, spoken = runner._split_voice_reply_text("Hola sin bloque oculto")
+
+        assert visible == "Hola sin bloque oculto"
+        assert spoken == "Hola sin bloque oculto"
+
+    def test_apply_voice_reply_preferences_for_voice_messages(self, runner, monkeypatch):
+        event = _make_event(message_type=MessageType.VOICE)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "voice": {
+                    "reply_style_prompt": "Responde con tono casual, ligero y cercano.",
+                }
+            },
+        )
+
+        enriched = runner._apply_voice_reply_preferences(
+            event, 'El usuario dijo: "hola"'
+        )
+
+        assert 'tono casual, ligero y cercano' in enriched
+        assert '<tts>' in enriched
+        assert 'El usuario dijo: "hola"' in enriched
+
+    def test_apply_voice_reply_preferences_ignores_text_messages(self, runner, monkeypatch):
+        event = _make_event(message_type=MessageType.TEXT)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "voice": {
+                    "reply_style_prompt": "Responde con tono casual, ligero y cercano.",
+                }
+            },
+        )
+
+        assert runner._apply_voice_reply_preferences(event, "Hola") == "Hola"
+
 class TestSendVoiceReply:
 
     @pytest.fixture
@@ -364,6 +416,28 @@ class TestSendVoiceReply:
         mock_adapter.send_voice.assert_called_once()
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
+
+    @pytest.mark.asyncio
+    async def test_uses_hidden_tts_block_for_audio_generation(self, runner):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        event = _make_event()
+        runner.adapters[event.source.platform] = mock_adapter
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result) as mock_tts, \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(
+                event,
+                "Texto visible.\n\n<tts>[chuckles] Texto hablado.</tts>",
+            )
+
+        assert mock_tts.call_args.kwargs["text"] == "[chuckles] Texto hablado."
+        mock_adapter.send_voice.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_empty_text_after_strip_skips(self, runner):


### PR DESCRIPTION
Summary:\n- add voice reply style prompt support for voice/audio-originated messages\n- support hidden <tts> blocks so spoken text can differ from visible chat text\n- sanitize assistant transcript storage to keep TTS-only content out of visible history\n- add gateway tests covering hidden TTS extraction and spoken-text generation\n\nValidation:\n- source venv/bin/activate\n- python -m pytest tests/gateway/test_voice_command.py -q\n- 173 passed\n\nNotes:\n- This was extracted from local changes onto a clean branch based on current origin/main.