### PR TITLE
fix(tools): surface incremental process output before exit

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -627,3 +627,37 @@ class TestProcessToolHandler:
         from tools.process_registry import _handle_process
         result = json.loads(_handle_process({"action": "unknown_action"}))
         assert "error" in result
+
+
+# =========================================================================
+# Incremental output visibility (regression)
+# =========================================================================
+
+class TestIncrementalOutput:
+    """poll() must see output while the process is still running, not only at EOF."""
+
+    def test_poll_sees_output_before_process_exits(self, registry, tmp_path):
+        """Spawn a process that prints lines with delays; poll mid-run."""
+        script = tmp_path / "slow_print.py"
+        script.write_text(
+            "import time\n"
+            "for i in range(20):\n"
+            "    print(f'line {i}', flush=True)\n"
+            "    time.sleep(0.3)\n"
+        )
+        session = registry.spawn_local(
+            f"{sys.executable} -u {script}",
+            cwd=str(tmp_path),
+            use_pty=False,
+        )
+        try:
+            # Wait until output appears (bash -lic startup can take a few seconds)
+            assert _wait_until(
+                lambda: "line 0" in registry.poll(session.id).get("output_preview", ""),
+                timeout=20.0,
+                interval=0.1,
+            ), f"Expected early output visible during run, got: {registry.poll(session.id)['output_preview']!r}"
+            # Confirm the process is still running when we see output
+            assert registry.poll(session.id)["status"] == "running"
+        finally:
+            registry.kill_process(session.id)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -627,3 +627,37 @@ class TestProcessToolHandler:
         from tools.process_registry import _handle_process
         result = json.loads(_handle_process({"action": "unknown_action"}))
         assert "error" in result
+
+
+# =========================================================================
+# Incremental output visibility (regression)
+# =========================================================================
+
+class TestIncrementalOutput:
+    """poll() must see output while the process is still running, not only at EOF."""
+
+    def test_poll_sees_output_before_process_exits(self, registry, tmp_path):
+        """Spawn a process that prints lines with delays; poll mid-run."""
+        script = tmp_path / "slow_print.py"
+        script.write_text(
+            "import time\n"
+            "for i in range(20):\n"
+            "    print(f'line {i}', flush=True)\n"
+            "    time.sleep(0.3)\n"
+        )
+        session = registry.spawn_local(
+            f"python3 -u {script}",
+            cwd=str(tmp_path),
+            use_pty=False,
+        )
+        try:
+            # Wait until output appears (bash -lic startup can take a few seconds)
+            assert _wait_until(
+                lambda: "line 0" in registry.poll(session.id).get("output_preview", ""),
+                timeout=10.0,
+                interval=0.1,
+            ), f"Expected early output visible during run, got: {registry.poll(session.id)['output_preview']!r}"
+            # Confirm the process is still running when we see output
+            assert registry.poll(session.id)["status"] == "running"
+        finally:
+            registry.kill_process(session.id)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -29,6 +29,7 @@ Usage:
     process_registry.kill(session.id)
 """
 
+import codecs
 import json
 import logging
 import os
@@ -473,12 +474,21 @@ class ProcessRegistry:
 
     def _reader_loop(self, session: ProcessSession):
         """Background thread: read stdout from a local Popen process."""
+        # Bypass TextIOWrapper.read() which tries to accumulate N chars before
+        # returning -- that hides incremental output from poll().  Instead read
+        # raw bytes via BufferedReader.read1() (at most one underlying read
+        # syscall, returns immediately with whatever is available) and decode
+        # through an IncrementalDecoder that handles multi-byte char boundaries.
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         first_chunk = True
         try:
             while True:
-                chunk = session.process.stdout.read(4096)
-                if not chunk:
+                raw = session.process.stdout.buffer.read1(4096)
+                if not raw:
                     break
+                chunk = decoder.decode(raw)
+                if not chunk:
+                    continue
                 if first_chunk:
                     chunk = self._clean_shell_noise(chunk)
                     first_chunk = False
@@ -490,6 +500,16 @@ class ProcessRegistry:
         except Exception as e:
             logger.debug("Process stdout reader ended: %s", e)
         finally:
+            # Flush any trailing bytes held by the incremental decoder before
+            # marking the process finished.
+            try:
+                trailing = decoder.decode(b"", final=True)
+                if trailing:
+                    with session._lock:
+                        session.output_buffer += trailing
+            except Exception:
+                pass
+
             # Always reap the child to prevent zombie processes.
             try:
                 session.process.wait(timeout=5)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -29,6 +29,7 @@ Usage:
     process_registry.kill(session.id)
 """
 
+import codecs
 import json
 import logging
 import os
@@ -381,12 +382,21 @@ class ProcessRegistry:
 
     def _reader_loop(self, session: ProcessSession):
         """Background thread: read stdout from a local Popen process."""
+        # Bypass TextIOWrapper.read() which tries to accumulate N chars before
+        # returning -- that hides incremental output from poll().  Instead read
+        # raw bytes via BufferedReader.read1() (at most one underlying read
+        # syscall, returns immediately with whatever is available) and decode
+        # through an IncrementalDecoder that handles multi-byte char boundaries.
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         first_chunk = True
         try:
             while True:
-                chunk = session.process.stdout.read(4096)
-                if not chunk:
+                raw = session.process.stdout.buffer.read1(4096)
+                if not raw:
                     break
+                chunk = decoder.decode(raw)
+                if not chunk:
+                    continue
                 if first_chunk:
                     chunk = self._clean_shell_noise(chunk)
                     first_chunk = False
@@ -396,6 +406,15 @@ class ProcessRegistry:
                         session.output_buffer = session.output_buffer[-session.max_output_chars:]
         except Exception as e:
             logger.debug("Process stdout reader ended: %s", e)
+
+        # Flush any trailing bytes held by the incremental decoder.
+        try:
+            trailing = decoder.decode(b"", final=True)
+            if trailing:
+                with session._lock:
+                    session.output_buffer += trailing
+        except Exception:
+            pass
 
         # Process exited
         try:


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in local background process output handling where `process(action="poll")`
would often show no incremental output until the child process exited.

The root cause was that the local stdout reader used `TextIOWrapper.read(4096)`, which
can buffer decoded text and delay visibility of partial output. This change switches the
reader to `stdout.buffer.read1(4096)` and decodes with an incremental UTF-8 decoder so
output becomes visible while the process is still running.

## Related Issue
 
N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [tools/process_registry.py](tools/process_registry.py) local process stdout reading logic:
  - replaced `TextIOWrapper.read(4096)` with `stdout.buffer.read1(4096)`
  - added an incremental UTF-8 decoder to preserve multibyte character boundaries
  - flushes any trailing decoder state on process exit
- Added a regression test in [tests/tools/test_process_registry.py](tests/tools/test_process_registry.py) that
verifies `poll()` can observe output before the process exits

## How to Test

1. Run:
   ```bash
   python3 -m pytest tests/tools/test_process_registry.py -q
   ``` 
2. Verify the new regression test passes:
    - TestIncrementalOutput::test_poll_sees_output_before_process_exits
3. Optionally reproduce manually by spawning a slow-printing local background process and confirming
   process(action="poll") shows output while status is still running

## Checklist

### Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope)
  :, etc.)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a dupl
  icate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 + WSL Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
  (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

python3 -m pytest tests/tools/test_process_registry.py -q
43 passed, 43 warnings in 21.58s