### PR TITLE
fix(providers): honour config.yaml api_key for anthropic provider

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -468,13 +468,20 @@ def _resolve_explicit_runtime(
         base_url = explicit_base_url or cfg_base_url or "https://api.anthropic.com"
         api_key = explicit_api_key
         if not api_key:
+            # Honour model.api_key from config.yaml before falling back to env.
+            for k in ("api_key", "api"):
+                v = model_cfg.get(k)
+                if isinstance(v, str) and v.strip():
+                    api_key = v.strip()
+                    break
+        if not api_key:
             from agent.anthropic_adapter import resolve_anthropic_token
 
             api_key = resolve_anthropic_token()
             if not api_key:
                 raise AuthError(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
-                    "run 'claude setup-token', or authenticate with 'claude /login'."
+                    "add api_key to config.yaml, run 'claude setup-token', or authenticate with 'claude /login'."
                 )
         return {
             "provider": "anthropic",
@@ -745,12 +752,19 @@ def resolve_runtime_provider(
 
     # Anthropic (native Messages API)
     if provider == "anthropic":
+        # Honour model.api_key from config.yaml (consistent with other providers).
+        cfg_api_key = ""
+        for k in ("api_key", "api"):
+            v = model_cfg.get(k)
+            if isinstance(v, str) and v.strip():
+                cfg_api_key = v.strip()
+                break
         from agent.anthropic_adapter import resolve_anthropic_token
-        token = resolve_anthropic_token()
+        token = cfg_api_key or resolve_anthropic_token()
         if not token:
             raise AuthError(
                 "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
-                "run 'claude setup-token', or authenticate with 'claude /login'."
+                "add api_key to config.yaml, run 'claude setup-token', or authenticate with 'claude /login'."
             )
         # Allow base URL override from config.yaml model.base_url, but only
         # when the configured provider is anthropic — otherwise a non-Anthropic

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -93,6 +93,71 @@ def test_resolve_runtime_provider_anthropic_explicit_override_skips_pool(monkeyp
     assert resolved.get("credential_pool") is None
 
 
+def test_resolve_runtime_provider_anthropic_respects_config_api_key(monkeypatch):
+    """Anthropic provider should use model.api_key from config.yaml when set,
+    without requiring ANTHROPIC_API_KEY or ANTHROPIC_TOKEN env vars."""
+
+    def _unexpected_anthropic_token():
+        raise AssertionError("resolve_anthropic_token should not be called when config api_key is set")
+
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": "https://proxy.example.com/anthropic",
+            "api_key": "config-anthropic-key",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        _unexpected_anthropic_token,
+    )
+    # Ensure no env vars are set
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["api_key"] == "config-anthropic-key"
+    assert resolved["base_url"] == "https://proxy.example.com/anthropic"
+
+
+def test_resolve_runtime_provider_anthropic_config_api_field(monkeypatch):
+    """Anthropic provider should also accept 'api' field from config.yaml."""
+
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": "https://proxy.example.com/anthropic",
+            "api": "config-api-field-key",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_key"] == "config-api-field-key"
+
+
 def test_resolve_runtime_provider_falls_back_when_pool_empty(monkeypatch):
     class _Pool:
         def has_credentials(self):


### PR DESCRIPTION
## Summary

Fixes #7579

- Add `model.api_key` / `model.api` from `config.yaml` as a candidate source for the anthropic provider, consistent with how all other providers (openrouter, custom, minimax, etc.) handle it
- Apply the fix in both the main resolution path (`resolve_runtime_provider`) and the explicit override path (`_resolve_explicit_runtime`)
- Add 2 new tests verifying config api_key and api field resolution

## Priority order after fix

1. Explicit API key (CLI `--api-key` flag)
2. `config.yaml` `model.api_key` / `model.api`
3. `ANTHROPIC_TOKEN` env var
4. `CLAUDE_CODE_OAUTH_TOKEN` env var
5. Claude Code credential files
6. `ANTHROPIC_API_KEY` env var

## Test plan

- [x] All 62 existing + new tests pass (`pytest tests/hermes_cli/test_runtime_provider_resolution.py`)
- [x] Manually verified: `hermes chat` works with only `config.yaml` api_key set (no env vars)
- [x] Existing anthropic env var resolution still works when config api_key is absent