### PR TITLE
fix(gateway): don't pay 5s shutdown tax when no stream consumer exists

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7982,8 +7982,13 @@ class GatewayRunner:
             interrupt_monitor.cancel()
             _notify_task.cancel()
 
-            # Wait for stream consumer to finish its final edit
+            # Wait for stream consumer to finish its final edit.
+            # If no consumer was ever created (streaming disabled, or setup
+            # failed), cancel the poller up front so the wait_for below
+            # returns immediately instead of burning the full 5s timeout.
             if stream_task:
+                if stream_consumer_holder[0] is None:
+                    stream_task.cancel()
                 try:
                     await asyncio.wait_for(stream_task, timeout=5.0)
                 except (asyncio.TimeoutError, asyncio.CancelledError):


### PR DESCRIPTION
## What

`_run_agent` unconditionally spawns `stream_task` via `asyncio.create_task(_start_stream_consumer())`, and the `finally:` block at the end of `_run_agent` blocks on `await asyncio.wait_for(stream_task, timeout=5.0)` for the full 5 seconds whenever no consumer was ever created. The fix: in the `finally:` block, if `stream_consumer_holder[0]` is still `None` at cleanup time, cancel `stream_task` before calling `wait_for`.

## When this bug fires

Two situations, both reachable today:

1. **`streaming.enabled` is False** (the default in `StreamingConfig`). `run_sync` never reaches the `GatewayStreamConsumer` setup, `stream_consumer_holder[0]` stays `None`, and `_start_stream_consumer` loops its 200-iteration sleep for the full 10-second poll window.

2. **`streaming.enabled` is True but the consumer never gets assigned.** For example, `self.adapters.get(source.platform)` returns `None`, or the `GatewayStreamConsumer` constructor raises (both paths are caught and logged by the existing try/except around consumer setup around `gateway/run.py:7272`).

Either way, `_start_stream_consumer` has nothing to do, but the finally block still burns the full 5.0s `wait_for` timeout on every turn.

## Repro

1. Start the gateway with default streaming config.
2. Send any message to any platform adapter.
3. Compare `response ready: time=...` against the actual LLM roundtrip. You'll see a consistent extra ~5 seconds that isn't LLM latency.

I traced it with `perf_counter()` markers at every await point inside `_run_agent`. For a turn with a ~2.3s LLM call I saw:

```
executor returned (run_conversation done)  t0
_run_agent returned                         t0 + 5.005s
```

The 5.005s is almost exactly the `wait_for(..., timeout=5.0)` cap in the finally block.

## Root cause

In `gateway/run.py::_run_agent`:

```python
async def _start_stream_consumer():
    for _ in range(200):  # Up to 10s wait
        if stream_consumer_holder[0] is not None:
            await stream_consumer_holder[0].run()
            return
        await asyncio.sleep(0.05)

stream_task = asyncio.create_task(_start_stream_consumer())
```

The consumer is only placed in `stream_consumer_holder[0]` inside the nested `run_sync`, and only when `_scfg.enabled and _scfg.transport != "off"`, AND `self.adapters.get(source.platform)` returns a valid adapter, AND the constructor doesn't raise. Any of those falling through leaves the holder as `None`.

Then the finally:

```python
if stream_task:
    try:
        await asyncio.wait_for(stream_task, timeout=5.0)
    except (asyncio.TimeoutError, asyncio.CancelledError):
        stream_task.cancel()
        ...
```

burns a real 5.0 seconds waiting on a task that was never going to do anything.

## Fix

```python
if stream_task:
    if stream_consumer_holder[0] is None:
        stream_task.cancel()
    try:
        await asyncio.wait_for(stream_task, timeout=5.0)
    ...
```

Three added lines plus a comment. `wait_for` on an already-cancelled task propagates `CancelledError` immediately and lands in the existing `except` clause, which drains the task cleanly. I grepped the whole function for `stream_task` and every read outside the creation point is in this same finally block, already guarded by `if stream_task`.

## Why not guard the creation site instead

I considered moving the fix to the `stream_task = asyncio.create_task(...)` line, reading `streaming.enabled` at the outer scope. That would only cover case (1). It would also duplicate the `_scfg` resolution that already exists a few hundred lines earlier in the same function (inside `run_sync`), which is a drift trap if one copy changes. Guarding the finally block instead covers both cases and doesn't duplicate anything.

## Impact

~5 seconds shaved off every turn for anyone running with default streaming config, plus a latency hazard removed for anyone whose consumer setup ever fails silently.

## Tests

I didn't add one. The finally block is inside a 1000-line async function with a lot of implicit setup, and pulling it out into a testable helper would be a separate change. Happy to either extract a `_finish_stream_task(stream_task, holder)` helper and add a unit test for it, or leave the fix as-is. Let me know which you'd prefer.