### PR TITLE
feat(gateway): add merge_messages option for Weixin channel

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1015,6 +1015,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         weixin_group_allowed_users = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "").strip()
         if weixin_group_allowed_users:
             extra["group_allow_from"] = weixin_group_allowed_users
+        weixin_merge = os.getenv("WEIXIN_MERGE_MESSAGES", "").strip().lower()
+        if weixin_merge in ("1", "true", "yes", "on"):
+            extra["merge_messages"] = True
         weixin_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
         if weixin_home:
             config.platforms[Platform.WEIXIN].home_channel = HomeChannel(

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -992,6 +992,10 @@ class WeixinAdapter(BasePlatformAdapter):
         self._allow_from = self._coerce_list(allow_from)
         self._group_allow_from = self._coerce_list(group_allow_from)
 
+        # When True, the entire response is sent as one message instead of
+        # splitting each newline/paragraph into a separate WeChat message.
+        self._merge_messages = bool(extra.get("merge_messages") or False)
+
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
             if persisted:
@@ -1344,7 +1348,16 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
         try:
-            for chunk in self._split_text(self.format_message(content)):
+            formatted = self.format_message(content)
+            # When merge_messages is enabled, send as single message (split only if exceeds max length)
+            if self._merge_messages:
+                chunks = _split_text_for_weixin_delivery(formatted, self.MAX_MESSAGE_LENGTH)
+                # If total content fits, force single message
+                if len(formatted) <= self.MAX_MESSAGE_LENGTH:
+                    chunks = [formatted]
+            else:
+                chunks = self._split_text(formatted)
+            for chunk in chunks:
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
                 await _send_message(
                     self._session,


### PR DESCRIPTION
## Problem

Long multi-paragraph replies sent via Weixin (personal WeChat via iLink Bot API) are split into a flood of individual messages, one per newline/paragraph. This is disruptive to the user experience.

## Solution

Add a `merge_messages` option that sends the entire response as a single WeChat message when the content fits within the platform limit (4000 chars).

### Configuration

**Environment variable:**
```
WEIXIN_MERGE_MESSAGES=true
```

**Or in gateway.json:**
```json
{
  "platforms": {
    "weixin": {
      "extra": {
        "merge_messages": true
      }
    }
  }
}
```

### Behavior

- **`merge_messages: false` (default)** — existing behavior: each paragraph/newline becomes a separate message
- **`merge_messages: true`** — entire response sent as one message; only splits when exceeding 4000 chars

### Changes

- `gateway/config.py` — read `WEIXIN_MERGE_MESSAGES` env var into platform extra config
- `gateway/platforms/weixin.py` — add `_merge_messages` flag and conditional send logic