### PR TITLE
[codex] Toolsets + Registry + MCP Authority

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -183,10 +183,18 @@ jobs:
           ---
           *Automated scan triggered by [supply-chain-audit](/.github/workflows/supply-chain-audit.yml). If this is a false positive, a maintainer can approve after manual review.*"
 
-          gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
+          if ! COMMENT_ERR="$(gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" 2>&1)"; then
+            printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
+            if printf '%s' "$COMMENT_ERR" | grep -Eqi 'resource not accessible by integration|http 403|forbidden'; then
+              echo "::warning::Unable to post PR comment due to token restrictions. Findings were written to the job summary instead."
+            else
+              echo "$COMMENT_ERR" >&2
+              exit 1
+            fi
+          fi
 
       - name: Fail on critical findings
         if: steps.scan.outputs.critical == 'true'
         run: |
-          echo "::error::CRITICAL supply chain risk patterns detected in this PR. See the PR comment for details."
+          echo "::error::CRITICAL supply chain risk patterns detected in this PR. See the PR comment or job summary for details."
           exit 1

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -41,7 +41,7 @@ from toolset_distributions import (
     sample_toolsets_from_distribution,
     validate_distribution
 )
-from model_tools import TOOL_TO_TOOLSET_MAP
+from model_tools import get_tool_to_toolset_map_snapshot
 
 
 # Global configuration for worker processes
@@ -53,7 +53,7 @@ DEFAULT_TOOL_STATS = {'count': 0, 'success': 0, 'failure': 0}
 
 def _all_possible_tools() -> set[str]:
     """Return the live set of known tools."""
