### PR TITLE
fix(cli): dynamically query session sources in stats command

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1594,7 +1594,7 @@ def _sessions_stats(_engine: HermesConsoleEngine, args: list[str]) -> str:
             f"Listable sessions: {listable}",
             f"Total messages: {messages}",
         ]
-        for source in ["cli", "tui", "telegram", "discord", "slack", "cron"]:
+        for source in db.session_sources():
             count = db.session_count(source=source)
             if count:
                 lines.append(f"  {source}: {count}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14544,7 +14544,7 @@ def main():
             msgs = db.message_count()
             print(f"Total sessions: {total}")
             print(f"Total messages: {msgs}")
-            for src in ["cli", "telegram", "discord", "whatsapp", "slack"]:
+            for src in db.session_sources():
                 c = db.session_count(source=src)
                 if c > 0:
                     print(f"  {src}: {c} sessions")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5319,7 +5319,7 @@ For more help on a command:
             msgs = db.message_count()
             print(f"Total sessions: {total}")
             print(f"Total messages: {msgs}")
-            for src in ["cli", "telegram", "discord", "whatsapp", "slack"]:
+            for src in db.session_sources():
                 c = db.session_count(source=src)
                 if c > 0:
                     print(f"  {src}: {c} sessions")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5164,10 +5164,11 @@ class SessionDB:
     # =========================================================================
 
     def session_sources(self) -> list[str]:
-        """Return distinct source values from all sessions."""
+        """Return distinct, non-empty source values from all sessions."""
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT DISTINCT source FROM sessions ORDER BY source"
+                "SELECT DISTINCT source FROM sessions "
+                "WHERE TRIM(source) <> '' ORDER BY source"
             )
             return [row[0] for row in cursor.fetchall()]
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5163,6 +5163,14 @@ class SessionDB:
     # Utility
     # =========================================================================
 
+    def session_sources(self) -> list[str]:
+        """Return distinct source values from all sessions."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT DISTINCT source FROM sessions ORDER BY source"
+            )
+            return [row[0] for row in cursor.fetchall()]
+
     def session_count(
         self,
         source: str = None,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1114,6 +1114,14 @@ class SessionDB:
     # Utility
     # =========================================================================
 
+    def session_sources(self) -> list[str]:
+        """Return distinct source values from all sessions."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT DISTINCT source FROM sessions ORDER BY source"
+            )
+            return [row[0] for row in cursor.fetchall()]
+
     def session_count(self, source: str = None) -> int:
         """Count sessions, optionally filtered by source."""
         with self._lock:

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -585,7 +585,7 @@ def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home
 
     db = SessionDB()
     try:
-        db.create_session("chat-session", source="cli", model="test/model")
+        db.create_session("matrix-session", source="matrix", model="test/model")
         db.create_session("tool-session", source="tool", model="test/model")
     finally:
         db.close()
@@ -595,10 +595,11 @@ def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home
     stats = engine.execute("sessions stats")
 
     assert listed.status == "ok"
-    assert "chat-session" in listed.output
+    assert "matrix-session" in listed.output
     assert "tool-session" not in listed.output
     assert "Total sessions: 2" in stats.output
     assert "Listable sessions: 1" in stats.output
+    assert "  matrix: 1" in stats.output.splitlines()
 
 
 def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):

--- a/tests/hermes_cli/test_sessions_stats.py
+++ b/tests/hermes_cli/test_sessions_stats.py
@@ -1,0 +1,20 @@
+import sys
+
+
+def test_sessions_stats_includes_dynamically_discovered_source(
+    monkeypatch, capsys, _isolate_hermes_home
+):
+    import hermes_cli.main as main_mod
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        db.create_session("matrix-session", source="matrix", model="test/model")
+    finally:
+        db.close()
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "stats"])
+
+    main_mod.main()
+
+    assert "  matrix: 1 sessions" in capsys.readouterr().out.splitlines()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2082,6 +2082,7 @@ class TestCounts:
         db.create_session(session_id="s2", source="cli")
         db.create_session(session_id="s3", source="telegram")
         db.create_session(session_id="s4", source="matrix")
+        db.create_session(session_id="s5", source="   ")
         assert db.session_sources() == ["cli", "matrix", "telegram"]
 
     def test_message_count_total(self, db):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2076,6 +2076,14 @@ class TestCounts:
 
         assert db.session_count(cwd_prefix="/repo") == 2
 
+    def test_session_sources(self, db):
+        assert db.session_sources() == []
+        db.create_session(session_id="s1", source="telegram")
+        db.create_session(session_id="s2", source="cli")
+        db.create_session(session_id="s3", source="telegram")
+        db.create_session(session_id="s4", source="matrix")
+        assert db.session_sources() == ["cli", "matrix", "telegram"]
+
     def test_message_count_total(self, db):
         assert db.message_count() == 0
         db.create_session(session_id="s1", source="cli")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -528,6 +528,14 @@ class TestCounts:
         assert db.session_count(source="cli") == 2
         assert db.session_count(source="telegram") == 1
 
+    def test_session_sources(self, db):
+        assert db.session_sources() == []
+        db.create_session(session_id="s1", source="telegram")
+        db.create_session(session_id="s2", source="cli")
+        db.create_session(session_id="s3", source="telegram")
+        db.create_session(session_id="s4", source="matrix")
+        assert db.session_sources() == ["cli", "matrix", "telegram"]
+
     def test_message_count_total(self, db):
         assert db.message_count() == 0
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## Summary
- The `hermes sessions stats` command hardcoded only 5 sources (`cli`, `telegram`, `discord`, `whatsapp`, `slack`), silently omitting sessions from 13+ other platforms
- Added `SessionDB.session_sources()` method that queries distinct sources from the database
- Replaced the hardcoded list with a call to this new method

## Test plan
- [x] Added `test_session_sources` to `TestCounts` in `tests/test_hermes_state.py`
- [x] Run `pytest tests/test_hermes_state.py::TestCounts -xvs` — all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)