### PR TITLE
feat(plugins): pass sender_id to pre_llm_call hook (#6913)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7533,6 +7533,7 @@ class AIAgent:
                 is_first_turn=(not bool(conversation_history)),
                 model=self.model,
                 platform=getattr(self, "platform", None) or "",
+                sender_id=getattr(self, "_user_id", None) or "",
             )
             _ctx_parts: list[str] = []
             for r in _pre_results:


### PR DESCRIPTION
Cherry-pick of #6913 (hata1234). Adds `sender_id` to the pre_llm_call plugin hook kwargs, enabling per-user ACL in plugins. 1 line.