### PR TITLE
Fix messaging toolset persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ skills/.hub/
 ignored/
 .worktrees/
 environments/benchmarks/evals/
+.hermes-gate/
 
 # Release script temp files
 .release_notes.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,6 +453,16 @@ def profile_env(tmp_path, monkeypatch):
     return home
 ```
 
+### Local gate enforcement lives in repo scripts, not memory
+For the local gated workflow:
+- install/update the active hook with `python scripts/install_local_gate_hook.py --force`
+- generate `.hermes-gate/gate.json` with `python scripts/write_gate.py ...`
+- validate gate artifacts with `python scripts/validate_gate.py`
+
+`pre-push` must reject pushes when `gate.json` is stale, when report files are missing, or when `review.md` / `test.md` do not contain these exact lines for the current commit:
+- `- Head SHA: <current HEAD>`
+- `- Verdict: PASS`
+
 ---
 
 ## Testing
@@ -460,6 +470,7 @@ def profile_env(tmp_path, monkeypatch):
 ```bash
 source venv/bin/activate
 python -m pytest tests/ -q          # Full suite (~3000 tests, ~3 min)
+python -m pytest tests/test_local_gate_workflow.py -q  # Local gate workflow
 python -m pytest tests/test_model_tools.py -q   # Toolset resolution
 python -m pytest tests/test_cli_init.py -q       # CLI config loading
 python -m pytest tests/gateway/ -q               # Gateway tests

