### PR TITLE
feat(gateway): multi-profile support for WhatsApp group agents

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -542,6 +542,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
+                if "bridge_port" in platform_cfg:
+                    bridged["bridge_port"] = int(platform_cfg["bridge_port"])
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if not bridged:

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -256,6 +256,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
     def _should_process_message(self, data: Dict[str, Any]) -> bool:
         if not data.get("isGroup"):
+            # Allow profiles (e.g. family agents) to ignore DMs and only
+            # operate in group chats via free_response_chats.
+            if self.config and self.config.extra.get("respond_to_dms") is False:
+                return False
             return True
         chat_id = str(data.get("chatId") or "")
         if chat_id in self._whatsapp_free_response_chats():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2108,6 +2108,21 @@ class GatewayRunner:
         _cmd_def = _resolve_cmd(command) if command else None
         canonical = _cmd_def.name if _cmd_def else command
 
+        # Restrict slash commands in group chats to admin users when configured.
+        # Set COMMAND_ADMIN_USERS=id1,id2 to limit who can run commands.
+        if canonical and source.chat_type == "group":
+            _admin_raw = os.getenv("COMMAND_ADMIN_USERS", "")
+            if _admin_raw:
+                _admin_ids = {uid.strip() for uid in _admin_raw.split(",") if uid.strip()}
+                _user_ids = {source.user_id}
+                if "@" in source.user_id:
+                    _user_ids.add(source.user_id.split("@")[0])
+                if source.platform == Platform.WHATSAPP:
+                    _user_ids.update(_expand_whatsapp_auth_aliases(source.user_id))
+                if not (_user_ids & _admin_ids):
+                    canonical = None
+                    command = None
+
         if canonical == "new":
             return await self._handle_reset_command(event)
         
@@ -2799,19 +2814,25 @@ class GatewayRunner:
         message_text = event.text or ""
 
         # -----------------------------------------------------------------
-        # Sender attribution for shared thread sessions.
+        # Sender attribution for shared sessions (threads + groups).
         #
-        # When multiple users share a single thread session (the default for
-        # threads), prefix each message with [sender name] so the agent can
-        # tell participants apart.  Skip for DMs (single-user by nature) and
-        # when per-user thread isolation is explicitly enabled.
+        # When multiple users share a single session, prefix each message
+        # with [sender name] so the agent can tell participants apart.
+        # Applies to:
+        #   - Shared thread sessions (default for threads)
+        #   - Group chats with group_sessions_per_user=false
+        # Skip for DMs (single-user by nature).
         # -----------------------------------------------------------------
         _is_shared_thread = (
             source.chat_type != "dm"
             and source.thread_id
             and not getattr(self.config, "thread_sessions_per_user", False)
         )
-        if _is_shared_thread and source.user_name:
+        _is_shared_group = (
+            source.chat_type == "group"
+            and not getattr(self.config, "group_sessions_per_user", True)
+        )
+        if (_is_shared_thread or _is_shared_group) and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
         if event.media_urls:
@@ -6968,7 +6989,7 @@ class GatewayRunner:
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
-            agent.status_callback = _status_callback_sync
+            agent.status_callback = _status_callback_sync if tool_progress_enabled else None
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")

