### PR TITLE
fix(gateway): show startup progress in foreground mode

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1317,7 +1317,8 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     """Run the gateway in foreground.
     
     Args:
-        verbose: Stderr log verbosity count added on top of default WARNING (0=WARNING, 1=INFO, 2+=DEBUG).
+        verbose: Additional foreground log verbosity. Foreground mode shows
+                 INFO-level startup progress by default; 2+ enables DEBUG.
         quiet: Suppress all stderr log output.
         replace: If True, kill any existing gateway instance before starting.
                  This prevents systemd restart loops when the old process
@@ -1337,7 +1338,9 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     
     # Exit with code 1 if gateway fails to connect any platform,
     # so systemd Restart=on-failure will retry on transient errors
-    verbosity = None if quiet else verbose
+    # Foreground runs should surface startup progress by default so the user
+    # can see connection milestones instead of a silent terminal.
+    verbosity = None if quiet else max(verbose, 1)
     success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
     if not success:
         sys.exit(1)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -267,3 +267,46 @@ class TestWaitForGatewayExit:
 
         assert killed == 2
         assert calls == [(11, True), (22, True)]
+
+def test_run_gateway_defaults_to_info_progress(monkeypatch, capsys):
+    calls = []
+
+    async def fake_start_gateway(*, replace=False, verbosity=0):
+        calls.append((replace, verbosity))
+        return True
+
+    monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+
+    gateway.run_gateway()
+
+    out = capsys.readouterr().out
+    assert "Hermes Gateway Starting" in out
+    assert calls == [(False, 1)]
+
+
+def test_run_gateway_preserves_higher_verbosity(monkeypatch):
+    calls = []
+
+    async def fake_start_gateway(*, replace=False, verbosity=0):
+        calls.append((replace, verbosity))
+        return True
+
+    monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+
+    gateway.run_gateway(verbose=2, replace=True)
+
+    assert calls == [(True, 2)]
+
+
+def test_run_gateway_quiet_disables_stderr_handler(monkeypatch):
+    calls = []
+
+    async def fake_start_gateway(*, replace=False, verbosity=0):
+        calls.append((replace, verbosity))
+        return True
+
+    monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+
+    gateway.run_gateway(quiet=True)
+
+    assert calls == [(False, None)]


### PR DESCRIPTION
Fix #4709

 ## Summary

  Fix foreground gateway runs so startup progress is visible by default.

  Previously, `hermes gateway` and the manual fallback path in `hermes gateway restart` could appear to hang after the startup banner. The gateway was still running, but most connection and startup
  milestone messages were logged at `INFO` level and only written to `~/.hermes/logs/gateway.log`.

  ## What changed

  - updated foreground `run_gateway()` to enable `INFO`-level stderr logging by default
  - preserved `--quiet` behavior so fully silent runs still remain silent
  - preserved higher verbosity levels so `-vv` and above still behave as expected
  - added regression tests covering:
    - default foreground progress output
    - higher explicit verbosity
    - quiet mode disabling stderr logging

  ## Why

  Foreground runs should show visible progress during startup, especially while connecting to messaging platforms.

  Without that output, users only see the startup banner and then a silent terminal, which looks like a hang even when the gateway is working correctly.

  ## Result

  In foreground/manual mode:
  - startup progress is now visible by default
  - users can see connection milestones as the gateway starts
  - `--quiet` still suppresses stderr logging
  - higher verbosity flags still work normally

  ## Tests

  Verified locally with:
  - `python3 -m pytest tests/hermes_cli/test_gateway.py -q`
  - `python3 -m pytest tests/hermes_cli/test_gateway_service.py -q`
