### PR TITLE
feat(skills): add Unraid devops skill suite

### DIFF
--- a/skills/devops/unraid-bypass-shfs-for-node-datadirs/SKILL.md
+++ b/skills/devops/unraid-bypass-shfs-for-node-datadirs/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: unraid-bypass-shfs-for-node-datadirs
+description: Move/point heavy blockchain node datadirs off /mnt/user (shfs/FUSE) to the direct pool path (/mnt/cache or /mnt/<pool>) with safe stop, verify, switch, recreate steps; includes Portainer compose and docker run cases.
+version: 1.0.0
+author: scotthawk-maker
+license: MIT
+metadata:
+  hermes:
+    tags: [Unraid, Docker, shfs, FUSE, performance, blockchain, node]
+    related_skills: [unraid-shfs-audit, unraid-container-repoint, unraid-container-limits, unraid-docker-cleanup]
+---
+
+# Goal
+Reduce `shfs` overhead by ensuring node datadirs are accessed via the **direct pool mount** (e.g. `/mnt/cache/appdata/...` or `/mnt/<pool>/appdata/...`) instead of `/mnt/user/appdata/...`.
+
+# Why
+`/mnt/user` goes through Unraid `shfs` (FUSE). Large DB workloads with many files can cause high `shfs` CPU and sluggish I/O.
+
+# Procedure
+
+## 0) Pre-flight checks
+Run:
+```bash
+cat /proc/mdstat | sed -n '1,160p'
+pgrep -x mover && pgrep -ax mover || echo mover_not_running
+find /mnt -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort
+
+df -hT /mnt/cache /mnt/cache/appdata /mnt/user /mnt/user/appdata
+```
+- If mover is running, wait.
+- If array/pool degraded and you can’t risk a long copy, consider postponing.
+
+## 1) Identify source folders and pool destinations
+Typical sources:
+- `/mnt/user/appdata/<container-folder>`
+Destinations:
+- `/mnt/cache/appdata/<container-folder>` (if pool name is `cache`)
+- or `/mnt/<poolname>/appdata/<container-folder>`
+
+Check sizes on both paths:
+```bash
+du -sh /mnt/user/appdata/<folder>
+du -sh /mnt/cache/appdata/<folder> || echo missing
+```
+
+### Key optimization (learned): if the destination already exists with the same size
+On Unraid, `/mnt/user/appdata/...` may already be a user-share view of the same pool path. If sizes match and the destination exists, you can often **skip rsync** and just repoint binds.
+
+## 2) Determine container management style
+### A) Compose-managed (often Portainer)
+Find compose files:
+```bash
+find /mnt/cache/appdata/portainer/compose -maxdepth 2 -type f -name docker-compose.yml -print
+```
+Then inspect labels to locate project + compose path:
+```bash
+docker inspect -f '{{.Name}} labels={{json .Config.Labels}}' <container> | head -c 5000
+```
+Common labels:
+- `com.docker.compose.project`
+- `com.docker.compose.project.config_files`
+
+### B) Direct docker run
+Check binds:
+```bash
+docker inspect -f '{{.Name}} Binds={{json .HostConfig.Binds}}' <container>
+```
+Also note network + published ports:
+```bash
+docker inspect -f '{{.Name}} Network={{.HostConfig.NetworkMode}} Ports={{json .NetworkSettings.Ports}} Cmd={{json .Config.Cmd}}' <container>
+```
+
+## 3) Stop containers (avoid DB corruption)
+```bash
+docker stop -t 120 <bitcoin> <doge> <tari>
+```
+
+## 4) Update mounts to direct pool paths
+
+### 4A) Compose case (Portainer stacks)
+1) **Back up** compose file:
+```bash
+cp -a /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml \
+      /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml.bak.$(date +%Y%m%d-%H%M%S)
+```
+2) Edit volume lines, e.g.:
+- From: `/mnt/user/appdata/bitcoin-node:/home/bitcoin/.bitcoin`
+- To:   `/mnt/cache/appdata/bitcoin-node:/home/bitcoin/.bitcoin`
+
+3) Redeploy with the correct project name:
+```bash
+docker compose -p <project> -f /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml up -d --force-recreate
+```
+
+### 4B) Direct docker run case (example: Tari)
+1) Record existing settings (network, ports, command, image).
+2) Remove old container:
+```bash
+docker rm -f <container>
+```
+3) Recreate with updated bind:
+```bash
+docker run -d \
+  --name <container> \
+  --network <network> \
+  -p <hostport>:<containerport> \
+  -v /mnt/cache/appdata/<path>:/var/tari/node \
+  <image> <cmd...>
+```
+
+## 5) Verify
+### Verify binds
+```bash
+for c in bitcoin-node dogecoin-node seahawks-tari; do
+  docker inspect -f '{{.Name}} Binds={{json .HostConfig.Binds}}' $c
+done
+```
+### Verify running
+```bash
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | egrep '^(NAMES|bitcoin-node|dogecoin-node|seahawks-tari)'
+```
+### Check shfs CPU and node CPU
+```bash
+ps -C shfs -o pid,%cpu,%mem,etime,cmd
+ps -eo pid,comm,%cpu,%mem,etime,args --sort=-%cpu | head -n 15
+```
+
+# Rollback
+- Compose: restore the backed-up compose file and rerun `docker compose up -d --force-recreate`.
+- Direct run: recreate container with original `/mnt/user/...` bind.
+
+# Notes / Pitfalls
+- `pgrep -af mover` can match your own command line; use `pgrep -x mover` to check mover reliably.
+- `docker compose` may need longer than 180s if it pulls images; rerun is idempotent.
+- Even after bypassing shfs for node DBs, the system can still feel slow due to CPU-heavy syncing; consider CPU caps (`--cpus`) before memory caps.
+- **Session-killing risk**: If your AI assistant (e.g. ollama) runs through one of the containers you're repointing, restarting that container will kill your active session. Always repoint the model-serving container LAST, or check first — it may already be on a direct path (e.g. ollama uses `/mnt/cache/ollama` rather than `/mnt/user/appdata/ollama`).
+- **Non-standard paths**: Not all containers use `/mnt/user/appdata/<container-name>`. Some (like ollama) use entirely different paths like `/mnt/cache/ollama`. Always `docker inspect` the actual Binds before assuming the pattern.
+- **Compose file location**: Docker labels (`com.docker.compose.project.config_files`) may show `/data/compose/80/docker-compose.yml` but the real filesystem path is `/mnt/cache/appdata/portainer/compose/80/docker-compose.yml`. Use `find` to locate the actual file if the label path doesn't resolve.
+- **Same-data shortcut confirmed**: When `du -sh` shows identical sizes on `/mnt/user/appdata/<folder>` and `/mnt/cache/appdata/<folder>`, they are the same data (FUSE view of the pool) — you can skip rsync entirely and just repoint the bind mount.

