### PR TITLE
fix(skills): honor conditional activation when registering slash commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -7,6 +7,7 @@ can invoke skills via /skill-name commands and prompt-only built-ins like
 
 import json
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -19,6 +20,44 @@ _PLAN_SLUG_RE = re.compile(r"[^a-z0-9]+")
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+
+
+def _get_skill_activation_context() -> tuple[set[str] | None, set[str] | None]:
+    """Return the current tool/toolset availability for conditional skill gating."""
+    try:
+        from gateway.session_context import get_session_env
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+        from model_tools import get_tool_definitions, get_toolset_for_tool
+
+        platform = (
+            os.getenv("HERMES_PLATFORM")
+            or get_session_env("HERMES_SESSION_PLATFORM")
+            or "cli"
+        )
+        config = load_config()
+        enabled_toolsets = sorted(_get_platform_tools(config, platform))
+        tool_defs = get_tool_definitions(
+            enabled_toolsets=enabled_toolsets,
+            quiet_mode=True,
+        )
+        available_tools = {
+            tool["function"]["name"]
+            for tool in tool_defs
+            if isinstance(tool, dict)
+            and isinstance(tool.get("function"), dict)
+            and tool["function"].get("name")
+        }
+        available_toolsets = {
+            toolset
+            for toolset in (
+                get_toolset_for_tool(tool_name) for tool_name in available_tools
+            )
+            if toolset
+        }
+        return available_tools, available_toolsets
+    except Exception:
+        return None, None
 
 
 def build_plan_path(
@@ -206,11 +245,21 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     global _skill_commands
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.prompt_builder import _skill_should_show
+        from agent.skill_utils import (
+            extract_skill_conditions,
+            get_external_skills_dirs,
+        )
+        from tools.skills_tool import (
+            SKILLS_DIR,
+            _get_disabled_skill_names,
+            _parse_frontmatter,
+            skill_matches_platform,
+        )
+
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
-
+        available_tools, available_toolsets = _get_skill_activation_context()
         # Scan local dir first, then external dirs
         dirs_to_scan = []
         if SKILLS_DIR.exists():
@@ -226,6 +275,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     frontmatter, body = _parse_frontmatter(content)
                     # Skip skills incompatible with the current OS platform
                     if not skill_matches_platform(frontmatter):
+                        continue
+                    if not _skill_should_show(
+                        extract_skill_conditions(frontmatter),
+                        available_tools,
+                        available_toolsets,
+                    ):
                         continue
                     name = frontmatter.get('name', skill_md.parent.name)
                     if name in seen_names:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -101,6 +101,48 @@ class TestScanSkillCommands:
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
 
+    def test_excludes_fallback_skills_when_primary_toolset_available(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_commands._get_skill_activation_context",
+                return_value=(set(), {"web"}),
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "duckduckgo",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    fallback_for_toolsets: [web]\n"
+                ),
+            )
+            _make_skill(tmp_path, "always-on")
+            result = scan_skill_commands()
+        assert "/always-on" in result
+        assert "/duckduckgo" not in result
+
+    def test_excludes_requires_skills_when_required_toolset_missing(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_commands._get_skill_activation_context",
+                return_value=(set(), set()),
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "openhue",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    requires_toolsets: [terminal]\n"
+                ),
+            )
+            result = scan_skill_commands()
+        assert "/openhue" not in result
+
 
     def test_special_chars_stripped_from_cmd_key(self, tmp_path):
         """Skill names with +, /, or other special chars produce clean cmd keys."""


### PR DESCRIPTION
## What changed

This fixes a bug in skill slash-command discovery where `scan_skill_commands()` ignored conditional activation rules declared in skill frontmatter.

Before this change, skills with `metadata.hermes.fallback_for_toolsets` or `fallback_for_tools` could still register `/skill-name` commands even when the primary tool or toolset was available. Likewise, skills with `metadata.hermes.requires_toolsets` or `requires_tools` could still register `/skill-name` commands even when their required tool or toolset was unavailable.

That made slash-command availability inconsistent with the runtime skills prompt, which already applies these conditions.

This fix keeps the change minimal:

* resolve the current tool and toolset availability in `agent/skill_commands.py`
* apply the existing `_skill_should_show(...)` logic during slash-command registration
* add regression tests covering both fallback and requires cases

## Root cause

`build_skills_system_prompt()` already filtered skills through conditional activation logic, but `scan_skill_commands()` only checked:

* platform compatibility
* disabled-skill config
* duplicate names

It never evaluated `fallback_for_*` or `requires_*`, so conditional skills leaked into the slash-command surface.

## How to reproduce

### Fallback case

Create a skill with:

```yaml
metadata:
  hermes:
    fallback_for_toolsets: [web]
```

Run Hermes in a context where the `web` toolset is available.

Before this fix, the skill still appeared as a `/skill-name` command.

### Requires case

Create a skill with:

```yaml
metadata:
  hermes:
    requires_toolsets: [terminal]
```

Run Hermes in a context where `terminal` is unavailable.

Before this fix, the skill still appeared as a `/skill-name` command.

## How to verify

Run the full test file:

```bash
py -3 -m pytest tests/agent/test_skill_commands.py -q
```

Run the new regression tests in isolation:

```bash
py -3 -m pytest tests/agent/test_skill_commands.py -q -k "fallback_skills_when_primary_toolset_available or requires_skills_when_required_toolset_missing"
```

Expected behavior:

* fallback skills are not registered when their primary toolset is available
* requires skills are not registered when their required toolset is missing

I also temporarily removed the fix and confirmed the two new regression tests fail without it, then restored the patch and confirmed they pass.

## Tests added

Added:

* `test_excludes_fallback_skills_when_primary_toolset_available`
* `test_excludes_requires_skills_when_required_toolset_missing`
