### PR TITLE
feat(gateway): add FEISHU_REQUIRE_MENTION config to control group @mention gate

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -275,6 +275,7 @@ class FeishuAdapterSettings:
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
     ws_ping_timeout: Optional[int] = None
+    require_mention: bool = True
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
@@ -307,6 +308,21 @@ def _escape_markdown_text(text: str) -> str:
 
 def _to_boolean(value: Any) -> bool:
     return value is True or value == 1 or value == "true"
+
+
+def _feishu_require_mention(extra: Dict[str, Any]) -> bool:
+    """Parse FEISHU_REQUIRE_MENTION using explicit-false semantics.
+
+    The safe default is True (mention gating on).  Only ``false``, ``0``,
+    ``no``, or ``off`` disable it — matching the pattern used by Slack,
+    Discord, and Matrix adapters.
+    """
+    configured = extra.get("require_mention")
+    if configured is not None:
+        if isinstance(configured, str):
+            return configured.strip().lower() not in ("false", "0", "no", "off")
+        return bool(configured)
+    return os.getenv("FEISHU_REQUIRE_MENTION", "true").strip().lower() not in ("false", "0", "no", "off")
 
 
 def _is_style_enabled(style: Dict[str, Any] | None, key: str) -> bool:
@@ -1140,6 +1156,7 @@ class FeishuAdapter(BasePlatformAdapter):
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
             ws_ping_timeout=_coerce_int(extra.get("ws_ping_timeout"), default=None, min_value=1),
             admins=admins,
+            require_mention=_feishu_require_mention(extra),
             default_group_policy=default_group_policy,
             group_rules=group_rules,
         )
@@ -1154,6 +1171,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._group_policy = settings.group_policy
         self._allowed_group_users = set(settings.allowed_group_users)
         self._admins = set(settings.admins)
+        self._require_mention = settings.require_mention
         self._default_group_policy = settings.default_group_policy or settings.group_policy
         self._group_rules = settings.group_rules
         self._bot_open_id = settings.bot_open_id
@@ -3021,9 +3039,16 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
     def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
-        """Require an explicit @mention before group messages enter the agent."""
+        """Gate group messages: policy check first, then optional mention check.
+
+        When ``require_mention`` is False (controlled via ``FEISHU_REQUIRE_MENTION``
+        env var or config ``extra[\"require_mention\"]``), the mention gate is
+        skipped entirely after the policy gate passes.
+        """
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        if not self._require_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2922,3 +2922,178 @@ class TestSenderNameResolution(unittest.TestCase):
             result = asyncio.run(adapter._resolve_sender_name_from_api("ou_broken"))
 
         self.assertIsNone(result)
