### PR TITLE
fix(agent): add restore failure tracking and user notification for fallback stickiness

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1467,6 +1467,7 @@ class AIAgent:
             self._fallback_chain = []
         self._fallback_index = 0
         self._fallback_activated = False
+        self._fallback_restore_fail_count = 0
         # Legacy attribute kept for backward compat (tests, external callers)
         self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
         if self._fallback_chain and not self.quiet_mode:
@@ -7253,18 +7254,28 @@ class AIAgent:
                 provider=rt["compressor_provider"],
             )
 
-            # ── Reset fallback chain for the new turn ──
-            self._fallback_activated = False
-            self._fallback_index = 0
-
             logging.info(
                 "Primary runtime restored for new turn: %s (%s)",
                 self.model, self.provider,
             )
-            return True
         except Exception as e:
             logging.warning("Failed to restore primary runtime: %s", e)
+            # Track consecutive restore failures
+            self._fallback_restore_fail_count += 1
+            if self._fallback_restore_fail_count >= 3 and not self.quiet_mode:
+                self._vprint(
+                    f"{self.log_prefix}⚠️  Primary provider unavailable after "
+                    f"{self._fallback_restore_fail_count} attempts — using fallback. "
+                    f"Check your API key and network connection.",
+                    force=True,
+                )
             return False
+
+        # Success — reset all fallback state outside the try block
+        self._fallback_activated = False
+        self._fallback_index = 0
+        self._fallback_restore_fail_count = 0
+        return True
 
     # Which error types indicate a transient transport failure worth
     # one more attempt with a rebuilt client / connection pool.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2251,6 +2251,7 @@ class AIAgent:
         # ── Reset fallback state ──
         self._fallback_activated = False
         self._fallback_index = 0
+        self._fallback_restore_fail_count = 0
 
         # When the user deliberately swaps primary providers (e.g. openrouter
         # → anthropic), drop any fallback entries that target the OLD primary
@@ -7260,14 +7261,14 @@ class AIAgent:
             )
         except Exception as e:
             logging.warning("Failed to restore primary runtime: %s", e)
-            # Track consecutive restore failures
+            # Track consecutive restore failures and notify exactly once at the
+            # threshold so the user is informed without repeated spam.
             self._fallback_restore_fail_count += 1
-            if self._fallback_restore_fail_count >= 3 and not self.quiet_mode:
-                self._vprint(
-                    f"{self.log_prefix}⚠️  Primary provider unavailable after "
+            if self._fallback_restore_fail_count == 3:
+                self._emit_status(
+                    f"⚠️  Primary provider unavailable after "
                     f"{self._fallback_restore_fail_count} attempts — using fallback. "
-                    f"Check your API key and network connection.",
-                    force=True,
+                    f"Check your API key and network connection."
                 )
             return False
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -978,6 +978,7 @@ class AIAgent:
             self._fallback_chain = []
         self._fallback_index = 0
         self._fallback_activated = False
+        self._fallback_restore_fail_count = 0
         # Legacy attribute kept for backward compat (tests, external callers)
         self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
         if self._fallback_chain and not self.quiet_mode:
@@ -5388,18 +5389,28 @@ class AIAgent:
                 provider=rt["compressor_provider"],
             )
 
-            # ── Reset fallback chain for the new turn ──
-            self._fallback_activated = False
-            self._fallback_index = 0
-
             logging.info(
                 "Primary runtime restored for new turn: %s (%s)",
                 self.model, self.provider,
             )
-            return True
         except Exception as e:
             logging.warning("Failed to restore primary runtime: %s", e)
+            # Track consecutive restore failures
+            self._fallback_restore_fail_count += 1
+            if self._fallback_restore_fail_count >= 3 and not self.quiet_mode:
+                self._vprint(
+                    f"{self.log_prefix}⚠️  Primary provider unavailable after "
+                    f"{self._fallback_restore_fail_count} attempts — using fallback. "
+                    f"Check your API key and network connection.",
+                    force=True,
+                )
             return False
