### PR TITLE
fix: use raw docstring to suppress SyntaxWarning in _split_path_input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1048,7 +1048,7 @@ def _termux_example_image_path(filename: str = "cat.png") -> str:
 
 
 def _split_path_input(raw: str) -> tuple[str, str]:
-    """Split a leading file path token from trailing free-form text.
+    r"""Split a leading file path token from trailing free-form text.
 
     Supports quoted paths and backslash-escaped spaces so callers can accept
     inputs like:


### PR DESCRIPTION
## Summary
- Python 3.12+ emits `SyntaxWarning: invalid escape sequence '\ '` at `cli.py:1056` due to a backslash-space in a regular docstring. Python 3.11 emits it as `DeprecationWarning`.
- Fix: change `"""` to `r"""` (raw docstring) on `_split_path_input`.

## Test plan
- [x] `python -W error cli.py` no longer raises SyntaxWarning
- [x] `py_compile.compile('cli.py')` passes clean