-    return set(TOOL_TO_TOOLSET_MAP.keys())
+    return set(get_tool_to_toolset_map_snapshot().keys())
 
 
 def _normalize_tool_stats(tool_stats: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:
@@ -787,6 +787,50 @@ class BatchRunner:
                 filtered_dataset.append((idx, entry))
         
         return filtered_dataset, skipped_indices
+
+    def _combine_batch_outputs(self) -> Dict[str, int]:
+        """Combine batch shards into trajectories.jsonl, filtering invalid tool names."""
+        combined_file = self.output_dir / "trajectories.jsonl"
+        print(f"\n📦 Combining ALL batch files into {combined_file.name}...")
+
+        valid_tools = _all_possible_tools()
+        total_entries = 0
+        filtered_entries = 0
+        batch_files_found = 0
+        all_batch_files = sorted(self.output_dir.glob("batch_*.jsonl"))
+
+        with open(combined_file, 'w', encoding='utf-8') as outfile:
+            for batch_file in all_batch_files:
+                batch_files_found += 1
+                batch_num = batch_file.stem.split("_")[1]
+
+                with open(batch_file, 'r', encoding='utf-8') as infile:
+                    for line in infile:
+                        total_entries += 1
+                        try:
+                            data = json.loads(line)
+                            tool_stats = data.get('tool_stats', {})
+                            invalid_tools = [k for k in tool_stats if k not in valid_tools]
+
+                            if invalid_tools:
+                                filtered_entries += 1
+                                invalid_preview = invalid_tools[0][:50] + "..." if len(invalid_tools[0]) > 50 else invalid_tools[0]
+                                print(f"   ⚠️  Filtering corrupted entry (batch {batch_num}): invalid tool '{invalid_preview}'")
+                                continue
+
+                            outfile.write(line)
+                        except json.JSONDecodeError:
+                            filtered_entries += 1
+                            print(f"   ⚠️  Filtering invalid JSON entry (batch {batch_num})")
+
+        if filtered_entries > 0:
+            print(f"⚠️  Filtered {filtered_entries} corrupted entries out of {total_entries} total")
+        print(f"✅ Combined {batch_files_found} batch files into trajectories.jsonl ({total_entries - filtered_entries} entries)")
+        return {
+            "total_entries": total_entries,
+            "filtered_entries": filtered_entries,
+            "batch_files_found": batch_files_found,
+        }
     
     def run(self, resume: bool = False):
         """
@@ -988,51 +1032,7 @@ class BatchRunner:
                 stats["success_rate"] = 0.0
                 stats["failure_rate"] = 0.0
         
-        # Combine ALL batch files in directory into a single trajectories.jsonl file
-        # This includes both old batches (from previous runs) and new batches (from resume)
-        # Also filter out corrupted entries (where model generated invalid tool names)
-        combined_file = self.output_dir / "trajectories.jsonl"
-        print(f"\n📦 Combining ALL batch files into {combined_file.name}...")
-        
-        # Valid tools auto-derived from model_tools.py — no manual updates needed
-        VALID_TOOLS = _all_possible_tools()
-        
-        total_entries = 0
-        filtered_entries = 0
-        batch_files_found = 0
-        
-        # Find ALL batch files in the output directory (handles resume merging old + new)
-        all_batch_files = sorted(self.output_dir.glob("batch_*.jsonl"))
-        
-        with open(combined_file, 'w', encoding='utf-8') as outfile:
-            for batch_file in all_batch_files:
-                batch_files_found += 1
-                batch_num = batch_file.stem.split("_")[1]  # Extract batch number for logging
-                
-                with open(batch_file, 'r', encoding='utf-8') as infile:
-                    for line in infile:
-                        total_entries += 1
-                        try:
-                            data = json.loads(line)
-                            tool_stats = data.get('tool_stats', {})
-                            
-                            # Check for invalid tool names (model hallucinations)
-                            invalid_tools = [k for k in tool_stats if k not in VALID_TOOLS]
-                            
-                            if invalid_tools:
-                                filtered_entries += 1
-                                invalid_preview = invalid_tools[0][:50] + "..." if len(invalid_tools[0]) > 50 else invalid_tools[0]
-                                print(f"   ⚠️  Filtering corrupted entry (batch {batch_num}): invalid tool '{invalid_preview}'")
-                                continue
-                            
-                            outfile.write(line)
-                        except json.JSONDecodeError:
-                            filtered_entries += 1
-                            print(f"   ⚠️  Filtering invalid JSON entry (batch {batch_num})")
-        
-        if filtered_entries > 0:
-            print(f"⚠️  Filtered {filtered_entries} corrupted entries out of {total_entries} total")
-        print(f"✅ Combined {batch_files_found} batch files into trajectories.jsonl ({total_entries - filtered_entries} entries)")
+        self._combine_batch_outputs()
         
         # Save final statistics
         final_stats = {

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -47,14 +47,13 @@ from model_tools import TOOL_TO_TOOLSET_MAP
 # Global configuration for worker processes
 _WORKER_CONFIG = {}
 
-# All possible tools - auto-derived from the master mapping in model_tools.py.
-# This stays in sync automatically when new tools are added to TOOL_TO_TOOLSET_MAP.
-# Used for consistent schema in Arrow/Parquet (HuggingFace datasets) and for
-# filtering corrupted entries during trajectory combination.
-ALL_POSSIBLE_TOOLS = set(TOOL_TO_TOOLSET_MAP.keys())
-
 # Default stats for tools that weren't used
 DEFAULT_TOOL_STATS = {'count': 0, 'success': 0, 'failure': 0}
+
+
+def _all_possible_tools() -> set[str]:
+    """Return the live set of known tools."""
+    return set(TOOL_TO_TOOLSET_MAP.keys())
 
 
 def _normalize_tool_stats(tool_stats: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:
@@ -73,7 +72,7 @@ def _normalize_tool_stats(tool_stats: Dict[str, Dict[str, int]]) -> Dict[str, Di
     normalized = {}
     
     # Add all possible tools with defaults
-    for tool in ALL_POSSIBLE_TOOLS:
+    for tool in _all_possible_tools():
         if tool in tool_stats:
             normalized[tool] = tool_stats[tool].copy()
         else:
@@ -100,7 +99,7 @@ def _normalize_tool_error_counts(tool_error_counts: Dict[str, int]) -> Dict[str,
     normalized = {}
     
     # Add all possible tools with zero defaults
-    for tool in ALL_POSSIBLE_TOOLS:
+    for tool in _all_possible_tools():
         normalized[tool] = tool_error_counts.get(tool, 0)
     
     # Also include any unexpected tools
@@ -1284,4 +1283,3 @@ def main(
 
 if __name__ == "__main__":
     fire.Fire(main)
-

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -995,7 +995,7 @@ class BatchRunner:
         print(f"\n📦 Combining ALL batch files into {combined_file.name}...")
         
         # Valid tools auto-derived from model_tools.py — no manual updates needed
-        VALID_TOOLS = ALL_POSSIBLE_TOOLS
+        VALID_TOOLS = _all_possible_tools()
         
         total_entries = 0
         filtered_entries = 0

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -331,7 +331,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         get_toolset_for_tool: Callable to map tool name -> toolset name.
         context_length: Model's context window size in tokens.
     """
-    from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
+    from model_tools import check_tool_availability, get_toolset_requirements_snapshot
     if get_toolset_for_tool is None:
         from model_tools import get_toolset_for_tool
 
@@ -346,7 +346,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     lazy_tools = set()
     for item in unavailable_toolsets:
         toolset_name = item.get("name", "")
-        ts_req = TOOLSET_REQUIREMENTS.get(toolset_name, {})
+        ts_req = get_toolset_requirements_snapshot().get(toolset_name, {})
         tools_in_ts = item.get("tools", [])
         if ts_req.get("check_fn"):
             lazy_tools.update(tools_in_ts)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -799,13 +799,14 @@ def run_doctor(args):
     try:
         # Add project root to path for imports
         sys.path.insert(0, str(PROJECT_ROOT))
-        from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
+        from model_tools import check_tool_availability, get_toolset_requirements_snapshot
         
         available, unavailable = check_tool_availability()
         available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
-        
+        toolset_requirements = get_toolset_requirements_snapshot()
+
         for tid in available:
-            info = TOOLSET_REQUIREMENTS.get(tid, {})
+            info = toolset_requirements.get(tid, {})
             check_ok(info.get("name", tid))
         
         for item in unavailable:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -799,11 +799,15 @@ def run_doctor(args):
     try:
         # Add project root to path for imports
         sys.path.insert(0, str(PROJECT_ROOT))
-        from model_tools import check_tool_availability, get_toolset_requirements_snapshot
-        
+        import model_tools as _model_tools
+
+        check_tool_availability = _model_tools.check_tool_availability
         available, unavailable = check_tool_availability()
         available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
-        toolset_requirements = get_toolset_requirements_snapshot()
+        if hasattr(_model_tools, "get_toolset_requirements_snapshot"):
+            toolset_requirements = _model_tools.get_toolset_requirements_snapshot()
+        else:
+            toolset_requirements = getattr(_model_tools, "TOOLSET_REQUIREMENTS", {})
 
         for tid in available:
             info = toolset_requirements.get(tid, {})

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -558,6 +558,12 @@ def _get_platform_tools(
     # as an allowlist. Otherwise include every globally enabled MCP server.
     # Special sentinel: "no_mcp" in the toolset list disables all MCP servers.
     mcp_servers = config.get("mcp_servers") or {}
+    enabled_mcp_server_toolsets = {
+        f"mcp-{name}"
+        for name, server_cfg in mcp_servers.items()
+        if isinstance(server_cfg, dict)
+        and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
+    }
     enabled_mcp_servers = {
         name
         for name, server_cfg in mcp_servers.items()
@@ -565,17 +571,22 @@ def _get_platform_tools(
         and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
     }
     # Allow "no_mcp" sentinel to opt out of all MCP servers for this platform
+    legacy_named_mcp_toolsets = {
+        f"mcp-{ts}"
+        for ts in explicit_passthrough & enabled_mcp_servers
+    }
+    explicit_passthrough = (explicit_passthrough - enabled_mcp_servers) | legacy_named_mcp_toolsets
     if "no_mcp" in toolset_names:
         explicit_mcp_servers = set()
-        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers - {"no_mcp"})
+        enabled_toolsets.update(explicit_passthrough - enabled_mcp_server_toolsets - {"no_mcp"})
     else:
-        explicit_mcp_servers = explicit_passthrough & enabled_mcp_servers
-        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers)
+        explicit_mcp_servers = explicit_passthrough & enabled_mcp_server_toolsets
+        enabled_toolsets.update(explicit_passthrough - enabled_mcp_server_toolsets)
     if include_default_mcp_servers:
         if explicit_mcp_servers or "no_mcp" in toolset_names:
             enabled_toolsets.update(explicit_mcp_servers)
         else:
-            enabled_toolsets.update(enabled_mcp_servers)
+            enabled_toolsets.update(enabled_mcp_server_toolsets)
     else:
         enabled_toolsets.update(explicit_mcp_servers)
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -558,12 +558,6 @@ def _get_platform_tools(
     # as an allowlist. Otherwise include every globally enabled MCP server.
     # Special sentinel: "no_mcp" in the toolset list disables all MCP servers.
     mcp_servers = config.get("mcp_servers") or {}
-    enabled_mcp_server_toolsets = {
-        f"mcp-{name}"
-        for name, server_cfg in mcp_servers.items()
-        if isinstance(server_cfg, dict)
-        and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
-    }
     enabled_mcp_servers = {
         name
         for name, server_cfg in mcp_servers.items()
@@ -571,22 +565,27 @@ def _get_platform_tools(
         and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
     }
     # Allow "no_mcp" sentinel to opt out of all MCP servers for this platform
-    legacy_named_mcp_toolsets = {
-        f"mcp-{ts}"
-        for ts in explicit_passthrough & enabled_mcp_servers
+    legacy_named_mcp_servers = {
+        ts[4:]
+        for ts in explicit_passthrough
+        if ts.startswith("mcp-") and ts[4:] in enabled_mcp_servers
     }
-    explicit_passthrough = (explicit_passthrough - enabled_mcp_servers) | legacy_named_mcp_toolsets
+    explicit_passthrough = {
+        ts
+        for ts in explicit_passthrough
+        if not ts.startswith("mcp-")
+    } | legacy_named_mcp_servers
     if "no_mcp" in toolset_names:
         explicit_mcp_servers = set()
-        enabled_toolsets.update(explicit_passthrough - enabled_mcp_server_toolsets - {"no_mcp"})
+        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers - {"no_mcp"})
     else:
-        explicit_mcp_servers = explicit_passthrough & enabled_mcp_server_toolsets
-        enabled_toolsets.update(explicit_passthrough - enabled_mcp_server_toolsets)
+        explicit_mcp_servers = explicit_passthrough & enabled_mcp_servers
+        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers)
     if include_default_mcp_servers:
         if explicit_mcp_servers or "no_mcp" in toolset_names:
             enabled_toolsets.update(explicit_mcp_servers)
         else:
-            enabled_toolsets.update(enabled_mcp_server_toolsets)
+            enabled_toolsets.update(enabled_mcp_servers)
     else:
         enabled_toolsets.update(explicit_mcp_servers)
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -11,8 +11,8 @@ environments consume.
 Public API (signatures preserved from the original 2,400-line version):
     get_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode) -> list
     handle_function_call(function_name, function_args, task_id, user_task) -> str
-    TOOL_TO_TOOLSET_MAP: dict          (for batch_runner.py)
-    TOOLSET_REQUIREMENTS: dict         (for cli.py, doctor.py)
+    get_tool_to_toolset_map_snapshot() -> dict
+    get_toolset_requirements_snapshot() -> dict
     get_all_tool_names() -> list
     get_toolset_for_tool(name) -> str
     get_available_toolsets() -> dict
@@ -20,8 +20,8 @@ Public API (signatures preserved from the original 2,400-line version):
     check_tool_availability(quiet) -> tuple
 """
 
-import json
 import asyncio
+import json
 import logging
 import threading
 from typing import Dict, Any, List, Optional, Tuple
@@ -131,56 +131,6 @@ def _run_async(coro):
     return tool_loop.run_until_complete(coro)
 
 
-class _DynamicDictView(dict):
-    """Live read-through dict for backward-compatible exported mappings."""
-
-    def __init__(self, supplier):
-        super().__init__()
-        self._supplier = supplier
-
-    def _refresh(self) -> None:
-        super().clear()
-        super().update(self._supplier())
-
-    def __getitem__(self, key):
-        self._refresh()
-        return super().__getitem__(key)
-
-    def __contains__(self, key):
-        self._refresh()
-        return super().__contains__(key)
-
-    def __iter__(self):
-        self._refresh()
-        return super().__iter__()
-
-    def __len__(self):
-        self._refresh()
-        return super().__len__()
-
-    def __repr__(self):
-        self._refresh()
-        return super().__repr__()
-
-    def get(self, key, default=None):
-        self._refresh()
-        return super().get(key, default)
-
-    def items(self):
-        self._refresh()
-        return super().items()
-
-    def keys(self):
-        self._refresh()
-        return super().keys()
-
-    def values(self):
-        self._refresh()
-        return super().values()
-
-    def copy(self):
-        self._refresh()
-        return dict(self)
 discover_builtin_tools()
 
 # MCP tool discovery (external MCP servers from config)
@@ -202,11 +152,26 @@ except Exception as e:
 # Backward-compat constants  (live views over the registry)
 # =============================================================================
 
-TOOL_TO_TOOLSET_MAP: Dict[str, str] = _DynamicDictView(registry.get_tool_to_toolset_map)
+def get_tool_to_toolset_map_snapshot() -> Dict[str, str]:
+    """Return a fresh registry-backed ``tool -> toolset`` snapshot."""
+    return registry.get_tool_to_toolset_map()
 
-TOOLSET_REQUIREMENTS: Dict[str, dict] = _DynamicDictView(registry.get_toolset_requirements)
 
-_LEGACY_TOOLSET_MAP = _DynamicDictView(get_legacy_toolset_map)
+def get_toolset_requirements_snapshot() -> Dict[str, dict]:
+    """Return a fresh registry-backed toolset requirements snapshot."""
+    return registry.get_toolset_requirements()
+
+
+def get_legacy_toolset_map_snapshot() -> Dict[str, List[str]]:
+    """Return a fresh resolved snapshot of the legacy alias map."""
+    return get_legacy_toolset_map()
+
+
+TOOL_TO_TOOLSET_MAP: Dict[str, str] = get_tool_to_toolset_map_snapshot()
+
+TOOLSET_REQUIREMENTS: Dict[str, dict] = get_toolset_requirements_snapshot()
+
+_LEGACY_TOOLSET_MAP = get_legacy_toolset_map_snapshot()
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.

--- a/model_tools.py
+++ b/model_tools.py
@@ -180,11 +180,11 @@ _last_resolved_tool_names: List[str] = []
 
 def _resolve_requested_toolset(name: str) -> Tuple[List[str], Optional[str]]:
     """Resolve a requested toolset or legacy alias to concrete tool names."""
-    if validate_toolset(name):
-        return resolve_toolset(name), "toolset"
-
     if is_legacy_toolset(name):
         return resolve_legacy_toolset(name), "legacy"
+
+    if validate_toolset(name):
+        return resolve_toolset(name), "toolset"
 
     return [], None
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -22,12 +22,14 @@ Public API (signatures preserved from the original 2,400-line version):
 
 import json
 import asyncio
+import ast
 import logging
 import threading
+from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import registry
-from toolsets import resolve_toolset, validate_toolset
+from toolsets import resolve_multiple_toolsets, resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
 
@@ -129,38 +131,97 @@ def _run_async(coro):
 # Tool Discovery  (importing each module triggers its registry.register calls)
 # =============================================================================
 
+
+class _DynamicDictView(dict):
+    """Live read-through dict for backward-compatible exported mappings."""
+
+    def __init__(self, supplier):
+        super().__init__()
+        self._supplier = supplier
+
+    def _refresh(self) -> None:
+        super().clear()
+        super().update(self._supplier())
+
+    def __getitem__(self, key):
+        self._refresh()
+        return super().__getitem__(key)
+
+    def __contains__(self, key):
+        self._refresh()
+        return super().__contains__(key)
+
+    def __iter__(self):
+        self._refresh()
+        return super().__iter__()
+
+    def __len__(self):
+        self._refresh()
+        return super().__len__()
+
+    def __repr__(self):
+        self._refresh()
+        return super().__repr__()
+
+    def get(self, key, default=None):
+        self._refresh()
+        return super().get(key, default)
+
+    def items(self):
+        self._refresh()
+        return super().items()
+
+    def keys(self):
+        self._refresh()
+        return super().keys()
+
+    def values(self):
+        self._refresh()
+        return super().values()
+
+    def copy(self):
+        self._refresh()
+        return dict(self)
+
+
+def _module_registers_tools(module_path: Path) -> bool:
+    """Return True when the module contains a ``registry.register(...)`` call."""
+    try:
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(module_path))
+    except (OSError, SyntaxError):
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "register"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "registry"
+        ):
+            return True
+    return False
+
 def _discover_tools():
     """Import all tool modules to trigger their registry.register() calls.
 
-    Wrapped in a function so import errors in optional tools (e.g., fal_client
-    not installed) don't prevent the rest from loading.
+    Uses source inspection instead of a hand-maintained module list so new
+    built-in tools become discoverable as soon as they self-register.
     """
-    _modules = [
-        "tools.web_tools",
-        "tools.terminal_tool",
-        "tools.file_tools",
-        "tools.vision_tools",
-        "tools.mixture_of_agents_tool",
-        "tools.image_generation_tool",
-        "tools.skills_tool",
-        "tools.skill_manager_tool",
-        "tools.browser_tool",
-        "tools.cronjob_tools",
-        "tools.rl_training_tool",
-        "tools.tts_tool",
-        "tools.todo_tool",
-        "tools.memory_tool",
-        "tools.session_search_tool",
-        "tools.clarify_tool",
-        "tools.code_execution_tool",
-        "tools.delegate_tool",
-        "tools.process_registry",
-        "tools.send_message_tool",
-        # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
-        "tools.homeassistant_tool",
-    ]
     import importlib
-    for mod_name in _modules:
+
+    tools_dir = Path(__file__).resolve().parent / "tools"
+    module_names = [
+        f"tools.{path.stem}"
+        for path in sorted(tools_dir.glob("*.py"))
+        if path.name not in {"__init__.py", "registry.py"}
+        and _module_registers_tools(path)
+    ]
+
+    for mod_name in module_names:
         try:
             importlib.import_module(mod_name)
         except Exception as e:
@@ -185,46 +246,52 @@ except Exception as e:
 
 
 # =============================================================================
-# Backward-compat constants  (built once after discovery)
+# Backward-compat constants  (live views over the registry)
 # =============================================================================
 
-TOOL_TO_TOOLSET_MAP: Dict[str, str] = registry.get_tool_to_toolset_map()
+_LEGACY_TOOLSET_ALIASES = {
+    "web_tools": ["web"],
+    "terminal_tools": ["terminal"],
+    "vision_tools": ["vision"],
+    "moa_tools": ["moa"],
+    "image_tools": ["image_gen"],
+    "skills_tools": ["skills"],
+    "browser_tools": ["browser"],
+    "cronjob_tools": ["cronjob"],
+    "rl_tools": ["rl"],
+    "file_tools": ["file"],
+    "tts_tools": ["tts"],
+}
 
-TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
+
+def _build_legacy_toolset_map() -> Dict[str, List[str]]:
+    return {
+        name: sorted(resolve_multiple_toolsets(toolsets))
+        for name, toolsets in _LEGACY_TOOLSET_ALIASES.items()
+    }
+
+
+TOOL_TO_TOOLSET_MAP: Dict[str, str] = _DynamicDictView(registry.get_tool_to_toolset_map)
+
+TOOLSET_REQUIREMENTS: Dict[str, dict] = _DynamicDictView(registry.get_toolset_requirements)
+
+_LEGACY_TOOLSET_MAP = _DynamicDictView(_build_legacy_toolset_map)
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.
 _last_resolved_tool_names: List[str] = []
 
 
-# =============================================================================
-# Legacy toolset name mapping  (old _tools-suffixed names -> tool name lists)
-# =============================================================================
+def _resolve_requested_toolset(name: str) -> Tuple[List[str], Optional[str]]:
+    """Resolve a requested toolset or legacy alias to concrete tool names."""
+    if validate_toolset(name):
+        return resolve_toolset(name), "toolset"
 
-_LEGACY_TOOLSET_MAP = {
-    "web_tools": ["web_search", "web_extract"],
-    "terminal_tools": ["terminal"],
-    "vision_tools": ["vision_analyze"],
-    "moa_tools": ["mixture_of_agents"],
-    "image_tools": ["image_generate"],
-    "skills_tools": ["skills_list", "skill_view", "skill_manage"],
-    "browser_tools": [
-        "browser_navigate", "browser_snapshot", "browser_click",
-        "browser_type", "browser_scroll", "browser_back",
-        "browser_press", "browser_get_images",
-        "browser_vision", "browser_console"
-    ],
-    "cronjob_tools": ["cronjob"],
-    "rl_tools": [
-        "rl_list_environments", "rl_select_environment",
-        "rl_get_current_config", "rl_edit_config",
-        "rl_start_training", "rl_check_status",
-        "rl_stop_training", "rl_get_results",
-        "rl_list_runs", "rl_test_inference"
-    ],
-    "file_tools": ["read_file", "write_file", "patch", "search_files"],
-    "tts_tools": ["text_to_speech"],
-}
+    legacy_toolsets = _LEGACY_TOOLSET_ALIASES.get(name)
+    if legacy_toolsets:
+        return resolve_multiple_toolsets(legacy_toolsets), "legacy"
+
+    return [], None
 
 
 # =============================================================================
@@ -254,43 +321,37 @@ def get_tool_definitions(
 
     if enabled_toolsets is not None:
         for toolset_name in enabled_toolsets:
-            if validate_toolset(toolset_name):
-                resolved = resolve_toolset(toolset_name)
+            resolved, kind = _resolve_requested_toolset(toolset_name)
+            if kind == "toolset":
                 tools_to_include.update(resolved)
                 if not quiet_mode:
                     print(f"✅ Enabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
-            elif toolset_name in _LEGACY_TOOLSET_MAP:
-                legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.update(legacy_tools)
+            elif kind == "legacy":
+                tools_to_include.update(resolved)
                 if not quiet_mode:
-                    print(f"✅ Enabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
+                    print(f"✅ Enabled legacy toolset '{toolset_name}': {', '.join(resolved)}")
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
 
     elif disabled_toolsets:
-        from toolsets import get_all_toolsets
-        for ts_name in get_all_toolsets():
-            tools_to_include.update(resolve_toolset(ts_name))
+        tools_to_include.update(resolve_toolset("all"))
 
         for toolset_name in disabled_toolsets:
-            if validate_toolset(toolset_name):
-                resolved = resolve_toolset(toolset_name)
+            resolved, kind = _resolve_requested_toolset(toolset_name)
+            if kind == "toolset":
                 tools_to_include.difference_update(resolved)
                 if not quiet_mode:
                     print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
-            elif toolset_name in _LEGACY_TOOLSET_MAP:
-                legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.difference_update(legacy_tools)
+            elif kind == "legacy":
+                tools_to_include.difference_update(resolved)
                 if not quiet_mode:
-                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
+                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(resolved)}")
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
     else:
-        from toolsets import get_all_toolsets
-        for ts_name in get_all_toolsets():
-            tools_to_include.update(resolve_toolset(ts_name))
+        tools_to_include.update(resolve_toolset("all"))
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/model_tools.py
+++ b/model_tools.py
@@ -22,14 +22,18 @@ Public API (signatures preserved from the original 2,400-line version):
 
 import json
 import asyncio
-import ast
 import logging
 import threading
-from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import registry
-from toolsets import resolve_multiple_toolsets, resolve_toolset, validate_toolset
+from tools.registry import discover_builtin_tools, registry
+from toolsets import (
+    get_legacy_toolset_map,
+    is_legacy_toolset,
+    resolve_legacy_toolset,
+    resolve_toolset,
+    validate_toolset,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,11 +131,6 @@ def _run_async(coro):
     return tool_loop.run_until_complete(coro)
 
 
-# =============================================================================
-# Tool Discovery  (importing each module triggers its registry.register calls)
-# =============================================================================
-
-
 class _DynamicDictView(dict):
     """Live read-through dict for backward-compatible exported mappings."""
 
@@ -182,53 +181,7 @@ class _DynamicDictView(dict):
     def copy(self):
         self._refresh()
         return dict(self)
-
-
-def _module_registers_tools(module_path: Path) -> bool:
-    """Return True when the module contains a ``registry.register(...)`` call."""
-    try:
-        source = module_path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(module_path))
-    except (OSError, SyntaxError):
-        return False
-
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if (
-            isinstance(func, ast.Attribute)
-            and func.attr == "register"
-            and isinstance(func.value, ast.Name)
-            and func.value.id == "registry"
-        ):
-            return True
-    return False
-
-def _discover_tools():
-    """Import all tool modules to trigger their registry.register() calls.
-
-    Uses source inspection instead of a hand-maintained module list so new
-    built-in tools become discoverable as soon as they self-register.
-    """
-    import importlib
-
-    tools_dir = Path(__file__).resolve().parent / "tools"
-    module_names = [
-        f"tools.{path.stem}"
-        for path in sorted(tools_dir.glob("*.py"))
-        if path.name not in {"__init__.py", "registry.py"}
-        and _module_registers_tools(path)
-    ]
-
-    for mod_name in module_names:
-        try:
-            importlib.import_module(mod_name)
-        except Exception as e:
-            logger.warning("Could not import tool module %s: %s", mod_name, e)
-
-
-_discover_tools()
+discover_builtin_tools()
 
 # MCP tool discovery (external MCP servers from config)
 try:
@@ -249,33 +202,11 @@ except Exception as e:
 # Backward-compat constants  (live views over the registry)
 # =============================================================================
 
-_LEGACY_TOOLSET_ALIASES = {
-    "web_tools": ["web"],
-    "terminal_tools": ["terminal"],
-    "vision_tools": ["vision"],
-    "moa_tools": ["moa"],
-    "image_tools": ["image_gen"],
-    "skills_tools": ["skills"],
-    "browser_tools": ["browser"],
-    "cronjob_tools": ["cronjob"],
-    "rl_tools": ["rl"],
-    "file_tools": ["file"],
-    "tts_tools": ["tts"],
-}
-
-
-def _build_legacy_toolset_map() -> Dict[str, List[str]]:
-    return {
-        name: sorted(resolve_multiple_toolsets(toolsets))
-        for name, toolsets in _LEGACY_TOOLSET_ALIASES.items()
-    }
-
-
 TOOL_TO_TOOLSET_MAP: Dict[str, str] = _DynamicDictView(registry.get_tool_to_toolset_map)
 
 TOOLSET_REQUIREMENTS: Dict[str, dict] = _DynamicDictView(registry.get_toolset_requirements)
 
-_LEGACY_TOOLSET_MAP = _DynamicDictView(_build_legacy_toolset_map)
+_LEGACY_TOOLSET_MAP = _DynamicDictView(get_legacy_toolset_map)
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.
@@ -287,9 +218,8 @@ def _resolve_requested_toolset(name: str) -> Tuple[List[str], Optional[str]]:
     if validate_toolset(name):
         return resolve_toolset(name), "toolset"
 
-    legacy_toolsets = _LEGACY_TOOLSET_ALIASES.get(name)
-    if legacy_toolsets:
-        return resolve_multiple_toolsets(legacy_toolsets), "legacy"
+    if is_legacy_toolset(name):
+        return resolve_legacy_toolset(name), "legacy"
 
     return [], None
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -167,11 +167,23 @@ def get_legacy_toolset_map_snapshot() -> Dict[str, List[str]]:
     return get_legacy_toolset_map()
 
 
-TOOL_TO_TOOLSET_MAP: Dict[str, str] = get_tool_to_toolset_map_snapshot()
+TOOL_TO_TOOLSET_MAP: Dict[str, str] = {}
 
-TOOLSET_REQUIREMENTS: Dict[str, dict] = get_toolset_requirements_snapshot()
+TOOLSET_REQUIREMENTS: Dict[str, dict] = {}
 
-_LEGACY_TOOLSET_MAP = get_legacy_toolset_map_snapshot()
+_LEGACY_TOOLSET_MAP: Dict[str, List[str]] = {}
+
+
+def _refresh_compat_exports() -> None:
+    TOOL_TO_TOOLSET_MAP.clear()
+    TOOL_TO_TOOLSET_MAP.update(get_tool_to_toolset_map_snapshot())
+    TOOLSET_REQUIREMENTS.clear()
+    TOOLSET_REQUIREMENTS.update(get_toolset_requirements_snapshot())
+    _LEGACY_TOOLSET_MAP.clear()
+    _LEGACY_TOOLSET_MAP.update(get_legacy_toolset_map_snapshot())
+
+
+_refresh_compat_exports()
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -597,10 +597,10 @@ class TestToolsetIntegration:
             assert tool in gateway_tools
 
     def test_hermes_core_tools_includes_ha(self):
-        from toolsets import _HERMES_CORE_TOOLS
+        from toolsets import get_hermes_core_tools
 
         for tool in ("ha_list_entities", "ha_get_state", "ha_call_service", "ha_list_services"):
-            assert tool in _HERMES_CORE_TOOLS
+            assert tool in get_hermes_core_tools()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -157,3 +157,35 @@ class TestResumePreservesProgress:
 
         assert checkpoint_data["completed_prompts"] == []
         assert checkpoint_data["run_name"] == "test_run"
+
+
+class TestCombineBatchOutputs:
+    def test_filters_invalid_tool_entries_in_combined_output(self, tmp_path, monkeypatch):
+        runner = BatchRunner.__new__(BatchRunner)
+        runner.output_dir = tmp_path
+
+        (tmp_path / "batch_0.jsonl").write_text(
+            "\n".join([
+                json.dumps({"tool_stats": {"web_search": {"count": 1}}}),
+                json.dumps({"tool_stats": {"totally_fake_tool": {"count": 1}}}),
+                "{broken json",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(
+            "batch_runner.get_tool_to_toolset_map_snapshot",
+            lambda: {"web_search": "web"},
+        )
+
+        stats = runner._combine_batch_outputs()
+
+        combined_file = tmp_path / "trajectories.jsonl"
+        combined_lines = combined_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(combined_lines) == 1
+        assert json.loads(combined_lines[0])["tool_stats"]["web_search"]["count"] == 1
+        assert stats == {
+            "total_entries": 3,
+            "filtered_entries": 2,
+            "batch_files_found": 1,
+        }

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -9,6 +9,9 @@ from model_tools import (
     handle_function_call,
     get_all_tool_names,
     get_toolset_for_tool,
+    get_legacy_toolset_map_snapshot,
+    get_tool_to_toolset_map_snapshot,
+    get_toolset_requirements_snapshot,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
@@ -140,7 +143,7 @@ class TestBackwardCompat:
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
 
-    def test_live_registry_views_update_with_registration(self):
+    def test_snapshot_helpers_update_with_registration(self):
         registry.register(
             name="test_live_model_tools_mapping",
             toolset="test-live-model-tools",
@@ -152,11 +155,16 @@ class TestBackwardCompat:
             handler=lambda *_args, **_kwargs: "{}",
         )
         try:
-            assert TOOL_TO_TOOLSET_MAP["test_live_model_tools_mapping"] == "test-live-model-tools"
-            assert "test-live-model-tools" in TOOLSET_REQUIREMENTS
-            assert TOOLSET_REQUIREMENTS["test-live-model-tools"]["tools"] == ["test_live_model_tools_mapping"]
+            tool_map = get_tool_to_toolset_map_snapshot()
+            requirements = get_toolset_requirements_snapshot()
+            assert tool_map["test_live_model_tools_mapping"] == "test-live-model-tools"
+            assert "test-live-model-tools" in requirements
+            assert requirements["test-live-model-tools"]["tools"] == ["test_live_model_tools_mapping"]
         finally:
             registry.deregister("test_live_model_tools_mapping")
 
-        assert "test_live_model_tools_mapping" not in TOOL_TO_TOOLSET_MAP
-        assert "test-live-model-tools" not in TOOLSET_REQUIREMENTS
+        assert "test_live_model_tools_mapping" not in get_tool_to_toolset_map_snapshot()
+        assert "test-live-model-tools" not in get_toolset_requirements_snapshot()
+
+    def test_legacy_toolset_snapshot_helper(self):
+        assert get_legacy_toolset_map_snapshot()["browser_tools"]

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -168,3 +168,22 @@ class TestBackwardCompat:
 
     def test_legacy_toolset_snapshot_helper(self):
         assert get_legacy_toolset_map_snapshot()["browser_tools"]
+
+    def test_compatibility_globals_refresh_on_registry_update(self):
+        registry.register(
+            name="test_live_compat_mapping",
+            toolset="test-live-compat",
+            schema={
+                "name": "test_live_compat_mapping",
+                "description": "Compat test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert TOOL_TO_TOOLSET_MAP["test_live_compat_mapping"] == "test-live-compat"
+            assert "test-live-compat" in TOOLSET_REQUIREMENTS
+        finally:
+            registry.deregister("test_live_compat_mapping")
+
+        assert "test_live_compat_mapping" not in TOOL_TO_TOOLSET_MAP

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -12,7 +12,9 @@ from model_tools import (
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
+    TOOLSET_REQUIREMENTS,
 )
+from tools.registry import registry
 
 
 # =========================================================================
@@ -137,3 +139,24 @@ class TestBackwardCompat:
     def test_tool_to_toolset_map(self):
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
+
+    def test_live_registry_views_update_with_registration(self):
+        registry.register(
+            name="test_live_model_tools_mapping",
+            toolset="test-live-model-tools",
+            schema={
+                "name": "test_live_model_tools_mapping",
+                "description": "Live test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert TOOL_TO_TOOLSET_MAP["test_live_model_tools_mapping"] == "test-live-model-tools"
+            assert "test-live-model-tools" in TOOLSET_REQUIREMENTS
+            assert TOOLSET_REQUIREMENTS["test-live-model-tools"]["tools"] == ["test_live_model_tools_mapping"]
+        finally:
+            registry.deregister("test_live_model_tools_mapping")
+
+        assert "test_live_model_tools_mapping" not in TOOL_TO_TOOLSET_MAP
+        assert "test-live-model-tools" not in TOOLSET_REQUIREMENTS

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -115,6 +115,8 @@ class TestValidateToolset:
         try:
             assert get_toolset("web") is not None
             assert "mcp_web_ping" not in resolve_toolset("web")
+            assert "mcp-web" in get_toolset_names()
+            assert "web" in get_toolset_names()
         finally:
             registry.deregister("mcp_web_ping")
 
@@ -218,7 +220,7 @@ class TestToolsetConsistency:
         for ts in tool_sets[1:]:
             assert ts == tool_sets[0]
 
-    def test_all_excludes_hidden_mcp_collisions(self):
+    def test_colliding_mcp_toolset_stays_canonical_and_visible(self):
         registry.register(
             name="mcp_web_hidden_tool",
             toolset="mcp-web",
@@ -226,6 +228,8 @@ class TestToolsetConsistency:
             handler=lambda *_args, **_kwargs: "{}",
         )
         try:
-            assert "mcp_web_hidden_tool" not in resolve_toolset("all")
+            assert "mcp-web" in get_toolset_names()
+            assert "mcp_web_hidden_tool" in resolve_toolset("mcp-web")
+            assert "mcp_web_hidden_tool" in resolve_toolset("all")
         finally:
             registry.deregister("mcp_web_hidden_tool")

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -159,13 +159,13 @@ class TestLegacyToolsets:
     def test_legacy_aliases_are_owned_by_toolsets(self):
         assert is_legacy_toolset("web_tools") is True
         assert is_legacy_toolset("nonexistent_legacy_tools") is False
-        assert LEGACY_TOOLSET_ALIASES["web_tools"] == ["web"]
+        assert LEGACY_TOOLSET_ALIASES["web_tools"] == ["web_search", "web_extract"]
 
     def test_resolve_legacy_toolset(self):
         tools = resolve_legacy_toolset("web_tools")
         assert set(tools) == {"web_search", "web_extract"}
 
-    def test_legacy_toolset_map_is_live(self):
+    def test_legacy_toolset_map_is_frozen_to_explicit_compatibility_list(self):
         registry.register(
             name="test_live_legacy_file_tool",
             toolset="file",
@@ -173,9 +173,14 @@ class TestLegacyToolsets:
             handler=lambda *_args, **_kwargs: "{}",
         )
         try:
-            assert "test_live_legacy_file_tool" in get_legacy_toolset_map()["file_tools"]
+            assert "test_live_legacy_file_tool" not in get_legacy_toolset_map()["file_tools"]
         finally:
             registry.deregister("test_live_legacy_file_tool")
+
+    def test_legacy_aliases_are_explicit_not_bundle_derived(self):
+        tools = resolve_legacy_toolset("browser_tools")
+        assert "web_search" in tools
+        assert "web_extract" not in tools
 
 
 class TestToolsetConsistency:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from tools.registry import registry
 from toolsets import (
     TOOLSETS,
     get_toolset,
@@ -86,6 +87,20 @@ class TestValidateToolset:
     def test_invalid(self):
         assert validate_toolset("nonexistent") is False
 
+    def test_mcp_alias_uses_live_registry(self):
+        registry.register(
+            name="mcp_dynserver_ping",
+            toolset="mcp-dynserver",
+            schema={"name": "mcp_dynserver_ping", "description": "Ping", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert validate_toolset("dynserver") is True
+            assert validate_toolset("mcp-dynserver") is True
+            assert "mcp_dynserver_ping" in resolve_toolset("dynserver")
+        finally:
+            registry.deregister("mcp_dynserver_ping")
+
 
 class TestGetToolsetInfo:
     def test_leaf(self):
@@ -120,6 +135,22 @@ class TestCreateCustomToolset:
             del TOOLSETS["_test_custom"]
 
 
+class TestRegistryOwnedToolsets:
+    def test_registry_membership_is_live(self):
+        registry.register(
+            name="test_live_toolset_tool",
+            toolset="test-live-toolset",
+            schema={"name": "test_live_toolset_tool", "description": "Live", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert validate_toolset("test-live-toolset") is True
+            assert get_toolset("test-live-toolset")["tools"] == ["test_live_toolset_tool"]
+            assert resolve_toolset("test-live-toolset") == ["test_live_toolset_tool"]
+        finally:
+            registry.deregister("test_live_toolset_tool")
+
+
 class TestToolsetConsistency:
     """Verify structural integrity of the built-in TOOLSETS dict."""
 
@@ -137,7 +168,7 @@ class TestToolsetConsistency:
     def test_hermes_platforms_share_core_tools(self):
         """All hermes-* platform toolsets should have the same tools."""
         platforms = ["hermes-cli", "hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant"]
-        tool_sets = [set(TOOLSETS[p]["tools"]) for p in platforms]
+        tool_sets = [set(resolve_toolset(p)) for p in platforms]
         # All platform toolsets should be identical
         for ts in tool_sets[1:]:
             assert ts == tool_sets[0]

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -120,6 +120,18 @@ class TestValidateToolset:
         finally:
             registry.deregister("mcp_web_ping")
 
+    def test_dynamic_toolset_cannot_splice_into_static_bundle(self):
+        registry.register(
+            name="web_dynamic_splice",
+            toolset="web",
+            schema={"name": "web_dynamic_splice", "description": "Dyn", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert "web_dynamic_splice" not in resolve_toolset("web")
+        finally:
+            registry.deregister("web_dynamic_splice")
+
 
 class TestGetToolsetInfo:
     def test_leaf(self):

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -105,6 +105,19 @@ class TestValidateToolset:
         finally:
             registry.deregister("mcp_dynserver_ping")
 
+    def test_mcp_alias_collision_does_not_shadow_existing_toolset(self):
+        registry.register(
+            name="mcp_web_ping",
+            toolset="mcp-web",
+            schema={"name": "mcp_web_ping", "description": "Ping", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert get_toolset("web") is not None
+            assert "mcp_web_ping" not in resolve_toolset("web")
+        finally:
+            registry.deregister("mcp_web_ping")
+
 
 class TestGetToolsetInfo:
     def test_leaf(self):
@@ -204,3 +217,15 @@ class TestToolsetConsistency:
         # All platform toolsets should be identical
         for ts in tool_sets[1:]:
             assert ts == tool_sets[0]
+
+    def test_all_excludes_hidden_mcp_collisions(self):
+        registry.register(
+            name="mcp_web_hidden_tool",
+            toolset="mcp-web",
+            schema={"name": "mcp_web_hidden_tool", "description": "Hidden", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert "mcp_web_hidden_tool" not in resolve_toolset("all")
+        finally:
+            registry.deregister("mcp_web_hidden_tool")

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -4,12 +4,16 @@ import pytest
 
 from tools.registry import registry
 from toolsets import (
+    LEGACY_TOOLSET_ALIASES,
     TOOLSETS,
+    get_legacy_toolset_map,
     get_toolset,
     resolve_toolset,
+    resolve_legacy_toolset,
     resolve_multiple_toolsets,
     get_all_toolsets,
     get_toolset_names,
+    is_legacy_toolset,
     validate_toolset,
     create_custom_toolset,
     get_toolset_info,
@@ -149,6 +153,29 @@ class TestRegistryOwnedToolsets:
             assert resolve_toolset("test-live-toolset") == ["test_live_toolset_tool"]
         finally:
             registry.deregister("test_live_toolset_tool")
+
+
+class TestLegacyToolsets:
+    def test_legacy_aliases_are_owned_by_toolsets(self):
+        assert is_legacy_toolset("web_tools") is True
+        assert is_legacy_toolset("nonexistent_legacy_tools") is False
+        assert LEGACY_TOOLSET_ALIASES["web_tools"] == ["web"]
+
+    def test_resolve_legacy_toolset(self):
+        tools = resolve_legacy_toolset("web_tools")
+        assert set(tools) == {"web_search", "web_extract"}
+
+    def test_legacy_toolset_map_is_live(self):
+        registry.register(
+            name="test_live_legacy_file_tool",
+            toolset="file",
+            schema={"name": "test_live_legacy_file_tool", "description": "Live", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        try:
+            assert "test_live_legacy_file_tool" in get_legacy_toolset_map()["file_tools"]
+        finally:
+            registry.deregister("test_live_legacy_file_tool")
 
 
 class TestToolsetConsistency:

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -125,8 +125,8 @@ class TestBrowserConsoleToolsetWiring:
         assert "browser_console" in resolve_toolset("browser")
 
     def test_in_hermes_core_tools(self):
-        from toolsets import _HERMES_CORE_TOOLS
-        assert "browser_console" in _HERMES_CORE_TOOLS
+        from toolsets import get_hermes_core_tools
+        assert "browser_console" in get_hermes_core_tools()
 
     def test_in_legacy_toolset_map(self):
         from model_tools import _LEGACY_TOOLSET_MAP

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -121,8 +121,8 @@ class TestBrowserConsoleToolsetWiring:
     """browser_console must be reachable via toolset resolution."""
 
     def test_in_browser_toolset(self):
-        from toolsets import TOOLSETS
-        assert "browser_console" in TOOLSETS["browser"]["tools"]
+        from toolsets import resolve_toolset
+        assert "browser_console" in resolve_toolset("browser")
 
     def test_in_hermes_core_tools(self):
         from toolsets import _HERMES_CORE_TOOLS

--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -21,34 +21,23 @@ class TestRegisterServerTools:
     def mock_registry(self):
         return ToolRegistry()
 
-    @pytest.fixture
-    def mock_toolsets(self):
-        return {
-            "hermes-cli": {"tools": ["terminal"], "description": "CLI", "includes": []},
-            "hermes-telegram": {"tools": ["terminal"], "description": "TG", "includes": []},
-            "custom-toolset": {"tools": [], "description": "Other", "includes": []},
-        }
-
-    def test_injects_hermes_toolsets(self, mock_registry, mock_toolsets):
-        """Tools are injected into hermes-* toolsets but not custom ones."""
+    def test_registers_live_toolsets(self, mock_registry):
+        """MCP tools become resolvable via the live registry-backed toolset layer."""
         server = MCPServerTask("my_srv")
         server._tools = [_make_mcp_tool("my_tool", "desc")]
         server.session = MagicMock()
 
         with patch("tools.registry.registry", mock_registry), \
-            patch("toolsets.create_custom_toolset"), \
-            patch.dict("toolsets.TOOLSETS", mock_toolsets, clear=True):
+            patch("toolsets.registry", mock_registry):
+            from toolsets import resolve_toolset, validate_toolset
 
             registered = _register_server_tools("my_srv", server, {})
-
-        assert "mcp_my_srv_my_tool" in registered
-        assert "mcp_my_srv_my_tool" in mock_registry.get_all_tool_names()
-
-        # Injected into hermes-* toolsets
-        assert "mcp_my_srv_my_tool" in mock_toolsets["hermes-cli"]["tools"]
-        assert "mcp_my_srv_my_tool" in mock_toolsets["hermes-telegram"]["tools"]
-        # NOT into non-hermes toolsets
-        assert "mcp_my_srv_my_tool" not in mock_toolsets["custom-toolset"]["tools"]
+            assert "mcp_my_srv_my_tool" in registered
+            assert "mcp_my_srv_my_tool" in mock_registry.get_all_tool_names()
+            assert validate_toolset("my_srv") is True
+            assert validate_toolset("mcp-my_srv") is True
+            assert "mcp_my_srv_my_tool" in resolve_toolset("my_srv")
+            assert "mcp_my_srv_my_tool" in resolve_toolset("mcp-my_srv")
 
 
 class TestRefreshTools:
@@ -58,15 +47,8 @@ class TestRefreshTools:
     def mock_registry(self):
         return ToolRegistry()
 
-    @pytest.fixture
-    def mock_toolsets(self):
-        return {
-            "hermes-cli": {"tools": ["terminal"], "description": "CLI", "includes": []},
-            "hermes-telegram": {"tools": ["terminal"], "description": "TG", "includes": []},
-        }
-
     @pytest.mark.asyncio
-    async def test_nuke_and_repave(self, mock_registry, mock_toolsets):
+    async def test_nuke_and_repave(self, mock_registry):
         """Old tools are removed and new tools registered on refresh."""
         server = MCPServerTask("live_srv")
         server._refresh_lock = asyncio.Lock()
@@ -79,7 +61,6 @@ class TestRefreshTools:
             description="", emoji="",
         )
         server._registered_tool_names = ["mcp_live_srv_old_tool"]
-        mock_toolsets["hermes-cli"]["tools"].append("mcp_live_srv_old_tool")
 
         # New tool list from server
         new_tool = _make_mcp_tool("new_tool", "new behavior")
@@ -90,19 +71,17 @@ class TestRefreshTools:
         )
 
         with patch("tools.registry.registry", mock_registry), \
-            patch("toolsets.create_custom_toolset"), \
-            patch.dict("toolsets.TOOLSETS", mock_toolsets, clear=True):
+            patch("toolsets.registry", mock_registry):
+            from toolsets import resolve_toolset
 
             await server._refresh_tools()
+            # Old tool completely gone
+            assert "mcp_live_srv_old_tool" not in mock_registry.get_all_tool_names()
 
-        # Old tool completely gone
-        assert "mcp_live_srv_old_tool" not in mock_registry.get_all_tool_names()
-        assert "mcp_live_srv_old_tool" not in mock_toolsets["hermes-cli"]["tools"]
-
-        # New tool registered
-        assert "mcp_live_srv_new_tool" in mock_registry.get_all_tool_names()
-        assert "mcp_live_srv_new_tool" in mock_toolsets["hermes-cli"]["tools"]
-        assert server._registered_tool_names == ["mcp_live_srv_new_tool"]
+            # New tool registered
+            assert "mcp_live_srv_new_tool" in mock_registry.get_all_tool_names()
+            assert "mcp_live_srv_new_tool" in resolve_toolset("live_srv")
+            assert server._registered_tool_names == ["mcp_live_srv_new_tool"]
 
 
 class TestMessageHandler:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2936,8 +2936,8 @@ class TestSanitizeMcpNameComponent:
             assert "/" not in name
             assert "." not in name
 
-    def test_slash_in_sync_mcp_toolsets(self):
-        """_sync_mcp_toolsets uses sanitize consistently with _convert_mcp_schema."""
+    def test_slash_in_mcp_toolset_prefix(self):
+        """sanitize_mcp_name_component matches MCP tool prefix generation."""
         from tools.mcp_tool import sanitize_mcp_name_component
 
         # Verify the prefix generation matches what _convert_mcp_schema produces

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -292,9 +292,10 @@ class TestDiscoverAndRegister:
 
         _servers.pop("fs", None)
 
-    def test_toolset_created(self):
-        """A custom toolset is created for the MCP server."""
+    def test_toolset_resolves_live_from_registry(self):
+        """Raw server names resolve without mutating static TOOLSETS state."""
         from tools.mcp_tool import _discover_and_register_server, _servers, MCPServerTask
+        from toolsets import resolve_toolset, validate_toolset
 
         mock_tools = [_make_mcp_tool("ping", "Ping")]
         mock_session = MagicMock()
@@ -305,18 +306,21 @@ class TestDiscoverAndRegister:
             server._tools = mock_tools
             return server
 
-        mock_create = MagicMock()
-        with patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
-             patch("toolsets.create_custom_toolset", mock_create):
-            asyncio.run(
-                _discover_and_register_server("myserver", {"command": "test"})
-            )
+        try:
+            with patch("tools.mcp_tool._connect_server", side_effect=fake_connect):
+                asyncio.run(
+                    _discover_and_register_server("myserver", {"command": "test"})
+                )
 
-        mock_create.assert_called_once()
-        call_kwargs = mock_create.call_args
-        assert call_kwargs[1]["name"] == "mcp-myserver" or call_kwargs[0][0] == "mcp-myserver"
+            assert validate_toolset("myserver") is True
+            assert validate_toolset("mcp-myserver") is True
+            assert "mcp_myserver_ping" in resolve_toolset("myserver")
+            assert "mcp_myserver_ping" in resolve_toolset("mcp-myserver")
+        finally:
+            from tools.registry import registry
 
-        _servers.pop("myserver", None)
+            registry.deregister("mcp_myserver_ping")
+            _servers.pop("myserver", None)
 
     def test_schema_format_correct(self):
         """Registered schemas have the correct format."""
@@ -477,12 +481,15 @@ class TestMCPServerTask:
 # ---------------------------------------------------------------------------
 
 class TestToolsetInjection:
-    def test_mcp_tools_added_to_all_hermes_toolsets(self):
-        """Discovered MCP tools are dynamically injected into all hermes-* toolsets."""
+    def test_mcp_tools_resolve_through_server_aliases(self):
+        """Discovered MCP tools are exposed through live MCP toolset aliases."""
         from tools.mcp_tool import MCPServerTask
+        from tools.registry import ToolRegistry
+        from toolsets import resolve_toolset, validate_toolset
 
         mock_tools = [_make_mcp_tool("list_files", "List files")]
         mock_session = MagicMock()
+        mock_registry = ToolRegistry()
 
         fresh_servers = {}
 
@@ -492,43 +499,32 @@ class TestToolsetInjection:
             server._tools = mock_tools
             return server
 
-        fake_toolsets = {
-            "hermes-cli": {"tools": ["terminal"], "description": "CLI", "includes": []},
-            "hermes-telegram": {"tools": ["terminal"], "description": "TG", "includes": []},
-            "hermes-gateway": {"tools": [], "description": "GW", "includes": []},
-            "non-hermes": {"tools": [], "description": "other", "includes": []},
-        }
         fake_config = {"fs": {"command": "npx", "args": []}}
 
         with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
              patch("tools.mcp_tool._servers", fresh_servers), \
              patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
              patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
-             patch("toolsets.TOOLSETS", fake_toolsets):
+             patch("tools.registry.registry", mock_registry), \
+             patch("toolsets.registry", mock_registry):
             from tools.mcp_tool import discover_mcp_tools
             result = discover_mcp_tools()
-
-        assert "mcp_fs_list_files" in result
-        # All hermes-* toolsets get injection
-        assert "mcp_fs_list_files" in fake_toolsets["hermes-cli"]["tools"]
-        assert "mcp_fs_list_files" in fake_toolsets["hermes-telegram"]["tools"]
-        assert "mcp_fs_list_files" in fake_toolsets["hermes-gateway"]["tools"]
-        # Non-hermes toolset should NOT get injection
-        assert "mcp_fs_list_files" not in fake_toolsets["non-hermes"]["tools"]
-        # Original tools preserved
-        assert "terminal" in fake_toolsets["hermes-cli"]["tools"]
-        # Server name becomes a standalone toolset
-        assert "fs" in fake_toolsets
-        assert "mcp_fs_list_files" in fake_toolsets["fs"]["tools"]
-        assert fake_toolsets["fs"]["description"].startswith("MCP server '")
+            assert "mcp_fs_list_files" in result
+            assert validate_toolset("fs") is True
+            assert validate_toolset("mcp-fs") is True
+            assert "mcp_fs_list_files" in resolve_toolset("fs")
+            assert "mcp_fs_list_files" in resolve_toolset("mcp-fs")
 
     def test_server_toolset_skips_builtin_collision(self):
-        """MCP server named after a built-in toolset shouldn't overwrite it."""
+        """Raw MCP aliases never shadow built-in toolset names."""
         from tools.mcp_tool import MCPServerTask
+        from tools.registry import ToolRegistry
+        from toolsets import resolve_toolset
 
         mock_tools = [_make_mcp_tool("run", "Run command")]
         mock_session = MagicMock()
         fresh_servers = {}
+        mock_registry = ToolRegistry()
 
         async def fake_connect(name, config):
             server = MCPServerTask(name)
@@ -536,23 +532,18 @@ class TestToolsetInjection:
             server._tools = mock_tools
             return server
 
-        fake_toolsets = {
-            "hermes-cli": {"tools": ["terminal"], "description": "CLI", "includes": []},
-            # Built-in toolset named "terminal" — must not be overwritten
-            "terminal": {"tools": ["terminal"], "description": "Terminal tools", "includes": []},
-        }
         fake_config = {"terminal": {"command": "npx", "args": []}}
 
         with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
              patch("tools.mcp_tool._servers", fresh_servers), \
              patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
              patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
-             patch("toolsets.TOOLSETS", fake_toolsets):
+             patch("tools.registry.registry", mock_registry), \
+             patch("toolsets.registry", mock_registry):
             from tools.mcp_tool import discover_mcp_tools
             discover_mcp_tools()
-
-        # Built-in toolset preserved — description unchanged
-        assert fake_toolsets["terminal"]["description"] == "Terminal tools"
+            assert "mcp_terminal_run" not in resolve_toolset("terminal")
+            assert "mcp_terminal_run" in resolve_toolset("mcp-terminal")
 
     def test_server_connection_failure_skipped(self):
         """If one server fails to connect, others still proceed."""
@@ -578,15 +569,10 @@ class TestToolsetInjection:
             "broken": {"command": "bad"},
             "good": {"command": "npx", "args": []},
         }
