### PR TITLE
fix(gateway): show startup progress in foreground

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1313,11 +1313,29 @@ def launchd_status(deep: bool = False):
 # Gateway Runner
 # =============================================================================
 
+def _foreground_stderr_verbosity(verbose: int = 0, quiet: bool = False):
+    """Return the effective stderr verbosity for manual foreground runs.
+
+    Manual foreground gateway runs should surface INFO-level startup progress by
+    default so the terminal does not appear hung after the startup banner.
+    Service-mode launches are unaffected because they are not attached to a TTY.
+    """
+    if quiet:
+        return None
+    try:
+        if verbose == 0 and sys.stderr.isatty():
+            return 1
+    except Exception:
+        pass
+    return verbose
+
+
 def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     """Run the gateway in foreground.
     
     Args:
-        verbose: Stderr log verbosity count added on top of default WARNING (0=WARNING, 1=INFO, 2+=DEBUG).
+        verbose: Stderr log verbosity count added on top of the foreground default
+                 (TTY foreground defaults to INFO; -v/-vv promote to DEBUG).
         quiet: Suppress all stderr log output.
         replace: If True, kill any existing gateway instance before starting.
                  This prevents systemd restart loops when the old process
@@ -1336,8 +1354,11 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     print()
     
     # Exit with code 1 if gateway fails to connect any platform,
-    # so systemd Restart=on-failure will retry on transient errors
-    verbosity = None if quiet else verbose
+    # so systemd Restart=on-failure will retry on transient errors.
+    # Foreground TTY runs promote the default stderr level to INFO so startup
+    # milestones remain visible; non-interactive/service-style launches keep the
+    # existing WARNING default.
+    verbosity = _foreground_stderr_verbosity(verbose=verbose, quiet=quiet)
     success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
     if not success:
         sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4449,7 +4449,7 @@ For more help on a command:
     # gateway run (default)
     gateway_run = gateway_subparsers.add_parser("run", help="Run gateway in foreground")
     gateway_run.add_argument("-v", "--verbose", action="count", default=0,
-                             help="Increase stderr log verbosity (-v=INFO, -vv=DEBUG)")
+                             help="Increase stderr log verbosity (foreground TTY defaults to INFO; -v/-vv=DEBUG)")
     gateway_run.add_argument("-q", "--quiet", action="store_true",
                              help="Suppress all stderr log output")
     gateway_run.add_argument("--replace", action="store_true",

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch, call
 
+import gateway.run as gateway_run_module
 import hermes_cli.gateway as gateway
 
 
@@ -177,6 +178,39 @@ def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeyp
 
     assert (scope, did_install) == ("system", True)
     assert calls == [(True, True, "alice")]
+
+
+def test_foreground_stderr_verbosity_promotes_info_for_tty(monkeypatch):
+    monkeypatch.setattr(gateway.sys.stderr, "isatty", lambda: True, raising=False)
+
+    assert gateway._foreground_stderr_verbosity(verbose=0, quiet=False) == 1
+
+
+def test_foreground_stderr_verbosity_keeps_default_for_non_tty(monkeypatch):
+    monkeypatch.setattr(gateway.sys.stderr, "isatty", lambda: False, raising=False)
+
+    assert gateway._foreground_stderr_verbosity(verbose=0, quiet=False) == 0
+
+
+def test_foreground_stderr_verbosity_respects_quiet(monkeypatch):
+    monkeypatch.setattr(gateway.sys.stderr, "isatty", lambda: True, raising=False)
+
+    assert gateway._foreground_stderr_verbosity(verbose=0, quiet=True) is None
+
+
+def test_run_gateway_promotes_default_stderr_verbosity_for_tty(monkeypatch):
+    seen = []
+
+    async def fake_start_gateway(config=None, replace=False, verbosity=0):
+        seen.append((replace, verbosity))
+        return True
+
+    monkeypatch.setattr(gateway.sys.stderr, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(gateway_run_module, "start_gateway", fake_start_gateway)
+
+    gateway.run_gateway(verbose=0, quiet=False, replace=True)
+
+    assert seen == [(True, 1)]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- promote the default foreground stderr verbosity to INFO only when the gateway is attached to a TTY
- keep non-interactive/service-style launches on the existing WARNING default
- add focused regression coverage for the foreground verbosity helper and wrapper behavior

## Root cause
Manual foreground gateway runs (`hermes gateway` and the manual restart fallback) printed the startup banner and then appeared hung because `start_gateway()` mapped `verbosity=0` to `WARNING`, while the important startup milestones are emitted with `logger.info()`.

## Test Plan
- `uv run pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py tests/gateway/test_runner_startup_failures.py -q -o addopts=`
- `python3 -m py_compile hermes_cli/gateway.py hermes_cli/main.py tests/hermes_cli/test_gateway.py`

Closes #7409