### PR TITLE
fix(agent): refund iteration budget on transient network errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -78,6 +78,7 @@ class ClassifiedError:
     should_compress: bool = False
     should_rotate_credential: bool = False
     should_fallback: bool = False
+    should_refund_budget: bool = False  # True for transient errors that never reached the server
 
     @property
     def is_auth(self) -> bool:
@@ -506,12 +507,12 @@ def classify_api_error(
                 retryable=True,
                 should_compress=True,
             )
-        return _result(FailoverReason.timeout, retryable=True)
+        return _result(FailoverReason.timeout, retryable=True, should_refund_budget=True)
 
     # ── 7. Transport / timeout heuristics ───────────────────────────
 
     if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
-        return _result(FailoverReason.timeout, retryable=True)
+        return _result(FailoverReason.timeout, retryable=True, should_refund_budget=True)
 
     # ── 8. Fallback: unknown ────────────────────────────────────────
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -77,6 +77,7 @@ class ClassifiedError:
     should_compress: bool = False
     should_rotate_credential: bool = False
     should_fallback: bool = False
+    should_refund_budget: bool = False  # True for transient errors that never reached the server
 
     @property
     def is_auth(self) -> bool:
@@ -383,12 +384,12 @@ def classify_api_error(
                 retryable=True,
                 should_compress=True,
             )
-        return _result(FailoverReason.timeout, retryable=True)
+        return _result(FailoverReason.timeout, retryable=True, should_refund_budget=True)
 
     # ── 6. Transport / timeout heuristics ───────────────────────────
 
     if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
-        return _result(FailoverReason.timeout, retryable=True)
+        return _result(FailoverReason.timeout, retryable=True, should_refund_budget=True)
 
     # ── 7. Fallback: unknown ────────────────────────────────────────
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -11152,11 +11152,20 @@ class AIAgent:
                         num_messages=len(api_messages) if api_messages else 0,
                     )
                     logger.debug(
-                        "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s",
+                        "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s refund=%s",
                         classified.reason.value, classified.status_code,
                         classified.retryable, classified.should_compress,
                         classified.should_rotate_credential, classified.should_fallback,
+                        classified.should_refund_budget,
                     )
+                    # Refund iteration budget for transient network errors that
+                    # never reached the server — no API resources were consumed.
+                    if classified.should_refund_budget:
+                        self.iteration_budget.refund()
+                        logger.debug(
+                            "Refunded iteration budget after transient error: %s",
+                            classified.reason.value,
+                        )
 
                     recovered_with_pool, has_retried_429 = self._recover_with_credential_pool(
                         status_code=status_code,

--- a/run_agent.py
+++ b/run_agent.py
@@ -254,7 +254,8 @@ class IterationBudget:
 
     @property
     def used(self) -> int:
-        return self._used
+        with self._lock:
+            return self._used
 
     @property
     def remaining(self) -> int:
@@ -10248,6 +10249,7 @@ class AIAgent:
             has_retried_429 = False
             restart_with_compressed_messages = False
             restart_with_length_continuation = False
+            _budget_refunded_this_iteration = False  # Guard: refund at most once per consume()
 
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
@@ -11160,7 +11162,13 @@ class AIAgent:
                     )
                     # Refund iteration budget for transient network errors that
                     # never reached the server — no API resources were consumed.
-                    if classified.should_refund_budget:
+                    # Guard: only refund once per outer-loop iteration even if the
+                    # inner retry loop fires the except block multiple times (e.g.
+                    # max_retries=3 all failing with TimeoutError).  Without this
+                    # guard, 3 retries → 3 refunds for 1 consume(), granting the
+                    # agent (max_retries - 1) extra iterations for free.
+                    if classified.should_refund_budget and not _budget_refunded_this_iteration:
+                        _budget_refunded_this_iteration = True
                         self.iteration_budget.refund()
                         logger.debug(
                             "Refunded iteration budget after transient error: %s",

--- a/run_agent.py
+++ b/run_agent.py
@@ -8453,11 +8453,20 @@ class AIAgent:
                         num_messages=len(api_messages) if api_messages else 0,
                     )
                     logger.debug(
-                        "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s",
+                        "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s refund=%s",
                         classified.reason.value, classified.status_code,
                         classified.retryable, classified.should_compress,
                         classified.should_rotate_credential, classified.should_fallback,
+                        classified.should_refund_budget,
                     )
