### PR TITLE
fix: auto-detect anthropic_messages api_mode for third-party /anthropic endpoints

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -39,10 +39,14 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
 
     Direct api.openai.com endpoints need the Responses API for GPT-5.x
     tool calls with reasoning (chat/completions returns 400).
+    Third-party Anthropic-compatible endpoints (URL ending in ``/anthropic``)
+    need the Anthropic Messages API — e.g. MiniMax, Zhipu GLM, LiteLLM proxies.
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
     if "api.openai.com" in normalized and "openrouter" not in normalized:
         return "codex_responses"
+    if normalized.endswith("/anthropic") or "api.anthropic.com" in normalized:
+        return "anthropic_messages"
     return None
 
 

--- a/tests/hermes_cli/test_detect_api_mode_for_url.py
+++ b/tests/hermes_cli/test_detect_api_mode_for_url.py
@@ -1,0 +1,62 @@
+"""Tests for _detect_api_mode_for_url in runtime_provider."""
+
+from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+
+# --- OpenAI / Codex Responses ---
+
+
+def test_openai_direct_returns_codex_responses():
+    assert _detect_api_mode_for_url("https://api.openai.com/v1") == "codex_responses"
+
+
+def test_openai_direct_case_insensitive():
+    assert _detect_api_mode_for_url("https://API.OPENAI.COM/v1") == "codex_responses"
+
+
+def test_openrouter_excluded():
+    """OpenRouter proxies OpenAI but uses chat_completions."""
+    assert _detect_api_mode_for_url("https://openrouter.ai/api.openai.com") is None
+
+
+# --- Anthropic-compatible endpoints ---
+
+
+def test_anthropic_direct():
+    assert _detect_api_mode_for_url("https://api.anthropic.com") == "anthropic_messages"
+
+
+def test_minimax_global_anthropic():
+    assert _detect_api_mode_for_url("https://api.minimax.io/anthropic") == "anthropic_messages"
+
+
+def test_minimax_cn_anthropic():
+    assert _detect_api_mode_for_url("https://api.minimaxi.com/anthropic") == "anthropic_messages"
+
+
+def test_zhipu_glm_anthropic():
+    assert _detect_api_mode_for_url("https://open.bigmodel.cn/api/anthropic") == "anthropic_messages"
+
+
+def test_trailing_slash_stripped():
+    assert _detect_api_mode_for_url("https://api.minimax.io/anthropic/") == "anthropic_messages"
+
+
+def test_litellm_proxy_anthropic():
+    """LiteLLM and similar proxies commonly expose /anthropic."""
+    assert _detect_api_mode_for_url("https://my-proxy.internal/anthropic") == "anthropic_messages"
+
+
+# --- Unrecognised URLs fall through ---
+
+
+def test_unknown_url_returns_none():
+    assert _detect_api_mode_for_url("https://api.together.xyz/v1") is None
+
+
+def test_empty_string_returns_none():
+    assert _detect_api_mode_for_url("") is None
+
+
+def test_none_returns_none():
+    assert _detect_api_mode_for_url(None) is None


### PR DESCRIPTION
## Problem

`_detect_api_mode_for_url()` in `runtime_provider.py` only recognises `api.openai.com` → `codex_responses`. For every other URL it returns `None`, and the caller in `_resolve_from_pool()` (line 248) defaults to `"chat_completions"`:

```python
api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions"
```

This means custom providers using **Anthropic-compatible endpoints** — MiniMax (`api.minimax.io/anthropic`), Zhipu GLM (`open.bigmodel.cn/api/anthropic`), LiteLLM proxies, etc. — are silently routed to `/chat/completions` instead of `/v1/messages`, producing empty responses or connection errors.

The parallel detection in `providers.py` (`determine_api_mode`) already handles `/anthropic` suffixes correctly, but the credential-pool path in `runtime_provider.py` bypasses it entirely.

## Fix

Add Anthropic-compatible URL detection to `_detect_api_mode_for_url()`:

- URLs ending in `/anthropic` → `anthropic_messages`
- URLs containing `api.anthropic.com` → `anthropic_messages`

This is the minimal, generic fix — no hardcoded vendor domains. Any provider whose base URL ends in `/anthropic` (the standard convention) is correctly detected.

## Testing

12 new unit tests covering OpenAI, Anthropic direct, MiniMax (global + CN), Zhipu GLM, LiteLLM proxy, trailing slashes, case sensitivity, and edge cases.

Verified end-to-end with MiniMax M2.5 and Zhipu GLM-5 via their Anthropic-compatible endpoints on a Discord gateway profile.

Closes #6209 (auto-detection side — the explicit `api_mode` selection UI proposed there is a separate enhancement).