### PR TITLE
feat: add 'web' as a first-class platform for WebAPI sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -453,24 +453,34 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        platform: str = "api_server",
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
 
         Uses _resolve_runtime_agent_kwargs() to pick up model, api_key,
         base_url, etc. from config.yaml / env vars.  Toolsets are resolved
-        from config.yaml platform_toolsets.api_server (same as all other
-        gateway platforms), falling back to the hermes-api-server default.
+        from config.yaml platform_toolsets.<platform> (same as all other
+        gateway platforms), falling back to the platform's default toolset.
+
+        The ``platform`` parameter defaults to ``"api_server"`` for backward
+        compatibility but can be overridden by passing ``X-Platform: web``
+        (or any other registered platform key) in the HTTP request header.
+        When ``platform="web"`` the agent uses ``platform_toolsets.web`` from
+        config.yaml, falling back to ``hermes-web`` if not configured.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
-        from hermes_cli.tools_config import _get_platform_tools
+        from hermes_cli.tools_config import _get_platform_tools, PLATFORMS
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         model = _resolve_gateway_model()
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        # Resolve the effective platform: honour the caller-supplied value only
+        # if it is a known platform key; otherwise fall back to "api_server".
+        effective_platform = platform if platform in PLATFORMS else "api_server"
+        enabled_toolsets = sorted(_get_platform_tools(user_config, effective_platform))
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
@@ -488,7 +498,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=ephemeral_system_prompt or None,
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
-            platform="api_server",
+            platform=effective_platform,
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             session_db=self._ensure_session_db(),
@@ -628,6 +638,13 @@ class APIServerAdapter(BasePlatformAdapter):
         model_name = body.get("model", self._model_name)
         created = int(time.time())
 
