### PR TITLE
fix(models): dedupe openai-codex model list, use canonical source

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7,6 +7,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import urllib.request
@@ -86,12 +87,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-pro",
         "openai/gpt-5.4-nano",
     ],
-    "openai-codex": [
-        "gpt-5.3-codex",
-        "gpt-5.2-codex",
-        "gpt-5.1-codex-mini",
-        "gpt-5.1-codex-max",
-    ],
+    # "openai-codex" is populated below from hermes_cli.codex_models to avoid
+    # two sources of truth disagreeing (this list was previously hardcoded and
+    # drifted stale — missing gpt-5.4, gpt-5.4-mini, etc.). The key is
+    # declared here so that iteration order in detect_provider_for_model()
+    # preserves openai-codex's historical priority over copilot for Codex
+    # slugs; its value is filled in right after the dict literal.
+    "openai-codex": [],
     "copilot-acp": [
         "copilot-acp",
     ],
@@ -281,6 +283,39 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "moonshotai/Kimi-K2-Thinking",
     ],
 }
+
+
+@functools.lru_cache(maxsize=1)
+def _get_codex_models_for_registry() -> list[str]:
+    """Return the canonical Codex model list for ``_PROVIDER_MODELS``.
+
+    Routes through :func:`hermes_cli.codex_models.get_codex_model_ids` with no
+    access token so the resolution falls through API → config.toml → cache →
+    ``DEFAULT_CODEX_MODELS`` without any network calls at import time. Cached
+    because this is hit from catalog-lookup hot paths.
+    """
+    try:
+        from hermes_cli.codex_models import (
+            DEFAULT_CODEX_MODELS,
+            get_codex_model_ids,
+        )
+    except Exception:
+        return []
+    try:
+        models = get_codex_model_ids(access_token=None)
+    except Exception:
+        models = list(DEFAULT_CODEX_MODELS)
+    # Defensive: if the resolver somehow returns an empty list, fall back
+    # to the hardcoded defaults so /model <codex-slug> still works.
+    if not models:
+        models = list(DEFAULT_CODEX_MODELS)
+    return list(models)
+
+
+# Populate the openai-codex entry from the canonical source of truth. This
+# runs once at module import; the cached helper makes repeat lookups cheap.
+_PROVIDER_MODELS["openai-codex"] = _get_codex_models_for_registry()
+
 
 # ---------------------------------------------------------------------------
 # Nous Portal free-model filtering

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -189,6 +189,74 @@ class TestDetectProviderForModel:
         assert result[0] not in ("nous",)  # nous has claude models but shouldn't be suggested
 
 
+class TestCodexProviderModels:
+    """Regression tests for the ``openai-codex`` provider model list.
+
+    Previously the entry was hardcoded inside ``_PROVIDER_MODELS`` and drifted
+    stale — missing newer Codex slugs like ``gpt-5.4`` and ``gpt-5.4-mini``.
+    The fix routes it through ``hermes_cli.codex_models.get_codex_model_ids``,
+    which falls back to ``DEFAULT_CODEX_MODELS`` when no access token is
+    available. This guards against the two-sources-of-truth regression.
+    """
+
+    def test_codex_list_matches_default_codex_models(self):
+        from hermes_cli.codex_models import DEFAULT_CODEX_MODELS
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        codex_models = _PROVIDER_MODELS["openai-codex"]
+        # Every canonical default Codex model must be present in the
+        # provider catalog used by auto-detection.
+        for mid in DEFAULT_CODEX_MODELS:
+            assert mid in codex_models, (
+                f"Codex model {mid!r} from DEFAULT_CODEX_MODELS missing from "
+                f"_PROVIDER_MODELS['openai-codex']; regression risk: the two "
+                f"sources of truth have diverged again."
+            )
+
+    def test_codex_list_includes_gpt_5_4_family(self):
+        """Explicit spot-check for the originally reported missing slugs."""
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        codex_models = _PROVIDER_MODELS["openai-codex"]
+        assert "gpt-5.4" in codex_models
+        assert "gpt-5.4-mini" in codex_models
+        assert "gpt-5.3-codex" in codex_models
+        assert "gpt-5.2-codex" in codex_models
+
+    def test_detect_provider_for_gpt_5_4_routes_to_codex(self, monkeypatch):
+        """`/model gpt-5.4` from a non-Codex current provider should auto-
+        detect ``openai-codex`` (not Copilot).
+
+        Iteration order in ``_PROVIDER_MODELS`` is significant: ``openai-codex``
+        is declared before ``copilot`` so the Codex provider wins the first
+        direct match for Codex slugs that appear in both lists. Copilot still
+        wins for its Copilot-only models (e.g. ``gpt-4.1``).
+        """
+        # Make sure no real provider credentials bias the result.
+        for env_var in (
+            "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "COPILOT_TOKEN",
+            "GITHUB_TOKEN", "CODEX_API_KEY",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=LIVE_OPENROUTER_MODELS):
+            result = detect_provider_for_model("gpt-5.4", "anthropic")
+        assert result is not None
+        assert result[0] == "openai-codex"
+        assert result[1] == "gpt-5.4"
+
+    def test_detect_provider_for_gpt_5_4_mini_routes_to_codex(self, monkeypatch):
+        for env_var in (
+            "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "COPILOT_TOKEN",
+            "GITHUB_TOKEN", "CODEX_API_KEY",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=LIVE_OPENROUTER_MODELS):
+            result = detect_provider_for_model("gpt-5.4-mini", "anthropic")
+        assert result is not None
+        assert result[0] == "openai-codex"
+        assert result[1] == "gpt-5.4-mini"
+
+
 class TestFilterNousFreeModels:
     """Tests for filter_nous_free_models — Nous Portal free-model policy."""
 


