### PR TITLE
fix(tools): size PTY background sessions from terminal dimensions

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -8,6 +8,7 @@ import sys
 import time
 import pytest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tools.environments.local import _HERMES_PROVIDER_ENV_FORCE_PREFIX
@@ -69,6 +70,7 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
 # Get / Poll
 # =========================================================================
 
+
 class TestGetAndPoll:
     def test_get_not_found(self, registry):
         assert registry.get("nonexistent") is None
@@ -107,6 +109,7 @@ class TestGetAndPoll:
 # Read log
 # =========================================================================
 
+
 class TestReadLog:
     def test_not_found(self, registry):
         result = registry.read_log("nonexistent")
@@ -138,6 +141,7 @@ class TestReadLog:
 # =========================================================================
 # Stdin helpers
 # =========================================================================
+
 
 class TestStdinHelpers:
     def test_close_stdin_not_found(self, registry):
@@ -197,6 +201,7 @@ class TestStdinHelpers:
 # List sessions
 # =========================================================================
 
+
 class TestListSessions:
     def test_empty(self, registry):
         assert registry.list_sessions() == []
@@ -233,6 +238,7 @@ class TestListSessions:
 # Active process queries
 # =========================================================================
 
+
 class TestActiveQueries:
     def test_has_active_processes(self, registry):
         s = _make_session(task_id="t1")
@@ -256,6 +262,7 @@ class TestActiveQueries:
 # =========================================================================
 # Pruning
 # =========================================================================
+
 
 class TestPruning:
     def test_prune_expired_finished(self, registry):
@@ -297,6 +304,7 @@ class TestPruning:
 # Spawn env sanitization
 # =========================================================================
 
+
 class TestSpawnEnvSanitization:
     def test_spawn_local_strips_blocked_vars_from_background_env(self, registry):
         captured = {}
@@ -312,17 +320,23 @@ class TestSpawnEnvSanitization:
 
         fake_thread = MagicMock()
 
-        with patch.dict(os.environ, {
-            "PATH": "/usr/bin:/bin",
-            "HOME": "/home/user",
-            "USER": "tester",
-            "TELEGRAM_BOT_TOKEN": "bot-secret",
-            "FIRECRAWL_API_KEY": "fc-secret",
-        }, clear=True), \
-            patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
-            patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=fake_thread), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "PATH": "/usr/bin:/bin",
+                    "HOME": "/home/user",
+                    "USER": "tester",
+                    "TELEGRAM_BOT_TOKEN": "bot-secret",
+                    "FIRECRAWL_API_KEY": "fc-secret",
+                },
+                clear=True,
+            ),
+            patch("tools.process_registry._find_shell", return_value="/bin/bash"),
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=fake_thread),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             registry.spawn_local(
                 "echo hello",
                 cwd="/tmp",
@@ -340,6 +354,60 @@ class TestSpawnEnvSanitization:
         assert f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}TELEGRAM_BOT_TOKEN" not in env
         assert env["PYTHONUNBUFFERED"] == "1"
 
