### PR TITLE
fix(model-normalize): stop converting dots to hyphens for opencode-zen

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -8,8 +8,7 @@ Different LLM providers expect model identifiers in different formats:
   hyphens: ``claude-sonnet-4-6``.
 - **Copilot** expects bare names *with* dots preserved:
   ``claude-sonnet-4.6``.
-- **OpenCode Zen** follows the same dot-to-hyphen convention as
-  Anthropic: ``claude-sonnet-4-6``.
+- **OpenCode Zen** preserves dots in model names: ``minimax-m2.5``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
 - **DeepSeek** only accepts two model identifiers:
   ``deepseek-chat`` and ``deepseek-reasoner``.
@@ -67,7 +66,6 @@ _AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
 # Providers that want bare names with dots replaced by hyphens.
 _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
     "anthropic",
-    "opencode-zen",
 })
 
 # Providers that want bare names with dots preserved.
@@ -92,6 +90,7 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "minimax-cn",
     "alibaba",
     "qwen-oauth",
+    "opencode-zen",
     "custom",
 })
 
@@ -325,8 +324,8 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         >>> normalize_model_for_provider("openai/gpt-5.4", "copilot")
         'gpt-5.4'
 
-        >>> normalize_model_for_provider("claude-sonnet-4.6", "opencode-zen")
-        'claude-sonnet-4-6'
+        >>> normalize_model_for_provider("minimax-m2.5", "opencode-zen")
+        'minimax-m2.5'
 
         >>> normalize_model_for_provider("deepseek-v3", "deepseek")
         'deepseek-chat'

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -54,20 +54,21 @@ class TestAnthropicDotToHyphen:
 
 # ── OpenCode Zen regression ────────────────────────────────────────────
 
-class TestOpenCodeZenDotToHyphen:
-    """OpenCode Zen follows Anthropic convention (dots→hyphens)."""
+class TestOpenCodeZenDotPreservation:
+    """OpenCode Zen preserves dots in model names."""
 
     @pytest.mark.parametrize("model,expected", [
-        ("claude-sonnet-4.6", "claude-sonnet-4-6"),
-        ("glm-4.5", "glm-4-5"),
+        ("minimax-m2.5-free", "minimax-m2.5-free"),
+        ("claude-sonnet-4.6", "claude-sonnet-4.6"),
+        ("glm-4.5", "glm-4.5"),
     ])
-    def test_zen_converts_dots(self, model, expected):
+    def test_zen_preserves_dots(self, model, expected):
         result = normalize_model_for_provider(model, "opencode-zen")
         assert result == expected
 
-    def test_zen_strips_vendor_prefix(self):
+    def test_zen_strips_matching_vendor_prefix(self):
         result = normalize_model_for_provider("opencode-zen/claude-sonnet-4.6", "opencode-zen")
-        assert result == "claude-sonnet-4-6"
+        assert result == "claude-sonnet-4.6"
 
 
 # ── Copilot dot preservation (regression) ──────────────────────────────


### PR DESCRIPTION
## Summary
- Remove `opencode-zen` from `_DOT_TO_HYPHEN_PROVIDERS` — OpenCode Zen accepts dots in model names natively
- Move it to `_MATCHING_PREFIX_STRIP_PROVIDERS` so vendor prefixes are stripped but dots preserved
- Update docstring and tests to reflect correct behavior
- Previously, models like `minimax-m2.5-free` were mangled to `minimax-m2-5-free`, causing 401 errors

Fixes #7421

## Test plan
- [ ] Verify `minimax-m2.5-free` is sent as-is to OpenCode Zen API (no dot-to-hyphen conversion)
- [ ] Verify `opencode-zen/claude-sonnet-4.6` strips prefix but preserves dots -> `claude-sonnet-4.6`
- [ ] Verify Anthropic provider still converts dots to hyphens (`claude-sonnet-4.6` -> `claude-sonnet-4-6`)
- [ ] Run `pytest tests/hermes_cli/test_model_normalize.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)