### PR TITLE
feat: pass live agent context to plugin tools

### DIFF
--- a/docs/plans/2026-04-10-plugin-runtime-seam-plan.md
+++ b/docs/plans/2026-04-10-plugin-runtime-seam-plan.md
@@ -1,0 +1,369 @@
+# Plugin Runtime Agent-Access Seam Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add the smallest generic core seam that lets plugins access the active agent/runtime context during tool execution, so a plugin-owned `reasoning_effort` tool can mutate live session state without feature-specific logic in Hermes core.
+
+**Architecture:** Extend the tool dispatch path to optionally pass a narrow runtime context into plugin tool handlers. The first practical version can include `agent=self`, `session_id`, and `tool_call_id`, but the implementation should be written as a generic plugin-runtime facility, not a reasoning-effort special case. Keep hooks unchanged for now; the plugin tool itself should own the behavior by mutating the live agent when called.
+
+**Tech Stack:** `run_agent.py`, `model_tools.py`, `tools/registry.py`, `hermes_cli/plugins.py`, pytest, existing plugin system.
+
+---
+
+## Why this seam
+
+Current findings in this checkout:
+
+- plugin tool handlers currently receive generic registry dispatch kwargs like `task_id`
+- they do **not** receive the live `AIAgent`
+- `pre_api_request` hooks are currently read-only in practice because return values are collected but not applied
+
+If the goal is to empower plugins to do more than patch request kwargs — including richer session-aware behaviors — then passing runtime agent context is the more flexible seam.
+
+Compared with request-patching, this gives plugins the ability to:
+- mutate live session state
+- invalidate cached prompt state if necessary
+- inspect current model/provider/runtime configuration
+- support more advanced plugin behaviors beyond request shaping
+
+The downside is more power and therefore more risk. To manage that, the design should be explicit and documented as a **plugin-runtime API**, not an accidental leak of internals.
+
+---
+
+## Design principles
+
+1. **Generic, not feature-specific**
+   - no `reasoning_effort` special case in core
+   - core only exposes runtime context to plugin tools
+
+2. **Minimal first exposure**
+   - pass `agent=self` to plugin tools only from the agent loop path
+   - do not retrofit every call site blindly without tests
+
+3. **Safe fallback behavior**
+   - if a plugin ignores runtime kwargs, nothing breaks
+   - non-plugin tools should behave exactly as before
+
+4. **Document the contract honestly**
+   - plugins may access the active agent during tool execution
+   - this is powerful and should be used deliberately
+
+---
+
+## Proposed runtime contract
+
+When a plugin tool is dispatched from a live conversation, its handler may receive:
+
+```python
+handler(args, agent=self, task_id=..., session_id=..., tool_call_id=..., user_task=...)
+```
+
+Recommended v1 guaranteed fields:
+- `agent`
+- `task_id`
+- `session_id`
+- `tool_call_id`
+
+Optional fields can continue to flow as they already do.
+
+---
+
+## Task 1: Add failing tests for plugin tool agent access
+
+**Objective:** Define the new runtime contract before implementation.
+
+**Files:**
+- Modify: `tests/hermes_cli/test_plugins.py`
+- Modify: `tests/run_agent/test_run_agent.py`
+
+**Step 1: Add a failing plugin-runtime unit test proving plugin handlers can receive `agent`**
+
+Add a test in `tests/hermes_cli/test_plugins.py` that registers a tiny plugin tool and verifies that a dispatch call can pass an `agent` kwarg through to the handler.
+
+Suggested shape:
+
+```python
+def test_plugin_tool_handler_can_receive_agent_runtime_context(...):
+    ...
+    result = registry.dispatch("kwarg_probe", {}, task_id="t1", session_id="s1", agent=fake_agent)
+    parsed = json.loads(result)
+    assert parsed["has_agent"] is True
+```
+
+This is the narrowest proof that the registry path allows the seam.
+
+**Step 2: Add a failing agent-loop integration test**
+
+In `tests/run_agent/test_run_agent.py`, simulate a plugin tool call routed through the real agent execution path and assert the plugin handler can observe and mutate the active agent.
+
+Suggested behavior:
+- set `agent.reasoning_config = {"enabled": True, "effort": "medium"}`
+- register a fake plugin tool handler that does:
+
+```python
+agent = kwargs["agent"]
+agent.reasoning_config = {"enabled": True, "effort": "high"}
+return json.dumps({"success": True})
+```
+
+- call the tool through the same path real tools use
+- assert `agent.reasoning_config` became `high`
+
+**Step 3: Add a regression test proving non-plugin behavior is unchanged**
+
+Add a test that dispatching a normal built-in tool still works without any special plugin-only breakage.
+
+**Verification command:**
+
+```bash
+uv run --with pyyaml --with pytest --with pytest-asyncio python -m pytest -o addopts='' tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py -q
+```
+
+Expected before implementation: new tests fail.
+
+---
+
+## Task 2: Add plugin-tool identification helper if needed
+
+**Objective:** Ensure Hermes can distinguish plugin tools from built-in tools when deciding whether to pass live agent context.
+
+**Files:**
+- Inspect/modify: `hermes_cli/plugins.py`
+- Inspect/modify: `model_tools.py`
+
+**Step 1: Reuse existing plugin tool tracking if already available**
+
+`PluginContext.register_tool(...)` already records plugin tool names in the manager.
+
+If there is already a helper like `get_plugin_tool_names()`, use it.
+If not, add a tiny helper returning the current plugin-provided tool-name set.
+
+Suggested public helper:
+
+```python
+def is_plugin_tool(name: str) -> bool:
+    return name in get_plugin_tool_names()
+```
+
+**Step 2: Keep the helper cheap and side-effect free**
+
+No new caching layer is needed.
+This should just consult plugin-manager state.
+
+---
+
+## Task 3: Pass `agent=self` through the agent execution path for plugin tools
+
+**Objective:** Make live agent context available to plugin tool handlers without changing built-in tool semantics.
+
+**Files:**
+- Modify: `run_agent.py`
+- Modify: `model_tools.py` if needed
+
+**Step 1: Identify the agent-loop-to-tool boundary**
+
+Current flow:
+- `run_agent.py` invokes tool execution helpers
+- non-intercepted tools eventually flow to `handle_function_call(...)` in `model_tools.py`
+- `model_tools.py` calls `registry.dispatch(...)`
+
+**Step 2: Thread the active agent into `handle_function_call(...)`**
+
+Extend `handle_function_call(...)` with an optional parameter:
+
+```python
+def handle_function_call(..., agent=None) -> str:
+```
+
+Default must remain `None` for all existing callers.
+
+**Step 3: Only pass `agent` to plugin tools**
+
+Inside `handle_function_call(...)`, when dispatching through the registry, check whether the tool is plugin-provided.
+
+Suggested pattern:
+
+```python
+extra_dispatch_kwargs = {}
+if agent is not None and is_plugin_tool(function_name):
+    extra_dispatch_kwargs["agent"] = agent
+```
+
+Then:
+
+```python
+result = registry.dispatch(..., **extra_dispatch_kwargs)
+```
+
+This avoids spraying `agent` into every tool handler unnecessarily.
+
+**Step 4: Pass `self` from `run_agent.py` into the dispatcher**
+
+Wherever `run_agent.py` calls `handle_function_call(...)`, add:
+
+```python
+agent=self
+```
+
+Only the live agent-loop path needs this.
+
+**Step 5: Preserve existing agent-loop special cases**
+
+Do not disturb:
+- `clarify`
+- `delegate_task`
+- memory-manager routing
+- any special-cased loop tools already intercepted in `run_agent.py`
+
+This seam should simply make normal registry-routed plugin tools more capable.
+
+---
+
+## Task 4: Document the plugin runtime contract
+
+**Objective:** Make the new capability explicit for plugin authors.
+
+**Files:**
+- Modify: `hermes_cli/plugins.py`
+- Optionally add/update docs comments in `tools/registry.py` or plugin docs references
+
+**Step 1: Update plugin docs/comments**
+
+Add a note that plugin tool handlers may receive runtime kwargs like:
+
+```python
+args, agent=..., task_id=..., session_id=..., tool_call_id=...
+```
+
+Clarify that:
+- runtime kwargs are only available during live agent execution
+- plugins should treat `agent` as advanced API surface
+- misuse can break session behavior, so plugins should mutate only what they own
+
+**Step 2: Keep the contract modest**
+
+Do not promise more than Hermes can stably support.
+Recommend plugin authors prefer:
+- session-scoped mutations they understand
+- minimal touch points
+- no random mutation of unrelated internal state
+
+---
+
+## Task 5: Add a reasoning-effort-enabling regression test
+
+**Objective:** Prove that this seam is sufficient for the plugin-first feature you actually care about.
+
+**Files:**
+- Modify: `tests/run_agent/test_run_agent.py`
+
+**Step 1: Simulate a plugin-owned reasoning tool**
+
+Create a fake plugin tool handler inside the test that:
+
+```python
+def _handler(args, **kwargs):
+    agent = kwargs["agent"]
+    level = args["level"]
+    agent.reasoning_config = {"enabled": True, "effort": level}
+    return json.dumps({"success": True, "level": level})
+```
+
+**Step 2: Route it through the real agent tool path**
+
+Call through `_execute_single_tool(...)`, `_invoke_single_tool(...)`, or the closest real path in this checkout.
+
+**Step 3: Assert live state changed**
+
+```python
+assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+```
+
+That proves the seam is enough for the plugin implementation to proceed.
+
+---
+
+## Task 6: Run focused tests
+
+**Objective:** Verify the seam works and does not regress the plugin system.
+
+**Run:**
+
+```bash
+uv run --with pyyaml --with pytest --with pytest-asyncio python -m pytest -o addopts='' tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py -q
+```
+
+If failures occur, fix in this order:
+1. plugin tool identification helper
+2. `handle_function_call(..., agent=None)` plumbing
+3. run-agent call-site updates
+4. docs/comments if tests rely on helper names
+
+---
+
+## Task 7: Save a follow-up note for the plugin implementation branch
+
+**Objective:** Make the next plugin step obvious once the seam lands.
+
+**Files:**
+- Create: `docs/plans/2026-04-10-reasoning-effort-plugin-followup.md`
+
+**Include:**
+- plugin tool can now receive `agent`
+- plugin should validate level with existing Hermes parser
+- plugin should set `agent.reasoning_config`
+- plugin v1 should reject `persist=true`
+- plugin may optionally add compact current-level guidance via `pre_llm_call`
+- plugin should avoid mutating unrelated agent internals
+
+---
+
+## Guardrails
+
+### Do not overbuild a plugin runtime framework
+This does **not** need:
+- a new runtime context class
+- a new plugin RPC layer
+- a broad permission system
+- a generic mutable request abstraction
+
+For v1, just passing `agent=self` to plugin tools in the live path is enough.
+
+### Keep the seam explicit
+Prefer code that makes it obvious this is a plugin capability, not a silent global behavior change.
+
+### Preserve backwards compatibility
+- existing plugin tools that ignore `**kwargs` keep working
+- built-in tools remain unchanged
+- non-agent call sites can still use `handle_function_call(..., agent=None)`
+
+---
+
+## Acceptance criteria
+
+This seam is complete when:
+
+1. plugin tool handlers can receive the live `AIAgent` from the agent loop
+2. a plugin-style handler can mutate `agent.reasoning_config`
+3. existing built-in tool behavior is unchanged
+4. tests prove the runtime contract works
+5. the seam is generic and not reasoning-effort-specific
+
+---
+
+## Implementation summary
+
+If done correctly, the plugin-first `reasoning_effort` flow becomes:
+
+1. plugin registers `reasoning_effort`
+2. plugin handler receives `agent`
+3. plugin validates `level`
+4. plugin sets:
+
+```python
+agent.reasoning_config = parsed
+```
+
+5. next request uses the updated config through existing core logic
+
+That gives you a true plugin-owned implementation with a small generic host seam and more room for future powerful plugins.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -142,7 +142,13 @@ class PluginContext:
         description: str = "",
         emoji: str = "",
     ) -> None:
