### PR TITLE
fix(cli): sync CLI model/provider from agent after fallback activation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11762,6 +11762,19 @@ class HermesCLI:
                 self.session_id = self.agent.session_id
                 self._pending_title = None
 
+            # Sync CLI-visible model/provider from agent state.  The agent's
+            # _try_activate_fallback() may have switched to a fallback model
+            # during this turn; propagate that back so /model, session headers,
+            # and any non-status-bar displays show the actually active model.
+            agent = getattr(self, "agent", None)
+            if agent is not None:
+                _active_model = getattr(agent, "model", None)
+                _active_provider = getattr(agent, "provider", None)
+                if _active_model and _active_model != self.model:
+                    self.model = _active_model
+                if _active_provider and _active_provider != getattr(self, "provider", None):
+                    self.provider = _active_provider
+
             # Get the final response
             response = result.get("final_response", "") if result else ""
 

--- a/cli.py
+++ b/cli.py
@@ -7218,6 +7218,19 @@ class HermesCLI:
             # Update history with full conversation
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
+            # Sync CLI-visible model/provider from agent state.  The agent's
+            # _try_activate_fallback() may have switched to a fallback model
+            # during this turn; propagate that back so /model, session headers,
+            # and any non-status-bar displays show the actually active model.
+            agent = getattr(self, "agent", None)
+            if agent is not None:
+                _active_model = getattr(agent, "model", None)
+                _active_provider = getattr(agent, "provider", None)
+                if _active_model and _active_model != self.model:
+                    self.model = _active_model
+                if _active_provider and _active_provider != getattr(self, "provider", None):
+                    self.provider = _active_provider
+
             # Get the final response
             response = result.get("final_response", "") if result else ""
 

--- a/tests/cli/test_cli_model_sync.py
+++ b/tests/cli/test_cli_model_sync.py
@@ -1,0 +1,68 @@
+"""Test that CLI syncs model/provider from agent after fallback activation (#7385)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def test_cli_model_synced_after_fallback():
+    """After run_conversation, CLI.model should reflect agent's active model."""
+    # Simulate the post-conversation sync logic directly
+    # (testing the logic, not the full CLI)
+    class FakeCLI:
+        model = "original-model"
+        provider = "original-provider"
+        agent = SimpleNamespace(model="fallback-model", provider="fallback-provider")
+
+    cli = FakeCLI()
+
+    # This is the sync logic from the fix
+    agent = getattr(cli, "agent", None)
+    if agent is not None:
+        _active_model = getattr(agent, "model", None)
+        _active_provider = getattr(agent, "provider", None)
+        if _active_model and _active_model != cli.model:
+            cli.model = _active_model
+        if _active_provider and _active_provider != getattr(cli, "provider", None):
+            cli.provider = _active_provider
+
+    assert cli.model == "fallback-model"
+    assert cli.provider == "fallback-provider"
+
+
+def test_cli_model_not_synced_when_same():
+    """If agent model matches CLI model, no sync occurs."""
+    class FakeCLI:
+        model = "same-model"
+        provider = "same-provider"
+        agent = SimpleNamespace(model="same-model", provider="same-provider")
+
+    cli = FakeCLI()
+
+    agent = getattr(cli, "agent", None)
+    if agent is not None:
+        _active_model = getattr(agent, "model", None)
+        _active_provider = getattr(agent, "provider", None)
+        if _active_model and _active_model != cli.model:
+            cli.model = _active_model
+        if _active_provider and _active_provider != getattr(cli, "provider", None):
+            cli.provider = _active_provider
+
+    assert cli.model == "same-model"
+
+
+def test_cli_model_sync_handles_no_agent():
+    """No crash when agent is None."""
+    class FakeCLI:
+        model = "orig"
+        provider = "orig"
+        agent = None
+
+    cli = FakeCLI()
+
+    agent = getattr(cli, "agent", None)
+    if agent is not None:
+        _active_model = getattr(agent, "model", None)
+        if _active_model and _active_model != cli.model:
+            cli.model = _active_model
+
+    assert cli.model == "orig"


### PR DESCRIPTION
## What does this PR do?

After `run_conversation()` returns, the agent's model and provider may have changed due to `_try_activate_fallback()`. The status bar already reads `agent.model`, but `self.model` (used by `/model` display, session headers, etc.) was never updated. This syncs both fields back from the agent after each conversation turn.

## Related Issue

Closes #7385

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: After `run_conversation()` completes, sync `self.model` and `self.provider` from `self.agent` when they differ.

## How to Test

1. Configure a primary model and a fallback model.
2. Exhaust or rate-limit the primary provider.
3. After fallback activates, check that `/model` and session headers show the fallback model.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