--- a/README.md
+++ b/README.md
@@ -150,8 +150,31 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
+python scripts/install_local_gate_hook.py
 python -m pytest tests/ -q
 ```
+
+Local gate workflow for code changes:
+
+```bash
+python scripts/install_local_gate_hook.py
+python -m pytest tests/test_local_gate_workflow.py -q
+python scripts/write_gate.py \
+  --review-status PASS \
+  --reviewer hermes-subagent-review \
+  --review-summary "clean implementation; no blocker" \
+  --review-report .hermes-gate/review.md \
+  --test-status PASS \
+  --tester hermes-subagent-test \
+  --test-summary "tests passed; no regression found" \
+  --test-report .hermes-gate/test.md
+```
+
+`pre-push` validates `.hermes-gate/gate.json` against the current `HEAD` and also checks that `.hermes-gate/review.md` and `.hermes-gate/test.md` both contain these exact lines:
+- `- Head SHA: <current HEAD>`
+- `- Verdict: PASS`
+
+Use `--force` only when you intentionally want to replace an unmanaged existing hook.
 
 > **RL Training (optional):** To work on the RL/Tinker-Atropos integration:
 > ```bash

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -84,6 +84,7 @@ CONFIGURABLE_TOOLSETS = [
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
+    ("messaging",       "💬 Messaging",                 "send_message"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
 ]
 

--- a/scripts/install_local_gate_hook.py
+++ b/scripts/install_local_gate_hook.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+MANAGED_MARKER = "# Managed by scripts/install_local_gate_hook.py"
+HOOK_BODY = f"""#!/usr/bin/env bash
+set -euo pipefail
+{MANAGED_MARKER}
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "${{repo_root:-}}" ]; then
+  exit 0
+fi
+cd "$repo_root"
+
+if [ ! -f "scripts/validate_gate.py" ]; then
+  exit 0
+fi
+
+if [ ! -d ".hermes-gate" ] && [ ! -f "scripts/write_gate.py" ]; then
+  exit 0
+fi
+
+python_bin="${{HERMES_GATE_PYTHON:-}}"
+if [ -z "${{python_bin:-}}" ] && [ -x "$repo_root/venv/bin/python" ]; then
+  python_bin="$repo_root/venv/bin/python"
+elif [ -z "${{python_bin:-}}" ] && [ -x "$repo_root/.venv/bin/python" ]; then
+  python_bin="$repo_root/.venv/bin/python"
+else
+  python_bin="${{python_bin:-python3}}"
+fi
+
+exec "$python_bin" scripts/validate_gate.py --gate-file "${{HERMES_GATE_FILE:-.hermes-gate/gate.json}}"
+"""
+
+
+def git_output(*args: str, allow_empty: bool = False, cwd: Path | None = None) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True, cwd=cwd)
+    if result.returncode != 0:
+        if allow_empty:
+            return ""
+        raise RuntimeError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def ensure_repo_root() -> Path:
+    return Path(git_output("rev-parse", "--show-toplevel"))
+
+
+def resolve_hooks_dir(repo_root: Path, override: str | None) -> Path:
+    if override:
+        return Path(override).expanduser().resolve()
+
+    hooks_path = git_output("config", "--get", "core.hooksPath", allow_empty=True, cwd=repo_root)
+    if hooks_path:
+        hooks_dir = Path(hooks_path).expanduser()
+        if not hooks_dir.is_absolute():
+            hooks_dir = repo_root / hooks_dir
+        return hooks_dir.resolve()
+
+    git_hooks_path = git_output("rev-parse", "--git-path", "hooks", cwd=repo_root)
+    hooks_dir = Path(git_hooks_path)
+    if not hooks_dir.is_absolute():
+        hooks_dir = repo_root / hooks_dir
+    return hooks_dir.resolve()
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Install the managed local gate pre-push hook")
+    p.add_argument("--hooks-dir", help="Override hooks directory (default: git core.hooksPath or .git/hooks)")
+    p.add_argument("--hook-name", default="pre-push")
+    p.add_argument("--force", action="store_true", help="Overwrite an unmanaged existing hook")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = ensure_repo_root()
+    hooks_dir = resolve_hooks_dir(repo_root, args.hooks_dir)
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hooks_dir / args.hook_name
+
+    if hook_path.exists():
+        existing = hook_path.read_text(encoding="utf-8")
+        if MANAGED_MARKER not in existing and not args.force:
+            print(
+                f"refusing to overwrite unmanaged hook: {hook_path} (use --force)",
+                file=sys.stderr,
+            )
+            return 1
+
+    hook_path.write_text(HOOK_BODY, encoding="utf-8")
+    hook_path.chmod(0o755)
+    print(hook_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_gate.py
+++ b/scripts/validate_gate.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+HEAD_SHA_RE = re.compile(r"(?m)^\s*-\s*Head SHA:\s*(\S+)\s*$")
+VERDICT_RE = re.compile(r"(?m)^\s*-\s*Verdict:\s*(\S+)\s*$")
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def ensure_repo_root() -> Path:
+    return Path(git_output("rev-parse", "--show-toplevel"))
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Validate local gate artifacts for the current HEAD")
+    p.add_argument("--gate-file", default=".hermes-gate/gate.json", help="Gate JSON path relative to repo root")
+    return p.parse_args()
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def _extract(pattern: re.Pattern[str], text: str, label: str, report_path: Path) -> Optional[str]:
+    match = pattern.search(text)
+    if not match:
+        print(f"{label} missing in {report_path}", file=sys.stderr)
+        return None
+    return match.group(1)
+
+
+def validate_report(report_path: Path, head_sha: str, section_name: str) -> int:
+    if not report_path.exists():
+        return fail(f"{section_name} report missing: {report_path}")
+
+    text = report_path.read_text(encoding="utf-8")
+    report_head_sha = _extract(HEAD_SHA_RE, text, "Head SHA", report_path)
+    if report_head_sha is None:
+        return 1
+    if report_head_sha != head_sha:
+        return fail(
+            f"{section_name} report Head SHA mismatch: expected {head_sha}, got {report_head_sha}"
+        )
+
+    verdict = _extract(VERDICT_RE, text, "Verdict", report_path)
+    if verdict is None:
+        return 1
+    if verdict != "PASS":
+        return fail(f"{section_name} report Verdict is not PASS: {verdict}")
+
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = ensure_repo_root().resolve()
+    head_sha = git_output("rev-parse", "HEAD")
+
+    gate_path = Path(args.gate_file)
+    if not gate_path.is_absolute():
+        gate_path = repo_root / gate_path
+    if not gate_path.exists():
+        return fail(f"missing {gate_path}")
+
+    try:
+        data = json.loads(gate_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return fail(f"invalid gate file: {exc}")
+
+    for key in ("head_sha", "review", "test"):
+        if key not in data:
+            return fail(f"gate.json missing top-level key: {key}")
+
+    if data["head_sha"] != head_sha:
+        return fail(f"gate.json head_sha mismatch: expected {head_sha}, got {data['head_sha']}")
+
+    for section_name in ("review", "test"):
+        section = data.get(section_name) or {}
+        for key in ("status", "head_sha", "report_path"):
+            if key not in section:
+                return fail(f"gate.json {section_name} missing key: {key}")
+        if section["status"] != "PASS":
+            return fail(f"{section_name} status is not PASS: {section['status']}")
+        if section["head_sha"] != head_sha:
+            return fail(
+                f"{section_name} head_sha mismatch: expected {head_sha}, got {section['head_sha']}"
+            )
+
+        report_path = Path(section["report_path"])
+        if not report_path.is_absolute():
+            report_path = repo_root / report_path
+        report_path = report_path.resolve()
+        try:
+            report_path.relative_to(repo_root)
+        except ValueError:
+            return fail(f"{section_name} report is outside repo root: {report_path}")
+
+        rc = validate_report(report_path, head_sha, section_name)
+        if rc:
+            return rc
+
+    print(f"pre-push gate passed for {head_sha[:12]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_gate.py
+++ b/scripts/write_gate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def git_head_sha() -> str:
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+
+def ensure_repo_root() -> Path:
+    root = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
+    return Path(root)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Write .hermes-gate/gate.json for the current HEAD")
+    p.add_argument("--gate-dir", default=".hermes-gate", help="Directory for gate artifacts (default: .hermes-gate)")
+
+    p.add_argument("--review-status", required=True, choices=["PASS", "FAIL"])
+    p.add_argument("--reviewer", required=True)
+    p.add_argument("--review-summary", required=True)
+    p.add_argument("--review-report", required=True)
+
+    p.add_argument("--test-status", required=True, choices=["PASS", "FAIL"])
+    p.add_argument("--tester", required=True)
+    p.add_argument("--test-summary", required=True)
+    p.add_argument("--test-report", required=True)
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = ensure_repo_root()
+    head_sha = git_head_sha()
+
+    gate_dir = repo_root / args.gate_dir
+    gate_dir.mkdir(parents=True, exist_ok=True)
+
+    review_report = Path(args.review_report)
+    test_report = Path(args.test_report)
+    if not review_report.is_absolute():
+        review_report = repo_root / review_report
+    if not test_report.is_absolute():
+        test_report = repo_root / test_report
+
+    if not review_report.exists():
+        print(f"review report not found: {review_report}", file=sys.stderr)
+        return 1
+    if not test_report.exists():
+        print(f"test report not found: {test_report}", file=sys.stderr)
+        return 1
+
+    payload = {
+        "head_sha": head_sha,
+        "generated_at": datetime.now(timezone.utc).astimezone().isoformat(),
+        "review": {
+            "status": args.review_status,
+            "head_sha": head_sha,
+            "reviewer": args.reviewer,
+            "summary": args.review_summary,
+            "report_path": str(review_report.relative_to(repo_root)),
+        },
+        "test": {
+            "status": args.test_status,
+            "head_sha": head_sha,
+            "tester": args.tester,
+            "summary": args.test_summary,
+            "report_path": str(test_report.relative_to(repo_root)),
+        },
+    }
+
+    gate_path = gate_dir / "gate.json"
+    gate_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(gate_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -286,6 +286,42 @@ def test_save_platform_tools_still_preserves_mcp_with_platform_default_present()
     assert "terminal" not in saved
 
 
+def test_save_platform_tools_round_trip_preserves_messaging_toolset():
+    """messaging is a built-in configurable toolset, not a passthrough entry."""
+    config = {
+        "platform_toolsets": {
+            "cli": ["web", "messaging"]
+        }
+    }
+
+    assert "messaging" in _get_platform_tools(config, "cli")
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web", "messaging"})
+
+    saved = config["platform_toolsets"]["cli"]
+    assert "messaging" in saved
+
+    reloaded = _get_platform_tools(config, "cli")
+    assert "messaging" in reloaded
+
+
+def test_save_platform_tools_drops_deselected_messaging_toolset():
+    """messaging must disappear when the user explicitly disables it."""
+    config = {
+        "platform_toolsets": {
+            "cli": ["web", "messaging"]
+        }
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web"})
+
+    saved = config["platform_toolsets"]["cli"]
+    assert "messaging" not in saved
+    assert _get_platform_tools(config, "cli") == {"web"}
+
+
 def test_visible_providers_include_nous_subscription_when_logged_in(monkeypatch):
     monkeypatch.setenv("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1")
     config = {"model": {"provider": "nous"}}

--- a/tests/test_local_gate_workflow.py
+++ b/tests/test_local_gate_workflow.py
@@ -1,0 +1,324 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WRITE_GATE = REPO_ROOT / "scripts" / "write_gate.py"
+VALIDATE_GATE = REPO_ROOT / "scripts" / "validate_gate.py"
+INSTALL_HOOK = REPO_ROOT / "scripts" / "install_local_gate_hook.py"
+
+
+def run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, env=merged_env)
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(["git", "init", "-b", "main"], cwd=repo)
+    run(["git", "config", "user.name", "Test User"], cwd=repo)
+    run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    run(["git", "add", "README.md"], cwd=repo)
+    commit = run(["git", "commit", "-m", "init"], cwd=repo)
+    assert commit.returncode == 0, commit.stderr
+    return repo
+
+
+def write_reports(repo: Path, head_sha: str) -> None:
+    gate_dir = repo / ".hermes-gate"
+    gate_dir.mkdir(exist_ok=True)
+    (gate_dir / "review.md").write_text(
+        "\n".join(
+            [
+                "# Review Report",
+                f"- Head SHA: {head_sha}",
+                "- Reviewer: hermes-subagent-review",
+                "- Verdict: PASS",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (gate_dir / "test.md").write_text(
+        "\n".join(
+            [
+                "# Test Report",
+                f"- Head SHA: {head_sha}",
+                "- Tester: hermes-subagent-test",
+                "- Verdict: PASS",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def git_head(repo: Path) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=repo)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_write_gate_writes_current_head_and_relative_paths(tmp_path):
+    repo = init_repo(tmp_path)
+    head_sha = git_head(repo)
+    write_reports(repo, head_sha)
+
+    result = run(
+        [
+            sys.executable,
+            str(WRITE_GATE),
+            "--review-status",
+            "PASS",
+            "--reviewer",
+            "hermes-subagent-review",
+            "--review-summary",
+            "clean",
+            "--review-report",
+            ".hermes-gate/review.md",
+            "--test-status",
+            "PASS",
+            "--tester",
+            "hermes-subagent-test",
+            "--test-summary",
+            "clean",
+            "--test-report",
+            ".hermes-gate/test.md",
+        ],
+        cwd=repo,
+    )
+
+    assert result.returncode == 0, result.stderr
+    gate_path = repo / ".hermes-gate" / "gate.json"
+    payload = json.loads(gate_path.read_text(encoding="utf-8"))
+    assert payload["head_sha"] == head_sha
+    assert payload["review"]["head_sha"] == head_sha
+    assert payload["test"]["head_sha"] == head_sha
+    assert payload["review"]["report_path"] == ".hermes-gate/review.md"
+    assert payload["test"]["report_path"] == ".hermes-gate/test.md"
+
+
+def test_validate_gate_rejects_report_sha_mismatch(tmp_path):
+    repo = init_repo(tmp_path)
+    head_sha = git_head(repo)
+    write_reports(repo, head_sha)
+
+    write_result = run(
+        [
+            sys.executable,
+            str(WRITE_GATE),
+            "--review-status",
+            "PASS",
+            "--reviewer",
+            "hermes-subagent-review",
+            "--review-summary",
+            "clean",
+            "--review-report",
+            ".hermes-gate/review.md",
+            "--test-status",
+            "PASS",
+            "--tester",
+            "hermes-subagent-test",
+            "--test-summary",
+            "clean",
+            "--test-report",
+            ".hermes-gate/test.md",
+        ],
+        cwd=repo,
+    )
+    assert write_result.returncode == 0, write_result.stderr
+
+    (repo / ".hermes-gate" / "review.md").write_text(
+        "# Review Report\n- Head SHA: deadbeef\n- Reviewer: hermes-subagent-review\n- Verdict: PASS\n",
+        encoding="utf-8",
+    )
+
+    validate_result = run([sys.executable, str(VALIDATE_GATE)], cwd=repo)
+    assert validate_result.returncode == 1
+    assert "review report Head SHA mismatch" in validate_result.stderr
+
+
+def test_validate_gate_rejects_report_verdict_fail(tmp_path):
+    repo = init_repo(tmp_path)
+    head_sha = git_head(repo)
+    write_reports(repo, head_sha)
+    write_result = run(
+        [
+            sys.executable,
+            str(WRITE_GATE),
+            "--review-status",
+            "PASS",
+            "--reviewer",
+            "hermes-subagent-review",
+            "--review-summary",
+            "clean",
+            "--review-report",
+            ".hermes-gate/review.md",
+            "--test-status",
+            "PASS",
+            "--tester",
+            "hermes-subagent-test",
+            "--test-summary",
+            "clean",
+            "--test-report",
+            ".hermes-gate/test.md",
+        ],
+        cwd=repo,
+    )
+    assert write_result.returncode == 0, write_result.stderr
+
+    (repo / ".hermes-gate" / "test.md").write_text(
+        f"# Test Report\n- Head SHA: {head_sha}\n- Tester: hermes-subagent-test\n- Verdict: FAIL\n",
+        encoding="utf-8",
+    )
+
+    validate_result = run([sys.executable, str(VALIDATE_GATE)], cwd=repo)
+    assert validate_result.returncode == 1
+    assert "test report Verdict is not PASS" in validate_result.stderr
+
+
+def test_validate_gate_rejects_report_path_escape(tmp_path):
+    repo = init_repo(tmp_path)
+    head_sha = git_head(repo)
+    outside = tmp_path / "outside.md"
+    outside.write_text(
+        f"# Report\n- Head SHA: {head_sha}\n- Verdict: PASS\n",
+        encoding="utf-8",
+    )
+    gate_dir = repo / ".hermes-gate"
+    gate_dir.mkdir(exist_ok=True)
+    (gate_dir / "gate.json").write_text(
+        json.dumps(
+            {
+                "head_sha": head_sha,
+                "review": {
+                    "status": "PASS",
+                    "head_sha": head_sha,
+                    "report_path": "../outside.md",
+                },
+                "test": {
+                    "status": "PASS",
+                    "head_sha": head_sha,
+                    "report_path": "../outside.md",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    validate_result = run([sys.executable, str(VALIDATE_GATE)], cwd=repo)
+    assert validate_result.returncode == 1
+    assert "outside repo root" in validate_result.stderr
+
+
+def test_install_hook_uses_repo_root_for_relative_core_hookspath(tmp_path):
+    repo = init_repo(tmp_path)
+    config_result = run(["git", "config", "core.hooksPath", ".githooks"], cwd=repo)
+    assert config_result.returncode == 0, config_result.stderr
+
+    nested = repo / "nested"
+    nested.mkdir()
+    install_result = run([sys.executable, str(INSTALL_HOOK), "--force"], cwd=nested)
+    assert install_result.returncode == 0, install_result.stderr
+    assert (repo / ".githooks" / "pre-push").exists()
+    assert not (nested / ".githooks" / "pre-push").exists()
+
+
+def test_installed_hook_noops_without_validate_script(tmp_path):
+    repo = init_repo(tmp_path)
+    hooks_dir = tmp_path / "hooks"
+    install_result = run(
+        [sys.executable, str(INSTALL_HOOK), "--hooks-dir", str(hooks_dir), "--force"],
+        cwd=repo,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    (repo / ".hermes-gate").mkdir(exist_ok=True)
+    hook_result = run([str(hooks_dir / "pre-push")], cwd=repo)
+    assert hook_result.returncode == 0, hook_result.stderr
+    assert hook_result.stdout == ""
+
+
+def test_install_hook_uses_git_path_hooks_in_worktree(tmp_path):
+    repo = init_repo(tmp_path)
+    worktree = tmp_path / "wt"
+    worktree_result = run(["git", "worktree", "add", str(worktree), "-d"], cwd=repo)
+    assert worktree_result.returncode == 0, worktree_result.stderr
+
+    isolated_git_env = {
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": str(tmp_path / "empty-gitconfig"),
+    }
+    (tmp_path / "empty-gitconfig").write_text("", encoding="utf-8")
+
+    install_result = run(
+        [sys.executable, str(INSTALL_HOOK), "--force"],
+        cwd=worktree,
+        env=isolated_git_env,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    hooks_path_result = run(
+        ["git", "rev-parse", "--git-path", "hooks"],
+        cwd=worktree,
+        env=isolated_git_env,
+    )
+    assert hooks_path_result.returncode == 0, hooks_path_result.stderr
+    hook_dir = Path(hooks_path_result.stdout.strip())
+    if not hook_dir.is_absolute():
+        hook_dir = worktree / hook_dir
+    assert (hook_dir.resolve() / "pre-push").exists()
+
+
+def test_install_hook_and_run_pre_push_smoke(tmp_path):
+    repo = init_repo(tmp_path)
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "write_gate.py").write_text(WRITE_GATE.read_text(encoding="utf-8"), encoding="utf-8")
+    (scripts_dir / "validate_gate.py").write_text(VALIDATE_GATE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    head_sha = git_head(repo)
+    write_reports(repo, head_sha)
+    write_result = run(
+        [
+            sys.executable,
+            str(scripts_dir / "write_gate.py"),
+            "--review-status",
+            "PASS",
+            "--reviewer",
+            "hermes-subagent-review",
+            "--review-summary",
+            "clean",
+            "--review-report",
+            ".hermes-gate/review.md",
+            "--test-status",
+            "PASS",
+            "--tester",
+            "hermes-subagent-test",
+            "--test-summary",
+            "clean",
+            "--test-report",
+            ".hermes-gate/test.md",
+        ],
+        cwd=repo,
+    )
+    assert write_result.returncode == 0, write_result.stderr
+
+    hooks_dir = tmp_path / "hooks"
+    install_result = run(
+        [sys.executable, str(INSTALL_HOOK), "--hooks-dir", str(hooks_dir), "--force"],
+        cwd=repo,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    hook_path = hooks_dir / "pre-push"
+    hook_result = run([str(hook_path)], cwd=repo)
+    assert hook_result.returncode == 0, hook_result.stderr
+    assert "pre-push gate passed" in hook_result.stdout

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -82,7 +82,40 @@ hermes chat -q "Hello"
 
 ```bash
 pytest tests/ -v
+pytest tests/test_local_gate_workflow.py -q
 ```
+
+### Local gate workflow
+
+Install the managed `pre-push` hook into the active hooks directory (`core.hooksPath` when set, otherwise `.git/hooks`):
+
+```bash
+python scripts/install_local_gate_hook.py
+```
+
+Write gate artifacts after independent review + test reports exist:
+
+```bash
+python scripts/write_gate.py \
+  --review-status PASS \
+  --reviewer hermes-subagent-review \
+  --review-summary "clean implementation; no blocker" \
+  --review-report .hermes-gate/review.md \
+  --test-status PASS \
+  --tester hermes-subagent-test \
+  --test-summary "tests passed; no regression found" \
+  --test-report .hermes-gate/test.md
+```
+
+The hook validates four things before push:
+- `.hermes-gate/gate.json` exists
+- `gate.json` matches the current `HEAD`
+- review/test report files exist
+- both reports contain these exact lines:
+  - `- Head SHA: <current HEAD>`
+  - `- Verdict: PASS`
+
+Use `--force` only when you intentionally want to replace an unmanaged existing hook.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary
- add `messaging` to built-in `CONFIGURABLE_TOOLSETS`
- fix save/load round-trip semantics for the messaging toolset
- add regression tests covering preservation and explicit deselection

## Root cause
`messaging` existed in `toolsets.py` but was missing from `CONFIGURABLE_TOOLSETS`, so `platform_toolsets` persistence treated it like an unknown passthrough entry instead of a built-in configurable toolset.

## Testing
- python -m pytest tests/hermes_cli/test_tools_config.py -q
- python -m pytest tests/cli/test_cli_tools_command.py -q
- python -m pytest tests/gateway/test_api_server_toolset.py -q

## Notes
- Broader local test runs surfaced unrelated pre-existing failures in env loader / full-suite limits; not caused by this diff.