### PR TITLE
fix: use raw docstring to suppress invalid escape sequence warning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1048,7 +1048,7 @@ def _termux_example_image_path(filename: str = "cat.png") -> str:
 
 
 def _split_path_input(raw: str) -> tuple[str, str]:
-    """Split a leading file path token from trailing free-form text.
+    r"""Split a leading file path token from trailing free-form text.
 
     Supports quoted paths and backslash-escaped spaces so callers can accept
     inputs like:


### PR DESCRIPTION
## Summary
Cherry-picked from PR #7365 by @0xbyt4 onto current main.

Python 3.12+ emits `SyntaxWarning: invalid escape sequence '\\ '` at `cli.py:1043` due to a backslash-space example path in `_split_path_input`'s docstring. Python 3.11 emits it as `DeprecationWarning`. Future Python versions will make this a hard `SyntaxError`.

Fix: `"""` → `r"""` (raw docstring).

## Verification
- `python3 -W error py_compile.compile('cli.py')` — clean
- `python3 -W all -c 'import cli'` — no warnings

Closes #7365 — contributor credit to @0xbyt4.