+        # Resolve the effective platform for this request.
+        # Callers (e.g. web UIs) may supply ``X-Platform: web`` to opt into
+        # the platform_toolsets.web configuration from config.yaml.  Any
+        # unrecognised value silently falls back to "api_server" inside
+        # _create_agent, so no validation is needed here.
+        request_platform = request.headers.get("X-Platform", "api_server").strip().lower() or "api_server"
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -685,6 +702,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_delta_callback=_on_delta,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
+                platform=request_platform,
             ))
 
             return await self._write_sse_chat_completion(
@@ -699,6 +717,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                platform=request_platform,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -974,6 +993,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if body.get("truncation") == "auto" and len(conversation_history) > 100:
             conversation_history = conversation_history[-100:]
 
+        # Resolve the effective platform for this request (same logic as chat completions).
+        request_platform = request.headers.get("X-Platform", "api_server").strip().lower() or "api_server"
+
         # Run the agent (with Idempotency-Key support)
         session_id = str(uuid.uuid4())
 
@@ -983,6 +1005,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                platform=request_platform,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1404,6 +1427,7 @@ class APIServerAdapter(BasePlatformAdapter):
         stream_delta_callback=None,
         tool_progress_callback=None,
         agent_ref: Optional[list] = None,
+        platform: str = "api_server",
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -1424,6 +1448,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
                 tool_progress_callback=tool_progress_callback,
+                platform=platform,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
@@ -1584,6 +1609,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         session_id = body.get("session_id") or run_id
         ephemeral_system_prompt = instructions
+        run_platform = request.headers.get("X-Platform", "api_server").strip().lower() or "api_server"
 
         async def _run_and_close():
             try:
@@ -1592,6 +1618,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    platform=run_platform,
                 )
                 def _run_sync():
                     r = agent.run_conversation(

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -135,6 +135,7 @@ PLATFORMS = {
     "wecom": {"label": "💬 WeCom", "default_toolset": "hermes-wecom"},
     "weixin": {"label": "💬 Weixin", "default_toolset": "hermes-weixin"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
+    "web":        {"label": "🌍 Web",        "default_toolset": "hermes-web"},
     "mattermost": {"label": "💬 Mattermost", "default_toolset": "hermes-mattermost"},
     "webhook": {"label": "🔗 Webhook", "default_toolset": "hermes-webhook"},
 }

--- a/toolsets.py
+++ b/toolsets.py
@@ -274,7 +274,35 @@ TOOLSETS = {
         ],
         "includes": []
     },
-    
+
+    "hermes-web": {
+        "description": "Web UI / WebAPI toolset — default for browser-facing sessions via X-Platform: web; omits terminal and code execution for safer interactive use",
+        "tools": [
+            # Web
+            "web_search", "web_extract",
+            # File manipulation
+            "read_file", "write_file", "patch", "search_files",
+            # Vision + image generation
+            "vision_analyze", "image_generate",
+            # Skills
+            "skills_list", "skill_view", "skill_manage",
+            # Browser automation
+            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_type", "browser_scroll", "browser_back",
+            "browser_press", "browser_get_images",
+            "browser_vision", "browser_console",
+            # Planning & memory
+            "todo", "memory",
+            # Session history search
+            "session_search",
+            # Delegation
+            "delegate_task",
+            # Cronjob management
+            "cronjob",
+        ],
+        "includes": []
+    },
+
     "hermes-cli": {
         "description": "Full interactive CLI toolset - all default tools plus cronjob management",
         "tools": _HERMES_CORE_TOOLS,


### PR DESCRIPTION
## Summary

Closes #7590.

Adds `web` as a recognized platform identifier for the WebAPI adapter so that `platform_toolsets.web` in `config.yaml` is applied to HTTP sessions that send `X-Platform: web`.

### Changes

**`toolsets.py`**
- New `hermes-web` toolset — mirrors `hermes-api-server` but omits `terminal` and `execute_code` for safer browser-facing / interactive use. It is the default fallback when `platform_toolsets.web` is not configured.

**`hermes_cli/tools_config.py`**
- Added `"web"` to the `PLATFORMS` dict with `default_toolset: "hermes-web"`. This makes `web` a configurable platform in `hermes tools` alongside all existing platforms.

**`gateway/platforms/api_server.py`**
- `_create_agent()` gains an optional `platform` parameter (default `"api_server"` for full backward compatibility). The value is validated against `PLATFORMS` and falls back to `"api_server"` if unrecognised.
- `_run_agent()` propagates the `platform` parameter.
- `_handle_chat_completions()`, `_handle_responses()`, and `_handle_runs()` each read the `X-Platform` request header and pass it through to `_run_agent` / `_create_agent`.

### Behaviour

| Request | Effective platform | Toolset used |
|---|---|---|
| No `X-Platform` header | `api_server` | `platform_toolsets.api_server` (unchanged) |
| `X-Platform: web` | `web` | `platform_toolsets.web` → fallback `hermes-web` |
| `X-Platform: <unknown>` | `api_server` | `platform_toolsets.api_server` (safe fallback) |

When the `X-Platform` header is absent or unrecognised, behaviour is **identical to before this change** — no existing integration is affected.

### Example config

```yaml
platform_toolsets:
  web:
    - memory
    - vision
    - todo
    - web
  api_server:
    - terminal
    - file
    - browser
    - code_execution
```

## Test plan

- [ ] Start `hermes gateway` with `api_server` platform enabled
- [ ] `POST /v1/chat/completions` without `X-Platform` → agent uses `platform_toolsets.api_server` (or `hermes-api-server` default)
- [ ] `POST /v1/chat/completions` with `X-Platform: web` → agent uses `platform_toolsets.web` (or `hermes-web` default)
- [ ] `POST /v1/chat/completions` with `X-Platform: unknown` → agent falls back to `api_server` silently
- [ ] `hermes tools` shows a new "Web" platform entry
- [ ] Setting `platform_toolsets.web` in `config.yaml` and restarting confirms the restricted toolset is active for web sessions