### PR TITLE
fix(cli): route voice reply behavior by input origin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6352,10 +6352,12 @@ class HermesCLI:
 
             if result.get("success") and result.get("transcript", "").strip():
                 transcript = result["transcript"].strip()
-                self._attached_images.clear()
+                attached_images = getattr(self, '_attached_images', None)
+                if attached_images is not None:
+                    attached_images.clear()
                 if hasattr(self, '_app') and self._app:
                     self._app.invalidate()
-                self._pending_input.put(transcript)
+                self._pending_input.put((transcript, [], "voice"))
                 submitted = True
             elif result.get("success"):
                 _cprint(f"{_DIM}No speech detected.{_RST}")
@@ -6477,6 +6479,19 @@ class HermesCLI:
         else:
             _cprint(f"Unknown voice subcommand: {subcommand}")
             _cprint("Usage: /voice [on|off|tts|status]")
+
+    def _get_voice_message_reply_mode(self) -> str:
+        """Return normalized CLI voice reply mode from config."""
+        try:
+            from hermes_cli.config import load_config
+
+            voice_config = load_config().get("voice", {})
+            reply_mode = str(voice_config.get("message_reply_mode", "all")).strip().lower()
+            if reply_mode in ("voice_only", "all"):
+                return reply_mode
+        except Exception:
+            pass
+        return "all"
 
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""
@@ -6932,7 +6947,15 @@ class HermesCLI:
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def _clear_current_input(self) -> None:
+        if getattr(self, "_app", None):
+            try:
+                self._app.current_buffer.text = ""
+            except Exception:
+                pass
+
+
+    def chat(self, message, images: list = None, input_origin: str = "text") -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -6947,6 +6970,7 @@ class HermesCLI:
         Args:
             message: The user's message (str or multimodal content list)
             images: Optional list of Path objects for attached images
+            input_origin: Where the turn came from ("text" or "voice")
             
         Returns:
             The agent's response, or None on error
@@ -7039,7 +7063,12 @@ class HermesCLI:
             stream_callback = None
             stop_event = None
 