--- a/tests/gateway/test_gateway_multi_profile.py
+++ b/tests/gateway/test_gateway_multi_profile.py
@@ -1,0 +1,149 @@
+"""Tests for multi-profile gateway features.
+
+Covers:
+- bridge_port config passthrough
+- COMMAND_ADMIN_USERS group command restriction
+- Shared group session sender attribution
+- status_callback gated on tool_progress_enabled
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+
+
+# ---------------------------------------------------------------------------
+# bridge_port config passthrough
+# ---------------------------------------------------------------------------
+
+class TestBridgePortConfig:
+    def test_bridge_port_bridged_from_config(self, tmp_path, monkeypatch):
+        """bridge_port in platform config should be parsed as int and
+        forwarded into the bridged platform data."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  bridge_port: 3001\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("WHATSAPP_ENABLED", "true")
+
+        config = load_gateway_config()
+        wa_config = config.platforms.get(Platform.WHATSAPP)
+        assert wa_config is not None
+        assert wa_config.extra.get("bridge_port") == 3001
+
+    def test_bridge_port_cast_to_int(self, tmp_path, monkeypatch):
+        """bridge_port should be cast to int even if specified as a string."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  bridge_port: '3002'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("WHATSAPP_ENABLED", "true")
+
+        config = load_gateway_config()
+        wa_config = config.platforms.get(Platform.WHATSAPP)
+        assert wa_config is not None
+        assert wa_config.extra.get("bridge_port") == 3002
+        assert isinstance(wa_config.extra["bridge_port"], int)
+
+
+# ---------------------------------------------------------------------------
+# COMMAND_ADMIN_USERS — group slash command restriction
+# ---------------------------------------------------------------------------
+
+class TestCommandAdminUsers:
+    """The admin-user gating logic is tested indirectly by verifying
+    the env var parsing and ID matching, since the full dispatch path
+    requires the entire GatewayRunner."""
+
+    def test_admin_ids_parsed_from_env(self, monkeypatch):
+        """COMMAND_ADMIN_USERS should be parsed into a set of trimmed IDs."""
+        monkeypatch.setenv("COMMAND_ADMIN_USERS", "alice, bob , charlie")
+        raw = os.getenv("COMMAND_ADMIN_USERS", "")
+        admin_ids = {uid.strip() for uid in raw.split(",") if uid.strip()}
+        assert admin_ids == {"alice", "bob", "charlie"}
+
+    def test_empty_admin_env_means_no_restriction(self, monkeypatch):
+        """When COMMAND_ADMIN_USERS is empty, no restriction applies."""
+        monkeypatch.setenv("COMMAND_ADMIN_USERS", "")
+        raw = os.getenv("COMMAND_ADMIN_USERS", "")
+        assert not raw  # falsy → skip restriction
+
+    def test_user_id_at_split_for_matching(self):
+        """User IDs like 'number@domain' should also match the bare number."""
+        user_id = "4912345678@s.whatsapp.net"
+        user_ids = {user_id}
+        if "@" in user_id:
+            user_ids.add(user_id.split("@")[0])
+        assert "4912345678" in user_ids
+        assert "4912345678@s.whatsapp.net" in user_ids
+
+    def test_non_admin_blocked(self, monkeypatch):
+        """A non-admin user in a group should have their command nullified."""
+        monkeypatch.setenv("COMMAND_ADMIN_USERS", "admin_user")
+        admin_raw = os.getenv("COMMAND_ADMIN_USERS", "")
+        admin_ids = {uid.strip() for uid in admin_raw.split(",") if uid.strip()}
+        user_ids = {"random_user"}
+        assert not (user_ids & admin_ids)
+
+    def test_admin_allowed(self, monkeypatch):
+        """An admin user should pass the check."""
+        monkeypatch.setenv("COMMAND_ADMIN_USERS", "4912345678,other_admin")
+        admin_raw = os.getenv("COMMAND_ADMIN_USERS", "")
+        admin_ids = {uid.strip() for uid in admin_raw.split(",") if uid.strip()}
+        user_ids = {"4912345678@s.whatsapp.net", "4912345678"}
+        assert user_ids & admin_ids
+
+
+# ---------------------------------------------------------------------------
+# Shared group session sender attribution
+# ---------------------------------------------------------------------------
+
+class TestSharedGroupAttribution:
+    """Verify the logic for prefixing messages with [sender name] in
+    shared group sessions (group_sessions_per_user=false)."""
+
+    def _should_attribute(self, chat_type, thread_id, group_per_user, thread_per_user):
+        """Replicate the attribution logic from gateway/run.py."""
+        _is_shared_thread = (
+            chat_type != "dm"
+            and thread_id
+            and not thread_per_user
+        )
+        _is_shared_group = (
+            chat_type == "group"
+            and not group_per_user
+        )
+        return _is_shared_thread or _is_shared_group
+
+    def test_dm_never_attributed(self):
+        assert not self._should_attribute("dm", None, True, False)
+        assert not self._should_attribute("dm", None, False, False)
+
+    def test_shared_group_attributed(self):
+        """group_sessions_per_user=false → messages should be attributed."""
+        assert self._should_attribute("group", None, False, False)
+
+    def test_per_user_group_not_attributed(self):
+        """group_sessions_per_user=true (default) → no attribution needed."""
+        assert not self._should_attribute("group", None, True, False)
+
+    def test_shared_thread_attributed(self):
+        """Shared thread sessions should still be attributed."""
+        assert self._should_attribute("group", "thread-123", True, False)
+
+    def test_per_user_thread_not_attributed(self):
+        """thread_sessions_per_user=true → no thread attribution."""
+        assert not self._should_attribute("group", "thread-123", True, True)

--- a/tests/gateway/test_whatsapp_respond_to_dms.py
+++ b/tests/gateway/test_whatsapp_respond_to_dms.py
@@ -1,0 +1,72 @@
+"""Tests for the respond_to_dms flag on WhatsApp profiles.
+
+When running multiple agent profiles on the same WhatsApp number (e.g. a
+family agent that should only operate in specific group chats), setting
+respond_to_dms=false in the platform config causes the adapter to ignore
+all DM messages.
+"""
+
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _make_adapter(**extra_overrides):
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    extra = {}
+    extra.update(extra_overrides)
+
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra=extra)
+    adapter._message_handler = AsyncMock()
+    adapter._mention_patterns = adapter._compile_mention_patterns()
+    return adapter
+
+
+def _dm_message(body="hello"):
+    return {
+        "isGroup": False,
+        "body": body,
+        "chatId": "4912345678@s.whatsapp.net",
+        "mentionedIds": [],
+        "botIds": ["15551230000@s.whatsapp.net"],
+        "quotedParticipant": "",
+    }
+
+
+def test_dms_accepted_by_default():
+    """Without respond_to_dms set, DMs are processed normally."""
+    adapter = _make_adapter()
+    assert adapter._should_process_message(_dm_message()) is True
+
+
+def test_dms_accepted_when_explicitly_true():
+    """respond_to_dms=true should behave the same as the default."""
+    adapter = _make_adapter(respond_to_dms=True)
+    assert adapter._should_process_message(_dm_message()) is True
+
+
+def test_dms_rejected_when_false():
+    """respond_to_dms=false should cause DMs to be ignored."""
+    adapter = _make_adapter(respond_to_dms=False)
+    assert adapter._should_process_message(_dm_message()) is False
+
+
+def test_groups_unaffected_by_respond_to_dms_false():
+    """respond_to_dms only controls DMs — group messages should still
+    be processed via the normal group gating logic."""
+    adapter = _make_adapter(
+        respond_to_dms=False,
+        free_response_chats="120363001234567890@g.us",
+    )
+    group_msg = {
+        "isGroup": True,
+        "body": "hello",
+        "chatId": "120363001234567890@g.us",
+        "mentionedIds": [],
+        "botIds": ["15551230000@s.whatsapp.net"],
+        "quotedParticipant": "",
+    }
+    assert adapter._should_process_message(group_msg) is True


### PR DESCRIPTION
## What does this PR do?

Adds features needed to run multiple agent profiles on the same WhatsApp number — e.g. a family agent that only operates in specific group chats alongside a main agent that handles DMs and other groups.

**Use case:** You have a WhatsApp bridge running on one number, but you want separate agent profiles with different personalities, skills, and scopes. Profile A handles DMs and general groups. Profile B only operates in a specific family group chat and should ignore everything else.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

### 1. `bridge_port` config passthrough (`gateway/config.py`)
- Forwards `bridge_port` from platform YAML config into the bridged platform data, cast to `int`
- Allows multiple WhatsApp bridge instances on different ports for different profiles

### 2. `COMMAND_ADMIN_USERS` group restriction (`gateway/run.py`)
- New env var `COMMAND_ADMIN_USERS=id1,id2` restricts slash commands in group chats to listed user IDs
- Prevents non-admin group members from running `/new`, `/model`, etc. on shared agents
- Supports bare numbers, full WhatsApp JIDs, and LID alias expansion

### 3. `respond_to_dms` flag (`gateway/platforms/whatsapp.py`)
- New per-platform config: `respond_to_dms: false` causes the adapter to skip all DM messages
- Group-only profiles can set this to avoid responding to direct messages while still operating in their assigned groups via `free_response_chats`

### 4. Shared group sender attribution (`gateway/run.py`)
- Extends existing thread-based `[sender name]` prefixing to group chats when `group_sessions_per_user: false`
- So the agent can tell participants apart in shared group sessions (previously only worked for threads)

### 5. `status_callback` guard (`gateway/run.py`)
- Gates `status_callback` on `tool_progress_enabled`, consistent with `tool_progress_callback`
- Avoids unnecessary status messages when progress reporting is disabled

### Test files
- `tests/gateway/test_gateway_multi_profile.py` — 12 tests covering bridge_port config, admin user parsing/matching, and shared group attribution logic
- `tests/gateway/test_whatsapp_respond_to_dms.py` — 4 tests covering the respond_to_dms flag behavior

## How to Test

1. Run the new tests: `pytest tests/gateway/test_gateway_multi_profile.py tests/gateway/test_whatsapp_respond_to_dms.py -v`
2. For manual testing of the multi-profile setup:
   - Create two profiles, each with their own `config.yaml` and gateway service
   - Set `respond_to_dms: false` on the group-only profile
   - Set `COMMAND_ADMIN_USERS` to your WhatsApp number on the group-only profile
   - Set `group_sessions_per_user: false` and verify `[sender name]` prefixes appear
3. Verify existing behavior is unchanged when none of the new config options are set

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (16 new test cases)
- [x] I've tested on my platform: Pop!_OS (Ubuntu-based) Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (env var and config options are self-documenting via code comments)
- [x] I've considered cross-platform impact — N/A (env var parsing and config logic only)