### PR TITLE
Fix: opencode-zen model name + smart Discord threading

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -47,6 +47,7 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
 
 class Platform(Enum):
     """Supported messaging platforms."""
+
     LOCAL = "local"
     TELEGRAM = "telegram"
     DISCORD = "discord"
@@ -71,21 +72,22 @@ class Platform(Enum):
 class HomeChannel:
     """
     Default destination for a platform.
-    
+
     When a cron job specifies deliver="telegram" without a specific chat ID,
     messages are sent to this home channel.
     """
+
     platform: Platform
     chat_id: str
     name: str  # Human-readable name for display
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "platform": self.platform.value,
             "chat_id": self.chat_id,
             "name": self.name,
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
         return cls(
@@ -99,19 +101,23 @@ class HomeChannel:
 class SessionResetPolicy:
     """
     Controls when sessions reset (lose context).
-    
+
     Modes:
     - "daily": Reset at a specific hour each day
     - "idle": Reset after N minutes of inactivity
     - "both": Whichever triggers first (daily boundary OR idle timeout)
     - "none": Never auto-reset (context managed only by compression)
     """
+
     mode: str = "both"  # "daily", "idle", "both", or "none"
     at_hour: int = 4  # Hour for daily reset (0-23, local time)
     idle_minutes: int = 1440  # Minutes of inactivity before reset (24 hours)
     notify: bool = True  # Send a notification to the user when auto-reset occurs
-    notify_exclude_platforms: tuple = ("api_server", "webhook")  # Platforms that don't get reset notifications
-    
+    notify_exclude_platforms: tuple = (
+        "api_server",
+        "webhook",
+    )  # Platforms that don't get reset notifications
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "mode": self.mode,
@@ -120,7 +126,7 @@ class SessionResetPolicy:
             "notify": self.notify,
             "notify_exclude_platforms": list(self.notify_exclude_platforms),
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
         # Handle both missing keys and explicit null values (YAML null → None)
@@ -134,27 +140,30 @@ class SessionResetPolicy:
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=notify if notify is not None else True,
-            notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
+            notify_exclude_platforms=tuple(exclude)
+            if exclude is not None
+            else ("api_server", "webhook"),
         )
 
 
 @dataclass
 class PlatformConfig:
     """Configuration for a single messaging platform."""
+
     enabled: bool = False
     token: Optional[str] = None  # Bot token (Telegram, Discord)
     api_key: Optional[str] = None  # API key if different from token
     home_channel: Optional[HomeChannel] = None
-    
+
     # Reply threading mode (Telegram/Slack)
     # - "off": Never thread replies to original message
     # - "first": Only first chunk threads to user's message (default)
     # - "all": All chunks in multi-part replies thread to user's message
     reply_to_mode: str = "first"
-    
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "enabled": self.enabled,
@@ -168,13 +177,13 @@ class PlatformConfig:
         if self.home_channel:
             result["home_channel"] = self.home_channel.to_dict()
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+
         return cls(
             enabled=data.get("enabled", False),
             token=data.get("token"),
@@ -188,11 +197,12 @@ class PlatformConfig:
 @dataclass
 class StreamingConfig:
     """Configuration for real-time token streaming to messaging platforms."""
+
     enabled: bool = False
-    transport: str = "edit"       # "edit" (progressive editMessageText) or "off"
-    edit_interval: float = 0.3    # Seconds between message edits
-    buffer_threshold: int = 40    # Chars before forcing an edit
-    cursor: str = " ▉"           # Cursor shown during streaming
+    transport: str = "edit"  # "edit" (progressive editMessageText) or "off"
+    edit_interval: float = 0.3  # Seconds between message edits
+    buffer_threshold: int = 40  # Chars before forcing an edit
+    cursor: str = " ▉"  # Cursor shown during streaming
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -220,26 +230,27 @@ class StreamingConfig:
 class GatewayConfig:
     """
     Main gateway configuration.
-    
+
     Manages all platform connections, session policies, and delivery settings.
     """
+
     # Platform configurations
     platforms: Dict[Platform, PlatformConfig] = field(default_factory=dict)
-    
+
     # Session reset policies by type
     default_reset_policy: SessionResetPolicy = field(default_factory=SessionResetPolicy)
     reset_by_type: Dict[str, SessionResetPolicy] = field(default_factory=dict)
     reset_by_platform: Dict[Platform, SessionResetPolicy] = field(default_factory=dict)
-    
+
     # Reset trigger commands
     reset_triggers: List[str] = field(default_factory=lambda: ["/new", "/reset"])
 
     # User-defined quick commands (slash commands that bypass the agent loop)
     quick_commands: Dict[str, Any] = field(default_factory=dict)
-    
+
     # Storage paths
     sessions_dir: Path = field(default_factory=lambda: get_hermes_home() / "sessions")
-    
+
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
 
@@ -248,7 +259,9 @@ class GatewayConfig:
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
-    thread_sessions_per_user: bool = False  # When False (default), threads are shared across all participants
+    thread_sessions_per_user: bool = (
+        False  # When False (default), threads are shared across all participants
+    )
 
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
@@ -264,7 +277,9 @@ class GatewayConfig:
                 continue
             # Weixin requires both a token and an account_id
             if platform == Platform.WEIXIN:
-                if config.extra.get("account_id") and (config.token or config.extra.get("token")):
+                if config.extra.get("account_id") and (
+                    config.token or config.extra.get("token")
+                ):
                     connected.append(platform)
                 continue
             # Platforms that use token/api_key auth
@@ -295,46 +310,44 @@ class GatewayConfig:
             elif platform == Platform.WECOM and config.extra.get("bot_id"):
                 connected.append(platform)
             # BlueBubbles uses extra dict for local server config
-            elif platform == Platform.BLUEBUBBLES and config.extra.get("server_url") and config.extra.get("password"):
+            elif (
+                platform == Platform.BLUEBUBBLES
+                and config.extra.get("server_url")
+                and config.extra.get("password")
+            ):
                 connected.append(platform)
         return connected
-    
+
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
         if config:
             return config.home_channel
         return None
-    
+
     def get_reset_policy(
-        self, 
-        platform: Optional[Platform] = None,
-        session_type: Optional[str] = None
+        self, platform: Optional[Platform] = None, session_type: Optional[str] = None
     ) -> SessionResetPolicy:
         """
         Get the appropriate reset policy for a session.
-        
+
         Priority: platform override > type override > default
         """
         # Platform-specific override takes precedence
         if platform and platform in self.reset_by_platform:
             return self.reset_by_platform[platform]
-        
+
         # Type-specific override (dm, group, thread)
         if session_type and session_type in self.reset_by_type:
             return self.reset_by_type[session_type]
-        
+
         return self.default_reset_policy
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "platforms": {
-                p.value: c.to_dict() for p, c in self.platforms.items()
-            },
+            "platforms": {p.value: c.to_dict() for p, c in self.platforms.items()},
             "default_reset_policy": self.default_reset_policy.to_dict(),
-            "reset_by_type": {
-                k: v.to_dict() for k, v in self.reset_by_type.items()
-            },
+            "reset_by_type": {k: v.to_dict() for k, v in self.reset_by_type.items()},
             "reset_by_platform": {
                 p.value: v.to_dict() for p, v in self.reset_by_platform.items()
             },
@@ -348,7 +361,7 @@ class GatewayConfig:
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GatewayConfig":
         platforms = {}
@@ -358,11 +371,11 @@ class GatewayConfig:
                 platforms[platform] = PlatformConfig.from_dict(platform_data)
             except ValueError:
                 pass  # Skip unknown platforms
-        
+
         reset_by_type = {}
         for type_name, policy_data in data.get("reset_by_type", {}).items():
             reset_by_type[type_name] = SessionResetPolicy.from_dict(policy_data)
-        
+
         reset_by_platform = {}
         for platform_name, policy_data in data.get("reset_by_platform", {}).items():
             try:
@@ -370,22 +383,26 @@ class GatewayConfig:
                 reset_by_platform[platform] = SessionResetPolicy.from_dict(policy_data)
             except ValueError:
                 pass
-        
+
         default_policy = SessionResetPolicy()
         if "default_reset_policy" in data:
             default_policy = SessionResetPolicy.from_dict(data["default_reset_policy"])
-        
+
         sessions_dir = get_hermes_home() / "sessions"
         if "sessions_dir" in data:
             sessions_dir = Path(data["sessions_dir"])
-        
+
         quick_commands = data.get("quick_commands", {})
         if not isinstance(quick_commands, dict):
             quick_commands = {}
 
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
-            stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
+            stt_enabled = (
+                data.get("stt", {}).get("enabled")
+                if isinstance(data.get("stt"), dict)
+                else None
+            )
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -452,6 +469,7 @@ def load_gateway_config() -> GatewayConfig:
     # Primary source: config.yaml
     try:
         import yaml
+
         config_yaml_path = _home / "config.yaml"
         if config_yaml_path.exists():
             with open(config_yaml_path, encoding="utf-8") as f:
@@ -482,7 +500,9 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["group_sessions_per_user"] = yaml_cfg["group_sessions_per_user"]
 
             if "thread_sessions_per_user" in yaml_cfg:
-                gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
+                gw_data["thread_sessions_per_user"] = yaml_cfg[
+                    "thread_sessions_per_user"
+                ]
 
             streaming_cfg = yaml_cfg.get("streaming")
             if isinstance(streaming_cfg, dict):
@@ -495,9 +515,11 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
 
             if "unauthorized_dm_behavior" in yaml_cfg:
-                gw_data["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(
-                    yaml_cfg.get("unauthorized_dm_behavior"),
-                    "pair",
+                gw_data["unauthorized_dm_behavior"] = (
+                    _normalize_unauthorized_dm_behavior(
+                        yaml_cfg.get("unauthorized_dm_behavior"),
+                        "pair",
+                    )
                 )
 
             # Merge platforms section from config.yaml into gw_data so that
@@ -515,7 +537,10 @@ def load_gateway_config() -> GatewayConfig:
                     if not isinstance(existing, dict):
                         existing = {}
                     # Deep-merge extra dicts so gateway.json defaults survive
-                    merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
+                    merged_extra = {
+                        **existing.get("extra", {}),
+                        **plat_block.get("extra", {}),
+                    }
                     merged = {**existing, **plat_block}
                     if merged_extra:
                         merged["extra"] = merged_extra
@@ -530,26 +555,49 @@ def load_gateway_config() -> GatewayConfig:
                 # Collect bridgeable keys from this platform section
                 bridged = {}
                 if "unauthorized_dm_behavior" in platform_cfg:
-                    bridged["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(
-                        platform_cfg.get("unauthorized_dm_behavior"),
-                        gw_data.get("unauthorized_dm_behavior", "pair"),
+                    bridged["unauthorized_dm_behavior"] = (
+                        _normalize_unauthorized_dm_behavior(
+                            platform_cfg.get("unauthorized_dm_behavior"),
+                            gw_data.get("unauthorized_dm_behavior", "pair"),
+                        )
                     )
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
-                    bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                    bridged["free_response_channels"] = platform_cfg[
+                        "free_response_channels"
+                    ]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
-                if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
-                    bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if "auto_thread" in platform_cfg:
+                    bridged["auto_thread"] = platform_cfg["auto_thread"]
+                if (
+                    plat == Platform.DISCORD
+                    and "channel_skill_bindings" in platform_cfg
+                ):
+                    bridged["channel_skill_bindings"] = platform_cfg[
+                        "channel_skill_bindings"
+                    ]
+                # Copy any extra keys from root-level platform config
+                if "extra" in platform_cfg and isinstance(platform_cfg["extra"], dict):
+                    for k, v in platform_cfg["extra"].items():
+                        if k not in bridged:
+                            bridged[k] = v
+                # Special case: reply_to_mode should be at top level, not in extra
+                if "reply_to_mode" in bridged:
+                    # Set it at top level instead of in extra
+                    pass  # Will handle below
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})
                 if not isinstance(plat_data, dict):
                     plat_data = {}
                     platforms_data[plat.value] = plat_data
+                # Move reply_to_mode to top level
+                if "reply_to_mode" in bridged:
+                    plat_data["reply_to_mode"] = bridged.pop("reply_to_mode")
                 extra = plat_data.setdefault("extra", {})
                 if not isinstance(extra, dict):
                     extra = {}
@@ -559,10 +607,16 @@ def load_gateway_config() -> GatewayConfig:
             # Slack settings → env vars (env vars take precedence)
             slack_cfg = yaml_cfg.get("slack", {})
             if isinstance(slack_cfg, dict):
-                if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
-                    os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
+                if "require_mention" in slack_cfg and not os.getenv(
+                    "SLACK_REQUIRE_MENTION"
+                ):
+                    os.environ["SLACK_REQUIRE_MENTION"] = str(
+                        slack_cfg["require_mention"]
+                    ).lower()
                 if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
-                    os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
+                    os.environ["SLACK_ALLOW_BOTS"] = str(
+                        slack_cfg["allow_bots"]
+                    ).lower()
                 frc = slack_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("SLACK_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):
@@ -572,17 +626,27 @@ def load_gateway_config() -> GatewayConfig:
             # Discord settings → env vars (env vars take precedence)
             discord_cfg = yaml_cfg.get("discord", {})
             if isinstance(discord_cfg, dict):
-                if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
-                    os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                if "require_mention" in discord_cfg and not os.getenv(
+                    "DISCORD_REQUIRE_MENTION"
+                ):
+                    os.environ["DISCORD_REQUIRE_MENTION"] = str(
+                        discord_cfg["require_mention"]
+                    ).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
-                if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
-                    os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                if "auto_thread" in discord_cfg and not os.getenv(
+                    "DISCORD_AUTO_THREAD"
+                ):
+                    os.environ["DISCORD_AUTO_THREAD"] = str(
+                        discord_cfg["auto_thread"]
+                    ).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
-                    os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+                    os.environ["DISCORD_REACTIONS"] = str(
+                        discord_cfg["reactions"]
+                    ).lower()
                 # ignored_channels: channels where bot never responds (even when mentioned)
                 ic = discord_cfg.get("ignored_channels")
                 if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):
@@ -605,25 +669,44 @@ def load_gateway_config() -> GatewayConfig:
             # Telegram settings → env vars (env vars take precedence)
             telegram_cfg = yaml_cfg.get("telegram", {})
             if isinstance(telegram_cfg, dict):
-                if "require_mention" in telegram_cfg and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
-                    os.environ["TELEGRAM_REQUIRE_MENTION"] = str(telegram_cfg["require_mention"]).lower()
-                if "mention_patterns" in telegram_cfg and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
+                if "require_mention" in telegram_cfg and not os.getenv(
+                    "TELEGRAM_REQUIRE_MENTION"
+                ):
+                    os.environ["TELEGRAM_REQUIRE_MENTION"] = str(
+                        telegram_cfg["require_mention"]
+                    ).lower()
+                if "mention_patterns" in telegram_cfg and not os.getenv(
+                    "TELEGRAM_MENTION_PATTERNS"
+                ):
                     import json as _json
-                    os.environ["TELEGRAM_MENTION_PATTERNS"] = _json.dumps(telegram_cfg["mention_patterns"])
+
+                    os.environ["TELEGRAM_MENTION_PATTERNS"] = _json.dumps(
+                        telegram_cfg["mention_patterns"]
+                    )
                 frc = telegram_cfg.get("free_response_chats")
                 if frc is not None and not os.getenv("TELEGRAM_FREE_RESPONSE_CHATS"):
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] = str(frc)
                 if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
