### PR TITLE
fix(cli): handle null user names in pairing list

### DIFF
--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -28,6 +28,11 @@ def pairing_command(args):
         print("Run 'hermes pairing --help' for details.")
 
 
+def _display_cell(value) -> str:
+    """Coerce nullable display values into safe strings for table formatting."""
+    return "" if value is None else str(value)
+
+
 def _cmd_list(store):
     """List all pending and approved users."""
     pending = store.list_pending()
@@ -42,9 +47,14 @@ def _cmd_list(store):
         print(f"  {'Platform':<12} {'Code':<10} {'User ID':<20} {'Name':<20} {'Age'}")
         print(f"  {'--------':<12} {'----':<10} {'-------':<20} {'----':<20} {'---'}")
         for p in pending:
+            platform = _display_cell(p.get("platform"))
+            code = _display_cell(p.get("code"))
+            user_id = _display_cell(p.get("user_id"))
+            user_name = _display_cell(p.get("user_name"))
+            age_minutes = p.get("age_minutes", 0)
             print(
-                f"  {p['platform']:<12} {p['code']:<10} {p['user_id']:<20} "
-                f"{p.get('user_name', ''):<20} {p['age_minutes']}m ago"
+                f"  {platform:<12} {code:<10} {user_id:<20} "
+                f"{user_name:<20} {age_minutes}m ago"
             )
     else:
         print("\n  No pending pairing requests.")
@@ -54,7 +64,10 @@ def _cmd_list(store):
         print(f"  {'Platform':<12} {'User ID':<20} {'Name':<20}")
         print(f"  {'--------':<12} {'-------':<20} {'----':<20}")
         for a in approved:
-            print(f"  {a['platform']:<12} {a['user_id']:<20} {a.get('user_name', ''):<20}")
+            platform = _display_cell(a.get("platform"))
+            user_id = _display_cell(a.get("user_id"))
+            user_name = _display_cell(a.get("user_name"))
+            print(f"  {platform:<12} {user_id:<20} {user_name:<20}")
     else:
         print("\n  No approved users.")
 

--- a/tests/hermes_cli/test_pairing.py
+++ b/tests/hermes_cli/test_pairing.py
@@ -1,0 +1,35 @@
+from hermes_cli.pairing import _cmd_list
+
+
+class _FakePairingStore:
+    def list_pending(self):
+        return [
+            {
+                "platform": "telegram",
+                "code": "ABCD1234",
+                "user_id": "user-1",
+                "user_name": None,
+                "age_minutes": 5,
+            }
+        ]
+
+    def list_approved(self):
+        return [
+            {
+                "platform": "telegram",
+                "user_id": "user-2",
+                "user_name": None,
+            }
+        ]
+
+
+def test_cmd_list_handles_null_user_names(capsys):
+    _cmd_list(_FakePairingStore())
+
+    output = capsys.readouterr().out
+    assert "Pending Pairing Requests (1)" in output
+    assert "Approved Users (1)" in output
+    assert "telegram" in output
+    assert "ABCD1234" in output
+    assert "user-1" in output
+    assert "user-2" in output


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes pairing list` from crashing when pairing entries contain `user_name = None`.

Some messaging platforms can persist pairing data with missing profile fields. The CLI table formatter in `hermes_cli/pairing.py` left-aligns `user_name` directly, which raises `TypeError` when the stored value is `None`.

This change normalizes nullable display values before formatting and adds a regression test for the null-name case.

## Related Issue

Fixes #7392

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize nullable `user_name` values before rendering the pairing tables in `hermes_cli/pairing.py`
- Add a regression test in `tests/hermes_cli/test_pairing.py` covering `user_name=None` in both pending and approved entries

## How to Test

1. Run:
   ```bash
   pytest -o addopts='' tests/hermes_cli/test_pairing.py tests/gateway/test_pairing.py -q
   ```
2. Reproduce the issue with pairing data containing `user_name: null`
3. Run `hermes pairing list` and verify the table renders instead of crashing

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.12.74+deb13+1-amd64 (Debian)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted verification:
```bash
pytest -o addopts='' tests/hermes_cli/test_pairing.py tests/gateway/test_pairing.py -q
# 29 passed
```
