### PR TITLE
fix(gateway): strip cursor from frozen message when fallback continuation is empty

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -328,6 +328,25 @@ class GatewayStreamConsumer:
         self._fallback_final_send = False
         if not continuation.strip():
             # Nothing new to send — the visible partial already matches final text.
+            # However, the last edit may still show the cursor character.  Try
+            # one final edit to strip it so the message doesn't freeze with "▉".
+            if (
+                self._message_id
+                and self._last_sent_text
+                and self.cfg.cursor
+                and self._last_sent_text.endswith(self.cfg.cursor)
+            ):
+                clean_text = self._last_sent_text[:-len(self.cfg.cursor)]
+                try:
+                    result = await self.adapter.edit_message(
+                        chat_id=self.chat_id,
+                        message_id=self._message_id,
+                        content=clean_text,
+                    )
+                    if result.success:
+                        self._last_sent_text = clean_text
+                except Exception:
+                    pass
             self._already_sent = True
             return
 

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -505,3 +505,72 @@ class TestSegmentBreakOnToolBoundary:
         assert len(sent_texts) == 3
         assert sent_texts[0].startswith(prefix)
         assert sum(len(t) for t in sent_texts[1:]) == len(tail)
+
+
+# ── Cursor stripping on fallback (#7183) ───────────────────────────────────
+
+
+class TestCursorStrippingOnFallback:
+    """Regression: cursor must be stripped when fallback continuation is empty (#7183)."""
+
+    @pytest.mark.asyncio
+    async def test_cursor_stripped_when_continuation_empty(self):
+        """When _send_fallback_final has nothing new to send, it should edit to remove cursor."""
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg-1")
+        )
+
+        consumer = GatewayStreamConsumer(adapter, "chat-1",
+            config=StreamConsumerConfig(cursor=" ▉"))
+        consumer._message_id = "msg-1"
+        consumer._last_sent_text = "Hello world ▉"
+        consumer._fallback_final_send = False
+
+        await consumer._send_fallback_final("Hello world")
+
+        # Should have attempted to edit the message to strip cursor
+        adapter.edit_message.assert_called_once()
+        call_args = adapter.edit_message.call_args
+        assert call_args.kwargs.get("content", call_args[1].get("content", "")) == "Hello world"
+        assert consumer._already_sent is True
+
+    @pytest.mark.asyncio
+    async def test_cursor_not_stripped_when_no_cursor_configured(self):
+        """No edit attempted when cursor is not configured."""
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat-1",
+            config=StreamConsumerConfig(cursor=""))
+        consumer._message_id = "msg-1"
+        consumer._last_sent_text = "Hello world"
+        consumer._fallback_final_send = False
+
+        await consumer._send_fallback_final("Hello world")
+
+        adapter.edit_message = AsyncMock()
+        assert consumer._already_sent is True
+
+    @pytest.mark.asyncio
+    async def test_cursor_strip_edit_failure_handled(self):
+        """If cursor-stripping edit fails, it should not crash."""
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="flood_control")
+        )
+
+        consumer = GatewayStreamConsumer(adapter, "chat-1",
+            config=StreamConsumerConfig(cursor=" ▉"))
+        consumer._message_id = "msg-1"
+        consumer._last_sent_text = "Hello ▉"
+        consumer._fallback_final_send = False
+
+        await consumer._send_fallback_final("Hello")
+
+        # Should still set already_sent despite edit failure
+        assert consumer._already_sent is True
+        # last_sent_text should NOT be updated on failure
+        assert consumer._last_sent_text == "Hello ▉"


### PR DESCRIPTION
## Description

When the final cursor-removal edit fails (e.g. Telegram flood control), the stream consumer enters the fallback path. If the continuation text is empty (all content already visible), the fallback returns early without removing the cursor character, leaving the message permanently frozen with "▉".

Adds a cursor-stripping edit attempt before the early return so the visible message is cleaned up even when no new content needs sending.

Related issue: #7183

## Type of Change
- [x] Bug fix

## Changes Made
- `gateway/stream_consumer.py`: In `_send_fallback_final()`, attempt to edit the message to strip the cursor before returning early on empty continuation.

## How to Test
1. Run Hermes gateway on Telegram with streaming enabled
2. Send a message that triggers a tool call followed by a short response
3. If Telegram flood control hits the final edit, the message should no longer freeze with "▉"

## Checklist
- [x] All tests pass
- [x] Follows Conventional Commits
- [x] Tests added for this bug fix

Closes #7183