### PR TITLE
fix(weixin): send single message per response instead of splitting

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -758,20 +758,13 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
 def _split_text_for_weixin_delivery(content: str, max_length: int) -> List[str]:
     """Split content into sequential Weixin messages.
 
-    Prefer one message per top-level line/markdown unit when the author used
-    explicit line breaks. Oversized units fall back to block-aware packing so
-    long code fences still split safely.
+    A single response = a single Weixin message.  Only split when the content
+    genuinely exceeds the API limit.  Oversized content is truncated (not
+    broken into multiple messages) to preserve readability.
     """
-    if len(content) <= max_length and "\n" not in content:
+    if len(content) <= max_length:
         return [content]
-
-    chunks: List[str] = []
-    for unit in _split_delivery_units_for_weixin(content):
-        if len(unit) <= max_length:
-            chunks.append(unit)
-            continue
-        chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
-    return chunks or [content]
+    return [BasePlatformAdapter.truncate_message(content, max_length)]
 
 
 def _extract_text(item_list: List[Dict[str, Any]]) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":


### PR DESCRIPTION
## Summary

优化微信消息回复策略：将原来按换行/markdown 单元拆分多条消息的方式，改为"一次回复 = 一条消息"。

## Problem

之前的 `_split_text_for_weixin_delivery` 会把一条回复按换行、markdown 单元拆成多条消息发送，导致用户体验碎片化。

## Solution

- 短内容（≤ max_length）：直接发送单条消息
- 超长内容：截断（truncate）而非拆分，保留可读性

```diff
- Prefer one message per top-level line/markdown unit when the author used
- explicit line breaks. Oversized units fall back to block-aware packing so
- long code fences still split safely.
+ A single response = a single Weixin message.  Only split when the content
+ genuinely exceeds the API limit.  Oversized content is truncated (not
+ broken into multiple messages) to preserve readability.
```