-                    os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
+                    os.environ["TELEGRAM_REACTIONS"] = str(
+                        telegram_cfg["reactions"]
+                    ).lower()
 
             whatsapp_cfg = yaml_cfg.get("whatsapp", {})
             if isinstance(whatsapp_cfg, dict):
-                if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
-                    os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
-                if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
-                    os.environ["WHATSAPP_MENTION_PATTERNS"] = json.dumps(whatsapp_cfg["mention_patterns"])
+                if "require_mention" in whatsapp_cfg and not os.getenv(
+                    "WHATSAPP_REQUIRE_MENTION"
+                ):
+                    os.environ["WHATSAPP_REQUIRE_MENTION"] = str(
+                        whatsapp_cfg["require_mention"]
+                    ).lower()
+                if "mention_patterns" in whatsapp_cfg and not os.getenv(
+                    "WHATSAPP_MENTION_PATTERNS"
+                ):
+                    os.environ["WHATSAPP_MENTION_PATTERNS"] = json.dumps(
+                        whatsapp_cfg["mention_patterns"]
+                    )
                 frc = whatsapp_cfg.get("free_response_chats")
                 if frc is not None and not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"):
                     if isinstance(frc, list):
@@ -633,15 +716,21 @@ def load_gateway_config() -> GatewayConfig:
             # Matrix settings → env vars (env vars take precedence)
             matrix_cfg = yaml_cfg.get("matrix", {})
             if isinstance(matrix_cfg, dict):
-                if "require_mention" in matrix_cfg and not os.getenv("MATRIX_REQUIRE_MENTION"):
-                    os.environ["MATRIX_REQUIRE_MENTION"] = str(matrix_cfg["require_mention"]).lower()
+                if "require_mention" in matrix_cfg and not os.getenv(
+                    "MATRIX_REQUIRE_MENTION"
+                ):
+                    os.environ["MATRIX_REQUIRE_MENTION"] = str(
+                        matrix_cfg["require_mention"]
+                    ).lower()
                 frc = matrix_cfg.get("free_response_rooms")
                 if frc is not None and not os.getenv("MATRIX_FREE_RESPONSE_ROOMS"):
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["MATRIX_FREE_RESPONSE_ROOMS"] = str(frc)
                 if "auto_thread" in matrix_cfg and not os.getenv("MATRIX_AUTO_THREAD"):
-                    os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
+                    os.environ["MATRIX_AUTO_THREAD"] = str(
+                        matrix_cfg["auto_thread"]
+                    ).lower()
 
     except Exception as e:
         logger.warning(
@@ -655,7 +744,7 @@ def load_gateway_config() -> GatewayConfig:
 
     # Override with environment variables
     _apply_env_overrides(config)
-    
+
     # --- Validate loaded values ---
     policy = config.default_reset_policy
 
@@ -690,7 +779,8 @@ def load_gateway_config() -> GatewayConfig:
             logger.warning(
                 "%s is enabled but %s is empty. "
                 "The adapter will likely fail to connect.",
-                platform.value, env_name,
+                platform.value,
+                env_name,
             )
 
     return config
@@ -698,7 +788,7 @@ def load_gateway_config() -> GatewayConfig:
 
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
-    
+
     # Telegram
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token:
@@ -706,14 +796,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.TELEGRAM] = PlatformConfig()
         config.platforms[Platform.TELEGRAM].enabled = True
         config.platforms[Platform.TELEGRAM].token = telegram_token
-    
+
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = os.getenv("TELEGRAM_REPLY_TO_MODE", "").lower()
     if telegram_reply_mode in ("off", "first", "all"):
         if Platform.TELEGRAM not in config.platforms:
             config.platforms[Platform.TELEGRAM] = PlatformConfig()
         config.platforms[Platform.TELEGRAM].reply_to_mode = telegram_reply_mode
-    
+
     telegram_fallback_ips = os.getenv("TELEGRAM_FALLBACK_IPS", "")
     if telegram_fallback_ips:
         if Platform.TELEGRAM not in config.platforms:
@@ -729,7 +819,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             chat_id=telegram_home,
             name=os.getenv("TELEGRAM_HOME_CHANNEL_NAME", "Home"),
         )
-    
+
     # Discord
     discord_token = os.getenv("DISCORD_BOT_TOKEN")
     if discord_token:
@@ -737,7 +827,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.DISCORD] = PlatformConfig()
         config.platforms[Platform.DISCORD].enabled = True
         config.platforms[Platform.DISCORD].token = discord_token
-    
+
     discord_home = os.getenv("DISCORD_HOME_CHANNEL")
     if discord_home and Platform.DISCORD in config.platforms:
         config.platforms[Platform.DISCORD].home_channel = HomeChannel(
@@ -745,21 +835,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             chat_id=discord_home,
             name=os.getenv("DISCORD_HOME_CHANNEL_NAME", "Home"),
         )
-    
+
     # Reply threading mode for Discord (off/first/all)
     discord_reply_mode = os.getenv("DISCORD_REPLY_TO_MODE", "").lower()
     if discord_reply_mode in ("off", "first", "all"):
         if Platform.DISCORD not in config.platforms:
             config.platforms[Platform.DISCORD] = PlatformConfig()
         config.platforms[Platform.DISCORD].reply_to_mode = discord_reply_mode
-    
+
     # WhatsApp (typically uses different auth mechanism)
     whatsapp_enabled = os.getenv("WHATSAPP_ENABLED", "").lower() in ("true", "1", "yes")
     if whatsapp_enabled:
         if Platform.WHATSAPP not in config.platforms:
             config.platforms[Platform.WHATSAPP] = PlatformConfig()
         config.platforms[Platform.WHATSAPP].enabled = True
-    
+
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:
@@ -774,7 +864,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             chat_id=slack_home,
             name=os.getenv("SLACK_HOME_CHANNEL_NAME", ""),
         )
-    
+
     # Signal
     signal_url = os.getenv("SIGNAL_HTTP_URL")
     signal_account = os.getenv("SIGNAL_ACCOUNT")
@@ -782,11 +872,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.SIGNAL not in config.platforms:
             config.platforms[Platform.SIGNAL] = PlatformConfig()
         config.platforms[Platform.SIGNAL].enabled = True
