### PR TITLE
fix(credential-pool): resolve kimi-coding base URL from API key prefix

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -24,6 +24,7 @@ from hermes_cli.auth import (
     _import_codex_cli_tokens,
     _load_auth_store,
     _load_provider_state,
+    _resolve_kimi_base_url,
     _resolve_zai_base_url,
     read_credential_pool,
     write_credential_pool,
@@ -1078,6 +1079,8 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
 
     for env_var in env_vars:
         token = os.getenv(env_var, "").strip()
+        # Strip terminal escape sequences that may contaminate pasted keys
+        token = re.sub(r'\x1b\[[A-Za-z0-9;]*|\x1b.', '', token).strip()
         if not token:
             continue
         source = f"env:{env_var}"
@@ -1086,6 +1089,8 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         base_url = env_url or pconfig.inference_base_url
         if provider == "zai":
             base_url = _resolve_zai_base_url(token, pconfig.inference_base_url, env_url)
+        elif provider == "kimi-coding":
+            base_url = _resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
         changed |= _upsert_entry(
             entries,
             provider,


### PR DESCRIPTION
## What does this PR do?

`_seed_from_env()` resolves provider-specific base URLs when seeding the credential pool from environment variables. It already handles the `zai` provider via `_resolve_zai_base_url()`, but `kimi-coding` was missing the equivalent `_resolve_kimi_base_url()` call. This caused `sk-kimi-` prefixed API keys (issued by platform.kimi.ai subscriptions) to always route to `api.moonshot.ai/v1` instead of the correct `api.kimi.com/coding/v1`, resulting in persistent HTTP 400 errors.

Additionally, pasted API keys can pick up invisible terminal escape sequences (e.g. `ESC[B`, `ESC+TAB`) that get persisted into the credential pool, breaking the `startswith("sk-kimi-")` prefix detection. This PR strips such sequences before persisting tokens.

## Related Issue

No existing issue — discovered during debugging of Kimi subscription key routing failures.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py`: Added `_resolve_kimi_base_url` import from `hermes_cli.auth`
- `agent/credential_pool.py`: Added `kimi-coding` branch in `_seed_from_env()` alongside existing `zai` handling (line ~1090)
- `agent/credential_pool.py`: Strip terminal escape sequences from env var tokens before use (line ~1081)

## How to Test

1. Set `KIMI_API_KEY` to a `sk-kimi-` prefixed key
2. Run `hermes` with `kimi-coding` provider and `kimi-k2.5` model
3. Verify the endpoint resolves to `https://api.kimi.com/coding/v1` (not `api.moonshot.ai/v1`)
4. Check `~/.hermes/auth.json` credential pool entry has the correct `base_url`

**Bonus (escape sequence test):**
1. Set `KIMI_API_KEY` to a value with leading escape chars: `export KIMI_API_KEY=$'\x1b[Bsk-kimi-testkey'`
2. Run hermes — verify the key is cleaned and routes correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A