### PR TITLE
feat(plugins): add EverOS memory provider plugin

### DIFF
--- a/plugins/memory/everos/README.md
+++ b/plugins/memory/everos/README.md
@@ -1,0 +1,128 @@
+# EverOS Memory Provider
+
+Structured memory extraction with episodic, profile, and foresight memory for Hermes Agent. Powered by [EverOS](https://github.com/EverMind-AI/EverOS) — 93% accuracy on the LoCoMo benchmark.
+
+## Features
+
+- **Auto-extraction**: Conversations are automatically analyzed to extract episodic memories, user profile facts, event logs, and foresight predictions
+- **Multi-method retrieval**: keyword (BM25), vector semantic, hybrid, RRF fusion, and agentic (LLM-guided multi-round) search
+- **Progressive profiles**: Builds a user profile over time from conversation patterns
+- **Circuit breaker**: Gracefully handles EverOS server downtime without blocking the agent
+
+## Prerequisites
+
+1. **EverOS server** running via Docker:
+   ```bash
+   git clone https://github.com/EverMind-AI/EverOS.git
+   cd EverOS
+   docker compose up -d
+   cp env.template .env
+   # Edit .env: set LLM_API_KEY and VECTORIZE_API_KEY
+   uv sync
+   uv run python src/run.py
+   ```
+
+2. **Required services** (via Docker Compose):
+   - MongoDB
+   - Milvus (vector DB)
+   - Elasticsearch
+   - Redis
+
+   See the [EverOS setup guide](https://github.com/EverMind-AI/EverOS#quick-start) for details.
+
+## Setup
+
+```bash
+# Activate the provider
+hermes memory setup
+# Select "everos" from the list
+# Enter your EverOS URL (default: http://localhost:1995)
+
+# Or manually set in config.yaml:
+hermes config set memory.provider everos
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EVEROS_URL` | `http://localhost:1995` | EverOS API base URL |
+| `EVEROS_USER_ID` | `hermes-user` | User identifier in EverOS |
+
+### Config File
+
+Non-secret settings can be stored in `$HERMES_HOME/everos.json`:
+
+```json
+{
+  "url": "http://localhost:1995",
+  "user_id": "hermes-user"
+}
+```
+
+## Agent Tools
+
+Once active, two tools are available to the agent:
+
+### `everos_search`
+Search memories by meaning across all types.
+
+```json
+{
+  "query": "What did the user say about their trading preferences?",
+  "method": "hybrid",
+  "memory_types": ["episodic_memory", "profile"],
+  "top_k": 10
+}
+```
+
+**Retrieval methods:**
+- `keyword` — BM25 text matching (fast, good for exact terms)
+- `vector` — Semantic similarity search
+- `hybrid` — Keyword + vector combined (recommended default)
+- `rrf` — Reciprocal Rank Fusion of multiple methods
+- `agentic` — LLM-guided multi-round retrieval (slowest, most thorough)
+
+### `everos_recall`
+Fetch memories by type (no semantic search, just retrieval).
+
+```json
+{
+  "memory_type": "profile",
+  "limit": 10
+}
+```
+
+**Memory types:**
+- `episodic_memory` — Narrative memories of events and conversations
+- `profile` — Extracted user profile facts and preferences
+- `foresight` — Predicted future associations and trends
+- `event_log` — Atomic facts extracted from conversations
+
+## CLI Commands
+
+```bash
+hermes everos status    # Connection status and memory stats
+hermes everos config    # Show current configuration
+hermes everos reset     # Delete all memories for current user
+```
+
+## How It Works
+
+1. **sync_turn()** — After each conversation turn, both user and assistant messages are sent to EverOS via `POST /api/v1/memories`. EverOS automatically performs boundary detection and structured extraction.
+
+2. **queue_prefetch()** — After each turn, a background search is queued using the turn content as the query. Results are cached for the next turn's `prefetch()`.
+
+3. **on_session_end()** — Final flush of the last turn pair to ensure nothing is lost.
+
+4. **on_memory_write()** — Built-in memory writes (MEMORY.md, USER.md) are mirrored to EverOS as assistant messages.
+
+## Threading
+
+All API calls run in daemon threads to avoid blocking the agent loop. A circuit breaker pauses calls after 5 consecutive failures for 120 seconds.
+
+## License
+
+This plugin is part of Hermes Agent (MIT License). EverOS is separately licensed under the Apache License 2.0.

--- a/plugins/memory/everos/__init__.py
+++ b/plugins/memory/everos/__init__.py
@@ -1,0 +1,461 @@
+"""EverOS memory plugin — MemoryProvider interface for the EverMind EverOS memory system.
+
+EverOS provides structured memory extraction from conversations, intelligent retrieval
+with multiple search methods (keyword, vector, hybrid, RRF, agentic), and progressive
+user profile building. It achieves 93% reasoning accuracy on the LoCoMo benchmark.
+
+API Reference: https://github.com/EverMind-AI/EverOS
+Requires: EverOS server running (Docker) at configured URL (default: localhost:1995).
+
+Config via environment variables:
+  EVEROS_URL       — EverOS API base URL (default: http://localhost:1995)
+  EVEROS_USER_ID   — User identifier (default: hermes-user)
+
+Or via $HERMES_HOME/everos.json.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker: after this many consecutive failures, pause API calls
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper (no external deps)
+# ---------------------------------------------------------------------------
+
+def _http_request(url: str, method: str = "GET", data: dict = None, timeout: int = 10) -> dict:
+    """Make an HTTP request and return parsed JSON response."""
+    body = json.dumps(data).encode("utf-8") if data else None
+    req = Request(url, data=body, method=method)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except URLError as e:
+        return {"error": str(e)}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    """Load config from env vars, with $HERMES_HOME/everos.json overrides."""
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "url": os.environ.get("EVEROS_URL", "http://localhost:1995"),
+        "user_id": os.environ.get("EVEROS_USER_ID", "hermes-user"),
+    }
+
+    config_path = get_hermes_home() / "everos.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items()
+                           if v is not None and v != ""})
+        except Exception:
+            pass
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+SEARCH_SCHEMA = {
+    "name": "everos_search",
+    "description": (
+        "Search memories stored in EverOS by meaning. Supports keyword, vector, "
+        "hybrid, and agentic retrieval. Returns grouped results ranked by relevance. "
+        "Use this to recall past conversations, user preferences, facts, and events."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to search for in stored memories.",
+            },
+            "method": {
+                "type": "string",
+                "enum": ["keyword", "vector", "hybrid", "rrf", "agentic"],
+                "description": "Retrieval method. 'hybrid' is a good default. 'agentic' is slowest but most thorough.",
+            },
+            "memory_types": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Memory types to search: episodic_memory, profile, foresight, event_log.",
+            },
+            "top_k": {
+                "type": "integer",
+                "description": "Max result groups to return (default: 10, max: 50).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "everos_recall",
+    "description": (
+        "Fetch stored memories by type — user profile, episodic memories, or event logs. "
+        "Use at conversation start to load user context, or when you need the full profile "
+        "rather than a semantic search."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_type": {
+                "type": "string",
+                "enum": ["profile", "episodic_memory", "foresight", "event_log"],
+                "description": "Type of memories to fetch (default: episodic_memory).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max memories to return (default: 10, max: 100).",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class EverOSMemoryProvider(MemoryProvider):
+    """EverOS memory provider with structured extraction and multi-method retrieval.
+
+    Ingests conversations via sync_turn(), auto-extracts episodic memories,
+    user profiles, and foresight predictions. Provides semantic search and
+    typed recall as agent tools.
+    """
+
+    def __init__(self):
+        self._config = _load_config()
+        self._session_id = ""
+        self._agent_context = "primary"
+        self._sync_thread: Optional[threading.Thread] = None
+        self._prefetch_cache: Dict[str, str] = {}
+        # Circuit breaker state
+        self._consecutive_failures = 0
+        self._breaker_until = 0.0
+
+    @property
+    def name(self) -> str:
+        return "everos"
+
+    # -- Core lifecycle -------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Check if EverOS server is reachable. NO network calls in check."""
+        url = os.environ.get("EVEROS_URL", self._config.get("url", ""))
+        return bool(url)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Initialize EverOS connection and verify server health."""
+        self._session_id = session_id
+        self._config = _load_config()
+        self._agent_context = kwargs.get("agent_context", "primary")
+
+        # Verify server is reachable
+        base_url = self._config["url"].rstrip("/")
+        health = _http_request(f"{base_url}/health", timeout=5)
+        if "error" in health:
+            logger.warning(
+                "EverOS server not reachable at %s: %s. "
+                "Plugin will retry on first use.",
+                base_url, health["error"],
+            )
+        else:
+            logger.info("EverOS connected: %s", health.get("status", "ok"))
+
+    def system_prompt_block(self) -> str:
+        """Static info about EverOS for the system prompt."""
+        return (
+            "EverOS memory is active. Use everos_search to find past memories by "
+            "meaning, or everos_recall to fetch memories by type (profile, episodic). "
+            "Memories are auto-extracted from conversations."
+        )
+
+    # -- Prefetch / recall context --------------------------------------------
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return cached prefetch results for the upcoming turn."""
+        cache_key = session_id or "default"
+        return self._prefetch_cache.pop(cache_key, "")
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Background recall for the next turn."""
+        cache_key = session_id or "default"
+
+        def _fetch():
+            try:
+                results = self._search(query, method="hybrid", top_k=5)
+                if results:
+                    self._prefetch_cache[cache_key] = self._format_search_results(results)
+            except Exception as e:
+                logger.debug("EverOS prefetch failed: %s", e)
+
+        t = threading.Thread(target=_fetch, daemon=True)
+        t.start()
+
+    # -- Sync turns (ingest) --------------------------------------------------
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Persist a completed turn to EverOS. Non-blocking."""
+        # Skip writes for non-primary contexts (cron, subagent, flush)
+        if self._agent_context != "primary":
+            return
+
+        def _sync():
+            if not self._check_breaker():
+                return
+            try:
+                self._ingest_message(user_content, role="user")
+                self._ingest_message(assistant_content, role="assistant")
+                self._consecutive_failures = 0
+            except Exception as e:
+                self._record_failure(e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(target=_sync, daemon=True)
+        self._sync_thread.start()
+
+    # -- Tool schemas and dispatch --------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Expose everos_search and everos_recall tools."""
+        return [SEARCH_SCHEMA, RECALL_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        """Dispatch tool calls for everos_search and everos_recall."""
+        if tool_name == "everos_search":
+            return self._handle_search(args)
+        elif tool_name == "everos_recall":
+            return self._handle_recall(args)
+        return tool_error(f"Unknown EverOS tool: {tool_name}")
+
+    # -- Optional hooks -------------------------------------------------------
+
+    def on_session_end(self, messages: list) -> None:
+        """Final extraction flush at session end."""
+        if self._agent_context != "primary":
+            return
+        # Ingest the full conversation summary if available
+        if messages:
+            last_user = ""
+            last_asst = ""
+            for msg in reversed(messages):
+                role = msg.get("role", "")
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    content = " ".join(
+                        c.get("text", "") for c in content if isinstance(c, dict)
+                    )
+                if role == "user" and not last_user:
+                    last_user = content
+                elif role == "assistant" and not last_asst:
+                    last_asst = content
+                if last_user and last_asst:
+                    break
+            if last_user or last_asst:
+                self.sync_turn(last_user, last_asst)
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in memory writes to EverOS."""
+        if self._agent_context != "primary" or not self._check_breaker():
+            return
+        try:
+            self._ingest_message(
+                f"[Memory {action}] target={target}: {content}",
+                role="assistant",
+            )
+        except Exception as e:
+            logger.debug("EverOS memory mirror failed: %s", e)
+
+    def shutdown(self) -> None:
+        """Wait for pending sync to complete."""
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=10.0)
+
+    # -- Config ---------------------------------------------------------------
+
+    def get_config_schema(self) -> list:
+        return [
+            {
+                "key": "url",
+                "description": "EverOS server URL",
+                "default": "http://localhost:1995",
+                "required": True,
+            },
+            {
+                "key": "user_id",
+                "description": "User identifier in EverOS",
+                "default": "hermes-user",
+            },
+        ]
+
+    def save_config(self, values: dict, hermes_home: str) -> None:
+        """Write non-secret config to $HERMES_HOME/everos.json."""
+        from pathlib import Path
+        config_path = Path(hermes_home) / "everos.json"
+        config_path.write_text(json.dumps(values, indent=2))
+
+    # -- Internal API methods -------------------------------------------------
+
+    def _base_url(self) -> str:
+        return self._config["url"].rstrip("/")
+
+    def _ingest_message(self, content: str, role: str = "user") -> dict:
+        """Send a single message to EverOS for memory extraction."""
+        url = f"{self._base_url()}/api/v1/memories"
+        payload = {
+            "message_id": f"{self._session_id}_{int(time.time() * 1000)}",
+            "create_time": datetime.now(timezone.utc).isoformat(),
+            "sender": self._config["user_id"],
+            "content": content,
+            "role": role,
+            "sender_name": self._config["user_id"],
+        }
+        return _http_request(url, method="POST", data=payload, timeout=15)
+
+    def _search(self, query: str, method: str = "hybrid",
+                memory_types: list = None, top_k: int = 10) -> dict:
+        """Search EverOS memories."""
+        url = f"{self._base_url()}/api/v1/memories/search"
+        payload = {
+            "query": query,
+            "user_id": self._config["user_id"],
+            "retrieve_method": method,
+            "top_k": top_k,
+        }
+        if memory_types:
+            payload["memory_types"] = memory_types
+        return _http_request(url, method="GET", data=payload, timeout=15)
+
+    def _fetch(self, memory_type: str = "episodic_memory", limit: int = 10) -> dict:
+        """Fetch memories by type."""
+        url = f"{self._base_url()}/api/v1/memories"
+        payload = {
+            "user_id": self._config["user_id"],
+            "memory_type": memory_type,
+            "limit": limit,
+        }
+        return _http_request(url, method="GET", data=payload, timeout=15)
+
+    # -- Tool handlers --------------------------------------------------------
+
+    def _handle_search(self, args: dict) -> str:
+        """Handle everos_search tool call."""
+        query = args.get("query", "")
+        method = args.get("method", "hybrid")
+        memory_types = args.get("memory_types")
+        top_k = args.get("top_k", 10)
+
+        if not query:
+            return json.dumps({"error": "query is required"})
+
+        if not self._check_breaker():
+            return json.dumps({"error": "EverOS temporarily unavailable (circuit breaker active)"})
+
+        try:
+            result = self._search(query, method=method, memory_types=memory_types, top_k=top_k)
+            if "error" in result:
+                self._record_failure(result["error"])
+                return json.dumps({"error": f"EverOS search failed: {result['error']}"})
+            self._consecutive_failures = 0
+            return json.dumps(result)
+        except Exception as e:
+            self._record_failure(e)
+            return json.dumps({"error": f"EverOS search error: {e}"})
+
+    def _handle_recall(self, args: dict) -> str:
+        """Handle everos_recall tool call."""
+        memory_type = args.get("memory_type", "episodic_memory")
+        limit = args.get("limit", 10)
+
+        if not self._check_breaker():
+            return json.dumps({"error": "EverOS temporarily unavailable (circuit breaker active)"})
+
+        try:
+            result = self._fetch(memory_type=memory_type, limit=limit)
+            if "error" in result:
+                self._record_failure(result["error"])
+                return json.dumps({"error": f"EverOS recall failed: {result['error']}"})
+            self._consecutive_failures = 0
+            return json.dumps(result)
+        except Exception as e:
+            self._record_failure(e)
+            return json.dumps({"error": f"EverOS recall error: {e}"})
+
+    # -- Formatting -----------------------------------------------------------
+
+    @staticmethod
+    def _format_search_results(result: dict) -> str:
+        """Format search results for injection as context."""
+        lines = ["[EverOS recalled memories]"]
+        memories = result.get("result", {}).get("memories", [])
+        if not memories:
+            return ""
+        for group in memories[:5]:
+            if isinstance(group, dict):
+                summary = group.get("summary", group.get("episode", ""))
+                if summary:
+                    lines.append(f"- {summary}")
+        return "\n".join(lines) if len(lines) > 1 else ""
+
+    # -- Circuit breaker ------------------------------------------------------
+
+    def _check_breaker(self) -> bool:
+        """Check if circuit breaker allows API calls."""
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            if time.time() < self._breaker_until:
+                return False
+            # Cooldown expired, allow one attempt
+            return True
+        return True
+
+    def _record_failure(self, error) -> None:
+        """Record a failure for the circuit breaker."""
+        self._consecutive_failures += 1
+        logger.warning("EverOS failure #%d: %s", self._consecutive_failures, error)
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_until = time.time() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "EverOS circuit breaker OPEN — pausing calls for %ds",
+                _BREAKER_COOLDOWN_SECS,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Called by the memory plugin discovery system."""
+    ctx.register_memory_provider(EverOSMemoryProvider())

--- a/plugins/memory/everos/cli.py
+++ b/plugins/memory/everos/cli.py
@@ -1,0 +1,132 @@
+"""EverOS CLI commands — hermes everos status/config/reset."""
+
+
+def _load_config():
+    """Load EverOS config from hermes home."""
+    import json
+    from pathlib import Path
+    from hermes_constants import get_hermes_home
+
+    config_path = get_hermes_home() / "everos.json"
+    if config_path.exists():
+        return json.loads(config_path.read_text(encoding="utf-8"))
+    return {}
+
+
+def _get_url():
+    """Get EverOS base URL."""
+    import os
+    cfg = _load_config()
+    return os.environ.get("EVEROS_URL", cfg.get("url", "http://localhost:1995"))
+
+
+def everos_command(args):
+    """Handler dispatched by argparse."""
+    sub = getattr(args, "everos_command", None)
+    if sub == "status":
+        _cmd_status(args)
+    elif sub == "config":
+        _cmd_config(args)
+    elif sub == "reset":
+        _cmd_reset(args)
+    else:
+        print("Usage: hermes everos <status|config|reset>")
+
+
+def _cmd_status(args):
+    """Show EverOS connection status and memory stats."""
+    import json
+    from urllib.request import urlopen, Request
+    from urllib.error import URLError
+
+    base_url = _get_url().rstrip("/")
+    print(f"EverOS URL: {base_url}")
+
+    # Health check
+    try:
+        req = Request(f"{base_url}/health")
+        with urlopen(req, timeout=5) as resp:
+            health = json.loads(resp.read().decode("utf-8"))
+        print(f"Status: {health.get('status', 'unknown')}")
+    except URLError as e:
+        print(f"Status: UNREACHABLE ({e})")
+        return
+    except Exception as e:
+        print(f"Status: ERROR ({e})")
+        return
+
+    # Config
+    cfg = _load_config()
+    user_id = cfg.get("user_id", "hermes-user")
+    print(f"User ID: {user_id}")
+
+    # Try to fetch memory count
+    try:
+        req = Request(f"{base_url}/api/v1/memories")
+        req.add_header("Content-Type", "application/json")
+        data = json.dumps({"user_id": user_id, "memory_type": "episodic_memory", "limit": 1}).encode()
+        req.data = data
+        req.method = "GET"
+        with urlopen(req, timeout=5) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+        mems = result.get("result", {}).get("memories", [])
+        print(f"Episodic memories: {len(mems)}+ (limited query)")
+    except Exception:
+        print("Episodic memories: unable to query")
+
+    print("\nEverOS is active as memory provider.")
+
+
+def _cmd_config(args):
+    """Show current EverOS configuration."""
+    import json
+    cfg = _load_config()
+    if cfg:
+        print("Current EverOS config:")
+        print(json.dumps(cfg, indent=2))
+    else:
+        print("No everos.json found. Using defaults:")
+        print("  URL: http://localhost:1995")
+        print("  User ID: hermes-user")
+    print(f"\nConfig file: ~/.hermes/everos.json")
+
+
+def _cmd_reset(args):
+    """Delete all EverOS memories for the configured user."""
+    import json
+    from urllib.request import urlopen, Request
+
+    base_url = _get_url().rstrip("/")
+    cfg = _load_config()
+    user_id = cfg.get("user_id", "hermes-user")
+
+    confirm = input(f"Delete ALL memories for user '{user_id}'? This cannot be undone. [y/N] ")
+    if confirm.lower() != "y":
+        print("Cancelled.")
+        return
+
+    try:
+        req = Request(
+            f"{base_url}/api/v1/memories",
+            data=json.dumps({"user_id": user_id}).encode(),
+            method="DELETE",
+        )
+        req.add_header("Content-Type", "application/json")
+        with urlopen(req, timeout=10) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+        count = result.get("result", {}).get("count", "?")
+        print(f"Deleted {count} memories.")
+    except Exception as e:
+        print(f"Delete failed: {e}")
+
+
+def register_cli(subparser) -> None:
+    """Build the hermes everos argparse tree.
+
+    Called by discover_plugin_cli_commands() at argparse setup time.
+    """
+    subs = subparser.add_subparsers(dest="everos_command")
+    subs.add_parser("status", help="Show EverOS connection status and memory stats")
+    subs.add_parser("config", help="Show current EverOS configuration")
+    subs.add_parser("reset", help="Delete all EverOS memories for current user")
+    subparser.set_defaults(func=everos_command)

--- a/plugins/memory/everos/plugin.yaml
+++ b/plugins/memory/everos/plugin.yaml
@@ -1,0 +1,6 @@
+name: everos
+version: 1.0.0
+description: "EverOS — structured memory extraction with episodic, profile, and foresight memory. Multi-method retrieval (keyword, vector, hybrid, agentic). 93% accuracy on LoCoMo benchmark."
+hooks:
+  - on_session_end
+  - on_memory_write

--- a/tests/plugins/memory/test_everos_provider.py
+++ b/tests/plugins/memory/test_everos_provider.py
@@ -1,0 +1,516 @@
+"""Tests for the EverOS memory provider plugin.
+
+Tests cover config loading, tool handlers (search, recall), prefetch,
+sync_turn, circuit breaker, profile isolation, schema completeness,
+and the register() entry point. All HTTP calls are mocked — no live
+EverOS server required.
+"""
+
+import json
+import time
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.memory.everos import (
+    EverOSMemoryProvider,
+    SEARCH_SCHEMA,
+    RECALL_SCHEMA,
+    _load_config,
+    _http_request,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure no stale env vars leak between tests."""
+    for key in ("EVEROS_URL", "EVEROS_USER_ID"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture()
+def provider(tmp_path, monkeypatch):
+    """Create an EverOSMemoryProvider with mocked HTTP and config."""
+    config = {"url": "http://localhost:1995", "user_id": "test-user"}
+    config_path = tmp_path / "everos.json"
+    config_path.write_text(json.dumps(config))
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home", lambda: tmp_path
+    )
+
+    p = EverOSMemoryProvider()
+    p.initialize(
+        session_id="test-session",
+        hermes_home=str(tmp_path),
+        platform="cli",
+    )
+    return p
+
+
+@pytest.fixture()
+def provider_with_config(tmp_path, monkeypatch):
+    """Create a provider factory that accepts custom config overrides."""
+
+    def _make(**overrides):
+        config = {"url": "http://localhost:1995", "user_id": "test-user"}
+        config.update(overrides)
+        config_path = tmp_path / "everos.json"
+        config_path.write_text(json.dumps(config))
+
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path
+        )
+
+        p = EverOSMemoryProvider()
+        p.initialize(
+            session_id="test-session",
+            hermes_home=str(tmp_path),
+            platform="cli",
+        )
+        return p
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchemas:
+    def test_search_schema_has_query(self):
+        assert SEARCH_SCHEMA["name"] == "everos_search"
+        assert "query" in SEARCH_SCHEMA["parameters"]["properties"]
+        assert "query" in SEARCH_SCHEMA["parameters"]["required"]
+
+    def test_recall_schema_has_memory_type(self):
+        assert RECALL_SCHEMA["name"] == "everos_recall"
+        assert "memory_type" in RECALL_SCHEMA["parameters"]["properties"]
+
+    def test_get_tool_schemas_returns_two(self, provider):
+        schemas = provider.get_tool_schemas()
+        assert len(schemas) == 2
+        names = {s["name"] for s in schemas}
+        assert names == {"everos_search", "everos_recall"}
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_values(self, tmp_path, monkeypatch):
+        """Without config file, uses env defaults."""
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("EVEROS_URL", "http://custom:1995")
+        monkeypatch.setenv("EVEROS_USER_ID", "custom-user")
+
+        cfg = _load_config()
+        assert cfg["url"] == "http://custom:1995"
+        assert cfg["user_id"] == "custom-user"
+
+    def test_config_file_overrides_env(self, tmp_path, monkeypatch):
+        """Config file values take precedence over env defaults."""
+        config = {"url": "http://file-url:1995", "user_id": "file-user"}
+        config_path = tmp_path / "everos.json"
+        config_path.write_text(json.dumps(config))
+
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path
+        )
+
+        cfg = _load_config()
+        assert cfg["url"] == "http://file-url:1995"
+        assert cfg["user_id"] == "file-user"
+
+    def test_get_config_schema(self, provider):
+        schema = provider.get_config_schema()
+        assert len(schema) == 2
+        keys = {s["key"] for s in schema}
+        assert keys == {"url", "user_id"}
+
+    def test_save_config(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path
+        )
+        p = EverOSMemoryProvider()
+        p.save_config({"url": "http://saved:1995"}, str(tmp_path))
+
+        saved = json.loads((tmp_path / "everos.json").read_text())
+        assert saved["url"] == "http://saved:1995"
+
+
+# ---------------------------------------------------------------------------
+# Tool handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolHandlers:
+    @patch("plugins.memory.everos._http_request")
+    def test_search_success(self, mock_http, provider):
+        mock_http.return_value = {
+            "result": {
+                "memories": [
+                    {"summary": "User prefers dark mode"},
+                    {"summary": "User likes espresso"},
+                ]
+            }
+        }
+        result = json.loads(
+            provider.handle_tool_call(
+                "everos_search", {"query": "coffee preferences"}
+            )
+        )
+        assert "result" in result
+        assert len(result["result"]["memories"]) == 2
+
+    @patch("plugins.memory.everos._http_request")
+    def test_search_missing_query(self, mock_http, provider):
+        result = json.loads(
+            provider.handle_tool_call("everos_search", {})
+        )
+        assert "error" in result
+        mock_http.assert_not_called()
+
+    @patch("plugins.memory.everos._http_request")
+    def test_search_passes_method(self, mock_http, provider):
+        mock_http.return_value = {"result": {"memories": []}}
+        provider.handle_tool_call(
+            "everos_search", {"query": "test", "method": "agentic"}
+        )
+        call_args = mock_http.call_args
+        payload = call_args[1].get("data", call_args[0][1] if len(call_args[0]) > 1 else {})
+        # Method is passed in the URL payload
+        assert call_args.called
+
+    @patch("plugins.memory.everos._http_request")
+    def test_recall_success(self, mock_http, provider):
+        mock_http.return_value = {
+            "result": {
+                "memories": [{"summary": "Profile fact"}]
+            }
+        }
+        result = json.loads(
+            provider.handle_tool_call(
+                "everos_recall", {"memory_type": "profile"}
+            )
+        )
+        assert "result" in result
+
+    @patch("plugins.memory.everos._http_request")
+    def test_recall_default_type(self, mock_http, provider):
+        mock_http.return_value = {"result": {"memories": []}}
+        provider.handle_tool_call("everos_recall", {})
+        # Verify it was called (default episodic_memory)
+        mock_http.assert_called_once()
+
+    def test_unknown_tool(self, provider):
+        result = json.loads(
+            provider.handle_tool_call("everos_unknown", {})
+        )
+        assert "error" in result
+
+    @patch("plugins.memory.everos._http_request")
+    def test_search_error_handling(self, mock_http, provider):
+        mock_http.return_value = {"error": "connection refused"}
+        result = json.loads(
+            provider.handle_tool_call(
+                "everos_search", {"query": "test"}
+            )
+        )
+        assert "error" in result
+        assert "connection refused" in result["error"]
+
+    @patch("plugins.memory.everos._http_request")
+    def test_recall_error_handling(self, mock_http, provider):
+        mock_http.return_value = {"error": "timeout"}
+        result = json.loads(
+            provider.handle_tool_call("everos_recall", {})
+        )
+        assert "error" in result
+
+    @patch("plugins.memory.everos._http_request")
+    def test_search_resets_consecutive_failures_on_success(
+        self, mock_http, provider
+    ):
+        provider._consecutive_failures = 3
+        mock_http.return_value = {"result": {"memories": []}}
+        provider.handle_tool_call(
+            "everos_search", {"query": "test"}
+        )
+        assert provider._consecutive_failures == 0
+
+
+# ---------------------------------------------------------------------------
+# Prefetch tests
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetch:
+    def test_prefetch_returns_empty_initially(self, provider):
+        assert provider.prefetch("test") == ""
+
+    @patch("plugins.memory.everos._http_request")
+    def test_queue_prefetch_populates_cache(self, mock_http, provider):
+        mock_http.return_value = {
+            "result": {
+                "memories": [{"summary": "remembered fact"}]
+            }
+        }
+        provider.queue_prefetch("test query", session_id="s1")
+        # Wait for background thread
+        time.sleep(0.5)
+
+        result = provider.prefetch("anything", session_id="s1")
+        assert "remembered fact" in result
+
+    def test_prefetch_returns_empty_for_wrong_session(self, provider):
+        provider._prefetch_cache["s1"] = "some data"
+        assert provider.prefetch("test", session_id="s2") == ""
+
+
+# ---------------------------------------------------------------------------
+# sync_turn tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncTurn:
+    @patch("plugins.memory.everos._http_request")
+    def test_sync_turn_ingests_both_messages(self, mock_http, provider):
+        mock_http.return_value = {"status": "ok"}
+        provider.sync_turn("user message", "assistant reply")
+        # Wait for background thread
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        # Should have called _http_request twice (user + assistant)
+        assert mock_http.call_count == 2
+
+    @patch("plugins.memory.everos._http_request")
+    def test_sync_turn_skips_non_primary_context(
+        self, mock_http, provider
+    ):
+        provider._agent_context = "subagent"
+        provider.sync_turn("user", "assistant")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+        mock_http.assert_not_called()
+
+    @patch("plugins.memory.everos._http_request")
+    def test_sync_turn_resets_failures_on_success(
+        self, mock_http, provider
+    ):
+        provider._consecutive_failures = 3
+        mock_http.return_value = {"status": "ok"}
+        provider.sync_turn("u", "a")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+        assert provider._consecutive_failures == 0
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker tests
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_check_breaker_allows_when_under_threshold(self, provider):
+        provider._consecutive_failures = 4
+        assert provider._check_breaker() is True
+
+    def test_check_breaker_blocks_when_over_threshold(self, provider):
+        provider._consecutive_failures = 5
+        provider._breaker_until = time.time() + 9999
+        assert provider._check_breaker() is False
+
+    def test_check_breaker_allows_after_cooldown(self, provider):
+        provider._consecutive_failures = 5
+        provider._breaker_until = time.time() - 1  # expired
+        assert provider._check_breaker() is True
+
+    def test_record_failure_increments(self, provider):
+        provider._record_failure("test error")
+        assert provider._consecutive_failures == 1
+
+    def test_record_failure_opens_breaker_at_threshold(self, provider):
+        for _ in range(5):
+            provider._record_failure("error")
+        assert provider._breaker_until > time.time()
+
+    @patch("plugins.memory.everos._http_request")
+    def test_search_blocked_by_breaker(self, mock_http, provider):
+        provider._consecutive_failures = 5
+        provider._breaker_until = time.time() + 9999
+        result = json.loads(
+            provider.handle_tool_call(
+                "everos_search", {"query": "test"}
+            )
+        )
+        assert "circuit breaker" in result["error"]
+        mock_http.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_name(self, provider):
+        assert provider.name == "everos"
+
+    def test_is_available_with_url(self, provider):
+        assert provider.is_available() is True
+
+    def test_is_available_without_url(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.delenv("EVEROS_URL", raising=False)
+        # _load_config defaults to "http://localhost:1995" when env is unset,
+        # so is_available is True even without explicit config. Test that
+        # setting EVEROS_URL="" makes it unavailable.
+        monkeypatch.setenv("EVEROS_URL", "")
+        p = EverOSMemoryProvider()
+        assert p.is_available() is False
+
+    def test_system_prompt_block(self, provider):
+        block = provider.system_prompt_block()
+        assert "EverOS" in block
+        assert "everos_search" in block
+
+    @patch("plugins.memory.everos._http_request")
+    def test_initialize_health_check(self, mock_http, tmp_path, monkeypatch):
+        mock_http.return_value = {"status": "ok"}
+        config_path = tmp_path / "everos.json"
+        config_path.write_text(
+            json.dumps({"url": "http://localhost:1995"})
+        )
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path
+        )
+
+        p = EverOSMemoryProvider()
+        p.initialize(session_id="test", hermes_home=str(tmp_path))
+        # Health check is called during init
+        mock_http.assert_called_once()
+        assert "/health" in mock_http.call_args[0][0]
+
+    def test_shutdown_waits_for_thread(self, provider):
+        provider._sync_thread = threading.Thread(
+            target=lambda: None, daemon=True
+        )
+        provider._sync_thread.start()
+        provider.shutdown()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Optional hooks tests
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalHooks:
+    @patch("plugins.memory.everos._http_request")
+    def test_on_session_end_flushes_last_turn(self, mock_http, provider):
+        mock_http.return_value = {"status": "ok"}
+        messages = [
+            {"role": "user", "content": "last user msg"},
+            {"role": "assistant", "content": "last assistant msg"},
+        ]
+        provider.on_session_end(messages)
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+        assert mock_http.call_count >= 1
+
+    def test_on_session_end_skips_non_primary(self, provider):
+        provider._agent_context = "cron"
+        provider.on_session_end(
+            [{"role": "user", "content": "msg"}]
+        )
+        # No thread should be started
+        assert provider._sync_thread is None or not provider._sync_thread.is_alive()
+
+    @patch("plugins.memory.everos._http_request")
+    def test_on_memory_write_mirrors(self, mock_http, provider):
+        mock_http.return_value = {"status": "ok"}
+        provider.on_memory_write("add", "user", "Timezone: UTC")
+        assert mock_http.called
+
+    def test_on_memory_write_skips_non_primary(self, provider):
+        provider._agent_context = "subagent"
+        provider.on_memory_write("add", "user", "test")
+        # Should not throw
+
+
+# ---------------------------------------------------------------------------
+# register() entry point tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register_calls_ctx(self):
+        from plugins.memory.everos import register
+
+        mock_ctx = MagicMock()
+        register(mock_ctx)
+        mock_ctx.register_memory_provider.assert_called_once()
+        provider = mock_ctx.register_memory_provider.call_args[0][0]
+        assert isinstance(provider, EverOSMemoryProvider)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestHttpRequest:
+    @patch("plugins.memory.everos.urlopen")
+    def test_http_request_success(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"status": "ok"}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = _http_request("http://localhost/test")
+        assert result == {"status": "ok"}
+
+    @patch("plugins.memory.everos.urlopen")
+    def test_http_request_error(self, mock_urlopen):
+        from urllib.error import URLError
+
+        mock_urlopen.side_effect = URLError("connection refused")
+        result = _http_request("http://localhost/test")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Profile isolation test
+# ---------------------------------------------------------------------------
+
+
+class TestProfileIsolation:
+    def test_config_uses_hermes_home(self, tmp_path, monkeypatch):
+        """Config path should be under get_hermes_home(), not hardcoded."""
+        config = {"url": "http://profile-test:1995"}
+        config_path = tmp_path / "everos.json"
+        config_path.write_text(json.dumps(config))
+
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path
+        )
+
+        cfg = _load_config()
+        assert cfg["url"] == "http://profile-test:1995"


### PR DESCRIPTION
Adds `plugins/memory/everos/` — a MemoryProvider plugin integrating [EverOS](https://github.com/EverMind-AI/EverOS) for structured memory extraction with multi-method retrieval (keyword, vector, hybrid, RRF, agentic).

**Files:**
- `plugins/memory/everos/__init__.py` — EverOSMemoryProvider (full MemoryProvider ABC)
- `plugins/memory/everos/plugin.yaml` — plugin metadata
- `plugins/memory/everos/cli.py` — hermes everos status/config/reset
- `plugins/memory/everos/README.md` — setup docs
- `tests/plugins/memory/test_everos_provider.py` — 42 tests

**Features:**
- Auto-extraction of episodic memories, profiles, foresight from conversations
- Two agent tools: everos_search and everos_recall
- Background prefetch via queue_prefetch()
- Circuit breaker (5-failure threshold, 120s cooldown)
- Zero external deps (stdlib urllib only)
- Profile-scoped config via get_hermes_home()
- Daemon threads for all I/O

**Tests:** 42 passing — schemas, config, tool handlers, prefetch, sync_turn, circuit breaker, lifecycle, hooks, registration, profile isolation. All HTTP mocked, no live server needed.

Follows the [Memory Provider Plugin](https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin) developer guide.