--- a/skills/devops/unraid-container-limits/SKILL.md
+++ b/skills/devops/unraid-container-limits/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: unraid-container-limits
+description: Apply and persist Docker container memory/CPU resource limits on Unraid. Re-applies limits after container recreations. Uses docker update for live application and provides persistent re-apply commands.
+version: 1.0.0
+author: scotthawk-maker
+license: MIT
+metadata:
+  hermes:
+    tags: [Unraid, Docker, resource-limits, memory, CPU, performance]
+    related_skills: [unraid-container-repoint, unraid-docker-cleanup]
+---
+
+# Goal
+Apply resource limits to all Docker containers on Unraid to prevent resource hogging. Limits are applied live via `docker update` but must be re-applied after any container recreation.
+
+# Current Limits (ScottHawk system)
+
+These are the tested and working limits for this specific system (Xeon E5-2620 v3, 62GB RAM, 12 threads):
+
+| Container | Memory | Reservation | CPUs |
+|-----------|--------|-------------|------|
+| PortainerCE | 512m | 256m | 0.5 |
+| unomp-redis | 512m | 256m | 0.5 |
+| dogecoin-exporter | 256m | 128m | 0.5 |
+| Dashboard-Logs | 256m | 128m | 0.5 |
+| seahawks-p2pool | 256m | 128m | 0.5 |
+| seahawks-proxy | 256m | 128m | 0.5 |
+| seahawks-dashboard | 256m | 128m | 0.5 |
+| obsidian | 1g | 512m | 1 |
+| mcpo | 1g | 512m | 1 |
+| public-pool | 1g | 512m | 1 |
+| unomp-portal | 1g | 512m | 1 |
+| seahawks-monero | 2g | 1g | 2 |
+| open-webui | 2g | 1g | 1 |
+| bitcoin-node | 4g | 2g | 2 |
+| ollama | 8g | 4g | 4 |
+| unsloth-studio | 16g | 8g | 4 |
+
+# Procedure
+
+## 1) Apply limits to all containers (live, no restart)
+
+```bash
+docker update --memory=512m --memory-reservation=256m --cpus=0.5 PortainerCE
+docker update --memory=512m --memory-reservation=256m --cpus=0.5 unomp-redis
+docker update --memory=256m --memory-reservation=128m --cpus=0.5 dogecoin-exporter
+docker update --memory=256m --memory-reservation=128m --cpus=0.5 Dashboard-Logs
+docker update --memory=256m --memory-reservation=128m --cpus=0.5 seahawks-p2pool
+docker update --memory=256m --memory-reservation=128m --cpus=0.5 seahawks-proxy
+docker update --memory=256m --memory-reservation=128m --cpus=0.5 seahawks-dashboard
+docker update --memory=1g --memory-reservation=512m --cpus=1 obsidian
+docker update --memory=1g --memory-reservation=512m --cpus=1 mcpo
+docker update --memory=1g --memory-reservation=512m --cpus=1 public-pool
+docker update --memory=1g --memory-reservation=512m --cpus=1 unomp-portal
+docker update --memory=2g --memory-reservation=1g --cpus=2 seahawks-monero
+docker update --memory=2g --memory-reservation=1g --cpus=1 open-webui
+docker update --memory=4g --memory-reservation=2g --cpus=2 bitcoin-node
+docker update --memory=8g --memory-reservation=4g --cpus=4 ollama
+docker update --memory=16g --memory-reservation=8g --cpus=4 unsloth-studio
+```
+
+## 2) Verify limits applied
+
+```bash
+for c in PortainerCE unomp-redis dogecoin-exporter Dashboard-Logs seahawks-p2pool seahawks-proxy seahawks-dashboard obsidian mcpo public-pool unomp-portal seahawks-monero open-webui bitcoin-node ollama unsloth-studio; do
+  echo "$(docker inspect -f '{{.Name}} mem={{.HostConfig.Memory}} reservation={{.HostConfig.MemoryReservation}} cpus={{.HostConfig.NanoCpus}}' $c)"
+done
+```
+
+## 3) Verify all containers still running
+
+```bash
+docker ps --format '{{.Names}}\t{{.Status}}'
+```
+
+# Pitfalls
+- `docker update` limits are NOT persistent. If a container is recreated (docker rm + run, compose up --force-recreate, image update), limits must be re-applied.
+- The "Your kernel does not support swap limit capabilities" warning is normal on Unraid — memory limits work, just no swap accounting.
+- If a container gets OOM killed, check `docker inspect -f '{{.State.OOMKilled}}' <container>` and consider raising its memory limit.
+- For compose-managed containers, limits can be added to docker-compose.yml under `deploy.resources.limits` for persistence.

