### PR TITLE
fix(skills): support HERMES_SESSION_PLATFORM in skill disable check

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -389,6 +389,30 @@ class TestSkillView:
         assert result["success"] is False
         assert "disabled" in result["error"].lower()
 
+    def test_view_disabled_skill_blocked_for_session_platform(self, tmp_path):
+        """Gateway session platform overrides should hide disabled skills too."""
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.dict(
+                os.environ,
+                {"HERMES_SESSION_PLATFORM": "telegram"},
+                clear=False,
+            ),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "skills": {
+                        "platform_disabled": {"telegram": ["hidden-skill"]},
+                    }
+                },
+            ),
+        ):
+            _make_skill(tmp_path, "hidden-skill")
+            raw = skill_view("hidden-skill")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "disabled" in result["error"].lower()
+
     def test_view_enabled_skill_allowed(self, tmp_path):
         """Non-disabled skills should be viewable normally."""
         with (

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -507,7 +507,11 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         from hermes_cli.config import load_config
         config = load_config()
         skills_cfg = config.get("skills", {})
-        resolved_platform = platform or os.getenv("HERMES_PLATFORM")
+        resolved_platform = (
+            platform
+            or os.getenv("HERMES_PLATFORM")
+            or os.getenv("HERMES_SESSION_PLATFORM")
+        )
         if resolved_platform:
             platform_disabled = skills_cfg.get("platform_disabled", {}).get(resolved_platform)
             if platform_disabled is not None:


### PR DESCRIPTION
Summary
Gateway/session-only platform disables were not enforced when loading skills via skill_view().

A skill disabled under:

YAML
skills:
  platform_disabled:
    telegram:
      - hidden-skill
could still be loaded in gateway flows where only HERMES_SESSION_PLATFORM=telegram was set.

Root Cause
tools/skills_tool.py::_is_skill_disabled() only checked HERMES_PLATFORM when no explicit platform argument was passed. That diverged from the rest of the skill-loading path, which commonly relies on HERMES_SESSION_PLATFORM in gateway/session contexts.

Result: Per-platform disabled skills were correctly hidden in some paths, but skill_view() could still load them during gateway sessions.

Fix
Small surgical change in tools/skills_tool.py:

Keep explicit platform argument highest priority.

Fall back to HERMES_PLATFORM.

Also fall back to HERMES_SESSION_PLATFORM.

This makes skill disable resolution consistent with session/gateway behavior.

Test Plan
Added regression coverage in tests/tools/test_skills_tool.py:

New test verifies a skill disabled for telegram is blocked when only HERMES_SESSION_PLATFORM=telegram is set.

Confirmed the new test fails without the fix.

Confirmed the new test passes with the fix.

Relevant test runs:
Bash
python -m pytest tests/tools/test_skills_tool.py -q
python -m pytest tests/hermes_cli/test_skills_config.py -q
python -m pytest tests/agent/test_skill_commands.py -q
python -m pytest tests/agent/test_prompt_builder.py -q
