### PR TITLE
fix: guard api_kwargs in except handler to prevent UnboundLocalError

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7706,6 +7706,7 @@ class AIAgent:
 
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
+            api_kwargs = None  # Guard against UnboundLocalError in except handler
 
             while retry_count < max_retries:
                 try:
@@ -8740,9 +8741,10 @@ class AIAgent:
                         if self._try_activate_fallback():
                             retry_count = 0
                             continue
-                        self._dump_api_request_debug(
-                            api_kwargs, reason="non_retryable_client_error", error=api_error,
-                        )
+                        if api_kwargs is not None:
+                            self._dump_api_request_debug(
+                                api_kwargs, reason="non_retryable_client_error", error=api_error,
+                            )
                         self._emit_status(
                             f"❌ Non-retryable error (HTTP {status_code}): "
                             f"{self._summarize_api_error(api_error)}"
@@ -8845,9 +8847,10 @@ class AIAgent:
                             self.log_prefix, max_retries, _final_summary,
                             _provider, _model, len(api_messages), f"{approx_tokens:,}",
                         )
-                        self._dump_api_request_debug(
-                            api_kwargs, reason="max_retries_exhausted", error=api_error,
-                        )
+                        if api_kwargs is not None:
+                            self._dump_api_request_debug(
+                                api_kwargs, reason="max_retries_exhausted", error=api_error,
+                            )
                         self._persist_session(messages, conversation_history)
                         _final_response = f"API call failed after {max_retries} retries: {_final_summary}"
                         if _is_stream_drop:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2125,6 +2125,28 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "rate limited" in result["error"]
 
+    def test_build_api_kwargs_error_no_unbound_local(self, agent):
+        """When _build_api_kwargs raises, except handler must not crash with UnboundLocalError.
+
+        Regression: _dump_api_request_debug(api_kwargs, ...) in the except block
+        referenced api_kwargs before it was assigned when _build_api_kwargs threw.
+        """
+        self._setup_agent(agent)
+        with (
+            patch.object(agent, "_build_api_kwargs", side_effect=ValueError("bad messages")),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time", self._make_fast_time_mock()),
+        ):
+            result = agent.run_conversation("hello")
+        # Must surface the real error, not UnboundLocalError
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "error" in result
+        assert "UnboundLocalError" not in result.get("error", "")
+        assert "bad messages" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # Flush sentinel leak


### PR DESCRIPTION
## Summary

Discord user gruman0 reported getting this error after updating:

```
Sorry, I encountered an error (UnboundLocalError).
cannot access local variable 'api_kwargs' where it is not associated with a value
```

**Root cause:** In the API retry loop in `run_conversation()`, `api_kwargs` is assigned inside the `try` block at line 7712 via `_build_api_kwargs()`. If that method throws an exception, the `except` handler tries to pass `api_kwargs` to `_dump_api_request_debug()` — but it was never assigned, causing `UnboundLocalError` that masks the real error.

Two unguarded references:
1. Line 8743: `_dump_api_request_debug(api_kwargs, reason="non_retryable_client_error")`
2. Line 8848: `_dump_api_request_debug(api_kwargs, reason="max_retries_exhausted")`

**Fix:**
- Initialize `api_kwargs = None` before the retry loop (same pattern as existing `response = None` guard)
- Guard both `_dump_api_request_debug` calls with `if api_kwargs is not None:`

**Note:** This fixes the masking bug so the *real* error surfaces. The user's underlying issue (whatever causes `_build_api_kwargs` to throw) will now show a descriptive error message instead of the opaque UnboundLocalError.

## Test plan
- Added regression test `test_build_api_kwargs_error_no_unbound_local` that mocks `_build_api_kwargs` to raise and verifies the real error propagates
- All 3 `TestRetryExhaustion` tests pass
- Full `tests/run_agent/test_run_agent.py` suite passes (243 tests)