### PR TITLE
feat(gateway): per-platform model overrides via config.yaml

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -464,20 +464,76 @@ def _load_gateway_config() -> dict:
     return {}
 
 
-def _resolve_gateway_model(config: dict | None = None) -> str:
+def _resolve_gateway_model(config: dict | None = None, platform: str | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
     Without this, temporary AIAgent instances (memory flush, /compress) fall
     back to the hardcoded default which fails when the active provider is
     openai-codex.
+
+    When *platform* is provided, checks ``model.platforms.{platform}`` first,
+    falling back to the default model. This allows per-platform model overrides
+    (e.g. a cheaper model for Hub conversations).
     """
     cfg = config if config is not None else _load_gateway_config()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
         return model_cfg
     elif isinstance(model_cfg, dict):
+        # Per-platform override (string shorthand or dict with model key)
+        if platform:
+            platforms = model_cfg.get("platforms")
+            if isinstance(platforms, dict):
+                override = platforms.get(platform)
+                if isinstance(override, str) and override:
+                    return override
+                if isinstance(override, dict) and override.get("model"):
+                    return override["model"]
         return model_cfg.get("default") or model_cfg.get("model") or ""
     return ""
+
+
+def _resolve_platform_provider_overrides(
+    config: dict | None = None,
+    platform: str | None = None,
+) -> dict | None:
+    """Return per-platform provider overrides (base_url, api_key) if configured.
+
+    Supports two config forms::
+
+        # String shorthand — model name only, same provider
+        model:
+          platforms:
+            hub: slate-2
+
+        # Dict — full provider override
+        model:
+          platforms:
+            hub:
+              model: slate-2
+              base_url: "https://other-endpoint/v1"
+              api_key: "sk-..."
+
+    Returns a dict with keys to merge into runtime_kwargs, or None.
+    """
+    if not platform:
+        return None
+    cfg = config if config is not None else _load_gateway_config()
+    model_cfg = cfg.get("model", {})
+    if not isinstance(model_cfg, dict):
+        return None
+    platforms = model_cfg.get("platforms")
+    if not isinstance(platforms, dict):
+        return None
+    override = platforms.get(platform)
+    if not isinstance(override, dict):
+        return None
+    result = {}
+    if override.get("base_url"):
+        result["base_url"] = override["base_url"]
+    if override.get("api_key"):
+        result["api_key"] = override["api_key"]
+    return result or None
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -919,6 +975,10 @@ class GatewayRunner:
         If the session override already contains a complete provider bundle
         (provider/api_key/base_url/api_mode), prefer it directly instead of
         resolving fresh global runtime state first.
+
+        When *source* is provided, per-platform model/provider overrides from
+        ``config.yaml`` (``model.platforms.<platform>``) are applied underneath
+        any session override.
         """
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
@@ -927,7 +987,9 @@ class GatewayRunner:
             except Exception:
                 resolved_session_key = None
 
-        model = _resolve_gateway_model(user_config)
+        platform_key = _platform_config_key(source.platform) if source is not None else None
+
+        model = _resolve_gateway_model(user_config, platform=platform_key)
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
         if override:
             override_model = override.get("model", model)
@@ -958,6 +1020,9 @@ class GatewayRunner:
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        platform_overrides = _resolve_platform_provider_overrides(user_config, platform=platform_key)
+        if platform_overrides:
+            runtime_kwargs = {**runtime_kwargs, **platform_overrides}
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
@@ -6263,7 +6328,6 @@ class GatewayRunner:
                 )
                 return
 
-            platform_key = _platform_config_key(source.platform)
             reasoning_config = self._load_reasoning_config()
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
@@ -9882,7 +9946,8 @@ class GatewayRunner:
             _result_for_fb = result_holder[0]
             _run_failed = _result_for_fb.get("failed") if _result_for_fb else False
             if _agent is not None and hasattr(_agent, 'model') and not _run_failed:
