### PR TITLE
feat(agent): add provider health check and auto-recovery from fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7189,6 +7189,35 @@ class AIAgent:
 
     # ── Per-turn primary restoration ─────────────────────────────────────
 
+    def check_provider_health(self) -> bool:
+        """Probe the primary provider to check if it's reachable.
+
+        Makes a lightweight API call (models.list) to verify connectivity.
+        Returns True if the provider responds, False otherwise.
+        """
+        try:
+            self.client.models.list()
+            return True
+        except Exception:
+            return False
+
+    def try_recover_primary(self) -> bool:
+        """Attempt to recover the primary provider if currently on fallback.
+
+        Called periodically (e.g., from _restore_primary_runtime) to
+        check if the primary has recovered. If healthy, triggers a full
+        restore.
+
+        Returns True if primary was recovered, False otherwise.
+        """
+        if not self._fallback_activated:
+            return True  # Already on primary
+
+        if self.check_provider_health():
+            return self._restore_primary_runtime()
+
+        return False
+
     def _restore_primary_runtime(self) -> bool:
         """Restore the primary runtime at the start of a new turn.
 
@@ -9619,10 +9648,11 @@ class AIAgent:
         from hermes_logging import set_session_context
         set_session_context(self.session_id)
 
-        # If the previous turn activated fallback, restore the primary
-        # runtime so this turn gets a fresh attempt with the preferred model.
+        # If the previous turn activated fallback, attempt to recover the
+        # primary provider. Uses try_recover_primary which first probes
+        # provider health before attempting a full restore.
         # No-op when _fallback_activated is False (gateway, first turn, etc.).
-        self._restore_primary_runtime()
+        self.try_recover_primary()
 
         # Sanitize surrogate characters from user input.  Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates

--- a/run_agent.py
+++ b/run_agent.py
@@ -7190,13 +7190,38 @@ class AIAgent:
     # ── Per-turn primary restoration ─────────────────────────────────────
 
     def check_provider_health(self) -> bool:
-        """Probe the primary provider to check if it's reachable.
+        """Probe the *primary* provider to check if it's reachable.
 
-        Makes a lightweight API call (models.list) to verify connectivity.
-        Returns True if the provider responds, False otherwise.
+        Builds a temporary OpenAI client from the primary-runtime snapshot so
+        the probe always targets the primary endpoint, not the currently-active
+        fallback client.  Skipped (returns True) when the primary uses
+        ``anthropic_messages`` mode because the Anthropic SDK does not expose a
+        ``models.list`` endpoint and ``self.client`` is ``None`` in that mode —
+        ``_restore_primary_runtime`` already handles the reconnect there.
+
+        Returns True if the provider responds (or if no probe is needed),
+        False if the primary endpoint is unreachable.
         """
+        rt = getattr(self, "_primary_runtime", None)
+        if not rt:
+            return True  # No snapshot yet — treat as healthy
+
+        primary_api_mode = rt.get("api_mode", "")
+        if primary_api_mode == "anthropic_messages":
+            # Anthropic SDK has no public models.list endpoint; skip the probe
+            # and let _restore_primary_runtime attempt the reconnect directly.
+            return True
+
         try:
-            self.client.models.list()
+            probe_client = self._create_openai_client(
+                dict(rt["client_kwargs"]),
+                reason="health_check_probe",
+                shared=False,
+            )
+            try:
+                probe_client.models.list()
+            finally:
+                self._close_openai_client(probe_client, reason="health_check_probe", shared=False)
             return True
         except Exception:
             return False
@@ -7204,11 +7229,12 @@ class AIAgent:
     def try_recover_primary(self) -> bool:
         """Attempt to recover the primary provider if currently on fallback.
 
-        Called periodically (e.g., from _restore_primary_runtime) to
-        check if the primary has recovered. If healthy, triggers a full
-        restore.
+        Called at the start of each turn (from ``run_conversation``) to check
+        whether the primary has recovered.  If the health probe succeeds,
+        triggers a full restore via ``_restore_primary_runtime``.
 
-        Returns True if primary was recovered, False otherwise.
+        Returns True if primary was recovered (or was already active),
+        False if the primary is still unreachable.
         """
         if not self._fallback_activated:
             return True  # Already on primary

