### PR TITLE
fix(hermes_state): preserve session-local search context

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1071,10 +1071,55 @@ class SessionDB:
             try:
                 with self._lock:
                     ctx_cursor = self._conn.execute(
-                        """SELECT role, content FROM messages
-                           WHERE session_id = ? AND id >= ? - 1 AND id <= ? + 1
-                           ORDER BY id""",
-                        (match["session_id"], match["id"], match["id"]),
+                        """
+                        WITH context_rows AS (
+                            SELECT role, content, -1 AS ord
+                            FROM messages
+                            WHERE id = (
+                                SELECT id
+                                FROM messages
+                                WHERE session_id = ?
+                                  AND (
+                                      timestamp < ?
+                                      OR (timestamp = ? AND id < ?)
+                                  )
+                                ORDER BY timestamp DESC, id DESC
+                                LIMIT 1
+                            )
+                            UNION ALL
+                            SELECT role, content, 0 AS ord
+                            FROM messages
+                            WHERE id = ?
+                            UNION ALL
+                            SELECT role, content, 1 AS ord
+                            FROM messages
+                            WHERE id = (
+                                SELECT id
+                                FROM messages
+                                WHERE session_id = ?
+                                  AND (
+                                      timestamp > ?
+                                      OR (timestamp = ? AND id > ?)
+                                  )
+                                ORDER BY timestamp ASC, id ASC
+                                LIMIT 1
+                            )
+                        )
+                        SELECT role, content
+                        FROM context_rows
+                        ORDER BY ord
+                        """,
+                        (
+                            match["session_id"],
+                            match["timestamp"],
+                            match["timestamp"],
+                            match["id"],
+                            match["id"],
+                            match["session_id"],
+                            match["timestamp"],
+                            match["timestamp"],
+                            match["id"],
+                        ),
                     )
                     context_msgs = [
                         {"role": r["role"], "content": (r["content"] or "")[:200]}

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -334,6 +334,23 @@ class TestFTS5Search:
         assert isinstance(results[0]["context"], list)
         assert len(results[0]["context"]) > 0
 
+    def test_search_context_uses_adjacent_messages_within_session(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli")
+
+        db.append_message("s1", role="user", content="first message in s1")
+        db.append_message("s2", role="user", content="interleaving message in s2")
+        db.append_message("s1", role="assistant", content="match target keyword")
+        db.append_message("s1", role="user", content="last message in s1")
+
+        results = db.search_messages("target")
+        assert len(results) == 1
+        assert [msg["content"] for msg in results[0]["context"]] == [
+            "first message in s1",
+            "match target keyword",
+            "last message in s1",
+        ]
+
     def test_search_special_chars_do_not_crash(self, db):
         """FTS5 special characters in queries must not raise OperationalError."""
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
### 📝 Summary
Fix **`SessionDB.search_messages()`** so FTS search context is taken from the matched session's adjacent messages, not from globally adjacent message IDs.

Before this change, `search_messages()` fetched context with an `id >= match_id - 1 AND id <= match_id + 1` query scoped only by `session_id`. That looks reasonable at first glance, but message IDs are global across all sessions. If messages from another session were inserted in between, the matched session's actual previous or next message could be skipped, producing incomplete or misleading context in search results.

### Bug
This showed up when messages from two sessions were interleaved:
1. **Session s1:** first message
2. **Session s2:** unrelated message
3. **Session s1:** matching message
4. **Session s1:** next message

Searching for the match in **s1** returned context that started at the matching message instead of including **s1's** real previous message. In other words, search context depended on global insertion order across all sessions, not the session-local conversation order.

### Fix
Replace the global `id ± 1` context lookup with a session-local neighbor lookup based on the session's actual ordering:
* **Previous message** in the same session by `(timestamp DESC, id DESC)`
* **Matched message**
* **Next message** in the same session by `(timestamp ASC, id ASC)`

This keeps the change surgical and preserves the existing API shape. Only the context selection logic changed.

### Why this is correct
`search_messages()` is documented to return surrounding context for the match. In a multi-session database, **“surrounding”** must mean the previous and next messages within the same session, not whichever rows happen to have nearby global IDs. 

Using `(timestamp, id)` also keeps ordering deterministic when timestamps are equal.

### Tests
Added a regression test that proves the old behavior was wrong and the new behavior is correct:
- Create two sessions.
- Interleave their message inserts.
- Search for a match in one session.
- Assert that context contains that session's real previous/matched/next messages.

**Focused verification run:**
```bash
python -m pytest tests/test_hermes_state.py -q