### PR TITLE
fix: support custom providers in context + /model picker

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -60,6 +60,100 @@ def _strip_provider_prefix(model: str) -> str:
         return suffix
     return model
 
+
+def _normalize_custom_provider_name(name: str) -> str:
+    return name.strip().lower().replace(" ", "-")
+
+
+def _candidate_custom_provider_models(model: str, entry_provider_name: str = "") -> List[str]:
+    candidates: List[str] = []
+    seen: set[str] = set()
+
+    def _add(value: str) -> None:
+        if not value or value in seen:
+            return
+        seen.add(value)
+        candidates.append(value)
+
+    current = model
+    _add(current)
+    while True:
+        stripped = _strip_provider_prefix(current)
+        if stripped == current:
+            break
+        current = stripped
+        _add(current)
+
+    if entry_provider_name:
+        for candidate in list(candidates):
+            if ":" not in candidate:
+                continue
+            candidate_prefix, candidate_suffix = candidate.split(":", 1)
+            if _normalize_custom_provider_name(candidate_prefix) == entry_provider_name:
+                _add(candidate_suffix)
+
+    return candidates
+
+
+def get_custom_provider_context_length(
+    model: str,
+    base_url: str = "",
+    provider: str = "",
+) -> Optional[int]:
+    """Return per-model context_length from config.yaml custom_providers."""
+    from hermes_constants import get_hermes_home
+
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return None
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as e:
+        logger.debug("Failed to load config.yaml for custom provider context lookup: %s", e)
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    custom_providers = data.get("custom_providers")
+    if not isinstance(custom_providers, list):
+        return None
+
+    normalized_base_url = _normalize_base_url(base_url)
+    normalized_provider_name = ""
+    if isinstance(provider, str) and provider.lower().startswith("custom:"):
+        normalized_provider_name = _normalize_custom_provider_name(provider.split(":", 1)[1])
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_base_url = _normalize_base_url(entry.get("base_url") or "")
+        entry_name = entry.get("name") or ""
+        entry_provider_name = (
+            _normalize_custom_provider_name(entry_name)
+            if isinstance(entry_name, str) and entry_name.strip()
+            else ""
+        )
+        matches_base_url = bool(normalized_base_url and entry_base_url == normalized_base_url)
+        matches_provider_name = bool(normalized_provider_name and entry_provider_name == normalized_provider_name)
+        if not (matches_base_url or matches_provider_name):
+            continue
+
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            return None
+
+        for candidate_model in _candidate_custom_provider_models(model, entry_provider_name):
+            model_cfg = models.get(candidate_model)
+            if isinstance(model_cfg, dict):
+                return _coerce_reasonable_int(model_cfg.get("context_length"))
+
+        return None
+
+    return None
+
 _model_metadata_cache: Dict[str, Dict[str, Any]] = {}
 _model_metadata_cache_time: float = 0
 _MODEL_CACHE_TTL = 3600
