### PR TITLE
fix(feishu): register group chat member event handlers

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1190,6 +1190,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 lambda data: self._on_reaction_event("im.message.reaction.deleted_v1", data)
             )
             .register_p2_card_action_trigger(self._on_card_action_trigger)
+            .register_p2_im_chat_member_bot_added_v1(self._on_bot_added_to_chat)
+            .register_p2_im_chat_member_bot_deleted_v1(self._on_bot_removed_from_chat)
             .build()
         )
 


### PR DESCRIPTION
## Problem

Closes #6889

Group messages never reached the Feishu gateway because `_on_bot_added_to_chat` and `_on_bot_removed_from_chat` handlers existed but were never registered in `_build_event_handler()`.

## Fix

Register the two missing handlers in the event handler builder chain:
- `register_p2_im_chat_member_bot_added_v1`
- `register_p2_im_chat_member_bot_deleted_v1`

2 lines added in `gateway/platforms/feishu.py`.

> Originally included in a larger PR — resubmitted as standalone fix per maintainer request.