--- a/skills/devops/unraid-container-repoint/SKILL.md
+++ b/skills/devops/unraid-container-repoint/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: unraid-container-repoint
+description: Stop, remove, and recreate a Docker container on Unraid with updated volume bind mounts. Handles both direct docker-run and Portainer compose-managed containers. Preserves all original config (env, ports, network, restart policy, image).
+version: 1.0.0
+author: scotthawk-maker
+license: MIT
+metadata:
+  hermes:
+    tags: [Unraid, Docker, volumes, bind-mount, repoint]
+    related_skills: [unraid-shfs-audit, unraid-bypass-shfs-for-node-datadirs, unraid-container-limits]
+---
+
+# Goal
+Safely repoint a container's volume binds from `/mnt/user/...` (shfs/FUSE) to direct pool paths (`/mnt/cache/...`, `/mnt/diskX/...`) on Unraid, preserving all other configuration.
+
+# Determine management style first
+
+```bash
+docker inspect -f '{{.Name}} compose={{index .Config.Labels "com.docker.compose.project"}} compose_config={{index .Config.Labels "com.docker.compose.project.config_files"}}' <container>
+```
+
+- If `compose=` is empty: **direct docker run** — use Procedure A
+- If `compose=` has a value: **compose-managed** — use Procedure B
+
+---
+
+## Procedure A: Direct docker-run container
+
+### 1) Capture full container config
+```bash
+docker inspect <container> --format '{{json .Config.Env}}'
+docker inspect <container> --format '{{json .HostConfig.RestartPolicy}}'
+docker inspect <container> --format '{{json .HostConfig.PortBindings}}'
+docker inspect <container> --format '{{json .HostConfig.Binds}}'
+docker inspect <container> --format '{{.Config.Image}}'
+docker inspect <container> --format '{{.HostConfig.NetworkMode}}'
+docker inspect <container> --format '{{json .Config.Cmd}}'
+```
+
+### 2) Stop and remove the container
+```bash
+docker stop -t 30 <container> && docker rm <container>
+```
+
+### 3) Recreate with updated binds
+Replace `/mnt/user/appdata/...` with `/mnt/cache/appdata/...` (or `/mnt/diskX/appdata/...`) in the `-v` flags. Keep all other flags identical.
+
+```bash
+docker run -d \
+  --name <container> \
+  --network <network> \
+  -e "KEY=VALUE" \
+  -p <hostport>:<containerport> \
+  -v /mnt/cache/appdata/<path>:/container/path:rw \
+  <image>
+```
+
+### 4) Verify
+```bash
+docker inspect -f '{{.Name}} Binds={{json .HostConfig.Binds}} Status={{.State.Status}}' <container>
+```
+
+---
+
+## Procedure B: Compose-managed (Portainer stack)
+
+### 1) Locate the compose file
+```bash
+# From compose_config label, e.g. /data/compose/80/docker-compose.yml
+# On Unraid, actual file is usually at:
+find /mnt/cache/appdata/portainer/compose -name docker-compose.yml
+```
+
+### 2) Backup the compose file
+```bash
+cp -a /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml \
+      /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml.bak.$(date +%Y%m%d-%H%M%S)
+```
+
+### 3) Edit volume paths in the compose file
+```bash
+sed -i 's|/mnt/user/appdata/|/mnt/cache/appdata/|g' \
+  /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml
+```
+
+### 4) Stop, remove, and recreate with compose
+```bash
+docker stop -t 30 <container1> <container2>
+docker rm <container1> <container2>
+docker compose -p <project> -f /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml up -d --force-recreate
+```
+
+### 5) Verify
+```bash
+for c in <container1> <container2>; do
+  docker inspect -f '{{.Name}} Binds={{json .HostConfig.Binds}} Status={{.State.Status}}' $c
+done
+```
+
+### 6) Cleanup (optional, after verifying)
+```bash
+rm /mnt/cache/appdata/portainer/compose/<id>/docker-compose.yml.bak.*
+```
+
+---
+
+# Re-applying resource limits after recreation
+`docker update` resource limits are NOT persistent across container recreations. After running Procedure A step 3 or Procedure B step 4, re-apply the container's limits using the unraid-container-limits skill.
+
+Quick reference for `docker run` recreation — add these flags:
+```
+--memory=<limit> --memory-reservation=<soft_limit> --cpus=<cores>
+```
+
+# Pitfalls
+- **Don't skip the config capture** — if you rm a container without recording env vars, ports, network, etc., you'll have to reconstruct from memory.
+- **Compose `version` attribute is obsolete** in newer docker compose — warning is harmless, can be removed.
+- **Check data exists at the new path first** — if `/mnt/cache/appdata/<folder>` doesn't exist or sizes don't match, you may need to rsync data before repointing.
+- **For containers running the current AI session** (e.g., ollama): restarting will kill the session. Repoint these LAST and warn the user they'll need to reconnect.
+- **Resource limits reset on recreate** — always re-apply `docker update` limits after any container recreation. See unraid-container-limits skill.