@@ -860,6 +954,14 @@ def get_model_context_length(
     if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
         return config_context_length
 
+    custom_provider_context = get_custom_provider_context_length(
+        model,
+        base_url=base_url,
+        provider=provider,
+    )
+    if custom_provider_context is not None:
+        return custom_provider_context
+
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
@@ -903,7 +1005,7 @@ def get_model_context_length(
             logger.info(
                 "Could not detect context length for model %r at %s — "
                 "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
+                "or custom_providers[].models.<model>.context_length in config.yaml to override.",
                 model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
             )
             return DEFAULT_FALLBACK_CONTEXT

--- a/cli.py
+++ b/cli.py
@@ -3786,16 +3786,19 @@ class HermesCLI:
             try:
                 # Load user providers from config
                 user_provs = None
+                custom_provs = None
                 try:
                     from hermes_cli.config import load_config
                     cfg = load_config()
                     user_provs = cfg.get("providers")
+                    custom_provs = cfg.get("custom_providers")
                 except Exception:
                     pass
 
                 providers = list_authenticated_providers(
                     current_provider=self.provider or "",
                     user_providers=user_provs,
+                    custom_providers=custom_provs,
                     max_models=6,
                 )
                 if providers:
@@ -3836,6 +3839,8 @@ class HermesCLI:
             current_api_key=self.api_key or "",
             is_global=persist_global,
             explicit_provider=explicit_provider,
+            user_providers=user_provs,
+            custom_providers=custom_provs,
         )
 
         if not result.success:

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -1,0 +1,151 @@
+"""Per-platform display/verbosity configuration resolver.
+
+Provides ``resolve_display_setting()`` — the single entry-point for reading
+display settings with platform-specific overrides and sensible defaults.
+
+Resolution order (first non-None wins):
+    1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
+    2. ``display.<key>``                       — global user setting
+    3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
+    4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+
+Backward compatibility: ``display.tool_progress_overrides`` is still read as a
+fallback for ``tool_progress`` when no ``display.platforms`` entry exists.  A
+config migration (version bump) automatically moves the old format into the new
+``display.platforms`` structure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_GLOBAL_DEFAULTS: dict[str, Any] = {
+    "tool_progress": "all",
+    "show_reasoning": False,
+    "tool_preview_length": 0,
+    "streaming": None,
+}
+
+_TIER_HIGH = {
+    "tool_progress": "all",
+    "show_reasoning": False,
+    "tool_preview_length": 40,
+    "streaming": None,
+}
+
+_TIER_MEDIUM = {
+    "tool_progress": "new",
+    "show_reasoning": False,
+    "tool_preview_length": 40,
+    "streaming": None,
+}
+
+_TIER_LOW = {
+    "tool_progress": "off",
+    "show_reasoning": False,
+    "tool_preview_length": 40,
+    "streaming": False,
+}
+
+_TIER_MINIMAL = {
+    "tool_progress": "off",
+    "show_reasoning": False,
+    "tool_preview_length": 0,
+    "streaming": False,
+}
+
+_PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
+    "telegram": _TIER_HIGH,
+    "discord": _TIER_HIGH,
+    "slack": _TIER_MEDIUM,
+    "mattermost": _TIER_MEDIUM,
+    "matrix": _TIER_MEDIUM,
+    "feishu": _TIER_MEDIUM,
+    "signal": _TIER_LOW,
+    "whatsapp": _TIER_LOW,
+    "bluebubbles": _TIER_LOW,
+    "weixin": _TIER_LOW,
+    "wecom": _TIER_LOW,
+    "wecom_callback": _TIER_LOW,
+    "dingtalk": _TIER_LOW,
+    "email": _TIER_MINIMAL,
+    "sms": _TIER_MINIMAL,
+    "webhook": _TIER_MINIMAL,
+    "homeassistant": _TIER_MINIMAL,
+    "api_server": {**_TIER_HIGH, "tool_preview_length": 0},
+}
+
+OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
+
+
+def resolve_display_setting(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+    fallback: Any = None,
+) -> Any:
+    """Resolve a display setting with per-platform override support."""
+    display_cfg = user_config.get("display") or {}
+
+    platforms = display_cfg.get("platforms") or {}
+    plat_overrides = platforms.get(platform_key)
+    if isinstance(plat_overrides, dict):
+        val = plat_overrides.get(setting)
+        if val is not None:
+            return _normalise(setting, val)
+
+    if setting == "tool_progress":
+        legacy = display_cfg.get("tool_progress_overrides")
+        if isinstance(legacy, dict):
+            val = legacy.get(platform_key)
+            if val is not None:
+                return _normalise(setting, val)
+
+    val = display_cfg.get(setting)
+    if val is not None:
+        return _normalise(setting, val)
+
+    plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)
+    if plat_defaults:
+        val = plat_defaults.get(setting)
+        if val is not None:
+            return val
+
+    val = _GLOBAL_DEFAULTS.get(setting)
+    if val is not None:
+        return val
+
+    return fallback
+
+
+def get_platform_defaults(platform_key: str) -> dict[str, Any]:
+    """Return the built-in default display settings for a platform."""
+    return dict(_PLATFORM_DEFAULTS.get(platform_key, _GLOBAL_DEFAULTS))
+
+
+def get_effective_display(user_config: dict, platform_key: str) -> dict[str, Any]:
+    """Return the fully-resolved display settings for a platform."""
+    return {
+        key: resolve_display_setting(user_config, platform_key, key)
+        for key in OVERRIDEABLE_KEYS
+    }
+
+
+def _normalise(setting: str, value: Any) -> Any:
+    """Normalise YAML quirks (bare ``off`` → False in YAML 1.1)."""
+    if setting == "tool_progress":
+        if value is False:
+            return "off"
+        if value is True:
+            return "all"
+        return str(value).lower()
+    if setting in ("show_reasoning", "streaming"):
+        if isinstance(value, str):
+            return value.lower() in ("true", "1", "yes", "on")
+        return bool(value)
+    if setting == "tool_preview_length":
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+    return value

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3667,6 +3667,18 @@ class GatewayRunner:
                             if mi.has_cost_data():
                                 lines.append(f"Cost: {mi.format_cost()}")
                             lines.append(f"Capabilities: {mi.format_capabilities()}")
+                        else:
+                            try:
+                                from agent.model_metadata import get_model_context_length
+                                ctx = get_model_context_length(
+                                    result.new_model,
+                                    base_url=result.base_url or _cur_base_url,
+                                    api_key=result.api_key or _cur_api_key,
+                                    provider=result.target_provider,
+                                )
+                                lines.append(f"Context: {ctx:,} tokens")
+                            except Exception:
+                                pass
                         lines.append("_(session only — use `/model <name> --global` to persist)_")
                         return "\n".join(lines)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3170,7 +3170,11 @@ class GatewayRunner:
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
         """
-        from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
+        from agent.model_metadata import (
+            get_model_context_length,
+            get_custom_provider_context_length,
+            DEFAULT_FALLBACK_CONTEXT,
+        )
 
         model = _resolve_gateway_model()
         config_context_length = None
@@ -3214,11 +3218,19 @@ class GatewayRunner:
             provider=provider or "",
         )
 
