### PR TITLE
feat(gateway): add correlation ID context variable for request tracing

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -22,6 +22,7 @@ Requires:
 """
 
 import asyncio
+import contextvars
 import hashlib
 import hmac
 import json
@@ -49,6 +50,18 @@ from gateway.platforms.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ── Correlation ID context ─────────────────────────────────────────────
+_correlation_id: contextvars.ContextVar[str] = contextvars.ContextVar("correlation_id", default=None)
+
+
+def _get_correlation_id() -> str:
+    return _correlation_id.get()
+
+
+def _set_correlation_id(cid: str) -> None:
+    _correlation_id.set(cid)
+
 
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
@@ -415,6 +428,20 @@ if AIOHTTP_AVAILABLE:
         return response
 else:
     cors_middleware = None  # type: ignore[assignment]
+
+
+if AIOHTTP_AVAILABLE:
+    @web.middleware
+    async def correlation_id_middleware(request, handler):
+        """Assign a unique correlation ID to each request for log tracing."""
+        import uuid
+        cid = request.headers.get("X-Correlation-ID") or str(uuid.uuid4())[:8]
+        _set_correlation_id(cid)
+        response = await handler(request)
+        response.headers["X-Correlation-ID"] = cid
+        return response
+else:
+    correlation_id_middleware = None  # type: ignore[assignment]
 
 
 def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
@@ -2614,7 +2641,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+            mws = [mw for mw in (correlation_id_middleware, cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -52,10 +52,10 @@ from gateway.platforms.base import (
 logger = logging.getLogger(__name__)
 
 # ── Correlation ID context ─────────────────────────────────────────────
-_correlation_id: contextvars.ContextVar[str] = contextvars.ContextVar("correlation_id", default=None)
+_correlation_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("correlation_id", default=None)
 
 
-def _get_correlation_id() -> str:
+def _get_correlation_id() -> Optional[str]:
     return _correlation_id.get()
 
 
@@ -434,8 +434,7 @@ if AIOHTTP_AVAILABLE:
     @web.middleware
     async def correlation_id_middleware(request, handler):
         """Assign a unique correlation ID to each request for log tracing."""
-        import uuid
-        cid = request.headers.get("X-Correlation-ID") or str(uuid.uuid4())[:8]
+        cid = request.headers.get("X-Correlation-ID") or uuid.uuid4().hex
         _set_correlation_id(cid)
         response = await handler(request)
         response.headers["X-Correlation-ID"] = cid
@@ -2292,8 +2291,15 @@ class APIServerAdapter(BasePlatformAdapter):
         another thread to stop in-progress LLM calls.
         """
         loop = asyncio.get_running_loop()
+        # ContextVar values are not propagated to ThreadPoolExecutor threads
+        # automatically.  Capture the current correlation ID here (in the async
+        # context where it is set) and restore it inside the thread so that any
+        # logging emitted by the agent carries the same request-scoped ID.
+        captured_cid = _get_correlation_id()
 
         def _run():
+            if captured_cid is not None:
+                _set_correlation_id(captured_cid)
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
@@ -2473,7 +2479,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=event_cb,
                 )
                 self._active_run_agents[run_id] = agent
+                # Capture correlation ID in the async context before handing off
+                # to a ThreadPoolExecutor thread, which would otherwise see None.
+                captured_cid = _get_correlation_id()
+
                 def _run_sync():
