### PR TITLE
fix(gateway): replace os.environ session state with contextvars to prevent concurrent message cross-contamination

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1548,8 +1548,8 @@ class GatewayRunner:
         # Build session context
         context = build_session_context(source, self.config, session_entry)
         
-        # Set environment variables for tools
-        self._set_session_env(context)
+        # Set session context variables for tools (task-local, concurrency-safe)
+        _session_env_tokens = self._set_session_env(context)
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -2213,8 +2213,8 @@ class GatewayRunner:
                 "Try again or use /reset to start a fresh session."
             )
         finally:
-            # Clear session env
-            self._clear_session_env()
+            # Restore session context variables to their pre-handler state
+            self._clear_session_env(_session_env_tokens)
     
     async def _handle_reset_command(self, event: MessageEvent) -> str:
         """Handle /new or /reset command."""
@@ -3959,20 +3959,27 @@ class GatewayRunner:
 
         return True
 
-    def _set_session_env(self, context: SessionContext) -> None:
-        """Set environment variables for the current session."""
-        os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
-        os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
-        if context.source.chat_name:
-            os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
-        if context.source.thread_id:
-            os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
-    
-    def _clear_session_env(self) -> None:
-        """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
-            if var in os.environ:
-                del os.environ[var]
+    def _set_session_env(self, context: SessionContext) -> list:
+        """Set session context variables for the current async task.
+
+        Uses ``contextvars`` instead of ``os.environ`` so that concurrent
+        gateway messages cannot overwrite each other's session state.
+
+        Returns a list of reset tokens; pass them to ``_clear_session_env``
+        in a ``finally`` block.
+        """
+        from gateway.session_context import set_session_vars
+        return set_session_vars(
+            platform=context.source.platform.value,
+            chat_id=context.source.chat_id,
+            chat_name=context.source.chat_name or "",
+            thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+        )
+
+    def _clear_session_env(self, tokens: list) -> None:
+        """Restore session context variables to their pre-handler values."""
+        from gateway.session_context import clear_session_vars
+        clear_session_vars(tokens)
     
     async def _enrich_message_with_vision(
         self,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -1,0 +1,105 @@
+"""
+Session-scoped context variables for the Hermes gateway.
+
+Replaces the previous ``os.environ``-based session state
+(``HERMES_SESSION_PLATFORM``, ``HERMES_SESSION_CHAT_ID``, etc.) with
+Python's ``contextvars.ContextVar``.
+
+**Why this matters**
+
+The gateway processes messages concurrently via ``asyncio``.  When two
+messages arrive at the same time the old code did:
+
+    os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
+
+Because ``os.environ`` is *process-global*, Message A's value was
+silently overwritten by Message B before Message A's agent finished
+running.  Background-task notifications and tool calls therefore routed
+to the wrong thread.
+
+``contextvars.ContextVar`` values are *task-local*: each ``asyncio``
+task (and any ``run_in_executor`` thread it spawns) gets its own copy,
+so concurrent messages never interfere.
+
+**Backward compatibility**
+
+The public helper ``get_session_env(name, default="")`` mirrors the old
+``os.getenv("HERMES_SESSION_*", ...)`` calls.  Existing tool code only
+needs to replace the import + call site:
+
+    # before
+    import os
+    platform = os.getenv("HERMES_SESSION_PLATFORM", "")
+
+    # after
+    from gateway.session_context import get_session_env
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+"""
+
+from contextvars import ContextVar
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Per-task session variables
+# ---------------------------------------------------------------------------
+
+_SESSION_PLATFORM: ContextVar[str] = ContextVar("HERMES_SESSION_PLATFORM", default="")
+_SESSION_CHAT_ID: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_ID", default="")
+_SESSION_CHAT_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_NAME", default="")
+_SESSION_THREAD_ID: ContextVar[str] = ContextVar("HERMES_SESSION_THREAD_ID", default="")
+
+_VAR_MAP = {
+    "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
+    "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
+    "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
+    "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
+}
+
+
+def set_session_vars(
+    platform: str = "",
+    chat_id: str = "",
+    chat_name: str = "",
+    thread_id: str = "",
+) -> list:
+    """Set all session context variables and return reset tokens.
+
+    Call ``clear_session_vars(tokens)`` in a ``finally`` block to restore
+    the previous values when the handler exits.
+
+    Returns a list of ``Token`` objects (one per variable) that can be
+    passed to ``clear_session_vars``.
+    """
+    tokens = [
+        _SESSION_PLATFORM.set(platform),
+        _SESSION_CHAT_ID.set(chat_id),
+        _SESSION_CHAT_NAME.set(chat_name),
+        _SESSION_THREAD_ID.set(thread_id),
+    ]
+    return tokens
+
+
+def clear_session_vars(tokens: list) -> None:
+    """Restore session context variables to their pre-handler values."""
+    vars_in_order = [
+        _SESSION_PLATFORM,
+        _SESSION_CHAT_ID,
+        _SESSION_CHAT_NAME,
+        _SESSION_THREAD_ID,
+    ]
+    for var, token in zip(vars_in_order, tokens):
+        var.reset(token)
+
+
+def get_session_env(name: str, default: str = "") -> str:
+    """Read a session context variable by its legacy ``HERMES_SESSION_*`` name.
+
+    Drop-in replacement for ``os.getenv("HERMES_SESSION_*", default)``.
+    Falls back to *default* when the variable has not been set for the
+    current task (e.g. in the CLI, where no gateway handler is active).
+    """
+    var = _VAR_MAP.get(name)
+    if var is None:
+        return default
+    value = var.get()
+    return value if value else default

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -64,14 +64,20 @@ def _scan_cron_prompt(prompt: str) -> str:
 
 
 def _origin_from_env() -> Optional[Dict[str, str]]:
-    origin_platform = os.getenv("HERMES_SESSION_PLATFORM")
-    origin_chat_id = os.getenv("HERMES_SESSION_CHAT_ID")
+    try:
+        from gateway.session_context import get_session_env as _gse
+        origin_platform = _gse("HERMES_SESSION_PLATFORM")
+        origin_chat_id = _gse("HERMES_SESSION_CHAT_ID")
+    except ImportError:
+        origin_platform = os.getenv("HERMES_SESSION_PLATFORM", "")
+        origin_chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "")
+        _gse = os.getenv  # type: ignore[assignment]
     if origin_platform and origin_chat_id:
         return {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
-            "chat_name": os.getenv("HERMES_SESSION_CHAT_NAME"),
-            "thread_id": os.getenv("HERMES_SESSION_THREAD_ID"),
+            "chat_name": _gse("HERMES_SESSION_CHAT_NAME") or None,
+            "thread_id": _gse("HERMES_SESSION_THREAD_ID") or None,
         }
     return None
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -177,7 +177,11 @@ def _handle_send(args):
         if isinstance(result, dict) and result.get("success") and mirror_text:
             try:
                 from gateway.mirror import mirror_to_session
-                source_label = os.getenv("HERMES_SESSION_PLATFORM", "cli")
+                try:
+                    from gateway.session_context import get_session_env as _gse
+                    source_label = _gse("HERMES_SESSION_PLATFORM", "cli")
+                except ImportError:
+                    source_label = os.getenv("HERMES_SESSION_PLATFORM", "cli")
                 if mirror_to_session(platform_name, chat_id, mirror_text, source_label=source_label, thread_id=thread_id):
                     result["mirrored"] = True
             except Exception:
@@ -664,7 +668,11 @@ async def _send_sms(auth_token, chat_id, message):
 
 def _check_send_message():
     """Gate send_message on gateway running (always available on messaging platforms)."""
-    platform = os.getenv("HERMES_SESSION_PLATFORM", "")
+    try:
+        from gateway.session_context import get_session_env as _gse
+        platform = _gse("HERMES_SESSION_PLATFORM", "")
+    except ImportError:
+        platform = os.getenv("HERMES_SESSION_PLATFORM", "")
     if platform and platform != "local":
         return True
     try:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -348,7 +348,11 @@ def _capture_required_environment_variables(
 def _is_gateway_surface() -> bool:
     if os.getenv("HERMES_GATEWAY_SESSION"):
         return True
-    return bool(os.getenv("HERMES_SESSION_PLATFORM"))
+    try:
+        from gateway.session_context import get_session_env as _gse
+        return bool(_gse("HERMES_SESSION_PLATFORM"))
+    except ImportError:
+        return bool(os.getenv("HERMES_SESSION_PLATFORM"))
 
 
 def _get_terminal_backend_name() -> str:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1082,9 +1082,13 @@ def terminal_tool(
                         result_data["check_interval_note"] = (
                             f"Requested {check_interval}s raised to minimum 30s"
                         )
-                    watcher_platform = os.getenv("HERMES_SESSION_PLATFORM", "")
-                    watcher_chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "")
-                    watcher_thread_id = os.getenv("HERMES_SESSION_THREAD_ID", "")
+                    try:
+                        from gateway.session_context import get_session_env as _gse
+                    except ImportError:
+                        _gse = os.getenv  # type: ignore[assignment]
+                    watcher_platform = _gse("HERMES_SESSION_PLATFORM", "")
+                    watcher_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
+                    watcher_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
 
                     # Store on session for checkpoint persistence
                     proc_session.watcher_platform = watcher_platform

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -374,7 +374,11 @@ def text_to_speech_tool(
     # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
     # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
     # and needs ffmpeg for conversion.
-    platform = os.getenv("HERMES_SESSION_PLATFORM", "").lower()
+    try:
+        from gateway.session_context import get_session_env as _gse
+        platform = _gse("HERMES_SESSION_PLATFORM", "").lower()
+    except ImportError:
+        platform = os.getenv("HERMES_SESSION_PLATFORM", "").lower()
     want_opus = (platform == "telegram")
 
     # Determine output path


### PR DESCRIPTION
## Problem

Fixes #7358

When two gateway messages arrived concurrently, `_set_session_env` wrote `HERMES_SESSION_PLATFORM`, `HERMES_SESSION_CHAT_ID`, and `HERMES_SESSION_THREAD_ID` into the process-global `os.environ`. Because asyncio tasks share the same process, Message B would overwrite Message A's values mid-flight, causing background-task notifications and tool calls (cronjob, TTS, terminal watcher, send_message) to route to the wrong thread/chat permanently.

## Root Cause

```python
# gateway/run.py – old code (racy)
os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
```

With `asyncio` + thread-pool executors, two concurrent message handlers run "simultaneously". The second write corrupts the first handler's context before its tools finish executing.

## Fix

Replace `os.environ` with Python's `contextvars.ContextVar`. Each asyncio task (and any `run_in_executor` thread it spawns) gets its own copy of a `ContextVar`, so concurrent messages never see each other's state.

### Changes

- **`gateway/session_context.py`** *(new)* — `ContextVar` instances for all four session variables plus `set_session_vars()`, `clear_session_vars()`, and `get_session_env()` helpers.
- **`gateway/run.py`** — `_set_session_env` now returns reset tokens and sets context vars instead of `os.environ`; `_clear_session_env` accepts and applies those tokens.
- **`tools/cronjob_tools.py`**, **`tools/tts_tool.py`**, **`tools/terminal_tool.py`**, **`tools/skills_tool.py`**, **`tools/send_message_tool.py`** — prefer `get_session_env()` with a graceful `os.getenv` fallback for non-gateway contexts (CLI, tests).

## Test plan

- [ ] Send two concurrent messages in a Telegram supergroup with Topics enabled and verify each response appears in the correct topic
- [ ] Existing `tests/tools/test_cronjob_tools.py` still passes (uses `monkeypatch.setenv` which continues to work via the fallback path)
- [ ] CLI usage unaffected (`get_session_env` returns empty string by default when no gateway handler is active)