### PR TITLE
fix(webhook): scope idempotency per route

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -105,3 +105,5 @@ tesseracttars-creator <tesseracttars@gmail.com> <tesseracttars@gmail.com>
 xinbenlv <zzn+pa@zzn.im> <zzn+pa@zzn.im>
 SaulJWu <saul.jj.wu@gmail.com> <saul.jj.wu@gmail.com>
 angelos <angelos@oikos.lan.home.malaiwah.com> <angelos@oikos.lan.home.malaiwah.com>
+MestreY0d4-Uninter <mateus-scheuer-macedo@users.noreply.github.com> <mateus-scheuer-macedo@users.noreply.github.com>
+MestreY0d4-Uninter <MestreY0d4-Uninter@users.noreply.github.com> <MestreY0d4-Uninter@users.noreply.github.com>

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -90,9 +90,11 @@ class WebhookAdapter(BasePlatformAdapter):
         # Reference to gateway runner for cross-platform delivery (set externally)
         self.gateway_runner = None
 
-        # Idempotency: TTL cache of recently processed delivery IDs.
-        # Prevents duplicate agent runs when webhook providers retry.
-        self._seen_deliveries: Dict[str, float] = {}
+        # Idempotency: TTL cache of recently processed (route, delivery) keys.
+        # Prevents duplicate agent runs when webhook providers retry the same
+        # route, while still allowing intentional fan-out of one provider
+        # delivery across multiple configured webhook routes.
+        self._seen_deliveries: Dict[tuple[str, str], float] = {}
         self._idempotency_ttl: int = 3600  # 1 hour
 
         # Rate limiting: per-route timestamps in a fixed window.
@@ -401,23 +403,26 @@ class WebhookAdapter(BasePlatformAdapter):
         )
 
         # ── Idempotency ─────────────────────────────────────────
-        # Skip duplicate deliveries (webhook retries).
+        # Skip duplicate deliveries (webhook retries) per route.
         now = time.time()
+        dedup_key = (route_name, delivery_id)
         # Prune expired entries
         self._seen_deliveries = {
             k: v
             for k, v in self._seen_deliveries.items()
             if now - v < self._idempotency_ttl
         }
-        if delivery_id in self._seen_deliveries:
+        if dedup_key in self._seen_deliveries:
             logger.info(
-                "[webhook] Skipping duplicate delivery %s", delivery_id
+                "[webhook] Skipping duplicate delivery %s on route %s",
+                delivery_id,
+                route_name,
             )
             return web.json_response(
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
-        self._seen_deliveries[delivery_id] = now
+        self._seen_deliveries[dedup_key] = now
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,8 @@ AUTHOR_MAP = {
     "258577966+voidborne-d@users.noreply.github.com": "voidborne-d",
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
+    "mateus-scheuer-macedo@users.noreply.github.com": "MestreY0d4-Uninter",
     # contributors (manual mapping from git names)
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -412,6 +412,29 @@ class TestIdempotency:
             assert data["status"] == "duplicate"
 
     @pytest.mark.asyncio
+    async def test_same_delivery_id_on_different_routes_is_accepted(self):
+        """The same provider delivery may fan out to multiple configured routes."""
+        routes = {
+            "route_a": {"secret": _INSECURE_NO_AUTH, "prompt": "route a"},
+            "route_b": {"secret": _INSECURE_NO_AUTH, "prompt": "route b"},
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"X-GitHub-Delivery": "delivery-shared"}
+
+            resp1 = await cli.post("/webhooks/route_a", json={"x": 1}, headers=headers)
+            resp2 = await cli.post("/webhooks/route_b", json={"x": 1}, headers=headers)
+
+            assert resp1.status == 202
+            assert resp2.status == 202
+            assert adapter.handle_message.await_count == 2
+            assert adapter.handle_message.await_args_list[0].args[0].source.chat_id == "webhook:route_a:delivery-shared"
+            assert adapter.handle_message.await_args_list[1].args[0].source.chat_id == "webhook:route_b:delivery-shared"
+
+    @pytest.mark.asyncio
     async def test_expired_delivery_id_allows_reprocess(self):
         """After TTL expires, the same delivery ID is accepted again."""
         routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
@@ -427,7 +450,7 @@ class TestIdempotency:
             assert resp1.status == 202
 
             # Backdate the cache entry so it appears expired
-            adapter._seen_deliveries["delivery-456"] = time.time() - 3700
+            adapter._seen_deliveries[("idem", "delivery-456")] = time.time() - 3700
 
             resp2 = await cli.post("/webhooks/idem", json={"x": 1}, headers=headers)
             assert resp2.status == 202  # re-accepted


### PR DESCRIPTION
## Summary
- scope webhook idempotency by `(route_name, delivery_id)` instead of global `delivery_id`
- preserve same-route retry dedup while allowing valid multi-route fan-out
- add regression coverage for the same delivery hitting two different routes

## Root cause
Webhook deduplication was keyed only by `delivery_id`, so the same provider event sent intentionally to two configured webhook routes caused the second route to be skipped as a duplicate.

## Test Plan
- `uv run pytest tests/gateway/test_webhook_adapter.py -q -o addopts=`
- `source /home/ubuntu/hermes-uv-venv/bin/activate && pytest -q tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_dynamic_routes.py -o addopts=`
- `python3 -m py_compile gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py`

Closes #7448