-        config.platforms[Platform.SIGNAL].extra.update({
-            "http_url": signal_url,
-            "account": signal_account,
-            "ignore_stories": os.getenv("SIGNAL_IGNORE_STORIES", "true").lower() in ("true", "1", "yes"),
-        })
+        config.platforms[Platform.SIGNAL].extra.update(
+            {
+                "http_url": signal_url,
+                "account": signal_account,
+                "ignore_stories": os.getenv("SIGNAL_IGNORE_STORIES", "true").lower()
+                in ("true", "1", "yes"),
+            }
+        )
     signal_home = os.getenv("SIGNAL_HOME_CHANNEL")
     if signal_home and Platform.SIGNAL in config.platforms:
         config.platforms[Platform.SIGNAL].home_channel = HomeChannel(
@@ -819,7 +912,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     matrix_homeserver = os.getenv("MATRIX_HOMESERVER", "")
     if matrix_token or os.getenv("MATRIX_PASSWORD"):
         if not matrix_homeserver:
-            logger.warning("MATRIX_ACCESS_TOKEN/MATRIX_PASSWORD set but MATRIX_HOMESERVER is missing")
+            logger.warning(
+                "MATRIX_ACCESS_TOKEN/MATRIX_PASSWORD set but MATRIX_HOMESERVER is missing"
+            )
         if Platform.MATRIX not in config.platforms:
             config.platforms[Platform.MATRIX] = PlatformConfig()
         config.platforms[Platform.MATRIX].enabled = True
@@ -865,11 +960,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
-            "address": email_addr,
-            "imap_host": email_imap,
-            "smtp_host": email_smtp,
-        })
+        config.platforms[Platform.EMAIL].extra.update(
+            {
+                "address": email_addr,
+                "imap_host": email_imap,
+                "smtp_host": email_smtp,
+            }
+        )
     email_home = os.getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:
         config.platforms[Platform.EMAIL].home_channel = HomeChannel(
@@ -894,7 +991,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # API Server
-    api_server_enabled = os.getenv("API_SERVER_ENABLED", "").lower() in ("true", "1", "yes")
+    api_server_enabled = os.getenv("API_SERVER_ENABLED", "").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
     api_server_key = os.getenv("API_SERVER_KEY", "")
     api_server_cors_origins = os.getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = os.getenv("API_SERVER_PORT")
@@ -906,19 +1007,27 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if api_server_key:
             config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
         if api_server_cors_origins:
-            origins = [origin.strip() for origin in api_server_cors_origins.split(",") if origin.strip()]
+            origins = [
+                origin.strip()
+                for origin in api_server_cors_origins.split(",")
+                if origin.strip()
+            ]
             if origins:
                 config.platforms[Platform.API_SERVER].extra["cors_origins"] = origins
         if api_server_port:
             try:
-                config.platforms[Platform.API_SERVER].extra["port"] = int(api_server_port)
+                config.platforms[Platform.API_SERVER].extra["port"] = int(
+                    api_server_port
+                )
             except ValueError:
                 pass
         if api_server_host:
             config.platforms[Platform.API_SERVER].extra["host"] = api_server_host
         api_server_model_name = os.getenv("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
-            config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
+            config.platforms[Platform.API_SERVER].extra["model_name"] = (
+                api_server_model_name
+            )
 
     # Webhook platform
     webhook_enabled = os.getenv("WEBHOOK_ENABLED", "").lower() in ("true", "1", "yes")
@@ -943,18 +1052,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
         config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
-            "app_id": feishu_app_id,
-            "app_secret": feishu_app_secret,
-            "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
-            "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
-        })
+        config.platforms[Platform.FEISHU].extra.update(
+            {
+                "app_id": feishu_app_id,
+                "app_secret": feishu_app_secret,
+                "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
+                "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
+            }
+        )
         feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
             config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
         feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