-                _cfg_model = _resolve_gateway_model()
+                _platform_key = _platform_config_key(source.platform) if source else None
+                _cfg_model = _resolve_gateway_model(platform=_platform_key)
                 if _agent.model != _cfg_model and not self._is_intentional_model_switch(session_key, _agent.model):
                     # Fallback activated on a successful run — evict cached
                     # agent so the next message retries the primary model.

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -220,7 +220,7 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None, platform=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -140,7 +140,7 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None, platform=None: "gpt-5.4")
 
     response = await runner._handle_fast_command(_make_event("/fast fast"))
 
@@ -161,7 +161,7 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None, platform=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",

--- a/tests/gateway/test_per_platform_model.py
+++ b/tests/gateway/test_per_platform_model.py
@@ -1,0 +1,272 @@
+"""Unit tests for per-platform model overrides (PR #7297).
+
+Covers the helpers added in ``gateway/run.py``:
+
+* ``_resolve_gateway_model(config, platform=...)`` — per-platform model lookup
+  with fallback to ``model.default``.
+* ``_resolve_platform_provider_overrides(config, platform=...)`` — per-platform
+  provider bundle (``base_url``, ``api_key``).
+* ``GatewayRunner._resolve_session_agent_runtime`` — central helper the PR
+  pushes platform-awareness into.  Verifies:
+  - ``source=None`` (memory flush / hygiene-less paths) → default model.
+  - ``source=<platform>`` → platform override applied.
+  - Session ``/model`` override takes precedence over platform override.
+"""
+
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+# ── _resolve_gateway_model ──────────────────────────────────────────
+
+
+def test_resolve_gateway_model_no_platform_returns_default():
+    cfg = {"model": {"default": "slate-1", "platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_gateway_model(cfg) == "slate-1"
+    assert gateway_run._resolve_gateway_model(cfg, platform=None) == "slate-1"
+
+
+def test_resolve_gateway_model_string_shorthand_override():
+    cfg = {"model": {"default": "slate-1", "platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-2"
+
+
+def test_resolve_gateway_model_dict_override():
+    cfg = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://other/v1",
+                    "api_key": "sk-zzz",
+                }
+            },
+        }
+    }
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-2"
+
+
+def test_resolve_gateway_model_platform_missing_falls_back_to_default():
+    cfg = {"model": {"default": "slate-1", "platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_gateway_model(cfg, platform="discord") == "slate-1"
+
+
+def test_resolve_gateway_model_platforms_key_absent():
+    cfg = {"model": {"default": "slate-1"}}
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-1"
+
+
+def test_resolve_gateway_model_string_model_config():
+    # model: "slate-1" (bare string, not a dict) — no platform overrides possible.
+    cfg = {"model": "slate-1"}
+    assert gateway_run._resolve_gateway_model(cfg) == "slate-1"
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-1"
+
+
+# ── _resolve_platform_provider_overrides ────────────────────────────
+
+
+def test_resolve_platform_provider_overrides_none_without_platform():
+    cfg = {"model": {"platforms": {"telegram": {"base_url": "x"}}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg) is None
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform=None) is None
+
+
+def test_resolve_platform_provider_overrides_string_shorthand_returns_none():
+    # String shorthand means "same provider, different model" — no provider bundle.
+    cfg = {"model": {"platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform="telegram") is None
+
+
+def test_resolve_platform_provider_overrides_dict_full_bundle():
+    cfg = {
+        "model": {
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://other/v1",
+                    "api_key": "sk-zzz",
+                }
+            }
+        }
+    }
+    result = gateway_run._resolve_platform_provider_overrides(cfg, platform="telegram")
+    assert result == {"base_url": "https://other/v1", "api_key": "sk-zzz"}
+
+
+def test_resolve_platform_provider_overrides_dict_model_only_returns_none():
+    cfg = {"model": {"platforms": {"telegram": {"model": "slate-2"}}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform="telegram") is None
+
+
+def test_resolve_platform_provider_overrides_missing_platform():
+    cfg = {"model": {"platforms": {"telegram": {"base_url": "x"}}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform="discord") is None
+
+
+# ── _resolve_session_agent_runtime ──────────────────────────────────
+
+
+def _make_runner(monkeypatch, platform_base="https://default/v1", platform_api_key="sk-default"):
+    """Build a minimal GatewayRunner with fake runtime resolution."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+
+    def _fake_runtime_kwargs():
+        return {
+            "provider": "custom",
+            "api_key": platform_api_key,
+            "base_url": platform_base,
+            "api_mode": "chat",
+        }
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _fake_runtime_kwargs)
+    return runner
+
+
+def test_session_runtime_no_source_uses_default_model(monkeypatch):
+    """Memory flush (source=None) must ignore platform overrides."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {"model": "slate-2", "base_url": "https://hub/v1"},
+            },
+        }
+    }
+    model, runtime = runner._resolve_session_agent_runtime(user_config=user_config)
+    assert model == "slate-1"
+    assert runtime["base_url"] == "https://default/v1"
+
+
+def test_session_runtime_platform_override_applied(monkeypatch):
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://hub/v1",
+                    "api_key": "sk-hub",
+                }
+            },
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, user_config=user_config
+    )
+    assert model == "slate-2"
+    assert runtime["base_url"] == "https://hub/v1"
+    assert runtime["api_key"] == "sk-hub"
+
+
+def test_session_runtime_string_shorthand_only_swaps_model(monkeypatch):
+    """String shorthand swaps the model but preserves the default provider bundle."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {"telegram": "slate-2"},
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, user_config=user_config
+    )
+    assert model == "slate-2"
+    # base_url/api_key stay on the default runtime, not swapped.
+    assert runtime["base_url"] == "https://default/v1"
+    assert runtime["api_key"] == "sk-default"
+
+
+def test_session_runtime_session_override_beats_platform_override(monkeypatch):
+    """A complete session /model override must fully replace the platform override."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://hub/v1",
+                    "api_key": "sk-hub",
+                }
+            },
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    session_key = "agent:main:telegram:dm:other"
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "api_key": "sk-session",
+        "base_url": "https://chatgpt/codex",
+        "api_mode": "codex_responses",
+    }
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, session_key=session_key, user_config=user_config
+    )
+    assert model == "gpt-5.4"
+    assert runtime["provider"] == "openai-codex"
+    assert runtime["base_url"] == "https://chatgpt/codex"
+    assert runtime["api_key"] == "sk-session"
+    assert runtime["api_mode"] == "codex_responses"
+
+
+def test_session_runtime_partial_session_override_keeps_platform_bundle(monkeypatch):
+    """A session override that only sets *model* should leave the platform
+    override's base_url / api_key intact."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://hub/v1",
+                    "api_key": "sk-hub",
+                }
+            },
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    session_key = "agent:main:telegram:dm:other"
+    # Model-only override — no api_key means the "complete bundle" short-circuit
+    # at line 936 does NOT fire, and we fall through to platform-aware merge.
+    runner._session_model_overrides[session_key] = {"model": "slate-turbo"}
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, session_key=session_key, user_config=user_config
+    )
+    assert model == "slate-turbo"
+    assert runtime["base_url"] == "https://hub/v1"
+    assert runtime["api_key"] == "sk-hub"


### PR DESCRIPTION
## What

Adds optional `model.platforms` config to override the default model on a per-platform basis. This allows using different models for different messaging platforms while keeping a single inference endpoint.

## Why

Multi-platform agents often want a primary model for user-facing conversations (Telegram, Discord) but a cheaper/faster model for high-volume automated conversations (Hub agent-to-agent messaging, webhooks). Currently there's no way to do this without running separate instances.

## Config

```yaml
model:
  provider: custom
  default: claude-sonnet-4-6
  base_url: "https://my-endpoint/v1"
  api_key: "sk-..."
  platforms:
    hub: claude-haiku-4-5
    discord: claude-sonnet-4-6
```

When `model.platforms.{platform}` is set, that model is used for conversations on that platform. When not set, falls back to `model.default`. Internal operations (memory flush, compress, context estimation) always use the default model.

## How it works

`_resolve_gateway_model()` gains an optional `platform` parameter. The three message-handling call sites (main conversation, background tasks, /btw) pass the platform key. All other call sites (internal operations) continue using the default.

## How to test

1. Set `model.platforms.hub: some-model` in config.yaml
2. Send a message via Hub → agent should use `some-model`
3. Send a message via Telegram → agent should use `model.default`
4. Run `/compress` or trigger memory flush → should use `model.default`

Tested on Linux (Ubuntu 24.04).