+
+
+class TestRequireMention(unittest.TestCase):
+    """Tests for the FEISHU_REQUIRE_MENTION configuration (closes #5465)."""
+
+    # ── Parsing: _feishu_require_mention helper ──────────────────────────
+
+    def test_parse_require_mention_defaults_to_true(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(_feishu_require_mention({}))
+
+    def test_parse_require_mention_explicit_true(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "true"}, clear=True):
+            self.assertTrue(_feishu_require_mention({}))
+
+    def test_parse_require_mention_false(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "false"}, clear=True):
+            self.assertFalse(_feishu_require_mention({}))
+
+    def test_parse_require_mention_zero(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "0"}, clear=True):
+            self.assertFalse(_feishu_require_mention({}))
+
+    def test_parse_require_mention_no(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "no"}, clear=True):
+            self.assertFalse(_feishu_require_mention({}))
+
+    def test_parse_require_mention_off(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "off"}, clear=True):
+            self.assertFalse(_feishu_require_mention({}))
+
+    def test_parse_require_mention_random_string_stays_true(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "yes"}, clear=True):
+            self.assertTrue(_feishu_require_mention({}))
+
+    def test_parse_require_mention_empty_string_stays_true(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": ""}, clear=True):
+            self.assertTrue(_feishu_require_mention({}))
+
+    def test_parse_require_mention_config_extra_overrides_env(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "true"}, clear=True):
+            self.assertFalse(_feishu_require_mention({"require_mention": "false"}))
+
+    def test_parse_require_mention_config_extra_bool_true(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(_feishu_require_mention({"require_mention": True}))
+
+    def test_parse_require_mention_config_extra_bool_false(self):
+        from gateway.platforms.feishu import _feishu_require_mention
+
+        with patch.dict(os.environ, {"FEISHU_REQUIRE_MENTION": "true"}, clear=True):
+            self.assertFalse(_feishu_require_mention({"require_mention": False}))
+
+    # ── Adapter integration ──────────────────────────────────────────────
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "open", "FEISHU_REQUIRE_MENTION": "false"},
+        clear=True,
+    )
+    def test_group_message_accepted_without_mention_when_require_mention_false(self):
+        """When require_mention=false, group messages bypass the mention gate."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(mentions=[], content='{"text":"hello"}', message_type="text")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id, ""))
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "open", "FEISHU_REQUIRE_MENTION": "false"},
+        clear=True,
+    )
+    def test_group_message_still_requires_policy_gate_when_require_mention_false(self):
+        """Policy gate still applies even when mention gate is disabled."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        config = PlatformConfig(
+            extra={
+                "group_rules": {
+                    "oc_chat_a": {"policy": "disabled"},
+                },
+                "require_mention": False,
+            }
+        )
+        adapter = FeishuAdapter(config)
+        message = SimpleNamespace(mentions=[], content='{"text":"hello"}', message_type="text")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, "oc_chat_a"))
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "allowlist", "FEISHU_ALLOWED_USERS": "ou_allowed", "FEISHU_REQUIRE_MENTION": "false"},
+        clear=True,
+    )
+    def test_allowlist_policy_still_applies_without_mention(self):
+        """With require_mention=false + allowlist policy, only allowed users pass."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(mentions=[], content='{"text":"hello"}', message_type="text")
+
+        self.assertTrue(
+            adapter._should_accept_group_message(
+                message,
+                SimpleNamespace(open_id="ou_allowed", user_id=None),
+                "",
+            )
+        )
+        self.assertFalse(
+            adapter._should_accept_group_message(
+                message,
+                SimpleNamespace(open_id="ou_blocked", user_id=None),
+                "",
+            )
+        )
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "open"},
+        clear=True,
+    )
+    def test_default_require_mention_still_enforces_mention(self):
+        """Backward compat: when FEISHU_REQUIRE_MENTION is not set, mention is required."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(mentions=[], content='{"text":"hello"}', message_type="text")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, ""))
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "open", "FEISHU_REQUIRE_MENTION": "false"},
+        clear=True,
+    )
+    def test_require_mention_false_via_config_extra(self):
+        """require_mention=false can also be set via PlatformConfig.extra."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        config = PlatformConfig(extra={"require_mention": "false"})
+        adapter = FeishuAdapter(config)
+        message = SimpleNamespace(mentions=[], content='{"text":"hello"}', message_type="text")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id, ""))


### PR DESCRIPTION
## Summary

Add a `FEISHU_REQUIRE_MENTION` configuration option to the Feishu gateway adapter, allowing users to disable the requirement for @mentioning the bot in group chats. By default, the bot still requires being @mentioned in groups (backward compatible), but this can be turned off via config or environment variable.

## Motivation

Currently, the Feishu bot **only** responds when @mentioned in group chats. Some users prefer the bot to respond to **all** messages in a group (e.g., dedicated bot channels). This PR makes the behavior configurable.

## Changes

- **gateway/platforms/feishu.py**:
  - Add `require_mention: bool = True` to `FeishuAdapterSettings` (default: `True`, backward compatible)
  - Add `_feishu_require_mention()` validation function for config parsing
  - Add `FEISHU_REQUIRE_MENTION` env var support in `FeishuAdapter.from_config()`
  - Gate the `_is_mentioned()` check on the new setting in `FeishuAdapter._process_message()`

- **tests/test_feishu.py**:
  - Add tests for `require_mention=False` (bot responds to all group messages)
  - Add tests for `require_mention=True` default (bot only responds when @mentioned)
  - Add tests for env var override `FEISHU_REQUIRE_MENTION`

## Configuration

```yaml
# config.yaml
feishu:
  require_mention: false  # bot responds to all group messages
```

Or via environment variable:
```bash
export FEISHU_REQUIRE_MENTION=false
```

## Important: Feishu Platform Event Subscription

**Setting `require_mention: false` alone is not sufficient.** You must also configure the event subscription on the Feishu Open Platform:

1. Go to [Feishu Developer Console](https://open.feishu.cn/app) > your app > **Events & Callbacks** (事件与回调)
2. Add the `im.message.receive_v1` event subscription
3. If you want the bot to receive **all** group messages (not just @mentions), also ensure the `im:message.group_msg:readonly` permission is granted under **Permissions** (权限管理)

Without the `im.message.receive_v1` event subscription, the Feishu platform will not push any message events to your bot, regardless of the `require_mention` setting.

**重要：飞书平台事件订阅配置**

仅设置 `require_mention: false` 是不够的。你还需要在飞书开放平台进行以下配置：

1. 前往 [飞书开发者后台](https://open.feishu.cn/app) > 你的应用 > **事件与回调**
2. 添加 `im.message.receive_v1` 事件订阅
3. 如果你希望机器人接收群里的**所有消息**（而不仅仅是 @消息），还需要在**权限管理**中开通 `im:message.group_msg:readonly` 权限

如果没有添加 `im.message.receive_v1` 事件订阅，飞书平台不会向你的机器人推送任何消息事件，无论 `require_mention` 如何设置。

## Backward Compatibility

Fully backward compatible. Default is `require_mention: true`, preserving existing behavior.