### PR TITLE
fix: guard against None request_overrides in AIAgent

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'NoneType' object has no attribute 'get'` when `self.request_overrides` is `None` in `AIAgent._make_assistant_request_params()`.

## Fix

```python
# Before
fast_mode=self.request_overrides.get("speed") == "fast",

# After
fast_mode=(self.request_overrides or {}).get("speed") == "fast",
```

This guards against the case where `request_overrides` has not been initialized yet.