### PR TITLE
fix(hindsight): restart daemon after idle timeout shutdown

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -437,7 +437,28 @@ class HindsightMemoryProvider(MemoryProvider):
         ]
 
     def _get_client(self):
-        """Return the cached Hindsight client (created once, reused)."""
+        """Return the cached Hindsight client (created once, reused).
+
+        For local_embedded mode, verifies the daemon is still alive and
+        restarts it if the idle timeout shut it down.
+        """
+        # Health check: if we have a cached local_embedded client, verify
+        # the daemon is still running.  The daemon auto-stops after 5 min
+        # of inactivity; without this check, subsequent operations fail
+        # with "Cannot connect to host 127.0.0.1:8888".
+        if self._client is not None and self._mode == "local_embedded":
+            try:
+                manager = getattr(self._client, "_manager", None)
+                profile = self._config.get("profile", "hermes")
+                if manager and hasattr(manager, "is_running") and not manager.is_running(profile):
+                    logger.info("Hindsight daemon stopped (idle timeout), restarting...")
+                    self._client._ensure_started()
+                    logger.info("Hindsight daemon restarted successfully")
+            except Exception as e:
+                logger.warning("Failed to restart hindsight daemon: %s", e)
+                # Clear client so it gets re-created on next call
+                self._client = None
+
         if self._client is None:
             if self._mode == "local_embedded":
                 from hindsight import HindsightEmbedded

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -596,3 +596,74 @@ class TestAvailability:
         monkeypatch.setenv("HINDSIGHT_MODE", "local")
         p = HindsightMemoryProvider()
         assert p.is_available()
+
+
+# ---------------------------------------------------------------------------
+# Regression: daemon health check (#7149)
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonHealthCheck:
+    """Regression: _get_client must restart daemon after idle timeout (#7149)."""
+
+    def test_daemon_restarted_when_not_running(self, provider):
+        """If manager.is_running() returns False, _ensure_started is called."""
+        mock_client = _make_mock_client()
+        mock_manager = MagicMock()
+        mock_manager.is_running.return_value = False
+        mock_client._manager = mock_manager
+        mock_client._ensure_started = MagicMock()
+
+        provider._client = mock_client
+        provider._mode = "local_embedded"
+
+        result = provider._get_client()
+        mock_client._ensure_started.assert_called_once()
+        assert result is mock_client
+
+    def test_no_restart_when_running(self, provider):
+        """If daemon is running, _ensure_started is NOT called."""
+        mock_client = _make_mock_client()
+        mock_manager = MagicMock()
+        mock_manager.is_running.return_value = True
+        mock_client._manager = mock_manager
+        mock_client._ensure_started = MagicMock()
+
+        provider._client = mock_client
+        provider._mode = "local_embedded"
+
+        result = provider._get_client()
+        mock_client._ensure_started.assert_not_called()
+        assert result is mock_client
+
+    def test_client_cleared_on_restart_failure(self, provider):
+        """If _ensure_started raises, client is set to None."""
+        mock_client = _make_mock_client()
+        mock_manager = MagicMock()
+        mock_manager.is_running.return_value = False
+        mock_client._manager = mock_manager
+        mock_client._ensure_started = MagicMock(side_effect=RuntimeError("daemon failed"))
+
+        provider._client = mock_client
+        provider._mode = "local_embedded"
+
+        # The health check should clear _client to None on failure.
+        # The subsequent re-creation attempt will fail because
+        # hindsight is not installed in the test env, so catch that.
+        try:
+            provider._get_client()
+        except (ModuleNotFoundError, ImportError):
+            pass  # Expected — hindsight package not installed
+        assert provider._client is None or provider._client is not mock_client
+
+    def test_no_health_check_for_cloud_mode(self, provider):
+        """Health check only runs for local_embedded, not cloud mode."""
+        mock_client = _make_mock_client()
+        mock_client._manager = MagicMock()
+
+        provider._client = mock_client
+        provider._mode = "cloud"
+
+        result = provider._get_client()
+        mock_client._manager.is_running.assert_not_called()
+        assert result is mock_client


### PR DESCRIPTION
## Description

The Hindsight embedded daemon auto-stops after 5 minutes of inactivity. Subsequent memory operations failed with `Cannot connect to host 127.0.0.1:8888` because `_get_client()` returned the stale cached client without checking if the daemon was still alive.

Adds a health check in `_get_client()` that detects when the daemon has stopped and calls `_ensure_started()` to bring it back before returning the client.

Related issue: #7149

## Type of Change
- [x] Bug fix

## Changes Made
- `plugins/memory/hindsight/__init__.py`: In `_get_client()`, check `manager.is_running(profile)` for local_embedded mode. If stopped, call `_ensure_started()`. On failure, clear `_client` for re-creation.

## How to Test
1. Set hindsight as memory backend in local embedded mode
2. Perform a memory operation (recall/retain)
3. Wait 5+ minutes for idle timeout
4. Perform another memory operation — should succeed without `Cannot connect` error

## Checklist
- [x] All tests pass
- [x] Follows Conventional Commits
- [x] Tests added for this bug fix

Closes #7149