### PR TITLE
fix(matrix): bootstrap E2EE sessions for fresh bot devices

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -168,6 +168,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # Buffer for undecrypted events pending key receipt.
         # Each entry: (room, event, timestamp)
         self._pending_megolm: list = []
+        self._e2ee_bootstrap_complete = False
 
         # Thread participation tracking (for require_mention bypass)
         self._bot_participated_threads: set = self._load_participated_threads()
@@ -821,6 +822,98 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.warning("Matrix: sync error: %s — retrying in 5s", exc)
                 await asyncio.sleep(5)
 
+    def _get_encrypted_room_ids(self) -> list[str]:
+        """Return joined encrypted room IDs known to the client."""
+        client = self._client
+        if not client:
+            return []
+
+        rooms = getattr(client, "rooms", {}) or {}
+        encrypted: list[str] = []
+        for room_id, room in rooms.items():
+            if getattr(room, "encrypted", False):
+                encrypted.append(room_id)
+        return encrypted
+
+    async def _bootstrap_e2ee_rooms(self) -> bool:
+        """Ensure encrypted room membership is synced at least once.
+
+        matrix-nio's key-query / key-claim flags are downstream of room/member
+        state. On a fresh bot device, we may know about an encrypted room but
+        still not have fully synced members, device keys, or claimable missing
+        sessions. A one-time joined_members bootstrap helps seed that state.
+
+        Returns True if all encrypted rooms are now members-synced (or there
+        were no encrypted rooms), False if any bootstrap request failed.
+        """
+        client = self._client
+        if not client:
+            return False
+
+        encrypted_room_ids = self._get_encrypted_room_ids()
+        if not encrypted_room_ids:
+            return True
+
+        all_synced = True
+        for room_id in encrypted_room_ids:
+            room = getattr(client, "rooms", {}).get(room_id)
+            if room is None:
+                continue
+            if getattr(room, "members_synced", False):
+                continue
+            try:
+                await client.joined_members(room_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Matrix: failed to sync joined members for encrypted room %s: %s",
+                    room_id,
+                    exc,
+                )
+                all_synced = False
+                continue
+
+            # Test doubles may not mutate room.members_synced automatically.
+            if not getattr(room, "members_synced", False):
+                try:
+                    room.members_synced = True
+                except Exception:
+                    pass
+
+        return all_synced
+
+    def _get_missing_session_claims(self) -> dict[str, list[str]]:
+        """Collect missing Olm sessions across encrypted rooms."""
+        client = self._client
+        if not client:
+            return {}
+
+        claims: dict[str, list[str]] = {}
+        for room_id in self._get_encrypted_room_ids():
+            room = getattr(client, "rooms", {}).get(room_id)
+            if room is None or not getattr(room, "members_synced", False):
+                continue
+            try:
+                missing = client.get_missing_sessions(room_id)
+            except Exception as exc:
+                logger.debug(
+                    "Matrix: could not compute missing sessions for %s: %s",
+                    room_id,
+                    exc,
+                )
+                continue
+
+            for user_id, device_ids in (missing or {}).items():
+                if not device_ids:
+                    continue
+                bucket = claims.setdefault(user_id, [])
+                for device_id in device_ids:
+                    if device_id not in bucket:
+                        bucket.append(device_id)
+
+        return claims
+
     async def _run_e2ee_maintenance(self) -> None:
         """Run matrix-nio E2EE housekeeping between syncs.
 
@@ -835,20 +928,15 @@ class MatrixAdapter(BasePlatformAdapter):
         if not client or not self._encryption or not getattr(client, "olm", None):
             return
 
-        did_query_keys = client.should_query_keys
-
         tasks = [asyncio.create_task(client.send_to_device_messages())]
 
         if client.should_upload_keys:
             tasks.append(asyncio.create_task(client.keys_upload()))
-
-        if did_query_keys:
-            tasks.append(asyncio.create_task(client.keys_query()))
-
-        if client.should_claim_keys:
-            users = client.get_users_for_key_claiming()
-            if users:
-                tasks.append(asyncio.create_task(client.keys_claim(users)))
+        bootstrap_requested = (not self._e2ee_bootstrap_complete) or bool(self._pending_megolm)
+        if bootstrap_requested:
+            bootstrap_ok = await self._bootstrap_e2ee_rooms()
+            if bootstrap_ok:
+                self._e2ee_bootstrap_complete = True
 
         for task in asyncio.as_completed(tasks):
             try:
@@ -857,6 +945,33 @@ class MatrixAdapter(BasePlatformAdapter):
                 raise
             except Exception as exc:
                 logger.warning("Matrix: E2EE maintenance task failed: %s", exc)
+
+        did_query_keys = bool(client.should_query_keys)
+        if did_query_keys:
+            try:
+                await client.keys_query()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Matrix: E2EE key query failed: %s", exc)
+                did_query_keys = False
+
+        claim_users: dict[str, list[str]] = {}
+        if client.should_claim_keys:
+            try:
+                claim_users = client.get_users_for_key_claiming()
+            except Exception as exc:
+                logger.warning("Matrix: E2EE key-claim planning failed: %s", exc)
+        elif bootstrap_requested or did_query_keys or self._pending_megolm:
+            claim_users = self._get_missing_session_claims()
+
+        if claim_users:
+            try:
+                await client.keys_claim(claim_users)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Matrix: E2EE key claim failed: %s", exc)
 
         # After key queries, auto-trust all devices so senders share keys with
         # us.  For a bot this is the right default — we want to decrypt

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -980,6 +980,83 @@ class TestMatrixE2EEMaintenance:
             {"@alice:example.org": ["DEVICE1"]}
         )
 
+    @pytest.mark.asyncio
+    async def test_maintenance_bootstraps_encrypted_room_members_before_key_work(self):
+        adapter = _make_adapter()
+        adapter._encryption = True
+
+        encrypted_room = MagicMock()
+        encrypted_room.encrypted = True
+        encrypted_room.members_synced = False
+
+        fake_client = MagicMock()
+        fake_client.olm = object()
+        fake_client.rooms = {"!room:example.org": encrypted_room}
+        fake_client.send_to_device_messages = AsyncMock(return_value=[])
+        fake_client.keys_upload = AsyncMock()
+        fake_client.keys_query = AsyncMock()
+        fake_client.keys_claim = AsyncMock()
+        fake_client.should_upload_keys = False
+        fake_client.should_query_keys = False
+        fake_client.should_claim_keys = False
+        fake_client.get_users_for_key_claiming = MagicMock(return_value={})
+        fake_client.get_missing_sessions = MagicMock(return_value={})
+
+        async def _joined_members(room_id):
+            assert room_id == "!room:example.org"
+            encrypted_room.members_synced = True
+            fake_client.should_query_keys = True
+            return MagicMock()
+
+        fake_client.joined_members = AsyncMock(side_effect=_joined_members)
+        adapter._client = fake_client
+        adapter._auto_trust_devices = MagicMock()
+
+        await adapter._run_e2ee_maintenance()
+
+        fake_client.joined_members.assert_awaited_once_with("!room:example.org")
+        fake_client.keys_query.assert_awaited_once()
+        adapter._auto_trust_devices.assert_called_once()
+        assert adapter._e2ee_bootstrap_complete is True
+
+    @pytest.mark.asyncio
+    async def test_maintenance_claims_missing_sessions_even_when_should_claim_false(self):
+        adapter = _make_adapter()
+        adapter._encryption = True
+        adapter._e2ee_bootstrap_complete = True
+
+        encrypted_room = MagicMock()
+        encrypted_room.encrypted = True
+        encrypted_room.members_synced = True
+
+        fake_client = MagicMock()
+        fake_client.olm = object()
+        fake_client.rooms = {"!room:example.org": encrypted_room}
+        fake_client.send_to_device_messages = AsyncMock(return_value=[])
+        fake_client.keys_upload = AsyncMock()
+        fake_client.keys_query = AsyncMock()
+        fake_client.keys_claim = AsyncMock()
+        fake_client.should_upload_keys = False
+        fake_client.should_query_keys = False
+        fake_client.should_claim_keys = False
+        fake_client.get_users_for_key_claiming = MagicMock(return_value={})
+        fake_client.get_missing_sessions = MagicMock(
+            return_value={"@alice:example.org": ["DEVICE1", "DEVICE2"]}
+        )
+        fake_client.joined_members = AsyncMock()
+
+        adapter._client = fake_client
+        adapter._pending_megolm = [(MagicMock(), MagicMock(), 0.0)]
+        adapter._retry_pending_decryptions = AsyncMock()
+
+        await adapter._run_e2ee_maintenance()
+
+        fake_client.get_missing_sessions.assert_called_once_with("!room:example.org")
+        fake_client.keys_claim.assert_awaited_once_with(
+            {"@alice:example.org": ["DEVICE1", "DEVICE2"]}
+        )
+        adapter._retry_pending_decryptions.assert_awaited_once()
+
 
 class TestMatrixEncryptedSendFallback:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Bootstraps Matrix E2EE for fresh bot devices by syncing members in encrypted rooms before relying only on nio's key-maintenance flags. After that bootstrap, Hermes computes missing Olm sessions across encrypted rooms and claims keys when startup or pending undecryptable events indicate the bot is stuck.

This targets the startup path where a fresh encrypted bot device can keep receiving undecryptable Megolm events without ever establishing the sessions needed to receive forwarded room keys.

## Related Issue

N/A yet. This came out of a Matrix E2EE support report.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- updated gateway/platforms/matrix.py to bootstrap encrypted room membership before relying solely on should_query_keys / should_claim_keys
- added missing-session claim collection across encrypted rooms so Hermes can claim Olm sessions even when nio's internal claim flag has not flipped yet
- kept the existing pending Megolm retry path and wired the new bootstrap/claim flow into it
- added regression tests in tests/gateway/test_matrix.py for fresh-room bootstrap and missing-session claim behavior

## How to Test

1. source venv/bin/activate
2. python -m pytest tests/gateway/test_matrix.py -q
3. If you have a live Matrix E2EE setup, start Hermes with a fresh bot device in an encrypted room and verify it can bootstrap decryption instead of only buffering undecryptable Megolm events

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

- python -m pytest tests/gateway/test_matrix.py -q
- 125 passed in 2.43s

Manual exercise note:

- I have not exercised this against a live Matrix homeserver / E2EE room myself
- this is code-reviewed and unit-tested, but not manually end-to-end validated on Matrix

