### PR TITLE
perf(ssh,modal): bulk file sync via tar pipe and tar/base64 archive

### DIFF
--- a/tests/tools/test_modal_bulk_upload.py
+++ b/tests/tools/test_modal_bulk_upload.py
@@ -1,0 +1,224 @@
+"""Tests for Modal bulk upload via tar/base64 archive."""
+
+import asyncio
+import base64
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.environments import modal as modal_env
+
+
+def _make_mock_modal_env(monkeypatch, tmp_path):
+    """Create a minimal mock ModalEnvironment for testing upload methods.
+
+    Returns a ModalEnvironment-like object with _sandbox and _worker mocked.
+    We don't call __init__ because it requires the Modal SDK.
+    """
+    env = object.__new__(modal_env.ModalEnvironment)
+    env._sandbox = MagicMock()
+    env._worker = MagicMock()
+    env._persistent = False
+    env._task_id = "test"
+    env._sync_manager = None
+    return env
+
+
+def _wire_async_exec(env, exec_calls=None):
+    """Wire mock sandbox.exec.aio and a real run_coroutine on the env.
+
+    Optionally captures exec call args into *exec_calls* list.
+    Returns a dict that will contain ``run_coroutine`` kwargs after
+    the next call (useful for timeout assertions).
+    """
+    if exec_calls is None:
+        exec_calls = []
+    run_kwargs: dict = {}
+
+    async def mock_exec(*args, **kwargs):
+        exec_calls.append(args)
+        proc = MagicMock()
+        proc.wait = MagicMock()
+        proc.wait.aio = AsyncMock(return_value=0)
+        return proc
+
+    env._sandbox.exec = MagicMock()
+    env._sandbox.exec.aio = mock_exec
+
+    def real_run_coroutine(coro, **kwargs):
+        run_kwargs.update(kwargs)
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    env._worker.run_coroutine = real_run_coroutine
+    return exec_calls, run_kwargs
+
+
+class TestModalBulkUpload:
+    """Test _modal_bulk_upload method."""
+
+    def test_empty_files_is_noop(self, monkeypatch, tmp_path):
+        """Empty file list should not call worker.run_coroutine."""
+        env = _make_mock_modal_env(monkeypatch, tmp_path)
+        env._modal_bulk_upload([])
+        env._worker.run_coroutine.assert_not_called()
+
+    def test_tar_archive_contains_all_files(self, monkeypatch, tmp_path):
+        """The tar archive sent to the sandbox should contain all files."""
+        env = _make_mock_modal_env(monkeypatch, tmp_path)
+
+        src_a = tmp_path / "a.json"
+        src_b = tmp_path / "b.py"
+        src_a.write_text("cred_content")
+        src_b.write_text("skill_content")
+
+        files = [
+            (str(src_a), "/root/.hermes/credentials/a.json"),
+            (str(src_b), "/root/.hermes/skills/b.py"),
+        ]
+
+        exec_calls, _ = _wire_async_exec(env)
+        env._modal_bulk_upload(files)
+
+        # Verify exec was called with bash -c and a tar command
+        assert len(exec_calls) == 1
+        args = exec_calls[0]
+        assert args[0] == "bash"
+        assert args[1] == "-c"
+        cmd = args[2]
+        assert "mkdir -p" in cmd
+        assert "base64 -d" in cmd
+        assert "tar xzf" in cmd
+        assert "-C /" in cmd
+
+        # Extract the base64 payload and verify tar contents
+        import re
+        match = re.search(r"echo '?([A-Za-z0-9+/=]+)'?", cmd)
+        assert match, f"Could not find base64 payload in command: {cmd}"
+        payload = match.group(1)
+
+        tar_data = base64.b64decode(payload)
+        buf = io.BytesIO(tar_data)
+        with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+            names = sorted(tar.getnames())
+            assert "root/.hermes/credentials/a.json" in names
+            assert "root/.hermes/skills/b.py" in names
+
+            # Verify content
+            a_content = tar.extractfile("root/.hermes/credentials/a.json").read()
+            assert a_content == b"cred_content"
+            b_content = tar.extractfile("root/.hermes/skills/b.py").read()
+            assert b_content == b"skill_content"
+
+    def test_mkdir_includes_all_parents(self, monkeypatch, tmp_path):
+        """Remote parent directories should be pre-created in the command."""
+        env = _make_mock_modal_env(monkeypatch, tmp_path)
+
+        src = tmp_path / "f.txt"
+        src.write_text("data")
+
+        files = [
+            (str(src), "/root/.hermes/credentials/f.txt"),
+            (str(src), "/root/.hermes/skills/deep/nested/f.txt"),
+        ]
+
+        exec_calls, _ = _wire_async_exec(env)
+        env._modal_bulk_upload(files)
+
+        cmd = exec_calls[0][2]
+        assert "/root/.hermes/credentials" in cmd
+        assert "/root/.hermes/skills/deep/nested" in cmd
+
+    def test_single_exec_call(self, monkeypatch, tmp_path):
+        """Bulk upload should use exactly one exec call regardless of file count."""
+        env = _make_mock_modal_env(monkeypatch, tmp_path)
+
+        files = []
+        for i in range(20):
+            src = tmp_path / f"file_{i}.txt"
+            src.write_text(f"content_{i}")
+            files.append((str(src), f"/root/.hermes/cache/file_{i}.txt"))
+
+        exec_calls, _ = _wire_async_exec(env)
+        env._modal_bulk_upload(files)
+
+        # Should be exactly 1 exec call, not 20
+        assert len(exec_calls) == 1
+
+    def test_bulk_upload_wired_in_filesyncmanager(self, monkeypatch):
+        """Verify ModalEnvironment passes bulk_upload_fn to FileSyncManager."""
+        captured_kwargs = {}
+
+        def capture_fsm(**kwargs):
+            captured_kwargs.update(kwargs)
+            return type("M", (), {"sync": lambda self, **k: None})()
+
+        monkeypatch.setattr(modal_env, "FileSyncManager", capture_fsm)
+
+        # Create a minimal env without full __init__
+        env = object.__new__(modal_env.ModalEnvironment)
+        env._sandbox = MagicMock()
+        env._worker = MagicMock()
+        env._persistent = False
+        env._task_id = "test"
+
+        # Manually call the part of __init__ that wires FileSyncManager
+        from tools.environments.file_sync import iter_sync_files
+        env._sync_manager = modal_env.FileSyncManager(
+            get_files_fn=lambda: iter_sync_files("/root/.hermes"),
+            upload_fn=env._modal_upload,
+            delete_fn=env._modal_delete,
+            bulk_upload_fn=env._modal_bulk_upload,
+        )
+
+        assert "bulk_upload_fn" in captured_kwargs
+        assert captured_kwargs["bulk_upload_fn"] is not None
+        assert callable(captured_kwargs["bulk_upload_fn"])
+
+    def test_timeout_set_to_120(self, monkeypatch, tmp_path):
+        """Bulk upload uses a 120s timeout (not the per-file 15s)."""
+        env = _make_mock_modal_env(monkeypatch, tmp_path)
+
+        src = tmp_path / "f.txt"
+        src.write_text("data")
+        files = [(str(src), "/root/.hermes/f.txt")]
+
+        _, run_kwargs = _wire_async_exec(env)
+        env._modal_bulk_upload(files)
+
+        assert run_kwargs.get("timeout") == 120
+
+    def test_nonzero_exit_raises(self, monkeypatch, tmp_path):
+        """Non-zero exit code from remote exec should raise RuntimeError."""
+        env = _make_mock_modal_env(monkeypatch, tmp_path)
+
+        src = tmp_path / "f.txt"
+        src.write_text("data")
+        files = [(str(src), "/root/.hermes/f.txt")]
+
+        async def mock_exec(*args, **kwargs):
+            proc = MagicMock()
+            proc.wait = MagicMock()
+            proc.wait.aio = AsyncMock(return_value=1)  # non-zero exit
+            return proc
+
+        env._sandbox.exec = MagicMock()
+        env._sandbox.exec.aio = mock_exec
+
+        def real_run_coroutine(coro, **kwargs):
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                loop.close()
+
+        env._worker.run_coroutine = real_run_coroutine
+
+        with pytest.raises(RuntimeError, match="Modal bulk upload failed"):
+            env._modal_bulk_upload(files)

