### PR TITLE
fix(nix): add setuptools build dependency for atomicwrites

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -49,7 +49,13 @@ let
       "alibabacloud-tea"
     ] (_: null));
 
-  pythonPackageOverrides = final: _prev:
+  pythonPackageOverrides = final: prev: {
+      # atomicwrites ships only an sdist and uses a legacy setup.py that
+      # requires setuptools at build time.
+      atomicwrites = prev.atomicwrites.overrideAttrs (old: {
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.setuptools ];
+      });
+    } // (
     if isAarch64Darwin then {
       numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
 
@@ -82,7 +88,7 @@ let
         tokenizers = [ ];
         tqdm = [ ];
       };
-    } else {};
+    } else {});
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {


### PR DESCRIPTION
## Summary
- `atomicwrites` 1.4.1 ships only an sdist with a legacy `setup.py` that requires `setuptools` at build time
- The `pyproject-build-systems` overlay does not include an override for this package, so `nix flake check` fails with `ModuleNotFoundError: No module named 'setuptools'` on all branches
- Adds an unconditional `setuptools` build input override in `nix/python.nix`

This is a pre-existing failure on `main` that is blocking the Nix CI checks on all open PRs.

## Test plan
- [x] `nix flake check` passes on ubuntu-latest (currently failing)
- [x] `nix flake check` passes on macos-latest (currently cancelled due to ubuntu failure)
- [x] No regression on aarch64-darwin prebuilt overrides

Closes #7577