-        fake_toolsets = {
-            "hermes-cli": {"tools": [], "description": "CLI", "includes": []},
-        }
-
         with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
              patch("tools.mcp_tool._servers", fresh_servers), \
              patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
-             patch("tools.mcp_tool._connect_server", side_effect=flaky_connect), \
-             patch("toolsets.TOOLSETS", fake_toolsets):
+             patch("tools.mcp_tool._connect_server", side_effect=flaky_connect):
             from tools.mcp_tool import discover_mcp_tools
             result = discover_mcp_tools()
 
@@ -620,15 +606,10 @@ class TestToolsetInjection:
             "broken": {"command": "bad"},
             "good": {"command": "npx", "args": []},
         }
-        fake_toolsets = {
-            "hermes-cli": {"tools": [], "description": "CLI", "includes": []},
-        }
-
         with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
              patch("tools.mcp_tool._servers", fresh_servers), \
              patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
-             patch("tools.mcp_tool._connect_server", side_effect=flaky_connect), \
-             patch("toolsets.TOOLSETS", fake_toolsets):
+             patch("tools.mcp_tool._connect_server", side_effect=flaky_connect):
             from tools.mcp_tool import discover_mcp_tools
 
             # First call: good connects, broken fails
@@ -2737,15 +2718,11 @@ class TestMCPSelectiveToolLoading:
                 "enabled": False,
             }
         }
