### PR TITLE
fix: add from __future__ import annotations to 3 remaining files

### DIFF
--- a/skills/research/polymarket/scripts/polymarket.py
+++ b/skills/research/polymarket/scripts/polymarket.py
@@ -11,6 +11,8 @@ Usage:
     python3 polymarket.py history <condition_id> [--interval all] [--fidelity 50]
     python3 polymarket.py trades [--limit 10] [--market CONDITION_ID]
 """
+from __future__ import annotations
+
 
 import json
 import sys

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -3,6 +3,8 @@
 Overridable at the RL environment level via HermesAgentEnvConfig fields.
 Per-tool resolution: pinned > config overrides > registry > default.
 """
+from __future__ import annotations
+
 
 from dataclasses import dataclass, field
 from typing import Dict

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -8,6 +8,8 @@ Dependencies (optional):
     pip install sounddevice numpy
     or: pip install hermes-agent[voice]
 """
+from __future__ import annotations
+
 
 import logging
 import os


### PR DESCRIPTION
## Problem

50 files were previously fixed by adding `from __future__ import annotations` for PEP 604 union syntax (`X | Y`) compatibility, but 3 files were missed:

- `tools/budget_config.py` — uses `int | float`
- `tools/voice_mode.py` — uses `AudioRecorder | TermuxAudioRecorder`
- `skills/research/polymarket/scripts/polymarket.py` — uses `dict | list`

## Fix

Added `from __future__ import annotations` to the 3 remaining files, consistent with the previous batch fix.

## Impact

Without this fix, these files could break on Python versions where PEP 604 union syntax is not supported at runtime without deferred annotation evaluation. Currently works on Python 3.10+ but this ensures broader compatibility and consistency across the codebase.