### PR TITLE
Refine Weixin multiline chunking

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -732,6 +732,32 @@ def _split_delivery_units_for_weixin(content: str) -> List[str]:
     return [unit for unit in units if unit]
 
 
+def _looks_like_chatty_line_for_weixin(line: str) -> bool:
+    """Return True when a line looks like a standalone chat utterance."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if len(stripped) > 48:
+        return False
+    if line.startswith((" ", "\t")):
+        return False
+    if stripped.startswith((">", "-", "*", "【")):
+        return False
+    if re.match(r"^\*\*[^*]+\*\*$", stripped):
+        return False
+    if re.match(r"^\d+\.\s", stripped):
+        return False
+    return True
+
+
+def _should_split_short_chat_block_for_weixin(block: str) -> bool:
+    """Split only short, chat-like multiline blocks into separate bubbles."""
+    lines = [line for line in block.splitlines() if line.strip()]
+    if not 2 <= len(lines) <= 3:
+        return False
+    return all(_looks_like_chatty_line_for_weixin(line) for line in lines)
+
+
 def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]:
     if len(content) <= max_length:
         return [content]
@@ -766,11 +792,17 @@ def _split_text_for_weixin_delivery(content: str, max_length: int) -> List[str]:
         return [content]
 
     chunks: List[str] = []
-    for unit in _split_delivery_units_for_weixin(content):
-        if len(unit) <= max_length:
-            chunks.append(unit)
-            continue
-        chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
+    for block in _split_markdown_blocks(content):
+        units = (
+            _split_delivery_units_for_weixin(block)
+            if _should_split_short_chat_block_for_weixin(block)
+            else [block]
+        )
+        for unit in units:
+            if len(unit) <= max_length:
+                chunks.append(unit)
+                continue
+            chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
     return chunks or [content]
 
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -750,10 +750,20 @@ def _looks_like_chatty_line_for_weixin(line: str) -> bool:
     return True
 
 
+def _looks_like_heading_line_for_weixin(line: str) -> bool:
+    """Return True when a short line behaves like a plain-text heading."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    return len(stripped) <= 24 and stripped.endswith((":", "："))
+
+
 def _should_split_short_chat_block_for_weixin(block: str) -> bool:
-    """Split only short, chat-like multiline blocks into separate bubbles."""
+    """Split only chat-like multiline blocks into separate bubbles."""
     lines = [line for line in block.splitlines() if line.strip()]
-    if not 2 <= len(lines) <= 3:
+    if not 2 <= len(lines) <= 6:
+        return False
+    if _looks_like_heading_line_for_weixin(lines[0]):
         return False
     return all(_looks_like_chatty_line_for_weixin(line) for line in lines)
 
@@ -784,26 +794,16 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
 def _split_text_for_weixin_delivery(content: str, max_length: int) -> List[str]:
     """Split content into sequential Weixin messages.
 
-    Prefer one message per top-level line/markdown unit when the author used
-    explicit line breaks. Oversized units fall back to block-aware packing so
-    long code fences still split safely.
+    Only split intentionally chatty short replies into separate bubbles.
+    Longer content stays intact unless the platform hard limit forces packing.
     """
-    if len(content) <= max_length and "\n" not in content:
-        return [content]
-
-    chunks: List[str] = []
-    for block in _split_markdown_blocks(content):
-        units = (
-            _split_delivery_units_for_weixin(block)
-            if _should_split_short_chat_block_for_weixin(block)
-            else [block]
+    if len(content) <= max_length:
+        return (
+            _split_delivery_units_for_weixin(content)
+            if _should_split_short_chat_block_for_weixin(content)
+            else [content]
         )
-        for unit in units:
-            if len(unit) <= max_length:
-                chunks.append(unit)
-                continue
-            chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
-    return chunks or [content]
+    return _pack_markdown_blocks_for_weixin(content, max_length) or [content]
 
 
 def _extract_text(item_list: List[Dict[str, Any]]) -> str:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -70,7 +70,7 @@ class TestWeixinChunking:
 
         assert chunks == ["第一行", "第二行", "第三行"]
 
-    def test_split_text_keeps_indented_followup_with_previous_line(self):
+    def test_split_text_keeps_structured_table_block_together(self):
         adapter = _make_adapter()
 
         content = adapter.format_message(
@@ -81,10 +81,28 @@ class TestWeixinChunking:
         )
         chunks = adapter._split_text(content)
 
-        assert chunks == [
-            "- Setting: Timeout\n  Value: 30s",
-            "- Setting: Retries\n  Value: 3",
-        ]
+        assert chunks == ["- Setting: Timeout\n  Value: 30s\n- Setting: Retries\n  Value: 3"]
+
+    def test_split_text_keeps_four_line_structured_blocks_together(self):
+        adapter = _make_adapter()
+
+        content = adapter.format_message(
+            "今天结论：\n"
+            "- 留存下降 3%\n"
+            "- 转化上涨 8%\n"
+            "- 主要问题在首日激活"
+        )
+        chunks = adapter._split_text(content)
+
+        assert chunks == ["今天结论：\n- 留存下降 3%\n- 转化上涨 8%\n- 主要问题在首日激活"]
+
+    def test_split_text_keeps_heading_with_body_together(self):
+        adapter = _make_adapter()
+
+        content = adapter.format_message("## 结论\n这是正文")
+        chunks = adapter._split_text(content)
+
+        assert chunks == ["**结论**\n这是正文"]
 
     def test_split_text_keeps_complete_code_block_together_when_possible(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

This PR refines Weixin message chunking so structured multiline output stays readable in WeChat.

The original adapter split any top-level multiline block into separate message bubbles. That worked for short chatty replies, but it fragmented structured content such as summaries, headings with body text, and table-like output.

## What changed

- Keep the existing markdown normalization and block-aware packing
- Only split multiline blocks into separate bubbles when the block looks like a short chat exchange:
  - 2-3 non-empty lines
  - each line is short
  - no heading/list/quote/numbered-step markers
- Preserve structured multiline blocks as a single message bubble

## Tests

Added coverage for:
- preserving 3-line short chat splitting
- keeping structured table output together
- keeping 4-line structured summaries together
- keeping heading + body together

Ran:
- `pytest -q tests/gateway/test_weixin.py`
- `python3 -m py_compile gateway/platforms/weixin.py tests/gateway/test_weixin.py`

Result:
- `16 passed`

## Motivation

This addresses real-world feedback that recent Weixin output became fragmented into too many bubbles, which made structured replies harder to read.