### PR TITLE
fix(cli): fallback to USERNAME/LOGNAME for SSH setup on Windows

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1455,7 +1455,14 @@ def setup_terminal_backend(config: dict):
 
         # SSH user
         current_user = get_env_value("TERMINAL_SSH_USER") or ""
-        user = prompt("  SSH user", current_user or os.getenv("USER", ""))
+        default_user = (
+            current_user
+            or os.getenv("USER")
+            or os.getenv("USERNAME")
+            or os.getenv("LOGNAME")
+            or ""
+        )
+        user = prompt("  SSH user", default_user)
         if user:
             save_env_value("TERMINAL_SSH_USER", user)
 

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -362,3 +362,33 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
 
     assert config["terminal"]["backend"] == "modal"
     assert config["terminal"]["modal_mode"] == "direct"
+
+
+def test_ssh_setup_uses_windows_username_as_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    monkeypatch.setenv("USERNAME", "WinUser")
+    config = load_config()
+
+    prompts = []
+    prompt_values = iter(["example.com", "", "22", "", ""])
+
+    def fake_prompt_choice(question, choices, default=0):
+        if question == "Select terminal backend:":
+            return 3
+        raise AssertionError(f"Unexpected prompt_choice call: {question}")
+
+    def fake_prompt(message, default="", **kwargs):
+        prompts.append((message, default))
+        return next(prompt_values)
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", fake_prompt)
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
+
+    from hermes_cli.setup import setup_terminal_backend
+
+    setup_terminal_backend(config)
+
+    assert ("  SSH user", "WinUser") in prompts


### PR DESCRIPTION
What changed
Fixed a Windows-specific setup bug in the SSH terminal backend wizard.

During hermes setup, the SSH username prompt only used the USER environment variable as its default value. On Windows, USER is typically unset and the username is exposed via USERNAME, so the prompt default was blank even when the OS already had the correct username available.

The fix keeps the existing behavior on Unix-like systems and adds a fallback chain for the default SSH username:

TERMINAL_SSH_USER from existing config/env
USER
USERNAME
LOGNAME
Also added a pytest regression test covering the Windows environment case.

Root cause
The SSH setup flow in hermes_cli/setup.py assumed a Unix-style environment by reading only os.getenv("USER") for the default username.

How to reproduce
Run Hermes setup on Windows.
Choose the SSH terminal backend.
Make sure TERMINAL_SSH_USER is not already configured.
Ensure USERNAME is set but USER is unset.
Observe that the SSH user prompt shows an empty default instead of the current Windows username.
How to verify
Run:
python -m pytest tests/hermes_cli/test_setup.py -q
Confirm the new regression test passes:
test_ssh_setup_uses_windows_username_as_default
Temporarily revert the fallback change in hermes_cli/setup.py.
Re-run the same targeted test and confirm it fails.
Restore the fix and confirm the test passes again.
Tests
Added:

tests/hermes_cli/test_setup.py::test_ssh_setup_uses_windows_username_as_default
Verified locally:

Targeted regression test fails without the fix and passes with it
Full tests/hermes_cli/test_setup.py passes