### PR TITLE
feat: drain Ockham outbox notifications via Hermes scheduler

### DIFF
--- a/cron/ockham_outbox.py
+++ b/cron/ockham_outbox.py
@@ -1,0 +1,192 @@
+"""Drain Ockham notification outbox records and deliver them via Hermes.
+
+Ockham writes structured notification records to ~/.config/ockham/outbox.db.
+Hermes owns transport and quiet-hours delivery policy.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+@dataclass
+class OckhamNotification:
+    id: str
+    type: str
+    title: str
+    body: str
+    priority: int
+    status: str
+    created_at: int
+    deliver_after: int
+    sent_at: int
+    dedup_key: str
+    coalesce_key: str
+
+
+def _default_user_config_root() -> Path:
+    if os.name == "nt":
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata)
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg)
+    return Path.home() / ".config"
+
+
+def _ockham_dir() -> Path:
+    return Path(os.getenv("OCKHAM_CONFIG_DIR", _default_user_config_root() / "ockham")).expanduser()
+
+
+def outbox_path() -> Path:
+    return Path(os.getenv("OCKHAM_OUTBOX_PATH", _ockham_dir() / "outbox.db")).expanduser()
+
+
+def config_path() -> Path:
+    return Path(os.getenv("OCKHAM_CONFIG_PATH", _ockham_dir() / "ockham.yaml")).expanduser()
+
+
+def _load_notify_config() -> dict:
+    path = config_path()
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    return data.get("notify", {}) or {}
+
+
+def _next_quiet_end(now: datetime, start: str, end: str) -> Optional[datetime]:
+    try:
+        sh, sm = map(int, start.split(":", 1))
+        eh, em = map(int, end.split(":", 1))
+    except Exception:
+        return None
+    start_min = sh * 60 + sm
+    end_min = eh * 60 + em
+    cur = now.hour * 60 + now.minute
+    overnight = start_min >= end_min
+    quiet = (cur >= start_min or cur < end_min) if overnight else (start_min <= cur < end_min)
+    if not quiet:
+        return None
+    end_dt = now.replace(hour=eh, minute=em, second=0, microsecond=0)
+    if overnight and cur >= start_min:
+        end_dt = end_dt + timedelta(days=1)
+    return end_dt
+
+
+def is_quiet_now(now: Optional[datetime] = None) -> bool:
+    notify_cfg = _load_notify_config()
+    quiet = notify_cfg.get("quiet_hours") or {}
+    start = quiet.get("start")
+    end = quiet.get("end")
+    if not start or not end:
+        return False
+    now = now or datetime.now()
+    return _next_quiet_end(now, start, end) is not None
+
+
+def should_send(notification_type: str, now: Optional[datetime] = None) -> bool:
+    if notification_type == "alert":
+        return True
+    return not is_quiet_now(now)
+
+
+def resolve_delivery_target() -> Optional[str]:
+    notify_cfg = _load_notify_config()
+    telegram_cfg = notify_cfg.get("telegram") or {}
+    if telegram_cfg.get("enabled", True) is False:
+        return None
+    chat_id = str(telegram_cfg.get("chat_id", "")).strip()
+    if chat_id:
+        return f"telegram:{chat_id}"
+    return "telegram"
+
+
+def list_ready(now_ts: Optional[int] = None) -> list[OckhamNotification]:
+    path = outbox_path()
+    if not path.exists():
+        return []
+    now_ts = int(now_ts if now_ts is not None else datetime.now().timestamp())
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, type, title, body, priority, status, created_at,
+                   deliver_after, sent_at, dedup_key, coalesce_key
+            FROM outbox
+            WHERE status = 'pending' AND deliver_after <= ?
+            ORDER BY priority DESC, created_at ASC, id ASC
+            """,
+            (now_ts,),
+        ).fetchall()
+        return [OckhamNotification(*row) for row in rows]
+    finally:
+        conn.close()
+
+
+def mark_sent(notification_id: str, sent_at: Optional[int] = None) -> None:
+    path = outbox_path()
+    if not path.exists():
+        return
+    sent_at = int(sent_at if sent_at is not None else datetime.now().timestamp())
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "UPDATE outbox SET status = 'sent', sent_at = ? WHERE id = ?",
+            (sent_at, notification_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def render_message(n: OckhamNotification) -> str:
+    title = (n.title or "").strip()
+    body = (n.body or "").strip()
+    if title and body:
+        return f"{title}\n\n{body}"
+    return title or body
+
+
+def drain(deliver_fn, now: Optional[datetime] = None) -> tuple[int, list[str]]:
+    """Deliver ready Ockham notifications.
+
+    Args:
+        deliver_fn: callable(notification, target, content) -> Optional[str]
+            Returns None on success, or an error string on failure.
+        now: optional datetime override for tests.
+
+    Returns:
+        (delivered_count, error_messages)
+    """
+    now = now or datetime.now()
+    target = resolve_delivery_target()
+    if not target:
+        return 0, []
+
+    delivered = 0
+    errors: list[str] = []
+    for n in list_ready(int(now.timestamp())):
+        if not should_send(n.type, now):
+            continue
+        content = render_message(n)
+        err = deliver_fn(n, target, content)
+        if err:
+            errors.append(err)
+            continue
+        mark_sent(n.id, int(now.timestamp()))
+        delivered += 1
+    return delivered, errors

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -810,6 +810,16 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
 
 
+def _deliver_ockham_notification(notification, target: str, content: str, adapters=None, loop=None) -> Optional[str]:
+    """Deliver an Ockham outbox notification via the existing scheduler path."""
+    pseudo_job = {
+        "id": f"ockham:{notification.id}",
+        "name": f"Ockham {notification.type}",
+        "deliver": target,
+    }
+    return _deliver_result(pseudo_job, content, adapters=adapters, loop=loop)
+
+
 def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     """
     Check and run all due jobs.
@@ -844,12 +854,11 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     try:
         due_jobs = get_due_jobs()
 
-        if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
-            return 0
-
         if verbose:
-            logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
+            if not due_jobs:
+                logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+            else:
+                logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
 
         executed = 0
         for job in due_jobs:
@@ -889,6 +898,21 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
             except Exception as e:
                 logger.error("Error processing job %s: %s", job['id'], e)
                 mark_job_run(job["id"], False, str(e))
+
+        try:
+            from cron.ockham_outbox import drain as drain_ockham_outbox
+
+            delivered, drain_errors = drain_ockham_outbox(
+                lambda notification, target, content: _deliver_ockham_notification(
+                    notification, target, content, adapters=adapters, loop=loop
+                )
+            )
+            if verbose and delivered:
+                logger.info("Delivered %d Ockham outbox notification(s)", delivered)
+            for err in drain_errors:
+                logger.warning("Ockham outbox delivery error: %s", err)
+        except Exception as e:
+            logger.debug("Ockham outbox drain error: %s", e)
 
         return executed
     finally:

--- a/tests/cron/test_ockham_outbox.py
+++ b/tests/cron/test_ockham_outbox.py
@@ -1,0 +1,96 @@
+import sqlite3
+from pathlib import Path
+
+import yaml
+
+from cron import ockham_outbox
+
+
+def _write_ockham_config(tmp_path: Path, *, chat_id="", enabled=True, start="23:00", end="07:00"):
+    cfg = {
+        "notify": {
+            "telegram": {"enabled": enabled, "chat_id": chat_id},
+            "quiet_hours": {"start": start, "end": end, "timezone": "America/New_York"},
+        }
+    }
+    path = tmp_path / "ockham.yaml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return path
+
+
+def _write_outbox(tmp_path: Path, rows):
+    path = tmp_path / "outbox.db"
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE outbox (
+                id TEXT PRIMARY KEY,
+                type TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body TEXT NOT NULL,
+                priority INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                deliver_after INTEGER NOT NULL DEFAULT 0,
+                sent_at INTEGER NOT NULL DEFAULT 0,
+                dedup_key TEXT NOT NULL DEFAULT '',
+                coalesce_key TEXT NOT NULL DEFAULT ''
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO outbox (id, type, title, body, priority, status, created_at, deliver_after, sent_at, dedup_key, coalesce_key) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def test_resolve_delivery_target_prefers_explicit_chat(monkeypatch, tmp_path):
+    cfg = _write_ockham_config(tmp_path, chat_id="12345")
+    monkeypatch.setenv("OCKHAM_CONFIG_PATH", str(cfg))
+    assert ockham_outbox.resolve_delivery_target() == "telegram:12345"
+
+
+def test_should_send_respects_quiet_hours_for_non_alert(monkeypatch, tmp_path):
+    cfg = _write_ockham_config(tmp_path, chat_id="12345")
+    monkeypatch.setenv("OCKHAM_CONFIG_PATH", str(cfg))
+    from datetime import datetime
+    quiet_time = datetime(2026, 4, 10, 23, 30)
+    assert ockham_outbox.should_send("alert", quiet_time) is True
+    assert ockham_outbox.should_send("approval", quiet_time) is False
+    assert ockham_outbox.should_send("digest", quiet_time) is False
+
+
+def test_drain_marks_sent_and_skips_quiet(monkeypatch, tmp_path):
+    cfg = _write_ockham_config(tmp_path, chat_id="12345")
+    db = _write_outbox(
+        tmp_path,
+        [
+            ("a1", "alert", "Alert", "body", 2, "pending", 100, 0, 0, "", ""),
+            ("p1", "approval", "Approval", "body", 1, "pending", 100, 0, 0, "approval:b1:2", ""),
+        ],
+    )
+    monkeypatch.setenv("OCKHAM_CONFIG_PATH", str(cfg))
+    monkeypatch.setenv("OCKHAM_OUTBOX_PATH", str(db))
+    sent = []
+
+    def deliver_fn(notification, target, content):
+        sent.append((notification.id, target, content))
+        return None
+
+    from datetime import datetime
+    delivered, errors = ockham_outbox.drain(deliver_fn, now=datetime(2026, 4, 10, 23, 30))
+    assert delivered == 1
+    assert errors == []
+    assert sent[0][0] == "a1"
+
+    conn = sqlite3.connect(db)
+    try:
+        rows = conn.execute("SELECT id, status FROM outbox ORDER BY id").fetchall()
+    finally:
+        conn.close()
+    assert rows == [("a1", "sent"), ("p1", "pending")]


### PR DESCRIPTION
## Summary
- add a small Ockham outbox reader for ~/.config/ockham/outbox.db
- drain pending Ockham notifications from the existing Hermes scheduler tick
- reuse Hermes delivery paths instead of adding a parallel sender
- add targeted tests for quiet-hours and sent-state behavior

## Behavior
- alerts are deliverable immediately
- approvals/digests remain pending during quiet hours and are delivered later
- explicit Ockham telegram chat_id is respected when configured; otherwise Hermes uses the Telegram home channel
- sent notifications are marked delivered in the Ockham outbox

## Test plan
- source venv/bin/activate
- pytest tests/cron/test_ockham_outbox.py -q
- python -m py_compile cron/ockham_outbox.py cron/scheduler.py