-        fake_toolsets = {
-            "hermes-cli": {"tools": [], "description": "CLI", "includes": []},
-        }
 
         with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
              patch("tools.mcp_tool._servers", {}), \
              patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
-             patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
-             patch("toolsets.TOOLSETS", fake_toolsets):
+             patch("tools.mcp_tool._connect_server", side_effect=fake_connect):
             result = discover_mcp_tools()
 
         assert connect_called == []

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,8 +1,9 @@
 """Tests for the central tool registry."""
 
 import json
+from unittest.mock import patch
 
-from tools.registry import ToolRegistry
+from tools.registry import ToolRegistry, discover_builtin_tools
 
 
 def _dummy_handler(args, **kwargs):
@@ -257,6 +258,25 @@ class TestCheckFnExceptionHandling:
         available, unavailable = reg.check_tool_availability()
         assert "works" in available
         assert any(u["name"] == "crashes" for u in unavailable)
+
+
+class TestBuiltinDiscovery:
+    def test_discovers_only_self_registering_modules(self, tmp_path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "__init__.py").write_text("", encoding="utf-8")
+        (tools_dir / "registry.py").write_text("", encoding="utf-8")
+        (tools_dir / "alpha.py").write_text(
+            "from tools.registry import registry\nregistry.register(name='alpha', toolset='x', schema={}, handler=lambda *_a, **_k: '{}')\n",
+            encoding="utf-8",
+        )
+        (tools_dir / "beta.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+        with patch("tools.registry.importlib.import_module") as mock_import:
+            imported = discover_builtin_tools(tools_dir)
+
+        assert imported == ["tools.alpha"]
+        mock_import.assert_called_once_with("tools.alpha")
 
 
 class TestEmojiMetadata:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1525,15 +1525,6 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     }
 
 
