### PR TITLE
fix(agent): validate LLM response shape in auxiliary call_llm/async_call_llm

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2069,15 +2069,24 @@ def call_llm(
         base_url=resolved_base_url)
 
     # Handle max_tokens vs max_completion_tokens retry, then payment fallback.
+    def _validate_response(resp):
+        """Fail fast if a provider returns a non-standard payload."""
+        if not getattr(resp, "choices", None):
+            raise TypeError(
+                f"LLM response has no 'choices' attribute (got {type(resp).__name__}). "
+                f"The provider may have returned an error page or malformed payload."
+            )
+        return resp
+
     try:
-        return client.chat.completions.create(**kwargs)
+        return _validate_response(client.chat.completions.create(**kwargs))
     except Exception as first_err:
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)
             kwargs["max_completion_tokens"] = max_tokens
             try:
-                return client.chat.completions.create(**kwargs)
+                return _validate_response(client.chat.completions.create(**kwargs))
             except Exception as retry_err:
                 # If the max_tokens retry also hits a payment error,
                 # fall through to the payment fallback below.
@@ -2110,7 +2119,7 @@ def call_llm(
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
                     extra_body=extra_body)
-                return fb_client.chat.completions.create(**fb_kwargs)
+                return _validate_response(fb_client.chat.completions.create(**fb_kwargs))
         raise
 
 
@@ -2130,6 +2139,9 @@ def extract_content_or_reasoning(response) -> str:
     Returns the best available text, or ``""`` if nothing found.
     """
     import re
+
+    if not getattr(response, "choices", None):
+        return ""
 
     msg = response.choices[0].message
     content = (msg.content or "").strip()
@@ -2250,12 +2262,21 @@ async def async_call_llm(
         tools=tools, timeout=effective_timeout, extra_body=extra_body,
         base_url=resolved_base_url)
 
+    def _validate_async_response(resp):
+        """Fail fast if a provider returns a non-standard payload."""
+        if not getattr(resp, "choices", None):
+            raise TypeError(
+                f"LLM response has no 'choices' attribute (got {type(resp).__name__}). "
+                f"The provider may have returned an error page or malformed payload."
+            )
+        return resp
+
     try:
-        return await client.chat.completions.create(**kwargs)
+        return _validate_async_response(await client.chat.completions.create(**kwargs))
     except Exception as first_err:
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)
             kwargs["max_completion_tokens"] = max_tokens
-            return await client.chat.completions.create(**kwargs)
+            return _validate_async_response(await client.chat.completions.create(**kwargs))
         raise

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1153,3 +1153,45 @@ def test_resolve_api_key_provider_skips_unconfigured_anthropic(monkeypatch):
 
     assert "anthropic" not in called, \
         "_try_anthropic() should not be called when anthropic is not explicitly configured"
+
+
+# ---------------------------------------------------------------------------
+# Regression: response validation (#7264)
+# ---------------------------------------------------------------------------
+
+
+class TestResponseValidation:
+    """Regression: call_llm/async_call_llm must reject non-OpenAI payloads (#7264)."""
+
+    def test_call_llm_rejects_string_response(self, monkeypatch):
+        """call_llm raises TypeError when provider returns a bare string."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = "not-a-response-object"
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *a, **k: ("custom", "test-model", "http://localhost/v1", "key"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *a, **k: (mock_client, "test-model"),
+        )
+
+        with pytest.raises(TypeError, match="no 'choices' attribute"):
+            call_llm(task="test", messages=[{"role": "user", "content": "hi"}])
+
+    def test_extract_content_or_reasoning_handles_bad_response(self):
+        """extract_content_or_reasoning returns '' on non-OpenAI response."""
+        from agent.auxiliary_client import extract_content_or_reasoning
+
+        assert extract_content_or_reasoning("bare string") == ""
+        assert extract_content_or_reasoning(None) == ""
+        assert extract_content_or_reasoning(42) == ""
+
+    def test_extract_content_or_reasoning_handles_empty_choices(self):
+        """extract_content_or_reasoning returns '' when choices is empty."""
+        from agent.auxiliary_client import extract_content_or_reasoning
+        from types import SimpleNamespace
+
+        response = SimpleNamespace(choices=[])
+        assert extract_content_or_reasoning(response) == ""


### PR DESCRIPTION
## Description

Add response validation before returning from `call_llm()` and `async_call_llm()` to fail fast with a clear `TypeError` when a provider returns a non-OpenAI-compliant payload (bare string, dict, HTML error page). Also adds a guard in `extract_content_or_reasoning()` so it returns `""` instead of crashing on malformed responses.

Previously, invalid payloads propagated silently and crashed downstream callers with misleading `'str' object has no attribute 'choices'`.

Related issue: #7264

## Type of Change
- [x] Bug fix

## Changes Made
- `agent/auxiliary_client.py`: Added `_validate_response()` / `_validate_async_response()` helpers that raise `TypeError` on malformed payloads. Added guard in `extract_content_or_reasoning()`.

## How to Test
1. Configure a custom provider that returns non-OpenAI payloads
2. Trigger a `session_search` or auxiliary call
3. Should get clear `TypeError` instead of downstream `AttributeError`

## Checklist
- [x] All tests pass
- [x] Follows Conventional Commits
- [x] Tests added for this bug fix

Closes #7264