### PR TITLE
fix(cron): preserve skill env passthrough in worker thread

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -10,6 +10,7 @@ runs at a time if multiple processes overlap.
 
 import asyncio
 import concurrent.futures
+import contextvars
 import json
 import logging
 import os
@@ -739,7 +740,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        _cron_future = _cron_pool.submit(agent.run_conversation, prompt)
+        # Preserve scheduler-scoped ContextVar state (for example skill-declared
+        # env passthrough registrations) when the cron run hops into the worker
+        # thread used for inactivity timeout monitoring.
+        _cron_context = contextvars.copy_context()
+        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 import pytest
 
 from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from tools.env_passthrough import clear_env_passthrough
 
 
 class TestResolveOrigin:
@@ -876,6 +877,57 @@ class TestRunJobPerJobOverrides:
 
 
 class TestRunJobSkillBacked:
+    def test_run_job_preserves_skill_env_passthrough_into_worker_thread(self, tmp_path):
+        job = {
+            "id": "skill-env-job",
+            "name": "skill env test",
+            "prompt": "Use the skill.",
+            "skill": "notion",
+        }
+
+        fake_db = MagicMock()
+
+        def _skill_view(name):
+            assert name == "notion"
+            from tools.env_passthrough import register_env_passthrough
+
+            register_env_passthrough(["NOTION_API_KEY"])
+            return json.dumps({"success": True, "content": "# notion\nUse Notion."})
+
+        def _run_conversation(prompt):
+            from tools.env_passthrough import get_all_passthrough
+
+            assert "NOTION_API_KEY" in get_all_passthrough()
+            return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.side_effect = _run_conversation
+            mock_agent_cls.return_value = mock_agent
+
+            try:
+                success, output, final_response, error = run_job(job)
+            finally:
+                clear_env_passthrough()
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+
     def test_run_job_loads_skill_and_disables_recursive_cron_tools(self, tmp_path):
         job = {
             "id": "skill-job",


### PR DESCRIPTION
## What does this PR do?

Preserves skill-declared environment variable passthrough when cron jobs hop from the scheduler thread into the worker thread used to run the agent conversation.

Today, cron loads any configured skills while building the job prompt. That skill load path registers declared env vars such as NOTION_API_KEY for sandbox passthrough. But the actual cron conversation runs inside a ThreadPoolExecutor worker, and that thread was not inheriting the scheduler thread's ContextVar state. The result is that a skill can load correctly while the sandboxed terminal inside the cron run still fails to see the required env var.

This change copies the current context before submitting the cron worker task and runs agent.run_conversation() inside that copied context.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- update cron/scheduler.py to preserve ContextVar state when cron submits agent.run_conversation() into its worker thread
- add a regression test in tests/cron/test_scheduler.py that verifies a skill-registered env var such as NOTION_API_KEY remains available inside the cron worker thread

## How to Test

1. source venv/bin/activate
2. python -m pytest tests/cron/test_scheduler.py -q
3. Optionally run python -m pytest tests/cron/test_scheduler.py -q -k "skill_env_passthrough or loads_skill_and_disables_recursive_cron_tools"
4. Verify the new regression passes and the cron scheduler test file stays green

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL Ubuntu / Python 3.11

### Documentation & Housekeeping

- [x] N/A

## Screenshots / Logs

- Focused test run: python -m pytest tests/cron/test_scheduler.py -q -> 62 passed
- Full suite on current main: python -m pytest tests/ -q -> 54 failed, 10215 passed, 37 skipped
- The observed full-suite failures appear unrelated to this cron change and were not in tests/cron/test_scheduler.py
