### PR TITLE
feat: add /editor command to compose messages in $EDITOR

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4088,6 +4088,44 @@ class HermesCLI:
         _cprint(f"  Original session: {parent_session_id}")
         _cprint(f"  Branch session:   {new_session_id}")
 
+    def _handle_editor_command(self):
+        """Open $EDITOR to compose a long message, then return it for sending."""
+        import shlex
+        import shutil
+        import tempfile
+        editor = os.environ.get("EDITOR") or os.environ.get("VISUAL")
+        if not editor:
+            for cmd in ("nano", "vim", "vi", "code", "notepad"):
+                if shutil.which(cmd):
+                    editor = cmd
+                    break
+        if not editor:
+            _cprint(f"{_DIM}No editor found. Set $EDITOR or install nano/vim.{_RST}")
+            return None
+        tf_path = None
+        try:
+            fd, tf_path = tempfile.mkstemp(suffix=".md", prefix="hermes_")
+            os.close(fd)
+            _cprint(f"{_DIM}Opening {editor}... Save and close to send, leave empty to cancel.{_RST}")
+            import subprocess as _sp
+            _sp.call(shlex.split(editor) + [tf_path])
+            content = Path(tf_path).read_text(encoding="utf-8").strip()
+            if content:
+                _cprint(f"{_DIM}({len(content)} chars from editor){_RST}")
+                return content
+            else:
+                _cprint(f"{_DIM}Editor returned empty content — cancelled.{_RST}")
+                return None
+        except Exception as e:
+            _cprint(f"{_DIM}Editor error: {e}{_RST}")
+            return None
+        finally:
+            if tf_path:
+                try:
+                    os.unlink(tf_path)
+                except OSError:
+                    pass
+
     def save_conversation(self):
         """Save the current conversation to a file."""
         if not self.conversation_history:
@@ -4951,6 +4989,10 @@ class HermesCLI:
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"
             self.console.print(f"  Status bar {state}")
+        elif canonical == "editor":
+            editor_text = self._handle_editor_command()
+            if editor_text and hasattr(self, '_pending_input'):
+                self._pending_input.put(editor_text)
         elif canonical == "verbose":
             self._toggle_verbose()
         elif canonical == "yolo":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -101,6 +101,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
     CommandDef("statusbar", "Toggle the context/model status bar", "Configuration",
                cli_only=True, aliases=("sb",)),
+    CommandDef("editor", "Open $EDITOR to compose a long message", "Session",
+               cli_only=True, aliases=("edit",)),
     CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",
                "Configuration", cli_only=True,
                gateway_config_gate="display.tool_progress_command"),


### PR DESCRIPTION
Open `$EDITOR` (or `$VISUAL`, or auto-detected nano/vim/vi) to compose a long message. Save and close to send; leave empty to cancel.

```
> /editor
Opening vim... Save and close to send, leave empty to cancel.
(847 chars from editor)
```

Aliases: `/editor`, `/edit`. Uses `shlex.split()` to handle editors with arguments (e.g. `code --wait`). Content queued via `_pending_input.put()` (same pattern as `/retry`).

44 lines across `cli.py` and `commands.py`. Supersedes #4106 (unsalvageable merge conflicts). Closes #7262

**Note:** Uses `subprocess.call()` to spawn the editor in the `process_loop` background thread. Terminal state restoration after editor exit needs testing across editors (vim, nano, `code --wait`).