### PR TITLE
fix(cli): resolve alias collision for /q between queue and quit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4810,7 +4810,7 @@ class HermesCLI:
         _cmd_def = _resolve_cmd(_base_word)
         canonical = _cmd_def.name if _cmd_def else _base_word
         
-        if canonical in ("quit", "exit", "q"):
+        if canonical in ("quit", "exit"):
             return False
         elif canonical == "help":
             self.show_help()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -154,7 +154,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",
-               cli_only=True, aliases=("exit", "q")),
+               cli_only=True, aliases=("exit",)),
 ]
 
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -123,6 +123,13 @@ class TestBusyInputMode:
         cli.process_command("/queue follow up")
         assert cli._pending_input.get_nowait() == "follow up"
 
+    def test_q_alias_queues_instead_of_exiting(self):
+        """Regression: /q <prompt> should dispatch to /queue, not /quit."""
+        cli = _make_cli()
+        cli._agent_running = False
+        assert cli.process_command("/q follow up") is True
+        assert cli._pending_input.get_nowait() == "follow up"
+
     def test_queue_mode_routes_busy_enter_to_pending(self):
         """In queue mode, Enter while busy should go to _pending_input, not _interrupt_queue."""
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -97,7 +97,7 @@ class TestResolveCommand:
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
         assert resolve_command("reset").name == "new"
-        assert resolve_command("q").name == "quit"
+        assert resolve_command("q").name == "queue"
         assert resolve_command("exit").name == "quit"
         assert resolve_command("gateway").name == "platforms"
         assert resolve_command("set-home").name == "sethome"


### PR DESCRIPTION
### Summary
Fixed a CLI dispatch bug where the `/q` alias was registered for both `queue` and `quit` commands. Due to the command registry's "last-writer-wins" behavior, `/q` was incorrectly resolving to `quit` instead of `queue`.

### Problem
When a user attempted to queue a message using `/q <message>`, the application would immediately trigger the quit command and exit, leading to potential data loss and a broken user experience.

### Changes
- **hermes_cli/commands.py**: Removed the `q` alias from the `quit` command, leaving it exclusively for `queue`.
- **cli.py**: Updated the dispatch logic to ensure compatibility with the alias change.
- **tests/cli/test_cli_init.py**: Added a regression test to verify that `/q` correctly dispatches to the queue logic.
- **tests/hermes_cli/test_commands.py**: Updated alias expectations to match the new command registry state.

### Verification
- Verified that `/q` now properly queues messages instead of exiting.
- Regression tests passed: `tests/cli/test_cli_init.py` and `tests/hermes_cli/test_commands.py` (**131 passed** in total).
