### PR TITLE
fix: per-profile subprocess HOME isolation (#4426)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,10 @@ INSTALL_DIR="/opt/hermes"
 # (cache/images, cache/audio, platforms/whatsapp, etc.) are created on
 # demand by the application — don't pre-create them here so new installs
 # get the consolidated layout from get_hermes_dir().
-mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills}
+# The "home/" subdirectory is a per-profile HOME for subprocesses (git,
+# ssh, gh, npm …).  Without it those tools write to /root which is
+# ephemeral and shared across profiles.  See issue #4426.
+mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,home}
 
 # .env
 if [ ! -f "$HERMES_HOME/.env" ]; then

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -42,6 +42,11 @@ _PROFILE_DIRS = [
     "plans",
     "workspace",
     "cron",
+    # Per-profile HOME for subprocesses: isolates system tool configs (git,
+    # ssh, gh, npm …) so credentials don't bleed between profiles.  In Docker
+    # this also ensures tool configs land inside the persistent volume.
+    # See hermes_constants.get_subprocess_home() and issue #4426.
+    "home",
 ]
 
 # Files copied during --clone (if they exist in the source)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -111,6 +111,32 @@ def display_hermes_home() -> str:
         return str(home)
 
 
+def get_subprocess_home() -> str | None:
+    """Return a per-profile HOME directory for subprocesses, or None.
+
+    When ``{HERMES_HOME}/home/`` exists on disk, subprocesses should use it
+    as ``HOME`` so system tools (git, ssh, gh, npm …) write their configs
+    inside the Hermes data directory instead of the OS-level ``/root`` or
+    ``~/``.  This provides:
+
+    * **Docker persistence** — tool configs land inside the persistent volume.
+    * **Profile isolation** — each profile gets its own git identity, SSH
+      keys, gh tokens, etc.
+
+    The Python process's own ``os.environ["HOME"]`` and ``Path.home()`` are
+    **never** modified — only subprocess environments should inject this value.
+    Activation is directory-based: if the ``home/`` subdirectory doesn't
+    exist, returns ``None`` and behavior is unchanged.
+    """
+    hermes_home = os.getenv("HERMES_HOME")
+    if not hermes_home:
+        return None
+    profile_home = os.path.join(hermes_home, "home")
+    if os.path.isdir(profile_home):
+        return profile_home
+    return None
+
+
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 
 

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -1,0 +1,198 @@
+"""Tests for per-profile subprocess HOME isolation (#4426).
+
+Verifies that subprocesses (terminal, execute_code, background processes)
+receive a per-profile HOME directory while the Python process's own HOME
+and Path.home() remain unchanged.
+
+See: https://github.com/NousResearch/hermes-agent/issues/4426
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# get_subprocess_home()
+# ---------------------------------------------------------------------------
+
+class TestGetSubprocessHome:
+    """Unit tests for hermes_constants.get_subprocess_home()."""
+
+    def test_returns_none_when_hermes_home_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() is None
+
+    def test_returns_none_when_home_dir_missing(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # No home/ subdirectory created
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() is None
+
+    def test_returns_path_when_home_dir_exists(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        profile_home = hermes_home / "home"
+        profile_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() == str(profile_home)
+
+    def test_returns_profile_specific_path(self, tmp_path, monkeypatch):
+        """Named profiles get their own isolated HOME."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        profile_home = profile_dir / "home"
+        profile_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() == str(profile_home)
+
+    def test_two_profiles_get_different_homes(self, tmp_path, monkeypatch):
+        base = tmp_path / ".hermes" / "profiles"
+        for name in ("alpha", "beta"):
+            p = base / name
+            p.mkdir(parents=True)
+            (p / "home").mkdir()
+
+        from hermes_constants import get_subprocess_home
+
+        monkeypatch.setenv("HERMES_HOME", str(base / "alpha"))
+        home_a = get_subprocess_home()
+
+        monkeypatch.setenv("HERMES_HOME", str(base / "beta"))
+        home_b = get_subprocess_home()
+
+        assert home_a != home_b
+        assert home_a.endswith("alpha/home")
+        assert home_b.endswith("beta/home")
+
+
+# ---------------------------------------------------------------------------
+# _make_run_env() injection
+# ---------------------------------------------------------------------------
+
+class TestMakeRunEnvHomeInjection:
+    """Verify _make_run_env() injects HOME into subprocess envs."""
+
+    def test_injects_home_when_profile_home_exists(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", "/root")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from tools.environments.local import _make_run_env
+        result = _make_run_env({})
+
+        assert result["HOME"] == str(hermes_home / "home")
+
+    def test_no_injection_when_home_dir_missing(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        # No home/ subdirectory
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", "/root")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from tools.environments.local import _make_run_env
+        result = _make_run_env({})
+
+        assert result["HOME"] == "/root"
+
+    def test_no_injection_when_hermes_home_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setenv("HOME", "/home/user")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from tools.environments.local import _make_run_env
+        result = _make_run_env({})
+
+        assert result["HOME"] == "/home/user"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_subprocess_env() injection
+# ---------------------------------------------------------------------------
+
+class TestSanitizeSubprocessEnvHomeInjection:
+    """Verify _sanitize_subprocess_env() injects HOME for background procs."""
+
+    def test_injects_home_when_profile_home_exists(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        base_env = {"HOME": "/root", "PATH": "/usr/bin", "USER": "root"}
+        from tools.environments.local import _sanitize_subprocess_env
+        result = _sanitize_subprocess_env(base_env)
+
+        assert result["HOME"] == str(hermes_home / "home")
+
+    def test_no_injection_when_home_dir_missing(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        base_env = {"HOME": "/root", "PATH": "/usr/bin"}
+        from tools.environments.local import _sanitize_subprocess_env
+        result = _sanitize_subprocess_env(base_env)
+
+        assert result["HOME"] == "/root"
+
+
+# ---------------------------------------------------------------------------
+# Profile bootstrap
+# ---------------------------------------------------------------------------
+
+class TestProfileBootstrap:
+    """Verify new profiles get a home/ subdirectory."""
+
+    def test_profile_dirs_includes_home(self):
+        from hermes_cli.profiles import _PROFILE_DIRS
+        assert "home" in _PROFILE_DIRS
+
+    def test_create_profile_bootstraps_home_dir(self, tmp_path, monkeypatch):
+        """create_profile() should create home/ inside the profile dir."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        from hermes_cli.profiles import create_profile
+        profile_dir = create_profile("testbot", no_alias=True)
+        assert (profile_dir / "home").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Python process HOME unchanged
+# ---------------------------------------------------------------------------
+
+class TestPythonProcessUnchanged:
+    """Confirm the Python process's own HOME is never modified."""
+
+    def test_path_home_unchanged_after_subprocess_home_resolved(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        original_home = os.environ.get("HOME")
+        original_path_home = str(Path.home())
+
+        from hermes_constants import get_subprocess_home
+        sub_home = get_subprocess_home()
+
+        # Subprocess home is set but Python HOME stays the same
+        assert sub_home is not None
+        assert os.environ.get("HOME") == original_home
+        assert str(Path.home()) == original_path_home

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1020,6 +1020,13 @@ def execute_code(
         if _tz_name:
             child_env["TZ"] = _tz_name
 
+        # Per-profile HOME isolation: redirect system tool configs into
+        # {HERMES_HOME}/home/ when that directory exists.
+        from hermes_constants import get_subprocess_home
+        _profile_home = get_subprocess_home()
+        if _profile_home:
+            child_env["HOME"] = _profile_home
+
         proc = subprocess.Popen(
             [sys.executable, "script.py"],
             cwd=tmpdir,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -129,6 +129,12 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
 
+    # Per-profile HOME isolation for background processes (same as _make_run_env).
+    from hermes_constants import get_subprocess_home
+    _profile_home = get_subprocess_home()
+    if _profile_home:
+        sanitized["HOME"] = _profile_home
+
     return sanitized
 
 
@@ -195,6 +201,15 @@ def _make_run_env(env: dict) -> dict:
     existing_path = run_env.get("PATH", "")
     if "/usr/bin" not in existing_path.split(":"):
         run_env["PATH"] = f"{existing_path}:{_SANE_PATH}" if existing_path else _SANE_PATH
+
+    # Per-profile HOME isolation: redirect system tool configs (git, ssh, gh,
+    # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
+    # subprocess sees the override — the Python process keeps the real HOME.
+    from hermes_constants import get_subprocess_home
+    _profile_home = get_subprocess_home()
+    if _profile_home:
+        run_env["HOME"] = _profile_home
+
     return run_env
 
 


### PR DESCRIPTION
## Summary

Isolates system tool configs (git, ssh, gh, npm) per profile by injecting a per-profile HOME into **subprocess environments only**. The Python process's own `os.environ["HOME"]` and `Path.home()` are never modified.

Closes #4426

## The problem

Two related bugs share a root cause:
1. **Docker**: tool configs written to `/root/` don't persist when the container is recreated — only `/opt/data` (the persistent volume) survives.
2. **Profiles**: all profiles share `/root/`'s git identity, SSH keys, gh tokens, etc.

## Why previous approaches were rejected

PR #4437 and PR #4685 both set `os.environ["HOME"]` globally in the Python process. This breaks `Path.home()` which is used by 42 files — profile infrastructure (`_get_profiles_root()`, `_get_default_hermes_home()`, `_get_wrapper_dir()`), systemd/launchd paths, and every Python library that calls `os.path.expanduser()`.

## This approach: subprocess-only injection

Every subprocess the agent spawns goes through one of three choke points that already build custom env dicts. We inject `HOME={HERMES_HOME}/home/` at these three points:

| Choke point | File | Covers |
|-------------|------|--------|
| `_make_run_env()` | `tools/environments/local.py` | Foreground terminal commands |
| `_sanitize_subprocess_env()` | `tools/environments/local.py` | Background processes (PTY + non-PTY) |
| `child_env` construction | `tools/code_execution_tool.py` | execute_code sandbox |

Single source of truth: `hermes_constants.get_subprocess_home()`

## Activation

Directory-based — zero config needed:
- **`{HERMES_HOME}/home/` exists** → subprocesses get it as HOME
- **Doesn't exist** → behavior unchanged

Who creates the directory:
- **Docker**: `entrypoint.sh` bootstraps it inside the persistent volume
- **Named profiles**: added `"home"` to `_PROFILE_DIRS` in profiles.py
- **Default non-Docker installs**: not created → zero behavior change

## What this preserves

- `Path.home()` untouched → profile infrastructure, systemd paths, wrapper dirs all work
- `os.environ["HOME"]` untouched → no impact on Python process internals
- Shell initialization unaffected — `bash -c` (non-login, used for terminal commands) doesn't source profile files

## Changes

| File | Change |
|------|--------|
| `hermes_constants.py` | New `get_subprocess_home()` — returns `{HERMES_HOME}/home/` if it exists |
| `tools/environments/local.py` | Inject HOME in `_make_run_env()` and `_sanitize_subprocess_env()` |
| `tools/code_execution_tool.py` | Inject HOME in child_env construction |
| `hermes_cli/profiles.py` | Add `"home"` to `_PROFILE_DIRS` |
| `docker/entrypoint.sh` | Add `home` to bootstrapped directories |
| `tests/test_subprocess_home_isolation.py` | 13 tests covering all paths |

## Test plan

- `python3 -m pytest tests/test_subprocess_home_isolation.py` — 13/13 ✓
- `python3 -m pytest tests/tools/test_local_env_blocklist.py tests/hermes_cli/test_profiles.py tests/tools/test_env_passthrough.py` — 121/121 ✓
- `python3 -m pytest tests/tools/test_code_execution.py` — 63/63 ✓