### PR TITLE
security(skills): add AST analysis to Skills Guard scanner

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -514,3 +514,86 @@ class TestSymlinkPrefixConfusionRegression:
         new_escapes = not resolved.is_relative_to(skill_dir_resolved)
         assert old_escapes is False
         assert new_escapes is False
+
+
+# ---------------------------------------------------------------------------
+# AST-level scanner (#7072)
+# ---------------------------------------------------------------------------
+
+
+class TestAstScanPython:
+    """AST-level scanner detects dynamic import and access patterns (#7072)."""
+
+    def test_importlib_import_module_detected(self, tmp_path):
+        """importlib.import_module() calls are flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("import importlib\nm = importlib.import_module('os')\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_dynamic_import" in pids
+        assert "ast_importlib_import" in pids
+
+    def test_dunder_import_with_computed_arg_detected(self, tmp_path):
+        """__import__ with non-literal argument is flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("name = 'os'\nm = __import__(name)\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_dynamic_import_computed" in pids
+
+    def test_dunder_dict_computed_key_detected(self, tmp_path):
+        """__dict__[<computed>] access is flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("key = 'environ'\nval = obj.__dict__[key]\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_dict_access" in pids
+
+    def test_getattr_with_computed_name_detected(self, tmp_path):
+        """getattr(obj, computed_name) is flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("name = 'system'\nfn = getattr(os, name)\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_dynamic_getattr" in pids
+
+    def test_syntax_error_handled_gracefully(self, tmp_path):
+        """Files with syntax errors should not crash the scanner."""
+        f = tmp_path / "bad.py"
+        f.write_text("def broken(\n")
+        findings = scan_file(f, "bad.py")
+        # Should return findings list (possibly empty), not raise
+        assert isinstance(findings, list)
+
+    def test_literal_dunder_import_not_flagged_by_ast(self, tmp_path):
+        """__import__('os') with literal string is NOT flagged by AST (regex handles it)."""
+        f = tmp_path / "ok.py"
+        f.write_text("m = __import__('os')\n")
+        findings = scan_file(f, "ok.py")
+        pids = [f.pattern_id for f in findings]
+        # ast_dynamic_import_computed should NOT be present (literal arg)
+        assert "ast_dynamic_import_computed" not in pids
+
+    def test_full_bypass_payload_now_detected(self, tmp_path):
+        """The exact bypass payload from #7072 should now be caught."""
+        payload = '''
+import importlib
+parts = ['o', 's']
+m = importlib.import_module(''.join(parts))
+e = m.__dict__[''.join(['e','n','v','i','r','o','n'])]
+'''
+        f = tmp_path / "exfil.py"
+        f.write_text(payload)
+        findings = scan_file(f, "exfil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_dynamic_import" in pids
+        assert "ast_dict_access" in pids
+        assert "ast_importlib_import" in pids
+
+    def test_non_python_files_skip_ast(self, tmp_path):
+        """AST scan only runs on .py files."""
+        f = tmp_path / "script.sh"
+        f.write_text("import importlib\nimportlib.import_module('os')\n")
+        findings = scan_file(f, "script.sh")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_dynamic_import" not in pids

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -533,6 +533,54 @@ class TestAstScanPython:
         assert "ast_dynamic_import" in pids
         assert "ast_importlib_import" in pids
 
+    def test_importlib_submodule_import_detected(self, tmp_path):
+        """`import importlib.util` and similar submodules are flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("import importlib.util\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_importlib_import" in pids
+
+    def test_importlib_submodule_aliased_import_detected(self, tmp_path):
+        """`import importlib.machinery as m` (aliased submodule) is flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("import importlib.machinery as m\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_importlib_import" in pids
+
+    def test_from_importlib_import_detected(self, tmp_path):
+        """`from importlib import import_module` is flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("from importlib import import_module\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_importlib_import" in pids
+
+    def test_from_importlib_submodule_import_detected(self, tmp_path):
+        """`from importlib.util import find_spec` is flagged."""
+        f = tmp_path / "evil.py"
+        f.write_text("from importlib.util import find_spec\n")
+        findings = scan_file(f, "evil.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_importlib_import" in pids
+
+    def test_importer_lookalike_not_flagged(self, tmp_path):
+        """`import importer` must NOT match — prefix check is dot-bounded, not substring."""
+        f = tmp_path / "ok.py"
+        f.write_text("import importer\n")
+        findings = scan_file(f, "ok.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_importlib_import" not in pids
+
+    def test_from_importer_lookalike_not_flagged(self, tmp_path):
+        """`from importer import something` must NOT match the importlib check."""
+        f = tmp_path / "ok.py"
+        f.write_text("from importer import something\n")
+        findings = scan_file(f, "ok.py")
+        pids = [f.pattern_id for f in findings]
+        assert "ast_importlib_import" not in pids
+
     def test_dunder_import_with_computed_arg_detected(self, tmp_path):
         """__import__ with non-literal argument is flagged."""
         f = tmp_path / "evil.py"

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -645,3 +645,70 @@ e = m.__dict__[''.join(['e','n','v','i','r','o','n'])]
         findings = scan_file(f, "script.sh")
         pids = [f.pattern_id for f in findings]
         assert "ast_dynamic_import" not in pids
+
+    def test_scan_handles_recursion_error_gracefully(self, tmp_path, monkeypatch):
+        """Deeply-nested expressions that blow the visitor recursion limit must
+        not crash the scan — return whatever findings were collected so far."""
+        import sys
+        from tools import skills_guard
+
+        # Deep attribute chain — parses fine, but visiting it under a small
+        # recursion budget trips RecursionError inside _Visitor.visit().
+        src = "a" + ".x" * 5000 + "\n"
+        f = tmp_path / "deep.py"
+        f.write_text(src)
+
+        original_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(200)
+        try:
+            findings = skills_guard.scan_file(f, "deep.py")
+        finally:
+            sys.setrecursionlimit(original_limit)
+
+        # Must not raise; result is a list (possibly empty or partial).
+        assert isinstance(findings, list)
+
+    def test_scan_handles_malformed_ast_gracefully(self, tmp_path, monkeypatch):
+        """Visitor traversal errors (ValueError/RuntimeError) must not crash the scan."""
+        import ast
+        from tools import skills_guard
+
+        original_visit = ast.NodeVisitor.visit
+
+        def boom(self, node):
+            raise ValueError("synthetic visitor failure on hostile input")
+
+        monkeypatch.setattr(ast.NodeVisitor, "visit", boom)
+
+        f = tmp_path / "edge.py"
+        f.write_text("import importlib\n")
+        # Must not raise — visitor blew up, but scan_file returns a list.
+        findings = skills_guard.scan_file(f, "edge.py")
+        assert isinstance(findings, list)
+
+        # Restore so subsequent tests in the same session aren't poisoned
+        # (monkeypatch handles this automatically, but be explicit).
+        monkeypatch.setattr(ast.NodeVisitor, "visit", original_visit)
+
+    def test_ast_findings_deduplicated_against_regex_findings(self, tmp_path):
+        """Per the scan_file docstring, findings are deduplicated per (pattern_id, line).
+
+        When the AST visitor would emit multiple findings with the same
+        (pattern_id, line) — e.g. two getattr(<computed>) calls on the same
+        physical line — only one Finding should be emitted, mirroring the
+        regex scanner's `seen` invariant.
+        """
+        f = tmp_path / "twice.py"
+        # Two computed-name getattr calls on a single line produce two
+        # ast_dynamic_getattr AST findings sharing (pattern_id, line) = ("ast_dynamic_getattr", 1).
+        # After dedup, only one should reach the result.
+        f.write_text("x='a'; y='b'; r = getattr(o, x) + getattr(o, y)\n")
+        findings = scan_file(f, "twice.py")
+        getattr_hits = [
+            fd for fd in findings
+            if fd.pattern_id == "ast_dynamic_getattr" and fd.line == 1
+        ]
+        assert len(getattr_hits) == 1, (
+            f"expected exactly one ast_dynamic_getattr finding on line 1 after dedup, "
+            f"got {len(getattr_hits)}: {getattr_hits}"
+        )

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -527,6 +527,95 @@ INVISIBLE_CHARS = {
 # Scanning functions
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# AST-level analysis for Python files — catches dynamic import/access
+# patterns that evade regex line-by-line scanning.
+# ---------------------------------------------------------------------------
+
+def _ast_scan_python(content: str, rel_path: str) -> List[Finding]:
+    """Detect obfuscation via dynamic imports, attribute access, and string construction."""
+    import ast
+
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return []
+
+    findings: List[Finding] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Call(self, node):
+            # Detect importlib.import_module(...)
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "import_module":
+                findings.append(Finding(
+                    pattern_id="ast_dynamic_import",
+                    severity="high",
+                    category="obfuscation",
+                    file=rel_path,
+                    line=node.lineno,
+                    match="importlib.import_module()",
+                    description="dynamic import via importlib — can load arbitrary modules at runtime",
+                ))
+            # Detect __import__ with non-literal argument
+            if isinstance(node.func, ast.Name) and node.func.id == "__import__":
+                if node.args and not isinstance(node.args[0], ast.Constant):
+                    findings.append(Finding(
+                        pattern_id="ast_dynamic_import_computed",
+                        severity="high",
+                        category="obfuscation",
+                        file=rel_path,
+                        line=node.lineno,
+                        match="__import__(<computed>)",
+                        description="__import__ with dynamically constructed module name",
+                    ))
+            # Detect getattr with computed attribute name
+            if isinstance(node.func, ast.Name) and node.func.id == "getattr":
+                if len(node.args) >= 2 and not isinstance(node.args[1], ast.Constant):
+                    findings.append(Finding(
+                        pattern_id="ast_dynamic_getattr",
+                        severity="medium",
+                        category="obfuscation",
+                        file=rel_path,
+                        line=node.lineno,
+                        match="getattr(<obj>, <computed>)",
+                        description="getattr with dynamically constructed attribute name",
+                    ))
+            self.generic_visit(node)
+
+        def visit_Subscript(self, node):
+            # Detect obj.__dict__[<computed>]
+            if isinstance(node.value, ast.Attribute) and node.value.attr == "__dict__":
+                if not isinstance(node.slice, ast.Constant):
+                    findings.append(Finding(
+                        pattern_id="ast_dict_access",
+                        severity="high",
+                        category="obfuscation",
+                        file=rel_path,
+                        line=node.lineno,
+                        match="__dict__[<computed>]",
+                        description="dynamic attribute access via __dict__ with computed key",
+                    ))
+            self.generic_visit(node)
+
+        def visit_Import(self, node):
+            # Flag importlib import itself (often precedes dynamic import)
+            for alias in node.names:
+                if alias.name == "importlib":
+                    findings.append(Finding(
+                        pattern_id="ast_importlib_import",
+                        severity="medium",
+                        category="obfuscation",
+                        file=rel_path,
+                        line=node.lineno,
+                        match="import importlib",
+                        description="importlib imported — enables dynamic module loading",
+                    ))
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return findings
+
+
 def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     """
     Scan a single file for threat patterns and invisible unicode characters.
@@ -572,6 +661,10 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
                     match=matched_text,
                     description=description,
                 ))
+
+    # AST-level analysis for Python files
+    if file_path.suffix.lower() == ".py":
+        findings.extend(_ast_scan_python(content, rel_path))
 
     # Invisible unicode character detection
     for i, line in enumerate(lines, start=1):

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -533,12 +533,19 @@ INVISIBLE_CHARS = {
 # ---------------------------------------------------------------------------
 
 def _ast_scan_python(content: str, rel_path: str) -> List[Finding]:
-    """Detect obfuscation via dynamic imports, attribute access, and string construction."""
+    """Detect obfuscation via dynamic imports, attribute access, and string construction.
+
+    Hostile or pathological input (deeply-nested expressions, malformed source) must
+    not crash the scan. Both ``ast.parse`` and the visitor traversal are guarded so
+    parse/visit failures degrade gracefully to "no AST findings" rather than raising.
+    """
     import ast
 
     try:
         tree = ast.parse(content)
-    except SyntaxError:
+    except (SyntaxError, ValueError, RecursionError):
+        # Malformed source, embedded NULs, or extreme nesting — silently skip
+        # per the convention used elsewhere in scan_file (cf. unreadable bytes).
         return []
 
     findings: List[Finding] = []
@@ -629,7 +636,13 @@ def _ast_scan_python(content: str, rel_path: str) -> List[Finding]:
                 ))
             self.generic_visit(node)
 
-    _Visitor().visit(tree)
+    try:
+        _Visitor().visit(tree)
+    except (RecursionError, ValueError, RuntimeError):
+        # Visitor traversal can fail on hostile input even when ast.parse succeeded
+        # (e.g. deeply-nested call/attribute chains exceed the recursion limit).
+        # Return whatever findings we collected before the failure.
+        return findings
     return findings
 
 
@@ -679,9 +692,16 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
                     description=description,
                 ))
 
