### PR TITLE
fix(memory): sort OpenViking tool search results by raw score

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -509,19 +509,24 @@ class OpenVikingMemoryProvider(MemoryProvider):
         result = resp.get("result", {})
 
         # Format results for the model — keep it concise
-        formatted = []
+        scored_entries = []
         for ctx_type in ("memories", "resources", "skills"):
             items = result.get(ctx_type, [])
             for item in items:
+                raw_score = item.get("score")
+                sort_score = raw_score if raw_score is not None else 0.0
                 entry = {
                     "uri": item.get("uri", ""),
                     "type": ctx_type.rstrip("s"),
-                    "score": round(item.get("score", 0), 3),
+                    "score": round(raw_score, 3) if raw_score is not None else 0.0,
                     "abstract": item.get("abstract", ""),
                 }
                 if item.get("relations"):
                     entry["related"] = [r.get("uri") for r in item["relations"][:3]]
-                formatted.append(entry)
+                scored_entries.append((sort_score, entry))
+
+        scored_entries.sort(key=lambda x: x[0], reverse=True)
+        formatted = [entry for _, entry in scored_entries]
 
         return json.dumps({
             "results": formatted,

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import MagicMock
+
+from plugins.memory.openviking import OpenVikingMemoryProvider
+
+
+def test_tool_search_sorts_by_raw_score_across_buckets():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "result": {
+            "memories": [
+                {"uri": "viking://memories/1", "score": 0.9003, "abstract": "memory result"},
+            ],
+            "resources": [
+                {"uri": "viking://resources/1", "score": 0.9004, "abstract": "resource result"},
+            ],
+            "skills": [
+                {"uri": "viking://skills/1", "score": 0.8999, "abstract": "skill result"},
+            ],
+            "total": 3,
+        }
+    }
+
+    result = json.loads(provider._tool_search({"query": "ranking"}))
+
+    assert [entry["uri"] for entry in result["results"]] == [
+        "viking://resources/1",
+        "viking://memories/1",
+        "viking://skills/1",
+    ]
+    assert [entry["score"] for entry in result["results"]] == [0.9, 0.9, 0.9]
+    assert result["total"] == 3
+
+
+def test_tool_search_sorts_missing_raw_score_after_negative_scores():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "result": {
+            "memories": [
+                {"uri": "viking://memories/missing", "abstract": "missing score"},
+            ],
+            "resources": [
+                {"uri": "viking://resources/negative", "score": -0.25, "abstract": "negative score"},
+            ],
+            "skills": [
+                {"uri": "viking://skills/positive", "score": 0.1, "abstract": "positive score"},
+            ],
+            "total": 3,
+        }
+    }
+
+    result = json.loads(provider._tool_search({"query": "ranking"}))
+
+    assert [entry["uri"] for entry in result["results"]] == [
+        "viking://skills/positive",
+        "viking://memories/missing",
+        "viking://resources/negative",
+    ]
+    assert [entry["score"] for entry in result["results"]] == [0.1, 0.0, -0.25]
+    assert result["total"] == 3


### PR DESCRIPTION
## What does this PR do?

This PR fixes result ordering in the OpenViking memory provider's `_tool_search()` path.

Before this change, results were grouped by bucket and concatenated in implicit bucket order (`memories -> resources -> skills`). That could cause lower-scoring results from an earlier bucket to appear ahead of higher-scoring results from a later bucket.

This change keeps the existing retrieval behavior and response shape, but changes the final ordering step so aggregated results are ordered by score rather than bucket position:
- when a raw score is present, ordering uses that raw score
- displayed `score` values in the response remain numeric and rounded for readability
- items without a score fall back to `0.0`, preserving numeric output compatibility

This keeps the fix narrowly scoped to ordering behavior without adding extra heuristics such as leaf boosts, directory penalties, tie-break rules, or filtering.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `plugins/memory/openviking/__init__.py` so `_tool_search()` aggregates bucketed results and then orders them by score instead of implicit bucket order.
- Preserved numeric `score` values in the returned payload.
- Added focused tests in `tests/plugins/memory/test_openviking_provider.py` for:
  - near-score cross-bucket ordering based on raw score
  - missing-score fallback behavior alongside positive and negative scores

## How to Test

1. Run the focused test file:
   - `pytest tests/plugins/memory/test_openviking_provider.py -q`
2. Run the memory plugin test suite:
   - `pytest tests/plugins/memory -q`
3. Optionally validate in a live Hermes runtime with representative `viking_search` queries to confirm the earlier bucket-order symptom does not reappear.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL2 / Linux user environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if needed — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if needed — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if needed — or N/A