### PR TITLE
fix: improve Hermes gateway reliability on macOS

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -555,6 +555,12 @@ class DiscordAdapter(BasePlatformAdapter):
             async def on_ready():
                 logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
 
+                # Mark the adapter ready as soon as Discord reports the bot online.
+                # Follow-up tasks like allowlist resolution and slash-command sync can
+                # take longer than the initial gateway handshake and should not cause
+                # startup to be treated as a failed connection.
+                adapter_self._ready_event.set()
+
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
 
@@ -564,7 +570,6 @@ class DiscordAdapter(BasePlatformAdapter):
                     logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
                 except Exception as e:  # pragma: no cover - defensive logging
                     logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
-                adapter_self._ready_event.set()
 
             @self._client.event
             async def on_message(message: DiscordMessage):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1086,10 +1086,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -138,3 +138,43 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     assert ok is False
     assert released == [("discord-bot-token", "test-token")]
     assert adapter._token_lock_identity is None
+
+
+@pytest.mark.asyncio
+async def test_connect_succeeds_even_if_slash_sync_is_slow(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    sync_gate = asyncio.Event()
+
+    class SlowTree(FakeTree):
+        async def sync(self):
+            await sync_gate.wait()
+            return []
+
+    class SlowSyncBot(FakeBot):
+        def __init__(self, *, intents, proxy=None):
+            super().__init__(intents=intents, proxy=proxy)
+            self.tree = SlowTree()
+
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: SlowSyncBot(intents=kwargs["intents"], proxy=kwargs.get("proxy")),
+    )
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    ok = await asyncio.wait_for(adapter.connect(), timeout=1)
+
+    assert ok is True
+    assert adapter._ready_event.is_set() is True
+
+    sync_gate.set()
+    await adapter.disconnect()
+    if adapter._bot_task:
+        await adapter._bot_task

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -817,6 +817,11 @@ class TestProfileArg:
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
 
+    def test_launchd_plist_uses_unconditional_keepalive(self):
+        plist = gateway_cli.generate_launchd_plist()
+        assert "<key>KeepAlive</key>\n    <true/>" in plist
+        assert "SuccessfulExit" not in plist
+
 
 class TestRemapPathForUser:
     """Unit tests for _remap_path_for_user()."""


### PR DESCRIPTION
## Summary
- mark Discord ready as soon as the bot connects instead of waiting on slash sync
- use unconditional launchd KeepAlive for the macOS gateway service
- add regression coverage for slow Discord slash-command sync and launchd plist generation

## Validation
- source venv/bin/activate && pytest tests/gateway/test_discord_connect.py tests/hermes_cli/test_gateway_service.py -q