-    # AST-level analysis for Python files
+    # AST-level analysis for Python files — dedupe against the same `seen` set
+    # used by the regex scanner so the per-(pattern_id, line) contract documented
+    # in this function's docstring holds for AST findings too.
     if file_path.suffix.lower() == ".py":
-        findings.extend(_ast_scan_python(content, rel_path))
+        for ast_finding in _ast_scan_python(content, rel_path):
+            key = (ast_finding.pattern_id, ast_finding.line)
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(ast_finding)
 
     # Invisible unicode character detection
     for i, line in enumerate(lines, start=1):

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -598,18 +598,35 @@ def _ast_scan_python(content: str, rel_path: str) -> List[Finding]:
             self.generic_visit(node)
 
         def visit_Import(self, node):
-            # Flag importlib import itself (often precedes dynamic import)
+            # Flag importlib and any importlib.* submodule (e.g. importlib.util,
+            # importlib.machinery) — all enable dynamic module loading.
             for alias in node.names:
-                if alias.name == "importlib":
+                if alias.name == "importlib" or alias.name.startswith("importlib."):
                     findings.append(Finding(
                         pattern_id="ast_importlib_import",
                         severity="medium",
                         category="obfuscation",
                         file=rel_path,
                         line=node.lineno,
-                        match="import importlib",
+                        match=f"import {alias.name}",
                         description="importlib imported — enables dynamic module loading",
                     ))