--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -1,0 +1,239 @@
+"""Tests for SSH bulk upload via tar pipe."""
+
+import os
+import shutil
+import subprocess
+import tarfile
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from tools.environments import ssh as ssh_env
+from tools.environments.ssh import SSHEnvironment
+
+
+@pytest.fixture
+def mock_ssh_env(monkeypatch, tmp_path):
+    """Create an SSHEnvironment with mocked SSH/subprocess calls."""
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda _: "/usr/bin/ssh")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/testuser")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env, "FileSyncManager",
+        lambda **kw: type("M", (), {"sync": lambda self, **k: None})(),
+    )
+    env = SSHEnvironment(host="testhost", user="testuser")
+    return env
+
+
+class TestSSHBulkUpload:
+    """Test _ssh_bulk_upload method."""
+
+    def test_empty_files_is_noop(self, mock_ssh_env):
+        """Empty file list should not spawn any subprocess."""
+        with patch.object(subprocess, "run") as mock_run, \
+             patch.object(subprocess, "Popen") as mock_popen:
+            mock_ssh_env._ssh_bulk_upload([])
+            mock_run.assert_not_called()
+            mock_popen.assert_not_called()
+
+    def test_staging_directory_mirrors_remote_paths(self, mock_ssh_env, tmp_path):
+        """Files are staged in a temp dir matching their remote path layout."""
+        # Create source files
+        src_a = tmp_path / "a.txt"
+        src_b = tmp_path / "b.txt"
+        src_a.write_text("content_a")
+        src_b.write_text("content_b")
+
+        files = [
+            (str(src_a), "/home/testuser/.hermes/credentials/a.txt"),
+            (str(src_b), "/home/testuser/.hermes/skills/b.txt"),
+        ]
+
+        staged_files = {}
+
+        original_popen = subprocess.Popen
+
+        def capture_tar_popen(cmd, **kwargs):
+            # Intercept the tar create command to inspect staging dir
+            if cmd[0] == "tar" and "cf" in cmd:
+                staging_dir = cmd[cmd.index("-C") + 1]
+                for root, _dirs, fnames in os.walk(staging_dir):
+                    for f in fnames:
+                        full = os.path.join(root, f)
+                        rel = os.path.relpath(full, staging_dir)
+                        staged_files[rel] = Path(full).read_text()
+            mock = MagicMock()
+            mock.stdout = MagicMock()
+            mock.stderr = MagicMock()
+            mock.communicate.return_value = (b"", b"")
+            mock.returncode = 0
+            mock.wait.return_value = 0
+            return mock
+
+        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)):
+            with patch.object(subprocess, "Popen", side_effect=capture_tar_popen):
+                mock_ssh_env._ssh_bulk_upload(files)
+
+        assert "home/testuser/.hermes/credentials/a.txt" in staged_files
+        assert "home/testuser/.hermes/skills/b.txt" in staged_files
+        assert staged_files["home/testuser/.hermes/credentials/a.txt"] == "content_a"
+        assert staged_files["home/testuser/.hermes/skills/b.txt"] == "content_b"
+
+    def test_mkdir_called_before_tar(self, mock_ssh_env, tmp_path):
+        """Remote parent dirs are pre-created via SSH before tar transfer."""
+        src = tmp_path / "f.txt"
+        src.write_text("data")
+
+        files = [
+            (str(src), "/home/testuser/.hermes/credentials/f.txt"),
+            (str(src), "/home/testuser/.hermes/skills/deep/nested/f.txt"),
+        ]
+
+        run_calls = []
+
+        def mock_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return subprocess.CompletedProcess([], 0)
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.communicate.return_value = (b"", b"")
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        with patch.object(subprocess, "run", side_effect=mock_run):
+            with patch.object(subprocess, "Popen", return_value=mock_proc):
+                mock_ssh_env._ssh_bulk_upload(files)
+
+        # First subprocess.run call should be the mkdir
+        assert len(run_calls) == 1
+        mkdir_cmd = " ".join(run_calls[0])
+        assert "mkdir -p" in mkdir_cmd
+        assert "/home/testuser/.hermes/credentials" in mkdir_cmd
+        assert "/home/testuser/.hermes/skills/deep/nested" in mkdir_cmd
+
+    def test_tar_pipe_structure(self, mock_ssh_env, tmp_path):
+        """Verify tar create pipes into ssh tar extract."""
+        src = tmp_path / "x.txt"
+        src.write_text("hello")
+
+        files = [(str(src), "/home/testuser/.hermes/x.txt")]
+
+        popen_calls = []
+
+        def mock_popen(cmd, **kwargs):
+            popen_calls.append((cmd, kwargs))
+            mock = MagicMock()
+            mock.stdout = MagicMock()
+            mock.communicate.return_value = (b"", b"")
+            mock.returncode = 0
+            mock.wait.return_value = 0
+            return mock
+
+        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)):
+            with patch.object(subprocess, "Popen", side_effect=mock_popen):
+                mock_ssh_env._ssh_bulk_upload(files)
+
+        assert len(popen_calls) == 2
+
+        # First: tar create
+        tar_cmd = popen_calls[0][0]
+        assert tar_cmd[0] == "tar"
+        assert "cf" in tar_cmd
+        assert "-C" in tar_cmd
+        assert "stdout" in popen_calls[0][1] and popen_calls[0][1]["stdout"] == subprocess.PIPE
+
+        # Second: ssh tar extract
+        ssh_cmd = popen_calls[1][0]
+        assert "ssh" in ssh_cmd[0]
+        assert "tar" in ssh_cmd
+        assert "xf" in ssh_cmd
+        assert "-C" in ssh_cmd
+        assert "/" in ssh_cmd
+
+    def test_ssh_extract_failure_raises(self, mock_ssh_env, tmp_path):
+        """Non-zero exit from remote tar should raise RuntimeError."""
+        src = tmp_path / "f.txt"
+        src.write_text("data")
+
+        files = [(str(src), "/home/testuser/.hermes/f.txt")]
+
+        def mock_popen(cmd, **kwargs):
+            mock = MagicMock()
+            mock.stdout = MagicMock()
+            mock.communicate.return_value = (b"", b"tar: error writing output")
+            mock.returncode = 1
+            mock.wait.return_value = 0
+            return mock
+
+        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)):
+            with patch.object(subprocess, "Popen", side_effect=mock_popen):
+                with pytest.raises(RuntimeError, match="SSH bulk upload failed"):
+                    mock_ssh_env._ssh_bulk_upload(files)
+
+    def test_bulk_upload_wired_in_filesyncmanager(self, monkeypatch, tmp_path):
+        """Verify SSHEnvironment passes bulk_upload_fn to FileSyncManager."""
+        monkeypatch.setattr(ssh_env.shutil, "which", lambda _: "/usr/bin/ssh")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/u")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+
+        captured_kwargs = {}
+
+        def capture_fsm(**kwargs):
+            captured_kwargs.update(kwargs)
+            return type("M", (), {"sync": lambda self, **k: None})()
+
+        monkeypatch.setattr(ssh_env, "FileSyncManager", capture_fsm)
+
+        env = SSHEnvironment(host="h", user="u")
+        assert "bulk_upload_fn" in captured_kwargs
+        assert captured_kwargs["bulk_upload_fn"] is not None
+        assert callable(captured_kwargs["bulk_upload_fn"])
+
+    def test_control_socket_in_ssh_command(self, mock_ssh_env, tmp_path):
+        """SSH commands in bulk upload use the ControlMaster socket."""
+        src = tmp_path / "f.txt"
+        src.write_text("data")
+        files = [(str(src), "/home/testuser/.hermes/f.txt")]
+
+        popen_cmds = []
+
+        def mock_popen(cmd, **kwargs):
+            popen_cmds.append(cmd)
+            mock = MagicMock()
+            mock.stdout = MagicMock()
+            mock.communicate.return_value = (b"", b"")
+            mock.returncode = 0
+            mock.wait.return_value = 0
+            return mock
+
+        with patch.object(subprocess, "run", return_value=subprocess.CompletedProcess([], 0)):
+            with patch.object(subprocess, "Popen", side_effect=mock_popen):
+                mock_ssh_env._ssh_bulk_upload(files)
+
+        # The SSH extract command should include ControlPath
+        ssh_cmd = " ".join(popen_cmds[1])
+        assert "ControlPath=" in ssh_cmd
+        assert "testuser@testhost" in ssh_cmd
+
+    def test_mkdir_failure_raises(self, mock_ssh_env, tmp_path):
+        """Non-zero exit from remote mkdir should raise RuntimeError."""
+        src = tmp_path / "f.txt"
+        src.write_text("data")
+        files = [(str(src), "/home/testuser/.hermes/f.txt")]
+
+        def mock_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, returncode=1, stderr="Permission denied"
+            )
+
+        with patch.object(subprocess, "run", side_effect=mock_run):
+            with pytest.raises(RuntimeError, match="SSH mkdir failed"):
+                mock_ssh_env._ssh_bulk_upload(files)

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -5,8 +5,11 @@ wrapper, while preserving Hermes' persistent snapshot behavior across sessions.
 """
 
 import asyncio
+import base64
+import io
 import logging
 import shlex
+import tarfile
 import threading
 from pathlib import Path
 from typing import Any, Optional
@@ -259,13 +262,13 @@ class ModalEnvironment(BaseEnvironment):
             get_files_fn=lambda: iter_sync_files("/root/.hermes"),
             upload_fn=self._modal_upload,
             delete_fn=self._modal_delete,
+            bulk_upload_fn=self._modal_bulk_upload,
         )
         self._sync_manager.sync(force=True)
         self.init_session()
 
     def _modal_upload(self, host_path: str, remote_path: str) -> None:
         """Upload a single file via base64-over-exec."""
-        import base64
         content = Path(host_path).read_bytes()
         b64 = base64.b64encode(content).decode("ascii")
         container_dir = str(Path(remote_path).parent)
@@ -279,6 +282,45 @@ class ModalEnvironment(BaseEnvironment):
             await proc.wait.aio()
 
         self._worker.run_coroutine(_write(), timeout=15)
+
+    def _modal_bulk_upload(self, files: list[tuple[str, str]]) -> None:
+        """Upload many files in a single exec call via tar archive.
+
+        Creates a tar archive in memory containing all files with their
+        remote paths, base64-encodes it, and decodes+extracts in one
+        ``exec`` call.  Avoids per-file exec+encoding overhead (~581 files
+        goes from minutes to seconds).
+        """
+        if not files:
+            return
+
+        # Build a tar archive in memory with files at their remote paths
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for host_path, remote_path in files:
+                # Store with absolute path stripped of leading '/' so
+                # extracting at '/' recreates the full path
+                arcname = remote_path.lstrip("/")
+                tar.add(host_path, arcname=arcname)
+        payload = base64.b64encode(buf.getvalue()).decode("ascii")
+
+        # Pre-create all unique parent directories in one call
+        parents = sorted({str(Path(rp).parent) for _, rp in files})
+        mkdir_part = "mkdir -p " + " ".join(shlex.quote(p) for p in parents)
+
+        # Decode and extract in one exec: echo <b64> | base64 -d | tar xzf - -C /
+        cmd = f"{mkdir_part} && echo {shlex.quote(payload)} | base64 -d | tar xzf - -C /"
+        sandbox = self._sandbox
+
+        async def _bulk():
+            proc = await sandbox.exec.aio("bash", "-c", cmd)
+            exit_code = await proc.wait.aio()
+            if exit_code != 0:
+                raise RuntimeError(
+                    f"Modal bulk upload failed (exit {exit_code})"
+                )
+
+        self._worker.run_coroutine(_bulk(), timeout=120)
 
     def _modal_delete(self, remote_paths: list[str]) -> None:
         """Batch-delete remote files via exec."""

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,6 +1,7 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
 import logging
+import os
 import shlex
 import shutil
 import subprocess
@@ -50,6 +51,7 @@ class SSHEnvironment(BaseEnvironment):
             get_files_fn=lambda: iter_sync_files(f"{self._remote_home}/.hermes"),
             upload_fn=self._scp_upload,
             delete_fn=self._ssh_delete,
+            bulk_upload_fn=self._ssh_bulk_upload,
         )
         self._sync_manager.sync(force=True)
 
@@ -130,6 +132,73 @@ class SSHEnvironment(BaseEnvironment):
         result = subprocess.run(scp_cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
             raise RuntimeError(f"scp failed: {result.stderr.strip()}")
+
+    def _ssh_bulk_upload(self, files: list[tuple[str, str]]) -> None:
+        """Upload many files in a single SSH stream via tar pipe.
+
+        Creates a temporary staging directory mirroring the remote path
+        layout, tars it, and pipes through ``ssh tar xf -`` on the remote.
+        Single TCP stream, single subprocess pair — avoids per-file scp
+        round-trips (~581 files goes from minutes to seconds).
+        """
+        if not files:
+            return
+
+        with tempfile.TemporaryDirectory(prefix="hermes-ssh-bulk-") as staging:
+            # Stage files into a directory tree matching their remote paths.
+            # All remote paths are absolute (e.g. /home/user/.hermes/...),
+            # so we strip the leading '/' and recreate relative to staging.
+            for host_path, remote_path in files:
+                rel = remote_path.lstrip("/")
+                staged = os.path.join(staging, rel)
+                os.makedirs(os.path.dirname(staged), exist_ok=True)
+                shutil.copy2(host_path, staged)
+
+            # Pre-create all unique parent directories on remote in one call
+            parents = sorted({str(Path(rp).parent) for _, rp in files})
+            mkdir_cmd = self._build_ssh_command()
+            mkdir_cmd.append(
+                "mkdir -p " + " ".join(shlex.quote(p) for p in parents)
+            )
+            mkdir_result = subprocess.run(
+                mkdir_cmd, capture_output=True, text=True, timeout=30,
+            )
+            if mkdir_result.returncode != 0:
+                raise RuntimeError(
+                    f"SSH mkdir failed: {mkdir_result.stderr.strip()}"
+                )
+
+            # Pipe: tar cf - -C staging . | ssh tar xf - -C /
+            tar_create = subprocess.Popen(
+                ["tar", "cf", "-", "-C", staging, "."],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            ssh_cmd = self._build_ssh_command()
+            ssh_cmd.extend(["tar", "xf", "-", "-C", "/"])
+            tar_extract = subprocess.Popen(
+                ssh_cmd,
+                stdin=tar_create.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            # Allow tar_create to receive SIGPIPE if ssh process exits early
+            tar_create.stdout.close()
+
+            _, extract_stderr = tar_extract.communicate(timeout=120)
+            tar_create.wait(timeout=10)
+
+            if tar_create.returncode != 0:
+                create_err = tar_create.stderr.read() if tar_create.stderr else b""
+                logger.warning(
+                    "SSH bulk upload: local tar failed (rc=%d): %s",
+                    tar_create.returncode,
+                    create_err.decode("utf-8", errors="replace").strip(),
+                )
+
+            if tar_extract.returncode != 0:
+                err = extract_stderr.decode("utf-8", errors="replace").strip()
+                raise RuntimeError(f"SSH bulk upload failed: {err}")
 
     def _ssh_delete(self, remote_paths: list[str]) -> None:
         """Batch-delete remote files in one SSH call."""


### PR DESCRIPTION
## Summary

Wire `bulk_upload_fn` into SSH and Modal backends, matching the pattern established for Daytona in #7447. Eliminates per-file transfer overhead during `FileSyncManager.sync()`.

## Changes

### SSH (`tools/environments/ssh.py`)
- Add `_ssh_bulk_upload()`: stages files in a temp directory mirroring the remote path layout, then pipes `tar cf - | ssh tar xf -` in a single TCP stream
- Pre-creates all unique parent directories on remote in one SSH call before transfer
- Uses ControlMaster socket for the SSH connection (same as existing `_scp_upload`)
- Checks mkdir return code and raises on failure
- Logs tar_create stderr on local tar failure for debugging

### Modal (`tools/environments/modal.py`)
- Add `_modal_bulk_upload()`: builds an in-memory gzipped tar archive, base64-encodes it, and decodes+extracts in one `exec` call
- Pre-creates parent dirs in the same command (single `exec` call total)
- Uses 120s timeout for bulk (vs 15s for per-file)
- Checks exec exit code and raises on failure (unlike pre-existing `_modal_upload`)

### Tests
- `test_ssh_bulk_upload.py` — 8 tests: empty noop, staging dir layout, mkdir ordering, tar pipe structure, extract error, mkdir error, FileSyncManager wiring, ControlMaster usage
- `test_modal_bulk_upload.py` — 7 tests: empty noop, tar archive contents, mkdir coverage, single-exec verification, exit code error, FileSyncManager wiring, timeout

## Backend status

| Backend | Upload method | Bulk support | Status |
|---------|--------------|--------------|--------|
| Daytona | SDK `upload_files()` | ✔ #7447 | Already merged |
| SSH | `tar cf \| ssh tar xf` | ✔ this PR | **New** |
| Modal | `tar+base64 \| exec` | ✔ this PR | **New** |
| Docker | Bind mount | N/A | No sync needed |
| Singularity | Bind mount | N/A | No sync needed |

15 new tests, all passing. Existing file_sync, SSH, and Modal tests unaffected.

Closes #7465
Closes #7467