+                    if captured_cid is not None:
+                        _set_correlation_id(captured_cid)
                     r = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -20,6 +20,7 @@ Requires:
 """
 
 import asyncio
+import contextvars
 import hashlib
 import hmac
 import json
@@ -47,6 +48,18 @@ from gateway.platforms.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ── Correlation ID context ─────────────────────────────────────────────
+_correlation_id: contextvars.ContextVar[str] = contextvars.ContextVar("correlation_id", default=None)
+
+
+def _get_correlation_id() -> str:
+    return _correlation_id.get()
+
+
+def _set_correlation_id(cid: str) -> None:
+    _correlation_id.set(cid)
+
 
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
@@ -200,6 +213,20 @@ if AIOHTTP_AVAILABLE:
         return response
 else:
     cors_middleware = None  # type: ignore[assignment]
+
+
+if AIOHTTP_AVAILABLE:
+    @web.middleware
+    async def correlation_id_middleware(request, handler):
+        """Assign a unique correlation ID to each request for log tracing."""
+        import uuid
+        cid = request.headers.get("X-Correlation-ID") or str(uuid.uuid4())[:8]
+        _set_correlation_id(cid)
+        response = await handler(request)
+        response.headers["X-Correlation-ID"] = cid
+        return response
+else:
+    correlation_id_middleware = None  # type: ignore[assignment]
 
 
 def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
@@ -1718,7 +1745,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+            mws = [mw for mw in (correlation_id_middleware, cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)

--- a/tests/gateway/test_correlation_ids.py
+++ b/tests/gateway/test_correlation_ids.py
@@ -1,5 +1,7 @@
 """Tests for correlation ID tracking in gateway requests."""
 import asyncio
+import concurrent.futures
+import re
 
 import pytest
 
@@ -41,3 +43,80 @@ class TestCorrelationIds:
 
         assert results["a"] == "req-a-123"
         assert results["b"] == "req-b-456"
+
+    def test_correlation_id_format_is_full_uuid_hex(self):
+        """Auto-generated correlation IDs must be 32-char hex strings (UUID4 hex).
+
+        A truncated 8-char ID has only 32 bits of entropy, giving a ~1% collision
+        probability at 10k concurrent requests (birthday paradox).  The full UUID4
+        hex (128 bits) eliminates this risk.
+        """
+        import uuid
+        from gateway.platforms.api_server import _set_correlation_id, _get_correlation_id
+
+        # Simulate what the middleware generates when no header is present
+        generated = uuid.uuid4().hex
+        _set_correlation_id(generated)
+        stored = _get_correlation_id()
+
+        assert stored is not None
+        assert len(stored) == 32, f"Expected 32-char hex, got {len(stored)}-char: {stored!r}"
+        assert re.fullmatch(r"[0-9a-f]{32}", stored), f"Not a lowercase hex string: {stored!r}"
+
+    def test_correlation_id_propagates_to_executor_thread(self):
+        """Correlation ID set in async context must be visible in ThreadPoolExecutor threads.
+
+        ContextVar values are NOT automatically inherited by threads submitted via
+        run_in_executor.  The fix (capturing the ID before submit and calling
+        _set_correlation_id inside the thread) must be verified explicitly.
+        """
+        from gateway.platforms.api_server import _get_correlation_id, _set_correlation_id
+
+        thread_result = {}
+
+        async def main():
+            _set_correlation_id("propagation-test-id")
+            captured_cid = _get_correlation_id()
+
+            loop = asyncio.get_event_loop()
+
+            def _thread_fn():
+                # Replicate the fix: set the captured ID inside the thread
+                if captured_cid is not None:
+                    _set_correlation_id(captured_cid)
+                thread_result["cid"] = _get_correlation_id()
+
+            await loop.run_in_executor(None, _thread_fn)
+
+        asyncio.run(main())
+
+        assert thread_result.get("cid") == "propagation-test-id", (
+            "Correlation ID was not visible inside the executor thread. "
+            "The captured_cid must be passed explicitly and set via _set_correlation_id."
+        )
+
+    def test_correlation_id_not_visible_in_thread_without_explicit_propagation(self):
+        """Confirm that without explicit propagation, threads see None.
+
+        This is the baseline that documents WHY explicit propagation is required.
+        """
+        from gateway.platforms.api_server import _get_correlation_id, _set_correlation_id
+
+        thread_result = {}
+
+        async def main():
+            _set_correlation_id("should-not-propagate")
+            loop = asyncio.get_event_loop()
+
+            def _thread_fn():
+                # No explicit _set_correlation_id call here
+                thread_result["cid"] = _get_correlation_id()
+
+            await loop.run_in_executor(None, _thread_fn)
+
+        asyncio.run(main())
+
+        assert thread_result.get("cid") is None, (
+            "ContextVar unexpectedly propagated to thread without explicit copy. "
+            "Python behavior may have changed."
+        )

--- a/tests/gateway/test_correlation_ids.py
+++ b/tests/gateway/test_correlation_ids.py
@@ -1,0 +1,43 @@
+"""Tests for correlation ID tracking in gateway requests."""
+import asyncio
+
+import pytest
+
+
+class TestCorrelationIds:
+    """Gateway requests should be tagged with correlation IDs."""
+
+    def test_correlation_id_generated_on_request(self):
+        """Each API request should generate a unique correlation ID."""
+        from gateway.platforms.api_server import _get_correlation_id, _set_correlation_id
+
+        # Before setting, should be None
+        assert _get_correlation_id() is None
+
+        # After setting
+        _set_correlation_id("test-123")
+        assert _get_correlation_id() == "test-123"
+
+    def test_correlation_id_isolated_between_contexts(self):
+        """Correlation IDs should not leak between concurrent requests."""
+        from gateway.platforms.api_server import _get_correlation_id, _set_correlation_id
+
+        results = {}
+
+        async def request_a():
+            _set_correlation_id("req-a-123")
+            await asyncio.sleep(0.01)
+            results["a"] = _get_correlation_id()
+
+        async def request_b():
+            _set_correlation_id("req-b-456")
+            await asyncio.sleep(0.01)
+            results["b"] = _get_correlation_id()
+
+        async def main():
+            await asyncio.gather(request_a(), request_b())
+
+        asyncio.run(main())
+
+        assert results["a"] == "req-a-123"
+        assert results["b"] == "req-b-456"


### PR DESCRIPTION
## Summary

- Add `contextvars.ContextVar`-based correlation ID tracking to the API server
- Each request gets a unique correlation ID from `X-Correlation-ID` header or auto-generated UUID
- Correlation ID is set per-request in a ContextVar and echoed in the response header
- Context isolation ensures concurrent requests don't leak correlation IDs

## Motivation

When multiple concurrent requests hit the API server, correlating log entries to specific requests is difficult. A per-request correlation ID propagated via ContextVar allows log filtering and distributed tracing without external infrastructure.

## Test plan

- [x] `test_correlation_id_generated_on_request` — ContextVar get/set works correctly
- [x] `test_correlation_id_isolated_between_contexts` — concurrent requests maintain separate IDs