### PR TITLE
feat(gateway): stream reasoning as collapsible blockquote on Telegram

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3037,18 +3037,36 @@ class GatewayRunner:
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
 
-            # Prepend reasoning/thinking if display is enabled
-            if getattr(self, "_show_reasoning", False) and response:
+            # Send reasoning as expandable blockquote (non-streaming fallback).
+            # In streaming mode, reasoning was already injected as the HTML
+            # prefix on the stream consumer's message.
+            if (getattr(self, "_show_reasoning", False) and response
+                    and not agent_result.get("_reasoning_already_sent")):
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
-                    # Collapse long reasoning to keep messages readable
-                    lines = last_reasoning.strip().splitlines()
-                    if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
+                    _tg_adapter = self.adapters.get(source.platform)
+                    if _tg_adapter and hasattr(_tg_adapter, '_bot'):
+                        import html as _html
+                        _escaped = _html.escape(last_reasoning.strip())
+                        _html_msg = (
+                            '<blockquote expandable>\U0001f4ad <b>Thinking</b>\n'
+                            + _escaped + '</blockquote>\n\n'
+                            + _html.escape(response)
+                        )
+                        try:
+                            _tid = getattr(source, "thread_id", None)
+                            await _tg_adapter._bot.send_message(
+                                chat_id=int(source.chat_id),
+                                text=_html_msg,
+                                parse_mode="HTML",
+                                message_thread_id=int(_tid) if _tid else None,
+                            )
+                            # Mark as sent so the normal send path skips
+                            response = None
+                        except Exception as _re:
+                            logger.warning("Failed to send reasoning: %s", _re)
                     else:
