### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -289,6 +289,7 @@ class GitHubSource(SkillSource):
         {"repo": "anthropics/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
         {"repo": "garrytan/gstack", "path": ""},
+        {"repo": "MiniMax-AI/cli", "path": "skill/"},
     ]
 
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `GitHubSource.DEFAULT_TAPS` so the mmx-cli skill is discoverable out of the box
- Users can install via `/skills install mmx-cli` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in hermes-agent

**1 line changed, 0 new files.**

## Test plan

- [ ] `/skills browse MiniMax-AI/cli` lists the mmx-cli skill
- [ ] `/skills install mmx-cli` installs successfully
- [ ] Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)