### PR TITLE
fix(gateway): default request_overrides to {} to avoid NoneType crash

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6971,7 +6971,7 @@ class GatewayRunner:
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
-            agent.request_overrides = turn_route.get("request_overrides")
+            agent.request_overrides = turn_route.get("request_overrides") or {}
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:


### PR DESCRIPTION
## Summary

The gateway's per-turn agent reuse path assigns `agent.request_overrides = turn_route.get(\"request_overrides\")` at `gateway/run.py:6974`. `dict.get()` returns `None` when the key is absent, so `request_overrides` becomes `None` on the running agent. The next turn crashes inside `_build_api_kwargs` at:

```python
fast_mode=self.request_overrides.get(\"speed\") == \"fast\",
```

with `AttributeError: 'NoneType' object has no attribute 'get'`.

The retry loop classifies this as a non-retryable API error and fast-fails into the fallback provider chain, so in practice every gateway turn silently falls back from the primary model to the first fallback (e.g. \`openai-codex\`) **without ever issuing an HTTP request to the primary provider**. The primary model is never actually tried.

## Root cause

All 7 other call sites pass `request_overrides` through the `AIAgent` constructor, which normalizes the value via `dict(request_overrides or {})` at `run_agent.py:678`. This direct attribute-assignment branch in `gateway/run.py` is the only path that bypassed that normalization.

## Fix

One-line change — mirror the constructor's defensive default:

```diff
-            agent.request_overrides = turn_route.get(\"request_overrides\")
+            agent.request_overrides = turn_route.get(\"request_overrides\") or {}
```

## Reproduction (before the fix)

1. Run `hermes --profile <p> gateway` with a primary provider that does not set \`request_overrides\` in its turn routing (e.g. a basic Discord DM flow through a custom provider).
2. Send a message. Gateway log shows:
   ```
   Fallback activated: <primary_model> → <fallback_model> (<fallback_provider>)
   ```
   with no HTTP request logged for the primary model and no \`request_dump_*.json\` written for the primary call.
3. Enabling DEBUG + a traceback in the error handler at \`run_agent.py:8296\` reveals:
   ```
   File \"run_agent.py\", line 5522, in _build_api_kwargs
       fast_mode=self.request_overrides.get(\"speed\") == \"fast\",
   AttributeError: 'NoneType' object has no attribute 'get'
   ```

After applying the fix, the primary model is invoked normally.

## Test plan

- [x] Manually verified on a \`wechat-investment\` profile with a custom Anthropic-Messages provider — primary model now handles Discord DMs correctly instead of fast-failing to the fallback.
- [ ] No existing tests covered the direct-attribute-assignment path; happy to add a regression test if maintainers would like one (simplest shape would assert that \`_build_api_kwargs\` works after \`agent.request_overrides = None\`).