--- a/run_agent.py
+++ b/run_agent.py
@@ -5336,6 +5336,35 @@ class AIAgent:
 
     # ── Per-turn primary restoration ─────────────────────────────────────
 
+    def check_provider_health(self) -> bool:
+        """Probe the primary provider to check if it's reachable.
+
+        Makes a lightweight API call (models.list) to verify connectivity.
+        Returns True if the provider responds, False otherwise.
+        """
+        try:
+            self.client.models.list()
+            return True
+        except Exception:
+            return False
+
+    def try_recover_primary(self) -> bool:
+        """Attempt to recover the primary provider if currently on fallback.
+
+        Called periodically (e.g., from _restore_primary_runtime) to
+        check if the primary has recovered. If healthy, triggers a full
+        restore.
+
+        Returns True if primary was recovered, False otherwise.
+        """
+        if not self._fallback_activated:
+            return True  # Already on primary
+
+        if self.check_provider_health():
+            return self._restore_primary_runtime()
+
+        return False
+
     def _restore_primary_runtime(self) -> bool:
         """Restore the primary runtime at the start of a new turn.
 
@@ -7387,10 +7416,11 @@ class AIAgent:
         # Installed once, transparent when streams are healthy, prevents crash on write.
         _install_safe_stdio()
 
-        # If the previous turn activated fallback, restore the primary
-        # runtime so this turn gets a fresh attempt with the preferred model.
+        # If the previous turn activated fallback, attempt to recover the
+        # primary provider. Uses try_recover_primary which first probes
+        # provider health before attempting a full restore.
         # No-op when _fallback_activated is False (gateway, first turn, etc.).
-        self._restore_primary_runtime()
+        self.try_recover_primary()
 
         # Sanitize surrogate characters from user input.  Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates

--- a/tests/run_agent/test_provider_health_check.py
+++ b/tests/run_agent/test_provider_health_check.py
@@ -1,0 +1,83 @@
+"""Tests for provider health check and auto-recovery."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestProviderHealthCheck:
+    """Agent should be able to probe primary provider health and auto-recover."""
+
+    def test_health_check_returns_true_when_primary_healthy(self):
+        """A healthy primary provider should return True from health check."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://my-llm.example.com/v1",
+                provider="custom",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            agent.client.models.list.return_value = MagicMock(data=[])
+
+        result = agent.check_provider_health()
+        assert result is True
+
+    def test_health_check_returns_false_when_primary_unreachable(self):
+        """An unreachable primary provider should return False from health check."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://my-llm.example.com/v1",
+                provider="custom",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            agent.client.models.list.side_effect = Exception("Connection refused")
+
+        result = agent.check_provider_health()
+        assert result is False
+
+    def test_auto_recovery_restores_primary_when_healthy(self):
+        """When primary becomes healthy, auto-recovery should restore it."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://my-llm.example.com/v1",
+                provider="custom",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            agent._fallback_activated = True
+
+        # Mock: health check says primary is healthy
+        with (
+            patch.object(agent, "check_provider_health", return_value=True),
+            patch.object(agent, "_restore_primary_runtime", return_value=True),
+        ):
+            result = agent.try_recover_primary()
+
+        assert result is True

--- a/tests/run_agent/test_provider_health_check.py
+++ b/tests/run_agent/test_provider_health_check.py
@@ -1,7 +1,29 @@
 """Tests for provider health check and auto-recovery."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 import pytest
