### PR TITLE
fix(cli): strip leaked bracketed-paste wrappers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 import logging
 import os
+import re
 import shutil
 import sys
 import json
@@ -1206,6 +1207,32 @@ def _format_image_attachment_badges(attached_images: list[Path], image_counter: 
 def _should_auto_attach_clipboard_image_on_paste(pasted_text: str) -> bool:
     """Auto-attach clipboard images only for image-only paste gestures."""
     return not pasted_text.strip()
+
+
+def _strip_leaked_bracketed_paste_wrappers(text: str) -> str:
+    """Strip leaked bracketed-paste wrapper markers from user-visible text.
+
+    Defensive normalization for cases where terminal/prompt_toolkit parsing
+    fails and bracketed-paste markers end up in the buffer as literal text.
+
+    We strip canonical wrappers unconditionally and also handle degraded
+    visible forms like ``[200~`` / ``[201~`` and ``00~`` / ``01~`` when they
+    look like wrapper boundaries, not arbitrary user content.
+    """
+    if not text:
+        return text
+
+    text = (
+        text.replace("\x1b[200~", "")
+        .replace("\x1b[201~", "")
+        .replace("^[[200~", "")
+        .replace("^[[201~", "")
+    )
+    text = re.sub(r"(^|[\s\n>:\]\)])\[200~", r"\1", text)
+    text = re.sub(r"\[201~(?=$|[\s\n<\[\(\):;.,!?])", "", text)
+    text = re.sub(r"(^|[\s\n>:\]\)])00~", r"\1", text)
+    text = re.sub(r"01~(?=$|[\s\n<\[\(\):;.,!?])", "", text)
+    return text
 
 
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
@@ -8091,6 +8118,7 @@ class HermesCLI:
             # Normalise line endings — Windows \r\n and old Mac \r both become \n
             # so the 5-line collapse threshold and display are consistent.
             pasted_text = pasted_text.replace('\r\n', '\n').replace('\r', '\n')
+            pasted_text = _strip_leaked_bracketed_paste_wrappers(pasted_text)
             if _should_auto_attach_clipboard_image_on_paste(pasted_text) and self._try_attach_clipboard_image():
                 event.app.invalidate()
             if pasted_text:
@@ -8223,7 +8251,15 @@ class HermesCLI:
                still batch newlines.  Alt+Enter only adds 1 newline per
                event so it never triggers this.
             """
-            text = buf.text
+            text = _strip_leaked_bracketed_paste_wrappers(buf.text)
+            if text != buf.text:
+                cursor = min(buf.cursor_position, len(text))
+                _paste_just_collapsed[0] = True
+                buf.text = text
+                buf.cursor_position = cursor
+                _prev_text_len[0] = len(text)
+                _prev_newline_count[0] = text.count('\n')
+                return
             chars_added = len(text) - _prev_text_len[0]
             _prev_text_len[0] = len(text)
             if _paste_just_collapsed[0]:
@@ -8807,6 +8843,9 @@ class HermesCLI:
                     submit_images = []
                     if isinstance(user_input, tuple):
                         user_input, submit_images = user_input
+
+                    if isinstance(user_input, str):
+                        user_input = _strip_leaked_bracketed_paste_wrappers(user_input)
                     
                     # Check for commands — but detect dragged/pasted file paths first.
                     # See _detect_file_drop() for details.

--- a/tests/cli/test_cli_bracketed_paste_sanitizer.py
+++ b/tests/cli/test_cli_bracketed_paste_sanitizer.py
@@ -1,0 +1,49 @@
+"""Tests for defensive bracketed-paste wrapper stripping in the CLI."""
+
+from cli import _strip_leaked_bracketed_paste_wrappers
+
+
+class TestStripLeakedBracketedPasteWrappers:
+    def test_plain_text_unchanged(self):
+        text = "hello world"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == text
+
+    def test_strips_canonical_escape_wrappers(self):
+        text = "\x1b[200~hello\x1b[201~"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "hello"
+
+    def test_strips_visible_caret_escape_wrappers(self):
+        text = "^[[200~hello^[[201~"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "hello"
+
+    def test_strips_degraded_bracket_only_wrappers(self):
+        text = "[200~hello[201~"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "hello"
+
+    def test_strips_degraded_bracket_only_wrappers_after_whitespace(self):
+        text = "prefix [200~hello[201~ suffix"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "prefix hello suffix"
+
+    def test_strips_wrapper_fragments_at_boundaries(self):
+        text = "00~hello world01~"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "hello world"
+
+    def test_strips_wrapper_fragments_after_whitespace(self):
+        text = "prefix 00~hello world01~ suffix"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "prefix hello world suffix"
+
+    def test_does_not_strip_non_wrapper_00_tilde_in_normal_text(self):
+        text = "build00~tag should stay"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == text
+
+    def test_does_not_strip_non_wrapper_bracket_forms_in_normal_text(self):
+        text = "literal[200~tag and literal[201~tag should stay"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == text
+
+    def test_preserves_multiline_content_while_stripping_wrappers(self):
+        text = "^[[200~line 1\nline 2\nline 3^[[201~"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "line 1\nline 2\nline 3"
+
+    def test_preserves_multiline_content_while_stripping_degraded_bracket_only_wrappers(self):
+        text = "[200~line 1\nline 2\nline 3[201~"
+        assert _strip_leaked_bracketed_paste_wrappers(text) == "line 1\nline 2\nline 3"


### PR DESCRIPTION
## Summary
- strip leaked bracketed-paste wrapper markers from CLI input text
- apply the sanitizer at three boundaries: explicit paste handling, fallback paste-collapse, and final submit
- extend the sanitizer and tests to cover parser-degraded bracket-only forms like `[200~` / `[201~`

## Why
In issue #7316 we captured cases where bracketed-paste markers leaked into user-visible input and Hermes became unresponsive afterward. The original captured form was `^[[200~`, but prompt_toolkit desync can also degrade the same wrapper family into bracket-only forms like `[200~` / `[201~` when `ESC` is emitted separately.

Even if the initial trigger is upstream timing in prompt_toolkit or terminal delivery, Hermes should defensively normalize these wrappers before persisting or submitting text.

This PR fixes one concrete failure mode in that incident: leaked bracketed-paste wrappers making it into Hermes input, persisted paste files, and submitted messages. It is a defensive sanitization fix, not a complete root-cause fix for every possible unresponsive-state path after malformed terminal input.

## Design
This keeps the fix small and local:
- one shared helper: `_strip_leaked_bracketed_paste_wrappers`
- three call sites only
- no prompt_toolkit monkeypatching
- no Ghostty-specific behavior changes
- no busy-input mode changes

Canonical wrappers are removed unconditionally:
- `\x1b[200~`
- `\x1b[201~`
- `^[[200~`
- `^[[201~`

Parser-degraded bracket-only wrappers are also stripped conservatively when they appear at wrapper-like boundaries:
- `[200~`
- `[201~`

Visible `00~` / `01~` fragments are still stripped conservatively only when they look like wrapper boundaries rather than arbitrary user content.

## Test Plan
- `venv/bin/python -m pytest -q tests/cli/test_cli_bracketed_paste_sanitizer.py`
- `venv/bin/python -m pytest -q tests/cli/test_cli_file_drop.py`
- `venv/bin/python -m pytest -q tests/cli/test_cli_init.py`

Closes #7316
