### PR TITLE
[codex] fix discord startup timeout during slash sync

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -432,6 +432,7 @@ class DiscordAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.DISCORD)
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
+        self._slash_sync_task: Optional[asyncio.Task] = None
         self._allowed_user_ids: set = set()  # For button approval authorization
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
@@ -502,6 +503,8 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
 
         try:
+            self._ready_event.clear()
+
             # Acquire scoped lock to prevent duplicate bot token usage
             from gateway.status import acquire_scoped_lock
             self._token_lock_identity = self.config.token
@@ -555,16 +558,24 @@ class DiscordAdapter(BasePlatformAdapter):
             async def on_ready():
                 logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
 
+                # Consider the adapter ready as soon as the Discord gateway is live.
+                # Slash command sync may be slow or rate-limited and should not make
+                # connect() fail while normal messaging is already available.
+                adapter_self._ready_event.set()
+
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
 
-                # Sync slash commands with Discord
-                try:
-                    synced = await adapter_self._client.tree.sync()
-                    logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
-                except Exception as e:  # pragma: no cover - defensive logging
-                    logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
-                adapter_self._ready_event.set()
+                async def _sync_slash_commands() -> None:
+                    try:
+                        synced = await adapter_self._client.tree.sync()
+                        logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:  # pragma: no cover - defensive logging
+                        logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
+
+                adapter_self._slash_sync_task = asyncio.create_task(_sync_slash_commands())
 
             @self._client.event
             async def on_message(message: DiscordMessage):
@@ -706,6 +717,14 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        if self._slash_sync_task:
+            self._slash_sync_task.cancel()
+            try:
+                await self._slash_sync_task
+            except asyncio.CancelledError:
+                pass
+            self._slash_sync_task = None
+
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -50,9 +50,19 @@ from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 class FakeTree:
     def __init__(self):
         self.sync = AsyncMock(return_value=[])
+        self._commands = []
 
     def command(self, *args, **kwargs):
-        return lambda fn: fn
+        def _decorator(fn):
+            self._commands.append(fn)
+            return fn
+        return _decorator
+
+    def add_command(self, command):
+        self._commands.append(command)
+
+    def get_commands(self):
+        return list(self._commands)
 
 
 class FakeBot:
@@ -138,3 +148,49 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     assert ok is False
     assert released == [("discord-bot-token", "test-token")]
     assert adapter._token_lock_identity is None
+
+
+@pytest.mark.asyncio
+async def test_connect_marks_ready_before_slash_sync_finishes(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    sync_started = asyncio.Event()
+    sync_should_finish = asyncio.Event()
+
+    class SlowTree(FakeTree):
+        def __init__(self):
+            super().__init__()
+
+            async def _slow_sync():
+                sync_started.set()
+                await sync_should_finish.wait()
+                return []
+
+            self.sync = _slow_sync
+
+    class SlowSyncBot(FakeBot):
+        def __init__(self, *, intents, proxy=None):
+            super().__init__(intents=intents, proxy=proxy)
+            self.tree = SlowTree()
+
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: SlowSyncBot(intents=kwargs["intents"], proxy=kwargs.get("proxy")),
+    )
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert adapter._ready_event.is_set() is True
+    await asyncio.wait_for(sync_started.wait(), timeout=1)
+
+    sync_should_finish.set()
+    await adapter.disconnect()


### PR DESCRIPTION
## What changed
- mark the Discord adapter ready as soon as the gateway connection is live
- move slash-command sync into a background task so rate-limited sync no longer blocks startup
- cancel the background sync task on disconnect
- add a regression test covering slow slash sync during connect

## Why it changed
Discord command sync can be rate-limited. Before this change, `connect()` waited for `tree.sync()` to finish inside `on_ready()`, so the adapter could log in successfully, answer messages, and still hit the 30-second startup timeout. That false timeout pushed the gateway into reconnect loops and noisy failure behavior.

## Impact
- Discord startup is more robust when slash sync is slow or rate-limited
- normal message handling becomes available as soon as the gateway is actually connected
- disconnect still cleans up the outstanding sync task

## Root cause
`DiscordAdapter.connect()` treated slash-command synchronization as part of readiness. When Discord rate-limited `tree.sync()`, `_ready_event` was never set before the 30-second wait expired, even though the bot had already connected.

## Validation
- `python -m pytest tests/gateway/test_discord_connect.py -q`
- `python -m pytest tests/gateway/test_discord_reactions.py tests/gateway/test_discord_slash_commands.py -q`
