### PR TITLE
fix(agent): prevent identity injection for third-party Anthropic providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -774,7 +774,7 @@ class AIAgent:
             self._anthropic_api_key = effective_key
             self._anthropic_base_url = base_url
             from agent.anthropic_adapter import _is_oauth_token as _is_oat
-            self._is_anthropic_oauth = _is_oat(effective_key)
+            self._is_anthropic_oauth = _is_oat(effective_key) if _is_native_anthropic else False
             self._anthropic_client = build_anthropic_client(effective_key, base_url)
             # No OpenAI client needed for Anthropic mode
             self.client = None
@@ -1369,7 +1369,7 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 effective_key, self._anthropic_base_url,
             )
-            self._is_anthropic_oauth = _is_oauth_token(effective_key)
+            self._is_anthropic_oauth = _is_oauth_token(effective_key) if new_provider == "anthropic" else False
             self.client = None
             self._client_kwargs = {}
         else:
@@ -4179,7 +4179,7 @@ class AIAgent:
         self._anthropic_api_key = new_token
         # Update OAuth flag — token type may have changed (API key ↔ OAuth)
         from agent.anthropic_adapter import _is_oauth_token
-        self._is_anthropic_oauth = _is_oauth_token(new_token)
+        self._is_anthropic_oauth = _is_oauth_token(new_token) if self.provider == "anthropic" else False
         return True
 
     def _apply_client_headers_for_base_url(self, base_url: str) -> None:
@@ -5061,7 +5061,7 @@ class AIAgent:
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = fb_base_url
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)
-                self._is_anthropic_oauth = _is_oauth_token(effective_key)
+                self._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
                 self.client = None
                 self._client_kwargs = {}
             else:
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":
@@ -7623,6 +7623,7 @@ class AIAgent:
 
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
+            api_kwargs = None  # Guard against UnboundLocalError in error handler
 
             while retry_count < max_retries:
                 try:


### PR DESCRIPTION
## Summary

- Guard all `_is_anthropic_oauth` assignments with a `provider == "anthropic"` check so third-party providers using `api_mode: anthropic_messages` (Kimi, MiniMax, DashScope, etc.) don't get Claude Code identity injected
- Fix `AttributeError` when gateway sets `request_overrides = None`
- Fix potential `UnboundLocalError` on `api_kwargs` in the retry-exhaustion error handler

## Details

`_is_oauth_token()` returns `True` for any key not starting with `sk-ant-api`. When third-party providers use `api_mode: anthropic_messages`, their keys (e.g. `sk-kimi-*`) are misclassified as Anthropic OAuth tokens. This sets `_is_anthropic_oauth = True`, which triggers:

1. System prompt prepend with Claude Code identity
2. Text replacement: "Hermes Agent" → "Claude Code", "Nous Research" → "Anthropic"
3. Tool name prefixing with `mcp_`

The fix adds a provider guard at all 4 unguarded call sites in `run_agent.py`, matching the pattern already used in `_swap_credential()` (line 4217).

Two secondary crashes are also fixed:
- `self.request_overrides.get("speed")` crashes with `AttributeError` when gateway sets `request_overrides = None` → changed to `(self.request_overrides or {}).get("speed")`
- `api_kwargs` is referenced in the retry-exhaustion error handler but was never initialized before the retry loop → added `api_kwargs = None` guard

Closes #7366

## Test plan

- [x] Full test suite passes (2857 passed, 4 pre-existing failures unrelated to this change)
- [ ] Manual: configure a Kimi/MiniMax provider with `api_mode: anthropic_messages`, ask "who are you?" — should respond as Hermes Agent, not Claude Code
- [ ] Manual: send a message via gateway with `request_overrides = None` — no AttributeError

## Platform

macOS