### PR TITLE
feat(skills): add creative ideation — constraint-driven project generation

### DIFF
--- a/skills/creative/creative-ideation/SKILL.md
+++ b/skills/creative/creative-ideation/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: ideation
+title: Creative Ideation — Constraint-Driven Project Generation
+description: "Generate project ideas through creative constraints. Use when the user says 'I want to build something', 'give me a project idea', 'I'm bored', 'what should I make', 'inspire me', or any variant of 'I have tools but no direction'. Works for code, art, hardware, writing, tools, and anything that can be made."
+version: 1.0.0
+author: SHL0MS
+license: MIT
+metadata:
+  hermes:
+    tags: [Creative, Ideation, Projects, Brainstorming, Inspiration]
+    category: creative
+    requires_toolsets: []
+---
+
+# Creative Ideation
+
+Generate project ideas through creative constraints. Constraint + direction = creativity.
+
+## How It Works
+
+1. **Pick a constraint** from the library below — random, or matched to the user's domain/mood
+2. **Interpret it broadly** — a coding prompt can become a hardware project, an art prompt can become a CLI tool
+3. **Generate 3 concrete project ideas** that satisfy the constraint
+4. **If they pick one, build it** — create the project, write the code, ship it
+
+## The Rule
+
+Every prompt is interpreted as broadly as possible. "Does this include X?" → Yes. The prompts provide direction and mild constraint. Without either, there is no creativity.
+
+## Constraint Library
+
+### For Developers
+
+**Solve your own itch:**
+Build the tool you wished existed this week. Under 50 lines. Ship it today.
+
+**Automate the annoying thing:**
+What's the most tedious part of your workflow? Script it away. Two hours to fix a problem that costs you five minutes a day.
+
+**The CLI tool that should exist:**
+Think of a command you've wished you could type. `git undo-that-thing-i-just-did`. `docker why-is-this-broken`. `npm explain-yourself`. Now build it.
+
+**Nothing new except glue:**
+Make something entirely from existing APIs, libraries, and datasets. The only original contribution is how you connect them.
+
+**Frankenstein week:**
+Take something that does X and make it do Y. A git repo that plays music. A Dockerfile that generates poetry. A cron job that sends compliments.
+
+**Subtract:**
+How much can you remove from a codebase before it breaks? Strip a tool to its minimum viable function. Delete until only the essence remains.
+
+**High concept, low effort:**
+A deep idea, lazily executed. The concept should be brilliant. The implementation should take an afternoon. If it takes longer, you're overthinking it.
+
+### For Makers & Artists
+
+**Blatantly copy something:**
+Pick something you admire — a tool, an artwork, an interface. Recreate it from scratch. The learning is in the gap between your version and theirs.
+
+**One million of something:**
+One million is both a lot and not that much. One million pixels is a 1MB photo. One million API calls is a Tuesday. One million of anything becomes interesting at scale.
+
+**Make something that dies:**
+A website that loses a feature every day. A chatbot that forgets. A countdown to nothing. An exercise in rot, killing, or letting go.
+
+**Do a lot of math:**
+Generative geometry, shader golf, mathematical art, computational origami. Time to re-learn what an arcsin is.
+
+### For Anyone
+
+**Text is the universal interface:**
+Build something where text is the only interface. No buttons, no graphics, just words in and words out. Text can go in and out of almost anything.
+
+**Start at the punchline:**
+Think of something that would be a funny sentence. Work backwards to make it real. "I taught my thermostat to gaslight me" → now build it.
+
+**Hostile UI:**
+Make something intentionally painful to use. A password field that requires 47 conditions. A form where every label lies. A CLI that judges your commands.
+
+**Take two:**
+Remember an old project. Do it again from scratch. No looking at the original. See what changed about how you think.
+
+See `references/full-prompt-library.md` for 30+ additional constraints across communication, scale, philosophy, transformation, and more.
+
+## Matching Constraints to Users
+
+| User says | Pick from |
+|-----------|-----------|
+| "I want to build something" (no direction) | Random — any constraint |
+| "I'm learning [language]" | Blatantly copy something, Automate the annoying thing |
+| "I want something weird" | Hostile UI, Frankenstein week, Start at the punchline |
+| "I want something useful" | Solve your own itch, The CLI that should exist, Automate the annoying thing |
+| "I want something beautiful" | Do a lot of math, One million of something |
+| "I'm burned out" | High concept low effort, Make something that dies |
+| "Weekend project" | Nothing new except glue, Start at the punchline |
+| "I want a challenge" | One million of something, Subtract, Take two |
+
+## Output Format
+
+```
+## Constraint: [Name]
+> [The constraint, one sentence]
+
+### Ideas
+
+1. **[One-line pitch]**
+   [2-3 sentences: what you'd build and why it's interesting]
+   ⏱ [weekend / week / month] • 🔧 [stack]
+
+2. **[One-line pitch]**
+   [2-3 sentences]
+   ⏱ ... • 🔧 ...
+
+3. **[One-line pitch]**
+   [2-3 sentences]
+   ⏱ ... • 🔧 ...
+```
+
+## Example
+
+```
+## Constraint: The CLI tool that should exist
+> Think of a command you've wished you could type. Now build it.
+
+### Ideas
+
+1. **`git whatsup` — show what happened while you were away**
+   Compares your last active commit to HEAD and summarizes what changed,
+   who committed, and what PRs merged. Like a morning standup from your repo.
+   ⏱ weekend • 🔧 Python, GitPython, click
+
+2. **`explain 503` — HTTP status codes for humans**
+   Pipe any status code or error message and get a plain-English explanation
+   with common causes and fixes. Pulls from a curated database, not an LLM.
+   ⏱ weekend • 🔧 Rust or Go, static dataset
+
+3. **`deps why <package>` — why is this in my dependency tree**
+   Traces a transitive dependency back to the direct dependency that pulled
+   it in. Answers "why do I have 47 copies of lodash" in one command.
+   ⏱ weekend • 🔧 Node.js, npm/yarn lockfile parsing
+```
+
+After the user picks one, start building — create the project, write the code, iterate.
+
+## Attribution
+
+Constraint approach inspired by [wttdotm.com/prompts.html](https://wttdotm.com/prompts.html). Adapted and expanded for software development and general-purpose ideation.

--- a/skills/creative/creative-ideation/references/full-prompt-library.md
+++ b/skills/creative/creative-ideation/references/full-prompt-library.md
@@ -1,0 +1,110 @@
+# Full Prompt Library
+
+Extended constraint library beyond the core set in SKILL.md. Load these when the user wants more variety or a specific category.
+
+## Communication & Connection
+
+**Create a means of distribution:**
+The project works when you can use what you made to give something to somebody else.
+
+**Make a way to communicate:**
+The project works when you can hold a conversation with someone else using what you created. Not chat — something weirder.
+
+**Write a love letter:**
+To a person, a programming language, a game, a place, a tool. On paper, in code, in music, in light. Mail it.
+
+**Mail chess / Asynchronous games:**
+Something turn-based played with no time limit. No requirement to be there at the same time. The game happens in the gaps.
+
+**Twitch plays X:**
+A group of people share control over something. Collective input, emergent behavior.
+
+## Screens & Interfaces
+
+**Something for your desktop:**
+You spend a lot of time there. Spruce it up. A custom clock, a pet that lives in your terminal, a wallpaper that changes based on your git activity.
+
+**One screen, two screen, old screen, new screen:**
+Take something you associate with one screen and put it on a very different one. DOOM on a smart fridge. A spreadsheet on a watch. A terminal in a painting.
+
+**Make a mirror:**
+Something that reflects the viewer back at themselves. A website that shows your browsing history. A CLI that prints your git sins.
+
+## Philosophy & Concept
+
+**Code as koan, koan as code:**
+What is the sound of one hand clapping? A program that answers a question it wasn't asked. A function that returns before it's called.
+
+**The useless tree:**
+Make something useless. Deliberately, completely, beautifully useless. No utility. No purpose. No point. That's the point.
+
+**Artificial stupidity:**
+Make fun of AI by showcasing its faults. Mistrain it. Lie to it. Build the opposite of what AI is supposed to be good at.
+
+**"I use technology in order to hate it properly":**
+Make something inspired by the tension between loving and hating your tools.
+
+**The more things change, the more they stay the same:**
+Reflect on time, difference, and similarity.
+
+## Transformation
+
+**Translate:**
+Take something meant for one audience and make it understandable by another. A research paper as a children's book. An API as a board game. A song as an architecture diagram.
+
+**I mean, I GUESS you could store something that way:**
+The project works when you can save and open something. Store data in DNS caches. Encode a novel in emoji. Write a file system on top of something that isn't a file system.
+
+**I mean, I GUESS those could be pixels:**
+The project works when you can display an image. Render anything visual in a medium that wasn't meant for rendering.
+
+## Identity & Reflection
+
+**Make a self-portrait:**
+Be yourself? Be fake? Be real? In code, in data, in sound, in a directory structure.
+
+**Make a pun:**
+The stupider the better. Physical, digital, linguistic, visual. The project IS the joke.
+
+**Doors, walls, borders, barriers, boundaries:**
+Things that intermediate two places: opening, closing, permeating, excluding, combining.
+
+## Scale & Repetition
+
+**Lists!:**
+Itemizations, taxonomies, exhaustive recountings, iterations. This one. A list of list of lists.
+
+**Did you mean *recursion*?**
+Did you mean recursion?
+
+**Animals:**
+Lions, and tigers, and bears. Crab logic gates. Fish plays the stock market.
+
+**Cats:**
+Where would the internet be without them.
+
+## Starting Points
+
+**An idea that comes from a book:**
+Read something. Make something inspired by it.
+
+**Go to a museum:**
+Project ensues.
+
+**NPC loot:**
+What do you drop when you die? What do you take on your journey? Build the item.
+
+**Mythological objects and entities:**
+Pandora's box, the ocarina of time, the palantir. Build the artifact.
+
+**69:**
+Nice. Make something with the joke being the number 69.
+
+**Office Space printer scene:**
+Capture the same energy. Channel the catharsis of destroying the thing that frustrates you.
+
+**Borges week:**
+Something inspired by the Argentine. The library of babel. The map that is the territory.
+
+**Lights!:**
+LED throwies, light installations, illuminated anything. Make something that glows.


### PR DESCRIPTION
Generate project ideas through creative constraints. User says 'I want to build something' → agent picks a constraint, generates 3 concrete ideas with pitch/time/stack, and builds the one they pick.

**Core skill (147 lines):** 15 curated constraints — developer-focused ('solve your own itch', 'the CLI tool that should exist', 'automate the annoying thing') + maker + general. Matching table maps user mood to constraints. Complete worked example with 3 real project ideas (`git whatsup`, `explain 503`, `deps why`).

**Extended library (110 lines):** 30+ additional constraints in `references/` — communication, philosophy, transformation, scale, identity.

Constraint approach inspired by [wttdotm.com/prompts.html](https://wttdotm.com/prompts.html). Adapted for software development and general-purpose ideation.

2 files, 257 lines at `skills/creative/creative-ideation/`.