-def _sync_mcp_toolsets(server_names: Optional[List[str]] = None) -> None:
-    """Backward-compatible no-op.
-
-    Toolset aliases and memberships now resolve directly from the live
-    registry, so there is no static TOOLSETS state to synchronize.
-    """
-    return None
-
-
 def _build_utility_schemas(server_name: str) -> List[dict]:
     """Build schemas for the MCP utility tools (resources & prompts).
 
@@ -1842,7 +1833,6 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         }
 
     if not new_servers:
-        _sync_mcp_toolsets(list(servers.keys()))
         return _existing_tool_names()
 
     # Start the background event loop for MCP connections
@@ -1872,8 +1862,6 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     # Per-server timeouts are handled inside _discover_and_register_server.
     # The outer timeout is generous: 120s total for parallel discovery.
     _run_on_mcp_loop(_discover_all(), timeout=120)
-
-    _sync_mcp_toolsets(list(servers.keys()))
 
     # Log a summary so ACP callers get visibility into what was registered.
     with _lock:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -793,23 +793,17 @@ class MCPServerTask:
         — atomic from the event loop's perspective.
         """
         from tools.registry import registry, tool_error
-        from toolsets import TOOLSETS
 
         async with self._refresh_lock:
             # 1. Fetch current tool list from server
             tools_result = await self.session.list_tools()
             new_mcp_tools = tools_result.tools if hasattr(tools_result, "tools") else []
 
-            # 2. Remove old tools from hermes-* umbrella toolsets
-            for ts_name, ts in TOOLSETS.items():
-                if ts_name.startswith("hermes-"):
-                    ts["tools"] = [t for t in ts["tools"] if t not in self._registered_tool_names]
-
-            # 3. Deregister old tools from the central registry
+            # 2. Deregister old tools from the central registry
             for prefixed_name in self._registered_tool_names:
                 registry.deregister(prefixed_name)
 
-            # 4. Re-register with fresh tool list
+            # 3. Re-register with fresh tool list
             self._tools = new_mcp_tools
             self._registered_tool_names = _register_server_tools(
                 self.name, self, self._config
@@ -1532,54 +1526,12 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
 
 
 def _sync_mcp_toolsets(server_names: Optional[List[str]] = None) -> None:
-    """Expose each MCP server as a standalone toolset and inject into hermes-* sets.
+    """Backward-compatible no-op.
 
-    Creates a real toolset entry in TOOLSETS for each server name (e.g.
-    TOOLSETS["github"] = {"tools": ["mcp_github_list_files", ...]}). This
-    makes raw server names resolvable in platform_toolsets overrides.
-
-    Also injects all MCP tools into hermes-* umbrella toolsets for the
-    default behavior.
-
-    Skips server names that collide with built-in toolsets.
+    Toolset aliases and memberships now resolve directly from the live
+    registry, so there is no static TOOLSETS state to synchronize.
     """
-    from toolsets import TOOLSETS
-
-    if server_names is None:
-        server_names = list(_load_mcp_config().keys())
-
-    existing = _existing_tool_names()
-    all_mcp_tools: List[str] = []
-
-    for server_name in server_names:
-        safe_prefix = f"mcp_{sanitize_mcp_name_component(server_name)}_"
-        server_tools = sorted(
-            t for t in existing if t.startswith(safe_prefix)
-        )
-        all_mcp_tools.extend(server_tools)
-
-        # Don't overwrite a built-in toolset that happens to share the name.
-        existing_ts = TOOLSETS.get(server_name)
-        if existing_ts and not str(existing_ts.get("description", "")).startswith("MCP server '"):
-            logger.warning(
-                "Skipping MCP toolset alias '%s' — a built-in toolset already uses that name",
-                server_name,
-            )
-            continue
-
-        TOOLSETS[server_name] = {
-            "description": f"MCP server '{server_name}' tools",
-            "tools": server_tools,
-            "includes": [],
-        }
-
-    # Also inject into hermes-* umbrella toolsets for default behavior.
-    for ts_name, ts in TOOLSETS.items():
-        if not ts_name.startswith("hermes-"):
-            continue
-        for tool_name in all_mcp_tools:
-            if tool_name not in ts["tools"]:
-                ts["tools"].append(tool_name)
+    return None
 
 
 def _build_utility_schemas(server_name: str) -> List[dict]:
@@ -1743,7 +1695,6 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         List of registered prefixed tool names.
     """
     from tools.registry import registry, tool_error
-    from toolsets import create_custom_toolset, TOOLSETS
 
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
@@ -1828,20 +1779,6 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             description=schema["description"],
         )
         registered_names.append(util_name)
-
-    # Create a custom toolset so these tools are discoverable
-    if registered_names:
-        create_custom_toolset(
-            name=toolset_name,
-            description=f"MCP tools from {name} server",
-            tools=registered_names,
-        )
-        # Inject into hermes-* umbrella toolsets for default behavior
-        for ts_name, ts in TOOLSETS.items():
-            if ts_name.startswith("hermes-"):
-                for tool_name in registered_names:
-                    if tool_name not in ts["tools"]:
-                        ts["tools"].append(tool_name)
 
     return registered_names
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -53,7 +53,7 @@ def discover_builtin_tools(tools_dir: Path | None = None) -> List[str]:
     module_names = [
         f"tools.{path.stem}"
         for path in sorted(tools_path.glob("*.py"))
-        if path.name not in {"__init__.py", "registry.py"}
+        if path.name not in {"__init__.py", "registry.py", "mcp_tool.py"}
         and _module_registers_tools(path)
     ]
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -197,6 +197,18 @@ class ToolRegistry:
         entry = self._tools.get(name)
         return entry.toolset if entry else None
 
+    def get_tools_for_toolset(self, toolset: str) -> List[str]:
+        """Return the sorted tool names currently registered to *toolset*."""
+        return sorted(
+            name
+            for name, entry in self._tools.items()
+            if entry.toolset == toolset
+        )
+
+    def get_registered_toolset_names(self) -> List[str]:
+        """Return sorted names of all toolsets currently present in the registry."""
+        return sorted({entry.toolset for entry in self._tools.values()})
+
     def get_emoji(self, name: str, default: str = "⚡") -> str:
         """Return the emoji for a tool, or *default* if unset."""
         entry = self._tools.get(name)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -14,11 +14,56 @@ Import chain (circular-import safe):
     run_agent.py, cli.py, batch_runner.py, etc.
 """
 
+import ast
+import importlib
 import json
 import logging
+from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+
+def _module_registers_tools(module_path: Path) -> bool:
+    """Return True when the module contains a ``registry.register(...)`` call."""
+    try:
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(module_path))
+    except (OSError, SyntaxError):
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "register"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "registry"
+        ):
+            return True
+    return False
+
+
+def discover_builtin_tools(tools_dir: Path | None = None) -> List[str]:
+    """Import self-registering built-in tool modules and return their names."""
+    tools_path = Path(tools_dir) if tools_dir is not None else Path(__file__).resolve().parent
+    module_names = [
+        f"tools.{path.stem}"
+        for path in sorted(tools_path.glob("*.py"))
+        if path.name not in {"__init__.py", "registry.py"}
+        and _module_registers_tools(path)
+    ]
+
+    imported: List[str] = []
+    for mod_name in module_names:
+        try:
+            importlib.import_module(mod_name)
+            imported.append(mod_name)
+        except Exception as e:
+            logger.warning("Could not import tool module %s: %s", mod_name, e)
+    return imported
 
 
 class ToolEntry:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import threading
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
@@ -96,6 +97,7 @@ class ToolRegistry:
     def __init__(self):
         self._tools: Dict[str, ToolEntry] = {}
         self._toolset_checks: Dict[str, Callable] = {}
+        self._lock = threading.RLock()
 
     # ------------------------------------------------------------------
     # Registration
@@ -115,27 +117,28 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
     ):
         """Register a tool.  Called at module-import time by each tool file."""
-        existing = self._tools.get(name)
-        if existing and existing.toolset != toolset:
-            logger.warning(
-                "Tool name collision: '%s' (toolset '%s') is being "
-                "overwritten by toolset '%s'",
-                name, existing.toolset, toolset,
+        with self._lock:
+            existing = self._tools.get(name)
+            if existing and existing.toolset != toolset:
+                logger.warning(
+                    "Tool name collision: '%s' (toolset '%s') is being "
+                    "overwritten by toolset '%s'",
+                    name, existing.toolset, toolset,
+                )
+            self._tools[name] = ToolEntry(
+                name=name,
+                toolset=toolset,
+                schema=schema,
+                handler=handler,
+                check_fn=check_fn,
+                requires_env=requires_env or [],
+                is_async=is_async,
+                description=description or schema.get("description", ""),
+                emoji=emoji,
+                max_result_size_chars=max_result_size_chars,
             )
-        self._tools[name] = ToolEntry(
-            name=name,
-            toolset=toolset,
-            schema=schema,
-            handler=handler,
-            check_fn=check_fn,
-            requires_env=requires_env or [],
-            is_async=is_async,
-            description=description or schema.get("description", ""),
-            emoji=emoji,
-            max_result_size_chars=max_result_size_chars,
-        )
-        if check_fn and toolset not in self._toolset_checks:
-            self._toolset_checks[toolset] = check_fn
+            if check_fn and toolset not in self._toolset_checks:
+                self._toolset_checks[toolset] = check_fn
 
     def deregister(self, name: str) -> None:
         """Remove a tool from the registry.
