### PR TITLE
docs: add GMI Cloud to compatible providers list

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -764,6 +764,7 @@ Any service with an OpenAI-compatible API works. Some popular options:
 | [Groq](https://groq.com) | `https://api.groq.com/openai/v1` | Ultra-fast inference |
 | [DeepSeek](https://deepseek.com) | `https://api.deepseek.com/v1` | DeepSeek models |
 | [Fireworks AI](https://fireworks.ai) | `https://api.fireworks.ai/inference/v1` | Fast open model hosting |
+| [GMI Cloud](https://www.gmicloud.ai/) | `https://api.gmi-serving.com/v1` | Managed OpenAI-compatible inference |
 | [Cerebras](https://cerebras.ai) | `https://api.cerebras.ai/v1` | Wafer-scale chip inference |
 | [Mistral AI](https://mistral.ai) | `https://api.mistral.ai/v1` | Mistral models |
 | [OpenAI](https://openai.com) | `https://api.openai.com/v1` | Direct OpenAI access |


### PR DESCRIPTION
## Summary

Add GMI Cloud to the compatible OpenAI-style providers list in the AI Providers docs.

## Why

GMI Cloud exposes an OpenAI-compatible API at `https://api.gmi-serving.com/v1`, so it fits Hermes' existing custom endpoint flow and belongs in the compatible providers list alongside other OpenAI-style endpoints.


## Scope

This change is docs-only:
- no runtime/provider registry changes
- no auth flow changes
- no model catalog changes

## Validation

- Confirmed the documented base URL matches GMI Cloud's OpenAI-compatible endpoint format
- Kept the change within the existing "Other Compatible Providers" section in `website/docs/integrations/providers.md`