### PR TITLE
fix(gateway): pass source.thread_id explicitly for Telegram forum routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2464,9 +2464,10 @@ class GatewayRunner:
                                 notice = f"{notice}\n\n{session_info}"
                         except Exception:
                             pass
+                        _reset_meta = {"thread_id": source.thread_id} if source.thread_id else None
                         await adapter.send(
                             source.chat_id, notice,
-                            metadata=getattr(event, 'metadata', None),
+                            metadata=_reset_meta,
                         )
             except Exception as e:
                 logger.debug("Auto-reset notification failed (non-fatal): %s", e)
@@ -7578,8 +7579,9 @@ class GatewayRunner:
                     first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
+                            _resp_meta = {"thread_id": source.thread_id} if source.thread_id else None
                             await adapter.send(source.chat_id, first_response,
-                                               metadata=getattr(event, "metadata", None))
+                                               metadata=_resp_meta)
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                 # else: interrupted — discard the interrupted response ("Operation


### PR DESCRIPTION
## Summary

- Fix two `adapter.send()` calls that used `getattr(event, 'metadata', None)` instead of explicitly passing `source.thread_id`, causing responses to land in the wrong Telegram forum topic
- Applies the same `{"thread_id": source.thread_id} if source.thread_id else None` pattern used consistently throughout the rest of the gateway

## Details

In Telegram supergroups with Topics enabled, two code paths lost the thread context:

1. **Final response send** (~line 7581) — when delivering a response before processing a queued follow-up message
2. **Auto-reset notification** (~line 2469) — when notifying the user of an automatic session reset

Both used `getattr(event, 'metadata', None)` which doesn't carry the `thread_id` from the message source. The `event` object's metadata is not guaranteed to contain routing info, while `source.thread_id` is the authoritative value set during message ingestion.

Closes #7355

## Test plan

- [x] Gateway test suite passes (1274 passed, 1 pre-existing failure unrelated to this change)
- [x] Manual: send a message in a Telegram forum topic, verify the response stays in the same topic
- [x] Manual: trigger an auto-reset in a forum topic, verify the notification stays in the same topic

## Platform

macOS