### PR TITLE
feat(gateway): support glob patterns in HA watch_entities and ignore_entities

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -13,13 +13,14 @@ Requires:
 """
 
 import asyncio
+import fnmatch
 import json
 import logging
 import os
 import time
 import uuid
 from datetime import datetime
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 try:
     import aiohttp
@@ -37,6 +38,30 @@ from gateway.platforms.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Characters that make an entity-ID filter entry an fnmatch glob pattern
+# rather than a literal.  Keeping this inline avoids importing ``glob`` just
+# for ``has_magic``.
+_GLOB_CHARS = frozenset("*?[")
+
+
+def _split_literal_and_glob(items: Iterable[str]) -> Tuple[Set[str], List[str]]:
+    """Split an iterable of entity-ID filter entries into literals and globs.
+
+    Literal IDs land in a set for O(1) lookup; glob patterns land in a list
+    that is only scanned when the literal lookup misses.  ``fnmatch.fnmatchcase``
+    is case-sensitive, which is what we want — Home Assistant entity IDs are
+    always lowercase and avoiding locale folding is both safer and faster.
+    """
+    literals: Set[str] = set()
+    patterns: List[str] = []
+    for item in items:
+        if any(c in _GLOB_CHARS for c in item):
+            patterns.append(item)
+        else:
+            literals.add(item)
+    return literals, patterns
 
 
 def check_ha_requirements() -> bool:
@@ -79,10 +104,19 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._hass_url: str = url.rstrip("/")
         self._hass_token: str = token
 
-        # Event filtering
+        # Event filtering.  ``watch_entities``/``ignore_entities`` accept
+        # both exact entity IDs (fast O(1) set lookup) and fnmatch-style
+        # glob patterns such as ``binary_sensor.*_occupancy`` (O(n) scan,
+        # only traversed when the literal lookup misses).
         self._watch_domains: Set[str] = set(extra.get("watch_domains", []))
-        self._watch_entities: Set[str] = set(extra.get("watch_entities", []))
-        self._ignore_entities: Set[str] = set(extra.get("ignore_entities", []))
+        (
+            self._watch_entity_literals,
+            self._watch_entity_patterns,
+        ) = _split_literal_and_glob(extra.get("watch_entities", []))
+        (
+            self._ignore_entity_literals,
+            self._ignore_entity_patterns,
+        ) = _split_literal_and_glob(extra.get("ignore_entities", []))
         self._watch_all: bool = bool(extra.get("watch_all", False))
         self._cooldown_seconds: int = int(extra.get("cooldown_seconds", 30))
 
@@ -119,7 +153,10 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             )
 
             # Warn if no event filters are configured
-            if not self._watch_domains and not self._watch_entities and not self._watch_all:
+            has_entity_filter = bool(
+                self._watch_entity_literals or self._watch_entity_patterns
+            )
+            if not self._watch_domains and not has_entity_filter and not self._watch_all:
                 logger.warning(
                     "[%s] No watch_domains, watch_entities, or watch_all configured. "
                     "All state_changed events will be dropped. Configure filters in "
@@ -267,16 +304,29 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         if not entity_id:
             return
 
-        # Apply ignore filter
-        if entity_id in self._ignore_entities:
+        # Apply ignore filter (literals first, then any glob patterns)
+        if entity_id in self._ignore_entity_literals:
+            return
+        if self._ignore_entity_patterns and any(
+            fnmatch.fnmatchcase(entity_id, p) for p in self._ignore_entity_patterns
+        ):
             return
 
         # Apply domain/entity watch filters (closed by default — require
         # explicit watch_domains, watch_entities, or watch_all to forward)
         domain = entity_id.split(".")[0] if "." in entity_id else ""
-        if self._watch_domains or self._watch_entities:
+        has_entity_filter = bool(
+            self._watch_entity_literals or self._watch_entity_patterns
+        )
+        if self._watch_domains or has_entity_filter:
             domain_match = domain in self._watch_domains if self._watch_domains else False
-            entity_match = entity_id in self._watch_entities if self._watch_entities else False
+            entity_match = entity_id in self._watch_entity_literals or (
+                bool(self._watch_entity_patterns)
+                and any(
+                    fnmatch.fnmatchcase(entity_id, p)
+                    for p in self._watch_entity_patterns
+                )
+            )
             if not domain_match and not entity_match:
                 return
         elif not self._watch_all:

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -218,8 +218,10 @@ class TestAdapterInit:
         )
         adapter = HomeAssistantAdapter(config)
         assert adapter._watch_domains == {"climate", "binary_sensor"}
-        assert adapter._watch_entities == {"sensor.special"}
-        assert adapter._ignore_entities == {"sensor.uptime", "sensor.cpu"}
+        assert adapter._watch_entity_literals == {"sensor.special"}
+        assert adapter._watch_entity_patterns == []
+        assert adapter._ignore_entity_literals == {"sensor.uptime", "sensor.cpu"}
+        assert adapter._ignore_entity_patterns == []
         assert adapter._watch_all is False
         assert adapter._cooldown_seconds == 120
 
@@ -231,13 +233,41 @@ class TestAdapterInit:
         adapter = HomeAssistantAdapter(config)
         assert adapter._watch_all is True
 
+    def test_entity_filters_split_literal_and_glob(self):
+        """Config with both literal IDs and glob patterns splits correctly."""
+        config = PlatformConfig(
+            enabled=True, token="t",
+            extra={
+                "watch_entities": [
+                    "sensor.special",
+                    "binary_sensor.*_occupancy",
+                    "sensor.other",
+                    "light.kitchen_?",
+                ],
+                "ignore_entities": [
+                    "sensor.uptime",
+                    "sensor.debug_*",
+                ],
+            },
+        )
+        adapter = HomeAssistantAdapter(config)
+        assert adapter._watch_entity_literals == {"sensor.special", "sensor.other"}
+        assert set(adapter._watch_entity_patterns) == {
+            "binary_sensor.*_occupancy",
+            "light.kitchen_?",
+        }
+        assert adapter._ignore_entity_literals == {"sensor.uptime"}
+        assert adapter._ignore_entity_patterns == ["sensor.debug_*"]
+
     def test_defaults_when_no_extra(self, monkeypatch):
         monkeypatch.setenv("HASS_TOKEN", "tok")
         config = PlatformConfig(enabled=True, token="***")
         adapter = HomeAssistantAdapter(config)
         assert adapter._watch_domains == set()
-        assert adapter._watch_entities == set()
-        assert adapter._ignore_entities == set()
+        assert adapter._watch_entity_literals == set()
+        assert adapter._watch_entity_patterns == []
+        assert adapter._ignore_entity_literals == set()
+        assert adapter._ignore_entity_patterns == []
         assert adapter._watch_all is False
         assert adapter._cooldown_seconds == 30
 
@@ -332,6 +362,111 @@ class TestEventFilteringPipeline:
         adapter = _make_adapter(watch_all=True)
         await adapter._handle_ha_event({"data": {"entity_id": ""}})
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_watched_entity_glob_forwarded(self):
+        """A fnmatch glob in watch_entities forwards matching entities."""
+        adapter = _make_adapter(
+            watch_entities=["binary_sensor.*_occupancy"], cooldown_seconds=0
+        )
+        await adapter._handle_ha_event(
+            _make_event(
+                "binary_sensor.living_occupancy", "off", "on",
+                new_attrs={"friendly_name": "Living Room Occupancy"},
+            )
+        )
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_watched_entity_glob_no_match_dropped(self):
+        """A fnmatch glob rejects non-matching entities in the same domain."""
+        adapter = _make_adapter(
+            watch_entities=["binary_sensor.*_occupancy"], cooldown_seconds=0
+        )
+        await adapter._handle_ha_event(
+            _make_event(
+                "binary_sensor.kitchen_temperature", "20", "21",
+                new_attrs={"friendly_name": "Kitchen Temp"},
+            )
+        )
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_watched_entity_mixed_literal_and_glob(self):
+        """Both literal IDs and glob patterns in the same list match correctly."""
+        adapter = _make_adapter(
+            watch_entities=["sensor.special", "binary_sensor.*_motion"],
+            cooldown_seconds=0,
+        )
+
+        # Literal match
+        await adapter._handle_ha_event(
+            _make_event(
+                "sensor.special", "10", "20",
+                new_attrs={"friendly_name": "Special", "unit_of_measurement": "W"},
+            )
+        )
+        # Glob match
+        await adapter._handle_ha_event(
+            _make_event(
+                "binary_sensor.hall_motion", "off", "on",
+                new_attrs={"friendly_name": "Hall Motion"},
+            )
+        )
+        # Neither
+        await adapter._handle_ha_event(
+            _make_event(
+                "sensor.unrelated", "1", "2",
+                new_attrs={"friendly_name": "Unrelated"},
+            )
+        )
+
+        assert adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ignored_entity_glob_suppresses(self):
+        """A glob in ignore_entities filters out matching events even when
+        the domain is watched."""
+        adapter = _make_adapter(
+            watch_domains=["sensor"],
+            ignore_entities=["sensor.debug_*"],
+            cooldown_seconds=0,
+        )
+
+        # Matching ignore glob — dropped
+        await adapter._handle_ha_event(
+            _make_event(
+                "sensor.debug_trace", "1", "2",
+                new_attrs={"friendly_name": "Debug Trace"},
+            )
+        )
+        # Not matching — forwarded
+        await adapter._handle_ha_event(
+            _make_event(
+                "sensor.temperature", "20", "21",
+                new_attrs={"friendly_name": "Temp", "unit_of_measurement": "C"},
+            )
+        )
+        assert adapter.handle_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_glob_only_config_counts_as_configured(self):
+        """A pattern-only watch config must forward matching events.
+
+        Regression test for the connect() warning update — the filter-config
+        check used to inspect a set attribute, and a pattern-only config would
+        have looked like "no filters" and dropped every event.
+        """
+        adapter = _make_adapter(
+            watch_entities=["binary_sensor.*_occupancy"], cooldown_seconds=0
+        )
+        await adapter._handle_ha_event(
+            _make_event(
+                "binary_sensor.office_occupancy", "off", "on",
+                new_attrs={"friendly_name": "Office Occupancy"},
+            )
+        )
+        adapter.handle_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_message_event_has_correct_source(self):

--- a/website/docs/user-guide/messaging/homeassistant.md
+++ b/website/docs/user-guide/messaging/homeassistant.md
@@ -144,23 +144,31 @@ platforms:
         - light
       watch_entities:
         - sensor.front_door_battery
+        - binary_sensor.*_occupancy   # fnmatch glob — all occupancy sensors
       ignore_entities:
         - sensor.uptime
         - sensor.cpu_usage
         - sensor.memory_usage
+        - sensor.debug_*              # fnmatch glob — suppress all debug sensors
       cooldown_seconds: 30
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `watch_domains` | *(none)* | Only watch these entity domains (e.g., `climate`, `light`, `binary_sensor`) |
-| `watch_entities` | *(none)* | Only watch these specific entity IDs |
+| `watch_entities` | *(none)* | Watch these entity IDs. Accepts literal IDs and [fnmatch-style glob patterns](https://docs.python.org/3/library/fnmatch.html) (`*`, `?`, `[seq]`) — e.g., `binary_sensor.*_occupancy` |
 | `watch_all` | `false` | Set to `true` to receive **all** state changes (not recommended for most setups) |
-| `ignore_entities` | *(none)* | Always ignore these entities (applied before domain/entity filters) |
+| `ignore_entities` | *(none)* | Always ignore these entities (applied before domain/entity filters). Also accepts fnmatch-style glob patterns |
 | `cooldown_seconds` | `30` | Minimum seconds between events for the same entity |
 
 :::tip
 Start with a focused set of domains — `climate`, `binary_sensor`, and `alarm_control_panel` cover the most useful automations. Add more as needed. Use `ignore_entities` to suppress noisy sensors like CPU temperature or uptime counters.
+
+**Glob patterns** in `watch_entities` and `ignore_entities` make it easy to match entity families without enumerating every ID. An entry containing any of `*`, `?`, or `[` is treated as an fnmatch pattern; everything else stays as a fast O(1) exact-match lookup. Common examples:
+
+- `binary_sensor.*_occupancy` — every occupancy sensor
+- `sensor.*_battery` — every battery level sensor
+- `light.kitchen_*` — every kitchen light
 :::
 
 ### Event Formatting


### PR DESCRIPTION
## Motivation

The Home Assistant adapter's `watch_entities` and `ignore_entities` filters currently require exact-match entity IDs. Watching a whole family of entities — say, every occupancy sensor in the house — means enumerating each ID in `config.yaml` and re-editing the file every time a new sensor is added in Home Assistant. In my own setup I had **27 lines** listing `binary_sensor.*_occupancy` entities one by one.

This PR lets the same config collapse to a single line:

```yaml
watch_entities:
  - binary_sensor.*_occupancy
```

## Behavior

`watch_entities` and `ignore_entities` now accept fnmatch-style glob patterns (`*`, `?`, `[seq]`) alongside literal entity IDs in the same list. Entries containing any of `*`, `?`, `[` are treated as patterns; everything else stays as a literal.

Matching is performed with `fnmatch.fnmatchcase` (case-sensitive — HA entity IDs are always lowercase, which matches the codebase convention in `tools/website_policy.py` of using `fnmatch` for wildcard config).

`watch_domains` is intentionally left as-is — domain names are finite simple tokens that don't benefit from globs.

## Performance

At load time each filter list is split into a `Set[str]` of literals and a `List[str]` of patterns. The hot path in `_handle_ha_event` checks the literal set first (O(1)) and only iterates the pattern list when the literal lookup misses. **Pure-literal configs keep their existing performance characteristics** — the only added cost is a one-time split during `__init__` and an empty-list check per event.

## Backward compatibility

Fully backward compatible. Pure literal lists behave identically to before. No config migration needed.

One subtle fix: the `connect()` "no filters configured" warning used to inspect the old `_watch_entities` set attribute. It now correctly recognizes a pattern-only config as configured, so a pure-glob config no longer trips the warning and silently drops every event. Covered by a dedicated regression test.

## Tests

Added to `tests/gateway/test_homeassistant.py`:

- `TestAdapterInit::test_entity_filters_split_literal_and_glob` — mixed literal/pattern config splits into the right buckets
- `TestEventFilteringPipeline::test_watched_entity_glob_forwarded` — pattern match forwards
- `TestEventFilteringPipeline::test_watched_entity_glob_no_match_dropped` — same pattern rejects a non-match in the same domain
- `TestEventFilteringPipeline::test_watched_entity_mixed_literal_and_glob` — literal and pattern in the same list both match; unrelated entity dropped
- `TestEventFilteringPipeline::test_ignored_entity_glob_suppresses` — ignore glob wins over a watched domain
- `TestEventFilteringPipeline::test_glob_only_config_counts_as_configured` — pattern-only watch config still forwards (regression test for the `connect()` warning fix)

Existing `test_watch_filters_parsed` / `test_defaults_when_no_extra` updated to reference the new `_watch_entity_literals` / `_watch_entity_patterns` / `_ignore_entity_literals` / `_ignore_entity_patterns` attributes.

**Results:** `pytest tests/gateway/test_homeassistant.py` — **55 passed** (49 existing + 6 new), no regressions. Broader `pytest tests/gateway/` shows only pre-existing failures in `telegram_conflict`, `feishu`, `reasoning_command`, and `run_progress_topics` tests that also fail on `main` and are unrelated to this change.

## Docs

Updated `website/docs/user-guide/messaging/homeassistant.md`:
- Config table notes that `watch_entities` and `ignore_entities` accept fnmatch patterns with a link to the Python docs
- Example YAML block now includes `binary_sensor.*_occupancy` and `sensor.debug_*` patterns
- Added a tip callout with common pattern examples