### PR TITLE
fix(agent): refresh skills prompt cache when disabled skills change

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -564,20 +564,20 @@ def build_skills_system_prompt(
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
+    disabled = get_disabled_skill_names()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
+        tuple(sorted(disabled)),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
         if cached is not None:
             _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
             return cached
-
-    disabled = get_disabled_skill_names()
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
     snapshot = _load_skills_snapshot(skills_dir)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -352,6 +352,24 @@ class TestBuildSkillsSystemPrompt:
         assert "web-search" in result
         assert "old-tool" not in result
 
+    def test_rebuilds_prompt_when_disabled_skills_change(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "cached-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: cached-skill\ndescription: Cached skill\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "cached-skill" in first
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  disabled: [cached-skill]\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "cached-skill" not in second
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)


### PR DESCRIPTION
# Cache invalidation for disabled skills in `build_skills_system_prompt()`

## What changed

Updated the prompt cache key in `build_skills_system_prompt()` to include the resolved disabled-skill set.

This ensures the skills prompt is rebuilt immediately when `skills.disabled` changes in `config.yaml`, even within the same long-lived Hermes process.

## Why

Previously, `build_skills_system_prompt()` could reuse an in-process cached skills prompt after the disabled skill configuration had changed.

The root cause was that the cache key did not account for the resolved disabled-skill set. Because of that, disabling a skill in `config.yaml` could still leave that skill visible in `<available_skills>` until the cache was manually cleared or the process was restarted.

## How to reproduce

1. Create a skill under `HERMES_HOME/skills/.../SKILL.md`.
2. Call `build_skills_system_prompt()` once.
3. Update `config.yaml` to disable that skill:

```yaml
skills:
  disabled: [cached-skill]
```

4. Call `build_skills_system_prompt()` again in the same process.

Before this fix, the disabled skill still appeared in the generated skills prompt because the old cached prompt was returned.

## How to verify

Run the targeted regression test:

```bash
python -m pytest tests/agent/test_prompt_builder.py -k disabled_skills_change -q
```

Confirm the new regression test passes.

Then temporarily revert the cache-key change and rerun the same test:

```bash
python -m pytest tests/agent/test_prompt_builder.py -k disabled_skills_change -q
```

Confirm it fails without the fix.

 run the full test suite:

```bash
python -m pytest tests/ -x -q
```

## Regression test

Added `test_rebuilds_prompt_when_disabled_skills_change` to `tests/agent/test_prompt_builder.py`.

The test reproduces the original bug by:

* building the skills prompt once
* changing `skills.disabled`
* rebuilding in the same process
* asserting that the disabled skill no longer appears

## Platform impact

This change affects platform-neutral Python logic only.