+    def test_get_terminal_dimensions_prefers_env(self, registry, monkeypatch):
+        monkeypatch.setenv("COLUMNS", "160")
+        monkeypatch.setenv("LINES", "45")
+
+        assert registry._get_terminal_dimensions() == (45, 160)
+
+    def test_get_terminal_dimensions_falls_back_when_terminal_size_invalid(
+        self, registry, monkeypatch
+    ):
+        monkeypatch.delenv("COLUMNS", raising=False)
+        monkeypatch.delenv("LINES", raising=False)
+
+        with patch(
+            "tools.process_registry.shutil.get_terminal_size",
+            return_value=os.terminal_size((0, 0)),
+        ):
+            assert registry._get_terminal_dimensions() == (30, 120)
+
+    def test_spawn_local_pty_uses_computed_terminal_dimensions(
+        self, registry, monkeypatch
+    ):
+        captured = {}
+        fake_thread = MagicMock()
+
+        class FakePtyProcess:
+            pid = 9876
+
+            @classmethod
+            def spawn(cls, cmd, **kwargs):
+                captured["cmd"] = cmd
+                captured.update(kwargs)
+                return cls()
+
+        monkeypatch.setattr(registry, "_get_terminal_dimensions", lambda: (42, 140))
+        monkeypatch.setitem(
+            sys.modules,
+            "ptyprocess",
+            SimpleNamespace(PtyProcess=FakePtyProcess),
+        )
+
+        with (
+            patch("tools.process_registry._find_shell", return_value="/bin/bash"),
+            patch("threading.Thread", return_value=fake_thread),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("echo hello", cwd="/tmp", use_pty=True)
+
+        assert session.pid == 9876
+        assert captured["dimensions"] == (42, 140)
+        assert captured["env"]["LINES"] == "42"
+        assert captured["env"]["COLUMNS"] == "140"
+        assert captured["env"]["PYTHONUNBUFFERED"] == "1"
+        fake_thread.start.assert_called_once()
+
     def test_spawn_via_env_uses_backend_temp_dir_for_artifacts(self, registry):
         class FakeEnv:
             def __init__(self):
@@ -355,8 +423,10 @@ class TestSpawnEnvSanitization:
         env = FakeEnv()
         fake_thread = MagicMock()
 
-        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("tools.process_registry.threading.Thread", return_value=fake_thread),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             session = registry.spawn_via_env(env, "echo hello")
 
         bg_command = env.commands[0][0]
@@ -375,11 +445,13 @@ class TestSpawnEnvSanitization:
         class FakeEnv:
             def __init__(self):
                 self.commands = []
-                self._responses = iter([
-                    {"output": "hello\n"},
-                    {"output": "1\n"},
-                    {"output": "0\n"},
-                ])
+                self._responses = iter(
+                    [
+                        {"output": "hello\n"},
+                        {"output": "1\n"},
+                        {"output": "0\n"},
+                    ]
+                )
 
             def execute(self, command, timeout=None):
                 self.commands.append((command, timeout))
@@ -387,8 +459,10 @@ class TestSpawnEnvSanitization:
 
         env = FakeEnv()
 
-        with patch("tools.process_registry.time.sleep", return_value=None), \
-            patch.object(registry, "_move_to_finished"):
+        with (
+            patch("tools.process_registry.time.sleep", return_value=None),
+            patch.object(registry, "_move_to_finished"),
+        ):
             registry._env_poller_loop(
                 session,
                 env,
@@ -398,13 +472,19 @@ class TestSpawnEnvSanitization:
             )
 
         assert env.commands[0][0] == "cat '/path with spaces/hermes_bg.log' 2>/dev/null"
-        assert env.commands[1][0] == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
-        assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
+        assert (
+            env.commands[1][0]
+            == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
+        )
+        assert (
+            env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
+        )
 
 
 # =========================================================================
 # Checkpoint
 # =========================================================================
+
 
 class TestCheckpoint:
     def test_write_checkpoint(self, registry, tmp_path):
@@ -423,12 +503,18 @@ class TestCheckpoint:
 
     def test_recover_dead_pid(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
-        checkpoint.write_text(json.dumps([{
-            "session_id": "proc_dead",
-            "command": "sleep 999",
-            "pid": 999999999,  # almost certainly not running
-            "task_id": "t1",
-        }]))
+        checkpoint.write_text(
+            json.dumps(
+                [
+                    {
+                        "session_id": "proc_dead",
+                        "command": "sleep 999",
+                        "pid": 999999999,  # almost certainly not running
+                        "task_id": "t1",
+                    }
+                ]
+            )
+        )
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             recovered = registry.recover_from_checkpoint()
             assert recovered == 0
@@ -452,17 +538,23 @@ class TestCheckpoint:
 
     def test_recover_enqueues_watchers(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
-        checkpoint.write_text(json.dumps([{
-            "session_id": "proc_live",
-            "command": "sleep 999",
-            "pid": os.getpid(),  # current process — guaranteed alive
-            "task_id": "t1",
-            "session_key": "sk1",
-            "watcher_platform": "telegram",
-            "watcher_chat_id": "123",
-            "watcher_thread_id": "42",
-            "watcher_interval": 60,
-        }]))
+        checkpoint.write_text(
+            json.dumps(
+                [
+                    {
+                        "session_id": "proc_live",
+                        "command": "sleep 999",
+                        "pid": os.getpid(),  # current process — guaranteed alive
+                        "task_id": "t1",
+                        "session_key": "sk1",
+                        "watcher_platform": "telegram",
+                        "watcher_chat_id": "123",
+                        "watcher_thread_id": "42",
+                        "watcher_interval": 60,
+                    }
+                ]
+            )
+        )
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             recovered = registry.recover_from_checkpoint()
             assert recovered == 1
@@ -476,13 +568,19 @@ class TestCheckpoint:
 
     def test_recover_skips_watcher_when_no_interval(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
-        checkpoint.write_text(json.dumps([{
-            "session_id": "proc_live",
-            "command": "sleep 999",
-            "pid": os.getpid(),
-            "task_id": "t1",
-            "watcher_interval": 0,
-        }]))
+        checkpoint.write_text(
+            json.dumps(
+                [
+                    {
+                        "session_id": "proc_live",
+                        "command": "sleep 999",
+                        "pid": os.getpid(),
+                        "task_id": "t1",
+                        "watcher_interval": 0,
+                    }
+                ]
+            )
+        )
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             recovered = registry.recover_from_checkpoint()
             assert recovered == 1
@@ -490,13 +588,19 @@ class TestCheckpoint:
 
     def test_recovery_keeps_live_checkpoint_entries(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
-        checkpoint.write_text(json.dumps([{
-            "session_id": "proc_live",
-            "command": "sleep 999",
-            "pid": os.getpid(),
-            "task_id": "t1",
-            "session_key": "sk1",
-        }]))
+        checkpoint.write_text(
+            json.dumps(
+                [
+                    {
+                        "session_id": "proc_live",
+                        "command": "sleep 999",
+                        "pid": os.getpid(),
+                        "task_id": "t1",
+                        "session_key": "sk1",
+                    }
+                ]
+            )
+        )
 
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             recovered = registry.recover_from_checkpoint()
@@ -511,13 +615,15 @@ class TestCheckpoint:
 
     def test_recovery_skips_explicit_sandbox_backed_entries(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
-        original = [{
-            "session_id": "proc_remote",
-            "command": "sleep 999",
-            "pid": os.getpid(),
-            "task_id": "t1",
-            "pid_scope": "sandbox",
-        }]
+        original = [
+            {
+                "session_id": "proc_remote",
+                "command": "sleep 999",
+                "pid": os.getpid(),
+                "task_id": "t1",
+                "pid_scope": "sandbox",
+            }
+        ]
         checkpoint.write_text(json.dumps(original))
 
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
@@ -531,13 +637,19 @@ class TestCheckpoint:
     def test_detached_recovered_process_eventually_exits(self, registry, tmp_path):
         proc = _spawn_python_sleep(0.4)
         checkpoint = tmp_path / "procs.json"
-        checkpoint.write_text(json.dumps([{
-            "session_id": "proc_live",
-            "command": "python -c 'import time; time.sleep(0.4)'",
-            "pid": proc.pid,
-            "task_id": "t1",
-            "session_key": "sk1",
-        }]))
+        checkpoint.write_text(
+            json.dumps(
+                [
+                    {
+                        "session_id": "proc_live",
+                        "command": "python -c 'import time; time.sleep(0.4)'",
+                        "pid": proc.pid,
+                        "task_id": "t1",
+                        "session_key": "sk1",
+                    }
+                ]
+            )
+        )
 
         try:
             with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
@@ -551,8 +663,10 @@ class TestCheckpoint:
                 proc.wait(timeout=5)
 
                 assert _wait_until(
-                    lambda: registry.get("proc_live") is not None
-                    and registry.get("proc_live").exited,
+                    lambda: (
+                        registry.get("proc_live") is not None
+                        and registry.get("proc_live").exited
+                    ),
                     timeout=5,
                 )
 
@@ -574,6 +688,7 @@ class TestCheckpoint:
 # =========================================================================
 # Kill process
 # =========================================================================
+
 
 class TestKillProcess:
     def test_kill_not_found(self, registry):
@@ -612,18 +727,22 @@ class TestKillProcess:
 # Tool handler
 # =========================================================================
 
+
 class TestProcessToolHandler:
     def test_list_action(self):
         from tools.process_registry import _handle_process
+
         result = json.loads(_handle_process({"action": "list"}))
         assert "processes" in result
 
     def test_poll_missing_session_id(self):
         from tools.process_registry import _handle_process
+
         result = json.loads(_handle_process({"action": "poll"}))
         assert "error" in result
 
     def test_unknown_action(self):
         from tools.process_registry import _handle_process
+
         result = json.loads(_handle_process({"action": "unknown_action"}))
         assert "error" in result

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -34,6 +34,7 @@ import logging
 import os
 import platform
 import shlex
+import shutil
 import signal
 import subprocess
 import threading

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -55,35 +55,36 @@ logger = logging.getLogger(__name__)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 
 # Limits
-MAX_OUTPUT_CHARS = 200_000      # 200KB rolling output buffer
-FINISHED_TTL_SECONDS = 1800     # Keep finished processes for 30 minutes
-MAX_PROCESSES = 64              # Max concurrent tracked processes (LRU pruning)
+MAX_OUTPUT_CHARS = 200_000  # 200KB rolling output buffer
+FINISHED_TTL_SECONDS = 1800  # Keep finished processes for 30 minutes
+MAX_PROCESSES = 64  # Max concurrent tracked processes (LRU pruning)
 
 
 @dataclass
 class ProcessSession:
     """A tracked background process with output buffering."""
-    id: str                                     # Unique session ID ("proc_xxxxxxxxxxxx")
-    command: str                                 # Original command string
-    task_id: str = ""                           # Task/sandbox isolation key
-    session_key: str = ""                       # Gateway session key (for reset protection)
-    pid: Optional[int] = None                   # OS process ID
+
+    id: str  # Unique session ID ("proc_xxxxxxxxxxxx")
+    command: str  # Original command string
+    task_id: str = ""  # Task/sandbox isolation key
+    session_key: str = ""  # Gateway session key (for reset protection)
+    pid: Optional[int] = None  # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
-    env_ref: Any = None                         # Reference to the environment object
-    cwd: Optional[str] = None                   # Working directory
-    started_at: float = 0.0                     # time.time() of spawn
-    exited: bool = False                        # Whether the process has finished
-    exit_code: Optional[int] = None             # Exit code (None if still running)
-    output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
+    env_ref: Any = None  # Reference to the environment object
+    cwd: Optional[str] = None  # Working directory
+    started_at: float = 0.0  # time.time() of spawn
+    exited: bool = False  # Whether the process has finished
+    exit_code: Optional[int] = None  # Exit code (None if still running)
+    output_buffer: str = ""  # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
-    detached: bool = False                      # True if recovered from crash (no pipe)
-    pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
+    detached: bool = False  # True if recovered from crash (no pipe)
+    pid_scope: str = "host"  # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
     watcher_thread_id: str = ""
-    watcher_interval: int = 0                   # 0 = no watcher configured
-    notify_on_complete: bool = False             # Queue agent notification on exit
+    watcher_interval: int = 0  # 0 = no watcher configured
+    notify_on_complete: bool = False  # Queue agent notification on exit
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
@@ -119,13 +120,16 @@ class ProcessRegistry:
         # on exit.  CLI process_loop and gateway drain this after each agent turn
         # to auto-trigger a new agent turn with the process results.
         import queue as _queue_mod
+
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
         """Strip shell startup warnings from the beginning of output."""
         lines = text.split("\n")
-        while lines and any(noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
+        while lines and any(
+            noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS
+        ):
             lines.pop(0)
         return "\n".join(lines)
 
@@ -140,9 +144,16 @@ class ProcessRegistry:
         except (ProcessLookupError, PermissionError):
             return False
 
-    def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
+    def _refresh_detached_session(
+        self, session: Optional[ProcessSession]
+    ) -> Optional[ProcessSession]:
         """Update recovered host-PID sessions when the underlying process has exited."""
-        if session is None or session.exited or not session.detached or session.pid_scope != "host":
+        if (
+            session is None
+            or session.exited
+            or not session.detached
+            or session.pid_scope != "host"
+        ):
             return session
 
         if self._is_host_pid_alive(session.pid):
@@ -186,6 +197,31 @@ class ProcessRegistry:
                 logger.debug("Could not resolve environment temp dir: %s", exc)
         return "/tmp"
 
+    @staticmethod
+    def _get_terminal_dimensions() -> tuple[int, int]:
+        """Best-effort PTY size as (rows, columns)."""
+
+        def _parse_positive_int(value: Optional[str]) -> Optional[int]:
+            try:
+                parsed = int(str(value))
+            except (TypeError, ValueError):
+                return None
+            return parsed if parsed > 0 else None
+
+        env_columns = _parse_positive_int(os.environ.get("COLUMNS"))
+        env_lines = _parse_positive_int(os.environ.get("LINES"))
+        if env_columns and env_lines:
+            return (env_lines, env_columns)
+
+        try:
+            size = shutil.get_terminal_size()
+            if size.columns > 0 and size.lines > 0:
+                return (size.lines, size.columns)
+        except OSError:
+            pass
+
+        return (30, 120)
+
     def spawn_local(
         self,
         command: str,
@@ -224,11 +260,14 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
+                rows, columns = self._get_terminal_dimensions()
+                pty_env["LINES"] = str(rows)
+                pty_env["COLUMNS"] = str(columns)
                 pty_proc = _PtyProcessCls.spawn(
                     [user_shell, "-lic", command],
                     cwd=session.cwd,
                     env=pty_env,
-                    dimensions=(30, 120),
+                    dimensions=(rows, columns),
                 )
                 session.pid = pty_proc.pid
                 # Store the pty handle on the session for read/write
@@ -394,7 +433,9 @@ class ProcessRegistry:
                 with session._lock:
                     session.output_buffer += chunk
                     if len(session.output_buffer) > session.max_output_chars:
-                        session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                        session.output_buffer = session.output_buffer[
+                            -session.max_output_chars :
+                        ]
         except Exception as e:
             logger.debug("Process stdout reader ended: %s", e)
 
@@ -408,7 +449,12 @@ class ProcessRegistry:
         self._move_to_finished(session)
 
     def _env_poller_loop(
-        self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str
+        self,
+        session: ProcessSession,
+        env: Any,
+        log_path: str,
+        pid_path: str,
+        exit_path: str,
     ):
         """Background thread: poll a sandbox log file for non-local backends."""
         quoted_log_path = shlex.quote(log_path)
@@ -424,11 +470,13 @@ class ProcessRegistry:
                     with session._lock:
                         session.output_buffer = new_output
                         if len(session.output_buffer) > session.max_output_chars:
-                            session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                            session.output_buffer = session.output_buffer[
+                                -session.max_output_chars :
+                            ]
 
                 # Check if process is still running
                 check = env.execute(
-                    f"kill -0 \"$(cat {quoted_pid_path} 2>/dev/null)\" 2>/dev/null; echo $?",
+                    f'kill -0 "$(cat {quoted_pid_path} 2>/dev/null)" 2>/dev/null; echo $?',
                     timeout=5,
                 )
                 check_output = check.get("output", "").strip()
@@ -463,11 +511,17 @@ class ProcessRegistry:
                     chunk = pty.read(4096)
                     if chunk:
                         # ptyprocess returns bytes
-                        text = chunk if isinstance(chunk, str) else chunk.decode("utf-8", errors="replace")
+                        text = (
+                            chunk
+                            if isinstance(chunk, str)
+                            else chunk.decode("utf-8", errors="replace")
+                        )
                         with session._lock:
                             session.output_buffer += text
                             if len(session.output_buffer) > session.max_output_chars:
-                                session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                                session.output_buffer = session.output_buffer[
+                                    -session.max_output_chars :
+                                ]
                 except EOFError:
                     break
                 except Exception:
@@ -481,7 +535,7 @@ class ProcessRegistry:
         except Exception as e:
             logger.debug("PTY wait timed out or failed: %s", e)
         session.exited = True
-        session.exit_code = pty.exitstatus if hasattr(pty, 'exitstatus') else -1
+        session.exit_code = pty.exitstatus if hasattr(pty, "exitstatus") else -1
         self._move_to_finished(session)
 
     def _move_to_finished(self, session: ProcessSession):
@@ -501,13 +555,20 @@ class ProcessRegistry:
         # _move_to_finished(), producing duplicate [SYSTEM: ...] messages.
         if was_running and session.notify_on_complete:
             from tools.ansi_strip import strip_ansi
-            output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
-            self.completion_queue.put({
-                "session_id": session.id,
-                "command": session.command,
-                "exit_code": session.exit_code,
-                "output": output_tail,
-            })
+
+            output_tail = (
+                strip_ansi(session.output_buffer[-2000:])
+                if session.output_buffer
+                else ""
+            )
+            self.completion_queue.put(
+                {
+                    "session_id": session.id,
+                    "command": session.command,
+                    "exit_code": session.exit_code,
+                    "output": output_tail,
+                }
+            )
 
     # ----- Query Methods -----
 
@@ -526,7 +587,11 @@ class ProcessRegistry:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
         with session._lock:
-            output_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
+            output_preview = (
+                strip_ansi(session.output_buffer[-1000:])
+                if session.output_buffer
+                else ""
+            )
 
         result = {
             "session_id": session.id,
@@ -540,7 +605,9 @@ class ProcessRegistry:
             result["exit_code"] = session.exit_code
         if session.detached:
             result["detached"] = True
-            result["note"] = "Process recovered after restart -- output history unavailable"
+            result["note"] = (
+                "Process recovered after restart -- output history unavailable"
+            )
         return result
 
     def read_log(self, session_id: str, offset: int = 0, limit: int = 200) -> dict:
@@ -561,7 +628,7 @@ class ProcessRegistry:
         if offset == 0 and limit > 0:
             selected = lines[-limit:]
         else:
-            selected = lines[offset:offset + limit]
+            selected = lines[offset : offset + limit]
 
         return {
             "session_id": session.id,
@@ -637,7 +704,9 @@ class ProcessRegistry:
         if timeout_note:
             result["timeout_note"] = timeout_note
         else:
-            result["timeout_note"] = f"Waited {effective_timeout}s, process still running"
+            result["timeout_note"] = (
+                f"Waited {effective_timeout}s, process still running"
+            )
         return result
 
     def kill_process(self, session_id: str) -> dict:
@@ -709,7 +778,7 @@ class ProcessRegistry:
             return {"status": "already_exited", "error": "Process has already finished"}
 
         # PTY mode -- write through pty handle (expects bytes)
-        if hasattr(session, '_pty') and session._pty:
+        if hasattr(session, "_pty") and session._pty:
             try:
                 pty_data = data.encode("utf-8") if isinstance(data, str) else data
                 session._pty.write(pty_data)
@@ -719,7 +788,10 @@ class ProcessRegistry:
 
         # Popen mode -- write through stdin pipe
         if not session.process or not session.process.stdin:
-            return {"status": "error", "error": "Process stdin not available (non-local backend or stdin closed)"}
+            return {
+                "status": "error",
+                "error": "Process stdin not available (non-local backend or stdin closed)",
+            }
         try:
             session.process.stdin.write(data)
             session.process.stdin.flush()
@@ -739,7 +811,7 @@ class ProcessRegistry:
         if session.exited:
             return {"status": "already_exited", "error": "Process has already finished"}
 
-        if hasattr(session, '_pty') and session._pty:
+        if hasattr(session, "_pty") and session._pty:
             try:
                 session._pty.sendeof()
                 return {"status": "ok", "message": "EOF sent"}
@@ -747,7 +819,10 @@ class ProcessRegistry:
                 return {"status": "error", "error": str(e)}
 
         if not session.process or not session.process.stdin:
-            return {"status": "error", "error": "Process stdin not available (non-local backend or stdin closed)"}
+            return {
+                "status": "error",
+                "error": "Process stdin not available (non-local backend or stdin closed)",
+            }
         try:
             session.process.stdin.close()
             return {"status": "ok", "message": "stdin closed"}
@@ -771,7 +846,9 @@ class ProcessRegistry:
                 "command": s.command[:200],
                 "cwd": s.cwd,
                 "pid": s.pid,
-                "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
+                "started_at": time.strftime(
+                    "%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)
+                ),
                 "uptime_seconds": int(time.time() - s.started_at),
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
@@ -795,8 +872,7 @@ class ProcessRegistry:
 
         with self._lock:
             return any(
-                s.task_id == task_id and not s.exited
-                for s in self._running.values()
+                s.task_id == task_id and not s.exited for s in self._running.values()
             )
 
     def has_active_for_session(self, session_key: str) -> bool:
@@ -817,7 +893,8 @@ class ProcessRegistry:
         """Kill all running processes, optionally filtered by task_id. Returns count killed."""
         with self._lock:
             targets = [
-                s for s in self._running.values()
+                s
+                for s in self._running.values()
                 if (task_id is None or s.task_id == task_id) and not s.exited
             ]
 
@@ -835,7 +912,8 @@ class ProcessRegistry:
         # First prune expired finished sessions
         now = time.time()
         expired = [
-            sid for sid, s in self._finished.items()
+            sid
+            for sid, s in self._finished.items()
             if (now - s.started_at) > FINISHED_TTL_SECONDS
         ]
         for sid in expired:
@@ -844,7 +922,9 @@ class ProcessRegistry:
         # If still over limit, remove oldest finished
         total = len(self._running) + len(self._finished)
         if total >= MAX_PROCESSES and self._finished:
-            oldest_id = min(self._finished, key=lambda sid: self._finished[sid].started_at)
+            oldest_id = min(
+                self._finished, key=lambda sid: self._finished[sid].started_at
+            )
             del self._finished[oldest_id]
 
     # ----- Checkpoint (crash recovery) -----
@@ -856,24 +936,27 @@ class ProcessRegistry:
                 entries = []
                 for s in self._running.values():
                     if not s.exited:
-                        entries.append({
-                            "session_id": s.id,
-                            "command": s.command,
-                            "pid": s.pid,
-                            "pid_scope": s.pid_scope,
-                            "cwd": s.cwd,
-                            "started_at": s.started_at,
-                            "task_id": s.task_id,
-                            "session_key": s.session_key,
-                            "watcher_platform": s.watcher_platform,
-                            "watcher_chat_id": s.watcher_chat_id,
-                            "watcher_thread_id": s.watcher_thread_id,
-                            "watcher_interval": s.watcher_interval,
-                            "notify_on_complete": s.notify_on_complete,
-                        })
-            
+                        entries.append(
+                            {
+                                "session_id": s.id,
+                                "command": s.command,
+                                "pid": s.pid,
+                                "pid_scope": s.pid_scope,
+                                "cwd": s.cwd,
+                                "started_at": s.started_at,
+                                "task_id": s.task_id,
+                                "session_key": s.session_key,
+                                "watcher_platform": s.watcher_platform,
+                                "watcher_chat_id": s.watcher_chat_id,
+                                "watcher_thread_id": s.watcher_thread_id,
+                                "watcher_interval": s.watcher_interval,
+                                "notify_on_complete": s.notify_on_complete,
+                            }
+                        )
+
             # Atomic write to avoid corruption on crash
             from utils import atomic_json_write
+
             atomic_json_write(CHECKPOINT_PATH, entries)
         except Exception as e:
             logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
@@ -934,19 +1017,23 @@ class ProcessRegistry:
                 with self._lock:
                     self._running[session.id] = session
                 recovered += 1
-                logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
+                logger.info(
+                    "Recovered detached process: %s (pid=%d)", session.command[:60], pid
+                )
 
                 # Re-enqueue watcher so gateway can resume notifications
                 if session.watcher_interval > 0:
-                    self.pending_watchers.append({
-                        "session_id": session.id,
-                        "check_interval": session.watcher_interval,
-                        "session_key": session.session_key,
-                        "platform": session.watcher_platform,
-                        "chat_id": session.watcher_chat_id,
-                        "thread_id": session.watcher_thread_id,
-                        "notify_on_complete": session.notify_on_complete,
-                    })
+                    self.pending_watchers.append(
+                        {
+                            "session_id": session.id,
+                            "check_interval": session.watcher_interval,
+                            "session_key": session.session_key,
+                            "platform": session.watcher_platform,
+                            "chat_id": session.watcher_chat_id,
+                            "thread_id": session.watcher_thread_id,
+                            "notify_on_complete": session.notify_on_complete,
+                        }
+                    )
 
         self._write_checkpoint()
 
@@ -976,65 +1063,101 @@ PROCESS_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit", "close"],
-                "description": "Action to perform on background processes"
+                "enum": [
+                    "list",
+                    "poll",
+                    "log",
+                    "wait",
+                    "kill",
+                    "write",
+                    "submit",
+                    "close",
+                ],
+                "description": "Action to perform on background processes",
             },
             "session_id": {
                 "type": "string",
-                "description": "Process session ID (from terminal background output). Required for all actions except 'list'."
+                "description": "Process session ID (from terminal background output). Required for all actions except 'list'.",
             },
             "data": {
                 "type": "string",
-                "description": "Text to send to process stdin (for 'write' and 'submit' actions)"
+                "description": "Text to send to process stdin (for 'write' and 'submit' actions)",
             },
             "timeout": {
                 "type": "integer",
                 "description": "Max seconds to block for 'wait' action. Returns partial output on timeout.",
-                "minimum": 1
+                "minimum": 1,
             },
             "offset": {
                 "type": "integer",
-                "description": "Line offset for 'log' action (default: last 200 lines)"
+                "description": "Line offset for 'log' action (default: last 200 lines)",
             },
             "limit": {
                 "type": "integer",
                 "description": "Max lines to return for 'log' action",
-                "minimum": 1
-            }
+                "minimum": 1,
+            },
         },
-        "required": ["action"]
-    }
+        "required": ["action"],
+    },
 }
 
 
 def _handle_process(args, **kw):
     import json as _json
+
     task_id = kw.get("task_id")
     action = args.get("action", "")
     # Coerce to string — some models send session_id as an integer
-    session_id = str(args.get("session_id", "")) if args.get("session_id") is not None else ""
+    session_id = (
+        str(args.get("session_id", "")) if args.get("session_id") is not None else ""
+    )
 
     if action == "list":
-        return _json.dumps({"processes": process_registry.list_sessions(task_id=task_id)}, ensure_ascii=False)
+        return _json.dumps(
+            {"processes": process_registry.list_sessions(task_id=task_id)},
+            ensure_ascii=False,
+        )
     elif action in ("poll", "log", "wait", "kill", "write", "submit", "close"):
         if not session_id:
             return tool_error(f"session_id is required for {action}")
         if action == "poll":
             return _json.dumps(process_registry.poll(session_id), ensure_ascii=False)
         elif action == "log":
-            return _json.dumps(process_registry.read_log(
-                session_id, offset=args.get("offset", 0), limit=args.get("limit", 200)), ensure_ascii=False)
+            return _json.dumps(
+                process_registry.read_log(
+                    session_id,
+                    offset=args.get("offset", 0),
+                    limit=args.get("limit", 200),
+                ),
+                ensure_ascii=False,
+            )
         elif action == "wait":
-            return _json.dumps(process_registry.wait(session_id, timeout=args.get("timeout")), ensure_ascii=False)
+            return _json.dumps(
+                process_registry.wait(session_id, timeout=args.get("timeout")),
+                ensure_ascii=False,
+            )
         elif action == "kill":
-            return _json.dumps(process_registry.kill_process(session_id), ensure_ascii=False)
+            return _json.dumps(
+                process_registry.kill_process(session_id), ensure_ascii=False
+            )
         elif action == "write":
-            return _json.dumps(process_registry.write_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            return _json.dumps(
+                process_registry.write_stdin(session_id, str(args.get("data", ""))),
+                ensure_ascii=False,
+            )
         elif action == "submit":
-            return _json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            return _json.dumps(
+                process_registry.submit_stdin(session_id, str(args.get("data", ""))),
+                ensure_ascii=False,
+            )
         elif action == "close":
-            return _json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
-    return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
+            return _json.dumps(
+                process_registry.close_stdin(session_id), ensure_ascii=False
+            )
+    return tool_error(
+        f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close"
+    )
 
 
 registry.register(


### PR DESCRIPTION
Fixes #7321

## Summary
- size PTY-backed background sessions from the current terminal dimensions instead of the hardcoded `30x120` default
- export `COLUMNS` and `LINES` into the PTY environment so terminal-aware tools see the same dimensions at session start
- add focused tests for env-driven dimension detection, fallback behavior, and PTY spawn arguments

## Why
PTY background sessions in `tools/process_registry.py` were always spawned with `dimensions=(30, 120)` and without explicit `COLUMNS` / `LINES` in the PTY environment. That caused terminal-aware commands inside `terminal(..., background=true, pty=true)` sessions to render as if the terminal were incorrectly sized.

This PR intentionally keeps scope narrow:
- fixes spawn-time PTY sizing
- does not attempt live resize propagation for already-running PTY sessions

## Testing
- `python -m pytest tests/tools/test_process_registry.py -q`
- `python -m pytest tests/tools/test_terminal_tool_pty_fallback.py -q`
- manual PTY repro: child PTY processes reported the current terminal size instead of the previous hardcoded `120x30`

## Notes
- I also ran `python -m pytest tests/tools/ -q` in this checkout.
- That broader suite currently has unrelated failures which also reproduce on a clean worktree of current `upstream/main` (for example in `test_browser_camofox_state`, `test_transcription`, and `test_voice_mode`).