### PR TITLE
fix(bluebubbles): remove invalid "message" webhook event type

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -53,7 +53,7 @@ _TAPBACK_REMOVED = {
 }
 
 # Webhook event types that carry user messages
-_MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_MESSAGE_EVENTS = {"new-message", "updated-message"}
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -267,7 +267,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message", "message"],
+            "events": ["new-message", "updated-message"],
         }
 
         try:


### PR DESCRIPTION
## Bug

The BlueBubbles server rejects webhook registrations that include `"message"` as an event type. The valid event types are `"new-message"` and `"updated-message"`.

**Error from BB server:**
```
Invalid webhook event: message! Webhook must be one of: *,new-message,updated-message,message-send-error,...
```

This causes `_register_webhook` to fail with `400 Bad Request` on every gateway startup, so no inbound messages are ever delivered.

## Fix

Removed `"message"` from two places:

1. `_MESSAGE_EVENTS` set (line 56)
2. The `events` list in the webhook registration payload (line 270)

## Test environment

- macOS 26.3.1
- Hermes 0.8.0
- Python 3.11.15
- BlueBubbles server (axios/1.7.2)