### PR TITLE
test: initialize codex gateway runner session overrides

### DIFF
--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -153,6 +153,7 @@ def test_gateway_run_agent_codex_path_handles_internal_401_refresh(monkeypatch):
     runner._fallback_model = None
     runner._running_agents = {}
     runner._smart_model_routing = {}
+    runner._session_model_overrides = {}
     from unittest.mock import MagicMock, AsyncMock
     runner.hooks = MagicMock()
     runner.hooks.emit = AsyncMock()


### PR DESCRIPTION
## Summary
- initialize `_session_model_overrides` in the codex gateway runner test fixture
- align this test with the newer `GatewayRunner` attribute expectations already reflected in other gateway tests
- keep the fix test-only and narrowly scoped to the inherited failing path

## Test Plan
- `/home/openclaw/Work/hermes-agent-local/hermes-agent/.venv/bin/python -m pytest tests/cron/test_codex_execution_paths.py::test_gateway_run_agent_codex_path_handles_internal_401_refresh -q`

## Context
Current `origin/main` still fails this test because it constructs `GatewayRunner` via `__new__` and skips the newer `_session_model_overrides` attribute initialization.