+                    # Refund iteration budget for transient network errors that
+                    # never reached the server — no API resources were consumed.
+                    if classified.should_refund_budget:
+                        self.iteration_budget.refund()
+                        logger.debug(
+                            "Refunded iteration budget after transient error: %s",
+                            classified.reason.value,
+                        )
 
                     recovered_with_pool, has_retried_429 = self._recover_with_credential_pool(
                         status_code=status_code,

--- a/tests/run_agent/test_budget_refund.py
+++ b/tests/run_agent/test_budget_refund.py
@@ -1,0 +1,61 @@
+"""Tests for iteration budget refund on transient network errors."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestBudgetRefundOnTransientError:
+    """Iteration budget should be refunded when API calls fail due to transient network errors."""
+
+    def test_timeout_error_classified_as_refundable(self):
+        """Connection timeout errors should have should_refund_budget=True."""
+        from agent.error_classifier import classify_api_error, FailoverReason
+
+        error = TimeoutError("Connection timed out")
+        classified = classify_api_error(error)
+
+        assert classified.reason == FailoverReason.timeout
+        assert classified.retryable is True
+        assert classified.should_refund_budget is True
+
+    def test_connection_error_classified_as_refundable(self):
+        """Connection errors should have should_refund_budget=True."""
+        from agent.error_classifier import classify_api_error, FailoverReason
+
+        error = ConnectionError("Connection refused")
+        classified = classify_api_error(error)
+
+        assert classified.reason == FailoverReason.timeout
+        assert classified.should_refund_budget is True
+
+    def test_os_error_classified_as_refundable(self):
+        """OS errors (network unreachable) should have should_refund_budget=True."""
+        from agent.error_classifier import classify_api_error, FailoverReason
+
+        error = OSError("Network is unreachable")
+        classified = classify_api_error(error)
+
+        assert classified.reason == FailoverReason.timeout
+        assert classified.should_refund_budget is True
+
+    def test_context_overflow_not_refundable(self):
+        """Context overflow errors should NOT have should_refund_budget=True (they used API resources)."""
+        from agent.error_classifier import classify_api_error, FailoverReason
+
+        error = Exception("context length exceeded")
+        error.status_code = 400
+        classified = classify_api_error(error)
+
+        assert classified.reason == FailoverReason.context_overflow
+        assert classified.should_refund_budget is False
+
+    def test_rate_limit_not_refundable(self):
+        """Rate limit errors should NOT have should_refund_budget=True (request reached the server)."""
+        from agent.error_classifier import classify_api_error, FailoverReason
+
+        error = Exception("rate limit exceeded")
+        error.status_code = 429
+        classified = classify_api_error(error)
+
+        assert classified.reason == FailoverReason.rate_limit
+        assert classified.should_refund_budget is False

--- a/tests/run_agent/test_budget_refund.py
+++ b/tests/run_agent/test_budget_refund.py
@@ -59,3 +59,57 @@ class TestBudgetRefundOnTransientError:
 
         assert classified.reason == FailoverReason.rate_limit
         assert classified.should_refund_budget is False
+
+
+class TestIterationBudgetRefundCap:
+    """IterationBudget.refund() must not grant more budget than was consumed."""
+
+    def test_refund_cannot_go_below_zero(self):
+        """Calling refund() more times than consume() must not underflow below 0."""
+        from run_agent import IterationBudget
+
+        budget = IterationBudget(10)
+        budget.consume()  # used=1
+        budget.refund()   # used=0
+        budget.refund()   # must not go to -1
+        budget.refund()
+
+        assert budget.used == 0
+        assert budget.remaining == 10
+
+    def test_multiple_retries_do_not_over_refund(self):
+        """Simulates the inner retry loop: 1 consume + 3 transient-error refunds.
+
+        The guard flag (_budget_refunded_this_iteration) in run_agent.py ensures
+        only the first refund fires.  This test verifies IterationBudget itself
+        has a floor at 0, so even without the guard the budget cannot go negative.
+        """
+        from run_agent import IterationBudget
+
+        budget = IterationBudget(10)
+        # Simulate 5 successful prior iterations
+        for _ in range(5):
+            budget.consume()
+        assert budget.used == 5
+
+        # One outer iteration with 3 retries all failing (worst case without guard)
+        budget.consume()  # outer loop consume → used=6
+        for _ in range(3):
+            budget.refund()  # inner loop retries
+
+        # With the floor, used cannot drop below 0; it stops at 3 (6 - 3)
+        # The guard in run_agent.py further limits this to used=5 (6 - 1)
+        assert budget.used >= 0, "used must never be negative"
+        assert budget.remaining <= budget.max_total, "remaining must not exceed max_total"
+
+    def test_refund_is_bounded_by_floor(self):
+        """Repeated refunds on a fresh budget stay at 0, not negative."""
+        from run_agent import IterationBudget
+
+        budget = IterationBudget(5)
+        budget.consume()  # used=1
+        for _ in range(10):
+            budget.refund()
+
+        assert budget.used == 0
+        assert budget.remaining == 5


### PR DESCRIPTION
## Summary
- Add `should_refund_budget` field to `ClassifiedError` dataclass (default `False`)
- Set `should_refund_budget=True` for timeout/transport errors (connection refused, OS errors, etc.) that never reached the API server
- Add budget refund in the main loop error handler after transient errors

Without this fix, agents can exhaust their iteration budget under flaky network conditions without completing any actual API calls, since the budget was consumed but never refunded for transient errors.

## Test plan
- [x] New tests in `tests/run_agent/test_budget_refund.py` verify timeout, connection, and OS errors are refundable, while context overflow and rate limit errors are not
- [x] No secrets, API keys, or sensitive data in changes