### PR TITLE
fix: prevent duplicate provider entries in /model picker (Section 3 dedup)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -878,6 +878,9 @@ def list_authenticated_providers(
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
                 continue
+            # Skip if this provider was already added by Sections 1/2
+            if ep_name in seen_slugs:
+                continue
             display_name = ep_cfg.get("name", "") or ep_name
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
@@ -898,6 +901,7 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            seen_slugs.add(ep_name)
 
     # --- 4. Saved custom providers from config ---
     if custom_providers and isinstance(custom_providers, list):


### PR DESCRIPTION
## Summary

Fixes duplicate provider entries in the `/model` picker when a provider exists in both the built-in catalog and the user's `config.yaml` `providers:` section.

## Problem

`list_authenticated_providers()` builds the provider list in 4 sections. Section 3 (user-defined providers from `config.yaml` `providers:`) is the **only section that doesn't check `seen_slugs`** before adding entries. This causes every provider defined in both the built-in catalog and user config to appear twice:

| Built-in entry (Section 2) | Duplicate (Section 3) |
|---|---|
| "Nous Portal (27)" | "nous (0)" |
| "GitHub Copilot (14)" | "copilot (0)" |
| "DeepSeek (2)" | "deepseek (0)" |
| "MiniMax (7)" | "minimax (0)" |

The Section 3 entries always show 0 models because they use `default_model` (which is typically empty for built-in provider overrides) instead of the curated model list.

## Root Cause

In `hermes_cli/model_switch.py`, `list_authenticated_providers()`:

- **Section 1** (PROVIDER_TO_MODELS_DEV): ✅ checks `seen_slugs`, adds to `seen_slugs`
- **Section 2** (HERMES_OVERLAYS): ✅ checks `seen_slugs`, adds to `seen_slugs`
- **Section 3** (user_providers): ❌ **no dedup at all**
- **Section 4** (custom_providers): ✅ checks `seen_slugs`, adds to `seen_slugs`

## Fix

Add `seen_slugs` check and tracking in Section 3, matching the pattern used by all other sections:

```python
# Skip if this provider was already added by Sections 1/2
if ep_name in seen_slugs:
    continue
# ... existing logic ...
seen_slugs.add(ep_name)
```

## Verification

```python
from hermes_cli.model_switch import list_authenticated_providers

providers = list_authenticated_providers(
    current_provider="nous",
    user_providers={"nous": {}, "minimax-cn": {}, "copilot": {}, "deepseek": {}, "minimax": {}},
    max_models=50,
)

slugs = [p["slug"] for p in providers]
# Before fix: nous appears twice, copilot appears twice, etc.
# After fix: each provider appears exactly once
assert len(slugs) == len(set(slugs))
```

## Related

- Fixes #7524
- Related: #5223 (overlay providers omitted — fixed by #7373)
- Related: #7373 (overlay slug mismatch — fixed Section 2 but not Section 3)
- Related: #7054 (broader config split architecture issue)
