### PR TITLE
feat(agent): context window usage telemetry

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -36,6 +36,7 @@ import sys
 import tempfile
 import time
 import threading
+from dataclasses import dataclass
 from types import SimpleNamespace
 import urllib.request
 import uuid
@@ -812,6 +813,31 @@ def _qwen_portal_headers() -> dict:
         "X-DashScope-UserAgent": _ua,
         "X-DashScope-AuthType": "qwen-oauth",
     }
+
+
+@dataclass
+class ContextUsageReport:
+    """Telemetry snapshot of context window utilization."""
+
+    used_tokens: int
+    total_tokens: int
+    message_count: int
+
+    @property
+    def percentage(self) -> float:
+        if self.total_tokens <= 0:
+            return 0.0
+        return (self.used_tokens / self.total_tokens) * 100
+
+    def is_warning(self, threshold_percent: float = 85.0) -> bool:
+        return self.percentage >= threshold_percent
+
+    def summary(self) -> str:
+        pct = self.percentage
+        return (
+            f"Context: {self.used_tokens:,}/{self.total_tokens:,} tokens "
+            f"({pct:.1f}%) — {self.message_count} messages"
+        )
 
 
 class AIAgent:
@@ -10205,7 +10231,22 @@ class AIAgent:
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = estimate_messages_tokens_rough(api_messages)
-            
+
+            # ── Context window usage telemetry ──
+            _compressor = getattr(self, "context_compressor", None)
+            _ctx_limit = getattr(_compressor, "context_length", None) if _compressor else None
+            if _ctx_limit:
+                _usage = ContextUsageReport(
+                    used_tokens=approx_tokens,
+                    total_tokens=_ctx_limit,
+                    message_count=len(api_messages),
+                )
+                if _usage.is_warning(threshold_percent=85):
+                    self._vprint(
+                        f"{self.log_prefix}⚠️  {_usage.summary()}",
+                        force=True,
+                    )
+
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
             

--- a/run_agent.py
+++ b/run_agent.py
@@ -1214,6 +1214,10 @@ class AIAgent:
         # after each API call.  Accessed by /usage slash command.
         self._rate_limit_state: Optional["RateLimitState"] = None
 
+        # Context window warning deduplication — emit once per conversation,
+        # not once per API call iteration.
+        self._context_warning_emitted: bool = False
+
         # Centralized logging — agent.log (INFO+) and errors.log (WARNING+)
         # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
         # (which creates a new AIAgent per message) won't duplicate handlers.
@@ -9683,6 +9687,7 @@ class AIAgent:
         self._last_content_tools_all_housekeeping = False
         self._mute_post_response = False
         self._unicode_sanitization_passes = 0
+        self._context_warning_emitted = False
 
         # Pre-turn connection health check: detect and clean up dead TCP
         # connections left over from provider outages or dropped streams.
@@ -10233,19 +10238,24 @@ class AIAgent:
             approx_tokens = estimate_messages_tokens_rough(api_messages)
 
             # ── Context window usage telemetry ──
+            # Use estimate_request_tokens_rough so tool schemas (20-30K tokens
+            # with 50+ tools) are included in the utilisation figure.  The
+            # system prompt is already embedded as a system-role dict inside
+            # api_messages, so no separate system_prompt= argument is needed.
             _compressor = getattr(self, "context_compressor", None)
             _ctx_limit = getattr(_compressor, "context_length", None) if _compressor else None
             if _ctx_limit:
+                _full_tokens = estimate_request_tokens_rough(
+                    api_messages, tools=self.tools or None
+                )
                 _usage = ContextUsageReport(
-                    used_tokens=approx_tokens,
+                    used_tokens=_full_tokens,
                     total_tokens=_ctx_limit,
                     message_count=len(api_messages),
                 )
-                if _usage.is_warning(threshold_percent=85):
-                    self._vprint(
-                        f"{self.log_prefix}⚠️  {_usage.summary()}",
-                        force=True,
-                    )
+                if _usage.is_warning(threshold_percent=85) and not self._context_warning_emitted:
+                    self._context_warning_emitted = True
+                    self._emit_warning(f"⚠️  {_usage.summary()}")
 
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -35,6 +35,7 @@ import sys
 import tempfile
 import time
 import threading
+from dataclasses import dataclass
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
@@ -517,6 +518,31 @@ def _qwen_portal_headers() -> dict:
         "X-DashScope-UserAgent": _ua,
         "X-DashScope-AuthType": "qwen-oauth",
     }
+
+
+@dataclass
+class ContextUsageReport:
+    """Telemetry snapshot of context window utilization."""
+
+    used_tokens: int
+    total_tokens: int
+    message_count: int
+
+    @property
+    def percentage(self) -> float:
+        if self.total_tokens <= 0:
+            return 0.0
+        return (self.used_tokens / self.total_tokens) * 100
+
+    def is_warning(self, threshold_percent: float = 85.0) -> bool:
+        return self.percentage >= threshold_percent
+
+    def summary(self) -> str:
+        pct = self.percentage
+        return (
+            f"Context: {self.used_tokens:,}/{self.total_tokens:,} tokens "
+            f"({pct:.1f}%) — {self.message_count} messages"
+        )
 
 
 class AIAgent:
