### PR TITLE
docs: add HermesClaw (community WeChat bridge) to ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ python -m pytest tests/ -q
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 💡 [Discussions](https://github.com/NousResearch/hermes-agent/discussions)
+- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
 
 ---
 


### PR DESCRIPTION
Adds a one-line entry for HermesClaw (community WeChat bridge) to the Community section. It lets users run Hermes Agent and OpenClaw on the same WeChat account.

## What

Adds a one-line entry for [HermesClaw](https://github.com/AaronWong1999/hermesclaw) to the community ecosystem section of the README. HermesClaw is a small Python bridge I wrote that lets a single WeChat Clawbot account route messages to Hermes Agent (and/or OpenClaw) over the existing iLink path.

## Why

Hermes Agent ships first-party connectors for Telegram / Discord / Slack / WhatsApp / Signal but not WeChat. I see roughly one issue a month from users asking about WeChat support. HermesClaw is a userspace workaround that exists today, so linking to it from the README saves people the search.

## Disclosure

I'm the author of HermesClaw. Happy to maintain the entry, and equally happy to have it removed if maintainers prefer not to link external community tools.

Thanks for the project — Hermes Agent is what made this possible at all.