### PR TITLE
fix(whatsapp): strip device suffix in ID normalization

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -199,8 +199,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if not value:
             return ""
         normalized = str(value).strip()
-        if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+        # Strip device suffix: "number:3@domain" → "number@domain"
+        # The old replace(":", "@", 1) produced "number@3@domain" — wrong.
+        colon_pos = normalized.find(":")
+        at_pos = normalized.find("@")
+        if colon_pos != -1 and at_pos != -1 and colon_pos < at_pos:
+            normalized = normalized[:colon_pos] + normalized[at_pos:]
         return normalized
 
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -64,7 +64,15 @@ function formatOutgoingMessage(message) {
 
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  const s = String(value);
+  // Strip device suffix: "number:3@domain" → "number@domain"
+  // The old replace(':', '@') produced "number@3@domain" — wrong.
+  const colonIdx = s.indexOf(':');
+  const atIdx = s.indexOf('@');
+  if (colonIdx !== -1 && atIdx !== -1 && colonIdx < atIdx) {
+    return s.substring(0, colonIdx) + s.substring(atIdx);
+  }
+  return s;
 }
 
 function getMessageContent(msg) {

--- a/tests/gateway/test_whatsapp_id_normalization.py
+++ b/tests/gateway/test_whatsapp_id_normalization.py
@@ -1,0 +1,44 @@
+"""Tests for WhatsApp ID normalization — device suffix stripping.
+
+WhatsApp multi-device IDs look like "number:device@domain".  The normalizer
+should strip the ":device" part so that bot-self detection, mention matching,
+and quoted-participant checks all work regardless of which device sent the
+message.
+
+The same logic exists in both the Python adapter and the Node.js bridge;
+this file covers the Python side.
+"""
+
+import pytest
+
+from gateway.platforms.whatsapp import WhatsAppAdapter
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Standard device-suffix stripping
+        ("4912345678:3@s.whatsapp.net", "4912345678@s.whatsapp.net"),
+        ("4912345678:0@s.whatsapp.net", "4912345678@s.whatsapp.net"),
+        ("4912345678:42@s.whatsapp.net", "4912345678@s.whatsapp.net"),
+        # LID format
+        ("123456789:5@lid", "123456789@lid"),
+        # Already clean — no colon, should pass through
+        ("4912345678@s.whatsapp.net", "4912345678@s.whatsapp.net"),
+        # Group IDs — no colon, should pass through
+        ("120363001234567890@g.us", "120363001234567890@g.us"),
+        # Edge: colon but no @ — leave as-is
+        ("something:else", "something:else"),
+        # Edge: @ but no colon — leave as-is
+        ("number@domain", "number@domain"),
+        # Edge: colon after @ — leave as-is
+        ("number@domain:extra", "number@domain:extra"),
+        # Edge: empty / None
+        ("", ""),
+        (None, ""),
+        # Edge: whitespace
+        ("  4912345678:3@s.whatsapp.net  ", "4912345678@s.whatsapp.net"),
+    ],
+)
+def test_normalize_whatsapp_id(raw, expected):
+    assert WhatsAppAdapter._normalize_whatsapp_id(raw) == expected


### PR DESCRIPTION
## What does this PR do?

Fixes WhatsApp ID normalization for multi-device JIDs. The format is `number:device@domain` (e.g. `4912345678:3@s.whatsapp.net`). The previous logic used `str.replace(":", "@", 1)` which produced `number@device@domain` — a malformed ID with two `@` signs.

This broke bot-self detection, mention matching, and quoted-participant checks whenever the bot or a mentioned user had a device suffix in their JID.

**Fix:** find the colon and `@` positions, then slice out the `:device` segment to produce `number@domain`. Applied to both the Python adapter and the Node.js bridge so they stay in sync.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/whatsapp.py` — `_normalize_whatsapp_id()`: replace naive `str.replace(":", "@", 1)` with position-based slicing that correctly strips the device suffix
- `scripts/whatsapp-bridge/bridge.js` — `normalizeWhatsAppId()`: same fix on the JS side so bridge and adapter stay in sync
- `tests/gateway/test_whatsapp_id_normalization.py` — new parametrized test covering device suffixes, LID format, group IDs, clean IDs, and edge cases (12 cases)

## How to Test

1. Run the new tests: `pytest tests/gateway/test_whatsapp_id_normalization.py -v`
2. Connect a WhatsApp account with multi-device enabled
3. Send a message to a group where the bot is present — verify the bot detects its own messages and does not reply to itself
4. Reply to a bot message in a group — verify quoted-participant matching works

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Pop!_OS (Ubuntu-based) Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (bug fix, no new config)
- [x] I've considered cross-platform impact — N/A (string operations only)