### PR TITLE
fix: handle NoneType request_overrides in fast_mode check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":


### PR DESCRIPTION
## Summary
- `self.request_overrides` can be `None` when `request_overrides` is not passed to `AIAgent`, causing `AttributeError: 'NoneType' object has no attribute 'get'` at the `fast_mode` parameter in `_build_anthropic_api_kwargs`.
- Fix: use `(self.request_overrides or {}).get("speed")` to safely handle `None`.

## Test plan
- [x] Verified on gateway with `request_overrides=None` — no more crash
- [x] Verified on CLI with `request_overrides` set — fast_mode still works correctly