### PR TITLE
fix(todo): filter completed/cancelled items when restoring from history

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2881,10 +2881,18 @@ class AIAgent:
                 continue
         
         if last_todo_response:
+            # Filter out completed/cancelled items when restoring from history,
+            # matching the logic in format_for_injection() -- these are intentionally
+            # excluded from context compression and should not be resurrected when
+            # the next turn hydrates the store from conversation history.
+            active_items = [
+                item for item in last_todo_response
+                if item.get("status") in ("pending", "in_progress")
+            ]
             # Replay the items into the store (replace mode)
-            self._todo_store.write(last_todo_response, merge=False)
+            self._todo_store.write(active_items, merge=False)
             if not self.quiet_mode:
-                self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
+                self._vprint(f"{self.log_prefix}📋 Restored {len(active_items)} todo item(s) from history ({len(last_todo_response) - len(active_items)} filtered)")
         _set_interrupt(False)
     
     @property


### PR DESCRIPTION
Closes #7599

## Bug Description

Cancelled (or completed) todo items spontaneously resurrect and get executed after subsequent tasks complete. When a user explicitly cancels a task (e.g. says 'don't do that'), the task should remain cancelled permanently. However, after completing another task, the cancelled task reappears and Hermes silently executes it.

## Root Cause

In `run_agent.py`, `_hydrate_todo_store()` (~line 2883) restores **all** todo items from conversation history without filtering out `completed`/`cancelled` ones. This contradicts `format_for_injection()` in `tools/todo_tool.py` which intentionally excludes them during context compression — causing a mismatch where cancelled items are excluded from compression but resurrected on hydration.

## Fix

Filter to only `pending`/`in_progress` items before writing to the todo store, matching `format_for_injection()`:

Before:
```python
if last_todo_response:
    self._todo_store.write(last_todo_response, merge=False)
    self._vprint(f"Restored {len(last_todo_response)} todo item(s) from history")
```

After:
```python
if last_todo_response:
    active_items = [
        item for item in last_todo_response
        if item.get("status") in ("pending", "in_progress")
    ]
    self._todo_store.write(active_items, merge=False)
    self._vprint(f"Restored {len(active_items)} todo item(s) from history ({len(last_todo_response) - len(active_items)} filtered)")
```

## Testing

- [x] Syntax verified with `python3 -m py_compile`
- [x] Bug reproduced and root cause identified via conversation history analysis
- [x] Fix applied to local Hermes and fork