### PR TITLE
fix: use x-api-key auth for third-party proxy API keys

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -171,6 +171,11 @@ def _is_oauth_token(key: str) -> bool:
     # Regular Console API keys use x-api-key header
     if key.startswith("sk-ant-api"):
         return False
+    # Third-party proxy keys that don't follow Anthropic's prefix convention
+    # also use x-api-key (e.g. road2all, custom proxies).
+    # Only treat keys with known Anthropic OAuth prefixes as OAuth tokens.
+    if not key.startswith(("sk-ant-oat", "sk-ant-mng", "eyJ")):
+        return False
     # Everything else (setup-tokens, managed keys, JWTs) uses Bearer auth
     return True
 


### PR DESCRIPTION
## Summary

Greetings from China! 🇨🇳

Third-party Anthropic-compatible proxies (e.g. road2all, custom gateways popular in China) issue their own API keys that don't follow Anthropic's `sk-ant-api*` prefix convention. These keys are misclassified as OAuth tokens by `_is_oauth_token()`, causing `Authorization: Bearer` to be sent instead of `x-api-key` — resulting in 401 errors from the proxy.

### Root cause

`_is_oauth_token()` treats **any** key not starting with `sk-ant-api` as an OAuth token. While `_is_third_party_anthropic_endpoint()` should catch this at the `build_anthropic_client` level, there are edge cases where the key prefix alone must determine the auth method.

### Fix

Invert the logic: only treat keys with **known** Anthropic OAuth prefixes (`sk-ant-oat`, `sk-ant-mng`, `eyJ` JWT) as OAuth tokens. All other keys default to `x-api-key`, which is the standard auth method for third-party proxies.

- `sk-ant-api*` → x-api-key (existing, unchanged)
- `sk-ant-oat*`, `sk-ant-mng*`, `eyJ*` → Bearer (OAuth)
- Everything else → x-api-key (NEW — was incorrectly Bearer)

### Tested with

- `api.road2all.com` (Anthropic-compatible proxy, China) — was 401, now works
- Standard Anthropic API keys (`sk-ant-api*`) — unchanged behavior
- The existing `_is_third_party_anthropic_endpoint()` check still applies as the first line of defense

## Test plan

- [ ] Verify `sk-ant-api*` keys still use x-api-key auth
- [ ] Verify `sk-ant-oat*` tokens still use Bearer auth
- [ ] Verify third-party proxy keys (non `sk-ant-*` prefix) use x-api-key auth
- [ ] Verify `_is_third_party_anthropic_endpoint()` still works for known base_urls