-            if self._voice_tts:
+            voice_reply_mode = self._get_voice_message_reply_mode()
+            should_speak_response = self._voice_tts and (
+                input_origin == "voice" or voice_reply_mode == "all"
+            )
+
+            if should_speak_response:
                 try:
                     from tools.tts_tool import (
                         _load_tts_config as _load_tts_cfg,
@@ -7090,7 +7119,7 @@ class HermesCLI:
             # model responds concisely. The prefix is API-call-local only —
             # run_conversation persists the original clean user message.
             _voice_prefix = ""
-            if self._voice_mode and isinstance(message, str):
+            if self._voice_mode and input_origin == "voice" and isinstance(message, str):
                 _voice_prefix = (
                     "[Voice input — respond concisely and conversationally, "
                     "2-3 sentences max. No code blocks or markdown.] "
@@ -7311,9 +7340,9 @@ class HermesCLI:
                 sys.stdout.write("\a")
                 sys.stdout.flush()
 
-            # Speak response aloud if voice TTS is enabled
-            # Skip batch TTS when streaming TTS already handled it
-            if self._voice_tts and response and not use_streaming_tts:
+            # Speak response aloud only when this turn qualifies for voice output.
+            # Skip batch TTS when streaming TTS already handled it.
+            if should_speak_response and response and not use_streaming_tts:
                 threading.Thread(
                     target=self._voice_speak_response,
                     args=(response,),
@@ -8803,10 +8832,16 @@ class HermesCLI:
                     if not user_input:
                         continue
 
-                    # Unpack image payload: (text, [Path, ...]) or plain str
+                    # Unpack queued payload: plain str, (text, [Path, ...]), or
+                    # (text, [Path, ...], input_origin) where input_origin is
+                    # "text" or "voice".
                     submit_images = []
+                    input_origin = "text"
                     if isinstance(user_input, tuple):
-                        user_input, submit_images = user_input
+                        if len(user_input) == 3:
+                            user_input, submit_images, input_origin = user_input
+                        else:
+                            user_input, submit_images = user_input
                     
                     # Check for commands — but detect dragged/pasted file paths first.
                     # See _detect_file_drop() for details.
@@ -8889,7 +8924,11 @@ class HermesCLI:
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            input_origin=input_origin,
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -494,6 +494,7 @@ DEFAULT_CONFIG = {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,
+        "message_reply_mode": "all",
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
     },

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -3,6 +3,7 @@ that only manifest at runtime (not in mocked unit tests)."""
 
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -158,6 +159,48 @@ class TestSingleQueryState:
         assert cli._voice_tts_done.is_set()
         assert hasattr(cli, "_interrupt_queue")
         assert hasattr(cli, "_pending_input")
+
+    def test_chat_accepts_voice_input_origin_without_name_error(self):
+        cli = _make_cli()
+        captured = {}
+
+        def fake_run_conversation(**kwargs):
+            captured.update(kwargs)
+            return {
+                "final_response": "",
+                "messages": [{"role": "user", "content": kwargs["persist_user_message"]}],
+                "completed": True,
+            }
+
+        cli._voice_tts = True
+        cli._voice_mode = True
+        cli._get_voice_message_reply_mode = lambda: "voice_only"
+        cli._ensure_runtime_credentials = lambda: True
+        cli._resolve_turn_agent_config = lambda message: {
+            "signature": "sig",
+            "model": None,
+            "runtime": None,
+            "label": "test",
+        }
+        cli._active_agent_route_signature = "sig"
+        cli._reset_stream_state = lambda: None
+        cli._flush_stream = lambda: None
+        cli._invalidate = lambda *args, **kwargs: None
+        cli.agent = SimpleNamespace(
+            run_conversation=fake_run_conversation,
+            interrupt=lambda _msg=None: None,
+            _active_children=[],
+            _interrupt_requested=False,
+        )
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "openai"}), patch(
+            "tools.tts_tool._get_provider", return_value="openai"
+        ):
+            response = cli.chat("Hello there", input_origin="voice")
+
+        assert response == ""
+        assert captured["user_message"].startswith("[Voice input — respond concisely")
+        assert captured["persist_user_message"] == "Hello there"
 
 
 class TestHistoryDisplay:

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -302,14 +302,14 @@ class TestVoiceMessagePrefix:
     """Voice mode should inject instruction via user message prefix,
     not by modifying the system prompt (which breaks prompt cache)."""
 
-    def test_prefix_added_when_voice_mode_active(self):
-        """When voice mode is active and message is str, agent_message
-        should have the voice instruction prefix."""
+    def test_prefix_added_only_for_voice_origin(self):
+        """Only STT-originated prompts should get the voice instruction prefix."""
         voice_mode = True
+        input_origin = "voice"
         message = "What's the weather like?"
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -319,13 +319,30 @@ class TestVoiceMessagePrefix:
         assert agent_message.startswith("[Voice input")
         assert "What's the weather like?" in agent_message
 
-    def test_no_prefix_when_voice_mode_inactive(self):
-        """When voice mode is off, message passes through unchanged."""
-        voice_mode = False
+    def test_no_prefix_for_typed_input_while_voice_mode_active(self):
+        """Typed prompts should remain plain text even when voice mode is on."""
+        voice_mode = True
+        input_origin = "text"
         message = "What's the weather like?"
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
+            agent_message = (
+                "[Voice input — respond concisely and conversationally, "
+                "2-3 sentences max. No code blocks or markdown.] "
+                + message
+            )
+
+        assert agent_message == message
+
+    def test_no_prefix_when_voice_mode_inactive(self):
+        """When voice mode is off, message passes through unchanged."""
+        voice_mode = False
+        input_origin = "voice"
+        message = "What's the weather like?"
+
+        agent_message = message
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -337,10 +354,11 @@ class TestVoiceMessagePrefix:
     def test_no_prefix_for_multimodal_content(self):
         """When message is a list (multimodal), no prefix is added."""
         voice_mode = True
+        input_origin = "voice"
         message = [{"type": "text", "text": "describe this"}, {"type": "image_url"}]
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -353,13 +371,14 @@ class TestVoiceMessagePrefix:
         """conversation_history should contain the original message,
         not the prefixed version."""
         voice_mode = True
+        input_origin = "voice"
         message = "Hello there"
         conversation_history = []
 
         conversation_history.append({"role": "user", "content": message})
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -1100,7 +1119,7 @@ class TestVoiceStopAndTranscribeReal:
         recorder.stop.return_value = "/tmp/test.wav"
         cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
         cli._voice_stop_and_transcribe()
-        assert cli._pending_input.get_nowait() == "hello world"
+        assert cli._pending_input.get_nowait() == ("hello world", [], "voice")
 
     @patch("cli._cprint")
     @patch("cli.os.unlink")


### PR DESCRIPTION
This PR makes Hermes treat speech-originated turns differently from typed turns, so voice-specific prompt shaping and TTS reply behavior only apply when the input actually came from voice.

## Summary
- route STT-submitted turns through an explicit `input_origin` path instead of treating them like typed input
- only apply voice-mode prompt shortening and TTS reply behavior to actual voice-origin turns
- add regression coverage for the voice queue payload and typed-vs-voice reply behavior

## For Humans:
This PR teaches Hermes to distinguish:
- text turns typed by the user
from
- turns that came from speech-to-text / voice input

Right now, those can get mixed together in the CLI voice flow.

The branch adds an explicit `input_origin` concept:
- default is `"text"`
- STT-submitted turns are queued as `"voice"`

Then Hermes uses that signal to decide when to apply voice-specific behavior.

Concretely, it changes 3 things

1. Voice transcripts are marked as voice
Instead of queueing a raw transcript string, the voice recorder now queues:
- `(transcript, [], "voice")`

That means the main input loop knows “this turn came from speech.”

2. Voice-only response behavior only applies to actual voice turns
When a turn is marked `"voice"`, Hermes can:
- add the concise conversational voice prefix
- optionally TTS the response back

When a turn is normal typed text, it won’t accidentally inherit that voice-specific behavior.

3. Adds a config knob for reply behavior
It introduces:
- `voice.message_reply_mode`
with default:
- `"all"`

That supports behavior like:
- `"voice_only"` = only speak responses for voice-origin turns
- `"all"` = speak for both, if that’s what the user wants

Who benefits

- People who keep voice mode enabled but still type sometimes
- Users on mobile / headset / accessibility workflows
- Anyone using push-to-talk and then switching back to keyboard
- People who want voice input without every typed prompt being treated like a spoken conversation

Problems it prevents

- Typed input getting an unwanted “respond briefly, conversationally” voice prompt style
- Typed input triggering TTS when the user only wanted spoken replies for actual voice turns
- STT turns being treated like generic text instead of first-class voice interactions
- A real bug/regression this branch guards against:
  - `NameError: input_origin is not defined`

Why that matters in practice

Without this routing, “voice mode on” can become too blunt:
- if you type while voice mode is enabled, Hermes may still behave as if you spoke
- that can change tone, brevity, and whether it talks back aloud

This PR makes voice mode more predictable:
- spoken turns get voice handling
- typed turns stay typed turns

That makes Hermes feel much more natural in hybrid use.

What changed in code terms

From the diff:
- `chat(..., input_origin: str = "text")`
- STT queue now sends `("voice")` origin
- voice prompt prefix only applies when `input_origin == "voice"`
- TTS reply decision now checks both:
  - `_voice_tts`
  - `input_origin` / `message_reply_mode`

Tests added/updated

The branch also adds regression coverage for:
- voice-origin chat not throwing `NameError`
- typed input not getting voice prefix while voice mode is on
- STT queue payload carrying the `"voice"` origin
- typed-vs-voice behavior staying separated

## Test Plan
- /home/kerozelvin/.hermes/hermes-agent/venv/bin/python -m pytest tests/cli/test_cli_init.py tests/tools/test_voice_cli_integration.py -q

## Notes
- current upstream has nearby voice/CLI changes, but not this `input_origin` routing behavior
- branch was rebased onto current `origin/main` and replay-verified locally