### PR TITLE
fix(gateway): add missing platforms to channel directory session discovery

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -76,8 +76,9 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
-    # Telegram, WhatsApp & Signal can't enumerate chats -- pull from session history
-    for plat_name in ("telegram", "whatsapp", "signal", "email", "sms", "bluebubbles"):
+    # These platforms can't enumerate chats directly -- pull from session history
+    for plat_name in ("telegram", "whatsapp", "signal", "email", "sms", "bluebubbles",
+                      "matrix", "mattermost", "dingtalk", "feishu", "wecom", "homeassistant"):
         if plat_name not in platforms:
             platforms[plat_name] = _build_from_sessions(plat_name)
 


### PR DESCRIPTION
## What does this PR do?

Six platforms were missing from the session-based channel discovery list in `gateway/channel_directory.py`. These platforms cannot enumerate chats directly and need the same session-history fallback as the other platforms.

## Type of Change
- [x] Bug fix

## Changes Made
- Added `matrix`, `mattermost`, `dingtalk`, `feishu`, `wecom`, and `homeassistant` to the session-based discovery tuple
- Updated the comment to be generic rather than listing specific platform names

## Root Cause
The original list only included `telegram`, `whatsapp`, `signal`, `email`, `sms`, and `bluebubbles`. When new platforms were added to the gateway, the channel directory was not updated to include them, so `/channels` and the send_message tool would return empty results for those platforms.

## How to Test
```bash
# Configure any of the missing platforms (e.g. matrix, mattermost)
# Run: hermes gateway
# Ask the agent: 'what channels do you have access to?'
# The agent should now list sessions from those platforms
```

## Checklist
- [x] Only touches the affected list and comment
- [x] No new dependencies
- [x] Consistent with how other platforms are handled