### PR TITLE
fix(gateway): add per-key asyncio.Lock to IdempotencyCache preventing duplicate computation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -249,12 +249,17 @@ else:
 
 
 class _IdempotencyCache:
-    """In-memory idempotency cache with TTL and basic LRU semantics."""
+    """In-memory idempotency cache with TTL and basic LRU semantics.
+
+    Uses per-key asyncio.Lock to prevent concurrent computations
+    for the same idempotency key, ensuring the idempotency guarantee.
+    """
     def __init__(self, max_items: int = 1000, ttl_seconds: int = 300):
         from collections import OrderedDict
         self._store = OrderedDict()
         self._ttl = ttl_seconds
         self._max = max_items
+        self._key_locks: Dict[str, asyncio.Lock] = {}
 
     def _purge(self):
         import time as _t
@@ -262,19 +267,32 @@ class _IdempotencyCache:
         expired = [k for k, v in self._store.items() if now - v["ts"] > self._ttl]
         for k in expired:
             self._store.pop(k, None)
+            self._key_locks.pop(k, None)
         while len(self._store) > self._max:
             self._store.popitem(last=False)
 
     async def get_or_set(self, key: str, fingerprint: str, compute_coro):
-        self._purge()
-        item = self._store.get(key)
-        if item and item["fp"] == fingerprint:
-            return item["resp"]
-        resp = await compute_coro()
-        import time as _t
-        self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
-        self._purge()
-        return resp
+        """Get cached response or compute and cache it.
+
+        Uses a per-key lock so that concurrent requests with the same
+        idempotency key wait for the first computation to finish, then
+        return its cached result instead of computing again.
+        """
+        # Ensure a lock exists for this key
+        if key not in self._key_locks:
+            self._key_locks[key] = asyncio.Lock()
+        key_lock = self._key_locks[key]
+
+        async with key_lock:
+            self._purge()
+            item = self._store.get(key)
+            if item and item["fp"] == fingerprint:
+                return item["resp"]
+            resp = await compute_coro()
+            import time as _t
+            self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
+            self._purge()
+            return resp
 
 
 _idem_cache = _IdempotencyCache()

--- a/tests/gateway/test_idempotency_cache_race.py
+++ b/tests/gateway/test_idempotency_cache_race.py
@@ -1,0 +1,58 @@
+"""Tests for IdempotencyCache async reentrancy safety.
+
+Verifies that concurrent requests with the same idempotency key
+do not both execute the compute callable (idempotency guarantee).
+"""
+import asyncio
+
+import pytest
+
+
+class TestIdempotencyCacheRace:
+    """IdempotencyCache should prevent duplicate computation for same key."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_key_only_computes_once(self):
+        """Two concurrent requests with same idempotency key should only compute once."""
+        from gateway.platforms.api_server import _IdempotencyCache
+
+        cache = _IdempotencyCache(max_items=10, ttl_seconds=60)
+        compute_count = 0
+
+        async def slow_compute():
+            nonlocal compute_count
+            compute_count += 1
+            await asyncio.sleep(0.1)
+            return {"result": "computed"}
+
+        # Launch two concurrent get_or_set with same key
+        results = await asyncio.gather(
+            cache.get_or_set("key_a", "fp_1", slow_compute),
+            cache.get_or_set("key_a", "fp_1", slow_compute),
+        )
+
+        # Both should return the same result
+        assert results[0] == {"result": "computed"}
+        assert results[1] == {"result": "computed"}
+        # But compute should only have been called ONCE
+        assert compute_count == 1, f"Expected 1 computation, got {compute_count}"
+
+    @pytest.mark.asyncio
+    async def test_different_keys_compute_independently(self):
+        """Different idempotency keys should compute independently."""
+        from gateway.platforms.api_server import _IdempotencyCache
+
+        cache = _IdempotencyCache(max_items=10, ttl_seconds=60)
+        compute_count = 0
+
+        async def compute():
+            nonlocal compute_count
+            compute_count += 1
+            return {"result": compute_count}
+
+        results = await asyncio.gather(
+            cache.get_or_set("key_a", "fp_1", compute),
+            cache.get_or_set("key_b", "fp_1", compute),
+        )
+
+        assert compute_count == 2, "Different keys should each trigger computation"


### PR DESCRIPTION
## Summary
- Add per-key `asyncio.Lock` to `_IdempotencyCache` to prevent concurrent computations for the same idempotency key
- Without this fix, concurrent requests with the same key both miss the cache and execute the compute callable, breaking the idempotency guarantee
- The second request now waits for the first computation to finish and returns the cached result

## Test plan
- [x] New tests in `tests/gateway/test_idempotency_cache_race.py` verify that concurrent same-key requests compute only once, and different keys compute independently
- [x] Existing `TestResponseStore` tests (7 tests) all pass with no regression
- [x] No secrets, API keys, or sensitive data in changes