### PR TITLE
fix: handle None request_overrides in _build_api_kwargs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":


### PR DESCRIPTION
Avoid AttributeError when request_overrides is None (e.g. models that don't support fast mode like MiniMax-M2.7). The gateway can reassign request_overrides to None per-message, causing a crash in _build_api_kwargs with 'NoneType' object has no attribute 'get'.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes an `AttributeError: 'NoneType' object has no attribute 'get'` crash in `_build_api_kwargs()` when Hermes runs on the Telegram gateway (or any platform adapter) with models that don't support fast mode (e.g. MiniMax-M2.7).

The root cause: the gateway reassigns `agent.request_overrides` on every message. For models that don't support fast mode, `resolve_fast_mode_overrides()` returns `None`, overwriting the `{}` initialized in `AIAgent.__init__()`. The fix adds a `or {}` guard so `.get()` is never called on `None`.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

https://github.com/NousResearch/hermes-agent/issues/7241, https://github.com/NousResearch/hermes-agent/issues/7215, https://github.com/NousResearch/hermes-agent/issues/7259

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `run_agent.py` line 5522: Added `or {}` guard to prevent calling `.get()` on `None`:
  ```python
  # Before
  fast_mode=self.request_overrides.get("speed") == "fast",
  # After
  fast_mode=(self.request_overrides or {}).get("speed") == "fast",
  ```

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run Hermes via Telegram gateway with MiniMax-M2.7 (or any model without fast mode support)
2. Send any message that triggers `_build_api_kwargs()` — previously this crashed, now it should respond normally
3. Verify CLI behavior is unchanged (no regression for models that support fast mode)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — CLI behavior unchanged, no regression
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python logic change, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A — bug fix, not a skill

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A — single-line logic fix with no visual change