### PR TITLE
fix(pairing): handle null user_name in pairing list display

### DIFF
--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -44,7 +44,7 @@ def _cmd_list(store):
         for p in pending:
             print(
                 f"  {p['platform']:<12} {p['code']:<10} {p['user_id']:<20} "
-                f"{p.get('user_name', ''):<20} {p['age_minutes']}m ago"
+                f"{(p.get('user_name') or ''):<20} {p['age_minutes']}m ago"
             )
     else:
         print("\n  No pending pairing requests.")
@@ -54,7 +54,7 @@ def _cmd_list(store):
         print(f"  {'Platform':<12} {'User ID':<20} {'Name':<20}")
         print(f"  {'--------':<12} {'-------':<20} {'----':<20}")
         for a in approved:
-            print(f"  {a['platform']:<12} {a['user_id']:<20} {a.get('user_name', ''):<20}")
+            print(f"  {a['platform']:<12} {a['user_id']:<20} {(a.get('user_name') or ''):<20}")
     else:
         print("\n  No approved users.")
 
@@ -69,7 +69,7 @@ def _cmd_approve(store, platform: str, code: str):
     result = store.approve_code(platform, code)
     if result:
         uid = result["user_id"]
-        name = result.get("user_name", "")
+        name = result.get("user_name") or ""
         display = f"{name} ({uid})" if name else uid
         print(f"\n  Approved! User {display} on {platform} can now use the bot~")
         print("  They'll be recognized automatically on their next message.\n")


### PR DESCRIPTION
## Summary
- Fix `TypeError` crash in `hermes pairing list` when `user_name` is `None`
- `dict.get('user_name', '')` returns `None` when the key exists with a `None` value — the default is only used for missing keys
- Changed to `(p.get('user_name') or '')` which correctly coerces `None` to empty string before the `:<20` format specifier is applied
- Also fixed the same pattern in `_cmd_approve`

Fixes #7392

## Test plan
- [ ] Run `hermes pairing list` with a pairing entry where `user_name` is `None`
- [ ] Verify pending and approved sections both render without `TypeError`
- [ ] Verify normal (non-null) `user_name` values still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)