### PR TITLE
feat(agent): add PLATFORM_HINTS for mattermost, matrix, feishu, and wecom

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -364,6 +364,41 @@ PLATFORM_HINTS = {
         "documents. You can also include image URLs in markdown format ![alt](url) and they "
         "will be downloaded and sent as native media when possible."
     ),
+    "mattermost": (
+        "You are in a Mattermost workspace communicating with your user. "
+        "Mattermost renders standard Markdown — headings, bold, italic, code "
+        "blocks, and tables all work. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png, .webp) are uploaded as photo "
+        "attachments, audio and video as file attachments. "
+        "Image URLs in markdown format ![alt](url) are rendered as inline previews automatically."
+    ),
+    "matrix": (
+        "You are in a Matrix room communicating with your user. "
+        "Matrix renders Markdown — bold, italic, code blocks, and links work; "
+        "the adapter converts your Markdown to HTML for rich display. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png, .webp) are sent as inline photos, "
+        "audio (.ogg, .mp3) as voice/audio messages, video (.mp4) inline, "
+        "and other files as downloadable attachments."
+    ),
+    "feishu": (
+        "You are in a Feishu (Lark) workspace communicating with your user. "
+        "Feishu renders Markdown in messages — bold, italic, code blocks, and "
+        "links are supported. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png, .webp) are uploaded and displayed "
+        "inline, audio files as voice messages, and other files as attachments."
+    ),
+    "wecom": (
+        "You are in a WeCom (企业微信) workspace communicating with your user. "
+        "WeCom renders a subset of Markdown — bold, italic, inline code, and "
+        "links are supported, but complex tables or nested formatting may not "
+        "render correctly. Keep formatting simple. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png) are sent as photo messages, "
+        "audio as voice messages, video inline, and other files as attachments."
+    ),
 }
 
 CONTEXT_FILE_MAX_CHARS = 20_000

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -769,6 +769,28 @@ class TestPromptBuilderConstants:
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
 
+    def test_platform_hints_mattermost(self):
+        hint = PLATFORM_HINTS["mattermost"]
+        assert "Mattermost" in hint
+        assert "MEDIA:" in hint
+        assert "Markdown" in hint
+
+    def test_platform_hints_matrix(self):
+        hint = PLATFORM_HINTS["matrix"]
+        assert "Matrix" in hint
+        assert "MEDIA:" in hint
+        assert "Markdown" in hint
+
+    def test_platform_hints_feishu(self):
+        hint = PLATFORM_HINTS["feishu"]
+        assert "Feishu" in hint
+        assert "MEDIA:" in hint
+
+    def test_platform_hints_wecom(self):
+        hint = PLATFORM_HINTS["wecom"]
+        assert "WeCom" in hint
+        assert "MEDIA:" in hint
+
 
 # =========================================================================
 # Conditional skill activation


### PR DESCRIPTION
## Summary

- Adds `PLATFORM_HINTS` entries for **Mattermost**, **Matrix**, **Feishu**, and **WeCom** in `agent/prompt_builder.py`
- Adds corresponding tests in `tests/agent/test_prompt_builder.py`

## Background

These four platform adapters fully implement media delivery (`send_image`, `send_image_file`, `send_document`, `send_voice`, `send_video`) but were missing from `PLATFORM_HINTS`. Without a hint, agents running on these platforms have no context about:
- Which platform they are on
- Whether Markdown renders
- How to send media files via `MEDIA:/path/to/file`

This was identified as an open gap in #4531 (item 6 of the integration checklist). dingtalk and homeassistant were intentionally left out — their adapters do not implement media sending methods.

## Changes

| Platform | Markdown | MEDIA: support |
|---|---|---|
| mattermost | ✅ standard Markdown | ✅ images, audio, video, documents |
| matrix | ✅ converted to HTML | ✅ images, audio, video, documents |
| feishu | ✅ subset | ✅ images, audio, documents |
| wecom | ✅ subset | ✅ images, audio, video, documents |

## Test plan

- [x] `pytest tests/agent/test_prompt_builder.py::TestPromptBuilderConstants` — 6 passed
- [x] Full suite `pytest tests/ -q` — 35 pre-existing failures, 0 new failures

## Platform tested

Linux