### PR TITLE
fix(models): add xAI provider prefixes to _PROVIDER_PREFIXES

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -34,6 +34,8 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
     "qwen-portal",
+    # xAI aliases (added with xAI overlay in 8bcb8b8e)
+    "xai", "x-ai", "x.ai",
 })
 
 


### PR DESCRIPTION
## Problem

`_strip_provider_prefix()` in `agent/model_metadata.py` does not recognize xAI prefixes (`xai:`, `x-ai:`, `x.ai:`). Model strings like `"xai:grok-4"` are left unstripped, causing silent failures in context-length lookups and model metadata queries.

The xAI overlay and aliases were added in `8bcb8b8e` but `_PROVIDER_PREFIXES` was not updated.

## Fix

Add `"xai"`, `"x-ai"`, and `"x.ai"` to the `_PROVIDER_PREFIXES` frozenset.

## Testing

```python
>>> _strip_provider_prefix('xai:grok-4')
'grok-4'  # was 'xai:grok-4'

>>> _strip_provider_prefix('x-ai:grok-4')
'grok-4'  # was 'x-ai:grok-4'

>>> _strip_provider_prefix('x.ai:grok-4')
'grok-4'  # was 'x.ai:grok-4'

# Ollama tags still preserved:
>>> _strip_provider_prefix('qwen3.5:27b')
'qwen3.5:27b'  # unchanged
```

Fixes #7575