### PR TITLE
feat(browser): add 6 new tools (hover/select/wait/forward/reload/scroll-to) + vision hardening

### DIFF
--- a/tests/tools/test_browser_new_tools.py
+++ b/tests/tools/test_browser_new_tools.py
@@ -1,0 +1,225 @@
+"""Tests for 6 new browser tools: hover, select, wait, forward, reload, scroll_to.
+
+Verifies schemas, handlers, description fixes, and _EMPTY_OK_COMMANDS updates.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    """Reset browser_tool module-level caches between tests."""
+    import tools.browser_tool as bt
+    bt._cached_agent_browser = None
+    bt._agent_browser_resolved = False
+    bt._cached_command_timeout = None
+    bt._command_timeout_resolved = False
+    yield
+    bt._cached_agent_browser = None
+    bt._agent_browser_resolved = False
+    bt._cached_command_timeout = None
+    bt._command_timeout_resolved = False
+
+
+# ---------------------------------------------------------------------------
+# PART 1: All 6 new tools present in BROWSER_TOOL_SCHEMAS
+# ---------------------------------------------------------------------------
+
+NEW_TOOL_NAMES = [
+    "browser_hover",
+    "browser_select",
+    "browser_wait",
+    "browser_forward",
+    "browser_reload",
+    "browser_scroll_to",
+]
+
+
+class TestNewToolSchemas:
+    """Verify all 6 new tool schemas are present and well-formed."""
+
+    def _schema_names(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        return [s["name"] for s in BROWSER_TOOL_SCHEMAS]
+
+    @pytest.mark.parametrize("tool_name", NEW_TOOL_NAMES)
+    def test_schema_exists(self, tool_name):
+        assert tool_name in self._schema_names()
+
+    def test_total_schema_count(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        assert len(BROWSER_TOOL_SCHEMAS) == 16
+
+    def test_hover_schema_has_ref(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_hover")
+        assert "ref" in schema["parameters"]["properties"]
+        assert "ref" in schema["parameters"]["required"]
+
+    def test_select_schema_has_ref_and_value(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_select")
+        props = schema["parameters"]["properties"]
+        assert "ref" in props
+        assert "value" in props
+        assert set(schema["parameters"]["required"]) == {"ref", "value"}
+
+    def test_wait_schema_has_selector_or_ms(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_wait")
+        assert "selector_or_ms" in schema["parameters"]["properties"]
+        assert "selector_or_ms" in schema["parameters"]["required"]
+
+    def test_forward_schema_no_params(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_forward")
+        assert schema["parameters"]["properties"] == {}
+        assert schema["parameters"]["required"] == []
+
+    def test_reload_schema_no_params(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_reload")
+        assert schema["parameters"]["properties"] == {}
+        assert schema["parameters"]["required"] == []
+
+    def test_scroll_to_schema_has_ref(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_scroll_to")
+        assert "ref" in schema["parameters"]["properties"]
+        assert "ref" in schema["parameters"]["required"]
+
+
+# ---------------------------------------------------------------------------
+# PART 1 (continued): All 6 handlers are callable
+# ---------------------------------------------------------------------------
+
+class TestNewToolHandlersCallable:
+    """Verify all 6 handler functions exist and are callable."""
+
+    @pytest.mark.parametrize("handler_name", NEW_TOOL_NAMES)
+    def test_handler_is_callable(self, handler_name):
+        import tools.browser_tool as bt
+        handler = getattr(bt, handler_name)
+        assert callable(handler)
+
+
+# ---------------------------------------------------------------------------
+# PART 1: forward and reload in _EMPTY_OK_COMMANDS
+# ---------------------------------------------------------------------------
+
+class TestEmptyOkCommands:
+
+    def test_forward_in_empty_ok(self):
+        from tools.browser_tool import _EMPTY_OK_COMMANDS
+        assert "forward" in _EMPTY_OK_COMMANDS
+
+    def test_reload_in_empty_ok(self):
+        from tools.browser_tool import _EMPTY_OK_COMMANDS
+        assert "reload" in _EMPTY_OK_COMMANDS
+
+    def test_original_commands_still_present(self):
+        from tools.browser_tool import _EMPTY_OK_COMMANDS
+        assert "close" in _EMPTY_OK_COMMANDS
+        assert "record" in _EMPTY_OK_COMMANDS
+
+
+# ---------------------------------------------------------------------------
+# PART 2: Schema description fixes
+# ---------------------------------------------------------------------------
+
+class TestSchemaDescriptionFixes:
+
+    def _get_description(self, name):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == name)
+        return schema["description"]
+
+    def test_browser_click_no_browser_snapshot(self):
+        desc = self._get_description("browser_click")
+        assert "browser_snapshot" not in desc
+        assert "browser_navigate" in desc
+
+    def test_browser_type_no_browser_snapshot(self):
+        desc = self._get_description("browser_type")
+        assert "browser_snapshot" not in desc
+        assert "browser_navigate" in desc
+
+    def test_browser_scroll_500px(self):
+        desc = self._get_description("browser_scroll")
+        assert "500px" in desc
+
+
+# ---------------------------------------------------------------------------
+# PART 1: Camofox mode returns unsupported for new tools
+# ---------------------------------------------------------------------------
+
+class TestCamofoxUnsupported:
+
+    @pytest.mark.parametrize("handler_name,kwargs", [
+        ("browser_hover", {"ref": "@e1"}),
+        ("browser_select", {"ref": "@e1", "value": "opt1"}),
+        ("browser_wait", {"selector_or_ms": "1000"}),
+        ("browser_forward", {}),
+        ("browser_reload", {}),
+        ("browser_scroll_to", {"ref": "@e1"}),
+    ])
+    @patch("tools.browser_tool._is_camofox_mode", return_value=True)
+    def test_camofox_returns_unsupported(self, _mock_camofox, handler_name, kwargs):
+        import tools.browser_tool as bt
+        handler = getattr(bt, handler_name)
+        result = json.loads(handler(**kwargs, task_id="test"))
+        assert result["success"] is False
+        assert "not supported in Camofox mode" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# PART 1: Ref normalization for ref-based tools
+# ---------------------------------------------------------------------------
+
+class TestRefNormalization:
+
+    @patch("tools.browser_tool._is_camofox_mode", return_value=False)
+    @patch("tools.browser_tool._run_browser_command")
+    def test_hover_adds_at_prefix(self, mock_cmd, _mock_camo):
+        mock_cmd.return_value = {"success": True}
+        import tools.browser_tool as bt
+        bt.browser_hover(ref="e5", task_id="test")
+        args = mock_cmd.call_args[0]
+        assert args[1] == "hover"
+        assert args[2] == ["@e5"]
+
+    @patch("tools.browser_tool._is_camofox_mode", return_value=False)
+    @patch("tools.browser_tool._run_browser_command")
+    def test_select_adds_at_prefix(self, mock_cmd, _mock_camo):
+        mock_cmd.return_value = {"success": True}
+        import tools.browser_tool as bt
+        bt.browser_select(ref="e3", value="option_a", task_id="test")
+        args = mock_cmd.call_args[0]
+        assert args[1] == "select"
+        assert args[2] == ["@e3", "option_a"]
+
+    @patch("tools.browser_tool._is_camofox_mode", return_value=False)
+    @patch("tools.browser_tool._run_browser_command")
+    def test_scroll_to_adds_at_prefix(self, mock_cmd, _mock_camo):
+        mock_cmd.return_value = {"success": True}
+        import tools.browser_tool as bt
+        bt.browser_scroll_to(ref="e10", task_id="test")
+        args = mock_cmd.call_args[0]
+        assert args[1] == "scrollintoview"
+        assert args[2] == ["@e10"]
+
+    @patch("tools.browser_tool._is_camofox_mode", return_value=False)
+    @patch("tools.browser_tool._run_browser_command")
+    def test_hover_preserves_at_prefix(self, mock_cmd, _mock_camo):
+        mock_cmd.return_value = {"success": True}
+        import tools.browser_tool as bt
+        bt.browser_hover(ref="@e5", task_id="test")
+        args = mock_cmd.call_args[0]
+        assert args[2] == ["@e5"]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -137,7 +137,7 @@ DEFAULT_COMMAND_TIMEOUT = 30
 SNAPSHOT_SUMMARIZE_THRESHOLD = 8000
 
 # Commands that legitimately return empty stdout (e.g. close, record).
-_EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record"})
+_EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record", "forward", "reload"})
 
 _cached_command_timeout: Optional[int] = None
 _command_timeout_resolved = False
@@ -563,7 +563,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_click",
-        "description": "Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first.",
+        "description": "Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate to be called first.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -577,7 +577,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_type",
-        "description": "Type text into an input field identified by its ref ID. Clears the field first, then types the new text. Requires browser_navigate and browser_snapshot to be called first.",
+        "description": "Type text into an input field identified by its ref ID. Clears the field first, then types the new text. Requires browser_navigate to be called first.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -595,7 +595,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_scroll",
-        "description": "Scroll the page in a direction. Use this to reveal more content that may be below or above the current viewport. Requires browser_navigate to be called first.",
+        "description": "Scroll the page in a direction. Use this to reveal more content that may be below or above the current viewport. Scrolls roughly one viewport (500px). Requires browser_navigate to be called first.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -676,6 +676,84 @@ BROWSER_TOOL_SCHEMAS = [
                 }
             },
             "required": []
+        }
+    },
+    {
+        "name": "browser_hover",
+        "description": "Hover over an element to trigger hover states, dropdown menus, or tooltips. Identify the element by its ref ID from the snapshot (e.g., '@e5').",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "type": "string",
+                    "description": "The element reference from the snapshot (e.g., '@e5', '@e12')"
+                }
+            },
+            "required": ["ref"]
+        }
+    },
+    {
+        "name": "browser_select",
+        "description": "Select an option from a dropdown menu (<select> element) by its value. Identify the dropdown by its ref ID from the snapshot.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "type": "string",
+                    "description": "The element reference from the snapshot (e.g., '@e5', '@e12')"
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The value of the option to select"
+                }
+            },
+            "required": ["ref", "value"]
+        }
+    },
+    {
+        "name": "browser_wait",
+        "description": "Wait for an element to appear or a specified number of milliseconds. Pass a CSS selector to wait for an element, or a number to wait for milliseconds. Useful for dynamic content on SPAs.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "selector_or_ms": {
+                    "type": "string",
+                    "description": "A CSS selector to wait for an element, or a number (in milliseconds) to wait"
+                }
+            },
+            "required": ["selector_or_ms"]
+        }
+    },
+    {
+        "name": "browser_forward",
+        "description": "Navigate forward to the next page in browser history.",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    },
+    {
+        "name": "browser_reload",
+        "description": "Reload the current page. Useful when page content may have changed or to retry a failed page load.",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    },
+    {
+        "name": "browser_scroll_to",
+        "description": "Scroll the page until a specific element is visible in the viewport. Identify the element by its ref ID from the snapshot.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "type": "string",
+                    "description": "The element reference from the snapshot (e.g., '@e5', '@e12')"
+                }
+            },
+            "required": ["ref"]
         }
     },
 ]
@@ -1793,6 +1871,216 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         }, ensure_ascii=False)
 
 
+def browser_hover(ref: str, task_id: Optional[str] = None) -> str:
+    """
+    Hover over an element to trigger hover states, dropdown menus, or tooltips.
+
+    Args:
+        ref: Element reference (e.g., "@e5")
+        task_id: Task identifier for session isolation
+
+    Returns:
+        JSON string with hover result
+    """
+    if _is_camofox_mode():
+        return json.dumps({
+            "success": False,
+            "error": "browser_hover not supported in Camofox mode"
+        }, ensure_ascii=False)
+
+    effective_task_id = task_id or "default"
+
+    # Ensure ref starts with @
+    if not ref.startswith("@"):
+        ref = f"@{ref}"
+
+    result = _run_browser_command(effective_task_id, "hover", [ref])
+
+    if result.get("success"):
+        return json.dumps({
+            "success": True,
+            "hovered": ref
+        }, ensure_ascii=False)
+    else:
+        return json.dumps({
+            "success": False,
+            "error": result.get("error", f"Failed to hover over {ref}")
+        }, ensure_ascii=False)
+
+
+def browser_select(ref: str, value: str, task_id: Optional[str] = None) -> str:
+    """
+    Select an option from a dropdown menu by its value.
+
+    Args:
+        ref: Element reference for the <select> element (e.g., "@e5")
+        value: The value of the option to select
+        task_id: Task identifier for session isolation
+
+    Returns:
+        JSON string with select result
+    """
+    if _is_camofox_mode():
+        return json.dumps({
+            "success": False,
+            "error": "browser_select not supported in Camofox mode"
+        }, ensure_ascii=False)
+
+    effective_task_id = task_id or "default"
+
+    # Ensure ref starts with @
+    if not ref.startswith("@"):
+        ref = f"@{ref}"
+
+    result = _run_browser_command(effective_task_id, "select", [ref, value])
+
+    if result.get("success"):
+        return json.dumps({
+            "success": True,
+            "selected": value,
+            "element": ref
+        }, ensure_ascii=False)
+    else:
+        return json.dumps({
+            "success": False,
+            "error": result.get("error", f"Failed to select '{value}' in {ref}")
+        }, ensure_ascii=False)
+
+
+def browser_wait(selector_or_ms: str, task_id: Optional[str] = None) -> str:
+    """
+    Wait for an element to appear or a specified number of milliseconds.
+
+    Args:
+        selector_or_ms: CSS selector to wait for, or number of milliseconds
+        task_id: Task identifier for session isolation
+
+    Returns:
+        JSON string with wait result
+    """
+    if _is_camofox_mode():
+        return json.dumps({
+            "success": False,
+            "error": "browser_wait not supported in Camofox mode"
+        }, ensure_ascii=False)
+
+    effective_task_id = task_id or "default"
+
+    result = _run_browser_command(effective_task_id, "wait", [selector_or_ms])
+
+    if result.get("success"):
+        return json.dumps({
+            "success": True,
+            "waited_for": selector_or_ms
+        }, ensure_ascii=False)
+    else:
+        return json.dumps({
+            "success": False,
+            "error": result.get("error", f"Failed to wait for {selector_or_ms}")
+        }, ensure_ascii=False)
+
+
+def browser_forward(task_id: Optional[str] = None) -> str:
+    """
+    Navigate forward in browser history.
+
+    Args:
+        task_id: Task identifier for session isolation
+
+    Returns:
+        JSON string with navigation result
+    """
+    if _is_camofox_mode():
+        return json.dumps({
+            "success": False,
+            "error": "browser_forward not supported in Camofox mode"
+        }, ensure_ascii=False)
+
+    effective_task_id = task_id or "default"
+    result = _run_browser_command(effective_task_id, "forward", [])
+
+    if result.get("success"):
+        data = result.get("data", {})
+        return json.dumps({
+            "success": True,
+            "url": data.get("url", "")
+        }, ensure_ascii=False)
+    else:
+        return json.dumps({
+            "success": False,
+            "error": result.get("error", "Failed to go forward")
+        }, ensure_ascii=False)
+
+
+def browser_reload(task_id: Optional[str] = None) -> str:
+    """
+    Reload the current page.
+
+    Args:
+        task_id: Task identifier for session isolation
+
+    Returns:
+        JSON string with reload result
+    """
+    if _is_camofox_mode():
+        return json.dumps({
+            "success": False,
+            "error": "browser_reload not supported in Camofox mode"
+        }, ensure_ascii=False)
+
+    effective_task_id = task_id or "default"
+    result = _run_browser_command(effective_task_id, "reload", [])
+
+    if result.get("success"):
+        data = result.get("data", {})
+        return json.dumps({
+            "success": True,
+            "url": data.get("url", "")
+        }, ensure_ascii=False)
+    else:
+        return json.dumps({
+            "success": False,
+            "error": result.get("error", "Failed to reload page")
+        }, ensure_ascii=False)
+
+
+def browser_scroll_to(ref: str, task_id: Optional[str] = None) -> str:
+    """
+    Scroll the page until a specific element is visible in the viewport.
+
+    Args:
+        ref: Element reference (e.g., "@e5")
+        task_id: Task identifier for session isolation
+
+    Returns:
+        JSON string with scroll result
+    """
+    if _is_camofox_mode():
+        return json.dumps({
+            "success": False,
+            "error": "browser_scroll_to not supported in Camofox mode"
+        }, ensure_ascii=False)
+
+    effective_task_id = task_id or "default"
+
+    # Ensure ref starts with @
+    if not ref.startswith("@"):
+        ref = f"@{ref}"
+
+    result = _run_browser_command(effective_task_id, "scrollintoview", [ref])
+
+    if result.get("success"):
+        return json.dumps({
+            "success": True,
+            "scrolled_to": ref
+        }, ensure_ascii=False)
+    else:
+        return json.dumps({
+            "success": False,
+            "error": result.get("error", f"Failed to scroll to {ref}")
+        }, ensure_ascii=False)
+
+
 def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
@@ -1816,6 +2104,58 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_vision
         return camofox_vision(question, annotate, task_id)
+
+    # --- Vision model pre-flight: fail fast if no vision-capable model ---
+    # Check the same chain that call_llm(task="vision") would use:
+    #   1. AUXILIARY_VISION_MODEL env var
+    #   2. auxiliary.vision.model config
+    #   3. AUXILIARY_MODEL env var
+    #   4. auxiliary.model config
+    # If none are set *and* no provider auto-detection is likely to work,
+    # return an actionable error instead of a cryptic RuntimeError deep
+    # inside the LLM call.
+    _preflight_model = (
+        os.getenv("AUXILIARY_VISION_MODEL", "").strip()
+        or os.getenv("AUXILIARY_MODEL", "").strip()
+    )
+    if not _preflight_model:
+        try:
+            from hermes_cli.config import load_config
+            _pf_cfg = load_config()
+            _pf_aux = _pf_cfg.get("auxiliary", {}) if isinstance(_pf_cfg, dict) else {}
+            _pf_vision = _pf_aux.get("vision", {}) if isinstance(_pf_aux, dict) else {}
+            if isinstance(_pf_vision, dict):
+                _preflight_model = str(_pf_vision.get("model", "")).strip()
+            if not _preflight_model:
+                _preflight_model = str(_pf_aux.get("model", "")).strip()
+        except Exception:
+            pass
+    if not _preflight_model:
+        # Last resort: check if any provider is configured that would auto-resolve
+        try:
+            from agent.auxiliary_client import resolve_vision_provider_client
+            _pf_provider, _pf_client, _pf_model = resolve_vision_provider_client(
+                provider="auto", async_mode=False)
+            if _pf_client is None:
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        "No vision-capable model is configured. "
+                        "Set AUXILIARY_VISION_MODEL env var, or configure "
+                        "auxiliary.vision.model in ~/.hermes/config.yaml, "
+                        "or run 'hermes setup' to configure a provider."
+                    ),
+                }, ensure_ascii=False)
+        except Exception:
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "No vision-capable model is configured. "
+                    "Set AUXILIARY_VISION_MODEL env var, or configure "
+                    "auxiliary.vision.model in ~/.hermes/config.yaml, "
+                    "or run 'hermes setup' to configure a provider."
+                ),
+            }, ensure_ascii=False)
 
     import base64
     import uuid as uuid_mod
@@ -1872,7 +2212,20 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                     f"or a stale daemon process."
                 ),
             }, ensure_ascii=False)
-        
+
+        # Check screenshot size before base64 encoding — reject huge files
+        _screenshot_size = screenshot_path.stat().st_size
+        if _screenshot_size > 5242880:  # 5 MB
+            return json.dumps({
+                "success": False,
+                "error": (
+                    f"Screenshot is too large ({_screenshot_size / 1048576:.1f} MB, "
+                    f"limit 5 MB). Try narrowing the viewport or using "
+                    f"browser_scroll to focus on a specific section."
+                ),
+                "screenshot_path": str(screenshot_path),
+            }, ensure_ascii=False)
+
         # Read and convert to base64
         image_data = screenshot_path.read_bytes()
         image_base64 = base64.b64encode(image_data).decode("ascii")
@@ -2273,4 +2626,52 @@ registry.register(
     handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖥️",
+)
+registry.register(
+    name="browser_hover",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_hover"],
+    handler=lambda args, **kw: browser_hover(ref=args.get("ref", ""), task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="👆",
+)
+registry.register(
+    name="browser_select",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_select"],
+    handler=lambda args, **kw: browser_select(ref=args.get("ref", ""), value=args.get("value", ""), task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="📋",
+)
+registry.register(
+    name="browser_wait",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_wait"],
+    handler=lambda args, **kw: browser_wait(selector_or_ms=args.get("selector_or_ms", ""), task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="⏳",
+)
+registry.register(
+    name="browser_forward",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_forward"],
+    handler=lambda args, **kw: browser_forward(task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="▶️",
+)
+registry.register(
+    name="browser_reload",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_reload"],
+    handler=lambda args, **kw: browser_reload(task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="🔄",
+)
+registry.register(
+    name="browser_scroll_to",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_scroll_to"],
+    handler=lambda args, **kw: browser_scroll_to(ref=args.get("ref", ""), task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="🎯",
 )


### PR DESCRIPTION
## Summary

Add 6 new browser tools, vision hardening, and schema description fixes. Follow-up to merged hardening PR #7354, as requested by maintainer in [#7276 review comment](https://github.com/NousResearch/hermes-agent/pull/7276#issuecomment).

**Tool count: 10 → 16. Tests: 35 new, 74 total passing.**

## New tools

Each is a thin wrapper around `_run_browser_command` following the existing tool patterns. All include Camofox unsupported handling and proper ref normalization.

| Tool | agent-browser command | Use case |
|------|----------------------|----------|
| `browser_hover` | `hover @eN` | Dropdown menus, tooltips, hover states |
| `browser_select` | `select @eN "value"` | Native `<select>` dropdown selection |
| `browser_wait` | `wait #selector` / `wait 2000` | SPA dynamic content loading |
| `browser_forward` | `forward` | Forward navigation |
| `browser_reload` | `reload` | Page reload |
| `browser_scroll_to` | `scrollintoview @eN` | Scroll specific element into viewport |

`forward` and `reload` added to `_EMPTY_OK_COMMANDS` (may legitimately return no stdout).

## Vision hardening

- **Screenshot size limit** — 5MB max before base64 encoding. Prevents OOM on infinite-scroll pages. Returns actionable error suggesting the user narrow focus.
- **Vision model pre-flight** — checks `AUXILIARY_VISION_MODEL` → config `auxiliary.vision.model` → `AUXILIARY_MODEL` → config `auxiliary.model` before taking screenshot. Returns clear error if no vision-capable model is configured, avoiding a wasted subprocess call.

## Schema description fixes

- `browser_click` / `browser_type` — removed stale "Requires browser_snapshot to be called first" (navigate already returns a compact snapshot)
- `browser_scroll` — added "Scrolls roughly one viewport (500px)" so the LLM knows the magnitude

## Test results

35 new tests covering: schema presence, handler callability, _EMPTY_OK_COMMANDS, description fixes, Camofox unsupported handling, ref normalization. 74 total browser tests passing.

Closes #7169