--- a/skills/devops/unraid-docker-cleanup/SKILL.md
+++ b/skills/devops/unraid-docker-cleanup/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: unraid-docker-cleanup
+description: Audit and clean orphaned Docker resources on Unraid — stopped containers, unused images, orphaned appdata dirs, dangling volumes, and build cache. Frees disk space on the cache pool.
+version: 1.0.0
+author: scotthawk-maker
+license: MIT
+metadata:
+  hermes:
+    tags: [Unraid, Docker, cleanup, disk-space, orphaned]
+    related_skills: [unraid-shfs-audit, unraid-container-repoint]
+---
+
+# Goal
+Free disk space on Unraid by removing orphaned Docker resources: stopped containers, unused images, orphaned appdata, dangling volumes, and build cache.
+
+# Procedure
+
+## 1) Inventory stopped containers
+```bash
+docker ps -a --format '{{.Names}}\t{{.Status}}\t{{.Image}}' | grep -v "Up "
+```
+Before removing, check their binds:
+```bash
+for c in <stopped_containers>; do
+  docker inspect -f '{{.Name}} Binds={{json .HostConfig.Binds}}' $c
+done
+```
+If the binds reference appdata dirs that should be kept (like blockchain data), ask the user before deleting.
+
+## 2) Remove stopped containers (after confirming)
+```bash
+docker rm <stopped_container_names>
+```
+
+## 3) Identify orphaned appdata dirs
+```bash
+for d in /mnt/cache/appdata/*/; do
+  name=$(basename "$d")
+  found=$(docker ps -a --format '{{.Names}}' | grep -i "$name" 2>/dev/null)
+  if [ -z "$found" ]; then
+    size=$(du -sh "$d" 2>/dev/null | awk '{print $1}')
+    echo "  ORPHANED: $name ($size)"
+  fi
+done
+```
+ALWAYS cross-reference with container binds — some appdata dirs have different names than their containers. Delete only dirs that have NO container reference.
+
+## 4) Remove orphaned appdata (after confirming)
+```bash
+rm -rf /mnt/cache/appdata/<orphaned_dir>
+```
+
+## 5) Prune unused Docker images
+```bash
+docker image prune -a -f
+```
+Removes images not used by any running container.
+
+## 6) Prune dangling volumes
+```bash
+# List first
+docker volume ls -q | while read v; do
+  used=$(docker ps -a --filter "volume=$v" --format '{{.Names}}' 2>/dev/null)
+  if [ -z "$used" ]; then
+    echo "  ORPHAN: $v"
+  fi
+done
+
+# Remove after confirming
+docker volume prune -f
+```
+
+## 7) Prune build cache
+```bash
+docker builder prune -f
+```
+
+## 8) Verify
+```bash
+docker system df
+du -sh /mnt/cache/appdata/
+```
+
+# Pitfalls
+- Blockchain data dirs (bitcoin-node, dogecoin-node, monero, etc.) can be 100+ GB — always confirm before deleting
+- Some appdata dirs are referenced by container names that don't match the folder name (e.g., seahawks-mining contains tari, monero, p2pool subdirs)
+- `docker volume prune` will NOT remove volumes referenced by stopped containers — remove containers first
+- Named volumes like `open-webui` are used by active containers — check before pruning

