### PR TITLE
fix(skills): prevent IndexError in build_plan_path on whitespace-only input

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -35,7 +35,8 @@ def build_plan_path(
     daytona, and similar terminal backends. That keeps the plan with the active
     workspace instead of the Hermes host's global home directory.
     """
-    slug_source = (user_instruction or "").strip().splitlines()[0] if user_instruction else ""
+    lines = (user_instruction or "").strip().splitlines()
+    slug_source = lines[0] if lines else ""
     slug = _PLAN_SLUG_RE.sub("-", slug_source.lower()).strip("-")
     if slug:
         slug = "-".join(part for part in slug.split("-")[:8] if part)[:48].strip("-")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -382,6 +382,30 @@ class TestPlanSkillHelpers:
 
         assert path == Path(".hermes") / "plans" / "2026-03-15_093045-implement-oauth-login-refresh-tokens.md"
 
+    def test_build_plan_path_whitespace_only_returns_default_slug(self):
+        path = build_plan_path(
+            "   \n   ",
+            now=datetime(2026, 3, 15, 9, 30, 45),
+        )
+        assert path == Path(".hermes") / "plans" / "2026-03-15_093045-conversation-plan.md"
+
+    def test_build_plan_path_normal_string_slug_unchanged(self):
+        path = build_plan_path(
+            "Add dark mode toggle",
+            now=datetime(2026, 3, 15, 9, 30, 45),
+        )
+        assert path == Path(".hermes") / "plans" / "2026-03-15_093045-add-dark-mode-toggle.md"
+
+    def test_build_plan_path_empty_string_and_none_return_default_slug(self):
+        for instruction in ("", None):
+            path = build_plan_path(
+                instruction,
+                now=datetime(2026, 3, 15, 9, 30, 45),
+            )
+            assert path == Path(".hermes") / "plans" / "2026-03-15_093045-conversation-plan.md", (
+                f"Expected default slug for instruction={instruction!r}"
+            )
+
     def test_plan_skill_message_can_include_runtime_save_path_note(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(


### PR DESCRIPTION
## Summary
- `build_plan_path()` crashes with `IndexError` when `user_instruction` is whitespace-only (e.g. `"  \n  "`), because `.strip().splitlines()` returns `[]` and then `[0]` is applied to the empty list.
- Split the expression into two steps: compute `lines` first, then index only when non-empty.

## Test plan
- [x] Pass whitespace-only string (`"   \n   "`) as `user_instruction` to `build_plan_path` — should return the default `conversation-plan` slug instead of crashing
- [x] Pass normal string — slug generation unchanged
- [x] Pass empty string / `None` — still returns default slug

Closes #7576