### PR TITLE
fix(plan): guard build_plan_path against whitespace-only input

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -33,7 +33,8 @@ def build_plan_path(
     daytona, and similar terminal backends. That keeps the plan with the active
     workspace instead of the Hermes host's global home directory.
     """
-    slug_source = (user_instruction or "").strip().splitlines()[0] if user_instruction else ""
+    stripped = (user_instruction or "").strip()
+    slug_source = stripped.splitlines()[0] if stripped else ""
     slug = _PLAN_SLUG_RE.sub("-", slug_source.lower()).strip("-")
     if slug:
         slug = "-".join(part for part in slug.split("-")[:8] if part)[:48].strip("-")


### PR DESCRIPTION
## Problem

`build_plan_path()` crashes with `IndexError` when `user_instruction` is whitespace-only (e.g. `"  \n  "`), because `.strip().splitlines()[0]` indexes into an empty list after strip produces an empty string.

## Fix

Split the strip and splitlines into two steps: only index into splitlines when the stripped result is non-empty. Falls back to the default `conversation-plan` slug as intended.

## Testing

```python
>>> build_plan_path('   \n   ')
PosixPath('.hermes/plans/2026-04-11_033158-conversation-plan.md')  # was IndexError

>>> build_plan_path('Fix the login page')
PosixPath('.hermes/plans/2026-04-11_033158-fix-the-login-page.md')  # unchanged
```

Existing test `test_build_plan_path_uses_workspace_relative_dir_and_slugifies_request` passes.

Fixes #7576