--- a/skills/devops/unraid-shfs-audit/SKILL.md
+++ b/skills/devops/unraid-shfs-audit/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: unraid-shfs-audit
+description: Scan all Docker containers on Unraid for /mnt/user binds that go through shfs/FUSE, and flag candidates for repointing to direct pool paths. Reports current CPU usage of shfs process.
+version: 1.0.0
+author: scotthawk-maker
+license: MIT
+metadata:
+  hermes:
+    tags: [Unraid, Docker, shfs, FUSE, performance, audit]
+    related_skills: [unraid-bypass-shfs-for-node-datadirs, unraid-container-repoint, unraid-container-limits, unraid-docker-cleanup]
+---
+
+# Goal
+Identify Docker containers still binding volumes through `/mnt/user/...` (shfs/FUSE) so they can be repointed to direct pool paths (`/mnt/cache/...` or `/mnt/diskX/...`) for better performance.
+
+# Why
+`/mnt/user` routes through Unraid's shfs (FUSE filesystem). Heavy I/O workloads (databases, node datadirs, etc.) on shfs can cause high CPU and sluggish I/O. Bypassing shfs by using direct pool paths eliminates this overhead.
+
+# Procedure
+
+## 1) Scan all running containers for /mnt/user binds
+```bash
+echo "=== Containers with /mnt/user binds (going through shfs) ==="
+docker ps --format '{{.Names}}' | while read c; do
+  binds=$(docker inspect -f '{{json .HostConfig.Binds}}' "$c" 2>/dev/null)
+  if echo "$binds" | grep -q "/mnt/user/"; then
+    echo "  $c: $binds"
+  fi
+done
+```
+
+If nothing prints, all containers are already bypassing shfs.
+
+## 2) Show containers already on direct pool paths
+```bash
+echo "=== Containers on direct pool paths (bypassing shfs) ==="
+docker ps --format '{{.Names}}' | while read c; do
+  binds=$(docker inspect -f '{{json .HostConfig.Binds}}' "$c" 2>/dev/null)
+  if echo "$binds" | grep -qE "/mnt/(cache|disk[0-9]+)/"; then
+    echo "  $c: $binds"
+  fi
+done
+```
+
+## 3) Check shfs CPU usage
+```bash
+ps -C shfs -o pid,%cpu,%mem,etime,cmd
+```
+
+Normal idle: ~0-1%. Sustained >5% suggests containers are hammering shfs.
+
+## 4) Check container sizes on both paths
+For each container flagged with `/mnt/user` binds, check if data already exists on the direct pool:
+```bash
+# Example for a container with /mnt/user/appdata/something
+du -sh /mnt/user/appdata/<folder>
+du -sh /mnt/cache/appdata/<folder> 2>/dev/null || echo "Not on cache yet"
+```
+
+If sizes match, the data is already on cache (user share is just a FUSE view) — no rsync needed, just repoint the bind.
+
+## 5) Also check stopped containers
+```bash
+echo "=== Stopped containers on /mnt/user ==="
+docker ps -a --format '{{.Names}}' | while read c; do
+  status=$(docker inspect -f '{{.State.Status}}' "$c")
+  if [ "$status" != "running" ]; then
+    binds=$(docker inspect -f '{{json .HostConfig.Binds}}' "$c" 2>/dev/null)
+    if echo "$binds" | grep -q "/mnt/user/"; then
+      echo "  $c (STOPPED): $binds"
+    fi
+  fi
+done
+```
+
+# Output interpretation
+- **No /mnt/user binds found**: System is fully bypassing shfs. investigate shfs CPU separately.
+- **/mnt/user binds found, matching /mnt/cache data exists**: Safe to repoint — just swap bind paths, no data copy needed.
+- **/mnt/user binds found, no cache data**: Need to rsync data first, then repoint. Use the unraid-bypass-shfs-for-node-datadirs skill.