+        custom_provider_context = get_custom_provider_context_length(
+            model,
+            base_url=base_url or "",
+            provider=provider or "",
+        )
+
         # Format context source hint
         if config_context_length is not None:
             ctx_source = "config"
+        elif custom_provider_context is not None:
+            ctx_source = "custom provider config"
         elif context_length == DEFAULT_FALLBACK_CONTEXT:
-            ctx_source = "default — set model.context_length in config to override"
+            ctx_source = "default — set model.context_length or custom_providers[].models.<model>.context_length in config to override"
         else:
             ctx_source = "detected"
 
@@ -3529,7 +3541,9 @@ class GatewayRunner:
         current_provider = "openrouter"
         current_base_url = ""
         current_api_key = ""
+        cfg = {}
         user_provs = None
+        custom_provs = None
         config_path = _hermes_home / "config.yaml"
         try:
             if config_path.exists():
@@ -3541,6 +3555,7 @@ class GatewayRunner:
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
                 user_provs = cfg.get("providers")
+                custom_provs = cfg.get("custom_providers")
         except Exception:
             pass
 
@@ -3568,6 +3583,7 @@ class GatewayRunner:
                     providers = list_authenticated_providers(
                         current_provider=current_provider,
                         user_providers=user_provs,
+                        custom_providers=custom_provs,
                         max_models=50,
                     )
                 except Exception:
@@ -3595,6 +3611,8 @@ class GatewayRunner:
                             current_api_key=_cur_api_key,
                             is_global=False,
                             explicit_provider=provider_slug,
+                            user_providers=user_provs,
+                            custom_providers=custom_provs,
                         )
                         if not result.success:
                             return f"Error: {result.error_message}"
@@ -3673,6 +3691,7 @@ class GatewayRunner:
                 providers = list_authenticated_providers(
                     current_provider=current_provider,
                     user_providers=user_provs,
+                    custom_providers=custom_provs,
                     max_models=5,
                 )
                 for p in providers:
@@ -3702,6 +3721,8 @@ class GatewayRunner:
             current_api_key=current_api_key,
             is_global=persist_global,
             explicit_provider=explicit_provider,