-                        display_reasoning = last_reasoning.strip()
-                    response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                        response = f"💭 Reasoning:\n{last_reasoning.strip()}\n\n{response}"
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -6967,11 +6985,46 @@ class GatewayRunner:
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
-            agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")
+
+            # Reasoning streaming: collect thinking deltas and inject them
+            # as an HTML expandable blockquote prefix on the stream consumer
+            # so thinking + response appear in the same message.
+            _reasoning_buf = []
+            _reasoning_sent = [False]
+            _show_reasoning_live = getattr(self, "_show_reasoning", False)
+
+            def _reasoning_cb(text: str) -> None:
+                _reasoning_buf.append(text)
+
+            def _flush_reasoning_prefix():
+                if _reasoning_sent[0] or not _reasoning_buf:
+                    return
+                _reasoning_sent[0] = True
+                if _stream_consumer is not None:
+                    import html as _html
+                    _escaped = _html.escape("".join(_reasoning_buf))
+                    _stream_consumer._html_prefix = (
+                        '<blockquote expandable>\U0001f4ad <b>Thinking</b>\n'
+                        + _escaped + '</blockquote>\n\n'
+                    )
+
+            _orig_stream_delta_cb = _stream_delta_cb
+
+            def _wrapped_stream_delta_cb(text: str) -> None:
+                if not _reasoning_sent[0] and _reasoning_buf:
+                    _flush_reasoning_prefix()
+                if _orig_stream_delta_cb:
+                    _orig_stream_delta_cb(text)
+
+            if _show_reasoning_live and _stream_consumer is not None:
+                agent.stream_delta_callback = _wrapped_stream_delta_cb
+                agent.reasoning_callback = _reasoning_cb
+            else:
+                agent.stream_delta_callback = _stream_delta_cb
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:
@@ -7150,6 +7203,7 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+            result["_reasoning_already_sent"] = _reasoning_sent[0]
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
@@ -7262,6 +7316,7 @@ class GatewayRunner:
             return {
                 "final_response": final_response,
                 "last_reasoning": result.get("last_reasoning"),
+                "_reasoning_already_sent": result.get("_reasoning_already_sent", False),
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
                 "tools": tools_holder[0] or [],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6990,33 +6990,36 @@ class GatewayRunner:
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")
 
-            # Reasoning streaming: collect thinking deltas and inject them
-            # as an HTML expandable blockquote prefix on the stream consumer
-            # so thinking + response appear in the same message.
+            # Reasoning streaming: thinking deltas stream in real-time,
+            # then collapse into an expandable blockquote when text starts.
             _reasoning_buf = []
             _reasoning_sent = [False]
+            _thinking_started = [False]
             _show_reasoning_live = getattr(self, "_show_reasoning", False)
 
             def _reasoning_cb(text: str) -> None:
+                """Stream thinking deltas to the consumer in real-time."""
                 _reasoning_buf.append(text)
-
-            def _flush_reasoning_prefix():
-                if _reasoning_sent[0] or not _reasoning_buf:
-                    return
-                _reasoning_sent[0] = True
                 if _stream_consumer is not None:
-                    import html as _html
-                    _escaped = _html.escape("".join(_reasoning_buf))
-                    _stream_consumer._html_prefix = (
-                        '<blockquote expandable>\U0001f4ad <b>Thinking</b>\n'
-                        + _escaped + '</blockquote>\n\n'
-                    )
+                    if not _thinking_started[0]:
+                        _thinking_started[0] = True
+                        _stream_consumer.start_thinking()
+                        _stream_consumer.on_delta("\U0001f4ad Thinking\u2026\n")
+                    _stream_consumer.on_delta(text)
 
             _orig_stream_delta_cb = _stream_delta_cb
 
             def _wrapped_stream_delta_cb(text: str) -> None:
-                if not _reasoning_sent[0] and _reasoning_buf:
-                    _flush_reasoning_prefix()
+                """On first text delta, switch consumer to HTML mode."""
+                if not _reasoning_sent[0] and _reasoning_buf and _stream_consumer is not None:
+                    _reasoning_sent[0] = True
+                    import html as _html
+                    _escaped = _html.escape("".join(_reasoning_buf))
+                    _prefix = (
+                        '<blockquote expandable>\U0001f4ad <b>Thinking</b>\n'
+                        + _escaped + '</blockquote>\n\n'
+                    )
+                    _stream_consumer.switch_to_html_mode(_prefix)
                 if _orig_stream_delta_cb:
                     _orig_stream_delta_cb(text)
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -76,6 +76,9 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        # When set, send/edit uses HTML mode with this prefix prepended.
+        # Used for thinking/reasoning expandable blockquote on Telegram.
+        self._html_prefix: str = ""
 
     @property
     def already_sent(self) -> bool:
@@ -378,6 +381,14 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return
+
+        # When an HTML prefix is set (thinking blockquote), bypass the
+        # adapter's MarkdownV2 path and use the Telegram bot API directly
+        # in HTML mode so the expandable blockquote renders correctly.
+        if self._html_prefix and hasattr(self.adapter, '_bot'):
+            await self._send_or_edit_html(text)
+            return
+
         try:
             if self._message_id is not None:
                 if self._edit_supported:
@@ -433,3 +444,53 @@ class GatewayStreamConsumer:
                     self._edit_supported = False
         except Exception as e:
             logger.error("Stream send/edit error: %s", e)
+
+    async def _send_or_edit_html(self, text: str) -> None:
+        """Send/edit using HTML mode with the thinking prefix prepended.
+
+        Used when _html_prefix is set (reasoning expandable blockquote).
+        Talks directly to the Telegram bot API to bypass MarkdownV2.
+        """
+        import html as _html_mod
+        escaped_body = _html_mod.escape(text)
+        full_html = self._html_prefix + escaped_body
+        try:
+            _tid_raw = (self.metadata or {}).get("thread_id")
+            _tid = int(_tid_raw) if _tid_raw else None
+            if self._message_id is not None and self._edit_supported:
+                if text == self._last_sent_text:
+                    return
+                try:
+                    await self.adapter._bot.edit_message_text(
+                        chat_id=int(self.chat_id),
+                        message_id=int(self._message_id),
+                        text=full_html,
+                        parse_mode="HTML",
+                    )
+                    self._already_sent = True
+                    self._last_sent_text = text
+                except Exception as _e:
+                    err_s = str(_e).lower()
+                    if "not modified" in err_s:
+                        pass
+                    elif "too many requests" in err_s or "flood" in err_s:
+                        self._edit_supported = False
+                        self._fallback_final_send = True
+                        self._already_sent = True
+                    else:
+                        logger.debug("HTML edit failed: %s", _e)
+                        self._edit_supported = False
+                        self._fallback_final_send = True
+                        self._already_sent = True
+            else:
+                msg = await self.adapter._bot.send_message(
+                    chat_id=int(self.chat_id),
+                    text=full_html,
+                    parse_mode="HTML",
+                    message_thread_id=_tid,
+                )
+                self._message_id = str(msg.message_id)
+                self._already_sent = True
+                self._last_sent_text = text
+        except Exception as e:
+            logger.error("HTML stream send/edit error: %s", e)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -79,6 +79,8 @@ class GatewayStreamConsumer:
         # When set, send/edit uses HTML mode with this prefix prepended.
         # Used for thinking/reasoning expandable blockquote on Telegram.
         self._html_prefix: str = ""
+        # True while streaming thinking content (before text starts)
+        self._in_thinking_phase: bool = False
 
     @property
     def already_sent(self) -> bool:
@@ -97,6 +99,21 @@ class GatewayStreamConsumer:
             self._queue.put(text)
         elif text is None:
             self._queue.put(_NEW_SEGMENT)
+
+    def start_thinking(self) -> None:
+        """Mark the start of thinking phase — deltas will show as thinking text."""
+        self._in_thinking_phase = True
+
+    def switch_to_html_mode(self, html_prefix: str) -> None:
+        """Switch from thinking phase to text phase.
+
+        Converts accumulated thinking text into an HTML expandable blockquote
+        prefix, clears the buffer, and subsequent edits use HTML mode.
+        Called from the agent's worker thread when the first text_delta arrives.
+        """
+        self._in_thinking_phase = False
+        self._html_prefix = html_prefix
+        self._accumulated = ""
 
     def finish(self) -> None:
         """Signal that the stream is complete."""


### PR DESCRIPTION
## Summary

When `display.show_reasoning` is enabled and the model returns thinking blocks, the gateway now streams thinking content in real-time and renders it as a Telegram expandable blockquote — all in a single message.

Previously, the gateway never registered `reasoning_callback`, so thinking deltas were silently dropped during streaming. The `show_reasoning` post-processing fallback was also skipped when `already_sent=True` (streaming mode), leaving users with zero thinking visibility and a perceived long TTFT.

## User-visible behavior

```
[t=0s]  💭 Thinking…
        The user asked about ▉           ← thinking streams in real-time

[t=2s]  💭 Thinking                      ← collapses into expandable blockquote
        ▶ (tap to expand full thinking)
        
        The answer is ▉                  ← response text starts streaming

[t=3s]  💭 Thinking                      ← stays collapsed
        
        The answer is **42**. This       ← response continues streaming
        is because...
```

Single message throughout. Both thinking and response are streamed progressively.

## Changes

### `gateway/stream_consumer.py`

- Add `_html_prefix` attribute and `_in_thinking_phase` flag
- Add `start_thinking()` — marks the consumer as in thinking phase
- Add `switch_to_html_mode(prefix)` — atomically sets the HTML expandable blockquote prefix and clears the accumulated thinking text from the buffer
- Add `_send_or_edit_html(text)` — bypasses the adapter's MarkdownV2 path and talks directly to the Telegram bot API in HTML mode, prepending `_html_prefix` to every send/edit. Handles flood control and edit failures gracefully.
- `_send_or_edit()` entry point routes to `_send_or_edit_html()` when `_html_prefix` is set

### `gateway/run.py`

- Register `reasoning_callback` on the agent when `show_reasoning` is enabled and a stream consumer is active
- `_reasoning_cb`: feeds thinking deltas to the stream consumer via `on_delta()` for real-time display, prefixed with `💭 Thinking…` on first delta
- `_wrapped_stream_delta_cb`: on first text delta, formats accumulated thinking as `<blockquote expandable>` HTML and calls `consumer.switch_to_html_mode()`, then forwards text deltas normally
- Pass `_reasoning_already_sent` flag through `agent_result` so the post-processing fallback path skips re-sending when streaming already delivered reasoning
- Non-streaming fallback: sends thinking + response as a single HTML message with expandable blockquote via the Telegram bot API
- Non-Telegram platforms: falls back to plain text prepend

## How to test

1. Set `display.show_reasoning: true` and `streaming.enabled: true` in `~/.hermes/config.yaml`
2. Use a model that supports thinking (e.g. Kimi with extended thinking, Claude with `reasoning_effort: medium`)
3. Send a message via Telegram gateway
4. Observe: thinking streams immediately → collapses when response starts → response streams below

## Platform tested

- Linux (Docker, Ubuntu 24.04, aarch64)
- Telegram gateway with Kimi (`kimi-for-coding`, Anthropic Messages API)
- Verified: `sendMessage` + `editMessageText` both preserve `expandable_blockquote` entity in HTML mode

Closes #7368