### PR TITLE
feat(cli): restore live per-tool elapsed timer in TUI spinner

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1709,6 +1709,7 @@ class HermesCLI:
         self._secret_state = None
         self._secret_deadline = 0
         self._spinner_text: str = ""  # thinking spinner text for TUI
+        self._tool_start_time: float = 0.0  # monotonic timestamp when current tool started (for live elapsed)
         self._command_running = False
         self._command_status = ""
         self._attached_images: list[Path] = []
@@ -2101,6 +2102,7 @@ class HermesCLI:
         if not text:
             self._flush_reasoning_preview(force=True)
         self._spinner_text = text or ""
+        self._tool_start_time = 0.0  # clear tool timer when switching to thinking
         self._invalidate()
 
     # ── Streaming display ────────────────────────────────────────────────
@@ -5927,11 +5929,20 @@ class HermesCLI:
         Updates the TUI spinner widget so the user can see what the agent
         is doing during tool execution (fills the gap between thinking
         spinner and next response).  Also plays audio cue in voice mode.
+
+        On tool.started, records a monotonic timestamp so get_spinner_text()
+        can show a live elapsed timer (the TUI poll loop already invalidates
+        every ~0.15s, so the counter updates automatically).
         """
-        # Only act on tool.started; ignore tool.completed, reasoning.available, etc.
+        if event_type == "tool.completed":
+            import time as _time
+            self._tool_start_time = 0.0
+            self._invalidate()
+            return
         if event_type != "tool.started":
             return
         if function_name and not function_name.startswith("_"):
+            import time as _time
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(function_name)
             label = preview or function_name
@@ -5940,6 +5951,7 @@ class HermesCLI:
             if _pl > 0 and len(label) > _pl:
                 label = label[:_pl - 3] + "..."
             self._spinner_text = f"{emoji} {label}"
+            self._tool_start_time = _time.monotonic()
             self._invalidate()
 
         if not self._voice_mode:
@@ -8135,6 +8147,17 @@ class HermesCLI:
             txt = cli_ref._spinner_text
             if not txt:
                 return []
+            # Append live elapsed timer when a tool is running
+            t0 = cli_ref._tool_start_time
+            if t0 > 0:
+                import time as _time
+                elapsed = _time.monotonic() - t0
+                if elapsed >= 60:
+                    _m, _s = int(elapsed // 60), int(elapsed % 60)
+                    elapsed_str = f"{_m}m {_s}s"
+                else:
+                    elapsed_str = f"{elapsed:.1f}s"
+                return [('class:hint', f'  {txt}  ({elapsed_str})')]
             return [('class:hint', f'  {txt}')]
 
         def get_spinner_height():
@@ -8669,6 +8692,7 @@ class HermesCLI:
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""
+                        self._tool_start_time = 0.0
 
                         app.invalidate()  # Refresh status line
 


### PR DESCRIPTION
## Summary

Brings back the live elapsed time counter that was lost when the CLI moved from raw KawaiiSpinner animation to prompt_toolkit TUI.

**Before (current main):** spinner shows static tool name only
```
  💻 git log --oneline
```

**After:** spinner shows tool name + live ticking timer
```
  💻 git log --oneline  (3.2s)
```

## Context

The original implementation (commit `9123cfb5`, Feb 2026) used a per-tool KawaiiSpinner with `\r`-based animation showing `(elapsed:.1f}s)` ticking up live. When `patch_stdout` was introduced for the TUI, the `\r` animation was disabled (each frame would land on its own line under StdoutProxy). The static `_spinner_text` widget replaced it but dropped the elapsed timer.

## Implementation

- Track `_tool_start_time` (`time.monotonic()`) when a `tool.started` event fires
- Clear it on `tool.completed`, thinking transitions, and turn end
- `get_spinner_text()` computes live elapsed on each TUI repaint
- The existing poll loop in `chat()` already calls `_invalidate(min_interval=0.15)` every ~0.1s while the agent runs, so the counter updates automatically with no extra timer thread

## Changes

- `cli.py` — 25 lines added, 1 deleted (4 touchpoints)

## Test plan

- `tests/cli/` — 377 passed (1 flaky pre-existing failure in test_quick_commands, passes in isolation)
- `tests/hermes_cli/test_skin_engine.py` — 32 passed
- `py_compile` clean

Addresses #4287, related to PR #4111 (post-response timer) and PR #7239 (closed).