### PR TITLE
feat(skills-hub): add claude-marketplace support

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -105,7 +105,8 @@ def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
     return lines
 
 
-def _resolve_source_meta_and_bundle(identifier: str, sources):
+def _resolve_source_meta_and_bundle(identifier: str, sources,
+                                    plugin_name: Optional[str] = None):
     """Resolve metadata and bundle for a specific identifier."""
     meta = None
     bundle = None
@@ -120,7 +121,12 @@ def _resolve_source_meta_and_bundle(identifier: str, sources):
             except Exception:
                 meta = None
         try:
-            bundle = src.fetch(identifier)
+            bundle = src.fetch(identifier, plugin_name=plugin_name)
+        except TypeError:
+            try:
+                bundle = src.fetch(identifier)
+            except Exception:
+                bundle = None
         except Exception:
             bundle = None
         if bundle:
@@ -307,9 +313,89 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
     c.print("[dim]Tip: 'hermes skills search <query>' searches deeper across all registries[/]\n")
 
 
+def _install_bundle(bundle, meta=None, category: str = "", force: bool = False,
+                    console: Optional[Console] = None, skip_confirm: bool = False) -> bool:
+    """Quarantine, scan, confirm, and install a pre-fetched SkillBundle.
+
+    Returns True on success, False otherwise.
+    """
+    from tools.skills_hub import (
+        quarantine_bundle, install_from_quarantine, HubLockFile,
+        SKILLS_DIR, append_audit_log,
+    )
+    from tools.skills_guard import scan_skill, should_allow_install, format_scan_report
+
+    c = console or _console
+
+    lock = HubLockFile()
+    existing = lock.get_installed(bundle.name)
+    if existing:
+        c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
+        if not force:
+            c.print("Use --force to reinstall.\n")
+            return False
+
+    try:
+        q_path = quarantine_bundle(bundle)
+    except ValueError as exc:
+        c.print(f"[bold red]Installation blocked:[/] {exc}\n")
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, "invalid_path", str(exc))
+        return False
+    c.print(f"[dim]Quarantined to {q_path.relative_to(q_path.parent.parent.parent)}[/]")
+
+    c.print("[bold]Running security scan...[/]")
+    scan_source = getattr(bundle, "identifier", "") or ""
+    result = scan_skill(q_path, source=scan_source)
+    c.print(format_scan_report(result))
+
+    allowed, reason = should_allow_install(result, force=force)
+    if not allowed:
+        c.print(f"\n[bold red]Installation blocked:[/] {reason}")
+        shutil.rmtree(q_path, ignore_errors=True)
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, result.verdict,
+                         f"{len(result.findings)}_findings")
+        return False
+
+    if not force and not skip_confirm:
+        c.print(Panel(
+            "[bold yellow]You are installing a third-party skill at your own risk.[/]\n\n"
+            "External skills can contain instructions that influence agent behavior,\n"
+            "shell commands, and scripts. Even after automated scanning, you should\n"
+            "review the installed files before use.\n\n"
+            f"Files will be at: [cyan]{display_hermes_home()}/skills/{category + '/' if category else ''}{bundle.name}/[/]",
+            title="Disclaimer",
+            border_style="yellow",
+        ))
+        c.print(f"[bold]Install '{bundle.name}'?[/]")
+        try:
+            answer = input("Confirm [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = "n"
+        if answer not in ("y", "yes"):
+            c.print("[dim]Installation cancelled.[/]\n")
+            shutil.rmtree(q_path, ignore_errors=True)
+            return False
+
+    try:
+        install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
+    except ValueError as exc:
+        c.print(f"[bold red]Installation blocked:[/] {exc}\n")
+        shutil.rmtree(q_path, ignore_errors=True)
+        append_audit_log("BLOCKED", bundle.name, bundle.source,
+                         bundle.trust_level, "invalid_path", str(exc))
+        return False
+
+    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
+    return True
+
+
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
-               invalidate_cache: bool = True) -> None:
+               invalidate_cache: bool = True,
+               plugin_name: Optional[str] = None) -> None:
     """Fetch, quarantine, scan, confirm, and install a skill."""
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
@@ -332,7 +418,9 @@ def do_install(identifier: str, category: str = "", force: bool = False,
 
     c.print(f"\n[bold]Fetching:[/] {identifier}")
 
-    meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
+    meta, bundle, _matched_source = _resolve_source_meta_and_bundle(
+        identifier, sources, plugin_name=plugin_name,
+    )
 
     if not bundle:
         c.print(f"[bold red]Error:[/] Could not fetch '{identifier}' from any source.\n")
@@ -352,6 +440,9 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         if not force:
             c.print("Use --force to reinstall.\n")
             return
+
+    # Pop non-serializable internal metadata before merging
+    extra_bundles = (bundle.metadata or {}).pop("_extra_bundles", [])
 
     extra_metadata = dict(getattr(meta, "extra", {}) or {})
     extra_metadata.update(getattr(bundle, "metadata", {}) or {})
@@ -437,6 +528,14 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
+    # Install remaining plugins if multiple were selected from marketplace.json
+    for extra_bundle in extra_bundles:
+        c.print(f"\n[bold]Installing additional plugin:[/] {extra_bundle.name}")
+        _install_bundle(
+            extra_bundle, meta=None, category=category, force=force,
+            console=console, skip_confirm=skip_confirm,
+        )
+
     if invalidate_cache:
         # Invalidate the skills prompt cache so the new skill appears immediately
         try:
@@ -462,7 +561,21 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
         if not identifier:
             return
 
-    meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
+    # For 2-part identifiers (owner/repo), only inspect — don't fetch
+    # to avoid triggering the interactive plugin selection prompt.
+    is_repo_root = identifier.count("/") == 1
+    if is_repo_root:
+        meta = None
+        for src in sources:
+            try:
+                meta = src.inspect(identifier)
+                if meta:
+                    break
+            except Exception:
+                pass
+        bundle = None
+    else:
+        meta, bundle, _ = _resolve_source_meta_and_bundle(identifier, sources)
 
     if not meta:
         c.print(f"[bold red]Error:[/] Could not find '{identifier}' in any source.\n")
@@ -594,8 +707,11 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     for entry in updates:
         installed = lock.get_installed(entry["name"])
         category = _derive_category_from_install_path(installed.get("install_path", "")) if installed else ""
+        metadata = (installed.get("metadata") or {}) if installed else {}
+        mp_plugin = metadata.get("marketplace_plugin")
         c.print(f"[bold]Updating:[/] {entry['name']}")
-        do_install(entry["identifier"], category=category, force=True, console=c)
+        do_install(entry["identifier"], category=category, force=True,
+                   console=c, plugin_name=mp_plugin)
 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 

--- a/tests/tools/test_skills_hub_plugin_discovery.py
+++ b/tests/tools/test_skills_hub_plugin_discovery.py
@@ -1,0 +1,565 @@
+"""Tests for GitHubSource repo-root plugin discovery (.claude-plugin support)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from tools.skills_hub import GitHubAuth, GitHubSource, SkillBundle
+
+
+# ---------------------------------------------------------------------------
+# _fetch_marketplace_json
+# ---------------------------------------------------------------------------
+
+
+@patch("tools.skills_hub._write_index_cache", new=lambda *a, **kw: None)
+@patch("tools.skills_hub._read_index_cache", return_value=None)
+class TestFetchMarketplaceJson:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_returns_plugins_list_from_valid_marketplace_json(self, mock_fetch, _cache):
+        mock_fetch.return_value = json.dumps({
+            "name": "test-marketplace",
+            "plugins": [
+                {"name": "plugin-a", "source": "./plugins/a", "description": "Plugin A"},
+                {"name": "plugin-b", "source": "./plugins/b", "description": "Plugin B"},
+            ],
+        })
+        src = self._source()
+        plugins = src._fetch_marketplace_json("owner/repo")
+        assert len(plugins) == 2
+        assert plugins[0]["name"] == "plugin-a"
+        mock_fetch.assert_called_once_with("owner/repo", ".claude-plugin/marketplace.json")
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_returns_empty_list_when_file_missing(self, mock_fetch, _cache):
+        mock_fetch.return_value = None
+        src = self._source()
+        assert src._fetch_marketplace_json("owner/repo") == []
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_returns_empty_list_on_invalid_json(self, mock_fetch, _cache):
+        mock_fetch.return_value = "not json {{"
+        src = self._source()
+        assert src._fetch_marketplace_json("owner/repo") == []
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_returns_empty_list_when_no_plugins_key(self, mock_fetch, _cache):
+        mock_fetch.return_value = json.dumps({"name": "test"})
+        src = self._source()
+        assert src._fetch_marketplace_json("owner/repo") == []
+
+
+# ---------------------------------------------------------------------------
+# _resolve_plugin_source
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePluginSource:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    def test_string_relative_path_dot_slash(self):
+        src = self._source()
+        repo, path = src._resolve_plugin_source("./plugins/formatter", "owner/repo")
+        assert repo == "owner/repo"
+        assert path == "plugins/formatter"
+
+    def test_string_relative_path_just_dot(self):
+        src = self._source()
+        repo, path = src._resolve_plugin_source("./", "owner/repo")
+        assert repo == "owner/repo"
+        assert path == ""
+
+    def test_github_object_source(self):
+        src = self._source()
+        source = {"source": "github", "repo": "company/plugin"}
+        repo, path = src._resolve_plugin_source(source, "owner/repo")
+        assert repo == "company/plugin"
+        assert path == ""
+
+    def test_url_object_source_github_https(self):
+        src = self._source()
+        source = {"source": "url", "url": "https://github.com/obra/superpowers.git"}
+        repo, path = src._resolve_plugin_source(source, "owner/repo")
+        assert repo == "obra/superpowers"
+        assert path == ""
+
+    def test_url_object_source_github_no_git_suffix(self):
+        src = self._source()
+        source = {"source": "url", "url": "https://github.com/obra/superpowers"}
+        repo, path = src._resolve_plugin_source(source, "owner/repo")
+        assert repo == "obra/superpowers"
+        assert path == ""
+
+    def test_git_subdir_object_source(self):
+        src = self._source()
+        source = {
+            "source": "git-subdir",
+            "url": "https://github.com/acme/monorepo.git",
+            "path": "tools/plugin",
+        }
+        repo, path = src._resolve_plugin_source(source, "owner/repo")
+        assert repo == "acme/monorepo"
+        assert path == "tools/plugin"
+
+    def test_npm_source_returns_none(self):
+        src = self._source()
+        source = {"source": "npm", "package": "@acme/plugin"}
+        result = src._resolve_plugin_source(source, "owner/repo")
+        assert result is None
+
+    def test_url_non_github_returns_none(self):
+        src = self._source()
+        source = {"source": "url", "url": "https://gitlab.com/team/plugin.git"}
+        result = src._resolve_plugin_source(source, "owner/repo")
+        assert result is None
+
+    def test_unknown_object_source_returns_none(self):
+        src = self._source()
+        source = {"source": "unknown", "foo": "bar"}
+        result = src._resolve_plugin_source(source, "owner/repo")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _select_plugins — name_hint auto-select
+# ---------------------------------------------------------------------------
+
+
+class TestSelectPluginNameHint:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    def test_auto_selects_by_name_hint(self):
+        src = self._source()
+        plugins = [
+            {"name": "alpha", "description": "A"},
+            {"name": "beta", "description": "B"},
+        ]
+        selected = src._select_plugins(plugins, name_hint="beta")
+        assert len(selected) == 1
+        assert selected[0]["name"] == "beta"
+
+    def test_falls_through_to_prompt_when_hint_not_found(self):
+        src = self._source()
+        plugins = [
+            {"name": "alpha", "description": "A"},
+            {"name": "beta", "description": "B"},
+        ]
+        with patch("builtins.input", side_effect=EOFError):
+            selected = src._select_plugins(plugins, name_hint="nonexistent")
+        assert selected == []
+
+    def test_no_hint_single_plugin_auto_selects(self):
+        src = self._source()
+        plugins = [{"name": "only", "description": "Only one"}]
+        selected = src._select_plugins(plugins)
+        assert len(selected) == 1
+        assert selected[0]["name"] == "only"
+
+    def test_multi_select_comma_separated(self):
+        src = self._source()
+        plugins = [
+            {"name": "alpha", "description": "A"},
+            {"name": "beta", "description": "B"},
+            {"name": "gamma", "description": "C"},
+        ]
+        with patch("builtins.input", return_value="1,3"):
+            selected = src._select_plugins(plugins)
+        assert len(selected) == 2
+        assert selected[0]["name"] == "alpha"
+        assert selected[1]["name"] == "gamma"
+
+    def test_multi_select_all(self):
+        src = self._source()
+        plugins = [
+            {"name": "alpha", "description": "A"},
+            {"name": "beta", "description": "B"},
+        ]
+        with patch("builtins.input", return_value="all"):
+            selected = src._select_plugins(plugins)
+        assert len(selected) == 2
+
+
+class TestFetchPluginFromMarketplaceMetadata:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_download_directory")
+    def test_stores_marketplace_plugin_in_metadata(self, mock_download):
+        mock_download.return_value = {
+            "skills/foo/SKILL.md": "---\nname: foo\n---\n",
+        }
+        src = self._source()
+        plugin = {"name": "my-plugin", "source": "./"}
+        bundle = src._fetch_plugin_from_marketplace(plugin, "owner/repo", 0)
+        assert bundle is not None
+        assert bundle.metadata.get("marketplace_plugin") == "my-plugin"
+
+    @patch.object(GitHubSource, "_download_directory")
+    def test_downloads_only_declared_skill_paths(self, mock_download):
+        """When plugin has a 'skills' list, only those directories are fetched."""
+        mock_download.side_effect = lambda repo, path: {
+            "SKILL.md": f"---\nname: {path.split('/')[-1]}\n---\n",
+            "helper.py": "# helper",
+        } if path else {}
+
+        src = self._source()
+        plugin = {
+            "name": "doc-skills",
+            "source": "./",
+            "skills": ["./skills/xlsx", "./skills/pdf"],
+        }
+        bundle = src._fetch_plugin_from_marketplace(plugin, "owner/repo", 0)
+        assert bundle is not None
+        assert bundle.name == "doc-skills"
+        # Should have called _download_directory for each skill path, not repo root
+        assert mock_download.call_count == 2
+        calls = [c.args for c in mock_download.call_args_list]
+        assert ("owner/repo", "skills/xlsx") in calls
+        assert ("owner/repo", "skills/pdf") in calls
+        # Files should be namespaced under skill path
+        assert "skills/xlsx/SKILL.md" in bundle.files
+        assert "skills/pdf/SKILL.md" in bundle.files
+
+    @patch.object(GitHubSource, "_download_directory")
+    def test_falls_back_to_full_download_without_skills_list(self, mock_download):
+        """Without a 'skills' list, downloads the full source path."""
+        mock_download.return_value = {"SKILL.md": "---\nname: test\n---\n"}
+        src = self._source()
+        plugin = {"name": "full-plugin", "source": "./"}
+        bundle = src._fetch_plugin_from_marketplace(plugin, "owner/repo", 0)
+        assert bundle is not None
+        mock_download.assert_called_once_with("owner/repo", "")
+
+
+# ---------------------------------------------------------------------------
+# _download_directory_via_tree — empty path (repo root)
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadDirectoryEmptyPath:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    @patch("tools.skills_hub.httpx.get")
+    def test_tree_api_handles_empty_path_for_repo_root(self, mock_get, mock_fetch_file):
+        """When path is empty, all blobs in the tree should be included."""
+        repo_resp = MagicMock()
+        repo_resp.status_code = 200
+        repo_resp.json.return_value = {"default_branch": "main"}
+
+        tree_resp = MagicMock()
+        tree_resp.status_code = 200
+        tree_resp.json.return_value = {
+            "truncated": False,
+            "tree": [
+                {"type": "blob", "path": "SKILL.md"},
+                {"type": "blob", "path": "skills/foo/SKILL.md"},
+                {"type": "tree", "path": "skills/foo"},
+            ],
+        }
+        mock_get.side_effect = [repo_resp, tree_resp]
+        mock_fetch_file.side_effect = lambda repo, path: f"content of {path}"
+
+        src = self._source()
+        files = src._download_directory_via_tree("owner/repo", "")
+        assert files is not None
+        assert "SKILL.md" in files
+        assert "skills/foo/SKILL.md" in files
+
+
+# ---------------------------------------------------------------------------
+# _resolve_repo_root
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRepoRoot:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_marketplace_json")
+    def test_follows_marketplace_json_single_plugin_string_source(
+        self, mock_marketplace, mock_download
+    ):
+        mock_marketplace.return_value = [
+            {"name": "my-plugin", "source": "./", "description": "A plugin"},
+        ]
+        mock_download.return_value = {
+            "skills/foo/SKILL.md": "---\nname: foo\n---\n",
+            "plugin.json": "{}",
+        }
+        src = self._source()
+        bundle = src._resolve_repo_root("owner/repo")
+        assert bundle is not None
+        assert bundle.name == "my-plugin"
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_marketplace_json")
+    def test_follows_marketplace_json_github_object_source(
+        self, mock_marketplace, mock_download
+    ):
+        mock_marketplace.return_value = [
+            {
+                "name": "ext-plugin",
+                "source": {"source": "github", "repo": "other/repo"},
+                "description": "External",
+            },
+        ]
+        mock_download.return_value = {
+            "skills/bar/SKILL.md": "---\nname: bar\n---\n",
+        }
+        src = self._source()
+        bundle = src._resolve_repo_root("owner/repo")
+        assert bundle is not None
+        assert bundle.name == "ext-plugin"
+        mock_download.assert_called_with("other/repo", "")
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_marketplace_json")
+    def test_falls_back_to_repo_root_when_no_marketplace_json(
+        self, mock_marketplace, mock_download
+    ):
+        mock_marketplace.return_value = []
+        mock_download.return_value = {
+            "skills/baz/SKILL.md": "---\nname: baz\n---\n",
+            "commands/cmd.md": "# cmd",
+        }
+        src = self._source()
+        bundle = src._resolve_repo_root("owner/repo")
+        assert bundle is not None
+        assert bundle.name == "repo"
+        mock_download.assert_called_with("owner/repo", "")
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_marketplace_json")
+    def test_returns_none_when_repo_root_download_empty(
+        self, mock_marketplace, mock_download
+    ):
+        mock_marketplace.return_value = []
+        mock_download.return_value = {}
+        src = self._source()
+        bundle = src._resolve_repo_root("owner/repo")
+        assert bundle is None
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_marketplace_json")
+    def test_depth_1_does_not_follow_marketplace_json(
+        self, mock_marketplace, mock_download
+    ):
+        mock_download.return_value = {"skills/x/SKILL.md": "---\nname: x\n---\n"}
+        src = self._source()
+        bundle = src._resolve_repo_root("other/repo", _depth=1)
+        assert bundle is not None
+        assert bundle.name == "repo"
+        mock_marketplace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# fetch() / inspect() — 2-part identifier
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTwoPartIdentifier:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_resolve_repo_root")
+    def test_fetch_delegates_two_part_to_resolve_repo_root(self, mock_resolve):
+        mock_resolve.return_value = SkillBundle(
+            name="superpowers",
+            files={"SKILL.md": "# test"},
+            source="github",
+            identifier="obra/superpowers",
+            trust_level="community",
+        )
+        src = self._source()
+        bundle = src.fetch("obra/superpowers")
+        assert bundle is not None
+        assert bundle.name == "superpowers"
+        mock_resolve.assert_called_once_with("obra/superpowers", plugin_name=None)
+
+    @patch.object(GitHubSource, "_download_directory")
+    def test_fetch_three_part_still_works(self, mock_download):
+        mock_download.return_value = {"SKILL.md": "---\nname: test\n---\n"}
+        src = self._source()
+        bundle = src.fetch("owner/repo/skills/test")
+        assert bundle is not None
+        assert bundle.name == "test"
+
+
+class TestInspectTwoPartIdentifier:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_fetch_marketplace_json")
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_inspect_two_part_returns_meta_from_marketplace_json(
+        self, mock_fetch_file, mock_marketplace
+    ):
+        mock_fetch_file.return_value = None
+        mock_marketplace.return_value = [
+            {"name": "superpowers", "source": "./", "description": "Core skills"},
+        ]
+        src = self._source()
+        meta = src.inspect("obra/superpowers")
+        assert meta is not None
+        assert meta.name == "superpowers"
+        assert meta.description == "Core skills"
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_inspect_three_part_still_works(self, mock_fetch_file):
+        mock_fetch_file.return_value = "---\nname: test\ndescription: Test\n---\n"
+        src = self._source()
+        meta = src.inspect("owner/repo/skills/test")
+        assert meta is not None
+        assert meta.name == "test"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration
+# ---------------------------------------------------------------------------
+
+
+@patch("tools.skills_hub._write_index_cache", new=lambda *a, **kw: None)
+@patch("tools.skills_hub._read_index_cache", return_value=None)
+class TestEndToEndRepoRootInstall:
+
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_full_flow_marketplace_json_with_relative_source(
+        self, mock_fetch_file, mock_download, _cache
+    ):
+        marketplace_json = json.dumps({
+            "name": "superpowers-dev",
+            "plugins": [
+                {
+                    "name": "superpowers",
+                    "source": "./",
+                    "description": "Core skills library",
+                    "version": "5.0.7",
+                },
+            ],
+        })
+
+        def fetch_file_side_effect(repo, path):
+            if path == "SKILL.md":
+                return None
+            if path == ".claude-plugin/marketplace.json":
+                return marketplace_json
+            return None
+
+        mock_fetch_file.side_effect = fetch_file_side_effect
+        mock_download.return_value = {
+            "skills/brainstorming/SKILL.md": "---\nname: brainstorming\n---\n",
+            "skills/debugging/SKILL.md": "---\nname: debugging\n---\n",
+            ".claude-plugin/plugin.json": '{"name": "superpowers"}',
+        }
+
+        src = self._source()
+        bundle = src.fetch("obra/superpowers")
+        assert bundle is not None
+        assert bundle.name == "superpowers"
+        assert bundle.source == "github"
+        assert "skills/brainstorming/SKILL.md" in bundle.files
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_full_flow_marketplace_json_with_github_object_source(
+        self, mock_fetch_file, mock_download, _cache
+    ):
+        marketplace_json = json.dumps({
+            "name": "my-marketplace",
+            "plugins": [
+                {
+                    "name": "ext-tool",
+                    "source": {"source": "github", "repo": "other/tool"},
+                    "description": "External tool",
+                },
+            ],
+        })
+
+        def fetch_file_side_effect(repo, path):
+            if repo == "owner/marketplace" and path == "SKILL.md":
+                return None
+            if repo == "owner/marketplace" and path == ".claude-plugin/marketplace.json":
+                return marketplace_json
+            if repo == "other/tool" and path == "SKILL.md":
+                return None
+            return None
+
+        mock_fetch_file.side_effect = fetch_file_side_effect
+        mock_download.return_value = {
+            "skills/tool/SKILL.md": "---\nname: tool\n---\n",
+        }
+
+        src = self._source()
+        bundle = src.fetch("owner/marketplace")
+        assert bundle is not None
+        assert bundle.name == "ext-tool"
+
+    @patch.object(GitHubSource, "_download_directory")
+    @patch.object(GitHubSource, "_fetch_file_content")
+    def test_full_flow_marketplace_json_with_url_object_source(
+        self, mock_fetch_file, mock_download, _cache
+    ):
+        marketplace_json = json.dumps({
+            "name": "my-marketplace",
+            "plugins": [
+                {
+                    "name": "url-plugin",
+                    "source": {
+                        "source": "url",
+                        "url": "https://github.com/obra/superpowers.git",
+                    },
+                    "description": "URL-sourced plugin",
+                },
+            ],
+        })
+
+        def fetch_file_side_effect(repo, path):
+            if repo == "owner/repo" and path == "SKILL.md":
+                return None
+            if repo == "owner/repo" and path == ".claude-plugin/marketplace.json":
+                return marketplace_json
+            if repo == "obra/superpowers" and path == "SKILL.md":
+                return None
+            return None
+
+        mock_fetch_file.side_effect = fetch_file_side_effect
+        mock_download.return_value = {
+            "skills/tdd/SKILL.md": "---\nname: tdd\n---\n",
+        }
+
+        src = self._source()
+        bundle = src.fetch("owner/repo")
+        assert bundle is not None
+        assert bundle.name == "url-plugin"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -337,16 +337,24 @@ class GitHubSource(SkillSource):
 
         return results[:limit]
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str, *, plugin_name: Optional[str] = None) -> Optional[SkillBundle]:
         """
         Download a skill from GitHub.
-        identifier format: "owner/repo/path/to/skill-dir"
+        identifier format: "owner/repo/path/to/skill-dir" or "owner/repo"
+
+        *plugin_name* auto-selects a specific plugin when the repo contains
+        a marketplace.json with multiple plugins (used during updates).
         """
         parts = identifier.split("/", 2)
-        if len(parts) < 3:
+        if len(parts) < 2:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
+
+        # 2-part identifier: owner/repo → repo-root resolution
+        if len(parts) < 3:
+            return self._resolve_repo_root(repo, plugin_name=plugin_name)
+
         skill_path = parts[2]
 
         files = self._download_directory(repo, skill_path)
@@ -367,10 +375,15 @@ class GitHubSource(SkillSource):
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""
         parts = identifier.split("/", 2)
-        if len(parts) < 3:
+        if len(parts) < 2:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
+
+        # 2-part identifier: owner/repo
+        if len(parts) < 3:
+            return self._inspect_repo_root(repo, identifier)
+
         skill_path = parts[2].rstrip("/")
         skill_md_path = f"{skill_path}/SKILL.md"
 
@@ -401,6 +414,42 @@ class GitHubSource(SkillSource):
             repo=repo,
             path=skill_path,
             tags=[str(t) for t in tags],
+        )
+
+    def _inspect_repo_root(self, repo: str, identifier: str) -> Optional[SkillMeta]:
+        """Inspect an owner/repo identifier — check marketplace.json."""
+        common = dict(
+            source="github",
+            identifier=identifier,
+            trust_level=self.trust_level_for(identifier),
+            repo=repo,
+            path="",
+        )
+        fallback_name = repo.split("/")[-1]
+
+        plugins = self._fetch_marketplace_json(repo)
+        if not plugins:
+            return None
+
+        # Build a summary of all available plugins
+        plugin_names = [p.get("name", "?") for p in plugins]
+        descriptions = [p.get("description", "") for p in plugins]
+
+        if len(plugins) == 1:
+            name = plugin_names[0]
+            desc = descriptions[0]
+        else:
+            name = fallback_name
+            desc = f"{len(plugins)} plugins available: {', '.join(plugin_names)}"
+
+        return SkillMeta(
+            name=name,
+            description=desc,
+            extra={"plugins": [
+                {"name": p.get("name", "?"), "description": p.get("description", "")}
+                for p in plugins
+            ]},
+            **common,
         )
 
     # -- Internal helpers --
@@ -489,15 +538,16 @@ class GitHubSource(SkillSource):
             return None
 
         # Filter to blobs under our target path and fetch content
-        prefix = f"{path}/"
+        is_root = (path == "")
+        prefix = "" if is_root else f"{path}/"
         files: Dict[str, str] = {}
         for item in tree_data.get("tree", []):
             if item.get("type") != "blob":
                 continue
             item_path = item.get("path", "")
-            if not item_path.startswith(prefix):
+            if not is_root and not item_path.startswith(prefix):
                 continue
-            rel_path = item_path[len(prefix):]
+            rel_path = item_path if is_root else item_path[len(prefix):]
             content = self._fetch_file_content(repo, item_path)
             if content is not None:
                 files[rel_path] = content
@@ -604,6 +654,257 @@ class GitHubSource(SkillSource):
         except httpx.HTTPError as e:
             logger.debug("GitHub contents API fetch failed: %s", e)
         return None
+
+    def _fetch_marketplace_json(self, repo: str) -> list:
+        """Fetch and parse .claude-plugin/marketplace.json from a repo.
+
+        Returns the ``plugins`` list, or an empty list if the file is
+        missing or unparseable.  Results are cached for ``INDEX_CACHE_TTL``.
+        """
+        cache_key = f"marketplace_{repo.replace('/', '_')}"
+        cached = _read_index_cache(cache_key)
+        if cached is not None:
+            return cached
+
+        content = self._fetch_file_content(repo, ".claude-plugin/marketplace.json")
+        if not content:
+            return []
+        try:
+            data = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        plugins = data.get("plugins", [])
+        result = plugins if isinstance(plugins, list) else []
+        _write_index_cache(cache_key, result)
+        return result
+
+    @staticmethod
+    def _github_url_to_repo(url: str) -> Optional[str]:
+        """Extract ``owner/repo`` from a GitHub URL, or return ``None``."""
+        parsed = urlparse(url)
+        hostname = parsed.hostname or ""
+        if "github.com" not in hostname:
+            logger.debug("Non-GitHub URL not supported: %s", url)
+            return None
+        parts = parsed.path.strip("/").removesuffix(".git").split("/")
+        if len(parts) < 2:
+            return None
+        return f"{parts[0]}/{parts[1]}"
+
+    def _resolve_plugin_source(
+        self, source, marketplace_repo: str
+    ) -> Optional[tuple]:
+        """Resolve a marketplace plugin's ``source`` field to ``(repo, path)``.
+
+        Returns ``None`` for unsupported source types (npm, non-GitHub URLs).
+        """
+        # String source: relative path within the same repo
+        if isinstance(source, str):
+            path = source
+            if path.startswith("./"):
+                path = path[2:]
+            path = path.rstrip("/")
+            return (marketplace_repo, path)
+
+        if not isinstance(source, dict):
+            return None
+
+        source_type = source.get("source", "")
+
+        if source_type == "github":
+            repo = source.get("repo", "")
+            if not repo:
+                return None
+            return (repo, "")
+
+        if source_type == "url":
+            repo = self._github_url_to_repo(source.get("url", ""))
+            if not repo:
+                return None
+            return (repo, "")
+
+        if source_type == "git-subdir":
+            repo = self._github_url_to_repo(source.get("url", ""))
+            if not repo:
+                return None
+            return (repo, source.get("path", ""))
+
+        # npm or unknown
+        logger.debug("Unsupported plugin source type: %s", source_type)
+        return None
+
+    def _resolve_repo_root(
+        self, repo: str, _depth: int = 0,
+        plugin_name: Optional[str] = None,
+    ) -> Optional[SkillBundle]:
+        """Resolve an ``owner/repo`` identifier to a SkillBundle.
+
+        Resolution order:
+        1. .claude-plugin/marketplace.json → plugin discovery (depth 0 only)
+        2. Repo root as plugin (download all files)
+
+        *_depth* prevents infinite recursion: external repos referenced from
+        marketplace.json are fetched at depth 1 which skips step 2.
+
+        *plugin_name* auto-selects a specific plugin from marketplace.json
+        without prompting (used during updates).
+        """
+        repo_name = repo.split("/")[-1]
+        trust = self.trust_level_for(repo)
+
+        # 1. Check marketplace.json (only at depth 0)
+        if _depth == 0:
+            plugins = self._fetch_marketplace_json(repo)
+            if plugins:
+                selected = self._select_plugins(plugins, name_hint=plugin_name)
+                if selected:
+                    bundle = self._fetch_plugin_from_marketplace(
+                        selected[0], repo, _depth,
+                    )
+                    if bundle and len(selected) > 1:
+                        extra_bundles = []
+                        for p in selected[1:]:
+                            b = self._fetch_plugin_from_marketplace(
+                                p, repo, _depth,
+                            )
+                            if b:
+                                extra_bundles.append(b)
+                        if extra_bundles:
+                            bundle.metadata["_extra_bundles"] = extra_bundles
+                    return bundle
+
+        # 3. Fallback: download repo root as plugin
+        files = self._download_directory(repo, "")
+        if not files:
+            return None
+        return SkillBundle(
+            name=repo_name,
+            files=files,
+            source="github",
+            identifier=repo,
+            trust_level=trust,
+        )
+
+    def _select_plugins(
+        self, plugins: list, name_hint: Optional[str] = None,
+    ) -> List[dict]:
+        """Select plugins from a marketplace plugins list.
+
+        Auto-selects if there is only one, or if *name_hint* matches a
+        plugin name (used during updates to avoid re-prompting).
+        Prompts the user interactively otherwise.  Accepts comma-separated
+        numbers or ``all`` to install every plugin.
+        """
+        if not plugins:
+            return []
+        if len(plugins) == 1:
+            return [plugins[0]]
+
+        # Auto-select by name hint (e.g. during updates)
+        if name_hint:
+            for p in plugins:
+                if p.get("name") == name_hint:
+                    return [p]
+
+        print(f"\nFound {len(plugins)} plugins:")
+        for i, p in enumerate(plugins, 1):
+            desc = p.get("description", "")
+            print(f"  [{i}] {p.get('name', '?')} — {desc}")
+
+        try:
+            answer = input(
+                f"\nSelect plugins to install [1-{len(plugins)}, comma-separated, or 'all']: "
+            ).strip()
+            if answer.lower() == "all":
+                return list(plugins)
+            selected = []
+            for part in answer.split(","):
+                idx = int(part.strip()) - 1
+                if 0 <= idx < len(plugins):
+                    selected.append(plugins[idx])
+            return selected
+        except (EOFError, KeyboardInterrupt):
+            logger.debug("Plugin selection cancelled (non-interactive environment?)")
+        except ValueError:
+            pass
+        return []
+
+    def _fetch_plugin_from_marketplace(
+        self, plugin: dict, marketplace_repo: str, depth: int,
+    ) -> Optional[SkillBundle]:
+        """Fetch a single plugin based on its marketplace entry."""
+        source = plugin.get("source", "")
+        resolved = self._resolve_plugin_source(source, marketplace_repo)
+        if resolved is None:
+            logger.debug(
+                "Unsupported source for plugin %s: %s",
+                plugin.get("name", "?"), source,
+            )
+            return None
+
+        target_repo, target_path = resolved
+        plugin_name = plugin.get("name", target_repo.split("/")[-1])
+        trust = self.trust_level_for(target_repo)
+
+        # External repo with no explicit path → repo-root resolution at depth+1
+        if target_repo != marketplace_repo and not target_path:
+            bundle = self._resolve_repo_root(target_repo, _depth=depth + 1)
+            if bundle:
+                bundle.name = plugin_name
+                bundle.metadata["marketplace_plugin"] = plugin_name
+            return bundle
+
+        # If the plugin declares specific skill paths, download only those
+        skill_paths = plugin.get("skills", [])
+        if skill_paths and isinstance(skill_paths, list):
+            files = self._download_plugin_skills(
+                target_repo, target_path, skill_paths,
+            )
+        elif target_path:
+            files = self._download_directory(target_repo, target_path)
+        else:
+            files = self._download_directory(target_repo, "")
+        if not files:
+            return None
+
+        return SkillBundle(
+            name=plugin_name,
+            files=files,
+            source="github",
+            identifier=f"{target_repo}/{target_path}" if target_path else target_repo,
+            trust_level=trust,
+            metadata={"marketplace_plugin": plugin_name},
+        )
+
+    def _download_plugin_skills(
+        self, repo: str, base_path: str, skill_paths: list,
+    ) -> Dict[str, str]:
+        """Download only the skill directories listed in a plugin entry.
+
+        Each path in *skill_paths* is relative to the plugin source root
+        (e.g. ``"./skills/xlsx"``).  The base_path is the resolved plugin
+        source path within the repo.
+        """
+        files: Dict[str, str] = {}
+        for sp in skill_paths:
+            if not isinstance(sp, str):
+                continue
+            # Normalize: strip "./" prefix
+            rel = sp
+            if rel.startswith("./"):
+                rel = rel[2:]
+            # Build full path within repo
+            if base_path:
+                full_path = f"{base_path}/{rel}".rstrip("/")
+            else:
+                full_path = rel.rstrip("/")
+            dir_files = self._download_directory(repo, full_path)
+            if dir_files:
+                for name, content in dir_files.items():
+                    # Prefix with the skill directory name for namespacing
+                    prefixed = f"{rel}/{name}" if rel else name
+                    files[prefixed] = content
+        return files
 
     def _read_cache(self, key: str) -> Optional[list]:
         """Read cached index if not expired."""
@@ -2620,10 +2921,18 @@ def check_for_skill_updates(
         source_name = entry.get("source", "")
         candidate_sources = [src for src in sources if _source_matches(src, source_name)] or sources
 
+        metadata = entry.get("metadata", {}) or {}
+        mp_plugin = metadata.get("marketplace_plugin")
+
         bundle = None
         for src in candidate_sources:
             try:
-                bundle = src.fetch(identifier)
+                bundle = src.fetch(identifier, plugin_name=mp_plugin)
+            except TypeError:
+                try:
+                    bundle = src.fetch(identifier)
+                except Exception:
+                    bundle = None
             except Exception:
                 bundle = None
             if bundle:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -367,6 +367,19 @@ A third-party skills marketplace integrated as a community source.
 
 Hermes supports marketplace repos that publish Claude-compatible plugin/marketplace manifests.
 
+You can install directly from any GitHub repo that contains a `.claude-plugin/marketplace.json`:
+
+```bash
+hermes skills install anthropics/skills
+```
+
+Hermes will:
+1. Check for `.claude-plugin/marketplace.json` — parse the plugins list and install
+2. Fall back to downloading the repo root as a plugin
+
+If the marketplace.json lists multiple plugins, you'll be prompted to choose.
+All marketplace plugin source types are supported: relative paths (`"./"`), GitHub repos (`{"source": "github", "repo": "..."}`), Git URLs (`{"source": "url", "url": "..."}`), and git subdirectories (`{"source": "git-subdir", ...}`).
+
 Known integrated sources include:
 - [anthropics/skills](https://github.com/anthropics/skills)
 - [aiskillstore/marketplace](https://github.com/aiskillstore/marketplace)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Enables hermes skills install owner/repo for repos that use .claude-plugin/marketplace.json (e.g. hermes skills install anthropics/skills).

This adds a resolution chain: parse .claude-plugin/marketplace.json → fallback to repo root as plugin. It also handles all official Claude Code marketplace source types and stores the selected plugin name in lock metadata so hermes skills update can auto-select without re-prompting.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #7514 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- tools/skills_hub.py: Add _github_url_to_repo(), _fetch_marketplace_json(), _resolve_plugin_source(), _resolve_repo_root(), _select_plugins(), _fetch_plugin_from_marketplace(), _inspect_repo_root() to GitHubSource
- tools/skills_hub.py: Modify GitHubSource.fetch() and inspect() to handle 2-part owner/repo identifiers
- tools/skills_hub.py: Fix _download_directory_via_tree() to handle empty path (repo root download)
- tools/skills_hub.py: Store marketplace_plugin in SkillBundle.metadata; thread plugin_name through check_for_skill_updates()
- hermes_cli/skills_hub.py: Add plugin_name param to do_install() and _resolve_source_meta_and_bundle(); pass it from do_update(). Install remaining plugins individually when multiple are selected


- website/docs/user-guide/features/skills.md: Update claude-marketplace section with direct install docs


- tests/tools/test_skills_hub_plugin_discovery.py: 32 new tests covering all source types, depth limits, multi-selection, caching, and end-to-end flows

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `hermes skills inspect anthropics/skills` — should display plugin metadata from marketplace.json
2. `hermes skills install anthropics/skills` — should discover marketplace.json, auto-select the single plugin, and install
3. `hermes skills update` — should update the installed plugin without prompting for selection
4. `hermes skills install anthropics/skills/skills/skill-creator` — existing 3-part identifiers should still work
5. `pytest tests/tools/test_skills_hub_plugin_discovery.py tests/tools/test_skills_hub.py -v`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

<details>
<summary>log output</summary>

<details>
<summary>Inspect</summary>

```sh
/Users/baegteun/Projects/hermes-agent/.venv/bin/hermes skills inspect anthropics/skills                             ✔

╭───────────────────────────────────────────────────────────────────────────────────── Skill: skills ─────────────────────────────────────────────────────────────────────────────────────╮
│ Name: skills                                                                                                                                                                            │
│ Description: 3 plugins available: document-skills, example-skills, claude-api                                                                                                           │
│ Source: skills.sh                                                                                                                                                                       │
│ Trust: trusted                                                                                                                                                                          │
│ Identifier: skills-sh/anthropics/skills                                                                                                                                                 │
│ Repo: https://github.com/anthropics/skills                                                                                                                                              │
│ Detail Page: https://skills.sh/anthropics/skills                                                                                                                                        │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
</details>


<details>
<summary>Install</summary>

```sh
/Users/baegteun/Projects/hermes-agent/.venv/bin/hermes skills install anthropics/skills --force                  ✔

Fetching: anthropics/skills

Found 3 plugins:
  [1] document-skills — Collection of document processing suite including Excel, Word, PowerPoint, and PDF capabilities
  [2] example-skills — Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling
  [3] claude-api — Claude API and SDK documentation skill for building LLM-powered applications

Select plugins to install [1-3, comma-separated, or 'all']: 1,3
Quarantined to .hub/quarantine/document-skills
Running security scan...
Scan: document-skills (skills-sh/anthropics/skills/trusted)  Verdict: CAUTION
  HIGH     structural     (directory):0                  "3323KB total"
  HIGH     exfiltration   skills/xlsx/scripts/office/soffice.py:25 "env = os.environ.copy()"
  HIGH     exfiltration   skills/pptx/scripts/office/soffice.py:25 "env = os.environ.copy()"
  HIGH     exfiltration   skills/docx/scripts/office/soffice.py:25 "env = os.environ.copy()"
  MEDIUM   structural     (directory):0                  "186 files"
  MEDIUM   supply_chain   skills/pdf/SKILL.md:235        "# Requires: pip install pytesseract pdf2image"
  MEDIUM   supply_chain   skills/pptx/pptxgenjs.md:238   "Install: `npm install -g react-icons react react-dom sharp`"
  MEDIUM   supply_chain   skills/pptx/SKILL.md:228       "- `pip install "markitdown"` - text extraction"
  MEDIUM   supply_chain   skills/pptx/SKILL.md:229       "- `pip install Pillow` - thumbnail grids"
  MEDIUM   supply_chain   skills/pptx/SKILL.md:230       "- `npm install -g pptxgenjs` - creating from scratch"
  MEDIUM   supply_chain   skills/docx/SKILL.md:58        "Generate .docx files with JavaScript, then validate. Install"
  MEDIUM   supply_chain   skills/docx/SKILL.md:588       "- **docx**: `npm install -g docx` (new documents)"
  MEDIUM   execution      skills/xlsx/scripts/recalc.py:34 "subprocess.run("
  MEDIUM   execution      skills/xlsx/scripts/recalc.py:55 "subprocess.run("
  MEDIUM   execution      skills/xlsx/scripts/recalc.py:92 "result = subprocess.run(cmd, capture_output=True, text=True,"
  MEDIUM   execution      skills/xlsx/scripts/office/soffice.py:14 "subprocess.run(["soffice", ...], env=env)"
  MEDIUM   execution      skills/xlsx/scripts/office/soffice.py:37 "return subprocess.run(["soffice"] + args, env=env, **kwargs)"
  MEDIUM   execution      skills/xlsx/scripts/office/soffice.py:59 "subprocess.run("
  MEDIUM   execution      skills/xlsx/scripts/office/validators/redlining.py:138 "result = subprocess.run("
  MEDIUM   execution      skills/xlsx/scripts/office/validators/redlining.py:167 "result = subprocess.run("
  MEDIUM   execution      skills/pptx/scripts/thumbnail.py:161 "result = subprocess.run("
  MEDIUM   execution      skills/pptx/scripts/thumbnail.py:178 "result = subprocess.run("
  MEDIUM   execution      skills/pptx/scripts/office/soffice.py:14 "subprocess.run(["soffice", ...], env=env)"
  MEDIUM   execution      skills/pptx/scripts/office/soffice.py:37 "return subprocess.run(["soffice"] + args, env=env, **kwargs)"
  MEDIUM   execution      skills/pptx/scripts/office/soffice.py:59 "subprocess.run("
  MEDIUM   execution      skills/pptx/scripts/office/validators/redlining.py:138 "result = subprocess.run("
  MEDIUM   execution      skills/pptx/scripts/office/validators/redlining.py:167 "result = subprocess.run("
  MEDIUM   execution      skills/docx/scripts/accept_changes.py:68 "result = subprocess.run("
  MEDIUM   execution      skills/docx/scripts/accept_changes.py:99 "subprocess.run("
  MEDIUM   execution      skills/docx/scripts/office/soffice.py:14 "subprocess.run(["soffice", ...], env=env)"
  MEDIUM   execution      skills/docx/scripts/office/soffice.py:37 "return subprocess.run(["soffice"] + args, env=env, **kwargs)"
  MEDIUM   execution      skills/docx/scripts/office/soffice.py:59 "subprocess.run("
  MEDIUM   execution      skills/docx/scripts/office/validators/redlining.py:138 "result = subprocess.run("
  MEDIUM   execution      skills/docx/scripts/office/validators/redlining.py:167 "result = subprocess.run("

Decision: ALLOWED — Allowed (trusted source, caution verdict)
╭─────────────────────────────────────────────────────────────────────────────────── Upstream Metadata ───────────────────────────────────────────────────────────────────────────────────╮
│ Repo: https://github.com/anthropics/skills                                                                                                                                              │
│ Detail Page: https://skills.sh/anthropics/skills                                                                                                                                        │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Installed: document-skills
Files: skills/xlsx/LICENSE.txt, skills/xlsx/SKILL.md, skills/xlsx/scripts/office/helpers/__init__.py, skills/xlsx/scripts/office/helpers/merge_runs.py,
skills/xlsx/scripts/office/helpers/simplify_redlines.py, skills/xlsx/scripts/office/pack.py, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd, skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd,
skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd, skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd,
skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd, skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd,
skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd, skills/xlsx/scripts/office/schemas/mce/mc.xsd, skills/xlsx/scripts/office/schemas/microsoft/wml-2010.xsd,
skills/xlsx/scripts/office/schemas/microsoft/wml-2012.xsd, skills/xlsx/scripts/office/schemas/microsoft/wml-2018.xsd, skills/xlsx/scripts/office/schemas/microsoft/wml-cex-2018.xsd,
skills/xlsx/scripts/office/schemas/microsoft/wml-cid-2016.xsd, skills/xlsx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd,
skills/xlsx/scripts/office/schemas/microsoft/wml-symex-2015.xsd, skills/xlsx/scripts/office/soffice.py, skills/xlsx/scripts/office/unpack.py, skills/xlsx/scripts/office/validate.py,
skills/xlsx/scripts/office/validators/__init__.py, skills/xlsx/scripts/office/validators/base.py, skills/xlsx/scripts/office/validators/docx.py,
skills/xlsx/scripts/office/validators/pptx.py, skills/xlsx/scripts/office/validators/redlining.py, skills/xlsx/scripts/recalc.py, skills/docx/LICENSE.txt, skills/docx/SKILL.md,
skills/docx/scripts/__init__.py, skills/docx/scripts/accept_changes.py, skills/docx/scripts/comment.py, skills/docx/scripts/office/helpers/__init__.py,
skills/docx/scripts/office/helpers/merge_runs.py, skills/docx/scripts/office/helpers/simplify_redlines.py, skills/docx/scripts/office/pack.py,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd, skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd,
skills/docx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd, skills/docx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd,
skills/docx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd, skills/docx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd,
skills/docx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd, skills/docx/scripts/office/schemas/mce/mc.xsd, skills/docx/scripts/office/schemas/microsoft/wml-2010.xsd,
skills/docx/scripts/office/schemas/microsoft/wml-2012.xsd, skills/docx/scripts/office/schemas/microsoft/wml-2018.xsd, skills/docx/scripts/office/schemas/microsoft/wml-cex-2018.xsd,
skills/docx/scripts/office/schemas/microsoft/wml-cid-2016.xsd, skills/docx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd,
skills/docx/scripts/office/schemas/microsoft/wml-symex-2015.xsd, skills/docx/scripts/office/soffice.py, skills/docx/scripts/office/unpack.py, skills/docx/scripts/office/validate.py,
skills/docx/scripts/office/validators/__init__.py, skills/docx/scripts/office/validators/base.py, skills/docx/scripts/office/validators/docx.py,
skills/docx/scripts/office/validators/pptx.py, skills/docx/scripts/office/validators/redlining.py, skills/docx/scripts/templates/comments.xml,
skills/docx/scripts/templates/commentsExtended.xml, skills/docx/scripts/templates/commentsExtensible.xml, skills/docx/scripts/templates/commentsIds.xml,
skills/docx/scripts/templates/people.xml, skills/pptx/LICENSE.txt, skills/pptx/SKILL.md, skills/pptx/editing.md, skills/pptx/pptxgenjs.md, skills/pptx/scripts/__init__.py,
skills/pptx/scripts/add_slide.py, skills/pptx/scripts/clean.py, skills/pptx/scripts/office/helpers/__init__.py, skills/pptx/scripts/office/helpers/merge_runs.py,
skills/pptx/scripts/office/helpers/simplify_redlines.py, skills/pptx/scripts/office/pack.py, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd, skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd,
skills/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd, skills/pptx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd,
skills/pptx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd, skills/pptx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd,
skills/pptx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd, skills/pptx/scripts/office/schemas/mce/mc.xsd, skills/pptx/scripts/office/schemas/microsoft/wml-2010.xsd,
skills/pptx/scripts/office/schemas/microsoft/wml-2012.xsd, skills/pptx/scripts/office/schemas/microsoft/wml-2018.xsd, skills/pptx/scripts/office/schemas/microsoft/wml-cex-2018.xsd,
skills/pptx/scripts/office/schemas/microsoft/wml-cid-2016.xsd, skills/pptx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd,
skills/pptx/scripts/office/schemas/microsoft/wml-symex-2015.xsd, skills/pptx/scripts/office/soffice.py, skills/pptx/scripts/office/unpack.py, skills/pptx/scripts/office/validate.py,
skills/pptx/scripts/office/validators/__init__.py, skills/pptx/scripts/office/validators/base.py, skills/pptx/scripts/office/validators/docx.py,
skills/pptx/scripts/office/validators/pptx.py, skills/pptx/scripts/office/validators/redlining.py, skills/pptx/scripts/thumbnail.py, skills/pdf/LICENSE.txt, skills/pdf/SKILL.md,
skills/pdf/forms.md, skills/pdf/reference.md, skills/pdf/scripts/check_bounding_boxes.py, skills/pdf/scripts/check_fillable_fields.py, skills/pdf/scripts/convert_pdf_to_images.py,
skills/pdf/scripts/create_validation_image.py, skills/pdf/scripts/extract_form_field_info.py, skills/pdf/scripts/extract_form_structure.py, skills/pdf/scripts/fill_fillable_fields.py,
skills/pdf/scripts/fill_pdf_form_with_annotations.py


Installing additional plugin: claude-api
Quarantined to .hub/quarantine/claude-api
Running security scan...
Scan: claude-api (anthropics/skills/trusted)  Verdict: DANGEROUS
  CRITICAL persistence    skills/claude-api/SKILL.md:90  "> **Managed Agents code examples**: dedicated language-speci"
  CRITICAL persistence    skills/claude-api/SKILL.md:234 "**Reading guide:** Start with `shared/managed-agents-overvie"
  CRITICAL persistence    skills/claude-api/SKILL.md:273 "→ Read `shared/managed-agents-overview.md` + the rest of the"
  CRITICAL persistence    skills/claude-api/shared/managed-agents-onboarding.md:114 "Pull exact syntax from `python/managed-agents/README.md`, `t"
  CRITICAL persistence    skills/claude-api/shared/managed-agents-client-patterns.md:5 "Code samples are TypeScript — Python and cURL follow the sam"
  CRITICAL credential_exposure skills/claude-api/go/managed-agents/README.md:512 "AuthorizationToken: "ghp_your_github_token","
  CRITICAL credential_exposure skills/claude-api/go/managed-agents/README.md:531 "AuthorizationToken: "ghp_your_github_token","
  CRITICAL credential_exposure skills/claude-api/go/managed-agents/README.md:539 "AuthorizationToken: "ghp_your_github_token","
  CRITICAL credential_exposure skills/claude-api/go/managed-agents/README.md:556 "AuthorizationToken: "ghp_your_new_github_token","
  CRITICAL credential_exposure skills/claude-api/php/managed-agents/README.md:433 "authorizationToken: 'ghp_your_new_github_token',"
  CRITICAL credential_exposure skills/claude-api/ruby/managed-agents/README.md:353 "authorization_token: "ghp_your_github_token""
  CRITICAL credential_exposure skills/claude-api/ruby/managed-agents/README.md:367 "authorization_token: "ghp_your_github_token""
  CRITICAL credential_exposure skills/claude-api/ruby/managed-agents/README.md:373 "authorization_token: "ghp_your_github_token""
  CRITICAL credential_exposure skills/claude-api/ruby/managed-agents/README.md:387 "authorization_token: "ghp_your_new_github_token""
  HIGH     exfiltration   skills/claude-api/shared/managed-agents-environments.md:182 ""authorization_token": os.environ["GITHUB_TOKEN"],  # repo c"
  HIGH     exfiltration   skills/claude-api/python/claude-api/README.md:227 "The API is stateless — send the full conversation history ea"
  HIGH     exfiltration   skills/claude-api/python/managed-agents/README.md:99 ""authorization_token": os.environ["GITHUB_TOKEN"],"
  HIGH     exfiltration   skills/claude-api/typescript/claude-api/README.md:225 "The API is stateless — send the full conversation history ea"
  MEDIUM   supply_chain   skills/claude-api/curl/managed-agents.md:175 "curl "https://api.anthropic.com/v1/sessions/$SESSION_ID/even"
  MEDIUM   supply_chain   skills/claude-api/curl/managed-agents.md:263 "curl "https://api.anthropic.com/v1/files?scope=$SESSION_ID" "
  MEDIUM   supply_chain   skills/claude-api/curl/managed-agents.md:267 "curl "https://api.anthropic.com/v1/files/$FILE_ID/content" \"
  MEDIUM   traversal      skills/claude-api/go/managed-agents/README.md:152 "> 💡 **Stream-first:** Open the stream *before* (or concurren"
  MEDIUM   traversal      skills/claude-api/python/claude-api/tool-use.md:3 "For conceptual overview (tool definitions, tool choice, tips"
  MEDIUM   supply_chain   skills/claude-api/python/claude-api/tool-use.md:54 "**Beta.** Convert [MCP (Model Context Protocol)](https://mod"
  MEDIUM   supply_chain   skills/claude-api/python/claude-api/README.md:6 "pip install anthropic"
  MEDIUM   traversal      skills/claude-api/python/managed-agents/README.md:122 "> 💡 **Stream-first:** Open the stream *before* (or concurren"
  MEDIUM   traversal      skills/claude-api/python/managed-agents/README.md:192 "> ⚠️ **Prefer the SDK over raw `requests`/`httpx`.** If you "
  MEDIUM   supply_chain   skills/claude-api/python/managed-agents/README.md:10 "pip install anthropic"
  MEDIUM   traversal      skills/claude-api/typescript/claude-api/tool-use.md:3 "For conceptual overview (tool definitions, tool choice, tips"
  MEDIUM   traversal      skills/claude-api/typescript/claude-api/README.md:219 "All classes extend `Anthropic.APIError` with a typed `status"
  MEDIUM   supply_chain   skills/claude-api/typescript/claude-api/README.md:6 "npm install @anthropic-ai/sdk"
  MEDIUM   traversal      skills/claude-api/typescript/managed-agents/README.md:132 "> 💡 **Stream-first:** Open the stream *before* (or concurren"
  MEDIUM   supply_chain   skills/claude-api/typescript/managed-agents/README.md:10 "npm install @anthropic-ai/sdk"
  MEDIUM   traversal      skills/claude-api/java/managed-agents/README.md:119 "> 💡 **Stream-first:** Open the stream *before* (or concurren"
  MEDIUM   traversal      skills/claude-api/php/managed-agents/README.md:107 "> 💡 **Stream-first:** Open the stream *before* (or concurren"
  MEDIUM   traversal      skills/claude-api/ruby/managed-agents/README.md:104 "> 💡 **Stream-first:** Open the stream *before* (or concurren"

Decision: BLOCKED — Blocked (trusted source + dangerous verdict, 36 findings). Use --force to override.
Installed: claude-api
Files: skills/claude-api/LICENSE.txt, skills/claude-api/SKILL.md, skills/claude-api/csharp/claude-api.md, skills/claude-api/curl/examples.md, skills/claude-api/curl/managed-agents.md,
skills/claude-api/go/claude-api.md, skills/claude-api/go/managed-agents/README.md, skills/claude-api/java/claude-api.md, skills/claude-api/java/managed-agents/README.md,
skills/claude-api/php/claude-api.md, skills/claude-api/php/managed-agents/README.md, skills/claude-api/python/claude-api/README.md, skills/claude-api/python/claude-api/batches.md,
skills/claude-api/python/claude-api/files-api.md, skills/claude-api/python/claude-api/streaming.md, skills/claude-api/python/claude-api/tool-use.md,
skills/claude-api/python/managed-agents/README.md, skills/claude-api/ruby/claude-api.md, skills/claude-api/ruby/managed-agents/README.md, skills/claude-api/shared/agent-design.md,
skills/claude-api/shared/error-codes.md, skills/claude-api/shared/live-sources.md, skills/claude-api/shared/managed-agents-api-reference.md,
skills/claude-api/shared/managed-agents-client-patterns.md, skills/claude-api/shared/managed-agents-core.md, skills/claude-api/shared/managed-agents-environments.md,
skills/claude-api/shared/managed-agents-events.md, skills/claude-api/shared/managed-agents-onboarding.md, skills/claude-api/shared/managed-agents-overview.md,
skills/claude-api/shared/managed-agents-tools.md, skills/claude-api/shared/models.md, skills/claude-api/shared/prompt-caching.md, skills/claude-api/shared/tool-use-concepts.md,
skills/claude-api/typescript/claude-api/README.md, skills/claude-api/typescript/claude-api/batches.md, skills/claude-api/typescript/claude-api/files-api.md,
skills/claude-api/typescript/claude-api/streaming.md, skills/claude-api/typescript/claude-api/tool-use.md, skills/claude-api/typescript/managed-agents/README.md

 ~/Projects/hermes-agent ╱ feat/claude-marketplace-install ⇡3 !1 ?3
```
</details>

<details>
<summary>skill list after install</summary>

```sh
/Users/baegteun/Projects/hermes-agent/.venv/bin/hermes skills list                                      ✔ ╱ 1m 35s
                                  Installed Skills
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Name                                   ┃ Category             ┃ Source  ┃ Trust   ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
...
│ claude-api                             │ claude-api           │ github  │ trusted │
...
│ docx                                   │ document-skills      │ local   │ local   │
│ pdf                                    │ document-skills      │ local   │ local   │
│ pptx                                   │ document-skills      │ local   │ local   │
│ xlsx                                   │ document-skills      │ local   │ local   │
...
└────────────────────────────────────────┴──────────────────────┴─────────┴─────────┘
1 hub-installed, 68 builtin, 49 local
```

<details>
<summary>all skill list</summary>

```sh
/Users/baegteun/Projects/hermes-agent/.venv/bin/hermes skills list                                      ✔ ╱ 1m 35s
                                  Installed Skills
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Name                                   ┃ Category             ┃ Source  ┃ Trust   ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ dogfood                                │                      │ builtin │ builtin │
│ ios-accessibility                      │                      │ local   │ local   │
│ swift-accessibility-skill              │                      │ local   │ local   │
│ apple-notes                            │ apple                │ builtin │ builtin │
│ apple-reminders                        │ apple                │ builtin │ builtin │
│ findmy                                 │ apple                │ builtin │ builtin │
│ imessage                               │ apple                │ builtin │ builtin │
│ claude-code                            │ autonomous-ai-agents │ builtin │ builtin │
│ codex                                  │ autonomous-ai-agents │ builtin │ builtin │
│ gemini-cli                             │ autonomous-ai-agents │ local   │ local   │
│ hermes-agent                           │ autonomous-ai-agents │ builtin │ builtin │
│ opencode                               │ autonomous-ai-agents │ builtin │ builtin │
│ claude-api                             │ claude-api           │ github  │ trusted │
│ ascii-art                              │ creative             │ builtin │ builtin │
│ ascii-video                            │ creative             │ builtin │ builtin │
│ excalidraw                             │ creative             │ builtin │ builtin │
│ manim-video                            │ creative             │ builtin │ builtin │
│ p5js                                   │ creative             │ builtin │ builtin │
│ popular-web-designs                    │ creative             │ builtin │ builtin │
│ songwriting-and-ai-music               │ creative             │ builtin │ builtin │
│ jupyter-live-kernel                    │ data-science         │ builtin │ builtin │
│ webhook-subscriptions                  │ devops               │ builtin │ builtin │
│ docx                                   │ document-skills      │ local   │ local   │
│ pdf                                    │ document-skills      │ local   │ local   │
│ pptx                                   │ document-skills      │ local   │ local   │
│ xlsx                                   │ document-skills      │ local   │ local   │
│ himalaya                               │ email                │ builtin │ builtin │
│ minecraft-modpack-server               │ gaming               │ builtin │ builtin │
│ pokemon-player                         │ gaming               │ builtin │ builtin │
│ codebase-inspection                    │ github               │ builtin │ builtin │
│ github-auth                            │ github               │ builtin │ builtin │
│ github-code-review                     │ github               │ builtin │ builtin │
│ github-issues                          │ github               │ builtin │ builtin │
│ github-pr-workflow                     │ github               │ builtin │ builtin │
│ github-repo-management                 │ github               │ builtin │ builtin │
│ inference-sh-cli                       │ inference-sh         │ local   │ local   │
│ claude-code-plugin-install             │ ios                  │ local   │ local   │
│ todaywhat-ios-build-testflight         │ ios                  │ local   │ local   │
│ todaywhat-ios-feature-development      │ ios                  │ local   │ local   │
│ find-nearby                            │ leisure              │ builtin │ builtin │
│ mcporter                               │ mcp                  │ builtin │ builtin │
│ native-mcp                             │ mcp                  │ builtin │ builtin │
│ gif-search                             │ media                │ builtin │ builtin │
│ heartmula                              │ media                │ builtin │ builtin │
│ songsee                                │ media                │ builtin │ builtin │
│ youtube-content                        │ media                │ builtin │ builtin │
│ audiocraft-audio-generation            │ mlops                │ local   │ local   │
│ axolotl                                │ mlops                │ builtin │ builtin │
│ chroma                                 │ mlops                │ local   │ local   │
│ clip                                   │ mlops                │ builtin │ builtin │
│ distributed-llm-pretraining-torchtitan │ mlops                │ local   │ local   │
│ dspy                                   │ mlops                │ builtin │ builtin │
│ evaluating-llms-harness                │ mlops                │ local   │ local   │
│ faiss                                  │ mlops                │ local   │ local   │
│ fine-tuning-with-trl                   │ mlops                │ local   │ local   │
│ gguf-quantization                      │ mlops                │ local   │ local   │
│ grpo-rl-training                       │ mlops                │ builtin │ builtin │
│ guidance                               │ mlops                │ builtin │ builtin │
│ hermes-atropos-environments            │ mlops                │ local   │ local   │
│ huggingface-accelerate                 │ mlops                │ local   │ local   │
│ huggingface-hub                        │ mlops                │ builtin │ builtin │
│ huggingface-tokenizers                 │ mlops                │ local   │ local   │
│ instructor                             │ mlops                │ local   │ local   │
│ lambda-labs-gpu-cloud                  │ mlops                │ local   │ local   │
│ llama-cpp                              │ mlops                │ builtin │ builtin │
│ llava                                  │ mlops                │ local   │ local   │
│ modal-serverless-gpu                   │ mlops                │ local   │ local   │
│ nemo-curator                           │ mlops                │ local   │ local   │
│ obliteratus                            │ mlops                │ builtin │ builtin │
│ optimizing-attention-flash             │ mlops                │ local   │ local   │
│ outlines                               │ mlops                │ builtin │ builtin │
│ peft-fine-tuning                       │ mlops                │ local   │ local   │
│ pinecone                               │ mlops                │ local   │ local   │
│ pytorch-fsdp                           │ mlops                │ builtin │ builtin │
│ pytorch-lightning                      │ mlops                │ local   │ local   │
│ qdrant-vector-search                   │ mlops                │ local   │ local   │
│ segment-anything-model                 │ mlops                │ local   │ local   │
│ serving-llms-vllm                      │ mlops                │ local   │ local   │
│ simpo-training                         │ mlops                │ local   │ local   │
│ slime-rl-training                      │ mlops                │ local   │ local   │
│ sparse-autoencoder-training            │ mlops                │ local   │ local   │
│ stable-diffusion-image-generation      │ mlops                │ local   │ local   │
│ tensorrt-llm                           │ mlops                │ local   │ local   │
│ unsloth                                │ mlops                │ builtin │ builtin │
│ weights-and-biases                     │ mlops                │ builtin │ builtin │
│ whisper                                │ mlops                │ builtin │ builtin │
│ obsidian                               │ note-taking          │ builtin │ builtin │
│ google-workspace                       │ productivity         │ builtin │ builtin │
│ linear                                 │ productivity         │ builtin │ builtin │
│ nano-pdf                               │ productivity         │ builtin │ builtin │
│ notion                                 │ productivity         │ builtin │ builtin │
│ notion-mcp-remote                      │ productivity         │ local   │ local   │
│ ocr-and-documents                      │ productivity         │ builtin │ builtin │
│ powerpoint                             │ productivity         │ builtin │ builtin │
│ godmode                                │ red-teaming          │ builtin │ builtin │
│ arxiv                                  │ research             │ builtin │ builtin │
│ autoresearch                           │ research             │ local   │ local   │
│ blogwatcher                            │ research             │ builtin │ builtin │
│ domain-intel                           │ research             │ local   │ local   │
│ duckduckgo-search                      │ research             │ local   │ local   │
│ file-first-llm-knowledge-base-eval     │ research             │ local   │ local   │
│ llm-wiki                               │ research             │ builtin │ builtin │
│ local-llm-knowledge-base-eval          │ research             │ local   │ local   │
│ ml-paper-writing                       │ research             │ local   │ local   │
│ parallel-cli                           │ research             │ local   │ local   │
│ polymarket                             │ research             │ builtin │ builtin │
│ research-paper-writing                 │ research             │ builtin │ builtin │
│ x-post-summarization                   │ research             │ local   │ local   │
│ openhue                                │ smart-home           │ builtin │ builtin │
│ xitter                                 │ social-media         │ builtin │ builtin │
│ code-review                            │ software-development │ local   │ local   │
│ plan                                   │ software-development │ builtin │ builtin │
│ planner-first-multi-review-design      │ software-development │ local   │ local   │
│ requesting-code-review                 │ software-development │ builtin │ builtin │
│ subagent-driven-development            │ software-development │ builtin │ builtin │
│ systematic-debugging                   │ software-development │ builtin │ builtin │
│ test-driven-development                │ software-development │ builtin │ builtin │
│ writing-plans                          │ software-development │ builtin │ builtin │
└────────────────────────────────────────┴──────────────────────┴─────────┴─────────┘
1 hub-installed, 68 builtin, 49 local
```

</details>

</details>

<details>
<summary>uninstall plugin</summary>

```sh
 ~/Projects/hermes-agent ╱ feat/claude-marketplace-install ⇡3 !1 ?3  /Users/baegteun/Projects/hermes-agent/.venv/bin/hermes skills uninstall document-skills                          ✔

Uninstall 'document-skills'?
Confirm [y/N]: y
Uninstalled 'document-skills' from document-skills


 ~/Projects/hermes-agent ╱ feat/claude-marketplace-install ⇡3 !1 ?3  /Users/baegteun/Projects/hermes-agent/.venv/bin/hermes skills uninstall claude-api                               ✔

Uninstall 'claude-api'?
Confirm [y/N]: y
Uninstalled 'claude-api' from claude-api
```

</details>

<details>
<summary>skill list after uninstall</summary>

```sh
/Users/baegteun/Projects/hermes-agent/.venv/bin/hermes skills list                                               ✔
                                  Installed Skills
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Name                                   ┃ Category             ┃ Source  ┃ Trust   ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ dogfood                                │                      │ builtin │ builtin │
│ ios-accessibility                      │                      │ local   │ local   │
│ swift-accessibility-skill              │                      │ local   │ local   │
│ apple-notes                            │ apple                │ builtin │ builtin │
│ apple-reminders                        │ apple                │ builtin │ builtin │
│ findmy                                 │ apple                │ builtin │ builtin │
│ imessage                               │ apple                │ builtin │ builtin │
│ claude-code                            │ autonomous-ai-agents │ builtin │ builtin │
│ codex                                  │ autonomous-ai-agents │ builtin │ builtin │
│ gemini-cli                             │ autonomous-ai-agents │ local   │ local   │
│ hermes-agent                           │ autonomous-ai-agents │ builtin │ builtin │
│ opencode                               │ autonomous-ai-agents │ builtin │ builtin │
│ ascii-art                              │ creative             │ builtin │ builtin │
│ ascii-video                            │ creative             │ builtin │ builtin │
│ excalidraw                             │ creative             │ builtin │ builtin │
│ manim-video                            │ creative             │ builtin │ builtin │
│ p5js                                   │ creative             │ builtin │ builtin │
│ popular-web-designs                    │ creative             │ builtin │ builtin │
│ songwriting-and-ai-music               │ creative             │ builtin │ builtin │
│ jupyter-live-kernel                    │ data-science         │ builtin │ builtin │
│ webhook-subscriptions                  │ devops               │ builtin │ builtin │
│ himalaya                               │ email                │ builtin │ builtin │
│ minecraft-modpack-server               │ gaming               │ builtin │ builtin │
│ pokemon-player                         │ gaming               │ builtin │ builtin │
│ codebase-inspection                    │ github               │ builtin │ builtin │
│ github-auth                            │ github               │ builtin │ builtin │
│ github-code-review                     │ github               │ builtin │ builtin │
│ github-issues                          │ github               │ builtin │ builtin │
│ github-pr-workflow                     │ github               │ builtin │ builtin │
│ github-repo-management                 │ github               │ builtin │ builtin │
│ inference-sh-cli                       │ inference-sh         │ local   │ local   │
│ claude-code-plugin-install             │ ios                  │ local   │ local   │
│ todaywhat-ios-build-testflight         │ ios                  │ local   │ local   │
│ todaywhat-ios-feature-development      │ ios                  │ local   │ local   │
│ find-nearby                            │ leisure              │ builtin │ builtin │
│ mcporter                               │ mcp                  │ builtin │ builtin │
│ native-mcp                             │ mcp                  │ builtin │ builtin │
│ gif-search                             │ media                │ builtin │ builtin │
│ heartmula                              │ media                │ builtin │ builtin │
│ songsee                                │ media                │ builtin │ builtin │
│ youtube-content                        │ media                │ builtin │ builtin │
│ audiocraft-audio-generation            │ mlops                │ local   │ local   │
│ axolotl                                │ mlops                │ builtin │ builtin │
│ chroma                                 │ mlops                │ local   │ local   │
│ clip                                   │ mlops                │ builtin │ builtin │
│ distributed-llm-pretraining-torchtitan │ mlops                │ local   │ local   │
│ dspy                                   │ mlops                │ builtin │ builtin │
│ evaluating-llms-harness                │ mlops                │ local   │ local   │
│ faiss                                  │ mlops                │ local   │ local   │
│ fine-tuning-with-trl                   │ mlops                │ local   │ local   │
│ gguf-quantization                      │ mlops                │ local   │ local   │
│ grpo-rl-training                       │ mlops                │ builtin │ builtin │
│ guidance                               │ mlops                │ builtin │ builtin │
│ hermes-atropos-environments            │ mlops                │ local   │ local   │
│ huggingface-accelerate                 │ mlops                │ local   │ local   │
│ huggingface-hub                        │ mlops                │ builtin │ builtin │
│ huggingface-tokenizers                 │ mlops                │ local   │ local   │
│ instructor                             │ mlops                │ local   │ local   │
│ lambda-labs-gpu-cloud                  │ mlops                │ local   │ local   │
│ llama-cpp                              │ mlops                │ builtin │ builtin │
│ llava                                  │ mlops                │ local   │ local   │
│ modal-serverless-gpu                   │ mlops                │ local   │ local   │
│ nemo-curator                           │ mlops                │ local   │ local   │
│ obliteratus                            │ mlops                │ builtin │ builtin │
│ optimizing-attention-flash             │ mlops                │ local   │ local   │
│ outlines                               │ mlops                │ builtin │ builtin │
│ peft-fine-tuning                       │ mlops                │ local   │ local   │
│ pinecone                               │ mlops                │ local   │ local   │
│ pytorch-fsdp                           │ mlops                │ builtin │ builtin │
│ pytorch-lightning                      │ mlops                │ local   │ local   │
│ qdrant-vector-search                   │ mlops                │ local   │ local   │
│ segment-anything-model                 │ mlops                │ local   │ local   │
│ serving-llms-vllm                      │ mlops                │ local   │ local   │
│ simpo-training                         │ mlops                │ local   │ local   │
│ slime-rl-training                      │ mlops                │ local   │ local   │
│ sparse-autoencoder-training            │ mlops                │ local   │ local   │
│ stable-diffusion-image-generation      │ mlops                │ local   │ local   │
│ tensorrt-llm                           │ mlops                │ local   │ local   │
│ unsloth                                │ mlops                │ builtin │ builtin │
│ weights-and-biases                     │ mlops                │ builtin │ builtin │
│ whisper                                │ mlops                │ builtin │ builtin │
│ obsidian                               │ note-taking          │ builtin │ builtin │
│ google-workspace                       │ productivity         │ builtin │ builtin │
│ linear                                 │ productivity         │ builtin │ builtin │
│ nano-pdf                               │ productivity         │ builtin │ builtin │
│ notion                                 │ productivity         │ builtin │ builtin │
│ notion-mcp-remote                      │ productivity         │ local   │ local   │
│ ocr-and-documents                      │ productivity         │ builtin │ builtin │
│ powerpoint                             │ productivity         │ builtin │ builtin │
│ godmode                                │ red-teaming          │ builtin │ builtin │
│ arxiv                                  │ research             │ builtin │ builtin │
│ autoresearch                           │ research             │ local   │ local   │
│ blogwatcher                            │ research             │ builtin │ builtin │
│ domain-intel                           │ research             │ local   │ local   │
│ duckduckgo-search                      │ research             │ local   │ local   │
│ file-first-llm-knowledge-base-eval     │ research             │ local   │ local   │
│ llm-wiki                               │ research             │ builtin │ builtin │
│ local-llm-knowledge-base-eval          │ research             │ local   │ local   │
│ ml-paper-writing                       │ research             │ local   │ local   │
│ parallel-cli                           │ research             │ local   │ local   │
│ polymarket                             │ research             │ builtin │ builtin │
│ research-paper-writing                 │ research             │ builtin │ builtin │
│ x-post-summarization                   │ research             │ local   │ local   │
│ openhue                                │ smart-home           │ builtin │ builtin │
│ xitter                                 │ social-media         │ builtin │ builtin │
│ code-review                            │ software-development │ local   │ local   │
│ plan                                   │ software-development │ builtin │ builtin │
│ planner-first-multi-review-design      │ software-development │ local   │ local   │
│ requesting-code-review                 │ software-development │ builtin │ builtin │
│ subagent-driven-development            │ software-development │ builtin │ builtin │
│ systematic-debugging                   │ software-development │ builtin │ builtin │
│ test-driven-development                │ software-development │ builtin │ builtin │
│ writing-plans                          │ software-development │ builtin │ builtin │
└────────────────────────────────────────┴──────────────────────┴─────────┴─────────┘
0 hub-installed, 68 builtin, 45 local
```
</details>

</details>