### PR TITLE
fix(gateway): derive channel directory platforms from enum instead of hardcoded list

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -76,10 +76,15 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
-    # Telegram, WhatsApp & Signal can't enumerate chats -- pull from session history
-    for plat_name in ("telegram", "whatsapp", "signal", "weixin", "email", "sms", "bluebubbles"):
-        if plat_name not in platforms:
-            platforms[plat_name] = _build_from_sessions(plat_name)
+    # Platforms that don't support direct channel enumeration get session-based
+    # discovery automatically.  Skip infrastructure entries that aren't messaging
+    # platforms — everything else falls through to _build_from_sessions().
+    _SKIP_SESSION_DISCOVERY = frozenset({"local", "api_server", "webhook"})
+    for plat in Platform:
+        plat_name = plat.value
+        if plat_name in _SKIP_SESSION_DISCOVERY or plat_name in platforms:
+            continue
+        platforms[plat_name] = _build_from_sessions(plat_name)
 
     directory = {
         "updated_at": datetime.now().isoformat(),


### PR DESCRIPTION
## Summary

Six platforms (matrix, mattermost, dingtalk, feishu, wecom, homeassistant) were missing from the session-based discovery loop in `gateway/channel_directory.py`, causing `/channels` and `send_message` to return empty results on those platforms.

Instead of adding them to the hardcoded tuple (which would break again when new platforms are added), this derives the list dynamically from the `Platform` enum. Only infrastructure entries (`local`, `api_server`, `webhook`) are excluded. Discord and Slack are skipped automatically because their direct builders already populate the `platforms` dict before the loop runs.

## Changes
- `gateway/channel_directory.py`: Replace hardcoded 7-platform tuple with dynamic Platform enum iteration (+9/-4 lines)

## Test results
- 22 channel_directory tests pass
- E2E verified: all 18 Platform enum values accounted for (13 session discovery + 2 direct builders + 3 infrastructure skip)

Salvaged from PR #7416 by @sprmn24 — upgraded from tuple expansion to dynamic enum derivation to prevent recurrence.