### PR TITLE
fix(tests): repair broken import in test_memory_user_id after dead code cleanup

### DIFF
--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -109,14 +109,12 @@ class TestMemoryManagerUserIdThreading:
         assert "user_id" not in p._init_kwargs
 
     def test_multiple_providers_all_receive_user_id(self):
-        from agent.builtin_memory_provider import BuiltinMemoryProvider
-
         mgr = MemoryManager()
-        # Use builtin + one external (MemoryManager only allows one external)
-        builtin = BuiltinMemoryProvider()
-        ext = RecordingProvider("external")
-        mgr.add_provider(builtin)
-        mgr.add_provider(ext)
+        # "builtin" slot + one external — MemoryManager allows at most one of each
+        p1 = RecordingProvider("builtin")
+        p2 = RecordingProvider("external")
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
 
         mgr.initialize_all(
             session_id="sess-multi",
@@ -124,8 +122,10 @@ class TestMemoryManagerUserIdThreading:
             user_id="slack_U12345",
         )
 
-        assert ext._init_kwargs.get("user_id") == "slack_U12345"
-        assert ext._init_kwargs.get("platform") == "slack"
+        assert p1._init_kwargs.get("user_id") == "slack_U12345"
+        assert p1._init_kwargs.get("platform") == "slack"
+        assert p2._init_kwargs.get("user_id") == "slack_U12345"
+        assert p2._init_kwargs.get("platform") == "slack"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `agent/builtin_memory_provider.py` was deleted in 96c06001 ("remove 115 verified dead code symbols") but `tests/agent/test_memory_user_id.py::test_multiple_providers_all_receive_user_id` still imported `BuiltinMemoryProvider` from it, causing a `ModuleNotFoundError`
- Replaced the deleted-class import with a second `RecordingProvider` using name `"builtin"` (the MemoryManager reserved slot), preserving the multi-provider user_id threading coverage
- Also strengthened the assertions to verify _both_ providers receive user_id (previously only the external one was checked)

## Test plan
- [x] All 12 tests in `test_memory_user_id.py` pass locally
- [x] No regressions in the broader test suite (6 remaining failures are all pre-existing async-test-without-pytest-asyncio issues, unrelated to this change)

Closes #7574