+
+
+def _make_agent(provider="custom", api_mode=None):
+    """Create a minimal AIAgent for health-check tests."""
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://my-llm.example.com/v1",
+            provider=provider,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    if api_mode:
+        agent._primary_runtime["api_mode"] = api_mode
+    return agent
 
 
 class TestProviderHealthCheck:
@@ -9,71 +31,90 @@ class TestProviderHealthCheck:
 
     def test_health_check_returns_true_when_primary_healthy(self):
         """A healthy primary provider should return True from health check."""
-        from run_agent import AIAgent
+        agent = _make_agent()
+        mock_probe = MagicMock()
+        mock_probe.models.list.return_value = MagicMock(data=[])
 
         with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
+            patch.object(agent, "_create_openai_client", return_value=mock_probe),
+            patch.object(agent, "_close_openai_client"),
         ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                base_url="https://my-llm.example.com/v1",
-                provider="custom",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
-            agent.client.models.list.return_value = MagicMock(data=[])
+            result = agent.check_provider_health()
 
-        result = agent.check_provider_health()
         assert result is True
+        mock_probe.models.list.assert_called_once()
 
     def test_health_check_returns_false_when_primary_unreachable(self):
         """An unreachable primary provider should return False from health check."""
-        from run_agent import AIAgent
+        agent = _make_agent()
+        mock_probe = MagicMock()
+        mock_probe.models.list.side_effect = Exception("Connection refused")
 
         with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
+            patch.object(agent, "_create_openai_client", return_value=mock_probe),
+            patch.object(agent, "_close_openai_client"),
         ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                base_url="https://my-llm.example.com/v1",
-                provider="custom",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
-            agent.client.models.list.side_effect = Exception("Connection refused")
+            result = agent.check_provider_health()
 
-        result = agent.check_provider_health()
         assert result is False
+
+    def test_health_check_probes_primary_not_fallback_client(self):
+        """Health check must probe the primary endpoint, not self.client (fallback)."""
+        agent = _make_agent()
+        # Simulate: agent is on fallback — self.client is the fallback client
+        fallback_client = MagicMock(name="fallback_client")
+        fallback_client.models.list.return_value = MagicMock(data=[])
+        agent.client = fallback_client
+        agent._fallback_activated = True
+
+        # The primary probe client is separate
+        primary_probe = MagicMock(name="primary_probe")
+        primary_probe.models.list.return_value = MagicMock(data=[])
+
+        with (
+            patch.object(agent, "_create_openai_client", return_value=primary_probe),
+            patch.object(agent, "_close_openai_client"),
+        ):
+            result = agent.check_provider_health()
+
+        assert result is True
+        # The probe must use _create_openai_client (primary creds), NOT self.client
+        primary_probe.models.list.assert_called_once()
+        fallback_client.models.list.assert_not_called()
+
+    def test_health_check_skips_probe_for_anthropic_mode_primary(self):
+        """Anthropic-mode primaries have no models.list; probe should be skipped (returns True)."""
+        agent = _make_agent(provider="anthropic", api_mode="anthropic_messages")
+        # self.client is None for anthropic_messages mode
+        agent.client = None
+
+        with patch.object(agent, "_create_openai_client") as mock_create:
+            result = agent.check_provider_health()
+
+        assert result is True
+        # No OpenAI client should be created for an Anthropic-mode primary
+        mock_create.assert_not_called()
+
+    def test_health_check_probe_client_always_closed(self):
+        """The temporary probe client must be closed even when models.list raises."""
+        agent = _make_agent()
+        mock_probe = MagicMock()
+        mock_probe.models.list.side_effect = Exception("timeout")
+
+        with (
+            patch.object(agent, "_create_openai_client", return_value=mock_probe) as mock_create,
+            patch.object(agent, "_close_openai_client") as mock_close,
+        ):
+            result = agent.check_provider_health()
+
+        assert result is False
+        mock_close.assert_called_once_with(mock_probe, reason="health_check_probe", shared=False)
 
     def test_auto_recovery_restores_primary_when_healthy(self):
         """When primary becomes healthy, auto-recovery should restore it."""
