### PR TITLE
feat(gateway): support model.gateway config override

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -436,6 +436,10 @@ def _load_gateway_config() -> dict:
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
+    Supports a dedicated ``model.gateway`` override so the gateway can use
+    a different model than the CLI.  Falls back to ``model.default`` when
+    ``model.gateway`` is not set.
+
     Without this, temporary AIAgent instances (memory flush, /compress) fall
     back to the hardcoded default which fails when the active provider is
     openai-codex.
@@ -445,6 +449,10 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     if isinstance(model_cfg, str):
         return model_cfg
     elif isinstance(model_cfg, dict):
+        # Gateway-specific model takes priority over the shared default.
+        gateway_model = model_cfg.get("gateway")
+        if gateway_model:
+            return gateway_model
         return model_cfg.get("default") or model_cfg.get("model") or ""
     return ""
 

--- a/tests/gateway/test_resolve_gateway_model.py
+++ b/tests/gateway/test_resolve_gateway_model.py
@@ -1,0 +1,61 @@
+"""Unit tests for _resolve_gateway_model() with model.gateway override."""
+
+from gateway.run import _resolve_gateway_model
+
+
+class TestResolveGatewayModel:
+    """_resolve_gateway_model reads model from config.yaml dict."""
+
+    def test_gateway_override_takes_priority(self):
+        """model.gateway should be returned when set."""
+        result = _resolve_gateway_model({
+            "model": {
+                "default": "cli-model",
+                "gateway": "gateway-model",
+            }
+        })
+        assert result == "gateway-model"
+
+    def test_falls_back_to_default_when_no_gateway(self):
+        """Without model.gateway, falls back to model.default."""
+        result = _resolve_gateway_model({
+            "model": {
+                "default": "shared-model",
+            }
+        })
+        assert result == "shared-model"
+
+    def test_falls_back_to_legacy_model_key(self):
+        """Legacy 'model' key inside model dict still works."""
+        result = _resolve_gateway_model({
+            "model": {
+                "model": "legacy-model",
+            }
+        })
+        assert result == "legacy-model"
+
+    def test_empty_gateway_falls_through(self):
+        """Empty string gateway should fall back to default."""
+        result = _resolve_gateway_model({
+            "model": {
+                "default": "cli-model",
+                "gateway": "",
+            }
+        })
+        # Empty string is falsy, so falls through to default
+        assert result == "cli-model"
+
+    def test_string_model_passthrough(self):
+        """Old format: model is a plain string."""
+        result = _resolve_gateway_model({"model": "plain-string-model"})
+        assert result == "plain-string-model"
+
+    def test_missing_model_returns_empty(self):
+        """No model key at all returns empty string."""
+        result = _resolve_gateway_model({})
+        assert result == ""
+
+    def test_none_config_returns_empty(self):
+        """None config (load failure) returns empty string."""
+        result = _resolve_gateway_model(None)
+        assert result == ""


### PR DESCRIPTION
## Summary

Currently the CLI chat agent and all gateway platforms (Telegram, Discord, Slack, etc.) share the same \`model.default\` setting. There is no way to give them different models.

This PR adds \`model.gateway\` support in \`_resolve_gateway_model()\`. When set, gateway uses this model instead of \`model.default\`. Falls back gracefully when empty — fully backward-compatible.

## Config example

\`\`\`yaml
model:
  default: glm-5v-turbo    # CLI chat agent
  provider: zai
  base_url: https://open.bigmodel.cn/api/paas/v4/
  gateway: gpt-4o           # Gateway platforms (Telegram, Discord, ...)
\`\`\`

## Changes

- **gateway/run.py**: \`_resolve_gateway_model()\` checks \`model.gateway\` first, then falls back to \`model.default\`
- No new dependencies, no migration needed

## Use case

Users who want a lighter/cheaper model for messaging platforms while keeping a powerful model for CLI work.