### PR TITLE
fix(db): isolate search context to session-local chronology

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1071,10 +1071,29 @@ class SessionDB:
             try:
                 with self._lock:
                     ctx_cursor = self._conn.execute(
-                        """SELECT role, content FROM messages
-                           WHERE session_id = ? AND id >= ? - 1 AND id <= ? + 1
-                           ORDER BY id""",
-                        (match["session_id"], match["id"], match["id"]),
+                        """WITH ordered_messages AS (
+                               SELECT
+                                   id,
+                                   role,
+                                   content,
+                                   ROW_NUMBER() OVER (
+                                       ORDER BY timestamp, id
+                                   ) AS row_num
+                               FROM messages
+                               WHERE session_id = ?
+                           ),
+                           matched_message AS (
+                               SELECT row_num
+                               FROM ordered_messages
+                               WHERE id = ?
+                           )
+                           SELECT role, content
+                           FROM ordered_messages
+                           WHERE row_num BETWEEN
+                               (SELECT row_num FROM matched_message) - 1 AND
+                               (SELECT row_num FROM matched_message) + 1
+                           ORDER BY row_num""",
+                        (match["session_id"], match["id"]),
                     )
                     context_msgs = [
                         {"role": r["role"], "content": (r["content"] or "")[:200]}

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -334,6 +334,24 @@ class TestFTS5Search:
         assert isinstance(results[0]["context"], list)
         assert len(results[0]["context"]) > 0
 
+    def test_search_context_uses_session_order_not_global_rowid(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli")
+
+        db.append_message("s1", role="user", content="before context")
+        db.append_message("s2", role="user", content="other session one")
+        db.append_message("s1", role="assistant", content="needle match")
+        db.append_message("s2", role="assistant", content="other session two")
+        db.append_message("s1", role="user", content="after context")
+
+        results = db.search_messages("needle")
+        assert len(results) == 1
+        assert [msg["content"] for msg in results[0]["context"]] == [
+            "before context",
+            "needle match",
+            "after context",
+        ]
+
     def test_search_special_chars_do_not_crash(self, db):
         """FTS5 special characters in queries must not raise OperationalError."""
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
Summary
This PR fixes a bug in SessionDB.search_messages() where search result context was retrieved using global message IDs, leading to context loss in concurrent or multi-session environments.

Problem
Previously, the context (previous/next messages) for a search match was fetched using an id ± 1 logic. Since messages.id is a global autoincrement primary key, any messages inserted from other sessions in between a session's messages would break the adjacency. This resulted in FTS summaries having missing or incorrect context, especially during concurrent usage.

Fix
Reimplemented the context retrieval logic in hermes_state.py to use session-local ordering:

Replaced global ID adjacency with a window-function-like approach using (timestamp, id) for deterministic ordering.

Context is now retrieved based on the actual chronological sequence within the specific session.

Test Plan
Added a regression test in tests/test_hermes_state.py:

Simulates two interleaved sessions.

Verifies that searching in one session returns the correct neighboring messages from the same session, ignoring the interleaved rows from the other session.