### PR TITLE
fix(plugins): restore plugin slash command registration

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -245,12 +245,52 @@ for _cmd in COMMAND_REGISTRY:
 # Set of all command names + aliases recognized by the gateway.
 # Includes config-gated commands so the gateway can dispatch them
 # (the handler checks the config gate at runtime).
-GATEWAY_KNOWN_COMMANDS: frozenset[str] = frozenset(
-    name
-    for cmd in COMMAND_REGISTRY
-    if not cmd.cli_only or cmd.gateway_config_gate
-    for name in (cmd.name, *cmd.aliases)
-)
+def _build_gateway_known_commands() -> frozenset[str]:
+    return frozenset(
+        name
+        for cmd in COMMAND_REGISTRY
+        if not cmd.cli_only or cmd.gateway_config_gate
+        for name in (cmd.name, *cmd.aliases)
+    )
+
+
+GATEWAY_KNOWN_COMMANDS: frozenset[str] = _build_gateway_known_commands()
+
+
+def rebuild_lookups() -> None:
+    """Refresh derived command lookup structures after registry mutation."""
+    global _COMMAND_LOOKUP, COMMANDS, COMMANDS_BY_CATEGORY, SUBCOMMANDS, GATEWAY_KNOWN_COMMANDS
+
+    _COMMAND_LOOKUP = _build_command_lookup()
+
+    COMMANDS = {}
+    for _cmd in COMMAND_REGISTRY:
+        if not _cmd.gateway_only:
+            COMMANDS[f"/{_cmd.name}"] = _build_description(_cmd)
+            for _alias in _cmd.aliases:
+                COMMANDS[f"/{_alias}"] = f"{_cmd.description} (alias for /{_cmd.name})"
+
+    COMMANDS_BY_CATEGORY = {}
+    for _cmd in COMMAND_REGISTRY:
+        if not _cmd.gateway_only:
+            _cat = COMMANDS_BY_CATEGORY.setdefault(_cmd.category, {})
+            _cat[f"/{_cmd.name}"] = COMMANDS[f"/{_cmd.name}"]
+            for _alias in _cmd.aliases:
+                _cat[f"/{_alias}"] = COMMANDS[f"/{_alias}"]
+
+    SUBCOMMANDS = {}
+    for _cmd in COMMAND_REGISTRY:
+        if _cmd.subcommands:
+            SUBCOMMANDS[f"/{_cmd.name}"] = list(_cmd.subcommands)
+    for _cmd in COMMAND_REGISTRY:
+        key = f"/{_cmd.name}"
+        if key in SUBCOMMANDS or not _cmd.args_hint:
+            continue
+        m = _PIPE_SUBS_RE.search(_cmd.args_hint)
+        if m:
+            SUBCOMMANDS[key] = m.group(0).split("|")
+
+    GATEWAY_KNOWN_COMMANDS = _build_gateway_known_commands()
 
 
 def _resolve_config_gates() -> set[str]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from hermes_constants import get_hermes_home
+from hermes_cli.commands import COMMAND_REGISTRY, CommandDef, rebuild_lookups, resolve_command
 from utils import env_var_enabled
 
 try:
@@ -112,6 +113,7 @@ class LoadedPlugin:
     module: Optional[types.ModuleType] = None
     tools_registered: List[str] = field(default_factory=list)
     hooks_registered: List[str] = field(default_factory=list)
+    commands_registered: List[str] = field(default_factory=list)
     enabled: bool = False
     error: Optional[str] = None
 
@@ -262,6 +264,62 @@ class PluginContext:
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
+    # -- slash command registration ------------------------------------------
+
+    def register_command(
+        self,
+        name: str,
+        handler: Callable,
+        description: str = "",
+        *,
+        aliases: tuple[str, ...] | list[str] = (),
+        args_hint: str = "",
+        subcommands: tuple[str, ...] | list[str] = (),
+        cli_only: bool = False,
+        gateway_only: bool = False,
+        gateway_config_gate: str | None = None,
+        category: str = "Plugins",
+    ) -> None:
+        """Register a plugin-provided slash command."""
+        command_name = name.strip().lstrip("/").lower()
+        if not command_name:
+            raise ValueError("Plugin command name cannot be empty")
+
+        normalized_aliases = tuple(
+            alias.strip().lstrip("/").lower()
+            for alias in aliases
+            if alias and alias.strip()
+        )
+        normalized_subcommands = tuple(
+            sub.strip()
+            for sub in subcommands
+            if sub and sub.strip()
+        )
+
+        for candidate in (command_name, *normalized_aliases):
+            existing = resolve_command(candidate)
+            if existing is not None:
+                raise ValueError(
+                    f"Plugin command '/{candidate}' conflicts with existing '/{existing.name}'"
+                )
+
+        self._manager._plugin_commands[command_name] = handler
+        COMMAND_REGISTRY.append(
+            CommandDef(
+                name=command_name,
+                description=description or f"Plugin command: {command_name}",
+                category=category,
+                aliases=normalized_aliases,
+                args_hint=args_hint,
+                subcommands=normalized_subcommands,
+                cli_only=cli_only,
+                gateway_only=gateway_only,
+                gateway_config_gate=gateway_config_gate,
+            )
+        )
+        rebuild_lookups()
+        logger.debug("Plugin %s registered command: %s", self.manifest.name, command_name)
+
     # -- skill registration -------------------------------------------------
 
     def register_skill(
@@ -321,6 +379,7 @@ class PluginManager:
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
+        self._plugin_commands: Dict[str, Callable] = {}
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._discovered: bool = False
@@ -485,6 +544,15 @@ class PluginManager:
                         for h in p.hooks_registered
                     }
                 )
