### PR TITLE
fix(feishu): stop official websocket client cleanly during disconnect

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -991,20 +991,18 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
-        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
-        for task in pending:
-            task.cancel()
-        if pending:
-            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
         try:
-            loop.stop()
+            pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.run_until_complete(loop.shutdown_asyncgens())
         except Exception:
             pass
-        try:
+        finally:
             loop.close()
-        except Exception:
-            pass
-        adapter._ws_thread_loop = None
+            adapter._ws_thread_loop = None
 
 
 def check_feishu_requirements() -> bool:
@@ -1246,37 +1244,8 @@ class FeishuAdapter(BasePlatformAdapter):
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
-        self._disable_websocket_auto_reconnect()
+        await self._stop_official_websocket_client()
         await self._stop_webhook_server()
-
-        ws_thread_loop = self._ws_thread_loop
-        if ws_thread_loop is not None and not ws_thread_loop.is_closed():
-            logger.debug("[Feishu] Cancelling websocket thread tasks and stopping loop")
-
-            def cancel_all_tasks() -> None:
-                tasks = [t for t in asyncio.all_tasks(ws_thread_loop) if not t.done()]
-                logger.debug("[Feishu] Found %d pending tasks in websocket thread", len(tasks))
-                for task in tasks:
-                    task.cancel()
-                ws_thread_loop.call_later(0.1, ws_thread_loop.stop)
-
-            ws_thread_loop.call_soon_threadsafe(cancel_all_tasks)
-
-        ws_future = self._ws_future
-        if ws_future is not None:
-            try:
-                logger.debug("[Feishu] Waiting for websocket thread to exit (timeout=10s)")
-                await asyncio.wait_for(asyncio.shield(ws_future), timeout=10.0)
-                logger.debug("[Feishu] Websocket thread exited cleanly")
-            except asyncio.TimeoutError:
-                logger.warning("[Feishu] Websocket thread did not exit within 10s - may be stuck")
-            except asyncio.CancelledError:
-                logger.debug("[Feishu] Websocket thread cancelled during disconnect")
-            except Exception as exc:
-                logger.debug("[Feishu] Websocket thread exited with error: %s", exc, exc_info=True)
-
-        self._ws_future = None
-        self._ws_thread_loop = None
         self._loop = None
         self._event_handler = None
         self._persist_seen_message_ids()
@@ -1305,8 +1274,41 @@ class FeishuAdapter(BasePlatformAdapter):
             setattr(self._ws_client, "_auto_reconnect", False)
         except Exception:
             pass
-        finally:
-            self._ws_client = None
+
+    async def _stop_official_websocket_client(self) -> None:
+        ws_future = self._ws_future
+        ws_loop = self._ws_thread_loop
+        ws_client = self._ws_client
+
+        self._disable_websocket_auto_reconnect()
+
+        if ws_client is not None and ws_loop is not None and not ws_loop.is_closed():
+            async def _disconnect_and_stop() -> None:
+                try:
+                    disconnect = getattr(ws_client, "_disconnect", None)
+                    if callable(disconnect):
+                        await disconnect()
+                finally:
+                    asyncio.get_running_loop().call_soon(asyncio.get_running_loop().stop)
+
+            try:
+                shutdown_future = asyncio.run_coroutine_threadsafe(_disconnect_and_stop(), ws_loop)
+                await asyncio.wait_for(asyncio.wrap_future(shutdown_future), timeout=3)
+            except Exception as exc:
+                logger.debug("[Feishu] Official websocket shutdown timed out: %s", exc)
+                try:
+                    ws_loop.call_soon_threadsafe(ws_loop.stop)
+                except Exception:
+                    pass
+        if ws_future is not None:
+            try:
+                await asyncio.wait_for(asyncio.shield(ws_future), timeout=3)
+            except Exception as exc:
+                logger.debug("[Feishu] Waiting for websocket worker exit timed out: %s", exc)
+
+        self._ws_future = None
+        self._ws_thread_loop = None
+        self._ws_client = None
 
     async def _stop_webhook_server(self) -> None:
         if self._webhook_runner is None:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -24,6 +24,8 @@ def _mock_event_dispatcher_builder(mock_handler_class):
     mock_builder.register_p2_im_message_reaction_created_v1 = Mock(return_value=mock_builder)
     mock_builder.register_p2_im_message_reaction_deleted_v1 = Mock(return_value=mock_builder)
     mock_builder.register_p2_card_action_trigger = Mock(return_value=mock_builder)