+            user_providers=user_provs,
+            custom_providers=custom_provs,
         )
 
         if not result.success:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,7 +76,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_yaml_write
+from agent.redact import RedactingFormatter
+from utils import atomic_yaml_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -383,6 +383,7 @@ def switch_model(
     is_global: bool = False,
     explicit_provider: str = "",
     user_providers: dict = None,
+    custom_providers: list | None = None,
 ) -> ModelSwitchResult:
     """Core model-switching pipeline shared between CLI and gateway.
 
@@ -416,6 +417,7 @@ def switch_model(
         is_global: Whether to persist the switch.
         explicit_provider: From --provider flag (empty = no explicit provider).
         user_providers: The ``providers:`` dict from config.yaml (for user endpoints).
+        custom_providers: The ``custom_providers:`` list from config.yaml.
 
     Returns:
         ModelSwitchResult with all information the caller needs.
@@ -437,11 +439,37 @@ def switch_model(
     if explicit_provider:
         # Resolve the provider
         pdef = resolve_provider_full(explicit_provider, user_providers)
+        if pdef is None and custom_providers and isinstance(custom_providers, list):
+            from agent.credential_pool import CUSTOM_POOL_PREFIX, _normalize_custom_pool_name
+            custom_slug = explicit_provider.strip().lower()
+            if custom_slug.startswith(CUSTOM_POOL_PREFIX):
+                custom_name = custom_slug[len(CUSTOM_POOL_PREFIX):]
+                for entry in custom_providers:
+                    if not isinstance(entry, dict):
+                        continue
+                    entry_name = (entry.get("name") or "").strip()
+                    entry_base_url = (entry.get("base_url") or "").strip()
+                    if not entry_name or not entry_base_url:
+                        continue
+                    if _normalize_custom_pool_name(entry_name) != custom_name:
+                        continue
+                    from hermes_cli.providers import ProviderDef
+                    pdef = ProviderDef(
+                        id=explicit_provider,
+                        name=entry_name,
+                        transport="openai_chat",
+                        api_key_env_vars=(),
+                        base_url=entry_base_url,
+                        is_aggregator=False,
+                        auth_type="api_key",
+                        source="custom-provider",
+                    )
+                    break
         if pdef is None:
             _switch_err = (
                 f"Unknown provider '{explicit_provider}'. "
                 f"Check 'hermes model' for available providers, or define it "
-                f"in config.yaml under 'providers:'."
+                f"in config.yaml under 'providers:' or 'custom_providers:'."
             )
             # Check for common config issues that cause provider resolution failures
             try:
@@ -706,6 +734,7 @@ def list_authenticated_providers(
     current_provider: str = "",
     user_providers: dict = None,
     max_models: int = 8,
+    custom_providers: list | None = None,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -720,11 +749,13 @@ def list_authenticated_providers(
       - is_user_defined: bool
       - models: list[str] — curated model IDs (up to max_models)
       - total_models: int — total curated count
-      - source: str — "built-in", "models.dev", "user-config"
+      - source: str — "built-in", "models.dev", "user-config", "custom-provider"
 
     Only includes providers that have API keys set or are user-defined endpoints.
     """
     import os
+    from agent.credential_pool import CUSTOM_POOL_PREFIX
+    from agent.credential_pool import _normalize_custom_pool_name
     from agent.models_dev import (
         PROVIDER_TO_MODELS_DEV,
         fetch_models_dev,
@@ -816,7 +847,50 @@ def list_authenticated_providers(
         })
         seen_slugs.add(pid)
 
