### PR TITLE
fix(opencode-zen): preserve dotted model ids

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -8,8 +8,9 @@ Different LLM providers expect model identifiers in different formats:
   hyphens: ``claude-sonnet-4-6``.
 - **Copilot** expects bare names *with* dots preserved:
   ``claude-sonnet-4.6``.
-- **OpenCode Zen** follows the same dot-to-hyphen convention as
-  Anthropic: ``claude-sonnet-4-6``.
+- **OpenCode Zen** uses provider-native model IDs. Claude models use
+  hyphens like ``claude-sonnet-4-6``; other Zen models preserve dots
+  like ``minimax-m2.5-free``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
 - **DeepSeek** only accepts two model identifiers:
   ``deepseek-chat`` and ``deepseek-reasoner``.
@@ -67,7 +68,6 @@ _AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
 # Providers that want bare names with dots replaced by hyphens.
 _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
     "anthropic",
-    "opencode-zen",
 })
 
 # Providers that want bare names with dots preserved.
@@ -328,6 +328,9 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         >>> normalize_model_for_provider("claude-sonnet-4.6", "opencode-zen")
         'claude-sonnet-4-6'
 
+        >>> normalize_model_for_provider("minimax-m2.5-free", "opencode-zen")
+        'minimax-m2.5-free'
+
         >>> normalize_model_for_provider("deepseek-v3", "deepseek")
         'deepseek-chat'
 
@@ -350,12 +353,21 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     if provider in _AGGREGATOR_PROVIDERS:
         return _prepend_vendor(name)
 
-    # --- Anthropic / OpenCode: strip matching provider prefix, dots -> hyphens ---
+    # --- Anthropic: strip matching provider prefix, dots -> hyphens ---
     if provider in _DOT_TO_HYPHEN_PROVIDERS:
         bare = _strip_matching_provider_prefix(name, provider)
         if "/" in bare:
             return bare
         return _dots_to_hyphens(bare)
+
+    # --- OpenCode Zen: Claude uses Anthropic-style ids; other models preserve dots ---
+    if provider == "opencode-zen":
+        bare = _strip_matching_provider_prefix(name, provider)
+        if "/" in bare:
+            return bare
+        if bare.lower().startswith("claude-"):
+            return _dots_to_hyphens(bare)
+        return bare
 
     # --- Copilot: strip matching provider prefix, keep dots ---
     if provider in _STRIP_VENDOR_ONLY_PROVIDERS:
@@ -383,4 +395,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -54,12 +54,16 @@ class TestAnthropicDotToHyphen:
 
 # ── OpenCode Zen regression ────────────────────────────────────────────
 
-class TestOpenCodeZenDotToHyphen:
-    """OpenCode Zen follows Anthropic convention (dots→hyphens)."""
+class TestOpenCodeZenNormalization:
+    """OpenCode Zen preserves native ids except for Claude-style names."""
 
     @pytest.mark.parametrize("model,expected", [
         ("claude-sonnet-4.6", "claude-sonnet-4-6"),
-        ("glm-4.5", "glm-4-5"),
+        ("minimax-m2.5", "minimax-m2.5"),
+        ("minimax-m2.5-free", "minimax-m2.5-free"),
+        ("gpt-5.4", "gpt-5.4"),
+        ("gemini-3.1-pro", "gemini-3.1-pro"),
+        ("glm-4.5", "glm-4.5"),
     ])
     def test_zen_converts_dots(self, model, expected):
         result = normalize_model_for_provider(model, "opencode-zen")
@@ -68,6 +72,10 @@ class TestOpenCodeZenDotToHyphen:
     def test_zen_strips_vendor_prefix(self):
         result = normalize_model_for_provider("opencode-zen/claude-sonnet-4.6", "opencode-zen")
         assert result == "claude-sonnet-4-6"
+
+    def test_zen_strips_vendor_prefix_for_non_claude_models(self):
+        result = normalize_model_for_provider("opencode-zen/minimax-m2.5-free", "opencode-zen")
+        assert result == "minimax-m2.5-free"
 
 
 # ── Copilot dot preservation (regression) ──────────────────────────────


### PR DESCRIPTION
 ## Summary

  Fix #7421 
  
  OpenCode Zen model normalization so Hermes preserves dotted model IDs for non-Claude models.

  Previously, Hermes treated `opencode-zen` like Anthropic and replaced `.` with `-` for all model names. That broke valid Zen model IDs such as `minimax-m2.5-free`, which were being sent as `minimax-m2-
  5-free`.

  ## What changed

  - removed `opencode-zen` from the global dot-to-hyphen provider set
  - added provider-specific normalization for OpenCode Zen
  - kept Anthropic-style normalization only for Zen `claude-*` models
  - preserved dotted IDs for other Zen models such as:
    - `minimax-m2.5`
    - `minimax-m2.5-free`
    - `gpt-5.4`
    - `gemini-3.1-pro`
    - `glm-4.5`

  ## Why

  OpenCode Zen uses mixed native model IDs:
  - Claude models use hyphenated Anthropic-style IDs such as `claude-sonnet-4-6`
  - other Zen models use dotted IDs such as `minimax-m2.5-free`

  Applying a blanket dot-to-hyphen transformation to all Zen models caused invalid API requests.

  ## Tests

  Updated OpenCode Zen normalization tests and added regression coverage for dotted non-Claude Zen model IDs.

  Verified locally:
  - `python3 -m pytest tests/hermes_cli/test_model_normalize.py -q`
  - `python3 -m pytest tests/hermes_cli/test_model_validation.py -q`

  ## Example

  Before:
  - `minimax-m2.5-free` -> `minimax-m2-5-free`

  After:
  - `minimax-m2.5-free` -> `minimax-m2.5-free`
  - `claude-sonnet-4.6` -> `claude-sonnet-4-6`