-            config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
+            config.platforms[Platform.FEISHU].extra["verification_token"] = (
+                feishu_verification_token
+            )
         feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
         if feishu_home:
             config.platforms[Platform.FEISHU].home_channel = HomeChannel(
@@ -970,10 +1083,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.WECOM not in config.platforms:
             config.platforms[Platform.WECOM] = PlatformConfig()
         config.platforms[Platform.WECOM].enabled = True
-        config.platforms[Platform.WECOM].extra.update({
-            "bot_id": wecom_bot_id,
-            "secret": wecom_secret,
-        })
+        config.platforms[Platform.WECOM].extra.update(
+            {
+                "bot_id": wecom_bot_id,
+                "secret": wecom_secret,
+            }
+        )
         wecom_ws_url = os.getenv("WECOM_WEBSOCKET_URL", "")
         if wecom_ws_url:
             config.platforms[Platform.WECOM].extra["websocket_url"] = wecom_ws_url
@@ -1030,14 +1145,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.BLUEBUBBLES not in config.platforms:
             config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
         config.platforms[Platform.BLUEBUBBLES].enabled = True
-        config.platforms[Platform.BLUEBUBBLES].extra.update({
-            "server_url": bluebubbles_server_url.rstrip("/"),
-            "password": bluebubbles_password,
-            "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
-            "webhook_port": int(os.getenv("BLUEBUBBLES_WEBHOOK_PORT", "8645")),
-            "webhook_path": os.getenv("BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"),
-            "send_read_receipts": os.getenv("BLUEBUBBLES_SEND_READ_RECEIPTS", "true").lower() in ("true", "1", "yes"),
-        })
+        config.platforms[Platform.BLUEBUBBLES].extra.update(
+            {
+                "server_url": bluebubbles_server_url.rstrip("/"),
+                "password": bluebubbles_password,
+                "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
+                "webhook_port": int(os.getenv("BLUEBUBBLES_WEBHOOK_PORT", "8645")),
+                "webhook_path": os.getenv(
+                    "BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"
+                ),
+                "send_read_receipts": os.getenv(
+                    "BLUEBUBBLES_SEND_READ_RECEIPTS", "true"
+                ).lower()
+                in ("true", "1", "yes"),
+            }
+        )
     bluebubbles_home = os.getenv("BLUEBUBBLES_HOME_CHANNEL")
     if bluebubbles_home and Platform.BLUEBUBBLES in config.platforms:
         config.platforms[Platform.BLUEBUBBLES].home_channel = HomeChannel(
@@ -1053,7 +1175,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.default_reset_policy.idle_minutes = int(idle_minutes)
         except ValueError:
             pass
-    
+
     reset_hour = os.getenv("SESSION_RESET_HOUR")
     if reset_hour:
         try:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -30,6 +30,7 @@ try:
     import discord
     from discord import Message as DiscordMessage, Intents
     from discord.ext import commands
+
     DISCORD_AVAILABLE = True
 except ImportError:
     DISCORD_AVAILABLE = False
@@ -40,6 +41,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
+
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
@@ -90,10 +92,10 @@ class VoiceReceiver:
     completed utterances via a callback.
     """
 
-    SILENCE_THRESHOLD = 1.5    # seconds of silence → end of utterance
+    SILENCE_THRESHOLD = 1.5  # seconds of silence → end of utterance
     MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
-    SAMPLE_RATE = 48000        # Discord native rate
-    CHANNELS = 2               # Discord sends stereo
+    SAMPLE_RATE = 48000  # Discord native rate
+    CHANNELS = 2  # Discord sends stereo
 
     def __init__(self, voice_client, allowed_user_ids: set = None):
         self._vc = voice_client
@@ -193,7 +195,8 @@ class VoiceReceiver:
         # Set on the current live websocket (for immediate effect)
         try:
             from discord.utils import MISSING
-            if hasattr(conn, 'ws') and conn.ws is not MISSING:
+
+            if hasattr(conn, "ws") and conn.ws is not MISSING:
                 conn.ws._hook = wrapped_hook
                 logger.info("Speaking hook installed on live websocket")
         except Exception as e:
@@ -212,7 +215,8 @@ class VoiceReceiver:
         if self._packet_debug_count <= 5:
             logger.debug(
                 "Raw UDP packet: len=%d, first_bytes=%s",
-                len(data), data[:4].hex() if len(data) >= 4 else "short",
+                len(data),
+                data[:4].hex() if len(data) >= 4 else "short",
             )
 
         if len(data) < 16:
@@ -223,7 +227,9 @@ class VoiceReceiver:
         # Payload type (byte 1 lower 7 bits) = 0x78 (120) for voice.
         if (data[0] >> 6) != 2 or (data[1] & 0x7F) != 0x78:
             if self._packet_debug_count <= 5:
-                logger.debug("Skipped non-RTP: byte0=0x%02x byte1=0x%02x", data[0], data[1])
+                logger.debug(
+                    "Skipped non-RTP: byte0=0x%02x byte1=0x%02x", data[0], data[1]
+                )
             return
 
         first_byte = data[0]
@@ -253,7 +259,11 @@ class VoiceReceiver:
                 known_user = self._ssrc_to_user.get(ssrc, "unknown")
             logger.debug(
                 "RTP packet: ssrc=%d, seq=%d, user=%s, hdr=%d, ext_data=%d",
-                ssrc, seq, known_user, header_size, ext_data_len,
+                ssrc,
+                seq,
+                known_user,
+                header_size,
+                ext_data_len,
             )
 
         header = bytes(data[:header_size])
@@ -268,11 +278,17 @@ class VoiceReceiver:
 
         try:
             import nacl.secret  # noqa: delayed import – only in voice path
+
             box = nacl.secret.Aead(self._secret_key)
             decrypted = box.decrypt(encrypted, header, bytes(nonce))
         except Exception as e:
             if self._packet_debug_count <= 10:
-                logger.warning("NaCl decrypt failed: %s (hdr=%d, enc=%d)", e, header_size, len(encrypted))
+                logger.warning(
+                    "NaCl decrypt failed: %s (hdr=%d, enc=%d)",
+                    e,
+                    header_size,
+                    len(encrypted),
+                )
             return
 
         # Skip encrypted extension data to get the actual opus payload
@@ -286,6 +302,7 @@ class VoiceReceiver:
             if user_id:
                 try:
                     import davey
+
                     decrypted = self._dave_session.decrypt(
                         user_id, davey.MediaType.audio, decrypted
                     )
@@ -293,7 +310,9 @@ class VoiceReceiver:
                     # Unencrypted passthrough — use NaCl-decrypted data as-is
                     if "Unencrypted" not in str(e):
                         if self._packet_debug_count <= 10:
-                            logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
+                            logger.warning(
+                                "DAVE decrypt failed for ssrc=%d: %s", ssrc, e
+                            )
                         return
             # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
             # Opus decode directly — audio may be in passthrough mode.
@@ -329,13 +348,16 @@ class VoiceReceiver:
             bot_id = self._vc.user.id if self._vc.user else 0
             allowed = self._allowed_user_ids
             candidates = [
-                m.id for m in channel.members
+                m.id
+                for m in channel.members
                 if m.id != bot_id and (not allowed or str(m.id) in allowed)
             ]
             if len(candidates) == 1:
                 uid = candidates[0]
                 self._ssrc_to_user[ssrc] = uid
-                logger.info("Auto-mapped ssrc=%d -> user=%d (sole allowed member)", ssrc, uid)
+                logger.info(
+                    "Auto-mapped ssrc=%d -> user=%d (sole allowed member)", ssrc, uid
+                )
                 return uid
         except Exception:
             pass
@@ -357,7 +379,10 @@ class VoiceReceiver:
                 # 48kHz, 16-bit, stereo = 192000 bytes/sec
                 buf_duration = len(buf) / (self.SAMPLE_RATE * self.CHANNELS * 2)
 
-                if silence_duration >= self.SILENCE_THRESHOLD and buf_duration >= self.MIN_SPEECH_DURATION:
+                if (
+                    silence_duration >= self.SILENCE_THRESHOLD
+                    and buf_duration >= self.MIN_SPEECH_DURATION
+                ):
                     user_id = ssrc_user_map.get(ssrc, 0)
                     if not user_id:
                         # SSRC not mapped (SPEAKING event missing after bot rejoin).
@@ -379,8 +404,9 @@ class VoiceReceiver:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def pcm_to_wav(pcm_data: bytes, output_path: str,
-                   src_rate: int = 48000, src_channels: int = 2):
+    def pcm_to_wav(
+        pcm_data: bytes, output_path: str, src_rate: int = 48000, src_channels: int = 2
+    ):
         """Convert raw PCM to 16kHz mono WAV via ffmpeg."""
         with tempfile.NamedTemporaryFile(suffix=".pcm", delete=False) as f:
             f.write(pcm_data)
@@ -388,13 +414,22 @@ class VoiceReceiver:
         try:
             subprocess.run(
                 [
-                    "ffmpeg", "-y", "-loglevel", "error",
-                    "-f", "s16le",
-                    "-ar", str(src_rate),
-                    "-ac", str(src_channels),
-                    "-i", pcm_path,
-                    "-ar", "16000",
-                    "-ac", "1",
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "s16le",
+                    "-ar",
+                    str(src_rate),
+                    "-ac",
+                    str(src_channels),
+                    "-i",
+                    pcm_path,
+                    "-ar",
+                    "16000",
+                    "-ac",
+                    "1",
                     output_path,
                 ],
                 check=True,
@@ -436,15 +471,25 @@ class DiscordAdapter(BasePlatformAdapter):
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        self._text_batch_delay_seconds = float(
+            os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6")
+        )
+        self._text_batch_split_delay_seconds = float(
+            os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
-        self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
+        self._voice_timeout_tasks: Dict[
+            int, asyncio.Task
+        ] = {}  # guild_id -> timeout task
         # Phase 2: voice listening
-        self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
-        self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
+        self._voice_receivers: Dict[
+            int, VoiceReceiver
+        ] = {}  # guild_id -> VoiceReceiver
+        self._voice_listen_tasks: Dict[
+            int, asyncio.Task
+        ] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
         # Track threads where the bot has participated so follow-up messages
@@ -460,29 +505,33 @@ class DiscordAdapter(BasePlatformAdapter):
         # Dedup cache: message_id → timestamp.  Prevents duplicate bot
         # responses when Discord RESUME replays events after reconnects.
         self._seen_messages: Dict[str, float] = {}
-        self._SEEN_TTL = 300   # 5 minutes
+        self._SEEN_TTL = 300  # 5 minutes
         self._SEEN_MAX = 2000  # prune threshold
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
-        self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        self._reply_to_mode: str = getattr(config, "reply_to_mode", "first") or "first"
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
         if not DISCORD_AVAILABLE:
-            logger.error("[%s] discord.py not installed. Run: pip install discord.py", self.name)
+            logger.error(
+                "[%s] discord.py not installed. Run: pip install discord.py", self.name
+            )
             return False
 
         # Load opus codec for voice channel support
         if not discord.opus.is_loaded():
             import ctypes.util
+
             opus_path = ctypes.util.find_library("opus")
             # ctypes.util.find_library fails on macOS with Homebrew-installed libs,
             # so fall back to known Homebrew paths if needed.
             if not opus_path:
                 import sys
+
                 _homebrew_paths = (
                     "/opt/homebrew/lib/libopus.dylib",  # Apple Silicon
-                    "/usr/local/lib/libopus.dylib",     # Intel Mac
+                    "/usr/local/lib/libopus.dylib",  # Intel Mac
                 )
                 if sys.platform == "darwin":
                     for _hp in _homebrew_paths:
@@ -493,7 +542,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 try:
                     discord.opus.load_opus(opus_path)
                 except Exception:
-                    logger.warning("Opus codec found at %s but failed to load", opus_path)
+                    logger.warning(
+                        "Opus codec found at %s but failed to load", opus_path
+                    )
             if not discord.opus.is_loaded():
                 logger.warning("Opus codec not found — voice channel playback disabled")
 
@@ -504,21 +555,30 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             # Acquire scoped lock to prevent duplicate bot token usage
             from gateway.status import acquire_scoped_lock
-            self._token_lock_identity = self.config.token
-            acquired, existing = acquire_scoped_lock('discord-bot-token', self._token_lock_identity, metadata={'platform': 'discord'})
-            if not acquired:
-                owner_pid = existing.get('pid') if isinstance(existing, dict) else None
-                message = f'Discord bot token already in use' + (f' (PID {owner_pid})' if owner_pid else '') + '. Stop the other gateway first.'
-                logger.error('[%s] %s', self.name, message)
-                self._set_fatal_error('discord_token_lock', message, retryable=False)
-                return False
 
+            self._token_lock_identity = self.config.token
+            acquired, existing = acquire_scoped_lock(
+                "discord-bot-token",
+                self._token_lock_identity,
+                metadata={"platform": "discord"},
+            )
+            if not acquired:
+                owner_pid = existing.get("pid") if isinstance(existing, dict) else None
+                message = (
+                    f"Discord bot token already in use"
+                    + (f" (PID {owner_pid})" if owner_pid else "")
+                    + ". Stop the other gateway first."
+                )
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error("discord_token_lock", message, retryable=False)
+                return False
 
             # Parse allowed user entries (may contain usernames or IDs)
             allowed_env = os.getenv("DISCORD_ALLOWED_USERS", "")
             if allowed_env:
                 self._allowed_user_ids = {
-                    _clean_discord_id(uid) for uid in allowed_env.split(",")
+                    _clean_discord_id(uid)
+                    for uid in allowed_env.split(",")
                     if uid.strip()
                 }
 
@@ -533,11 +593,14 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.message_content = True
             intents.dm_messages = True
             intents.guild_messages = True
-            intents.members = any(not entry.isdigit() for entry in self._allowed_user_ids)
+            intents.members = any(
+                not entry.isdigit() for entry in self._allowed_user_ids
+            )
             intents.voice_states = True
 
             # Resolve proxy (DISCORD_PROXY > generic env vars > macOS system proxy)
             from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_bot
+
             proxy_url = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             if proxy_url:
                 logger.info("[%s] Using proxy for Discord: %s", self.name, proxy_url)
@@ -553,7 +616,9 @@ class DiscordAdapter(BasePlatformAdapter):
             # Register event handlers
             @self._client.event
             async def on_ready():
-                logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
+                logger.info(
+                    "[%s] Connected as %s", adapter_self.name, adapter_self._client.user
+                )
 
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
@@ -561,9 +626,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Sync slash commands with Discord
                 try:
                     synced = await adapter_self._client.tree.sync()
-                    logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
+                    logger.info(
+                        "[%s] Synced %d slash command(s)",
+                        adapter_self.name,
+                        len(synced),
+                    )
                 except Exception as e:  # pragma: no cover - defensive logging
-                    logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
+                    logger.warning(
+                        "[%s] Slash command sync failed: %s",
+                        adapter_self.name,
+                        e,
+                        exc_info=True,
+                    )
                 adapter_self._ready_event.set()
 
             @self._client.event
@@ -577,7 +651,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 if len(adapter_self._seen_messages) > adapter_self._SEEN_MAX:
                     cutoff = now - adapter_self._SEEN_TTL
                     adapter_self._seen_messages = {
-                        k: v for k, v in adapter_self._seen_messages.items()
+                        k: v
+                        for k, v in adapter_self._seen_messages.items()
                         if v > cutoff
                     }
 
@@ -587,7 +662,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
                 # Ignore Discord system messages (thread renames, pins, member joins, etc.)
                 # Allow both default and reply types — replies have a distinct MessageType.
-                if message.type not in (discord.MessageType.default, discord.MessageType.reply):
+                if message.type not in (
+                    discord.MessageType.default,
+                    discord.MessageType.reply,
+                ):
                     return
 
                 # Check if the message author is in the allowed user list
@@ -603,7 +681,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if (
+                            not self._client.user
+                            or self._client.user not in message.mentions
+                        ):
                             return
                     # "all" falls through to handle_message
 
@@ -615,7 +696,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 _ignore_no_mention = os.getenv(
                     "DISCORD_IGNORE_NO_MENTION", "true"
                 ).lower() in ("true", "1", "yes")
-                if _ignore_no_mention and message.mentions and not isinstance(message.channel, discord.DMChannel):
+                if (
+                    _ignore_no_mention
+                    and message.mentions
+                    and not isinstance(message.channel, discord.DMChannel)
+                ):
                     _bot_mentioned = (
                         self._client.user is not None
                         and self._client.user in message.mentions
@@ -652,8 +737,10 @@ class DiscordAdapter(BasePlatformAdapter):
                         "Voice state: %s (%d) %s (guild %d)",
                         member.display_name,
                         member.id,
-                        "joined " + after.channel.name if joined
-                        else "left " + before.channel.name if left
+                        "joined " + after.channel.name
+                        if joined
+                        else "left " + before.channel.name
+                        if left
                         else f"moved {before.channel.name} -> {after.channel.name}",
                         guild_id,
                     )
@@ -671,21 +758,29 @@ class DiscordAdapter(BasePlatformAdapter):
             return True
 
         except asyncio.TimeoutError:
-            logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
+            logger.error(
+                "[%s] Timeout waiting for connection to Discord",
+                self.name,
+                exc_info=True,
+            )
             try:
                 from gateway.status import release_scoped_lock
-                if getattr(self, '_token_lock_identity', None):
-                    release_scoped_lock('discord-bot-token', self._token_lock_identity)
+
+                if getattr(self, "_token_lock_identity", None):
+                    release_scoped_lock("discord-bot-token", self._token_lock_identity)
                     self._token_lock_identity = None
             except Exception:
                 pass
             return False
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True
+            )
             try:
                 from gateway.status import release_scoped_lock
-                if getattr(self, '_token_lock_identity', None):
-                    release_scoped_lock('discord-bot-token', self._token_lock_identity)
+
+                if getattr(self, "_token_lock_identity", None):
+                    release_scoped_lock("discord-bot-token", self._token_lock_identity)
                     self._token_lock_identity = None
             except Exception:
                 pass
@@ -698,13 +793,17 @@ class DiscordAdapter(BasePlatformAdapter):
             try:
                 await self.leave_voice_channel(guild_id)
             except Exception as e:  # pragma: no cover - defensive logging
-                logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
+                logger.debug(
+                    "[%s] Error leaving voice channel %s: %s", self.name, guild_id, e
+                )
 
         if self._client:
             try:
                 await self._client.close()
             except Exception as e:  # pragma: no cover - defensive logging
-                logger.warning("[%s] Error during disconnect: %s", self.name, e, exc_info=True)
+                logger.warning(
+                    "[%s] Error during disconnect: %s", self.name, e, exc_info=True
+                )
 
         self._running = False
         self._client = None
@@ -713,8 +812,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # Release the token lock
         try:
             from gateway.status import release_scoped_lock
-            if getattr(self, '_token_lock_identity', None):
-                release_scoped_lock('discord-bot-token', self._token_lock_identity)
+
+            if getattr(self, "_token_lock_identity", None):
+                release_scoped_lock("discord-bot-token", self._token_lock_identity)
                 self._token_lock_identity = None
         except Exception:
             pass
@@ -734,7 +834,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _remove_reaction(self, message: Any, emoji: str) -> bool:
         """Remove the bot's own emoji reaction from a Discord message."""
-        if not message or not hasattr(message, "remove_reaction") or not self._client or not self._client.user:
+        if (
+            not message
+            or not hasattr(message, "remove_reaction")
+            or not self._client
+            or not self._client.user
+        ):
             return False
         try:
             await message.remove_reaction(emoji, self._client.user)
@@ -745,7 +850,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
-        return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no")
+        return os.getenv("DISCORD_REACTIONS", "true").lower() not in (
+            "false",
+            "0",
+            "no",
+        )
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction for normal Discord message events."""
@@ -755,7 +864,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if hasattr(message, "add_reaction"):
             await self._add_reaction(message, "👀")
 
-    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
         """Swap the in-progress reaction for a final success/failure reaction."""
         if not self._reactions_enabled():
             return
@@ -772,7 +883,7 @@ class DiscordAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a message to a Discord channel or thread.
 
@@ -794,14 +905,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     channel = await self._client.fetch_channel(int(thread_id))
                 if not channel:
-                    return SendResult(success=False, error=f"Thread {thread_id} not found")
+                    return SendResult(
+                        success=False, error=f"Thread {thread_id} not found"
+                    )
             else:
                 # Get the parent channel
                 channel = self._client.get_channel(int(chat_id))
                 if not channel:
                     channel = await self._client.fetch_channel(int(chat_id))
                 if not channel:
-                    return SendResult(success=False, error=f"Channel {chat_id} not found")
+                    return SendResult(
+                        success=False, error=f"Channel {chat_id} not found"
+                    )
 
             # Format and split message if needed
             formatted = self.format_message(content)
@@ -850,11 +965,13 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
-                raw_response={"message_ids": message_ids}
+                raw_response={"message_ids": message_ids},
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to send Discord message: %s", self.name, e, exc_info=True
+            )
             return SendResult(success=False, error=str(e))
 
     async def edit_message(
@@ -873,11 +990,17 @@ class DiscordAdapter(BasePlatformAdapter):
             msg = await channel.fetch_message(int(message_id))
             formatted = self.format_message(content)
             if len(formatted) > self.MAX_MESSAGE_LENGTH:
-                formatted = formatted[:self.MAX_MESSAGE_LENGTH - 3] + "..."
+                formatted = formatted[: self.MAX_MESSAGE_LENGTH - 3] + "..."
             await msg.edit(content=formatted)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to edit Discord message %s: %s",
+                self.name,
+                message_id,
+                e,
+                exc_info=True,
+            )
             return SendResult(success=False, error=str(e))
 
     async def _send_file_attachment(
@@ -916,7 +1039,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         for gid, text_ch_id in self._voice_text_channels.items():
             if str(text_ch_id) == str(chat_id) and self.is_in_voice_channel(gid):
-                logger.info("[%s] Playing TTS in voice channel (guild=%d)", self.name, gid)
+                logger.info(
+                    "[%s] Playing TTS in voice channel (guild=%d)", self.name, gid
+                )
                 success = await self.play_in_voice_channel(gid, audio_path)
                 return SendResult(success=success)
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
@@ -941,7 +1066,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error=f"Channel {chat_id} not found")
 
             if not os.path.exists(audio_path):
-                return SendResult(success=False, error=f"Audio file not found: {audio_path}")
+                return SendResult(
+                    success=False, error=f"Audio file not found: {audio_path}"
+                )
 
             filename = os.path.basename(audio_path)
 
@@ -955,6 +1082,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 duration_secs = 5.0
                 try:
                     from mutagen.oggopus import OggOpus
+
                     info = OggOpus(audio_path)
                     duration_secs = info.info.length
                 except Exception:
@@ -964,15 +1092,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 waveform_b64 = base64.b64encode(waveform_bytes).decode()
 
                 import json as _json
-                payload = _json.dumps({
-                    "flags": 8192,
-                    "attachments": [{
-                        "id": "0",
-                        "filename": "voice-message.ogg",
-                        "duration_secs": round(duration_secs, 2),
-                        "waveform": waveform_b64,
-                    }],
-                })
+
+                payload = _json.dumps(
+                    {
+                        "flags": 8192,
+                        "attachments": [
+                            {
+                                "id": "0",
+                                "filename": "voice-message.ogg",
+                                "duration_secs": round(duration_secs, 2),
+                                "waveform": waveform_b64,
+                            }
+                        ],
+                    }
+                )
                 form = [
                     {"name": "payload_json", "value": payload},
                     {
@@ -983,18 +1116,29 @@ class DiscordAdapter(BasePlatformAdapter):
                     },
                 ]
                 msg_data = await self._client.http.request(
-                    discord.http.Route("POST", "/channels/{channel_id}/messages", channel_id=channel.id),
+                    discord.http.Route(
+                        "POST", "/channels/{channel_id}/messages", channel_id=channel.id
+                    ),
                     form=form,
                 )
                 return SendResult(success=True, message_id=str(msg_data["id"]))
             except Exception as voice_err:
-                logger.debug("Voice message flag failed, falling back to file: %s", voice_err)
+                logger.debug(
+                    "Voice message flag failed, falling back to file: %s", voice_err
+                )
                 file = discord.File(io.BytesIO(file_data), filename=filename)
                 msg = await channel.send(file=file)
                 return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send audio, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_voice(chat_id, audio_path, caption, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send audio, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_voice(
+                chat_id, audio_path, caption, reply_to, metadata=metadata
+            )
 
     # ------------------------------------------------------------------
     # Voice channel methods (join / leave / play)
@@ -1089,7 +1233,9 @@ class DiscordAdapter(BasePlatformAdapter):
             try:
                 await asyncio.wait_for(done.wait(), timeout=self.PLAYBACK_TIMEOUT)
             except asyncio.TimeoutError:
-                logger.warning("Voice playback timed out after %ds", self.PLAYBACK_TIMEOUT)
+                logger.warning(
+                    "Voice playback timed out after %ds", self.PLAYBACK_TIMEOUT
+                )
                 vc.stop()
             self._reset_voice_timeout(guild_id)
             return True
@@ -1166,17 +1312,20 @@ class DiscordAdapter(BasePlatformAdapter):
         for m in channel.members:
             if bot_user and m.id == bot_user.id:
                 continue  # skip the bot itself
-            members_info.append({
-                "user_id": m.id,
-                "display_name": m.display_name,
-                "is_bot": m.bot,
-            })
+            members_info.append(
+                {
+                    "user_id": m.id,
+                    "display_name": m.display_name,
+                    "is_bot": m.bot,
+                }
+            )
 
         # Currently speaking users (from SSRC mapping + active buffers)
         speaking_user_ids: set = set()
         receiver = self._voice_receivers.get(guild_id)
         if receiver:
             import time as _time
+
             now = _time.monotonic()
             with receiver._lock:
                 for ssrc, last_t in receiver._last_packet_time.items():
@@ -1207,7 +1356,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not info:
             return ""
 
-        parts = [f"[Voice channel: #{info['channel_name']} — {info['member_count']} participant(s)]"]
+        parts = [
+            f"[Voice channel: #{info['channel_name']} — {info['member_count']} participant(s)]"
+        ]
         for m in info["members"]:
             status = " (speaking)" if m["is_speaking"] else ""
             parts.append(f"  - {m['display_name']}{status}")
@@ -1240,7 +1391,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     try:
                         vc = self._voice_clients.get(guild_id)
                         if vc and vc.is_connected():
-                            vc._connection.send_packet(b'\xf8\xff\xfe')
+                            vc._connection.send_packet(b"\xf8\xff\xfe")
                     except Exception:
                         pass
 
@@ -1258,13 +1409,16 @@ class DiscordAdapter(BasePlatformAdapter):
         """Convert PCM -> WAV -> STT -> callback."""
         from tools.voice_mode import is_whisper_hallucination
 
-        tmp_f = tempfile.NamedTemporaryFile(suffix=".wav", prefix="vc_listen_", delete=False)
+        tmp_f = tempfile.NamedTemporaryFile(
+            suffix=".wav", prefix="vc_listen_", delete=False
+        )
         wav_path = tmp_f.name
         tmp_f.close()
         try:
             await asyncio.to_thread(VoiceReceiver.pcm_to_wav, pcm_data, wav_path)
 
             from tools.transcription_tools import transcribe_audio
+
             result = await asyncio.to_thread(transcribe_audio, wav_path)
 
             if not result.get("success"):
@@ -1307,10 +1461,19 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             return await self._send_file_attachment(chat_id, image_path, caption)
         except FileNotFoundError:
-            return SendResult(success=False, error=f"Image file not found: {image_path}")
+            return SendResult(
+                success=False, error=f"Image file not found: {image_path}"
+            )
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send local image, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send local image, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_image_file(
+                chat_id, image_path, caption, reply_to, metadata=metadata
+            )
 
     async def send_image(
         self,
@@ -1325,8 +1488,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         if not is_safe_url(image_url):
-            logger.warning("[%s] Blocked unsafe image URL during Discord send_image", self.name)
-            return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
+            logger.warning(
+                "[%s] Blocked unsafe image URL during Discord send_image", self.name
+            )
+            return await super().send_image(
+                chat_id, image_url, caption, reply_to, metadata=metadata
+            )
 
         try:
             import aiohttp
@@ -1339,11 +1506,17 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
-            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+            from gateway.platforms.base import (
+                resolve_proxy_url,
+                proxy_kwargs_for_aiohttp,
+            )
+
             _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
             async with aiohttp.ClientSession(**_sess_kw) as session:
-                async with session.get(image_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw) as resp:
+                async with session.get(
+                    image_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw
+                ) as resp:
                     if resp.status != 200:
                         raise Exception(f"Failed to download image: HTTP {resp.status}")
 
@@ -1360,6 +1533,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         ext = "webp"
 
                     import io
+
                     file = discord.File(io.BytesIO(image_data), filename=f"image.{ext}")
 
                     msg = await channel.send(
@@ -1396,10 +1570,19 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             return await self._send_file_attachment(chat_id, video_path, caption)
         except FileNotFoundError:
-            return SendResult(success=False, error=f"Video file not found: {video_path}")
+            return SendResult(
+                success=False, error=f"Video file not found: {video_path}"
+            )
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send local video, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send local video, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_video(
+                chat_id, video_path, caption, reply_to, metadata=metadata
+            )
 
     async def send_document(
         self,
@@ -1412,12 +1595,21 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(
+                chat_id, file_path, caption, file_name=file_name
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send document, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send document, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_document(
+                chat_id, file_path, caption, file_name, reply_to, metadata=metadata
+            )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Start a persistent typing indicator for a channel.
@@ -1438,14 +1630,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 while True:
                     try:
                         route = discord.http.Route(
-                            "POST", "/channels/{channel_id}/typing",
+                            "POST",
+                            "/channels/{channel_id}/typing",
                             channel_id=chat_id,
                         )
                         await self._client.http.request(route)
                     except asyncio.CancelledError:
                         return
                     except Exception as e:
-                        logger.debug("Discord typing indicator failed for %s: %s", chat_id, e)
+                        logger.debug(
+                            "Discord typing indicator failed for %s: %s", chat_id, e
+                        )
                         return
                     await asyncio.sleep(8)
             except asyncio.CancelledError:
@@ -1495,11 +1690,21 @@ class DiscordAdapter(BasePlatformAdapter):
             return {
                 "name": name,
                 "type": chat_type,
-                "guild_id": str(channel.guild.id) if hasattr(channel, "guild") and channel.guild else None,
-                "guild_name": channel.guild.name if hasattr(channel, "guild") and channel.guild else None,
+                "guild_id": str(channel.guild.id)
+                if hasattr(channel, "guild") and channel.guild
+                else None,
+                "guild_name": channel.guild.name
+                if hasattr(channel, "guild") and channel.guild
+                else None,
             }
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to get chat info for %s: %s", self.name, chat_id, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to get chat info for %s: %s",
+                self.name,
+                chat_id,
+                e,
+                exc_info=True,
+            )
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
 
     async def _resolve_allowed_usernames(self) -> None:
@@ -1525,7 +1730,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not to_resolve:
             return
 
-        print(f"[{self.name}] Resolving {len(to_resolve)} username(s): {', '.join(to_resolve)}")
+        print(
+            f"[{self.name}] Resolving {len(to_resolve)} username(s): {', '.join(to_resolve)}"
+        )
         resolved_count = 0
 
         for guild in self._client.guilds:
@@ -1535,7 +1742,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 if len(members) < guild.member_count:
                     members = [m async for m in guild.fetch_members(limit=None)]
             except Exception as e:
-                logger.warning("Failed to fetch members for guild %s: %s", guild.name, e)
+                logger.warning(
+                    "Failed to fetch members for guild %s: %s", guild.name, e
+                )
                 continue
 
             for member in members:
@@ -1543,16 +1752,28 @@ class DiscordAdapter(BasePlatformAdapter):
                 display_lower = member.display_name.lower()
                 global_lower = (member.global_name or "").lower()
 
-                matched = name_lower in to_resolve or display_lower in to_resolve or global_lower in to_resolve
+                matched = (
+                    name_lower in to_resolve
+                    or display_lower in to_resolve
+                    or global_lower in to_resolve
+                )
                 if matched:
                     uid = str(member.id)
                     numeric_ids.add(uid)
                     resolved_count += 1
-                    matched_name = name_lower if name_lower in to_resolve else (
-                        display_lower if display_lower in to_resolve else global_lower
+                    matched_name = (
+                        name_lower
+                        if name_lower in to_resolve
+                        else (
+                            display_lower
+                            if display_lower in to_resolve
+                            else global_lower
+                        )
                     )
                     to_resolve.discard(matched_name)
-                    print(f"[{self.name}] Resolved '{matched_name}' -> {uid} ({member.name}#{member.discriminator})")
+                    print(
+                        f"[{self.name}] Resolved '{matched_name}' -> {uid} ({member.name}#{member.discriminator})"
+                    )
 
             if not to_resolve:
                 break
@@ -1564,7 +1785,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self._allowed_user_ids = numeric_ids
         os.environ["DISCORD_ALLOWED_USERS"] = ",".join(sorted(numeric_ids))
         if resolved_count:
-            print(f"[{self.name}] Updated DISCORD_ALLOWED_USERS with {resolved_count} resolved ID(s)")
+            print(
+                f"[{self.name}] Updated DISCORD_ALLOWED_USERS with {resolved_count} resolved ID(s)"
+            )
 
     def format_message(self, content: str) -> str:
         """
@@ -1608,24 +1831,32 @@ class DiscordAdapter(BasePlatformAdapter):
 
         @tree.command(name="new", description="Start a new conversation")
         async def slash_new(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/reset", "New conversation started~")
+            await self._run_simple_slash(
+                interaction, "/reset", "New conversation started~"
+            )
 
         @tree.command(name="reset", description="Reset your Hermes session")
         async def slash_reset(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/reset", "Session reset~")
 
         @tree.command(name="model", description="Show or change the model")
-        @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
+        @discord.app_commands.describe(
+            name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current."
+        )
         async def slash_model(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/model {name}".strip())
 
         @tree.command(name="reasoning", description="Show or change reasoning effort")
-        @discord.app_commands.describe(effort="Reasoning effort: none, minimal, low, medium, high, or xhigh.")
+        @discord.app_commands.describe(
+            effort="Reasoning effort: none, minimal, low, medium, high, or xhigh."
+        )
         async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
             await self._run_simple_slash(interaction, f"/reasoning {effort}".strip())
 
         @tree.command(name="personality", description="Set a personality")
-        @discord.app_commands.describe(name="Personality name. Leave empty to list available.")
+        @discord.app_commands.describe(
+            name="Personality name. Leave empty to list available."
+        )
         async def slash_personality(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/personality {name}".strip())
 
@@ -1654,12 +1885,16 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._run_simple_slash(interaction, "/compress")
 
         @tree.command(name="title", description="Set or show the session title")
-        @discord.app_commands.describe(name="Session title. Leave empty to show current.")
+        @discord.app_commands.describe(
+            name="Session title. Leave empty to show current."
+        )
         async def slash_title(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/title {name}".strip())
 
         @tree.command(name="resume", description="Resume a previously-named session")
-        @discord.app_commands.describe(name="Session name to resume. Leave empty to list sessions.")
+        @discord.app_commands.describe(
+            name="Session name to resume. Leave empty to list sessions."
+        )
         async def slash_resume(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/resume {name}".strip())
 
@@ -1685,33 +1920,56 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._run_simple_slash(interaction, "/reload-mcp")
 
         @tree.command(name="voice", description="Toggle voice reply mode")
-        @discord.app_commands.describe(mode="Voice mode: on, off, tts, channel, leave, or status")
-        @discord.app_commands.choices(mode=[
-            discord.app_commands.Choice(name="channel — join your voice channel", value="channel"),
-            discord.app_commands.Choice(name="leave — leave voice channel", value="leave"),
-            discord.app_commands.Choice(name="on — voice reply to voice messages", value="on"),
-            discord.app_commands.Choice(name="tts — voice reply to all messages", value="tts"),
-            discord.app_commands.Choice(name="off — text only", value="off"),
-            discord.app_commands.Choice(name="status — show current mode", value="status"),
-        ])
+        @discord.app_commands.describe(
+            mode="Voice mode: on, off, tts, channel, leave, or status"
+        )
+        @discord.app_commands.choices(
+            mode=[
+                discord.app_commands.Choice(
+                    name="channel — join your voice channel", value="channel"
+                ),
+                discord.app_commands.Choice(
+                    name="leave — leave voice channel", value="leave"
+                ),
+                discord.app_commands.Choice(
+                    name="on — voice reply to voice messages", value="on"
+                ),
+                discord.app_commands.Choice(
+                    name="tts — voice reply to all messages", value="tts"
+                ),
+                discord.app_commands.Choice(name="off — text only", value="off"),
+                discord.app_commands.Choice(
+                    name="status — show current mode", value="status"
+                ),
+            ]
+        )
         async def slash_voice(interaction: discord.Interaction, mode: str = ""):
             await self._run_simple_slash(interaction, f"/voice {mode}".strip())
 
-        @tree.command(name="update", description="Update Hermes Agent to the latest version")
+        @tree.command(
+            name="update", description="Update Hermes Agent to the latest version"
+        )
         async def slash_update(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/update", "Update initiated~")
 
         @tree.command(name="approve", description="Approve a pending dangerous command")
-        @discord.app_commands.describe(scope="Optional: 'all', 'session', 'always', 'all session', 'all always'")
+        @discord.app_commands.describe(
+            scope="Optional: 'all', 'session', 'always', 'all session', 'all always'"
+        )
         async def slash_approve(interaction: discord.Interaction, scope: str = ""):
             await self._run_simple_slash(interaction, f"/approve {scope}".strip())
 
         @tree.command(name="deny", description="Deny a pending dangerous command")
-        @discord.app_commands.describe(scope="Optional: 'all' to deny all pending commands")
+        @discord.app_commands.describe(
+            scope="Optional: 'all' to deny all pending commands"
+        )
         async def slash_deny(interaction: discord.Interaction, scope: str = ""):
             await self._run_simple_slash(interaction, f"/deny {scope}".strip())
 
-        @tree.command(name="thread", description="Create a new thread and start a Hermes session in it")
+        @tree.command(
+            name="thread",
+            description="Create a new thread and start a Hermes session in it",
+        )
         @discord.app_commands.describe(
             name="Thread name",
             message="Optional first message to send to Hermes in the thread",
@@ -1724,20 +1982,33 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_archive_duration: int = 1440,
         ):
             await interaction.response.defer(ephemeral=True)
-            await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
+            await self._handle_thread_create_slash(
+                interaction, name, message, auto_archive_duration
+            )
 
-        @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
+        @tree.command(
+            name="queue",
+            description="Queue a prompt for the next turn (doesn't interrupt)",
+        )
         @discord.app_commands.describe(prompt="The prompt to queue")
         async def slash_queue(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/queue {prompt}", "Queued for the next turn.")
+            await self._run_simple_slash(
+                interaction, f"/queue {prompt}", "Queued for the next turn."
+            )
 
         @tree.command(name="background", description="Run a prompt in the background")
         @discord.app_commands.describe(prompt="The prompt to run in the background")
         async def slash_background(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+            await self._run_simple_slash(
+                interaction, f"/background {prompt}", "Background task started~"
+            )
 
-        @tree.command(name="btw", description="Ephemeral side question using session context")
-        @discord.app_commands.describe(question="Your side question (no tools, not persisted)")
+        @tree.command(
+            name="btw", description="Ephemeral side question using session context"
+        )
+        @discord.app_commands.describe(
+            question="Your side question (no tools, not persisted)"
+        )
         async def slash_btw(interaction: discord.Interaction, question: str):
             await self._run_simple_slash(interaction, f"/btw {question}")
 
@@ -1759,8 +2030,13 @@ class DiscordAdapter(BasePlatformAdapter):
             for discord_name, description, cmd_key in skill_entries:
                 # Closure factory to capture cmd_key per iteration
                 def _make_skill_handler(_key: str):
-                    async def _skill_slash(interaction: discord.Interaction, args: str = ""):
-                        await self._run_simple_slash(interaction, f"{_key} {args}".strip())
+                    async def _skill_slash(
+                        interaction: discord.Interaction, args: str = ""
+                    ):
+                        await self._run_simple_slash(
+                            interaction, f"{_key} {args}".strip()
+                        )
+
                     return _skill_slash
 
                 handler = _make_skill_handler(cmd_key)
@@ -1771,18 +2047,26 @@ class DiscordAdapter(BasePlatformAdapter):
                     description=description,
                     callback=handler,
                 )
-                discord.app_commands.describe(args="Optional arguments for the skill")(cmd)
+                discord.app_commands.describe(args="Optional arguments for the skill")(
+                    cmd
+                )
                 tree.add_command(cmd)
 
             if skipped:
                 logger.warning(
                     "[%s] Discord slash command limit reached (%d): %d skill(s) not registered",
-                    self.name, _DISCORD_CMD_LIMIT, skipped,
+                    self.name,
+                    _DISCORD_CMD_LIMIT,
+                    skipped,
                 )
         except Exception as exc:
-            logger.warning("[%s] Failed to register skill slash commands: %s", self.name, exc)
+            logger.warning(
+                "[%s] Failed to register skill slash commands: %s", self.name, exc
+            )
 
-    def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
+    def _build_slash_event(
+        self, interaction: discord.Interaction, text: str
+    ) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""
         is_dm = isinstance(interaction.channel, discord.DMChannel)
         is_thread = isinstance(interaction.channel, discord.Thread)
@@ -1845,7 +2129,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not result.get("success"):
             error = result.get("error", "unknown error")
-            await interaction.followup.send(f"Failed to create thread: {error}", ephemeral=True)
+            await interaction.followup.send(
+                f"Failed to create thread: {error}", ephemeral=True
+            )
             return
 
         thread_id = result.get("thread_id")
@@ -1862,7 +2148,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # If a message was provided, kick off a new Hermes session in the thread
         starter = (message or "").strip()
         if starter and thread_id:
-            await self._dispatch_thread_session(interaction, thread_id, thread_name, starter)
+            await self._dispatch_thread_session(
+                interaction, thread_id, thread_name, starter
+            )
 
     async def _dispatch_thread_session(
         self,
@@ -1892,7 +2180,9 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
         )
 
-        _parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
+        _parent_id = str(
+            getattr(getattr(interaction, "channel", None), "parent_id", "") or ""
+        )
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
@@ -1903,7 +2193,9 @@ class DiscordAdapter(BasePlatformAdapter):
         )
         await self.handle_message(event)
 
-    def _resolve_channel_skills(self, channel_id: str, parent_id: str | None = None) -> list[str] | None:
+    def _resolve_channel_skills(
+        self, channel_id: str, parent_id: str | None = None
+    ) -> list[str] | None:
         """Look up auto-skill bindings for a Discord channel/forum thread.
 
         Config format (in platform extra):
@@ -1932,7 +2224,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
 
-    async def _resolve_interaction_channel(self, interaction: discord.Interaction) -> Optional[Any]:
+    async def _resolve_interaction_channel(
+        self, interaction: discord.Interaction
+    ) -> Optional[Any]:
         """Return the interaction channel, fetching it if the payload is partial."""
         channel = getattr(interaction, "channel", None)
         if channel is not None:
@@ -1969,20 +2263,29 @@ class DiscordAdapter(BasePlatformAdapter):
             return {"error": "Thread name is required."}
 
         if auto_archive_duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
-            allowed = ", ".join(str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES))
+            allowed = ", ".join(
+                str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES)
+            )
             return {"error": f"auto_archive_duration must be one of: {allowed}."}
 
         channel = await self._resolve_interaction_channel(interaction)
         if channel is None:
             return {"error": "Could not resolve the current Discord channel."}
         if isinstance(channel, discord.DMChannel):
-            return {"error": "Discord threads can only be created inside server text channels, not DMs."}
+            return {
+                "error": "Discord threads can only be created inside server text channels, not DMs."
+            }
 
         parent_channel = self._thread_parent_channel(channel)
         if parent_channel is None:
-            return {"error": "Could not determine a parent text channel for the new thread."}
+            return {
+                "error": "Could not determine a parent text channel for the new thread."
+            }
 
-        display_name = getattr(getattr(interaction, "user", None), "display_name", None) or "unknown user"
+        display_name = (
+            getattr(getattr(interaction, "user", None), "display_name", None)
+            or "unknown user"
+        )
         reason = f"Requested by {display_name} via /thread"
         starter_message = (message or "").strip()
 
@@ -2001,7 +2304,10 @@ class DiscordAdapter(BasePlatformAdapter):
             }
         except Exception as direct_error:
             try:
-                seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
+                seed_content = (
+                    starter_message
+                    or f"\U0001f9f5 Thread created by Hermes: **{name}**"
+                )
                 seed_msg = await parent_channel.send(seed_content)
                 thread = await seed_msg.create_thread(
                     name=name,
@@ -2025,7 +2331,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # Auto-thread helpers
     # ------------------------------------------------------------------
 
-    async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
+    async def _auto_create_thread(self, message: "DiscordMessage") -> Optional[Any]:
         """Create a thread from a user message for auto-threading.
 
         Returns the created thread object, or ``None`` on failure.
@@ -2037,14 +2343,19 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_name = thread_name[:77] + "..."
 
         try:
-            thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
+            thread = await message.create_thread(
+                name=thread_name, auto_archive_duration=1440
+            )
             return thread
         except Exception as e:
             logger.warning("[%s] Auto-thread creation failed: %s", self.name, e)
             return None
 
     async def send_exec_approval(
-        self, chat_id: str, command: str, session_key: str,
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
         description: str = "dangerous command",
         metadata: Optional[dict] = None,
     ) -> SendResult:
@@ -2069,7 +2380,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Discord embed description limit is 4096; show full command up to that
             max_desc = 4088
-            cmd_display = command if len(command) <= max_desc else command[: max_desc - 3] + "..."
+            cmd_display = (
+                command if len(command) <= max_desc else command[: max_desc - 3] + "..."
+            )
             embed = discord.Embed(
                 title="⚠️ Command Approval Required",
                 description=f"```\n{cmd_display}\n```",
@@ -2089,7 +2402,10 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def send_update_prompt(
-        self, chat_id: str, prompt: str, default: str = "",
+        self,
+        chat_id: str,
+        prompt: str,
+        default: str = "",
         session_key: str = "",
     ) -> SendResult:
         """Send an interactive button-based update prompt (Yes / No).
@@ -2149,6 +2465,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             try:
                 from hermes_cli.providers import get_label
+
                 provider_label = get_label(current_provider)
             except Exception:
                 provider_label = current_provider
@@ -2203,7 +2520,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 return True
         return False
 
-    def _get_effective_topic(self, channel: Any, is_thread: bool = False) -> Optional[str]:
+    def _get_effective_topic(
+        self, channel: Any, is_thread: bool = False
+    ) -> Optional[str]:
         """Return the channel topic, falling back to the parent forum's topic for forum threads."""
         topic = getattr(channel, "topic", None)
         if not topic and is_thread:
@@ -2214,7 +2533,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _format_thread_chat_name(self, thread: Any) -> str:
         """Build a readable chat name for thread-like Discord channels, including forum context when available."""
-        thread_name = getattr(thread, "name", None) or str(getattr(thread, "id", "thread"))
+        thread_name = getattr(thread, "name", None) or str(
+            getattr(thread, "id", "thread")
+        )
         parent = getattr(thread, "parent", None)
         guild = getattr(thread, "guild", None) or getattr(parent, "guild", None)
         guild_name = getattr(guild, "name", None)
@@ -2236,6 +2557,7 @@ class DiscordAdapter(BasePlatformAdapter):
     def _thread_state_path() -> Path:
         """Path to the persisted thread participation set."""
         from hermes_cli.config import get_hermes_home
+
         return get_hermes_home() / "discord_threads.json"
 
     @classmethod
@@ -2258,7 +2580,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Trim to most recent entries if over cap
             thread_list = list(self._bot_participated_threads)
             if len(thread_list) > self._MAX_TRACKED_THREADS:
-                thread_list = thread_list[-self._MAX_TRACKED_THREADS:]
+                thread_list = thread_list[-self._MAX_TRACKED_THREADS :]
                 self._bot_participated_threads = set(thread_list)
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(json.dumps(thread_list), encoding="utf-8")
@@ -2300,24 +2622,40 @@ class DiscordAdapter(BasePlatformAdapter):
             # Check allowed channels - if set, only respond in these channels
             allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
             if allowed_channels_raw:
-                allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
+                allowed_channels = {
+                    ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()
+                }
                 if not (channel_ids & allowed_channels):
-                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
+                    logger.debug(
+                        "[%s] Ignoring message in non-allowed channel: %s",
+                        self.name,
+                        channel_ids,
+                    )
                     return
 
             # Check ignored channels - never respond even when mentioned
             ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
-            ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
+            ignored_channels = {
+                ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()
+            }
             if channel_ids & ignored_channels:
-                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
+                logger.debug(
+                    "[%s] Ignoring message in ignored channel: %s",
+                    self.name,
+                    channel_ids,
+                )
                 return
 
             free_channels_raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
-            free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
+            free_channels = {
+                ch.strip() for ch in free_channels_raw.split(",") if ch.strip()
+            }
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
-            require_mention = os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
+            require_mention = os.getenv(
+                "DISCORD_REQUIRE_MENTION", "true"
+            ).lower() not in ("false", "0", "no")
             is_free_channel = bool(channel_ids & free_channels)
 
             # Skip the mention check if the message is in a thread where
@@ -2329,8 +2667,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
 
             if self._client.user and self._client.user in message.mentions:
-                message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
-                message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
+                message.content = message.content.replace(
+                    f"<@{self._client.user.id}>", ""
+                ).strip()
+                message.content = message.content.replace(
+                    f"<@!{self._client.user.id}>", ""
+                ).strip()
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
@@ -2339,16 +2681,48 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
-            no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
+            no_thread_channels = {
+                ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()
+            }
             skip_thread = bool(channel_ids & no_thread_channels)
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
-            if auto_thread and not skip_thread:
-                thread = await self._auto_create_thread(message)
-                if thread:
-                    is_thread = True
-                    thread_id = str(thread.id)
-                    auto_threaded_channel = thread
-                    self._track_thread(thread_id)
+        # Check extra config first, then fall back to env var
+        config_auto_thread = self.config.extra.get("auto_thread")
+        if config_auto_thread is not None:
+            if config_auto_thread == "smart":
+                # Smart mode: only create thread when explicitly mentioned in a public channel
+                # In DMs and threads, no auto-thread
+                auto_thread = False
+            else:
+                auto_thread = bool(config_auto_thread)
+        else:
+            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in (
+                "true",
+                "1",
+                "yes",
+            )
+
+        # Smart mode: don't auto-create thread in DMs or if not mentioned
+        if (
+            config_auto_thread == "smart"
+            and not is_thread
+            and not isinstance(message.channel, discord.DMChannel)
+        ):
+            # Check if message was a mention (explicit @bot)
+            mention_found = self._client.user and self._client.user in message.mentions
+            if mention_found:
+                # Mentioned - create thread
+                auto_thread = True
+            else:
+                # Not mentioned - don't create thread, respond directly
+                auto_thread = False
+
+        if auto_thread and not skip_thread:
+            thread = await self._auto_create_thread(message)
+            if thread:
+                is_thread = True
+                thread_id = str(thread.id)
+                auto_threaded_channel = thread
+                self._track_thread(thread_id)
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -2423,7 +2797,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     media_types.append(content_type)
                     print(f"[Discord] Cached user image: {cached_path}", flush=True)
                 except Exception as e:
-                    print(f"[Discord] Failed to cache image attachment: {e}", flush=True)
+                    print(
+                        f"[Discord] Failed to cache image attachment: {e}", flush=True
+                    )
                     # Fall back to the CDN URL if caching fails
                     media_urls.append(att.url)
                     media_types.append(content_type)
@@ -2437,7 +2813,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     media_types.append(content_type)
                     print(f"[Discord] Cached user audio: {cached_path}", flush=True)
                 except Exception as e:
-                    print(f"[Discord] Failed to cache audio attachment: {e}", flush=True)
+                    print(
+                        f"[Discord] Failed to cache audio attachment: {e}", flush=True
+                    )
                     media_urls.append(att.url)
                     media_types.append(content_type)
             else:
@@ -2452,19 +2830,25 @@ class DiscordAdapter(BasePlatformAdapter):
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
                     logger.warning(
                         "[Discord] Unsupported document type '%s' (%s), skipping",
-                        ext or "unknown", content_type,
+                        ext or "unknown",
+                        content_type,
                     )
                 else:
                     MAX_DOC_BYTES = 32 * 1024 * 1024
                     if att.size and att.size > MAX_DOC_BYTES:
                         logger.warning(
                             "[Discord] Document too large (%s bytes), skipping: %s",
-                            att.size, att.filename,
+                            att.size,
+                            att.filename,
                         )
                     else:
                         try:
                             import aiohttp
-                            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+                            from gateway.platforms.base import (
+                                resolve_proxy_url,
+                                proxy_kwargs_for_aiohttp,
+                            )
+
                             _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
                             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
                             async with aiohttp.ClientSession(**_sess_kw) as session:
@@ -2482,17 +2866,28 @@ class DiscordAdapter(BasePlatformAdapter):
                             doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
                             media_urls.append(cached_path)
                             media_types.append(doc_mime)
-                            logger.info("[Discord] Cached user document: %s", cached_path)
+                            logger.info(
+                                "[Discord] Cached user document: %s", cached_path
+                            )
                             # Inject text content for plain-text documents (capped at 100 KB)
                             MAX_TEXT_INJECT_BYTES = 100 * 1024
-                            if ext in (".md", ".txt", ".log") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                            if (
+                                ext in (".md", ".txt", ".log")
+                                and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES
+                            ):
                                 try:
                                     text_content = raw_bytes.decode("utf-8")
                                     display_name = att.filename or f"document{ext}"
-                                    display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                                    injection = f"[Content of {display_name}]:\n{text_content}"
+                                    display_name = re.sub(
+                                        r"[^\w.\- ]", "_", display_name
+                                    )
+                                    injection = (
+                                        f"[Content of {display_name}]:\n{text_content}"
+                                    )
                                     if pending_text_injection:
-                                        pending_text_injection = f"{pending_text_injection}\n\n{injection}"
+                                        pending_text_injection = (
+                                            f"{pending_text_injection}\n\n{injection}"
+                                        )
                                     else:
                                         pending_text_injection = injection
                                 except UnicodeDecodeError:
@@ -2500,12 +2895,18 @@ class DiscordAdapter(BasePlatformAdapter):
                         except Exception as e:
                             logger.warning(
                                 "[Discord] Failed to cache document %s: %s",
-                                att.filename, e, exc_info=True,
+                                att.filename,
+                                e,
+                                exc_info=True,
                             )
 
         event_text = message.content
         if pending_text_injection:
-            event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
+            event_text = (
+                f"{pending_text_injection}\n\n{event_text}"
+                if event_text
+                else pending_text_injection
+            )
 
         # Defense-in-depth: prevent empty user messages from entering session
         # (can happen when user sends @mention-only with no other text)
@@ -2524,7 +2925,9 @@ class DiscordAdapter(BasePlatformAdapter):
             message_id=str(message.id),
             media_urls=media_urls,
             media_types=media_types,
-            reply_to_message_id=str(message.reference.message_id) if message.reference else None,
+            reply_to_message_id=str(message.reference.message_id)
+            if message.reference
+            else None,
             timestamp=message.created_at,
             auto_skill=_skills,
         )
@@ -2548,10 +2951,15 @@ class DiscordAdapter(BasePlatformAdapter):
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
         from gateway.session import build_session_key
+
         return build_session_key(
             event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            group_sessions_per_user=self.config.extra.get(
+                "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=self.config.extra.get(
+                "thread_sessions_per_user", False
+            ),
         )
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
@@ -2569,7 +2977,9 @@ class DiscordAdapter(BasePlatformAdapter):
             self._pending_text_batches[key] = event
         else:
             if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+                existing.text = (
+                    f"{existing.text}\n{event.text}" if existing.text else event.text
+                )
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
@@ -2602,7 +3012,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 return
             logger.info(
                 "[Discord] Flushing text batch %s (%d chars)",
-                key, len(event.text or ""),
+                key,
+                len(event.text or ""),
             )
             await self.handle_message(event)
         finally:
@@ -2639,8 +3050,11 @@ if DISCORD_AVAILABLE:
             return str(interaction.user.id) in self.allowed_user_ids
 
         async def _resolve(
-            self, interaction: discord.Interaction, choice: str,
-            color: discord.Color, label: str,
+            self,
+            interaction: discord.Interaction,
+            choice: str,
+            color: discord.Color,
+            label: str,
         ):
             """Resolve the approval via the gateway approval queue and update the embed."""
             if self.resolved:
@@ -2658,7 +3072,9 @@ if DISCORD_AVAILABLE:
             self.resolved = True
 
             # Update the embed with the decision
-            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            embed = (
+                interaction.message.embeds[0] if interaction.message.embeds else None
+            )
             if embed:
                 embed.color = color
                 embed.set_footer(text=f"{label} by {interaction.user.display_name}")
@@ -2672,10 +3088,14 @@ if DISCORD_AVAILABLE:
             # Unblock the waiting agent thread via the gateway approval queue
             try:
                 from tools.approval import resolve_gateway_approval
+
                 count = resolve_gateway_approval(self.session_key, choice)
                 logger.info(
                     "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                    count, self.session_key, choice, interaction.user.display_name,
+                    count,
+                    self.session_key,
+                    choice,
+                    interaction.user.display_name,
                 )
             except Exception as exc:
                 logger.error("Failed to resolve gateway approval from button: %s", exc)
@@ -2684,19 +3104,25 @@ if DISCORD_AVAILABLE:
         async def allow_once(
             self, interaction: discord.Interaction, button: discord.ui.Button
         ):
-            await self._resolve(interaction, "once", discord.Color.green(), "Approved once")
+            await self._resolve(
+                interaction, "once", discord.Color.green(), "Approved once"
+            )
 
         @discord.ui.button(label="Allow Session", style=discord.ButtonStyle.grey)
         async def allow_session(
             self, interaction: discord.Interaction, button: discord.ui.Button
         ):
-            await self._resolve(interaction, "session", discord.Color.blue(), "Approved for session")
+            await self._resolve(
+                interaction, "session", discord.Color.blue(), "Approved for session"
+            )
 
         @discord.ui.button(label="Always Allow", style=discord.ButtonStyle.blurple)
         async def allow_always(
             self, interaction: discord.Interaction, button: discord.ui.Button
         ):
-            await self._resolve(interaction, "always", discord.Color.purple(), "Approved permanently")
+            await self._resolve(
+                interaction, "always", discord.Color.purple(), "Approved permanently"
+            )
 
         @discord.ui.button(label="Deny", style=discord.ButtonStyle.red)
         async def deny(
@@ -2731,8 +3157,11 @@ if DISCORD_AVAILABLE:
             return str(interaction.user.id) in self.allowed_user_ids
 
         async def _respond(
-            self, interaction: discord.Interaction, answer: str,
-            color: discord.Color, label: str,
+            self,
+            interaction: discord.Interaction,
+            answer: str,
+            color: discord.Color,
+            label: str,
         ):
             if self.resolved:
                 await interaction.response.send_message(
@@ -2748,7 +3177,9 @@ if DISCORD_AVAILABLE:
             self.resolved = True
 
             # Update embed
-            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            embed = (
+                interaction.message.embeds[0] if interaction.message.embeds else None
+            )
             if embed:
                 embed.color = color
                 embed.set_footer(text=f"{label} by {interaction.user.display_name}")
@@ -2760,6 +3191,7 @@ if DISCORD_AVAILABLE:
             # Write response file
             try:
                 from hermes_constants import get_hermes_home
+
                 home = get_hermes_home()
                 response_path = home / ".update_response"
                 tmp = response_path.with_suffix(".tmp")
@@ -2767,7 +3199,8 @@ if DISCORD_AVAILABLE:
                 tmp.replace(response_path)
                 logger.info(
                     "Discord update prompt answered '%s' by %s",
-                    answer, interaction.user.display_name,
+                    answer,
+                    interaction.user.display_name,
                 )
             except Exception as exc:
                 logger.error("Failed to write update response: %s", exc)
@@ -2915,7 +3348,11 @@ if DISCORD_AVAILABLE:
 
             total = provider.get("total_models", 0) if provider else 0
             shown = min(len(provider.get("models", [])), 25) if provider else 0
-            extra = f"\n*{total - shown} more available — type `/model <name>` directly*" if total > shown else ""
+            extra = (
+                f"\n*{total - shown} more available — type `/model <name>` directly*"
+                if total > shown
+                else ""
+            )
 
             await interaction.response.edit_message(
                 embed=discord.Embed(
@@ -2971,6 +3408,7 @@ if DISCORD_AVAILABLE:
 
             try:
                 from hermes_cli.providers import get_label
+
                 provider_label = get_label(self.current_provider)
             except Exception:
                 provider_label = self.current_provider

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -57,43 +57,52 @@ _VENDOR_PREFIXES: dict[str, str] = {
 }
 
 # Providers whose APIs consume vendor/model slugs.
-_AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
-    "openrouter",
-    "nous",
-    "ai-gateway",
-    "kilocode",
-})
+_AGGREGATOR_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "openrouter",
+        "nous",
+        "ai-gateway",
+        "kilocode",
+    }
+)
 
 # Providers that want bare names with dots replaced by hyphens.
-_DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
-    "anthropic",
-    "opencode-zen",
-})
+_DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "anthropic",
+    }
+)
 
 # Providers that want bare names with dots preserved.
-_STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
-    "copilot",
-    "copilot-acp",
-})
+_STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "copilot",
+        "copilot-acp",
+    }
+)
 
 # Providers whose native naming is authoritative -- pass through unchanged.
-_AUTHORITATIVE_NATIVE_PROVIDERS: frozenset[str] = frozenset({
-    "gemini",
-    "huggingface",
-    "openai-codex",
-})
+_AUTHORITATIVE_NATIVE_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "gemini",
+        "huggingface",
+        "openai-codex",
+    }
+)
 
 # Direct providers that accept bare native names but should repair a matching
 # provider/ prefix when users copy the aggregator form into config.yaml.