@@ -144,15 +147,16 @@ class ToolRegistry:
         same toolset.  Used by MCP dynamic tool discovery to nuke-and-repave
         when a server sends ``notifications/tools/list_changed``.
         """
-        entry = self._tools.pop(name, None)
-        if entry is None:
-            return
-        # Drop the toolset check if this was the last tool in that toolset
-        if entry.toolset in self._toolset_checks and not any(
-            e.toolset == entry.toolset for e in self._tools.values()
-        ):
-            self._toolset_checks.pop(entry.toolset, None)
-        logger.debug("Deregistered tool: %s", name)
+        with self._lock:
+            entry = self._tools.pop(name, None)
+            if entry is None:
+                return
+            # Drop the toolset check if this was the last tool in that toolset
+            if entry.toolset in self._toolset_checks and not any(
+                e.toolset == entry.toolset for e in self._tools.values()
+            ):
+                self._toolset_checks.pop(entry.toolset, None)
+            logger.debug("Deregistered tool: %s", name)
 
     # ------------------------------------------------------------------
     # Schema retrieval
@@ -166,8 +170,9 @@ class ToolRegistry:
         """
         result = []
         check_results: Dict[Callable, bool] = {}
-        for name in sorted(tool_names):
-            entry = self._tools.get(name)
+        with self._lock:
+            entries = {name: self._tools.get(name) for name in sorted(tool_names)}
+        for name, entry in entries.items():
             if not entry:
                 continue
             if entry.check_fn:
@@ -198,7 +203,8 @@ class ToolRegistry:
         * All exceptions are caught and returned as ``{"error": "..."}``
           for consistent error format.
         """
-        entry = self._tools.get(name)
+        with self._lock:
+            entry = self._tools.get(name)
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
         try:
@@ -226,7 +232,8 @@ class ToolRegistry:
 
     def get_all_tool_names(self) -> List[str]:
         """Return sorted list of all registered tool names."""
-        return sorted(self._tools.keys())
+        with self._lock:
+            return sorted(self._tools.keys())
 
     def get_schema(self, name: str) -> Optional[dict]:
         """Return a tool's raw schema dict, bypassing check_fn filtering.
@@ -234,25 +241,29 @@ class ToolRegistry:
         Useful for token estimation and introspection where availability
         doesn't matter — only the schema content does.
         """
-        entry = self._tools.get(name)
-        return entry.schema if entry else None
+        with self._lock:
+            entry = self._tools.get(name)
+            return entry.schema if entry else None
 
     def get_toolset_for_tool(self, name: str) -> Optional[str]:
         """Return the toolset a tool belongs to, or None."""
-        entry = self._tools.get(name)
-        return entry.toolset if entry else None
+        with self._lock:
+            entry = self._tools.get(name)
+            return entry.toolset if entry else None
 
     def get_tools_for_toolset(self, toolset: str) -> List[str]:
         """Return the sorted tool names currently registered to *toolset*."""
-        return sorted(
-            name
-            for name, entry in self._tools.items()
-            if entry.toolset == toolset
-        )
+        with self._lock:
+            return sorted(
+                name
+                for name, entry in self._tools.items()
+                if entry.toolset == toolset
+            )
 
     def get_registered_toolset_names(self) -> List[str]:
         """Return sorted names of all toolsets currently present in the registry."""
-        return sorted({entry.toolset for entry in self._tools.values()})
+        with self._lock:
+            return sorted({entry.toolset for entry in self._tools.values()})
 
     def get_emoji(self, name: str, default: str = "⚡") -> str:
         """Return the emoji for a tool, or *default* if unset."""
@@ -261,7 +272,8 @@ class ToolRegistry:
 
     def get_tool_to_toolset_map(self) -> Dict[str, str]:
         """Return ``{tool_name: toolset_name}`` for every registered tool."""
-        return {name: e.toolset for name, e in self._tools.items()}
+        with self._lock:
+            return {name: e.toolset for name, e in self._tools.items()}
 
     def is_toolset_available(self, toolset: str) -> bool:
         """Check if a toolset's requirements are met.
@@ -280,13 +292,16 @@ class ToolRegistry:
 
     def check_toolset_requirements(self) -> Dict[str, bool]:
         """Return ``{toolset: available_bool}`` for every toolset."""
-        toolsets = set(e.toolset for e in self._tools.values())
+        with self._lock:
+            toolsets = set(e.toolset for e in self._tools.values())
         return {ts: self.is_toolset_available(ts) for ts in sorted(toolsets)}
 
     def get_available_toolsets(self) -> Dict[str, dict]:
         """Return toolset metadata for UI display."""
+        with self._lock:
+            entries = list(self._tools.values())
         toolsets: Dict[str, dict] = {}