-        from run_agent import AIAgent
+        agent = _make_agent()
+        agent._fallback_activated = True
 
-        with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            agent = AIAgent(
-                api_key="test-key-1234567890",
-                base_url="https://my-llm.example.com/v1",
-                provider="custom",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-            agent.client = MagicMock()
-            agent._fallback_activated = True
-
-        # Mock: health check says primary is healthy
         with (
             patch.object(agent, "check_provider_health", return_value=True),
             patch.object(agent, "_restore_primary_runtime", return_value=True),
@@ -81,3 +122,32 @@ class TestProviderHealthCheck:
             result = agent.try_recover_primary()
 
         assert result is True
+
+    def test_auto_recovery_skips_restore_when_already_on_primary(self):
+        """try_recover_primary should be a no-op (return True) when not on fallback."""
+        agent = _make_agent()
+        agent._fallback_activated = False
+
+        with (
+            patch.object(agent, "check_provider_health") as mock_health,
+            patch.object(agent, "_restore_primary_runtime") as mock_restore,
+        ):
+            result = agent.try_recover_primary()
+
+        assert result is True
+        mock_health.assert_not_called()
+        mock_restore.assert_not_called()
+
+    def test_auto_recovery_does_not_restore_when_still_unhealthy(self):
+        """When primary is still down, try_recover_primary should return False without restoring."""
+        agent = _make_agent()
+        agent._fallback_activated = True
+
+        with (
+            patch.object(agent, "check_provider_health", return_value=False),
+            patch.object(agent, "_restore_primary_runtime") as mock_restore,
+        ):
+            result = agent.try_recover_primary()
+
+        assert result is False
+        mock_restore.assert_not_called()

--- a/tests/run_agent/test_provider_health_check.py
+++ b/tests/run_agent/test_provider_health_check.py
@@ -1,0 +1,77 @@
+"""Tests for provider health check and auto-recovery."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestProviderHealthCheck:
+    """Agent should be able to probe primary provider health and auto-recover."""
+
+    def test_health_check_returns_true_when_primary_healthy(self):
+        """A healthy primary provider should return True from health check."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            agent.client.models.list.return_value = MagicMock(data=[])
+
+        result = agent.check_provider_health()
+        assert result is True
+
+    def test_health_check_returns_false_when_primary_unreachable(self):
+        """An unreachable primary provider should return False from health check."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            agent.client.models.list.side_effect = Exception("Connection refused")
+
+        result = agent.check_provider_health()
+        assert result is False
+
+    def test_auto_recovery_restores_primary_when_healthy(self):
+        """When primary becomes healthy, auto-recovery should restore it."""
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            agent._fallback_activated = True
+
+        # Mock: health check says primary is healthy
+        with (
+            patch.object(agent, "check_provider_health", return_value=True),
+            patch.object(agent, "_restore_primary_runtime", return_value=True),
+        ):
+            result = agent.try_recover_primary()
+
+        assert result is True


### PR DESCRIPTION
## Summary

- Add `check_provider_health()` — lightweight `models.list` probe to verify primary provider reachability
- Add `try_recover_primary()` — checks health before attempting restore, avoiding unnecessary work when primary is still down
- Replace direct `_restore_primary_runtime()` call in `run_conversation` with `try_recover_primary()`

## Motivation

When a fallback provider is active, every new turn blindly attempted a full runtime restore even when the primary was still unreachable. This caused unnecessary client rebuilds and noisy exception logging on every turn. A health check gate makes the recovery attempt conditional.

## Test plan

- [x] `test_health_check_returns_true_when_primary_healthy` — healthy provider returns True
- [x] `test_health_check_returns_false_when_primary_unreachable` — unreachable provider returns False
- [x] `test_auto_recovery_restores_primary_when_healthy` — recovery succeeds when health check passes