@@ -7813,7 +7839,22 @@ class AIAgent:
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token
-            
+
+            # ── Context window usage telemetry ──
+            _compressor = getattr(self, "context_compressor", None)
+            _ctx_limit = getattr(_compressor, "context_length", None) if _compressor else None
+            if _ctx_limit:
+                _usage = ContextUsageReport(
+                    used_tokens=approx_tokens,
+                    total_tokens=_ctx_limit,
+                    message_count=len(api_messages),
+                )
+                if _usage.is_warning(threshold_percent=85):
+                    self._vprint(
+                        f"{self.log_prefix}⚠️  {_usage.summary()}",
+                        force=True,
+                    )
+
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
             

--- a/tests/run_agent/test_context_window_telemetry.py
+++ b/tests/run_agent/test_context_window_telemetry.py
@@ -1,0 +1,59 @@
+"""Tests for context window usage telemetry."""
+import pytest
+
+
+class TestContextWindowTelemetry:
+    """Agent should report context window usage to the user."""
+
+    def test_usage_report_format(self):
+        """Usage report should show percentage and absolute numbers."""
+        from run_agent import ContextUsageReport
+
+        report = ContextUsageReport(
+            used_tokens=50000,
+            total_tokens=128000,
+            message_count=20,
+        )
+
+        assert report.percentage == pytest.approx(39.06, abs=0.1)
+        assert report.used_tokens == 50000
+        assert report.total_tokens == 128000
+        assert "39%" in report.summary() or "39.1%" in report.summary()
+
+    def test_usage_report_below_threshold_no_warning(self):
+        """Below the warning threshold, is_warning should be False."""
+        from run_agent import ContextUsageReport
+
+        report = ContextUsageReport(
+            used_tokens=50000,
+            total_tokens=128000,
+            message_count=20,
+        )
+
+        assert report.is_warning(threshold_percent=85) is False
+
+    def test_usage_report_above_threshold_warns(self):
+        """Above the warning threshold, is_warning should be True."""
+        from run_agent import ContextUsageReport
+
+        report = ContextUsageReport(
+            used_tokens=110000,
+            total_tokens=128000,
+            message_count=40,
+        )
+
+        assert report.is_warning(threshold_percent=85) is True
+
+    def test_summary_includes_message_count(self):
+        """Summary should include the message count for context."""
+        from run_agent import ContextUsageReport
+
+        report = ContextUsageReport(
+            used_tokens=50000,
+            total_tokens=128000,
+            message_count=42,
+        )
+
+        summary = report.summary()
+        assert "42" in summary
+        assert "50,000" in summary or "50000" in summary

--- a/tests/run_agent/test_context_window_telemetry.py
+++ b/tests/run_agent/test_context_window_telemetry.py
@@ -57,3 +57,55 @@ class TestContextWindowTelemetry:
         summary = report.summary()
         assert "42" in summary
         assert "50,000" in summary or "50000" in summary
+
+    def test_zero_total_tokens_returns_zero_percent(self):
+        """A zero context limit must not raise ZeroDivisionError."""
+        from run_agent import ContextUsageReport
+
+        report = ContextUsageReport(
+            used_tokens=1000,
+            total_tokens=0,
+            message_count=5,
+        )
+
+        assert report.percentage == 0.0
+        assert report.is_warning() is False
+
+    def test_over_100_percent_usage(self):
+        """Used tokens exceeding the limit should report > 100% and warn."""
+        from run_agent import ContextUsageReport
+
+        report = ContextUsageReport(
+            used_tokens=130000,
+            total_tokens=128000,
+            message_count=60,
+        )
+
+        assert report.percentage > 100.0
+        assert report.is_warning() is True
+
+    def test_is_warning_at_exact_threshold(self):
+        """is_warning should be True when usage equals the threshold exactly."""
+        from run_agent import ContextUsageReport
+
+        # 108,800 / 128,000 = exactly 85.0%
+        report = ContextUsageReport(
+            used_tokens=108800,
+            total_tokens=128000,
+            message_count=30,
+        )
+
+        assert report.percentage == pytest.approx(85.0)
+        assert report.is_warning(threshold_percent=85.0) is True
+
+    def test_is_warning_just_below_threshold(self):
+        """is_warning should be False for usage just below the threshold."""
+        from run_agent import ContextUsageReport
+
+        report = ContextUsageReport(
+            used_tokens=108799,
+            total_tokens=128000,
+            message_count=30,
+        )
+
+        assert report.is_warning(threshold_percent=85.0) is False


### PR DESCRIPTION
## Summary

- Add `ContextUsageReport` dataclass that computes context utilization percentage, supports configurable warning thresholds, and formats a human-readable summary
- Surface context usage warnings in the main conversation loop when utilization exceeds 85%, giving users early visibility before hitting context limits

## Test plan

- [x] `test_usage_report_format` — verifies percentage calculation and summary formatting
- [x] `test_usage_report_below_threshold_no_warning` — confirms no false positive warnings
- [x] `test_usage_report_above_threshold_warns` — confirms warning triggers above 85%
- [x] `test_summary_includes_message_count` — verifies message count and token formatting in summary