### PR TITLE
fix(gateway): handle OSError/SystemError from os.kill on Windows

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7799,7 +7799,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 try:
                     os.kill(existing_pid, 0)
                     _time.sleep(0.5)
-                except (ProcessLookupError, PermissionError):
+                except (ProcessLookupError, PermissionError, OSError, SystemError):
                     break  # Process is gone
             else:
                 # Still alive after 10s — force kill

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -295,7 +295,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            except (ProcessLookupError, PermissionError, OSError, SystemError):
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -398,7 +398,7 @@ def get_running_pid() -> Optional[int]:
 
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    except (ProcessLookupError, PermissionError, OSError, SystemError):
         remove_pid_file()
         return None
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -215,7 +215,7 @@ def stop_profile_gateway() -> bool:
         try:
             os.kill(pid, 0)
             _time.sleep(0.5)
-        except (ProcessLookupError, PermissionError):
+        except (ProcessLookupError, PermissionError, OSError, SystemError):
             break
 
     remove_pid_file()

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -312,7 +312,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
         os.kill(pid, 0)  # existence check
         return True
     except (json.JSONDecodeError, KeyError, ValueError, TypeError,
-            ProcessLookupError, PermissionError, OSError):
+            ProcessLookupError, PermissionError, OSError, SystemError):
         return False
 
 
@@ -654,13 +654,13 @@ def _stop_gateway_process(profile_dir: Path) -> None:
             _time.sleep(0.5)
             try:
                 os.kill(pid, 0)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError, SystemError):
                 print(f"✓ Gateway stopped (PID {pid})")
                 return
         # Force kill
         try:
             os.kill(pid, _signal.SIGKILL)
-        except ProcessLookupError:
+        except (ProcessLookupError, OSError, SystemError):
             pass
         print(f"✓ Gateway force-stopped (PID {pid})")
     except (ProcessLookupError, PermissionError):

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,6 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
 import json
 import logging
 import os
@@ -146,10 +145,23 @@ class MemoryStore:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = open(lock_path, "w")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_EX)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            if os.name == "nt":
+                import msvcrt
+                try:
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_UN)
             fd.close()
 
     @staticmethod

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -136,7 +136,7 @@ class ProcessRegistry:
         try:
             os.kill(pid, 0)
             return True
-        except (ProcessLookupError, PermissionError):
+        except (ProcessLookupError, PermissionError, OSError, SystemError):
             return False
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -326,7 +326,17 @@ async def vision_analyze_tool(
         logger.info("User prompt: %s", user_prompt[:100])
         
         # Determine if this is a local file path or a remote URL
-        local_path = Path(os.path.expanduser(image_url))
+        # On Windows with Git Bash, paths like /h/Hermes/... need conversion
+        # to native Windows paths (H:\Hermes\...) for Path.is_file() to work.
+        resolved_url = image_url
+        if os.name == "nt" and resolved_url.startswith("/"):
+            import re as _re
+            _m = _re.match(r"^/([a-zA-Z])/(.*)$", resolved_url)
+            if _m:
+                _drive = _m.group(1).upper()
+                _rest = _m.group(2).replace("/", os.sep)
+                resolved_url = _drive + ":" + os.sep + _rest
+        local_path = Path(os.path.expanduser(resolved_url))
         if local_path.is_file():
             # Local file path (e.g. from platform image cache) -- skip download
             logger.info("Using local image file: %s", image_url)


### PR DESCRIPTION
## Summary

Three Windows compatibility bugs that break core functionality:

1. **`os.kill(pid, 0)` crashes on Windows** — raises `OSError` (WinError 87) or `SystemError` instead of `ProcessLookupError` for stale PIDs. Gateway cannot restart after non-clean shutdown.

2. **`memory_tool.py` fails to load on Windows** — unconditional `import fcntl` at module level. Persistent memory (MEMORY.md / USER.md) is completely unavailable for all Windows users.

3. **`vision_analyze` fails on Windows with Git Bash paths** — paths like `/h/Hermes/file.png` from terminal tool output are not valid Windows paths. `Path.is_file()` returns False, causing "Invalid image source" errors and agent loops.

## Changes

### os.kill exception handling (5 files, 6 call sites)
Added `OSError` and `SystemError` to except clauses:

| File | Function |
|------|----------|
| `gateway/status.py` | `get_running_pid()`, `acquire_scoped_lock()` |
| `gateway/run.py` | `start_gateway()` — wait for old process exit |
| `hermes_cli/gateway.py` | `stop_profile_gateway()` — wait for process exit |
| `hermes_cli/profiles.py` | `_check_gateway_running()`, `_stop_gateway_process()` |
| `tools/process_registry.py` | `_is_pid_alive()` |

### memory_tool fcntl → cross-platform (1 file)
- Removed top-level `import fcntl`
- `_file_lock()` now uses `msvcrt.locking` on Windows, `fcntl.flock` on Unix

### vision_tools Git Bash path conversion (1 file)
- Convert `/x/...` paths to `X:\...` on Windows before `Path.is_file()` check
- Uses regex match for `/drive-letter/rest` pattern

## Test plan

- [x] Windows 11 + Python 3.11: gateway restarts cleanly after non-clean shutdown
- [x] Windows 11: `import tools.memory_tool` succeeds
- [x] Windows 11: Git Bash path `/h/Hermes/hermes-agent/AGENTS.md` correctly resolves to `H:\Hermes\hermes-agent\AGENTS.md`
- [x] Verified `hermes gateway` connects to Feishu + Weixin with all tools available
- [ ] Linux/macOS: no behavior change — path conversion only triggers on `os.name == "nt"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)