### PR TITLE
fix(cli): handle None values in `hermes pairing list` table formatting

### DIFF
--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -42,9 +42,14 @@ def _cmd_list(store):
         print(f"  {'Platform':<12} {'Code':<10} {'User ID':<20} {'Name':<20} {'Age'}")
         print(f"  {'--------':<12} {'----':<10} {'-------':<20} {'----':<20} {'---'}")
         for p in pending:
+            platform = str(p.get('platform') or '')
+            code = str(p.get('code') or '')
+            user_id = str(p.get('user_id') or '')
+            user_name = str(p.get('user_name') or '')
+            age = p.get('age_minutes', 0)
             print(
-                f"  {p['platform']:<12} {p['code']:<10} {p['user_id']:<20} "
-                f"{p.get('user_name', ''):<20} {p['age_minutes']}m ago"
+                f"  {platform:<12} {code:<10} {user_id:<20} "
+                f"{user_name:<20} {age}m ago"
             )
     else:
         print("\n  No pending pairing requests.")
@@ -54,7 +59,10 @@ def _cmd_list(store):
         print(f"  {'Platform':<12} {'User ID':<20} {'Name':<20}")
         print(f"  {'--------':<12} {'-------':<20} {'----':<20}")
         for a in approved:
-            print(f"  {a['platform']:<12} {a['user_id']:<20} {a.get('user_name', ''):<20}")
+            platform = str(a.get('platform') or '')
+            user_id = str(a.get('user_id') or '')
+            user_name = str(a.get('user_name') or '')
+            print(f"  {platform:<12} {user_id:<20} {user_name:<20}")
     else:
         print("\n  No approved users.")
 

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -354,3 +354,58 @@ class TestListAndClear:
             store.generate_code("discord", "user2")
             count = store.clear_pending()
         assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Regression: None values in _cmd_list (#7392)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdListNoneValues:
+    """Regression: hermes pairing list must not crash when fields are None (#7392)."""
+
+    def test_pending_with_none_user_name(self, tmp_path, capsys):
+        """user_name=None should not raise TypeError."""
+        from unittest.mock import patch
+        from hermes_cli.pairing import _cmd_list
+
+        store = _make_store(tmp_path)
+        # Inject a pending entry with None user_name
+        store._pending = {"telegram": {
+            "ABCD": {"user_id": "123", "user_name": None, "age_minutes": 5}
+        }}
+        with patch.object(store, "list_pending", return_value=[
+            {"platform": "telegram", "code": "ABCD", "user_id": "123",
+             "user_name": None, "age_minutes": 5}
+        ]), patch.object(store, "list_approved", return_value=[]):
+            _cmd_list(store)
+        out = capsys.readouterr().out
+        assert "ABCD" in out
+        assert "123" in out
+
+    def test_approved_with_none_user_name(self, tmp_path, capsys):
+        """Approved user with user_name=None should not crash."""
+        from unittest.mock import patch
+        from hermes_cli.pairing import _cmd_list
+
+        store = _make_store(tmp_path)
+        with patch.object(store, "list_pending", return_value=[]), \
+             patch.object(store, "list_approved", return_value=[
+                 {"platform": "discord", "user_id": "456", "user_name": None}
+             ]):
+            _cmd_list(store)
+        out = capsys.readouterr().out
+        assert "456" in out
+
+    def test_pending_with_none_platform(self, tmp_path, capsys):
+        """All fields as None should not crash."""
+        from unittest.mock import patch
+        from hermes_cli.pairing import _cmd_list
+
+        store = _make_store(tmp_path)
+        with patch.object(store, "list_pending", return_value=[
+            {"platform": None, "code": None, "user_id": None,
+             "user_name": None, "age_minutes": 0}
+        ]), patch.object(store, "list_approved", return_value=[]):
+            _cmd_list(store)
+        # Should not crash


### PR DESCRIPTION
## Description

When a user with no display name messages the gateway bot, their `user_name` is stored as `None`. The f-string format specifier `{None:<20}` raises `TypeError`. This converts all fields through `str(x or '')` before formatting.

Related issue: #7392

## Type of Change
- [x] Bug fix

## Changes Made
- `hermes_cli/pairing.py`: Convert all table fields via `str(get(...) or '')` before f-string formatting in `_cmd_list()`

## How to Test
1. Create a pending pairing entry with `user_name=None`
2. Run `hermes pairing list`
3. Should display without crashing

## Checklist
- [x] All tests pass
- [x] Follows Conventional Commits
- [x] Tests added for this bug fix

Closes #7392