-_MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
-    "zai",
-    "kimi-coding",
-    "minimax",
-    "minimax-cn",
-    "alibaba",
-    "qwen-oauth",
-    "custom",
-})
+_MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "zai",
+        "kimi-coding",
+        "minimax",
+        "minimax-cn",
+        "alibaba",
+        "qwen-oauth",
+        "custom",
+    }
+)
 
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
@@ -101,18 +110,22 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
 # DeepSeek's API only recognises exactly two model identifiers.  We map
 # common aliases and patterns to the canonical names.
 
-_DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
-    "reasoner",
-    "r1",
-    "think",
-    "reasoning",
-    "cot",
-})
+_DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "reasoner",
+        "r1",
+        "think",
+        "reasoning",
+        "cot",
+    }
+)
 
-_DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-chat",
-    "deepseek-reasoner",
-})
+_DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset(
+    {
+        "deepseek-chat",
+        "deepseek-reasoner",
+    }
+)
 
 
 def _normalize_for_deepseek(model_name: str) -> str:
@@ -146,6 +159,7 @@ def _normalize_for_deepseek(model_name: str) -> str:
 # ---------------------------------------------------------------------------
 # Helper utilities
 # ---------------------------------------------------------------------------
+
 
 def _strip_vendor_prefix(model_name: str) -> str:
     """Remove a ``vendor/`` prefix if present.
@@ -287,6 +301,7 @@ def _prepend_vendor(model_name: str) -> str:
 # Main normalisation entry point
 # ---------------------------------------------------------------------------
 
+
 def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     """Translate a model name into the format the target provider's API expects.
 
