### PR TITLE
fix(gateway): add threading.Lock to ResponseStore for concurrent access safety

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -289,7 +289,9 @@ class ResponseStore:
     Thread-safe: all public methods acquire a threading.Lock to prevent
     concurrent access from causing application-level logic bugs (TOCTOU
     in LRU eviction, lost access-time updates) under multi-threaded
-    gateway execution.
+    gateway execution.  A ``_closed`` flag set by :meth:`close` makes
+    all subsequent method calls no-ops, preventing ``ProgrammingError``
+    from threads that call into the store after shutdown.
 
     Persists across gateway restarts.  Falls back to in-memory SQLite
     if the on-disk path is unavailable.
@@ -298,6 +300,7 @@ class ResponseStore:
     def __init__(self, max_size: int = MAX_STORED_RESPONSES, db_path: str = None):
         self._max_size = max_size
         self._lock = threading.Lock()
+        self._closed = False
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
@@ -327,6 +330,8 @@ class ResponseStore:
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
         with self._lock:
+            if self._closed:
+                return None
             row = self._conn.execute(
                 "SELECT data FROM responses WHERE response_id = ?", (response_id,)
             ).fetchone()
@@ -342,6 +347,8 @@ class ResponseStore:
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
         with self._lock:
+            if self._closed:
+                return
             self._conn.execute(
                 "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
                 (response_id, json.dumps(data, default=str), time.time()),
@@ -359,6 +366,8 @@ class ResponseStore:
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
         with self._lock:
+            if self._closed:
+                return False
             cursor = self._conn.execute(
                 "DELETE FROM responses WHERE response_id = ?", (response_id,)
             )
@@ -368,6 +377,8 @@ class ResponseStore:
     def get_conversation(self, name: str) -> Optional[str]:
         """Get the latest response_id for a conversation name."""
         with self._lock:
+            if self._closed:
+                return None
             row = self._conn.execute(
                 "SELECT response_id FROM conversations WHERE name = ?", (name,)
             ).fetchone()
@@ -376,6 +387,8 @@ class ResponseStore:
     def set_conversation(self, name: str, response_id: str) -> None:
         """Map a conversation name to its latest response_id."""
         with self._lock:
+            if self._closed:
+                return
             self._conn.execute(
                 "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
                 (name, response_id),
@@ -386,8 +399,13 @@ class ResponseStore:
         """Close the database connection.
 
         Acquires the lock so no in-flight query races with the close.
+        Sets ``_closed`` so subsequent calls to public methods become no-ops
+        instead of raising ``ProgrammingError`` on the closed connection.
         """
         with self._lock:
+            if self._closed:
+                return
+            self._closed = True
             try:
                 self._conn.close()
             except Exception:
@@ -395,6 +413,8 @@ class ResponseStore:
 
     def __len__(self) -> int:
         with self._lock:
+            if self._closed:
+                return 0
             row = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()
             return row[0] if row else 0
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -30,6 +30,7 @@ import os
 import socket as _socket
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from typing import Any, Dict, List, Optional
@@ -285,12 +286,18 @@ class ResponseStore:
     (with tool calls and results) so it can be reconstructed on subsequent
     requests via previous_response_id.
 
+    Thread-safe: all public methods acquire a threading.Lock to prevent
+    concurrent access from causing application-level logic bugs (TOCTOU
+    in LRU eviction, lost access-time updates) under multi-threaded
+    gateway execution.
+
     Persists across gateway restarts.  Falls back to in-memory SQLite
     if the on-disk path is unavailable.
     """
 
     def __init__(self, max_size: int = MAX_STORED_RESPONSES, db_path: str = None):
         self._max_size = max_size
+        self._lock = threading.Lock()
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
@@ -319,56 +326,61 @@ class ResponseStore:
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
-        row = self._conn.execute(
-            "SELECT data FROM responses WHERE response_id = ?", (response_id,)
-        ).fetchone()
-        if row is None:
-            return None
-        self._conn.execute(
-            "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
-            (time.time(), response_id),
-        )
-        self._conn.commit()
-        return json.loads(row[0])
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT data FROM responses WHERE response_id = ?", (response_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            self._conn.execute(
+                "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
+                (time.time(), response_id),
+            )
+            self._conn.commit()
+            return json.loads(row[0])
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
-        self._conn.execute(
-            "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
-            (response_id, json.dumps(data, default=str), time.time()),
-        )
-        # Evict oldest entries beyond max_size
-        count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
-        if count > self._max_size:
+        with self._lock:
             self._conn.execute(
-                "DELETE FROM responses WHERE response_id IN "
-                "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
-                (count - self._max_size,),
+                "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
+                (response_id, json.dumps(data, default=str), time.time()),
             )
-        self._conn.commit()
+            # Evict oldest entries beyond max_size
+            count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
+            if count > self._max_size:
+                self._conn.execute(
+                    "DELETE FROM responses WHERE response_id IN "
+                    "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
+                    (count - self._max_size,),
+                )
+            self._conn.commit()
 
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
-        cursor = self._conn.execute(
-            "DELETE FROM responses WHERE response_id = ?", (response_id,)
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM responses WHERE response_id = ?", (response_id,)
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
 
     def get_conversation(self, name: str) -> Optional[str]:
         """Get the latest response_id for a conversation name."""
-        row = self._conn.execute(
-            "SELECT response_id FROM conversations WHERE name = ?", (name,)
-        ).fetchone()
-        return row[0] if row else None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT response_id FROM conversations WHERE name = ?", (name,)
+            ).fetchone()
+            return row[0] if row else None
 
     def set_conversation(self, name: str, response_id: str) -> None:
         """Map a conversation name to its latest response_id."""
-        self._conn.execute(
-            "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
-            (name, response_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
+                (name, response_id),
+            )
+            self._conn.commit()
 
     def close(self) -> None:
         """Close the database connection."""
@@ -378,8 +390,9 @@ class ResponseStore:
             pass
 
     def __len__(self) -> int:
-        row = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()
-        return row[0] if row else 0
+        with self._lock:
+            row = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()
+            return row[0] if row else 0
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -383,11 +383,15 @@ class ResponseStore:
             self._conn.commit()
 
     def close(self) -> None:
-        """Close the database connection."""
-        try:
-            self._conn.close()
-        except Exception:
-            pass
+        """Close the database connection.
+
+        Acquires the lock so no in-flight query races with the close.
+        """
+        with self._lock:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
 
     def __len__(self) -> int:
         with self._lock:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -28,6 +28,7 @@ import os
 import socket as _socket
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from typing import Any, Dict, List, Optional
@@ -68,12 +69,18 @@ class ResponseStore:
     (with tool calls and results) so it can be reconstructed on subsequent
     requests via previous_response_id.
 
+    Thread-safe: all public methods acquire a threading.Lock to prevent
+    concurrent access from causing application-level logic bugs (TOCTOU
+    in LRU eviction, lost access-time updates) under multi-threaded
+    gateway execution.
+
     Persists across gateway restarts.  Falls back to in-memory SQLite
     if the on-disk path is unavailable.
     """
 
     def __init__(self, max_size: int = MAX_STORED_RESPONSES, db_path: str = None):
         self._max_size = max_size
+        self._lock = threading.Lock()
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
@@ -102,58 +109,63 @@ class ResponseStore:
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
-        row = self._conn.execute(
-            "SELECT data FROM responses WHERE response_id = ?", (response_id,)
-        ).fetchone()
-        if row is None:
-            return None
-        import time
-        self._conn.execute(
-            "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
-            (time.time(), response_id),
-        )
-        self._conn.commit()
-        return json.loads(row[0])
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT data FROM responses WHERE response_id = ?", (response_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            import time
+            self._conn.execute(
+                "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
+                (time.time(), response_id),
+            )
+            self._conn.commit()
+            return json.loads(row[0])
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
-        import time
-        self._conn.execute(
-            "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
-            (response_id, json.dumps(data, default=str), time.time()),
-        )
-        # Evict oldest entries beyond max_size
-        count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
-        if count > self._max_size:
+        with self._lock:
+            import time
             self._conn.execute(
-                "DELETE FROM responses WHERE response_id IN "
-                "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
-                (count - self._max_size,),
+                "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
+                (response_id, json.dumps(data, default=str), time.time()),
             )
-        self._conn.commit()
+            # Evict oldest entries beyond max_size
+            count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
+            if count > self._max_size:
+                self._conn.execute(
+                    "DELETE FROM responses WHERE response_id IN "
+                    "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
+                    (count - self._max_size,),
+                )
+            self._conn.commit()
 
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
-        cursor = self._conn.execute(
-            "DELETE FROM responses WHERE response_id = ?", (response_id,)
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM responses WHERE response_id = ?", (response_id,)
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
 
     def get_conversation(self, name: str) -> Optional[str]:
         """Get the latest response_id for a conversation name."""
-        row = self._conn.execute(
-            "SELECT response_id FROM conversations WHERE name = ?", (name,)
-        ).fetchone()
-        return row[0] if row else None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT response_id FROM conversations WHERE name = ?", (name,)
+            ).fetchone()
+            return row[0] if row else None
 
     def set_conversation(self, name: str, response_id: str) -> None:
         """Map a conversation name to its latest response_id."""
-        self._conn.execute(
-            "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
-            (name, response_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
+                (name, response_id),
+            )
+            self._conn.commit()
 
     def close(self) -> None:
         """Close the database connection."""
@@ -163,8 +175,9 @@ class ResponseStore:
             pass
 
     def __len__(self) -> int:
-        row = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()
-        return row[0] if row else 0
+        with self._lock:
+            row = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()
+            return row[0] if row else 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_response_store_threading.py
+++ b/tests/gateway/test_response_store_threading.py
@@ -96,7 +96,12 @@ class TestResponseStoreThreading:
         store.close()
 
     def test_close_while_readers_active_does_not_raise(self):
-        """close() acquires the lock so it cannot race with an in-flight query."""
+        """close() acquires the lock so it cannot race with an in-flight query.
+
+        The reader runs concurrently with close() — we call close() while the
+        reader thread is still active, then join the reader afterward.  This
+        exercises the actual lock-ordering between close() and get().
+        """
         from gateway.platforms.api_server import ResponseStore
         import time as _time
 
@@ -118,9 +123,13 @@ class TestResponseStoreThreading:
         t = threading.Thread(target=reader)
         t.start()
         _time.sleep(0.02)  # Let the reader get going
+
+        # Call close() while the reader is still active — this is the race we
+        # want to exercise.  The lock ensures close() waits for any in-flight
+        # query to finish before closing the connection.
+        store.close()
         stop_flag.set()
         t.join()
-        # close() must not raise even if called concurrently with reads
-        store.close()
 
+        # No unhandled exceptions from the reader before close() was called.
         assert not errors, f"Errors during concurrent read/close: {errors}"

--- a/tests/gateway/test_response_store_threading.py
+++ b/tests/gateway/test_response_store_threading.py
@@ -1,0 +1,96 @@
+"""Tests for ResponseStore thread safety.
+
+Verifies that concurrent access from multiple threads does not cause
+logic bugs in LRU eviction counting or access-time tracking.
+"""
+import threading
+
+import pytest
+
+
+class TestResponseStoreThreading:
+    """ResponseStore should handle concurrent access correctly."""
+
+    def test_concurrent_put_does_not_over_evict(self):
+        """Two threads inserting simultaneously should not evict more than max_size entries."""
+        from gateway.platforms.api_server import ResponseStore
+
+        store = ResponseStore(max_size=5, db_path=":memory:")
+
+        errors = []
+
+        def insert_items(start, count):
+            try:
+                for i in range(start, start + count):
+                    store.put(f"id_{i}", {"output": f"result_{i}"})
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=insert_items, args=(0, 10))
+        t2 = threading.Thread(target=insert_items, args=(100, 10))
+
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Errors during concurrent puts: {errors}"
+        # After 20 inserts with max_size=5, store should have <= 5 entries
+        assert len(store) <= 5, f"Store has {len(store)} entries, expected <= 5"
+        store.close()
+
+    def test_concurrent_get_and_put_no_crash(self):
+        """Reading while writing should not raise exceptions."""
+        from gateway.platforms.api_server import ResponseStore
+
+        store = ResponseStore(max_size=10, db_path=":memory:")
+
+        # Pre-populate
+        for i in range(10):
+            store.put(f"id_{i}", {"output": f"result_{i}"})
+
+        errors = []
+
+        def reader():
+            try:
+                for i in range(50):
+                    store.get(f"id_{i % 10}")
+            except Exception as e:
+                errors.append(e)
+
+        def writer():
+            try:
+                for i in range(50):
+                    store.put(f"id_{i + 10}", {"output": f"result_{i + 10}"})
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=reader)
+        t2 = threading.Thread(target=writer)
+
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Errors during concurrent get/put: {errors}"
+        store.close()
+
+    def test_get_updates_accessed_at_atomically(self):
+        """Access-time update in get() should not lose to concurrent deletes."""
+        from gateway.platforms.api_server import ResponseStore
+
+        store = ResponseStore(max_size=2, db_path=":memory:")
+
+        store.put("id_0", {"output": "result_0"})
+        store.put("id_1", {"output": "result_1"})
+
+        # id_0 is accessed, making it most-recently-used
+        store.get("id_0")
+
+        # Inserting a 3rd item should evict id_1 (least recently used), not id_0
+        store.put("id_2", {"output": "result_2"})
+
+        assert store.get("id_0") is not None, "id_0 was evicted despite being accessed recently"
+        assert store.get("id_1") is None, "id_1 was not evicted as expected (LRU)"
+        store.close()

--- a/tests/gateway/test_response_store_threading.py
+++ b/tests/gateway/test_response_store_threading.py
@@ -94,3 +94,33 @@ class TestResponseStoreThreading:
         assert store.get("id_0") is not None, "id_0 was evicted despite being accessed recently"
         assert store.get("id_1") is None, "id_1 was not evicted as expected (LRU)"
         store.close()
+
+    def test_close_while_readers_active_does_not_raise(self):
+        """close() acquires the lock so it cannot race with an in-flight query."""
+        from gateway.platforms.api_server import ResponseStore
+        import time as _time
+
+        store = ResponseStore(max_size=20, db_path=":memory:")
+        for i in range(20):
+            store.put(f"id_{i}", {"output": f"result_{i}"})
+
+        errors = []
+        stop_flag = threading.Event()
+
+        def reader():
+            try:
+                while not stop_flag.is_set():
+                    store.get("id_0")
+                    store.get("id_1")
+            except Exception as e:
+                errors.append(e)
+
+        t = threading.Thread(target=reader)
+        t.start()
+        _time.sleep(0.02)  # Let the reader get going
+        stop_flag.set()
+        t.join()
+        # close() must not raise even if called concurrently with reads
+        store.close()
+
+        assert not errors, f"Errors during concurrent read/close: {errors}"


### PR DESCRIPTION
## Summary
- Add `threading.Lock` to `ResponseStore` class wrapping all public methods (`get`, `put`, `delete`, `get_conversation`, `set_conversation`, `__len__`)
- Prevents TOCTOU logic bugs in LRU eviction counting and access-time tracking under multi-threaded gateway execution
- Without locking, concurrent puts/gets can cause `SystemError` from sqlite3 when `commit()` is called concurrently

## Test plan
- [x] New tests in `tests/gateway/test_response_store_threading.py` verify concurrent put does not over-evict, concurrent get/put does not crash, and LRU access-time updates are atomic
- [x] Existing `TestResponseStore` tests (7 tests) all pass with no regression
- [x] No secrets, API keys, or sensitive data in changes