+    mock_builder.register_p2_im_chat_member_bot_added_v1 = Mock(return_value=mock_builder)
+    mock_builder.register_p2_im_chat_member_bot_deleted_v1 = Mock(return_value=mock_builder)
     mock_builder.build = Mock(return_value=object())
     mock_handler_class.builder = Mock(return_value=mock_builder)
     return mock_builder
@@ -339,6 +341,28 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             metadata={"platform": "feishu"},
         )
         release_lock.assert_called_once_with("feishu-app-id", "cli_app")
+
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_app",
+        "FEISHU_APP_SECRET": "secret_app",
+    }, clear=True)
+    def test_disconnect_stops_official_websocket_client(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._ws_future = object()
+
+        with (
+            patch.object(adapter, "_cancel_pending_tasks", new=AsyncMock()),
+            patch.object(adapter, "_stop_official_websocket_client", new=AsyncMock()) as stop_ws,
+            patch.object(adapter, "_stop_webhook_server", new=AsyncMock()),
+            patch.object(adapter, "_release_app_lock", new=AsyncMock()),
+            patch.object(adapter, "_persist_seen_message_ids"),
+        ):
+            asyncio.run(adapter.disconnect())
+
+        stop_ws.assert_awaited_once()
 
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_app",
@@ -699,6 +723,14 @@ class TestAdapterBehavior(unittest.TestCase):
                 calls.append("card_action")
                 return self
 
+            def register_p2_im_chat_member_bot_added_v1(self, _handler):
+                calls.append("bot_added")
+                return self
+
+            def register_p2_im_chat_member_bot_deleted_v1(self, _handler):
+                calls.append("bot_deleted")
+                return self
+
             def build(self):
                 calls.append("build")
                 return "handler"
@@ -722,6 +754,8 @@ class TestAdapterBehavior(unittest.TestCase):
                 "reaction_created",
                 "reaction_deleted",
                 "card_action",
+                "bot_added",
+                "bot_deleted",
                 "build",
             ],
         )


### PR DESCRIPTION
# PR Draft: Feishu websocket shutdown

## Suggested title

`fix(feishu): stop official websocket client cleanly during disconnect`

## Problem

- `FeishuAdapter.disconnect()` 当前主要通过取消 websocket worker loop 上的任务并等待 `ws_future` 退出
- 在 systemd user service restart 场景下，官方 Lark websocket worker 可能没有及时沿着当前 stop 路径退出
- 结果是 `hermes-gateway.service` 停机路径卡住，最终打满 `TimeoutStopSec`

## Fix

- 保留 `_disable_websocket_auto_reconnect()`
- 新增 `_stop_official_websocket_client()`
  - 在 websocket worker loop 上调用官方 client 的 `_disconnect()`
  - 然后在同一 loop 上触发 stop
  - 主 loop 上等待 worker future，超时则退化为直接 stop worker loop
- 同时收紧 `_run_official_feishu_ws_client()` 的 finally 清理：
  - cancel pending tasks
  - gather return_exceptions
  - shutdown async generators
  - close loop

## Tests

- `uv run --extra dev python -m pytest tests/gateway/test_feishu.py -q`
  - local result on fresh branch: `95 passed, 16 skipped`
- Added regression coverage:
  - disconnect path awaits `_stop_official_websocket_client()`
  - event dispatcher test doubles updated for current builder shape

## Risk

- No hardcoded secrets or environment-specific identifiers introduced
- Main risk is SDK compatibility because the shutdown path relies on official websocket client private members such as `_disconnect` / `_auto_reconnect`
- This is a compatibility risk, not a data leak risk
