### PR TITLE
fix: expose AudioRecorder is_recording state

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -517,6 +517,15 @@ class TestAudioRecorderCancel:
 
 
 class TestAudioRecorderProperties:
+    def test_is_recording_reflects_internal_state(self):
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        assert recorder.is_recording is False
+
+        recorder._recording = True
+        assert recorder.is_recording is True
+
     def test_elapsed_seconds_when_not_recording(self):
         from tools.voice_mode import AudioRecorder
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -418,6 +418,10 @@ class AudioRecorder:
     # -- public properties ---------------------------------------------------
 
     @property
+    def is_recording(self) -> bool:
+        return self._recording
+
+    @property
     def elapsed_seconds(self) -> float:
         if not self._recording:
             return 0.0


### PR DESCRIPTION
## Summary
- add `AudioRecorder.is_recording` so it matches the recorder interface already exposed by `TermuxAudioRecorder`
- keep the change to a simple property over the existing `_recording` flag
- add a focused regression test for the property and keep the existing voice-mode lifecycle tests green

## Root cause
`AudioRecorder` tracked `_recording` internally but never exposed the public `is_recording` property that the rest of the recorder backends and tests expect. This caused voice mode tests and backend interface assumptions to fail with `AttributeError`.

## Test Plan
- /Users/gaixiaotongxue/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_voice_mode.py -q
- /Users/gaixiaotongxue/.hermes/hermes-agent/venv/bin/python -m py_compile tools/voice_mode.py
