### PR TITLE
fix(cron): coerce repeat parameter to int to prevent TypeError

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -231,3 +231,26 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         assert updated["job"]["skills"] == []
         assert updated["job"]["skill"] is None
+
+    def test_create_with_string_repeat_is_coerced_to_int(self):
+        """LLMs may pass repeat as a string despite the schema declaring integer."""
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Limited task",
+                schedule="every 1h",
+                repeat="3",
+            )
+        )
+        assert result["success"] is True
+        assert result["repeat"] == "3 times"
+
+    def test_update_with_string_repeat_is_coerced_to_int(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Check", schedule="every 1h")
+        )
+        updated = json.loads(
+            cronjob(action="update", job_id=created["job_id"], repeat="5")
+        )
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "5 times"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -240,6 +240,13 @@ def cronjob(
     del task_id  # unused but kept for handler signature compatibility
 
     try:
+        # Coerce repeat to int — LLMs may pass it as a string despite the
+        # schema declaring "type": "integer", which would crash the <= 0
+        # comparisons downstream (TypeError: '<=' not supported between
+        # instances of 'str' and 'int').
+        if repeat is not None:
+            repeat = int(repeat)
+
         normalized = (action or "").strip().lower()
 
         if normalized == "create":


### PR DESCRIPTION
## Summary

- Coerce the `repeat` parameter to `int` at the top of `cronjob()` before it reaches the `<= 0` comparisons in the create and update code paths
- LLMs may pass `repeat` as a string (e.g. `"3"`) despite the tool schema declaring `"type": "integer"`, causing `TypeError: '<=' not supported between instances of 'str' and 'int'`

Fixes #6709

## Test plan

- [x] New `test_create_with_string_repeat_is_coerced_to_int` — passes string `"3"` as repeat to create, verifies success
- [x] New `test_update_with_string_repeat_is_coerced_to_int` — passes string `"5"` as repeat to update, verifies success
- [x] All 41 `test_cronjob_tools.py` tests pass