-        """Register a tool in the global registry **and** track it as plugin-provided."""
+        """Register a tool in the global registry **and** track it as plugin-provided.
+
+        Plugin tool handlers may receive extra runtime kwargs during live agent
+        execution, including ``agent``, ``task_id``, ``session_id``, and
+        ``tool_call_id``. Handlers should accept ``**kwargs`` if they want to use
+        that context.
+        """
         from tools.registry import registry
 
         registry.register(

--- a/model_tools.py
+++ b/model_tools.py
@@ -464,6 +464,7 @@ def handle_function_call(
     session_id: Optional[str] = None,
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    agent: Optional[Any] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -510,6 +511,19 @@ def handle_function_call(
         except Exception:
             pass
 
+        _dispatch_kwargs = {
+            "task_id": task_id,
+            "user_task": user_task,
+        }
+        try:
+            from hermes_cli.plugins import get_plugin_tool_names
+            if agent is not None and function_name in get_plugin_tool_names():
+                _dispatch_kwargs["agent"] = agent
+                _dispatch_kwargs["session_id"] = session_id
+                _dispatch_kwargs["tool_call_id"] = tool_call_id
+        except Exception:
+            pass
+
         if function_name == "execute_code":
             # Prefer the caller-provided list so subagents can't overwrite
             # the parent's tool set via the process-global.
@@ -522,8 +536,7 @@ def handle_function_call(
         else:
             result = registry.dispatch(
                 function_name, function_args,
-                task_id=task_id,
-                user_task=user_task,
+                **_dispatch_kwargs,
             )
 
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6346,6 +6346,7 @@ class AIAgent:
                 tool_call_id=tool_call_id,
                 session_id=self.session_id or "",
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                agent=self,
             )
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
@@ -6779,6 +6780,7 @@ class AIAgent:
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        agent=self,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -6798,6 +6800,7 @@ class AIAgent:
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        agent=self,
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -295,6 +295,32 @@ class TestPluginHooks:
         )
         assert results == [{"seen": 2, "mc": 5, "tc": 3}]
 
+    def test_plugin_tool_handler_can_receive_agent_runtime_context(self, tmp_path, monkeypatch):
+        """Registry dispatch can pass a live agent object to plugin tool handlers."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        register_body = (
+            'import json; '
+            'schema = {"name": "agent_probe", "description": "probe", '
+            '"parameters": {"type": "object", "properties": {}}}; '
+            'ctx.register_tool("agent_probe", "testing", schema, '
+            'lambda args, **kwargs: json.dumps({'
+            '"has_agent": "agent" in kwargs'
+            '}))'
+        )
+        _make_plugin_dir(plugins_dir, "agent_probe_plugin", register_body=register_body)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        from tools.registry import registry
+        fake_agent = object()
+        result = registry.dispatch("agent_probe", {}, task_id="t1", session_id="s1", agent=fake_agent)
+
+        import json
+        parsed = json.loads(result)
+        assert parsed["has_agent"] is True
+
     def test_invalid_hook_name_warns(self, tmp_path, monkeypatch, caplog):
         """Registering an unknown hook name logs a warning."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1420,7 +1420,7 @@ class TestConcurrentToolExecution:
                 tool_call_id=None,
                 session_id=agent.session_id,
                 enabled_tools=list(agent.valid_tool_names),
-
+                agent=agent,
             )
             assert result == "result"
 
@@ -1645,6 +1645,48 @@ class TestRunConversation:
         assert all(call["session_id"] == agent.session_id for call in pre_request_calls)
         assert all("message_count" in c and "messages" not in c for c in pre_request_calls)
         assert all("usage" in c and "response" not in c for c in post_request_calls)
+
+    def test_tool_calls_pass_agent_to_plugin_tools(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "plugin_reasoning_effort"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent.client = MagicMock()
+
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="plugin_reasoning_effort", arguments='{"level":"high"}', call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        def _fake_handle(function_name, function_args, task_id=None, tool_call_id=None, session_id=None, user_task=None, enabled_tools=None, agent=None):
+            assert function_name == "plugin_reasoning_effort"
+            assert agent is not None
+            agent.reasoning_config = {"enabled": True, "effort": function_args["level"]}
+            return json.dumps({"success": True, "level": function_args["level"]})
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=_fake_handle),
+            patch("hermes_cli.plugins.get_plugin_tool_names", return_value={"plugin_reasoning_effort"}),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("raise reasoning")
+
+        assert result["final_response"] == "Done"
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
 
     def test_interrupt_breaks_loop(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary
- pass live `agent` context through the agent loop to plugin-provided tools
- keep built-in tool behavior unchanged by only exposing `agent` to plugin tool names
- add tests proving plugin handlers can receive and use live runtime context

## Why
Maintainers requested a plugin-first path for the reasoning effort feature. Plugin tool handlers currently cannot access the live `AIAgent`, which blocks plugin-owned session-state mutations like updating `agent.reasoning_config`.

This PR adds a small generic seam so plugin tools can receive:
- `agent`
- `task_id`
- `session_id`
- `tool_call_id`

That enables richer plugin behaviors without hardcoding feature logic into core.

## Implementation notes
- `model_tools.handle_function_call(...)` now accepts optional `agent`
- `run_agent.py` passes `agent=self` from the live agent loop
- only plugin-provided tools receive the live `agent` kwarg
- `PluginContext.register_tool(...)` docs now mention runtime kwargs

## Test plan
```bash
uv run --with pyyaml --with pytest --with pytest-asyncio python -m pytest -o addopts='' tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py -q
```

Passed locally:
- `270 passed`

Closes #7344
