### PR TITLE
Fix: Handle None request_overrides in gateway/run.py

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6971,7 +6971,7 @@ class GatewayRunner:
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
-            agent.request_overrides = turn_route.get("request_overrides")
+            agent.request_overrides = turn_route.get("request_overrides") or {}
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:


### PR DESCRIPTION
## Summary
Fixes `AttributeError: 'NoneType' object has no attribute 'get'` when `request_overrides` is `None` in `gateway/run.py`.

## Root Cause
When `service_tier` is empty/falsy, `_resolve_turn_route()` sets `route['request_overrides'] = None`. This `None` is then directly assigned to `agent.request_overrides` at line 6974, bypassing the safe `dict()` initialization in `run_agent.py` line 678.

Later, `_build_api_kwargs()` at line 5522 calls `self.request_overrides.get('speed')` which crashes on `None`.

## Fix
```python
# gateway/run.py line 6974
agent.request_overrides = turn_route.get("request_overrides") or {}
```

This ensures `request_overrides` is always a dict, matching the constructor's safe initialization.

## Testing
- [x] Verified fix resolves the `AttributeError` on local Hermes instance
- [x] No other changes to behavior when `request_overrides` is properly populated

## Credits
Issue identified by `@li3500764` in issue #7259.