### PR TITLE
fix(weixin): re-pack message chunks to avoid flooding WeChat chat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/hermes

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -757,6 +757,29 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
     return packed
 
 
+def _pack_units_for_weixin(units: List[str], max_length: int) -> List[str]:
+    """Re-pack fine-grained delivery units into fewer messages.
+
+    Adjacent units are merged (separated by double newlines) as long as the
+    combined text stays within *max_length*.  This prevents flooding the chat
+    with dozens of tiny messages when the upstream splitter produces one unit
+    per line.
+    """
+    if not units:
+        return []
+    packed: List[str] = []
+    current = units[0]
+    for unit in units[1:]:
+        merged = f"{current}\n\n{unit}"
+        if len(merged) <= max_length:
+            current = merged
+        else:
+            packed.append(current)
+            current = unit
+    packed.append(current)
+    return packed
+
+
 def _split_text_for_weixin_delivery(
     content: str, max_length: int, split_per_line: bool = False,
 ) -> List[str]:
@@ -769,23 +792,25 @@ def _split_text_for_weixin_delivery(
 
     *per_line* (``split_per_line=True``): Legacy behavior — top-level line
     breaks become separate chat messages; oversized units still use
-    block-aware packing.
+    block-aware packing.  Units are **re-packed** into as few messages as
+    possible to avoid flooding the chat (see #7565).
 
     The active mode is controlled via ``config.yaml`` ->
     ``platforms.weixin.extra.split_multiline_messages`` (``true`` / ``false``)
     or the env var ``WEIXIN_SPLIT_MULTILINE_MESSAGES``.
     """
     if split_per_line:
-        # Legacy: one message per top-level delivery unit.
+        # Legacy: split into delivery units, then re-pack adjacent small
+        # units to avoid flooding the chat with dozens of tiny messages.
         if len(content) <= max_length and "\n" not in content:
             return [content]
-        chunks: List[str] = []
+        units: List[str] = []
         for unit in _split_delivery_units_for_weixin(content):
             if len(unit) <= max_length:
-                chunks.append(unit)
+                units.append(unit)
                 continue
-            chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
-        return chunks or [content]
+            units.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
+        return _pack_units_for_weixin(units, max_length) or [content]
 
     # Compact (default): single message when under the limit.
     if len(content) <= max_length:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -85,6 +85,28 @@ class TestWeixinChunking:
 
         assert chunks == [content]
 
+    def test_split_text_does_not_pack_beyond_max_length(self):
+        adapter = _make_adapter()
+        adapter.MAX_MESSAGE_LENGTH = 10
+
+        content = adapter.format_message("第一行\n第二行\n第三行")
+        chunks = adapter._split_text(content)
+
+        assert len(chunks) > 1
+        assert all(len(c) <= adapter.MAX_MESSAGE_LENGTH for c in chunks)
+
+    def test_split_text_packs_many_lines_to_avoid_flooding(self):
+        adapter = _make_adapter()
+
+        lines = "\n".join(f"Line {i}" for i in range(20))
+        content = adapter.format_message(lines)
+        chunks = adapter._split_text(content)
+
+        assert len(chunks) < 20
+        combined = "\n\n".join(chunks)
+        for i in range(20):
+            assert f"Line {i}" in combined
+
     def test_split_text_keeps_complete_code_block_together_when_possible(self):
         adapter = _make_adapter()
         adapter.MAX_MESSAGE_LENGTH = 80
@@ -128,7 +150,7 @@ class TestWeixinChunking:
         content = adapter.format_message("第一行\n第二行\n第三行")
         chunks = adapter._split_text(content)
 
-        assert chunks == ["第一行", "第二行", "第三行"]
+        assert chunks == ["第一行\n\n第二行\n\n第三行"]
 
 
 class TestWeixinConfig:

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -5,29 +5,42 @@ from unittest.mock import patch
 
 from hermes_cli.model_switch import list_authenticated_providers
 
+# Minimal models.dev registry stub so the test doesn't depend on network
+# or in-memory cache state from other tests.
+_FAKE_MODELS_DEV = {
+    "opencode-go": {
+        "id": "opencode-go",
+        "name": "OpenCode Go",
+        "env": ["OPENCODE_GO_API_KEY"],
+        "models": {},
+    },
+}
 
+
+@patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_MODELS_DEV)
 @patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}, clear=False)
-def test_opencode_go_appears_when_api_key_set():
+def test_opencode_go_appears_when_api_key_set(_mock_fetch):
     """opencode-go should appear in list_authenticated_providers when OPENCODE_GO_API_KEY is set."""
     providers = list_authenticated_providers(current_provider="openrouter")
-    
+
     # Find opencode-go in results
     opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
-    
+
     assert opencode_go is not None, "opencode-go should appear when OPENCODE_GO_API_KEY is set"
     assert opencode_go["models"] == ["glm-5", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5"]
     # opencode-go is in PROVIDER_TO_MODELS_DEV, so it appears as "built-in" (Part 1)
     assert opencode_go["source"] == "built-in"
 
 
-def test_opencode_go_not_appears_when_no_creds():
+@patch("agent.models_dev.fetch_models_dev", return_value=_FAKE_MODELS_DEV)
+def test_opencode_go_not_appears_when_no_creds(_mock_fetch):
     """opencode-go should NOT appear when no credentials are set."""
     # Ensure OPENCODE_GO_API_KEY is not set
     env_without_key = {k: v for k, v in os.environ.items() if k != "OPENCODE_GO_API_KEY"}
-    
+
     with patch.dict(os.environ, env_without_key, clear=True):
         providers = list_authenticated_providers(current_provider="openrouter")
-        
+
         # opencode-go should not be in results
         opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
         assert opencode_go is None, "opencode-go should not appear without credentials"


### PR DESCRIPTION
## Summary

- The WeChat delivery splitter (`_split_delivery_units_for_weixin`) produces one message per non-indented line — a 20-line response generates 20 separate outbound messages
- WeChat's platform limits truncate rapid successive messages, causing users to see incomplete/truncated output (only ~10 messages delivered)
- Add a `_pack_units_for_weixin` step that merges adjacent small units back together (double-newline separated) while staying within `MAX_MESSAGE_LENGTH`, drastically reducing message count without losing readability

Fixes #7565

## Test plan

- [x] `test_split_text_packs_short_lines_into_single_message` — three short lines pack into a single message
- [x] `test_split_text_keeps_indented_followup_with_previous_line` — table-to-list transforms pack into one message
- [x] `test_split_text_does_not_pack_beyond_max_length` — packing respects message size limit
- [x] `test_split_text_packs_many_lines_to_avoid_flooding` — 20 lines pack into fewer messages while preserving all content
- [x] All 16 `test_weixin.py` tests pass (including pre-existing code block and config tests)