### PR TITLE
feat(cli): draft follow-ups in queue mode before blank-line submit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1521,7 +1521,7 @@ class HermesCLI:
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
-        # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
+        # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (busy Enter keeps composing until a blank trailing line submits)
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
 
@@ -7585,6 +7585,29 @@ class HermesCLI:
             completions_menu,
         ]
 
+    def _resolve_busy_enter_action(self, raw_text: str) -> str:
+        """Decide what Enter should do while the agent is already running.
+
+        Returns one of:
+        - ``"interrupt"``: submit immediately through the interrupt queue
+        - ``"queue"``: enqueue as the next turn
+        - ``"compose"``: insert a newline and keep editing the draft
+        """
+        text = raw_text or ""
+        stripped = text.strip()
+
+        if self.busy_input_mode != "queue":
+            return "interrupt"
+        if stripped and _looks_like_slash_command(stripped):
+            return "queue"
+        if not stripped:
+            return "compose"
+
+        lines = text.split("\n")
+        if len(lines) >= 2 and lines[-1].strip() == "" and any(line.strip() for line in lines[:-1]):
+            return "queue"
+        return "compose"
+
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         # Push the entire TUI to the bottom of the terminal so the banner,
@@ -7770,17 +7793,24 @@ class HermesCLI:
                 return
 
             # --- Normal input routing ---
-            text = event.app.current_buffer.text.strip()
+            raw_text = event.app.current_buffer.text
+            text = raw_text.strip()
             has_images = bool(self._attached_images)
+            if self._agent_running and not has_images:
+                busy_action = self._resolve_busy_enter_action(raw_text)
+                if busy_action == "compose":
+                    event.current_buffer.insert_text('\n')
+                    return
             if text or has_images:
-                # Snapshot and clear attached images
+                # Snapshot and clear attached images only once we're actually submitting.
                 images = list(self._attached_images)
                 self._attached_images.clear()
                 event.app.invalidate()
                 # Bundle text + images as a tuple when images are present
                 payload = (text, images) if images else text
                 if self._agent_running and not (text and _looks_like_slash_command(text)):
-                    if self.busy_input_mode == "queue":
+                    busy_action = self._resolve_busy_enter_action(raw_text)
+                    if busy_action == "queue":
                         # Queue for the next turn instead of interrupting
                         self._pending_input.put(payload)
                         preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -123,30 +123,35 @@ class TestBusyInputMode:
         cli.process_command("/queue follow up")
         assert cli._pending_input.get_nowait() == "follow up"
 
-    def test_queue_mode_routes_busy_enter_to_pending(self):
-        """In queue mode, Enter while busy should go to _pending_input, not _interrupt_queue."""
+    def test_queue_mode_busy_enter_without_blank_line_keeps_composing(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
-        cli._agent_running = True
-        # Simulate what handle_enter does for non-command input while busy
-        text = "follow up"
-        if cli.busy_input_mode == "queue":
-            cli._pending_input.put(text)
-        else:
-            cli._interrupt_queue.put(text)
-        assert cli._pending_input.get_nowait() == "follow up"
-        assert cli._interrupt_queue.empty()
+        action = cli._resolve_busy_enter_action("follow up")
+        assert action == "compose"
+
+    def test_queue_mode_busy_enter_on_single_blank_trailing_line_queues(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
+        action = cli._resolve_busy_enter_action("follow up\n")
+        assert action == "queue"
+
+    def test_queue_mode_busy_enter_on_blank_trailing_line_queues(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
+        action = cli._resolve_busy_enter_action("follow up\n\n")
+        assert action == "queue"
+
+    def test_queue_mode_busy_enter_on_blank_trailing_line_with_spaces_queues(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
+        action = cli._resolve_busy_enter_action("follow up\n   \n")
+        assert action == "queue"
+
+    def test_queue_mode_busy_enter_slash_command_still_queues_immediately(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
+        action = cli._resolve_busy_enter_action("/queue follow up")
+        assert action == "queue"
 
     def test_interrupt_mode_routes_busy_enter_to_interrupt(self):
-        """In interrupt mode (default), Enter while busy goes to _interrupt_queue."""
         cli = _make_cli()
-        cli._agent_running = True
-        text = "redirect"
-        if cli.busy_input_mode == "queue":
-            cli._pending_input.put(text)
-        else:
-            cli._interrupt_queue.put(text)
-        assert cli._interrupt_queue.get_nowait() == "redirect"
-        assert cli._pending_input.empty()
+        action = cli._resolve_busy_enter_action("redirect")
+        assert action == "interrupt"
 
 
 class TestSingleQueryState:

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -220,7 +220,7 @@ The `display.busy_input_mode` config key controls what happens when you press En
 | Mode | Behavior |
 |------|----------|
 | `"interrupt"` (default) | Your message interrupts the current operation and is processed immediately |
-| `"queue"` | Your message is silently queued and sent as the next turn after the agent finishes |
+| `"queue"` | Enter becomes composition-first while busy: regular Enter inserts a newline, and pressing Enter on a blank trailing line queues the drafted message for the next turn |
 
 ```yaml
 # ~/.hermes/config.yaml


### PR DESCRIPTION
## Summary
- make `display.busy_input_mode: "queue"` composition-first while the agent is busy
- keep ordinary `Enter` as newline insertion during busy drafting instead of immediate submission
- queue the drafted follow-up only when `Enter` is pressed on a blank trailing line
- preserve immediate queueing for slash commands and keep docs/tests aligned

## Testing
- `python -m pytest tests/cli/test_cli_init.py -q -o addopts=''`
- `python -m py_compile cli.py`

Fixes #6898

Carried patch: patch-feat-pr7525
Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.