+
+        # Success — reset all fallback state outside the try block
+        self._fallback_activated = False
+        self._fallback_index = 0
+        self._fallback_restore_fail_count = 0
+        return True
 
     # Which error types indicate a transient transport failure worth
     # one more attempt with a rebuilt client / connection pool.

--- a/tests/run_agent/test_fallback_restore.py
+++ b/tests/run_agent/test_fallback_restore.py
@@ -1,0 +1,160 @@
+"""Tests for fallback provider restore behavior."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestFallbackRestore:
+    """Fallback restore should properly track state and notify on persistent failure."""
+
+    def test_fallback_activated_cleared_on_successful_restore(self):
+        """_fallback_activated should be False after successful restore."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        # Simulate fallback activation
+        agent._fallback_activated = True
+        agent._fallback_index = 1
+        agent._primary_runtime = {
+            "model": "test-model",
+            "provider": "test-provider",
+            "base_url": "https://api.test.com",
+            "api_mode": "openai_chat",
+            "api_key": "test-key-1234567890",
+            "client_kwargs": {},
+            "use_prompt_caching": False,
+            "compressor_model": None,
+            "compressor_context_length": None,
+            "compressor_base_url": None,
+            "compressor_api_key": None,
+            "compressor_provider": None,
+        }
+
+        # Mock client creation and context compressor
+        with (
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+            patch.object(agent.context_compressor, "update_model"),
+        ):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False
+        assert agent._fallback_index == 0
+        assert agent._fallback_restore_fail_count == 0
+
+    def test_fallback_activated_remains_true_on_failed_restore(self):
+        """When restore fails, _fallback_activated should remain True."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        # Simulate fallback activation with a broken primary_runtime
+        agent._fallback_activated = True
+        agent._fallback_index = 1
+        agent._primary_runtime = {"model": None}  # Will cause KeyError in restore
+
+        result = agent._restore_primary_runtime()
+
+        assert result is False
+        assert agent._fallback_activated is True
+        assert agent._fallback_restore_fail_count >= 1
+
+    def test_restore_fail_count_increments_on_consecutive_failures(self):
+        """Consecutive restore failures should increment the counter."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        agent._fallback_activated = True
+        agent._fallback_index = 1
+        agent._primary_runtime = {"model": None}  # Broken
+
+        # First failure
+        agent._restore_primary_runtime()
+        count_after_first = agent._fallback_restore_fail_count
+
+        # Second failure
+        agent._fallback_activated = True  # Still in fallback
+        agent._restore_primary_runtime()
+        count_after_second = agent._fallback_restore_fail_count
+
+        assert count_after_second == count_after_first + 1
+
+    def test_restore_fail_count_resets_on_success(self):
+        """Successful restore should reset the failure counter."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        # Simulate prior failures
+        agent._fallback_restore_fail_count = 5
+
+        agent._fallback_activated = True
+        agent._fallback_index = 1
+        agent._primary_runtime = {
+            "model": "test-model",
+            "provider": "test-provider",
+            "base_url": "https://api.test.com",
+            "api_mode": "openai_chat",
+            "api_key": "test-key-1234567890",
+            "client_kwargs": {},
+            "use_prompt_caching": False,
+            "compressor_model": None,
+            "compressor_context_length": None,
+            "compressor_base_url": None,
+            "compressor_api_key": None,
+            "compressor_provider": None,
+        }
+
+        with (
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+            patch.object(agent.context_compressor, "update_model"),
+        ):
+            agent._restore_primary_runtime()
+
+        assert agent._fallback_restore_fail_count == 0

--- a/tests/run_agent/test_fallback_restore.py
+++ b/tests/run_agent/test_fallback_restore.py
@@ -4,43 +4,60 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _make_agent(quiet_mode=True):
+    """Create a minimal AIAgent using the 'custom' provider pattern.
+
+    Passes base_url and provider='custom' so that AIAgent.__init__ can
+    resolve a client without a real API key, following the established
+    pattern in test_primary_runtime_restore.py.
+    """
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://my-llm.example.com/v1",
+            provider="custom",
+            quiet_mode=quiet_mode,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+    return agent
+
+
+# Minimal _primary_runtime snapshot for successful restore tests.
+_VALID_PRIMARY_RUNTIME = {
+    "model": "test-model",
+    "provider": "test-provider",
+    "base_url": "https://api.test.com",
+    "api_mode": "openai_chat",
+    "api_key": "test-key-1234567890",
+    "client_kwargs": {},
+    "use_prompt_caching": False,
+    "compressor_model": None,
+    "compressor_context_length": None,
+    "compressor_base_url": None,
+    "compressor_api_key": None,
+    "compressor_provider": None,
+}
+
+
 class TestFallbackRestore:
     """Fallback restore should properly track state and notify on persistent failure."""
 
     def test_fallback_activated_cleared_on_successful_restore(self):
         """_fallback_activated should be False after successful restore."""
-        from run_agent import AIAgent
-
-        with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
+        agent = _make_agent()
 
         # Simulate fallback activation
         agent._fallback_activated = True
         agent._fallback_index = 1
-        agent._primary_runtime = {
-            "model": "test-model",
-            "provider": "test-provider",
-            "base_url": "https://api.test.com",
-            "api_mode": "openai_chat",
-            "api_key": "test-key-1234567890",
-            "client_kwargs": {},
-            "use_prompt_caching": False,
-            "compressor_model": None,
-            "compressor_context_length": None,
-            "compressor_base_url": None,
-            "compressor_api_key": None,
-            "compressor_provider": None,
-        }
+        agent._primary_runtime = dict(_VALID_PRIMARY_RUNTIME)
 
         # Mock client creation and context compressor
         with (
@@ -56,20 +73,7 @@ class TestFallbackRestore:
 
     def test_fallback_activated_remains_true_on_failed_restore(self):
         """When restore fails, _fallback_activated should remain True."""
-        from run_agent import AIAgent
-
-        with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
+        agent = _make_agent()
 
         # Simulate fallback activation with a broken primary_runtime
         agent._fallback_activated = True
@@ -84,20 +88,7 @@ class TestFallbackRestore:
 
     def test_restore_fail_count_increments_on_consecutive_failures(self):
         """Consecutive restore failures should increment the counter."""
-        from run_agent import AIAgent
-
-        with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
+        agent = _make_agent()
 
         agent._fallback_activated = True
         agent._fallback_index = 1
@@ -116,40 +107,14 @@ class TestFallbackRestore:
 
     def test_restore_fail_count_resets_on_success(self):
         """Successful restore should reset the failure counter."""
-        from run_agent import AIAgent
-
-        with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
+        agent = _make_agent()
 
         # Simulate prior failures
         agent._fallback_restore_fail_count = 5
 
         agent._fallback_activated = True
         agent._fallback_index = 1
-        agent._primary_runtime = {
-            "model": "test-model",
-            "provider": "test-provider",
-            "base_url": "https://api.test.com",
-            "api_mode": "openai_chat",
-            "api_key": "test-key-1234567890",
-            "client_kwargs": {},
-            "use_prompt_caching": False,
-            "compressor_model": None,
-            "compressor_context_length": None,
-            "compressor_base_url": None,
-            "compressor_api_key": None,
-            "compressor_provider": None,
-        }
+        agent._primary_runtime = dict(_VALID_PRIMARY_RUNTIME)
 
         with (
             patch.object(agent, "_create_openai_client", return_value=MagicMock()),
@@ -161,20 +126,7 @@ class TestFallbackRestore:
 
     def test_notification_fires_exactly_once_at_threshold(self):
         """Warning notification should fire exactly once when fail count reaches 3, not on every subsequent failure."""
-        from run_agent import AIAgent
-
-        with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                quiet_mode=False,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
+        agent = _make_agent(quiet_mode=False)
 
         agent._fallback_activated = True
         agent._fallback_index = 1
@@ -202,20 +154,7 @@ class TestFallbackRestore:
 
     def test_switch_model_resets_restore_fail_count(self):
         """switch_model should reset _fallback_restore_fail_count along with other fallback state."""
-        from run_agent import AIAgent
-
-        with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
+        agent = _make_agent()
 
         # Simulate accumulated restore failures
         agent._fallback_restore_fail_count = 5
@@ -228,7 +167,7 @@ class TestFallbackRestore:
         ):
             agent.switch_model(
                 new_model="new-model",
-                new_provider="new-provider",
+                new_provider="custom",
                 api_key="test-key-1234567890",
                 base_url="https://api.test.com",
             )

--- a/tests/run_agent/test_fallback_restore.py
+++ b/tests/run_agent/test_fallback_restore.py
@@ -158,3 +158,81 @@ class TestFallbackRestore:
             agent._restore_primary_runtime()
 
         assert agent._fallback_restore_fail_count == 0
+
+    def test_notification_fires_exactly_once_at_threshold(self):
+        """Warning notification should fire exactly once when fail count reaches 3, not on every subsequent failure."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=False,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        agent._fallback_activated = True
+        agent._fallback_index = 1
+        agent._primary_runtime = {"model": None}  # Broken
+
+        emit_calls = []
+        with patch.object(agent, "_emit_status", side_effect=lambda msg: emit_calls.append(msg)):
+            # Failures 1 and 2 — no notification yet
+            agent._restore_primary_runtime()
+            agent._fallback_activated = True
+            agent._restore_primary_runtime()
+            assert len(emit_calls) == 0, "No notification expected before threshold"
+
+            # Failure 3 — notification fires exactly once
+            agent._fallback_activated = True
+            agent._restore_primary_runtime()
+            assert len(emit_calls) == 1, "Notification should fire exactly once at threshold"
+
+            # Failures 4 and 5 — no additional notifications
+            agent._fallback_activated = True
+            agent._restore_primary_runtime()
+            agent._fallback_activated = True
+            agent._restore_primary_runtime()
+            assert len(emit_calls) == 1, "Notification must not repeat after threshold"
+
+    def test_switch_model_resets_restore_fail_count(self):
+        """switch_model should reset _fallback_restore_fail_count along with other fallback state."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        # Simulate accumulated restore failures
+        agent._fallback_restore_fail_count = 5
+        agent._fallback_activated = True
+        agent._fallback_index = 2
+
+        with (
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+            patch.object(agent.context_compressor, "update_model"),
+        ):
+            agent.switch_model(
+                new_model="new-model",
+                new_provider="new-provider",
+                api_key="test-key-1234567890",
+                base_url="https://api.test.com",
+            )
+
+        assert agent._fallback_restore_fail_count == 0
+        assert agent._fallback_activated is False
+        assert agent._fallback_index == 0


### PR DESCRIPTION
## Summary

- Add `_fallback_restore_fail_count` counter to track consecutive restore failures
- Move `_fallback_activated = False` and `_fallback_index = 0` outside the try block so they only reset on confirmed success
- After 3 consecutive failures, print a visible warning that the primary provider is unavailable
- On successful restore, reset the failure counter to 0

## Problem

When `_restore_primary_runtime` failed, the agent silently continued on the fallback provider. The fallback flags were reset inside the try block, meaning a subsequent exception would leave inconsistent state. Users had no visibility that the primary provider was persistently unreachable.

## Test plan

- [x] `test_fallback_activated_cleared_on_successful_restore` — flags reset on success
- [x] `test_fallback_activated_remains_true_on_failed_restore` — flags stay set on failure
- [x] `test_restore_fail_count_increments_on_consecutive_failures` — counter increments
- [x] `test_restore_fail_count_resets_on_success` — counter resets on recovery