### PR TITLE
fix(discord): avoid blocking gateway readiness on slash command sync

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -455,6 +455,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
+        self._slash_sync_task: Optional[asyncio.Task] = None
         # Cap to prevent unbounded growth (Discord threads get archived).
         self._MAX_TRACKED_THREADS = 500
         # Dedup cache: message_id → timestamp.  Prevents duplicate bot
@@ -558,13 +559,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
 
-                # Sync slash commands with Discord
-                try:
-                    synced = await adapter_self._client.tree.sync()
-                    logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
-                except Exception as e:  # pragma: no cover - defensive logging
-                    logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
                 adapter_self._ready_event.set()
+
+                async def sync_slash_commands():
+                    try:
+                        synced = await adapter_self._client.tree.sync()
+                        logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
+                    except asyncio.CancelledError:  # pragma: no cover - shutdown path
+                        logger.debug("[%s] Slash command sync cancelled", adapter_self.name)
+                        raise
+                    except Exception as e:  # pragma: no cover - defensive logging
+                        logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
+
+                adapter_self._slash_sync_task = asyncio.create_task(sync_slash_commands())
 
             @self._client.event
             async def on_message(message: DiscordMessage):
@@ -706,6 +713,16 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        if self._slash_sync_task:
+            self._slash_sync_task.cancel()
+            try:
+                await self._slash_sync_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:  # pragma: no cover - defensive logging
+                logger.debug("[%s] Error while stopping slash sync: %s", self.name, e)
+            self._slash_sync_task = None
+
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -111,6 +111,69 @@ async def test_connect_only_requests_members_intent_when_needed(monkeypatch, all
 
 
 @pytest.mark.asyncio
+async def test_connect_sets_ready_before_slash_sync_finishes(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    sync_started = asyncio.Event()
+    allow_sync_to_finish = asyncio.Event()
+    real_wait_for = asyncio.wait_for
+
+    class SlowSyncTree(FakeTree):
+        def __init__(self):
+            super().__init__()
+
+            async def _slow_sync():
+                sync_started.set()
+                await allow_sync_to_finish.wait()
+                return []
+
+            self.sync = AsyncMock(side_effect=_slow_sync)
+
+    class SlowSyncBot:
+        def __init__(self, *, intents):
+            self.intents = intents
+            self.user = SimpleNamespace(id=999, name="Hermes")
+            self._events = {}
+            self.tree = SlowSyncTree()
+
+        def event(self, fn):
+            self._events[fn.__name__] = fn
+            return fn
+
+        async def start(self, token):
+            if "on_ready" in self._events:
+                await self._events["on_ready"]()
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: SlowSyncBot(intents=kwargs["intents"]),
+    )
+
+    async def short_wait_for(awaitable, timeout):
+        return await real_wait_for(awaitable, timeout=0.05)
+
+    monkeypatch.setattr(discord_platform.asyncio, "wait_for", short_wait_for)
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    await real_wait_for(sync_started.wait(), timeout=0.05)
+    allow_sync_to_finish.set()
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 


### PR DESCRIPTION
# PR Draft: Discord readiness before slash sync

## Suggested title

`fix(discord): avoid blocking gateway readiness on slash command sync`

## Problem

- `DiscordAdapter.on_ready()` 里当前先执行 `tree.sync()`，再设置 `_ready_event`
- 在 service-like startup 场景下，如果 slash command sync 较慢，gateway connect 会一直等不到 ready
- 结果是外层启动路径可能误判为连接超时，即使 bot 已经实际登录成功

## Fix

- 新增 `self._slash_sync_task`
- `on_ready()` 中先完成 allowed usernames resolve，然后立刻 `set()` `_ready_event`
- 把 slash command sync 挪到后台 task 中执行
- `disconnect()` 时取消并回收 `_slash_sync_task`

## Tests

- `uv run --extra dev python -m pytest tests/gateway/test_discord_connect.py -q`
  - local result on fresh branch: `5 passed`
- Added regression coverage:
  - slow slash sync does not block `connect()`
  - disconnect still waits for the background slash sync task to be cancelled cleanly

## Risk

- No hardcoded tokens, guild IDs, channel IDs, paths, or operator-specific values introduced
- Behavioral change is limited to startup ordering:
  - readiness now means “bot session is live and message handling can start”
  - slash sync becomes best-effort background work instead of a readiness prerequisite