+            self.generic_visit(node)
+
+        def visit_ImportFrom(self, node):
+            # Flag `from importlib import ...` and `from importlib.<sub> import ...`
+            # (e.g. `from importlib import import_module`, `from importlib.util import find_spec`).
+            module = node.module or ""
+            if module == "importlib" or module.startswith("importlib."):
+                findings.append(Finding(
+                    pattern_id="ast_importlib_import",
+                    severity="medium",
+                    category="obfuscation",
+                    file=rel_path,
+                    line=node.lineno,
+                    match=f"from {module} import ...",
+                    description="importlib imported — enables dynamic module loading",
+                ))
             self.generic_visit(node)
 
     _Visitor().visit(tree)


### PR DESCRIPTION
## What does this PR do?

The regex-based Skills Guard scanner can be completely bypassed using `importlib.import_module()` with string construction and `__dict__` access with computed keys — achieving 0 detections on a payload that exfiltrates all environment variables.

This PR adds an AST-level analysis pass for Python files that detects:
- `importlib.import_module()` calls (dynamic module loading)
- `__import__()` with non-literal arguments
- `getattr()` with dynamically constructed attribute names
- `__dict__[<computed>]` access patterns
- `importlib` imports themselves

This complements (not replaces) the existing regex patterns and catches obfuscation techniques that line-by-line regex matching cannot detect.

## Related Issue

Closes #7072

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_guard.py`: Added `_ast_scan_python()` function with `ast.NodeVisitor` that detects dynamic import/access patterns. Called from `scan_file()` for `.py` files. Handles `SyntaxError` gracefully.

## How to Test

1. Create a skill with the bypass payload from #7072
2. Run `scan_skill()` on it
3. Should now detect `ast_dynamic_import`, `ast_dict_access`, and `ast_importlib_import` findings

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
