### PR TITLE
fix: include non-configurable toolsets (messaging/send_message) in gateway reverse-map

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -506,6 +506,22 @@ def _get_platform_tools(
             if ts_tools and ts_tools.issubset(all_tool_names):
                 enabled_toolsets.add(ts_key)
 
+        # Also include non-configurable, non-platform-default toolsets (e.g.
+        # "messaging") whose tools are fully covered by the base composite
+        # toolset.  These toolsets are always-on by design — they rely on
+        # check_fn at runtime for gating, not on UI config toggles.  Without
+        # this step the reverse-mapping silently drops send_message and any
+        # other core capability that lives outside CONFIGURABLE_TOOLSETS.
+        from toolsets import TOOLSETS as _ALL_TS
+        _platform_default_names = {p["default_toolset"] for p in PLATFORMS.values()}
+        for _ts_name in _ALL_TS:
+            if _ts_name in configurable_keys or _ts_name in _platform_default_names:
+                continue  # already handled above or is a composite toolset
+            _ts_tools = set(resolve_toolset(_ts_name))
+            if _ts_tools and _ts_tools.issubset(all_tool_names):
+                enabled_toolsets.add(_ts_name)
+                logger.debug("[toolsets] auto-enabled non-configurable toolset: %s", _ts_name)
+
     # Plugin toolsets: enabled by default unless explicitly disabled.
     # A plugin toolset is "known" for a platform once `hermes tools`
     # has been saved for that platform (tracked via known_plugin_toolsets).


### PR DESCRIPTION
## Problem

`_get_platform_tools()` builds the enabled toolset list via a reverse-mapping loop that only iterated over `CONFIGURABLE_TOOLSETS`. The `messaging` toolset (containing `send_message`) is intentionally not user-configurable, so it was never added to the enabled set.

Result: `send_message` was silently excluded before `check_fn` was even evaluated. The tool never appeared in the agent's schema when running via gateway.

## Root cause

```python
# Only checked CONFIGURABLE_TOOLSETS — messaging not in the list
for ts_key, _, _ in CONFIGURABLE_TOOLSETS:
    ts_tools = set(resolve_toolset(ts_key))
    if ts_tools and ts_tools.issubset(all_tool_names):
        enabled_toolsets.add(ts_key)
```

`send_message` is in `_HERMES_CORE_TOOLS` and fully present in `hermes-telegram`, but `messaging` was never reverse-mapped.

## Fix

After the `CONFIGURABLE_TOOLSETS` loop, also scan toolsets defined in `TOOLSETS` that are neither configurable nor platform defaults. Any whose tools are fully covered by the base composite toolset are auto-included. Adds a `logger.debug` line for visibility.

Only affects the `else` branch (no explicit saved config) — profiles that have run `hermes tools` and saved explicit toolset lists are unaffected.

## Test plan

- [ ] Fresh profile with no `platform_toolsets` config: confirm `send_message` appears in agent tool schema
- [ ] Profile with explicit `platform_toolsets` saved via `hermes tools`: confirm existing behaviour unchanged
- [ ] Confirm `check_fn` is now actually evaluated (and passes when gateway is running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)