@@ -383,4 +398,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-


### PR DESCRIPTION
## Summary

### Bug Fix 1: opencode-zen model name conversion
**Problem**: `opencode-zen` was incorrectly included in `_DOT_TO_HYPHEN_PROVIDERS`, causing model names like `minimax-m2.5-free` to be converted to `minimax-m2-5-free`, which OpenCode doesn't support (returns 401 "Model not supported")

**Fix**: Remove `opencode-zen` from `_DOT_TO_HYPHEN_PROVIDERS` in `hermes_cli/model_normalize.py`

### Bug Fix 2: Gateway config loading for extra keys
**Problem**: Platform config keys in `extra` section of config.yaml were not being loaded properly by the gateway

**Fix**: Added support for copying extra keys from root-level platform config in `gateway/config.py`

### Enhancement: smart auto_thread mode for Discord
**New feature**: Added support for `auto_thread: smart` in Discord config

**Behavior**: Creates thread only when the bot is explicitly @mentioned in a public channel; in DMs and when not mentioned, responds directly without creating a thread

## Testing
- Direct API call with `minimax-m2.5-free`: 200 OK
- Direct API call with `minimax-m2-5-free`: 401 "Model not supported"
- After fix: Gateway works correctly with minimax-m2.5-free on opencode-zen
- Smart mode tested with both @mention and non-@mention messages

Related issue: #7421