-        for entry in self._tools.values():
+        for entry in entries:
             ts = entry.toolset
             if ts not in toolsets:
                 toolsets[ts] = {
@@ -304,8 +319,10 @@ class ToolRegistry:
 
     def get_toolset_requirements(self) -> Dict[str, dict]:
         """Build a TOOLSET_REQUIREMENTS-compatible dict for backward compat."""
+        with self._lock:
+            entries = list(self._tools.values())
         result: Dict[str, dict] = {}
-        for entry in self._tools.values():
+        for entry in entries:
             ts = entry.toolset
             if ts not in result:
                 result[ts] = {
@@ -327,7 +344,9 @@ class ToolRegistry:
         available = []
         unavailable = []
         seen = set()
-        for entry in self._tools.values():
+        with self._lock:
+            entries = list(self._tools.values())
+        for entry in entries:
             ts = entry.toolset
             if ts in seen:
                 continue
@@ -338,7 +357,7 @@ class ToolRegistry:
                 unavailable.append({
                     "name": ts,
                     "env_vars": entry.requires_env,
-                    "tools": [e.name for e in self._tools.values() if e.toolset == ts],
+                    "tools": [e.name for e in entries if e.toolset == ts],
                 })
         return available, unavailable
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import sys
 import threading
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
@@ -73,7 +74,7 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars",
+        "max_result_size_chars", "handler_module",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
@@ -89,6 +90,7 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        self.handler_module = getattr(handler, "__module__", "")
 
 
 class ToolRegistry:
@@ -139,6 +141,7 @@ class ToolRegistry:
             )
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn
+        self._refresh_model_tools_exports()
 
     def deregister(self, name: str) -> None:
         """Remove a tool from the registry.
@@ -157,6 +160,7 @@ class ToolRegistry:
             ):
                 self._toolset_checks.pop(entry.toolset, None)
             logger.debug("Deregistered tool: %s", name)
+        self._refresh_model_tools_exports()
 
     # ------------------------------------------------------------------
     # Schema retrieval
@@ -251,14 +255,41 @@ class ToolRegistry:
             entry = self._tools.get(name)
             return entry.toolset if entry else None
 
-    def get_tools_for_toolset(self, toolset: str) -> List[str]:
+    def get_tools_for_toolset(self, toolset: str, *, builtin_only: bool = False) -> List[str]:
         """Return the sorted tool names currently registered to *toolset*."""
         with self._lock:
             return sorted(
                 name
                 for name, entry in self._tools.items()
                 if entry.toolset == toolset
+                and (
+                    not builtin_only
+                    or (
+                        entry.handler_module.startswith("tools.")
+                        and entry.handler_module != "tools.mcp_tool"
+                    )
+                )
             )
+
+    def _refresh_model_tools_exports(self) -> None:
+        """Best-effort sync for legacy exported maps in model_tools."""
+        model_tools = sys.modules.get("model_tools")
+        if model_tools is None:
+            return
+        try:
+            if hasattr(model_tools, "TOOL_TO_TOOLSET_MAP"):
+                model_tools.TOOL_TO_TOOLSET_MAP.clear()
+                model_tools.TOOL_TO_TOOLSET_MAP.update(self.get_tool_to_toolset_map())
+            if hasattr(model_tools, "TOOLSET_REQUIREMENTS"):
+                model_tools.TOOLSET_REQUIREMENTS.clear()
+                model_tools.TOOLSET_REQUIREMENTS.update(self.get_toolset_requirements())
+            if hasattr(model_tools, "_LEGACY_TOOLSET_MAP"):
+                from toolsets import get_legacy_toolset_map
+
+                model_tools._LEGACY_TOOLSET_MAP.clear()
+                model_tools._LEGACY_TOOLSET_MAP.update(get_legacy_toolset_map())
+        except Exception:
+            logger.debug("Failed to refresh model_tools compatibility exports", exc_info=True)
 
     def get_registered_toolset_names(self) -> List[str]:
         """Return sorted names of all toolsets currently present in the registry."""

--- a/toolsets.py
+++ b/toolsets.py
@@ -493,7 +493,6 @@ def get_toolset_names() -> List[str]:
     names = set(TOOLSETS.keys())
     for toolset_name in _get_registry_toolset_names():
         if toolset_name.startswith("mcp-"):
-            names.add(toolset_name)
             alias = toolset_name[4:]
             if (
                 alias
@@ -502,6 +501,8 @@ def get_toolset_names() -> List[str]:
                 and alias not in _get_registry_toolset_names()
             ):
                 names.add(alias)
+            else:
+                names.add(toolset_name)
             continue
         names.add(toolset_name)
     return sorted(names)

--- a/toolsets.py
+++ b/toolsets.py
@@ -13,38 +13,6 @@ from typing import Any, Dict, List, Optional, Set
 from tools.registry import registry
 
 
-class _ResolvedToolList(list):
-    """Live list view that resolves a toolset on demand."""
-
-    def __init__(self, toolset_name: str):
-        super().__init__()
-        self._toolset_name = toolset_name
-
-    def _refresh(self) -> None:
-        super().clear()
-        super().extend(sorted(resolve_toolset(self._toolset_name)))
-
-    def __contains__(self, item) -> bool:
-        self._refresh()
-        return super().__contains__(item)
-
-    def __iter__(self):
-        self._refresh()
-        return super().__iter__()
-
-    def __len__(self) -> int:
-        self._refresh()
-        return super().__len__()
-
-    def __repr__(self) -> str:
-        self._refresh()
-        return super().__repr__()
-
-    def copy(self):
-        self._refresh()
-        return list(self)
-
-
 _HERMES_CORE_TOOLSETS = [
     "web",
     "terminal",
@@ -365,10 +333,6 @@ TOOLSETS = {
     },
 }
 
-
-_HERMES_CORE_TOOLS = _ResolvedToolList("hermes-cli")
-
-
 def _get_registry_toolset_names() -> Set[str]:
     """Return live toolset names from the registry."""
     try:
@@ -529,8 +493,14 @@ def get_toolset_names() -> List[str]:
     names = set(TOOLSETS.keys())
     for toolset_name in _get_registry_toolset_names():
         if toolset_name.startswith("mcp-"):
+            names.add(toolset_name)
             alias = toolset_name[4:]
-            if alias and alias not in TOOLSETS:
+            if (
+                alias
+                and alias not in TOOLSETS
+                and alias not in LEGACY_TOOLSET_ALIASES
+                and alias not in _get_registry_toolset_names()
+            ):
                 names.add(alias)
             continue
         names.add(toolset_name)
@@ -585,6 +555,14 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
         "tool_count": len(resolved_tools),
         "is_composite": bool(toolset["includes"]),
     }
+
+
+def get_hermes_core_tools() -> List[str]:
+    """Return a snapshot of the default Hermes CLI tool inventory."""
+    return sorted(resolve_toolset("hermes-cli"))
+
+
+_HERMES_CORE_TOOLS = get_hermes_core_tools()
 
 
 if __name__ == "__main__":

--- a/toolsets.py
+++ b/toolsets.py
@@ -66,6 +66,21 @@ _HERMES_CORE_TOOLSETS = [
 ]
 
 
+LEGACY_TOOLSET_ALIASES: Dict[str, List[str]] = {
+    "web_tools": ["web"],
+    "terminal_tools": ["terminal"],
+    "vision_tools": ["vision"],
+    "moa_tools": ["moa"],
+    "image_tools": ["image_gen"],
+    "skills_tools": ["skills"],
+    "browser_tools": ["browser"],
+    "cronjob_tools": ["cronjob"],
+    "rl_tools": ["rl"],
+    "file_tools": ["file"],
+    "tts_tools": ["tts"],
+}
+
+
 # Static bundle definitions only. Registry-owned toolsets resolve their direct
 # membership live from ``tools.registry``; the ``tools`` lists here only contain
 # extra bundle-specific additions that are not owned by the toolset itself.
@@ -345,6 +360,27 @@ def _get_registry_tool_names(toolset_name: str) -> List[str]:
         return registry.get_tools_for_toolset(toolset_name)
     except Exception:
         return []
+
+
+def is_legacy_toolset(name: str) -> bool:
+    """Return True when *name* is a backward-compatible toolset alias."""
+    return name in LEGACY_TOOLSET_ALIASES
+
+
+def resolve_legacy_toolset(name: str) -> List[str]:
+    """Resolve a backward-compatible legacy toolset alias to live tool names."""
+    aliases = LEGACY_TOOLSET_ALIASES.get(name)
+    if not aliases:
+        return []
+    return resolve_multiple_toolsets(aliases)
+
+
+def get_legacy_toolset_map() -> Dict[str, List[str]]:
+    """Return live resolved tool names for every supported legacy alias."""
+    return {
+        name: sorted(resolve_legacy_toolset(name))
+        for name in LEGACY_TOOLSET_ALIASES
+    }
 
 
 def _get_mcp_toolset_aliases() -> Dict[str, str]:

--- a/toolsets.py
+++ b/toolsets.py
@@ -2,601 +2,514 @@
 """
 Toolsets Module
 
-This module provides a flexible system for defining and managing tool aliases/toolsets.
-Toolsets allow you to group tools together for specific scenarios and can be composed
-from individual tools or other toolsets.
-
-Features:
-- Define custom toolsets with specific tools
-- Compose toolsets from other toolsets
-- Built-in common toolsets for typical use cases
-- Easy extension for new toolsets
-- Support for dynamic toolset resolution
-
-Usage:
-    from toolsets import get_toolset, resolve_toolset, get_all_toolsets
-    
-    # Get tools for a specific toolset
-    tools = get_toolset("research")
-    
-    # Resolve a toolset to get all tool names (including from composed toolsets)
-    all_tools = resolve_toolset("full_stack")
+Registry-owned tool membership lives in ``tools.registry``. This module adds
+bundle/composition semantics on top of that live registry state so platform
+presets, scenario bundles, and compatibility aliases do not need to duplicate
+tool ownership.
 """
 
-from typing import List, Dict, Any, Set, Optional
+from typing import Any, Dict, List, Optional, Set
+
+from tools.registry import registry
 
 
-# Shared tool list for CLI and all messaging platform toolsets.
-# Edit this once to update all platforms simultaneously.
-_HERMES_CORE_TOOLS = [
-    # Web
-    "web_search", "web_extract",
-    # Terminal + process management
-    "terminal", "process",
-    # File manipulation
-    "read_file", "write_file", "patch", "search_files",
-    # Vision + image generation
-    "vision_analyze", "image_generate",
-    # Skills
-    "skills_list", "skill_view", "skill_manage",
-    # Browser automation
-    "browser_navigate", "browser_snapshot", "browser_click",
-    "browser_type", "browser_scroll", "browser_back",
-    "browser_press", "browser_get_images",
-    "browser_vision", "browser_console",
-    # Text-to-speech
-    "text_to_speech",
-    # Planning & memory
-    "todo", "memory",
-    # Session history search
+class _ResolvedToolList(list):
+    """Live list view that resolves a toolset on demand."""
+
+    def __init__(self, toolset_name: str):
+        super().__init__()
+        self._toolset_name = toolset_name
+
+    def _refresh(self) -> None:
+        super().clear()
+        super().extend(sorted(resolve_toolset(self._toolset_name)))
+
+    def __contains__(self, item) -> bool:
+        self._refresh()
+        return super().__contains__(item)
+
+    def __iter__(self):
+        self._refresh()
+        return super().__iter__()
+
+    def __len__(self) -> int:
+        self._refresh()
+        return super().__len__()
+
+    def __repr__(self) -> str:
+        self._refresh()
+        return super().__repr__()
+
+    def copy(self):
+        self._refresh()
+        return list(self)
+
+
+_HERMES_CORE_TOOLSETS = [
+    "web",
+    "terminal",
+    "file",
+    "vision",
+    "image_gen",
+    "skills",
+    "browser",
+    "tts",
+    "todo",
+    "memory",
     "session_search",
-    # Clarifying questions
     "clarify",
-    # Code execution + delegation
-    "execute_code", "delegate_task",
-    # Cronjob management
+    "code_execution",
+    "delegation",
     "cronjob",
-    # Cross-platform messaging (gated on gateway running via check_fn)
-    "send_message",
-    # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
-    "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    "messaging",
+    "homeassistant",
 ]
 
 
-# Core toolset definitions
-# These can include individual tools or reference other toolsets
+# Static bundle definitions only. Registry-owned toolsets resolve their direct
+# membership live from ``tools.registry``; the ``tools`` lists here only contain
+# extra bundle-specific additions that are not owned by the toolset itself.
 TOOLSETS = {
-    # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
-        "includes": []  # No other toolsets included
+        "tools": [],
+        "includes": [],
     },
-    
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
-        "includes": []
+        "includes": [],
     },
-    
     "vision": {
         "description": "Image analysis and vision tools",
-        "tools": ["vision_analyze"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "image_gen": {
         "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "terminal": {
         "description": "Terminal/command execution and process management tools",
-        "tools": ["terminal", "process"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "moa": {
         "description": "Advanced reasoning and problem-solving tools",
-        "tools": ["mixture_of_agents"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
-        "tools": ["skills_list", "skill_view", "skill_manage"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "browser": {
         "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
-        "tools": [
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "web_search"
-        ],
-        "includes": []
+        "tools": [],
+        "includes": ["search"],
     },
-    
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",
-        "tools": ["cronjob"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "rl": {
         "description": "RL training tools for running reinforcement learning on Tinker-Atropos",
-        "tools": [
-            "rl_list_environments", "rl_select_environment",
-            "rl_get_current_config", "rl_edit_config",
-            "rl_start_training", "rl_check_status",
-            "rl_stop_training", "rl_get_results",
-            "rl_list_runs", "rl_test_inference"
-        ],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "file": {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
-        "tools": ["read_file", "write_file", "patch", "search_files"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, or OpenAI",
-        "tools": ["text_to_speech"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "todo": {
         "description": "Task planning and tracking for multi-step work",
-        "tools": ["todo"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",
-        "tools": ["memory"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "session_search": {
         "description": "Search and recall past conversations with summarization",
-        "tools": ["session_search"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
-        "tools": ["clarify"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
-        "tools": ["execute_code"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-    
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
-    # Tools are injected via MemoryManager, not the toolset system.
-
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",
-        "tools": ["ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service"],
-        "includes": []
+        "tools": [],
+        "includes": [],
     },
-
-
-    # Scenario-specific toolsets
-    
     "debugging": {
         "description": "Debugging and troubleshooting toolkit",
-        "tools": ["terminal", "process"],
-        "includes": ["web", "file"]  # For searching error messages and solutions, and file operations
+        "tools": [],
+        "includes": ["terminal", "web", "file"],
     },
-    
     "safe": {
         "description": "Safe toolkit without terminal access",
         "tools": [],
-        "includes": ["web", "vision", "image_gen"]
+        "includes": ["web", "vision", "image_gen"],
     },
-    
-    # ==========================================================================
-    # Full Hermes toolsets (CLI + messaging platforms)
-    #
-    # All platforms share the same core tools (including send_message,
-    # which is gated on gateway running via its check_fn).
-    # ==========================================================================
-
     "hermes-acp": {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
-        "tools": [
-            "web_search", "web_extract",
-            "terminal", "process",
-            "read_file", "write_file", "patch", "search_files",
-            "vision_analyze",
-            "skills_list", "skill_view", "skill_manage",
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console",
-            "todo", "memory",
+        "tools": [],
+        "includes": [
+            "web",
+            "terminal",
+            "file",
+            "vision",
+            "skills",
+            "browser",
+            "todo",
+            "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "code_execution",
+            "delegation",
         ],
-        "includes": []
     },
-
     "hermes-api-server": {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
-        "tools": [
-            # Web
-            "web_search", "web_extract",
-            # Terminal + process management
-            "terminal", "process",
-            # File manipulation
-            "read_file", "write_file", "patch", "search_files",
-            # Vision + image generation
-            "vision_analyze", "image_generate",
-            # Skills
-            "skills_list", "skill_view", "skill_manage",
-            # Browser automation
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console",
-            # Planning & memory
-            "todo", "memory",
-            # Session history search
+        "tools": [],
+        "includes": [
+            "web",
+            "terminal",
+            "file",
+            "vision",
+            "image_gen",
+            "skills",
+            "browser",
+            "todo",
+            "memory",
             "session_search",
-            # Code execution + delegation
-            "execute_code", "delegate_task",
-            # Cronjob management
+            "code_execution",
+            "delegation",
             "cronjob",
-            # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
-            "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
-
+            "homeassistant",
         ],
-        "includes": []
     },
-    
     "hermes-cli": {
         "description": "Full interactive CLI toolset - all default tools plus cronjob management",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-    
     "hermes-telegram": {
         "description": "Telegram bot toolset - full access for personal use (terminal has safety checks)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-    
     "hermes-discord": {
         "description": "Discord bot toolset - full access (terminal has safety checks via dangerous command approval)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-    
     "hermes-whatsapp": {
         "description": "WhatsApp bot toolset - similar to Telegram (personal messaging, more trusted)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-    
     "hermes-slack": {
         "description": "Slack bot toolset - full access for workspace use (terminal has safety checks)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-    
     "hermes-signal": {
         "description": "Signal bot toolset - encrypted messaging platform (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-bluebubbles": {
         "description": "BlueBubbles iMessage bot toolset - Apple iMessage via local BlueBubbles server",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-homeassistant": {
         "description": "Home Assistant bot toolset - smart home event monitoring and control",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-email": {
         "description": "Email bot toolset - interact with Hermes via email (IMAP/SMTP)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-mattermost": {
         "description": "Mattermost bot toolset - self-hosted team messaging (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-dingtalk": {
         "description": "DingTalk bot toolset - enterprise messaging platform (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-feishu": {
         "description": "Feishu/Lark bot toolset - enterprise messaging via Feishu/Lark (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-weixin": {
         "description": "Weixin bot toolset - personal WeChat messaging via iLink (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-wecom": {
         "description": "WeCom bot toolset - enterprise WeChat messaging (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-sms": {
         "description": "SMS bot toolset - interact with Hermes via SMS (Twilio)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-webhook": {
         "description": "Webhook toolset - receive and process external webhook events",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "tools": [],
+        "includes": list(_HERMES_CORE_TOOLSETS),
     },
-
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-weixin", "hermes-webhook"]
-    }
+        "includes": [
+            "hermes-telegram",
+            "hermes-discord",
+            "hermes-whatsapp",
+            "hermes-slack",
+            "hermes-signal",
+            "hermes-bluebubbles",
+            "hermes-homeassistant",
+            "hermes-email",
+            "hermes-sms",
+            "hermes-mattermost",
+            "hermes-matrix",
+            "hermes-dingtalk",
+            "hermes-feishu",
+            "hermes-wecom",
+            "hermes-weixin",
+            "hermes-webhook",
+        ],
+    },
 }
 
+
+_HERMES_CORE_TOOLS = _ResolvedToolList("hermes-cli")
+
+
+def _get_registry_toolset_names() -> Set[str]:
+    """Return live toolset names from the registry."""
+    try:
+        return set(registry.get_registered_toolset_names())
+    except Exception:
+        return set()
+
+
+def _get_registry_tool_names(toolset_name: str) -> List[str]:
+    """Return live direct tool names for a registry-owned toolset."""
+    try:
+        return registry.get_tools_for_toolset(toolset_name)
+    except Exception:
+        return []
+
+
+def _get_mcp_toolset_aliases() -> Dict[str, str]:
+    """Map raw MCP server names to their internal registry toolset names."""
+    aliases: Dict[str, str] = {}
+    for toolset_name in _get_registry_toolset_names():
+        if not toolset_name.startswith("mcp-"):
+            continue
+        alias = toolset_name[4:]
+        if alias and alias not in TOOLSETS:
+            aliases.setdefault(alias, toolset_name)
+    return aliases
+
+
+def _default_toolset_description(name: str, display_name: Optional[str] = None) -> str:
+    """Return a synthetic description for dynamic toolsets."""
+    label = display_name or name
+    if name.startswith("mcp-"):
+        return f"MCP server '{name[4:]}' tools"
+    if display_name and name.startswith("mcp-"):
+        return f"MCP server '{display_name}' tools"
+    return f"Plugin toolset: {label}"
+
+
+def _normalize_toolset_name(name: str) -> str:
+    """Resolve user-facing aliases to the registry-owned toolset name."""
+    return _get_mcp_toolset_aliases().get(name, name)
 
 
 def get_toolset(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset definition by name.
-    
-    Args:
-        name (str): Name of the toolset
-        
-    Returns:
-        Dict: Toolset definition with description, tools, and includes
-        None: If toolset not found
+
+    Returns a merged live view where direct tool ownership comes from the
+    registry and static bundle metadata contributes descriptions/includes.
     """
-    # Return toolset definition
-    return TOOLSETS.get(name)
+    static_def = TOOLSETS.get(name)
+    normalized_name = _normalize_toolset_name(name)
+    registry_tools = _get_registry_tool_names(normalized_name)
+
+    if not static_def and not registry_tools:
+        return None
+
+    direct_tools = list(dict.fromkeys((static_def or {}).get("tools", []) + registry_tools))
+    includes = list((static_def or {}).get("includes", []))
+    description = (static_def or {}).get("description") or _default_toolset_description(
+        normalized_name,
+        display_name=name if name != normalized_name else None,
+    )
+
+    return {
+        "description": description,
+        "tools": direct_tools,
+        "includes": includes,
+    }
 
 
 def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     """
     Recursively resolve a toolset to get all tool names.
-    
-    This function handles toolset composition by recursively resolving
-    included toolsets and combining all tools.
-    
-    Args:
-        name (str): Name of the toolset to resolve
-        visited (Set[str]): Set of already visited toolsets (for cycle detection)
-        
-    Returns:
-        List[str]: List of all tool names in the toolset
     """
     if visited is None:
         visited = set()
-    
-    # Special aliases that represent all tools across every toolset
-    # This ensures future toolsets are automatically included without changes.
+
     if name in {"all", "*"}:
-        all_tools: Set[str] = set()
+        all_tools: Set[str] = set(registry.get_all_tool_names())
         for toolset_name in get_toolset_names():
-            # Use a fresh visited set per branch to avoid cross-branch contamination
-            resolved = resolve_toolset(toolset_name, visited.copy())
-            all_tools.update(resolved)
+            all_tools.update(resolve_toolset(toolset_name, visited.copy()))
         return list(all_tools)
 
-    # Check for cycles / already-resolved (diamond deps).
-    # Silently return [] — either this is a diamond (not a bug, tools already
-    # collected via another path) or a genuine cycle (safe to skip).
     if name in visited:
         return []
 
     visited.add(name)
 
-    # Get toolset definition
-    toolset = TOOLSETS.get(name)
+    toolset = get_toolset(name)
     if not toolset:
-        # Fall back to tool registry for plugin-provided toolsets
-        if name in _get_plugin_toolset_names():
-            try:
-                from tools.registry import registry
-                return [e.name for e in registry._tools.values() if e.toolset == name]
-            except Exception:
-                pass
         return []
 
-    # Collect direct tools
     tools = set(toolset.get("tools", []))
-
-    # Recursively resolve included toolsets, sharing the visited set across
-    # sibling includes so diamond dependencies are only resolved once and
-    # cycle warnings don't fire multiple times for the same cycle.
     for included_name in toolset.get("includes", []):
-        included_tools = resolve_toolset(included_name, visited)
-        tools.update(included_tools)
-    
+        tools.update(resolve_toolset(included_name, visited))
+
     return list(tools)
 
 
 def resolve_multiple_toolsets(toolset_names: List[str]) -> List[str]:
     """
     Resolve multiple toolsets and combine their tools.
-    
-    Args:
-        toolset_names (List[str]): List of toolset names to resolve
-        
-    Returns:
-        List[str]: Combined list of all tool names (deduplicated)
     """
     all_tools = set()
-    
     for name in toolset_names:
-        tools = resolve_toolset(name)
-        all_tools.update(tools)
-    
+        all_tools.update(resolve_toolset(name))
     return list(all_tools)
-
-
-def _get_plugin_toolset_names() -> Set[str]:
-    """Return toolset names registered by plugins (from the tool registry).
-
-    These are toolsets that exist in the registry but not in the static
-    ``TOOLSETS`` dict — i.e. they were added by plugins at load time.
-    """
-    try:
-        from tools.registry import registry
-        return {
-            entry.toolset
-            for entry in registry._tools.values()
-            if entry.toolset not in TOOLSETS
-        }
-    except Exception:
-        return set()
 
 
 def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     """
     Get all available toolsets with their definitions.
 
-    Includes both statically-defined toolsets and plugin-registered ones.
-    
-    Returns:
-        Dict: All toolset definitions
+    Includes static bundles, registry-owned leaf toolsets, and raw MCP server
+    aliases that resolve to live ``mcp-*`` registry toolsets.
     """
-    result = TOOLSETS.copy()
-    # Add plugin-provided toolsets (synthetic entries)
-    for ts_name in _get_plugin_toolset_names():
-        if ts_name not in result:
-            try:
-                from tools.registry import registry
-                tools = [e.name for e in registry._tools.values() if e.toolset == ts_name]
-                result[ts_name] = {
-                    "description": f"Plugin toolset: {ts_name}",
-                    "tools": tools,
-                }
-            except Exception:
-                pass
+    result: Dict[str, Dict[str, Any]] = {}
+    for name in get_toolset_names():
+        toolset = get_toolset(name)
+        if toolset:
+            result[name] = toolset
     return result
 
 
 def get_toolset_names() -> List[str]:
     """
-    Get names of all available toolsets (excluding aliases).
-
-    Includes plugin-registered toolset names.
-    
-    Returns:
-        List[str]: List of toolset names
+    Get names of all available toolsets (excluding the special all/* aliases).
     """
     names = set(TOOLSETS.keys())
-    names |= _get_plugin_toolset_names()
+    for toolset_name in _get_registry_toolset_names():
+        if toolset_name.startswith("mcp-"):
+            alias = toolset_name[4:]
+            if alias and alias not in TOOLSETS:
+                names.add(alias)
+            continue
+        names.add(toolset_name)
     return sorted(names)
-
-
 
 
 def validate_toolset(name: str) -> bool:
     """
     Check if a toolset name is valid.
-    
-    Args:
-        name (str): Toolset name to validate
-        
-    Returns:
-        bool: True if valid, False otherwise
     """
-    # Accept special alias names for convenience
     if name in {"all", "*"}:
         return True
     if name in TOOLSETS:
         return True
-    # Check tool registry for plugin-provided toolsets
-    return name in _get_plugin_toolset_names()
+    if name in _get_mcp_toolset_aliases():
+        return True
+    return name in _get_registry_toolset_names()
 
 
 def create_custom_toolset(
     name: str,
     description: str,
     tools: List[str] = None,
-    includes: List[str] = None
+    includes: List[str] = None,
 ) -> None:
     """
-    Create a custom toolset at runtime.
-    
-    Args:
-        name (str): Name for the new toolset
-        description (str): Description of the toolset
-        tools (List[str]): Direct tools to include
-        includes (List[str]): Other toolsets to include
+    Create a custom bundle toolset at runtime.
     """
     TOOLSETS[name] = {
         "description": description,
         "tools": tools or [],
-        "includes": includes or []
+        "includes": includes or [],
     }
-
-
 
 
 def get_toolset_info(name: str) -> Dict[str, Any]:
     """
     Get detailed information about a toolset including resolved tools.
-    
-    Args:
-        name (str): Toolset name
-        
-    Returns:
-        Dict: Detailed toolset information
     """
     toolset = get_toolset(name)
     if not toolset:
         return None
-    
+
     resolved_tools = resolve_toolset(name)
-    
+
     return {
         "name": name,
         "description": toolset["description"],
@@ -604,16 +517,14 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
         "includes": toolset["includes"],
         "resolved_tools": resolved_tools,
         "tool_count": len(resolved_tools),
-        "is_composite": bool(toolset["includes"])
+        "is_composite": bool(toolset["includes"]),
     }
-
-
 
 
 if __name__ == "__main__":
     print("Toolsets System Demo")
     print("=" * 60)
-    
+
     print("\nAvailable Toolsets:")
     print("-" * 40)
     for name, toolset in get_all_toolsets().items():
@@ -621,27 +532,27 @@ if __name__ == "__main__":
         composite = "[composite]" if info["is_composite"] else "[leaf]"
         print(f"  {composite} {name:20} - {toolset['description']}")
         print(f"     Tools: {len(info['resolved_tools'])} total")
-    
+
     print("\nToolset Resolution Examples:")
     print("-" * 40)
     for name in ["web", "terminal", "safe", "debugging"]:
         tools = resolve_toolset(name)
         print(f"\n  {name}:")
         print(f"    Resolved to {len(tools)} tools: {', '.join(sorted(tools))}")
-    
+
     print("\nMultiple Toolset Resolution:")
     print("-" * 40)
     combined = resolve_multiple_toolsets(["web", "vision", "terminal"])
     print("  Combining ['web', 'vision', 'terminal']:")
     print(f"    Result: {', '.join(sorted(combined))}")
-    
+
     print("\nCustom Toolset Creation:")
     print("-" * 40)
     create_custom_toolset(
         name="my_custom",
         description="My custom toolset for specific tasks",
         tools=["web_search"],
-        includes=["terminal", "vision"]
+        includes=["terminal", "vision"],
     )
     custom_info = get_toolset_info("my_custom")
     print("  Created 'my_custom' toolset:")

--- a/toolsets.py
+++ b/toolsets.py
@@ -349,6 +349,14 @@ def _get_registry_tool_names(toolset_name: str) -> List[str]:
         return []
 
 
+def _get_builtin_registry_tool_names(toolset_name: str) -> List[str]:
+    """Return only built-in direct tool names for a registry-owned toolset."""
+    try:
+        return registry.get_tools_for_toolset(toolset_name, builtin_only=True)
+    except Exception:
+        return []
+
+
 def is_legacy_toolset(name: str) -> bool:
     """Return True when *name* is a backward-compatible toolset alias."""
     return name in LEGACY_TOOLSET_ALIASES
@@ -413,7 +421,11 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
     """
     static_def = TOOLSETS.get(name)
     normalized_name = _normalize_toolset_name(name)
-    registry_tools = _get_registry_tool_names(normalized_name)
+    registry_tools = (
+        _get_builtin_registry_tool_names(normalized_name)
+        if static_def is not None
+        else _get_registry_tool_names(normalized_name)
+    )
 
     if not static_def and not registry_tools:
         return None

--- a/toolsets.py
+++ b/toolsets.py
@@ -67,17 +67,40 @@ _HERMES_CORE_TOOLSETS = [
 
 
 LEGACY_TOOLSET_ALIASES: Dict[str, List[str]] = {
-    "web_tools": ["web"],
-    "terminal_tools": ["terminal"],
-    "vision_tools": ["vision"],
-    "moa_tools": ["moa"],
-    "image_tools": ["image_gen"],
-    "skills_tools": ["skills"],
-    "browser_tools": ["browser"],
+    "web_tools": ["web_search", "web_extract"],
+    "terminal_tools": ["terminal", "process"],
+    "vision_tools": ["vision_analyze"],
+    "moa_tools": ["mixture_of_agents"],
+    "image_tools": ["image_generate"],
+    "skills_tools": ["skills_list", "skill_view", "skill_manage"],
+    "browser_tools": [
+        "browser_back",
+        "browser_click",
+        "browser_console",
+        "browser_get_images",
+        "browser_navigate",
+        "browser_press",
+        "browser_scroll",
+        "browser_snapshot",
+        "browser_type",
+        "browser_vision",
+        "web_search",
+    ],
     "cronjob_tools": ["cronjob"],
-    "rl_tools": ["rl"],
-    "file_tools": ["file"],
-    "tts_tools": ["tts"],
+    "rl_tools": [
+        "rl_list_environments",
+        "rl_select_environment",
+        "rl_get_current_config",
+        "rl_edit_config",
+        "rl_start_training",
+        "rl_check_status",
+        "rl_stop_training",
+        "rl_get_results",
+        "rl_list_runs",
+        "rl_test_inference",
+    ],
+    "file_tools": ["read_file", "write_file", "patch", "search_files"],
+    "tts_tools": ["text_to_speech"],
 }
 
 
@@ -369,10 +392,11 @@ def is_legacy_toolset(name: str) -> bool:
 
 def resolve_legacy_toolset(name: str) -> List[str]:
     """Resolve a backward-compatible legacy toolset alias to live tool names."""
-    aliases = LEGACY_TOOLSET_ALIASES.get(name)
-    if not aliases:
+    tool_names = LEGACY_TOOLSET_ALIASES.get(name)
+    if not tool_names:
         return []
-    return resolve_multiple_toolsets(aliases)
+    available = set(registry.get_all_tool_names())
+    return [tool_name for tool_name in tool_names if tool_name in available]
 
 
 def get_legacy_toolset_map() -> Dict[str, List[str]]:

--- a/toolsets.py
+++ b/toolsets.py
@@ -410,11 +410,17 @@ def get_legacy_toolset_map() -> Dict[str, List[str]]:
 def _get_mcp_toolset_aliases() -> Dict[str, str]:
     """Map raw MCP server names to their internal registry toolset names."""
     aliases: Dict[str, str] = {}
+    reserved_names = set(TOOLSETS) | set(LEGACY_TOOLSET_ALIASES)
+    reserved_names.update(
+        toolset_name
+        for toolset_name in _get_registry_toolset_names()
+        if not toolset_name.startswith("mcp-")
+    )
     for toolset_name in _get_registry_toolset_names():
         if not toolset_name.startswith("mcp-"):
             continue
         alias = toolset_name[4:]
-        if alias and alias not in TOOLSETS:
+        if alias and alias not in reserved_names:
             aliases.setdefault(alias, toolset_name)
     return aliases
 
@@ -470,7 +476,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
         visited = set()
 
     if name in {"all", "*"}:
-        all_tools: Set[str] = set(registry.get_all_tool_names())
+        all_tools: Set[str] = set()
         for toolset_name in get_toolset_names():
             all_tools.update(resolve_toolset(toolset_name, visited.copy()))
         return list(all_tools)


### PR DESCRIPTION
## What Changed
This makes the registry the only source of tool ownership, keeps `toolsets.py` focused on bundle composition plus explicit legacy aliases, and tightens MCP alias/listing behavior.

## Why
Tool authority still had three cleanup problems even after the first live-registry pass:
- compatibility wrappers were exporting mutable magic views instead of explicit snapshots
- dead MCP toolset sync paths and discovery overlap still existed
- colliding MCP aliases and `all` behavior could still disagree with what the CLI actually listed

## Impact
- live wrapper containers are gone; callers now use explicit snapshot helpers
- legacy `_tools` aliases remain explicit lists owned by `toolsets.py`
- MCP alias resolution is collision-safe against static toolsets, live registry toolsets, and legacy aliases
- colliding MCP toolsets stay visible via canonical `mcp-*` names
- `batch_runner` uses the live tool inventory helper and the final combine/filter path is now directly tested
- builtin AST discovery skips `tools.mcp_tool` because MCP discovery is handled explicitly
- the dead `_sync_mcp_toolsets()` path has been removed

## Validation
- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m pytest -o addopts='' tests/test_toolsets.py tests/test_model_tools.py tests/tools/test_registry.py tests/test_batch_runner_checkpoint.py tests/tools/test_mcp_tool.py tests/gateway/test_homeassistant.py tests/tools/test_browser_console.py -q`
- `314 passed` (with one pre-existing warning in `tests/tools/test_mcp_tool.py`)

## Merge Order
- Intended local merge order: #7584 -> #7544 -> #7602 -> #7649
- These PRs target `main` because GitHub cannot express a true stacked base chain from fork-only branches without matching upstream branch refs.
- The stack was validated locally on a stacked integration branch in that order.

## Full-Suite Note
A full `pytest tests/ -q` run was executed on the stacked integration branch. Stack-specific regressions found there were fixed; remaining failures reproduce on clean `origin/main` and are not introduced by this PR train.