### PR TITLE
fix: refresh runtime fallback chain on model switch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4523,6 +4523,7 @@ class HermesCLI:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    fallback_model=getattr(self, "_fallback_model", None),
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")

--- a/cli.py
+++ b/cli.py
@@ -4741,6 +4741,7 @@ class HermesCLI:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    fallback_model=getattr(self, "_fallback_model", None),
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4386,6 +4386,7 @@ class GatewayRunner:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
+                                    fallback_model=getattr(_self, "_fallback_model", None),
                                 )
                             except Exception as exc:
                                 logger.warning("Picker model switch failed for cached agent: %s", exc)
@@ -4501,6 +4502,7 @@ class GatewayRunner:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    fallback_model=getattr(self, "_fallback_model", None),
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)

--- a/run_agent.py
+++ b/run_agent.py
@@ -994,26 +994,7 @@ class AIAgent:
         # when the primary is exhausted (rate-limit, overload, connection
         # failure).  Supports both legacy single-dict ``fallback_model`` and
         # new list ``fallback_providers`` format.
-        if isinstance(fallback_model, list):
-            self._fallback_chain = [
-                f for f in fallback_model
-                if isinstance(f, dict) and f.get("provider") and f.get("model")
-            ]
-        elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-            self._fallback_chain = [fallback_model]
-        else:
-            self._fallback_chain = []
-        self._fallback_index = 0
-        self._fallback_activated = False
-        # Legacy attribute kept for backward compat (tests, external callers)
-        self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
-        if self._fallback_chain and not self.quiet_mode:
-            if len(self._fallback_chain) == 1:
-                fb = self._fallback_chain[0]
-                print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
-            else:
-                print(f"🔄 Fallback chain ({len(self._fallback_chain)} providers): " +
-                      " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain))
+        self._set_fallback_model(fallback_model)
 
         # Get available tools with filtering
         self.tools = get_tool_definitions(
@@ -1538,7 +1519,35 @@ class AIAgent:
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
     
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def _set_fallback_model(self, fallback_model) -> None:
+        """Normalize fallback config and refresh runtime fallback state."""
+        if isinstance(fallback_model, list):
+            self._fallback_chain = [
+                dict(entry)
+                for entry in fallback_model
+                if isinstance(entry, dict) and entry.get("provider") and entry.get("model")
+            ]
+        elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
+            self._fallback_chain = [dict(fallback_model)]
+        else:
+            self._fallback_chain = []
+
+        self._fallback_index = 0
+        self._fallback_activated = False
+        # Legacy attribute kept for backward compat (tests, external callers)
+        self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
+
+        if self._fallback_chain and not self.quiet_mode:
+            if len(self._fallback_chain) == 1:
+                fb = self._fallback_chain[0]
+                print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
+            else:
+                print(
+                    f"🔄 Fallback chain ({len(self._fallback_chain)} providers): "
+                    + " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain)
+                )
+
+    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode='', fallback_model=None):
         """Switch the model/provider in-place for a live agent.
 
         Called by the /model command handlers (CLI and gateway) after
@@ -1657,9 +1666,12 @@ class AIAgent:
                 "is_anthropic_oauth": self._is_anthropic_oauth,
             })
 
-        # ── Reset fallback state ──
-        self._fallback_activated = False
-        self._fallback_index = 0
+        # ── Refresh fallback state ──
+        if fallback_model is not None:
+            self._set_fallback_model(fallback_model)
+        else:
+            self._fallback_activated = False
+            self._fallback_index = 0
 
         logging.info(
             "Model switched in-place: %s (%s) -> %s (%s)",

--- a/tests/gateway/test_model_switch_runtime_fallback.py
+++ b/tests/gateway/test_model_switch_runtime_fallback.py
@@ -1,0 +1,134 @@
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._agent_cache = {}
+    runner._fallback_model = [{"provider": "zai", "model": "glm-5"}]
+    return runner
+
+
+def _make_event(text="/model gpt-5.4"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+    )
+
+
+def _result() -> ModelSwitchResult:
+    model_info = SimpleNamespace(
+        context_window=200_000,
+        max_output=8_000,
+        has_cost_data=lambda: False,
+        format_capabilities=lambda: "chat",
+    )
+    return ModelSwitchResult(
+        success=True,
+        new_model="gpt-5.4",
+        target_provider="openai",
+        api_key="new-key",
+        base_url="https://api.openai.com/v1",
+        api_mode="chat_completions",
+        provider_label="OpenAI",
+        model_info=model_info,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_passes_runtime_fallback_chain_to_cached_agent(tmp_path, monkeypatch):
+    runner = _make_runner()
+    event = _make_event()
+    session_key = runner._session_key_for_source(event.source)
+    cached_agent = MagicMock()
+    runner._agent_cache[session_key] = (cached_agent, None)
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    with (
+        patch("hermes_cli.model_switch.parse_model_flags", return_value=("gpt-5.4", None, False)),
+        patch("hermes_cli.model_switch.switch_model", return_value=_result()),
+    ):
+        await runner._handle_model_command(event)
+
+    cached_agent.switch_model.assert_called_once_with(
+        new_model="gpt-5.4",
+        new_provider="openai",
+        api_key="new-key",
+        base_url="https://api.openai.com/v1",
+        api_mode="chat_completions",
+        fallback_model=runner._fallback_model,
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_picker_callback_passes_runtime_fallback_chain_to_cached_agent(tmp_path, monkeypatch):
+    runner = _make_runner()
+
+    class _Adapter:
+        async def send_model_picker(self, **kwargs):
+            await kwargs["on_model_selected"](kwargs["chat_id"], "gpt-5.4", "openai")
+            return SimpleNamespace(success=True)
+
+    runner.adapters = {Platform.TELEGRAM: _Adapter()}
+    event = _make_event("/model")
+    session_key = runner._session_key_for_source(event.source)
+    cached_agent = MagicMock()
+    runner._agent_cache[session_key] = (cached_agent, None)
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    with (
+        patch(
+            "hermes_cli.model_switch.list_authenticated_providers",
+            return_value=[
+                {
+                    "name": "OpenAI",
+                    "slug": "openai",
+                    "models": ["gpt-5.4"],
+                    "total_models": 1,
+                    "is_current": True,
+                }
+            ],
+        ),
+        patch("hermes_cli.model_switch.parse_model_flags", return_value=("", None, False)),
+        patch("hermes_cli.model_switch.switch_model", return_value=_result()),
+    ):
+        reply = await runner._handle_model_command(event)
+
+    assert reply is None
+    cached_agent.switch_model.assert_called_once_with(
+        new_model="gpt-5.4",
+        new_provider="openai",
+        api_key="new-key",
+        base_url="https://api.openai.com/v1",
+        api_mode="chat_completions",
+        fallback_model=runner._fallback_model,
+    )

--- a/tests/hermes_cli/test_model_switch_runtime_fallback.py
+++ b/tests/hermes_cli/test_model_switch_runtime_fallback.py
@@ -51,3 +51,27 @@ def test_handle_model_switch_passes_runtime_fallback_chain_to_live_agent():
         api_mode="chat_completions",
         fallback_model=cli._fallback_model,
     )
+
+
+def test_apply_model_switch_result_passes_runtime_fallback_chain_to_live_agent():
+    cli = object.__new__(HermesCLI)
+    cli.model = "claude-sonnet-4-6"
+    cli.provider = "anthropic"
+    cli.base_url = "https://api.anthropic.com"
+    cli.api_key = "old-key"
+    cli.api_mode = "anthropic_messages"
+    cli.requested_provider = "anthropic"
+    cli._fallback_model = [{"provider": "zai", "model": "glm-5"}]
+    cli.agent = MagicMock()
+
+    with patch("cli._cprint"):
+        cli._apply_model_switch_result(_result(), persist_global=False)
+
+    cli.agent.switch_model.assert_called_once_with(
+        new_model="gpt-5.4",
+        new_provider="openai",
+        api_key="new-key",
+        base_url="https://api.openai.com/v1",
+        api_mode="chat_completions",
+        fallback_model=cli._fallback_model,
+    )

--- a/tests/hermes_cli/test_model_switch_runtime_fallback.py
+++ b/tests/hermes_cli/test_model_switch_runtime_fallback.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+def _result() -> ModelSwitchResult:
+    model_info = SimpleNamespace(
+        context_window=200_000,
+        max_output=8_000,
+        has_cost_data=lambda: False,
+        format_capabilities=lambda: "chat",
+    )
+    return ModelSwitchResult(
+        success=True,
+        new_model="gpt-5.4",
+        target_provider="openai",
+        api_key="new-key",
+        base_url="https://api.openai.com/v1",
+        api_mode="chat_completions",
+        provider_label="OpenAI",
+        model_info=model_info,
+    )
+
+
+def test_handle_model_switch_passes_runtime_fallback_chain_to_live_agent():
+    cli = object.__new__(HermesCLI)
+    cli.model = "claude-sonnet-4-6"
+    cli.provider = "anthropic"
+    cli.base_url = "https://api.anthropic.com"
+    cli.api_key = "old-key"
+    cli.api_mode = "anthropic_messages"
+    cli.requested_provider = "anthropic"
+    cli._fallback_model = [{"provider": "zai", "model": "glm-5"}]
+    cli.agent = MagicMock()
+
+    with (
+        patch("cli._cprint"),
+        patch("hermes_cli.model_switch.parse_model_flags", return_value=("gpt-5.4", None, False)),
+        patch("hermes_cli.model_switch.switch_model", return_value=_result()),
+        patch("hermes_cli.config.load_config", return_value={}),
+    ):
+        cli._handle_model_switch("/model gpt-5.4")
+
+    cli.agent.switch_model.assert_called_once_with(
+        new_model="gpt-5.4",
+        new_provider="openai",
+        api_key="new-key",
+        base_url="https://api.openai.com/v1",
+        api_mode="chat_completions",
+        fallback_model=cli._fallback_model,
+    )

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -197,3 +197,61 @@ class TestSwitchModelFallbackRefresh:
 
         assert agent._fallback_chain == []
         assert agent._fallback_model is None
+
+    def test_switch_model_uses_replaced_chain_when_fallback_activates(self):
+        agent = _make_agent(fallback_model=[{"provider": "zai", "model": "glm-5"}])
+        agent.context_compressor = None
+        agent._create_openai_client = MagicMock(return_value=_mock_client(
+            base_url="https://api.openai.com/v1",
+            api_key="new-key",
+        ))
+
+        new_chain = [{"provider": "anthropic", "model": "claude-sonnet-4-6"}]
+        agent.switch_model(
+            new_model="gpt-5.4",
+            new_provider="openai",
+            api_key="new-key",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat_completions",
+            fallback_model=new_chain,
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://api.anthropic.com", api_key="fb-key"), "claude-sonnet-4-6"),
+        ) as mock_rpc:
+            assert agent._try_activate_fallback() is True
+
+        mock_rpc.assert_called_once()
+        args, kwargs = mock_rpc.call_args
+        assert args == ("anthropic",)
+        assert kwargs["model"] == "claude-sonnet-4-6"
+        assert agent.model == "claude-sonnet-4-6"
+        assert agent.provider == "anthropic"
+        assert agent._fallback_index == 1
+        assert agent._fallback_activated is True
+
+    def test_switch_model_preserves_existing_chain_when_fallback_model_is_none(self):
+        original_chain = [{"provider": "zai", "model": "glm-5"}]
+        agent = _make_agent(fallback_model=original_chain)
+        agent.context_compressor = None
+        agent._create_openai_client = MagicMock(return_value=_mock_client(
+            base_url="https://api.openai.com/v1",
+            api_key="new-key",
+        ))
+
+        agent._fallback_index = 1
+        agent._fallback_activated = True
+        agent.switch_model(
+            new_model="gpt-5.4",
+            new_provider="openai",
+            api_key="new-key",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat_completions",
+            fallback_model=None,
+        )
+
+        assert agent._fallback_chain == original_chain
+        assert agent._fallback_model == original_chain[0]
+        assert agent._fallback_index == 0
+        assert agent._fallback_activated is False

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -154,3 +154,46 @@ class TestFallbackChainAdvancement:
             ]
             assert agent._try_activate_fallback() is True
             assert agent.model == "gpt-4o"
+
+
+class TestSwitchModelFallbackRefresh:
+    def test_switch_model_replaces_runtime_fallback_chain(self):
+        agent = _make_agent(fallback_model={"provider": "zai", "model": "glm-5"})
+        agent.context_compressor = None
+        agent._create_openai_client = MagicMock(return_value=_mock_client(
+            base_url="https://api.openai.com/v1",
+            api_key="new-key",
+        ))
+
+        new_chain = [{"provider": "anthropic", "model": "claude-sonnet-4-6"}]
+        agent.switch_model(
+            new_model="gpt-5.4",
+            new_provider="openai",
+            api_key="new-key",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat_completions",
+            fallback_model=new_chain,
+        )
+
+        assert agent._fallback_chain == new_chain
+        assert agent._fallback_model == new_chain[0]
+
+    def test_switch_model_clears_runtime_fallback_chain_when_given_empty_list(self):
+        agent = _make_agent(fallback_model={"provider": "zai", "model": "glm-5"})
+        agent.context_compressor = None
+        agent._create_openai_client = MagicMock(return_value=_mock_client(
+            base_url="https://api.openai.com/v1",
+            api_key="new-key",
+        ))
+
+        agent.switch_model(
+            new_model="gpt-5.4",
+            new_provider="openai",
+            api_key="new-key",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat_completions",
+            fallback_model=[],
+        )
+
+        assert agent._fallback_chain == []
+        assert agent._fallback_model is None


### PR DESCRIPTION
## Summary
- extract the fallback-chain normalization/printing logic into `AIAgent._set_fallback_model()`
- let `AIAgent.switch_model()` optionally replace or clear the runtime fallback chain in one place
- add regression coverage for replacing and clearing the runtime fallback chain during in-place model switches

## Notes
- this is the standalone `AIAgent` fallback refresh/refactor split out from #6896
- intentionally excludes the earlier Dockerfile/CI/session-fallback plumbing so the diff stays focused

## Test Plan
- /Users/gaixiaotongxue/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_fallback_model.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_switch_model_context.py -q
