### PR TITLE
fix(skill): update duckduckgo-search to use `-q` flag (deprecated `-k`)

### DIFF
--- a/optional-skills/research/duckduckgo-search/SKILL.md
+++ b/optional-skills/research/duckduckgo-search/SKILL.md
@@ -57,32 +57,32 @@ Use the `ddgs` command via `terminal` when it exists. This is the preferred path
 
 ```bash
 # Text search
-ddgs text -k "python async programming" -m 5
+ddgs text -q "python async programming" -m 5
 
 # News search
-ddgs news -k "artificial intelligence" -m 5
+ddgs news -q "artificial intelligence" -m 5
 
 # Image search
-ddgs images -k "landscape photography" -m 10
+ddgs images -q "landscape photography" -m 10
 
 # Video search
-ddgs videos -k "python tutorial" -m 5
+ddgs videos -q "python tutorial" -m 5
 
 # With region filter
-ddgs text -k "best restaurants" -m 5 -r us-en
+ddgs text -q "best restaurants" -m 5 -r us-en
 
 # Recent results only (d=day, w=week, m=month, y=year)
-ddgs text -k "latest AI news" -m 5 -t w
+ddgs text -q "latest AI news" -m 5 -t w
 
 # JSON output for parsing
-ddgs text -k "fastapi tutorial" -m 5 -o json
+ddgs text -q "fastapi tutorial" -m 5 -o json
 ```
 
 ### CLI Flags
 
 | Flag | Description | Example |
 |------|-------------|---------|
-| `-k` | Keywords (query) — **required** | `-k "search terms"` |
+| `-q` | Query (search terms) — **required** | `-q "search terms"` |
 | `-m` | Max results | `-m 5` |
 | `-r` | Region | `-r us-en` |
 | `-t` | Time limit | `-t w` (week) |
@@ -189,7 +189,7 @@ DuckDuckGo returns titles, URLs, and snippets — not full page content. To get 
 CLI example:
 
 ```bash
-ddgs text -k "fastapi deployment guide" -m 3 -o json
+ddgs text -q "fastapi deployment guide" -m 3 -o json
 ```
 
 Python example, only after verifying `ddgs` is installed in that runtime:
@@ -229,7 +229,7 @@ Then extract the best URL with `web_extract` or another content-retrieval tool.
 - **Do not assume the CLI exists**: Check `command -v ddgs` before using it.
 - **Do not assume `execute_code` can import `ddgs`**: `from ddgs import DDGS` may fail with `ModuleNotFoundError` unless that runtime was prepared separately.
 - **Package name**: The package is `ddgs` (previously `duckduckgo-search`). Install with `pip install ddgs`.
-- **Don't confuse `-k` and `-m`** (CLI): `-k` is for keywords, `-m` is for max results count.
+- **Don't confuse `-q` and `-m`** (CLI): `-q` is for query, `-m` is for max results count.
 - **Empty results**: If `ddgs` returns nothing, it may be rate-limited. Wait a few seconds and retry.
 
 ## Validated With

--- a/optional-skills/research/duckduckgo-search/scripts/duckduckgo.sh
+++ b/optional-skills/research/duckduckgo-search/scripts/duckduckgo.sh
@@ -25,4 +25,4 @@ if ! command -v ddgs &> /dev/null; then
     exit 1
 fi
 
-ddgs text -k "$QUERY" -m "$MAX_RESULTS"
+ddgs text -q "$QUERY" -m "$MAX_RESULTS"


### PR DESCRIPTION
## What broke

duckduckgo-search skill documents `-k` flag for ddgs CLI, which is deprecated and causes `AttributeError: 'NoneType' object has no attribute 'replace'` in current ddgs versions.

The skill's CLI examples, flags table, workflow example, and helper script all use `-k`, causing the agent to fail on first CLI attempt before falling back to Python API.

**Result**: Every CLI-first invocation costs one wasted tool call.

## Root cause

ddgs library deprecated `-k` in favor of `-q`. The skill documentation was not updated to match the new CLI syntax.

Upstream issue: https://github.com/deedy5/ddgs/issues/414

## Why this fix is minimal

- Updated all `-k` references to `-q` in SKILL.md
- Updated CLI Flags table: `-k` → `-q`
- Updated workflow example
- Updated Pitfalls section
- Updated helper script duckduckgo.sh

No code changes, only documentation and example script.

## Changes

| File | Change |
|------|--------|
| SKILL.md | CLI examples: `-k` → `-q` |
| SKILL.md | Flags table: `-k` → `-q` |
| SKILL.md | Workflow example: `-k` → `-q` |
| SKILL.md | Pitfalls: `-k` → `-q` |
| duckduckgo.sh | `-k` → `-q` |

## What I tested

- Verified no `-k` references remain in skill files
- Diff confirms all CLI examples updated

## What I intentionally did not change

- No changes to Python API examples (unchanged)
- No changes to skill structure or logic
- No opportunistic refactoring

Fixes #7361