### PR TITLE
fix(gateway): set empty dict instead of None for request_overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -793,7 +793,7 @@ class GatewayRunner:
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
-            route["request_overrides"] = None
+            route["request_overrides"] = {}
             return route
 
         try:


### PR DESCRIPTION
When service_tier is empty, _build_turn_route() was setting request_overrides to None, which would later override the dict initialized in AIAgent.__init__. This caused an AttributeError when code tried to call .get() on None in run_agent.py line 5522.

The fix is to use {} instead of None, consistent with how request_overrides is initialized in AIAgent.__init__.