### PR TITLE
fix(models): strip date-pinned suffixes in fast mode model matching

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.request
 import urllib.error
 from difflib import get_close_matches
@@ -1098,6 +1099,9 @@ _ANTHROPIC_FAST_MODE_MODELS: frozenset[str] = frozenset({
     "claude-opus-4.6",
 })
 
+# Matches a trailing -YYYYMMDD date suffix (e.g. '-20260401').
+_DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
+
 
 def _strip_vendor_prefix(model_id: str) -> str:
     """Strip vendor/ prefix from a model ID (e.g. 'anthropic/claude-opus-4-6' -> 'claude-opus-4-6')."""
@@ -1107,6 +1111,13 @@ def _strip_vendor_prefix(model_id: str) -> str:
     return raw
 
 
+def _strip_model_suffixes(model_id: str) -> str:
+    """Strip OpenRouter variant tags (:fast, :beta) and date-pinned suffixes (-YYYYMMDD)."""
+    base = model_id.split(":")[0]
+    base = _DATE_SUFFIX_RE.sub("", base)
+    return base
+
+
 def model_supports_fast_mode(model_id: Optional[str]) -> bool:
     """Return whether Hermes should expose the /fast toggle for this model."""
     raw = _strip_vendor_prefix(str(model_id or ""))
@@ -1114,14 +1125,14 @@ def model_supports_fast_mode(model_id: Optional[str]) -> bool:
         return True
     # Anthropic fast mode — strip date suffixes (e.g. claude-opus-4-6-20260401)
     # and OpenRouter variant tags (:fast, :beta) for matching.
-    base = raw.split(":")[0]
+    base = _strip_model_suffixes(raw)
     return base in _ANTHROPIC_FAST_MODE_MODELS
 
 
 def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
     """Return True if the model supports Anthropic's fast mode (speed='fast')."""
     raw = _strip_vendor_prefix(str(model_id or ""))
-    base = raw.split(":")[0]
+    base = _strip_model_suffixes(raw)
     return base in _ANTHROPIC_FAST_MODE_MODELS
 
 


### PR DESCRIPTION
## Problem

`model_supports_fast_mode()` and `_is_anthropic_fast_model()` fail to recognize date-pinned Anthropic model IDs (e.g. `claude-opus-4-6-20260401`) because the `-YYYYMMDD` suffix is not stripped before matching against `_ANTHROPIC_FAST_MODE_MODELS`.

The comment on line 1115 documented the intent to strip date suffixes but the implementation only handled OpenRouter variant tags (`:fast`, `:beta`) via `.split(":")[0]`.

## Fix

Extract a shared `_strip_model_suffixes()` helper that strips both:
1. OpenRouter variant tags (`:fast`, `:beta`) via colon split
2. Date-pinned suffixes (`-YYYYMMDD`) via regex `-\d{8}$`

Both `model_supports_fast_mode()` and `_is_anthropic_fast_model()` now use this helper.

## Testing

```python
>>> model_supports_fast_mode('claude-opus-4-6-20260401')
True  # was False

>>> model_supports_fast_mode('anthropic/claude-opus-4-6-20260401')
True  # was False

>>> resolve_fast_mode_overrides('claude-opus-4-6-20260401')
{'speed': 'fast'}  # was None

# Non-date-pinned still works:
>>> model_supports_fast_mode('claude-opus-4-6')
True  # unchanged
>>> model_supports_fast_mode('claude-sonnet-4-5')
False  # unchanged
```

Fixes #7573