### PR TITLE
fix(agent): prevent false OAuth detection for third-party Anthropic providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -774,7 +774,11 @@ class AIAgent:
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url
             from agent.anthropic_adapter import _is_oauth_token as _is_oat
-            self._is_anthropic_oauth = _is_oat(effective_key)
+            # Only treat as OAuth when talking to native Anthropic endpoints.
+            # Third-party anthropic_messages providers (Kimi, MiniMax, etc.)
+            # use their own API keys that happen to fail the sk-ant-api prefix
+            # check, causing false OAuth detection and Claude Code identity injection.
+            self._is_anthropic_oauth = _is_oat(effective_key) and _is_native_anthropic
             self._anthropic_client = build_anthropic_client(effective_key, base_url)
             # No OpenAI client needed for Anthropic mode
             self.client = None
@@ -1369,7 +1373,8 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 effective_key, self._anthropic_base_url,
             )
-            self._is_anthropic_oauth = _is_oauth_token(effective_key)
+            _is_native = new_provider == "anthropic"
+            self._is_anthropic_oauth = _is_oauth_token(effective_key) and _is_native
             self.client = None
             self._client_kwargs = {}
         else:
@@ -5519,7 +5524,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":
@@ -7623,6 +7628,7 @@ class AIAgent:
 
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
+            api_kwargs = None  # Guard against UnboundLocalError if _build_api_kwargs fails
 
             while retry_count < max_retries:
                 try:


### PR DESCRIPTION
## Summary

Third-party Anthropic-compatible providers (Kimi, MiniMax, DashScope, etc.) using `api_mode: anthropic_messages` get incorrectly identified as Anthropic OAuth sessions. This causes Claude Code identity injection into the system prompt and two cascading gateway crashes.

## Root cause

`_is_oauth_token()` only excludes `sk-ant-api*` prefixes. Any other key format (e.g. `sk-kimi-*`) returns `True`, setting `_is_anthropic_oauth = True`. This triggers:

1. **Identity injection**: System prompt prepended with `"You are Claude Code, Anthropic's official CLI for Claude."`, all occurrences of `"Hermes Agent"` replaced with `"Claude Code"`, `"Nous Research"` replaced with `"Anthropic"`, tool names prefixed with `mcp_`
2. **`request_overrides` crash**: Gateway assigns `agent.request_overrides = None` via `turn_route.get("request_overrides")` when no `service_tier` is configured, bypassing the `__init__` guard of `dict(request_overrides or {})`. The anthropic_messages code path then calls `self.request_overrides.get("speed")` → `AttributeError`
3. **`api_kwargs` unbound**: When `_build_api_kwargs()` raises before assigning `api_kwargs`, the retry-exhaustion error handler references the unbound variable → `UnboundLocalError` masks the real error

## Changes (`run_agent.py`)

- Gate `_is_anthropic_oauth` on `_is_native_anthropic` (`provider == "anthropic"`) in both the init path and the failover/credential-swap path
- Guard `self.request_overrides.get("speed")` with `(self.request_overrides or {}).get("speed")`
- Initialize `api_kwargs = None` before the retry loop

## How to test

1. Configure a non-Anthropic provider with `api_mode: anthropic_messages` (e.g. Kimi with `sk-kimi-*` key, `provider: custom`)
2. Ask the agent "who are you?" — should respond as Hermes Agent, not Claude Code
3. Send messages via gateway (Telegram/Discord/Slack) — no `AttributeError` or `UnboundLocalError` in logs

## Platform tested

- Linux (Docker, Ubuntu 24.04, aarch64)
- Telegram gateway with Kimi (`kimi-for-coding`, Anthropic Messages API)

Fixes #7366
Fixes #7277