### PR DESCRIPTION
## What does this PR do?

Adds 5 Unraid devops skills for Docker container management and system optimization on Unraid servers.

These skills form a cohesive workflow suite:
1. **Audit** → `unraid-shfs-audit`: Scan containers for `/mnt/user` FUSE binds, report shfs CPU usage, flag candidates for repointing
2. **Repoint** → `unraid-bypass-shfs-for-node-datadirs` or `unraid-container-repoint`: Move container data off shfs to direct pool paths
3. **Limit** → `unraid-container-limits`: Apply memory/CPU resource limits via `docker update` (live, no restart)
4. **Maintain** → `unraid-docker-cleanup`: Audit and remove orphaned containers, images, appdata dirs, volumes, and build cache

### Why Unraid?

Unraid is a popular DIY NAS OS that uses a FUSE filesystem (`shfs`) for its user shares (`/mnt/user/...`). Heavy I/O workloads (blockchain nodes, databases) routing through shfs can cause significant CPU overhead and sluggish performance. These skills help users identify and fix that bottleneck, plus manage container resources and cleanup.

### Skills added

| Skill | Description |
|-------|------------|
| `unraid-shfs-audit` | Scan all containers for `/mnt/user` FUSE binds, report shfs CPU usage, identify candidates for repointing |
| `unraid-bypass-shfs-for-node-datadirs` | Full stop→verify→switch→recreate procedure for repointing heavy I/O containers off shfs, including Portainer compose and docker run cases |
| `unraid-container-repoint` | Stop, remove, and recreate a container with updated volume bind mounts, preserving all original config (env, ports, network, image) |
| `unraid-container-limits` | Apply and persist Docker container memory/CPU resource limits with `docker update`; includes table of recommended limits and re-apply commands for after container recreation |
| `unraid-docker-cleanup` | Audit and clean orphaned Docker resources: stopped containers, unused images, orphaned appdata dirs, dangling volumes, and build cache |