-    # --- 3. User-defined endpoints from config ---
+    # --- 3. Named custom providers from config.yaml custom_providers ---
+    if custom_providers and isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            name = (entry.get("name") or "").strip()
+            base_url = (entry.get("base_url") or "").strip()
+            if not name or not base_url:
+                continue
+
+            slug = f"{CUSTOM_POOL_PREFIX}{_normalize_custom_pool_name(name)}"
+            if slug in seen_slugs:
+                continue
+
+            models_cfg = entry.get("models") or {}
+            if isinstance(models_cfg, dict):
+                model_ids = [mid for mid in models_cfg.keys() if isinstance(mid, str) and mid.strip()]
+            else:
+                model_ids = []
+
+            saved_model = entry.get("model")
+            if isinstance(saved_model, str) and saved_model.strip():
+                saved_model = saved_model.strip()
+                if saved_model in model_ids:
+                    model_ids.remove(saved_model)
+                model_ids.insert(0, saved_model)
+
+            total = len(model_ids)
+            top = model_ids[:max_models]
+            short_url = base_url.replace("https://", "").replace("http://", "").rstrip("/")
+
+            results.append({
+                "slug": slug,
+                "name": name,
+                "is_current": slug == current_provider,
+                "is_user_defined": True,
+                "models": top,
+                "total_models": total,
+                "source": "custom-provider",
+                "api_url": short_url,
+            })
+            seen_slugs.add(slug)
+
+    # --- 4. User-defined endpoints from config ---
     if user_providers and isinstance(user_providers, dict):
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -19,6 +19,8 @@ import yaml
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from hermes_constants import get_hermes_home
+
 from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
