### PR TITLE
fix(cli): force explicit utf-8 encoding for auth.json loading

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -612,7 +612,7 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     try:
-        raw = json.loads(auth_file.read_text())
+        raw = json.loads(auth_file.read_text(encoding="utf-8"))
     except Exception:
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 import pytest
 
 
@@ -76,3 +77,42 @@ def test_claude_code_oauth_token_does_not_count_as_explicit(tmp_path, monkeypatc
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("anthropic") is False
+
+
+def test_load_auth_store_reads_utf8_regardless_of_locale(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_file = hermes_home / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "anthropic",
+                "providers": {
+                    "anthropic": {
+                        "label": "kişisel",
+                    }
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    original_read_text = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        if self == auth_file and kwargs.get("encoding") != "utf-8":
+            raise UnicodeDecodeError("cp1252", b"\x81", 0, 1, "invalid start byte")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    from hermes_cli.auth import _load_auth_store
+
+    store = _load_auth_store()
+
+    assert store["active_provider"] == "anthropic"
+    assert store["providers"]["anthropic"]["label"] == "kişisel"


### PR DESCRIPTION
Summary
This PR enforces explicit UTF-8 encoding when reading auth.json, fixing a cross-platform bug where authentication stores appeared empty on certain Windows locales.

Problem
The authentication store loader in hermes_cli/auth.py relied on the system's default locale encoding for reading auth.json. Since Hermes consistently writes this file in UTF-8, any Windows environment with a non-UTF-8 default codepage would fail to decode non-ASCII labels correctly. This resulted in the auth store being silently treated as empty or corrupted, breaking the login flow for international users.

Changes
hermes_cli/auth.py: Updated the read_text() call to explicitly use encoding="utf-8".

tests/hermes_cli/test_auth_provider_gate.py: Added a regression test that simulates a non-UTF8 locale environment to verify that _load_auth_store() only succeeds with explicit UTF-8 decoding.

Verification
The new regression test confirms the failure in the previous implementation and passes with the fix.