### Testing

All skills have been battle-tested on a production Unraid server:
- Repointed 5 containers off shfs (PortainerCE, obsidian, unomp-redis, unomp-portal, plus verified ollama was already on cache)
- Applied resource limits to 16 containers via `docker update`
- Cleaned ~171 GB of orphaned appdata, stale images, and unused volumes

## Related Issue

No existing issue — new skills contribution.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/devops/unraid-shfs-audit/SKILL.md`
- `skills/devops/unraid-bypass-shfs-for-node-datadirs/SKILL.md`
- `skills/devops/unraid-container-repoint/SKILL.md`
- `skills/devops/unraid-container-limits/SKILL.md`
- `skills/devops/unraid-docker-cleanup/SKILL.md`

## How to Test

1. Copy any skill to `~/.hermes/skills/devops/`
2. Restart Hermes Agent (or reload skills)
3. Ask the agent to scan Docker containers for shfs usage (`unraid-shfs-audit`)
4. Follow the skill workflow to repoint, limit, or clean up containers

Skills that require an Unraid system will only trigger when the agent detects Unraid-specific paths and commands. On non-Unraid systems they simply won't match.

## Checklist

- [x] Skills follow the SKILL.md format with YAML frontmatter
- [x] Skills have been tested on a real Unraid system
- [x] Skills include step-by-step procedures, not just descriptions
- [x] Safety considerations and pitfalls are documented
- [x] Skills reference each other where appropriate (related_skills in metadata)