### PR DESCRIPTION
## Summary

`hermes_cli/models.py` had a stale hardcoded `_PROVIDER_MODELS["openai-codex"]` list that was missing newer Codex slugs like `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, etc. This was a second source of truth that had drifted out of sync with `hermes_cli/codex_models.py` (`DEFAULT_CODEX_MODELS` + `get_codex_model_ids()`).

## The bug

The old entry was:

```python
"openai-codex": [
    "gpt-5.3-codex",
    "gpt-5.2-codex",
    "gpt-5.1-codex-mini",
    "gpt-5.1-codex-max",
],
```

Consumed by:

1. `detect_provider_for_model()` in `hermes_cli/models.py` — the provider auto-detect path used by `/model <name>` with no explicit `--provider`. Because `gpt-5.4` was not in the list, Hermes couldn't infer that it belongs to `openai-codex` and failed to switch providers.
2. `list_authenticated_providers()` in `hermes_cli/model_switch.py` — the `/model` no-args display and selector showed a stale Codex model list via `curated.get(hermes_id, [])`.

Meanwhile `hermes_cli/codex_models.py` already had the canonical source of truth:

- `DEFAULT_CODEX_MODELS` — up-to-date fallback (`gpt-5.4-mini`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`).
- `get_codex_model_ids(access_token=None)` — live API → config.toml → cache → `DEFAULT_CODEX_MODELS` fallback chain.

Two sources disagreeing was the root cause.

## Reproduction

On a Codex-authed setup running Hermes:

- `/model gpt-5.4` fails to auto-switch to the `openai-codex` provider because `gpt-5.4` is not in the stale hardcoded list.
- `/model` with no arguments shows a stale Codex model list in the selector (missing `gpt-5.4`, `gpt-5.4-mini`).

## The fix

- Declare `"openai-codex"` in the `_PROVIDER_MODELS` literal as an empty list placeholder so iteration order is preserved (Codex still wins over Copilot for shared slugs like `gpt-5.4`).
- Add a small `_get_codex_models_for_registry()` helper wrapped in `functools.lru_cache(maxsize=1)` that calls `get_codex_model_ids(access_token=None)` from `hermes_cli.codex_models`. With no token, the resolver skips the network call and falls through to `DEFAULT_CODEX_MODELS`.
- Populate `_PROVIDER_MODELS["openai-codex"]` from the helper at module import time.

Because `list_authenticated_providers()` reads `curated.get(hermes_id, [])` from `_PROVIDER_MODELS`, it now automatically picks up the canonical list with no further changes.

## Tests

New regression tests in `tests/hermes_cli/test_models.py::TestCodexProviderModels`:

- `test_codex_list_matches_default_codex_models` — every entry in `DEFAULT_CODEX_MODELS` must also be in `_PROVIDER_MODELS["openai-codex"]`. Guards against the two-sources-of-truth regression.
- `test_codex_list_includes_gpt_5_4_family` — explicit spot-check for the originally missing slugs (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2-codex`).
- `test_detect_provider_for_gpt_5_4_routes_to_codex` — calling `detect_provider_for_model("gpt-5.4", "anthropic")` now returns `("openai-codex", "gpt-5.4")` rather than `None` or the OpenRouter fallback. Includes a comment explaining the `openai-codex` → `copilot` iteration order (Codex wins for Codex slugs; Copilot still wins for Copilot-only models like `gpt-4.1`).
- `test_detect_provider_for_gpt_5_4_mini_routes_to_codex` — same for `gpt-5.4-mini`.

All targeted tests pass:

```
tests/hermes_cli/test_models.py .................... 50 passed
tests/hermes_cli/test_codex_models.py ............... passed
tests/hermes_cli/test_model_switch_custom_providers.py ... passed
tests/hermes_cli/test_runtime_provider_resolution.py ... passed
tests/cli/test_cli_provider_resolution.py ........... passed
```

## Notes

- Reported by Marcel Ruhf (@marcelruhf) while using Hermes Agent.
- Minimal, surgical diff: no unrelated refactors, no touches to `~/.hermes` paths or code, no changes outside the stale-list bug.
- Iteration order preserved: `"openai-codex"` is still declared before `"copilot"` in `_PROVIDER_MODELS`, so auto-detect priority is unchanged for shared slugs.
