### PR TITLE
fix(cli): prevent crash when ssh binary is missing during setup test

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1484,12 +1484,16 @@ def setup_terminal_backend(config: dict):
                 ssh_cmd.extend(["-p", port])
             ssh_cmd.append(f"{user}@{host}" if user else host)
             ssh_cmd.append("echo ok")
-            result = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=10)
-            if result.returncode == 0:
-                print_success("  SSH connection successful!")
+            try:
+                result = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=10)
+            except FileNotFoundError:
+                print_warning("  SSH client not found. Install OpenSSH and retry the test.")
             else:
-                print_warning(f"  SSH connection failed: {result.stderr.strip()}")
-                print_info("  Check your SSH key and host settings.")
+                if result.returncode == 0:
+                    print_success("  SSH connection successful!")
+                else:
+                    print_warning(f"  SSH connection failed: {result.stderr.strip()}")
+                    print_info("  Check your SSH key and host settings.")
 
     # Sync terminal backend to .env so terminal_tool picks it up directly.
     # config.yaml is the source of truth, but terminal_tool reads TERMINAL_ENV.

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -362,3 +362,36 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
 
     assert config["terminal"]["backend"] == "modal"
     assert config["terminal"]["modal_mode"] == "direct"
+
+
+def test_ssh_setup_warns_when_ssh_binary_is_missing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+
+    def fake_prompt_choice(question, choices, default=0):
+        if question == "Select terminal backend:":
+            return 3
+        raise AssertionError(f"Unexpected prompt_choice call: {question}")
+
+    prompt_values = iter([
+        "example.com",
+        "alice",
+        "22",
+        str(tmp_path / "id_rsa"),
+    ])
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_values))
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("ssh")),
+    )
+
+    from hermes_cli.setup import setup_terminal_backend
+
+    setup_terminal_backend(config)
+
+    out = capsys.readouterr().out
+    assert config["terminal"]["backend"] == "ssh"
+    assert "SSH client not found" in out


### PR DESCRIPTION
## What changed

This PR fixes a crash in the setup wizard’s SSH terminal backend flow.

When a user selects the SSH backend in `hermes setup` and chooses to test the connection, Hermes currently invokes `ssh` directly via `subprocess.run(...)`. If the OpenSSH client is not installed or not available on `PATH`, that call raises `FileNotFoundError` and aborts the setup wizard.

This change preserves the existing SSH test flow, but handles the missing-client case gracefully:

* instead of crashing, Hermes now shows a warning that the SSH client is not installed
* setup continues normally
* a regression test was added to lock in that behavior

## Root cause

The SSH connection test path in `hermes_cli/setup.py` assumed that the `ssh` executable was always present.

That assumption does not hold on fresh Windows installations and some minimal environments.

## Fix

A narrow `FileNotFoundError` handler was added around the `subprocess.run(...)` call used for the SSH connection test.

No public APIs changed. No other setup behavior was modified.

## Reproduction

Before this fix:

1. Run `hermes setup`
2. Choose SSH as the terminal backend
3. Enter any host/user values
4. Choose **Yes** for **Test SSH connection?**
5. Run on a machine where `ssh` is not installed or not on `PATH`

### Actual result

Setup crashes with `FileNotFoundError`.

### Expected result

Setup should warn that the SSH client is missing and continue without crashing.

## Verification

### Regression test

Run:

```bash
python -m pytest tests/hermes_cli/test_setup.py -k ssh_setup_warns_when_ssh_binary_is_missing -q
```

Behavior confirmed:

* fails before the fix
* passes after the fix

### Changed-area coverage

Run:

```bash
python -m pytest tests/hermes_cli/test_setup.py -q
```

Result:

```text
13 passed
```