@@ -26,6 +28,7 @@ from agent.model_metadata import (
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
     get_model_context_length,
+    get_custom_provider_context_length,
     get_next_probe_tier,
     get_cached_context_length,
     parse_context_limit_from_error,
@@ -296,6 +299,112 @@ class TestGetModelContextLength:
         )
 
         assert result == 200000
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_custom_provider_context_from_config_beats_fallback(self, mock_fetch, tmp_path, monkeypatch):
+        """custom_providers per-model context_length should be resolved centrally."""
+        mock_fetch.return_value = {}
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "custom_providers": [
+                    {
+                        "name": "cpamc",
+                        "base_url": "http://100.93.186.121:8317/v1",
+                        "models": {
+                            "qwen3.6-plus": {"context_length": 1_000_000},
+                        },
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        result = get_model_context_length(
+            "qwen3.6-plus",
+            base_url="http://100.93.186.121:8317/v1",
+            provider="custom:cpamc",
+        )
+
+        assert result == 1_000_000
+
+    def test_get_custom_provider_context_length_matches_named_provider(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "custom_providers": [
+                    {
+                        "name": "CP AMC",
+                        "base_url": "http://different.example/v1",
+                        "models": {
+                            "gpt-5.4": {"context_length": 1_000_000},
+                        },
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        result = get_custom_provider_context_length(
+            "gpt-5.4",
+            provider="custom:cp-amc",
+        )
+
+        assert result == 1_000_000
+
+    def test_get_custom_provider_context_length_handles_named_provider_prefixed_model(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "custom_providers": [
+                    {
+                        "name": "cpamc",
+                        "base_url": "http://100.93.186.121:8317/v1",
+                        "models": {
+                            "gpt-5.4": {"context_length": 1_000_000},
+                        },
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        result = get_custom_provider_context_length(
+            "cpamc:gpt-5.4",
+            base_url="http://100.93.186.121:8317/v1",
+            provider="custom:cpamc",
+        )
+
+        assert result == 1_000_000
+
+    def test_get_custom_provider_context_length_handles_nested_custom_prefixes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "custom_providers": [
+                    {
+                        "name": "cpamc",
+                        "base_url": "http://100.93.186.121:8317/v1",
+                        "models": {
+                            "gpt-5.4": {"context_length": 1_000_000},
+                        },
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        result = get_custom_provider_context_length(
+            "custom:cpamc:gpt-5.4",
+            base_url="http://100.93.186.121:8317/v1",
+            provider="custom:cpamc",
+        )
+
+        assert result == 1_000_000
 
 
 # =========================================================================

--- a/tests/hermes_cli/test_model_switch_picker_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_picker_custom_providers.py
@@ -1,0 +1,98 @@
+"""Tests for /model provider listing with config.yaml custom_providers."""
+
+import hermes_cli.model_switch as ms
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def test_list_authenticated_providers_includes_custom_providers():
+    providers = list_authenticated_providers(
+        current_provider="custom:cpamc",
+        user_providers=None,
+        custom_providers=[
+            {
+                "name": "cpamc",
+                "base_url": "http://100.93.186.121:8317/v1",
+                "models": {
+                    "qwen3.6-plus": {"context_length": 1_000_000},
+                    "gpt-5.4": {"context_length": 1_000_000},
+                    "kimi-k2.5": {"context_length": 256_000},
+                },
+            }
+        ],
+        max_models=2,
+    )
+
+    cpamc = next(p for p in providers if p["slug"] == "custom:cpamc")
+    assert cpamc["name"] == "cpamc"
+    assert cpamc["is_current"] is True
+    assert cpamc["source"] == "custom-provider"
+    assert cpamc["total_models"] == 3
+    assert cpamc["models"] == ["qwen3.6-plus", "gpt-5.4"]
+    assert cpamc["api_url"] == "100.93.186.121:8317/v1"
+
+
+def test_list_authenticated_providers_includes_saved_custom_model_first():
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers=None,
+        custom_providers=[
+            {
+                "name": "cpamc",
+                "base_url": "http://100.93.186.121:8317/v1",
+                "model": "glm-5",
+                "models": {
+                    "qwen3.6-plus": {"context_length": 1_000_000},
+                    "glm-5": {"context_length": 202_752},
+                },
+            }
+        ],
+        max_models=3,
+    )
+
+    cpamc = next(p for p in providers if p["slug"] == "custom:cpamc")
+    assert cpamc["models"][0] == "glm-5"
+    assert cpamc["total_models"] == 2
+
+
+def test_switch_model_accepts_named_custom_provider(monkeypatch):
+    monkeypatch.setattr(ms, "resolve_provider_full", lambda provider, user_providers=None: None)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "test-key",
+            "base_url": "http://100.93.186.121:8317/v1",
+            "api_mode": "chat_completions",
+            "provider": requested,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **kw: {"accepted": True, "persist": True, "recognized": True, "message": None},
+    )
+    monkeypatch.setattr("hermes_cli.models.opencode_model_api_mode", lambda *a, **kw: "chat_completions")
+    monkeypatch.setattr(ms, "get_model_capabilities", lambda *a, **kw: {})
+    monkeypatch.setattr(ms, "get_model_info", lambda *a, **kw: None)
+    monkeypatch.setattr(ms, "normalize_model_for_provider", lambda model, provider: model)
+
+    result = ms.switch_model(
+        raw_input="glm-5",
+        current_provider="custom:cpamc",
+        current_model="gpt-5.4",
+        current_base_url="http://100.93.186.121:8317/v1",
+        current_api_key="test-key",
+        explicit_provider="custom:cpamc",
+        custom_providers=[
+            {
+                "name": "cpamc",
+                "base_url": "http://100.93.186.121:8317/v1",
+                "models": {
+                    "glm-5": {"context_length": 202_752},
+                },
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom:cpamc"
+    assert result.new_model == "glm-5"
+    assert result.base_url == "http://100.93.186.121:8317/v1"


### PR DESCRIPTION
## Summary
- resolve `custom_providers[].models.<model>.context_length` through the shared model metadata path, including prefixed runtime model names like `custom:cpamc:model`
- surface named `custom_providers` entries in `/model` provider listings and Telegram picker buttons
- allow picker-driven model switches for named custom providers such as `custom:cpamc`, with regression tests for both context resolution and picker switching

## Test plan
- [x] `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest -q /home/ubuntu/.hermes/hermes-agent/tests/agent/test_model_metadata.py /home/ubuntu/.hermes/hermes-agent/tests/hermes_cli/test_model_switch_picker_custom_providers.py`
- [x] `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m py_compile /home/ubuntu/.hermes/hermes-agent/agent/model_metadata.py /home/ubuntu/.hermes/hermes-agent/hermes_cli/model_switch.py /home/ubuntu/.hermes/hermes-agent/gateway/run.py /home/ubuntu/.hermes/hermes-agent/cli.py`

## Context
A named custom provider configured under `custom_providers:` could advertise per-model context lengths and appear in Hermes runtime state, but those values were not used consistently by the shared context resolver or the `/model` picker/switch flow. This caused 128K fallback context displays and prevented Telegram picker switching for `custom:<name>` providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)