+                loaded.commands_registered = [
+                    command_name
+                    for command_name in self._plugin_commands
+                    if command_name not in {
+                        registered_name
+                        for _name, plugin in self._plugins.items()
+                        for registered_name in plugin.commands_registered
+                    }
+                ]
                 loaded.enabled = True
 
         except Exception as exc:
@@ -598,6 +666,7 @@ class PluginManager:
                     "enabled": loaded.enabled,
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),
+                    "commands": len(loaded.commands_registered),
                     "error": loaded.error,
                 }
             )
@@ -644,6 +713,23 @@ def get_plugin_manager() -> PluginManager:
 def discover_plugins() -> None:
     """Discover and load all plugins (idempotent)."""
     get_plugin_manager().discover_and_load()
+
+
+def get_plugin_command_handler(name: str) -> Callable | None:
+    """Return a plugin slash-command handler by canonical name or alias."""
+    if not name:
+        return None
+
+    normalized = name.strip().lstrip("/").lower()
+    manager = get_plugin_manager()
+    handler = manager._plugin_commands.get(normalized)
+    if handler is not None:
+        return handler
+
+    resolved = resolve_command(normalized)
+    if resolved is None:
+        return None
+    return manager._plugin_commands.get(resolved.name)
 
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -10,6 +10,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+import hermes_cli.commands as commands_module
+import hermes_cli.plugins as plugins_module
+from hermes_cli.commands import COMMAND_REGISTRY, resolve_command
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
@@ -605,7 +608,78 @@ class TestPreLlmCallTargetRouting:
         assert "plain text C" in _plugin_user_context
 
 
-# NOTE: TestPluginCommands removed – register_command() was never implemented
-# in PluginContext (hermes_cli/plugins.py).  The tests referenced _plugin_commands,
-# commands_registered, get_plugin_command_handler, and GATEWAY_KNOWN_COMMANDS
-# integration — all of which are unimplemented features.
+class TestPluginCommands:
+    """Tests for plugin slash-command registration and lookup."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_plugin_command_state(self):
+        original_registry = list(COMMAND_REGISTRY)
+        original_manager = plugins_module._plugin_manager
+        try:
+            yield
+        finally:
+            plugins_module._plugin_manager = original_manager
+            COMMAND_REGISTRY[:] = original_registry
+            rebuild = getattr(commands_module, "rebuild_lookups", None)
+            if callable(rebuild):
+                rebuild()
+
+    def test_register_command_records_handler_and_updates_command_lookup(self):
+        manifest = PluginManifest(name="cmd_plugin")
+        manager = PluginManager()
+        plugins_module._plugin_manager = manager
+        ctx = PluginContext(manifest, manager)
+
+        def handler(args: str) -> str:
+            return f"ok:{args}"
+
+        ctx.register_command(
+            name="/mirror-status",
+            handler=handler,
+            description="Show mirror status",
+            aliases=("mirrorstat",),
+            args_hint="[scope]",
+        )
+
+        command_lookup = getattr(manager, "_plugin_commands", {})
+        assert command_lookup == {"mirror-status": handler}
+        assert plugins_module.get_plugin_command_handler("mirror-status") is handler
+        assert plugins_module.get_plugin_command_handler("/mirrorstat") is handler
+
+        cmd = resolve_command("mirror-status")
+        assert cmd is not None
+        assert cmd.name == "mirror-status"
+        assert cmd.aliases == ("mirrorstat",)
+        assert cmd.args_hint == "[scope]"
+        assert cmd.category == "Plugins"
+        assert "mirror-status" in commands_module.GATEWAY_KNOWN_COMMANDS
+        assert "mirrorstat" in commands_module.GATEWAY_KNOWN_COMMANDS
+
+    def test_discovery_loads_plugin_commands_and_tracks_command_count(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "cmd_plugin",
+            register_body=(
+                'ctx.register_command('
+                'name="mirror-test", '
+                'handler=lambda args: f"mirror:{args}", '
+                'description="Send mirror test", '
+                'aliases=("mt",)'
+                ')'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        discover_plugins()
+
+        handler = plugins_module.get_plugin_command_handler("mt")
+        assert handler is not None
+        assert handler("hello") == "mirror:hello"
+
+        cmd = resolve_command("mirror-test")
+        assert cmd is not None
+        assert cmd.description == "Send mirror test"
+
+        plugin_info = discover_plugins.__globals__["get_plugin_manager"]().list_plugins()
+        assert plugin_info[0]["commands"] == 1


### PR DESCRIPTION
Main already had partial command-side support for plugin slash commands, but the plugin runtime never actually implemented registration and lookup. This PR closes that gap by adding `PluginContext.register_command(...)`, wiring handlers into the shared command registry, and restoring regression tests.

## Summary
- restore plugin slash-command registration and lookup in `hermes_cli.plugins`
- wire plugin command definitions into the current command registry/lookup flow
- add regression coverage for handler lookup, discovery, aliases, and command registration

## Test Plan
- /home/kerozelvin/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_plugins.py -q

## Notes
- upstream currently references `_plugin_commands` from `hermes_cli.commands`, but still lacks the corresponding `plugins.py` registration/lookup implementation carried here
- branch was rebased onto current `origin/main` and replay-verified locally