### PR TITLE
[codex] Add canonical CLI model selector

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1718,6 +1718,7 @@ class HermesCLI:
         self._approval_lock = threading.Lock()
         self._secret_state = None
         self._secret_deadline = 0
+        self._model_selection_controller = None
         self._spinner_text: str = ""  # thinking spinner text for TUI
         self._tool_start_time: float = 0.0  # monotonic timestamp when current tool started (for live elapsed)
         self._command_running = False
@@ -4171,81 +4172,344 @@ class HermesCLI:
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
     
-    def _handle_model_switch(self, cmd_original: str):
-        """Handle /model command — switch model for this session.
+    def _maybe_accept_slash_completion_on_enter(self, buffer) -> bool:
+        """Handle Enter on the slash-command completion menu."""
+        complete_state = getattr(buffer, "complete_state", None)
+        raw_text = str(getattr(buffer, "text", "") or "")
+        stripped = raw_text.strip()
+        if complete_state is None or not stripped.startswith("/") or " " in stripped:
+            return False
 
-        Supports:
-          /model                              — show current model + usage hints
-          /model <name>                       — switch for this session only
-          /model <name> --global              — switch and persist to config.yaml
-          /model <name> --provider <provider> — switch provider + model
-          /model --provider <provider>        — switch to provider, auto-detect model
-        """
-        from hermes_cli.model_switch import switch_model, parse_model_flags, list_authenticated_providers
-        from hermes_cli.providers import get_label
+        completion = getattr(complete_state, "current_completion", None)
+        if completion is None:
+            try:
+                buffer.go_to_completion(0)
+            except Exception:
+                return False
+            complete_state = getattr(buffer, "complete_state", None)
+            completion = getattr(complete_state, "current_completion", None)
+        if completion is None:
+            return False
 
-        # Parse args from the original command
-        parts = cmd_original.split(None, 1)  # split off '/model'
-        raw_args = parts[1].strip() if len(parts) > 1 else ""
+        display_text = str(getattr(completion, "display_text", "") or "")
+        cmd_name = (
+            display_text[1:]
+            if display_text.startswith("/")
+            else str(getattr(completion, "text", "") or "").strip()
+        )
+        if not cmd_name or " " in cmd_name:
+            return False
 
-        # Parse --provider and --global flags
-        model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
+        if cmd_name == "model":
+            self._open_model_selection(buffer)
+            return True
+
+        try:
+            buffer.apply_completion(completion)
+        except Exception:
+            return False
+        return True
+
+    def _maybe_accept_model_selection_on_space(self, buffer) -> bool:
+        """Make Space commit or advance the canonical /model selector."""
+        if self._model_selection_active():
+            return self._commit_model_selection(buffer)
+
+        raw_text = str(getattr(buffer, "text", "") or "")
+        stripped = raw_text.strip()
+        if stripped == "/model":
+            self._open_model_selection(buffer)
+            return True
+
+        complete_state = getattr(buffer, "complete_state", None)
+        if complete_state is None:
+            return False
+        completion = getattr(complete_state, "current_completion", None)
+        if completion is None:
+            try:
+                buffer.go_to_completion(0)
+            except Exception:
+                return False
+            complete_state = getattr(buffer, "complete_state", None)
+            completion = getattr(complete_state, "current_completion", None)
+        if completion is None:
+            return False
+
+        display_text = str(getattr(completion, "display_text", "") or "")
+        cmd_name = (
+            display_text[1:]
+            if display_text.startswith("/")
+            else str(getattr(completion, "text", "") or "").strip()
+        )
+        if cmd_name == "model":
+            self._open_model_selection(buffer)
+            return True
+        return False
+
+    def _apply_model_switch_result(self, result, *, persist_global: bool = False) -> None:
+        """Apply a successful model switch to the live CLI state."""
+        old_model = self.model
+        self.model = result.new_model
+        self.provider = result.target_provider
+        self.requested_provider = result.target_provider
+        if result.api_key:
+            self.api_key = result.api_key
+            self._explicit_api_key = result.api_key
+        if result.base_url:
+            self.base_url = result.base_url
+            self._explicit_base_url = result.base_url
+        if result.api_mode:
+            self.api_mode = result.api_mode
+
+        if self.agent is not None:
+            try:
+                self.agent.switch_model(
+                    new_model=result.new_model,
+                    new_provider=result.target_provider,
+                    api_key=result.api_key,
+                    base_url=result.base_url,
+                    api_mode=result.api_mode,
+                )
+            except Exception as exc:
+                _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
+
+        self._pending_model_switch_note = (
+            f"[Note: model was just switched from {old_model} to {result.new_model} "
+            f"via {result.provider_label or result.target_provider}. "
+            f"Adjust your self-identification accordingly.]"
+        )
+
+        provider_label = result.provider_label or result.target_provider
+        _cprint(f"  ✓ Model switched: {result.new_model}")
+        _cprint(f"    Provider: {provider_label}")
+
+        mi = result.model_info
+        if mi:
+            if mi.context_window:
+                _cprint(f"    Context: {mi.context_window:,} tokens")
+            if mi.max_output:
+                _cprint(f"    Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                _cprint(f"    Cost: {mi.format_cost()}")
+            _cprint(f"    Capabilities: {mi.format_capabilities()}")
+        else:
+            try:
+                from agent.model_metadata import get_model_context_length
+
+                ctx = get_model_context_length(
+                    result.new_model,
+                    base_url=result.base_url or self.base_url,
+                    api_key=result.api_key or self.api_key,
+                    provider=result.target_provider,
+                )
+                _cprint(f"    Context: {ctx:,} tokens")
+            except Exception:
+                pass
+
+        cache_enabled = (
+            ("openrouter" in (result.base_url or "").lower() and "claude" in result.new_model.lower())
+            or result.api_mode == "anthropic_messages"
+        )
+        if cache_enabled:
+            _cprint("    Prompt caching: enabled")
+
+        if result.warning_message:
+            _cprint(f"    ⚠ {result.warning_message}")
+
+        if persist_global:
+            save_config_value("model.default", result.new_model)
+            if result.provider_changed:
+                save_config_value("model.provider", result.target_provider)
+            _cprint("    Saved to config.yaml (--global)")
+        else:
+            _cprint("    (session only — add --global to persist)")
+
+    def _model_selection_active(self) -> bool:
+        return getattr(self, "_model_selection_controller", None) is not None
+
+    def _commit_model_selection(self, buffer=None) -> bool:
+        return self._activate_model_selection(buffer)
+
+    def _sync_model_selection_completion(self, buffer) -> None:
+        controller = getattr(self, "_model_selection_controller", None)
+        if buffer is None:
+            return
+        if controller is None:
+            try:
+                buffer.cancel_completion()
+            except Exception:
+                pass
+            return
+        try:
+            if not buffer.complete_state:
+                buffer.start_completion(select_first=False)
+            if buffer.complete_state:
+                buffer.go_to_completion(controller.cursor)
+        except Exception:
+            pass
+
+    def _sync_model_selection_buffer(self, buffer) -> None:
+        controller = getattr(self, "_model_selection_controller", None)
+        if controller is None or buffer is None:
+            return
+        path_parts = ["/model"]
+        if controller.source_id:
+            path_parts.append(controller.source_id)
+        if controller.provider_id:
+            provider_id = controller.provider_id
+            if ":" in provider_id:
+                path_parts.append(provider_id.split(":", 1)[1])
+        text = " ".join(path_parts) + " "
+        from prompt_toolkit.document import Document
+
+        try:
+            buffer.set_document(
+                Document(text=text, cursor_position=len(text)),
+                bypass_readonly=True,
+            )
+        except Exception:
+            pass
+
+    def _open_model_selection(self, buffer=None) -> None:
+        """Open the canonical source -> provider -> model selector in the slash menu."""
+        from hermes_cli.model_selection import (
+            ModelSelectionController,
+            build_model_selection_tree,
+        )
 
         user_provs = None
         custom_provs = None
         try:
             from hermes_cli.config import load_config
+
             cfg = load_config()
             user_provs = cfg.get("providers")
             custom_provs = cfg.get("custom_providers")
         except Exception:
             pass
 
-        # No args at all: show available providers + models
+        tree = build_model_selection_tree(
+            current_provider=self.provider or "",
+            current_model=self.model or "",
+            user_providers=user_provs,
+            custom_providers=custom_provs,
+        )
+        self._model_selection_controller = ModelSelectionController(tree)
+        if buffer is not None:
+            self._sync_model_selection_buffer(buffer)
+            self._sync_model_selection_completion(buffer)
+        self._invalidate(min_interval=0.0)
+
+    def _close_model_selection(self, buffer=None, *, clear_text: bool = False) -> None:
+        self._model_selection_controller = None
+        if buffer is not None:
+            self._sync_model_selection_completion(buffer)
+            if clear_text:
+                try:
+                    buffer.reset(append_to_history=True)
+                except Exception:
+                    pass
+        self._invalidate(min_interval=0.0)
+
+    def _back_model_selection(self, buffer=None) -> bool:
+        controller = getattr(self, "_model_selection_controller", None)
+        if controller is None:
+            return False
+        if controller.back():
+            self._sync_model_selection_buffer(buffer)
+            self._sync_model_selection_completion(buffer)
+            self._invalidate(min_interval=0.0)
+            return True
+        self._close_model_selection(buffer, clear_text=True)
+        return True
+
+    def _move_model_selection(self, direction: int, buffer=None) -> bool:
+        controller = getattr(self, "_model_selection_controller", None)
+        if controller is None:
+            return False
+        if direction < 0:
+            controller.move_up()
+        else:
+            controller.move_down()
+        self._sync_model_selection_completion(buffer)
+        self._invalidate(min_interval=0.0)
+        return True
+
+    def _activate_model_selection(self, buffer=None) -> bool:
+        controller = getattr(self, "_model_selection_controller", None)
+        if controller is None:
+            return False
+
+        request = controller.enter()
+        if request is None:
+            self._sync_model_selection_buffer(buffer)
+            self._sync_model_selection_completion(buffer)
+            self._invalidate(min_interval=0.0)
+            return True
+
+        user_provs = None
+        custom_provs = None
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config()
+            user_provs = cfg.get("providers")
+            custom_provs = cfg.get("custom_providers")
+        except Exception:
+            pass
+
+        from hermes_cli.model_switch import switch_model
+
+        result = switch_model(
+            raw_input=request.model_id,
+            current_provider=self.provider or "",
+            current_model=self.model or "",
+            current_base_url=self.base_url or "",
+            current_api_key=self.api_key or "",
+            is_global=False,
+            explicit_provider=request.provider_slug,
+            user_providers=user_provs,
+            custom_providers=custom_provs,
+        )
+        self._close_model_selection(buffer, clear_text=True)
+        if not result.success:
+            _cprint(f"  ✗ {result.error_message}")
+            return True
+        self._apply_model_switch_result(result, persist_global=False)
+        return True
+
+    def _handle_model_switch(self, cmd_original: str):
+        """Handle /model command — switch model for this session.
+
+        Supports:
+          /model                              — open nested model picker
+          /model <name>                       — switch for this session only
+          /model <name> --global              — switch and persist to config.yaml
+          /model <name> --provider <provider> — switch provider + model
+          /model --provider <provider>        — switch to provider, auto-detect model
+        """
+        from hermes_cli.model_switch import switch_model, parse_model_flags
+
+        parts = cmd_original.split(None, 1)
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
+        model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
+
+        user_provs = None
+        custom_provs = None
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config()
+            user_provs = cfg.get("providers")
+            custom_provs = cfg.get("custom_providers")
+        except Exception:
+            pass
+
         if not model_input and not explicit_provider:
-            model_display = self.model or "unknown"
-            provider_display = get_label(self.provider) if self.provider else "unknown"
-            _cprint(f"  Current: {model_display} on {provider_display}")
-            _cprint("")
-
-            # Show authenticated providers with top models
-            try:
-                providers = list_authenticated_providers(
-                    current_provider=self.provider or "",
-                    user_providers=user_provs,
-                    custom_providers=custom_provs,
-                    max_models=6,
-                )
-                if providers:
-                    for p in providers:
-                        tag = " (current)" if p["is_current"] else ""
-                        _cprint(f"  {p['name']} [--provider {p['slug']}]{tag}:")
-                        if p["models"]:
-                            model_strs = ", ".join(p["models"])
-                            extra = f"  (+{p['total_models'] - len(p['models'])} more)" if p["total_models"] > len(p["models"]) else ""
-                            _cprint(f"    {model_strs}{extra}")
-                        elif p.get("api_url"):
-                            _cprint(f"    {p['api_url']} (use /model <name> --provider {p['slug']})")
-                        else:
-                            _cprint(f"    (no models listed)")
-                        _cprint("")
-                else:
-                    _cprint("  No authenticated providers found.")
-                    _cprint("")
-            except Exception:
-                pass
-
-            # Aliases
-            from hermes_cli.model_switch import MODEL_ALIASES
-            alias_list = ", ".join(sorted(MODEL_ALIASES.keys()))
-            _cprint(f"  Aliases: {alias_list}")
-            _cprint("")
-            _cprint("  /model <name>                        switch model")
-            _cprint("  /model <name> --provider <slug>      switch provider")
-            _cprint("  /model <name> --global               persist to config")
+            _cprint("  Use the inline slash menu: `/model` then Enter.")
+            _cprint("  Or run `/model <name> --provider <slug>` directly.")
             return
 
-        # Perform the switch
         result = switch_model(
             raw_input=model_input,
             current_provider=self.provider or "",
@@ -4262,93 +4526,7 @@ class HermesCLI:
             _cprint(f"  ✗ {result.error_message}")
             return
 
-        # Apply to CLI state.
-        # Update requested_provider so _ensure_runtime_credentials() doesn't
-        # overwrite the switch on the next turn (it re-resolves from this).
-        old_model = self.model
-        self.model = result.new_model
-        self.provider = result.target_provider
-        self.requested_provider = result.target_provider
-        if result.api_key:
-            self.api_key = result.api_key
-            self._explicit_api_key = result.api_key
-        if result.base_url:
-            self.base_url = result.base_url
-            self._explicit_base_url = result.base_url
-        if result.api_mode:
-            self.api_mode = result.api_mode
-
-        # Apply to running agent (in-place swap)
-        if self.agent is not None:
-            try:
-                self.agent.switch_model(
-                    new_model=result.new_model,
-                    new_provider=result.target_provider,
-                    api_key=result.api_key,
-                    base_url=result.base_url,
-                    api_mode=result.api_mode,
-                )
-            except Exception as exc:
-                _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
-
-        # Store a note to prepend to the next user message so the model
-        # knows a switch occurred (avoids injecting system messages mid-history
-        # which breaks providers and prompt caching).
-        self._pending_model_switch_note = (
-            f"[Note: model was just switched from {old_model} to {result.new_model} "
-            f"via {result.provider_label or result.target_provider}. "
-            f"Adjust your self-identification accordingly.]"
-        )
-
-        # Display confirmation with full metadata
-        provider_label = result.provider_label or result.target_provider
-        _cprint(f"  ✓ Model switched: {result.new_model}")
-        _cprint(f"    Provider: {provider_label}")
-
-        # Rich metadata from models.dev
-        mi = result.model_info
-        if mi:
-            if mi.context_window:
-                _cprint(f"    Context: {mi.context_window:,} tokens")
-            if mi.max_output:
-                _cprint(f"    Max output: {mi.max_output:,} tokens")
-            if mi.has_cost_data():
-                _cprint(f"    Cost: {mi.format_cost()}")
-            _cprint(f"    Capabilities: {mi.format_capabilities()}")
-        else:
-            # Fallback to old context length lookup
-            try:
-                from agent.model_metadata import get_model_context_length
-                ctx = get_model_context_length(
-                    result.new_model,
-                    base_url=result.base_url or self.base_url,
-                    api_key=result.api_key or self.api_key,
-                    provider=result.target_provider,
-                )
-                _cprint(f"    Context: {ctx:,} tokens")
-            except Exception:
-                pass
-
-        # Cache notice
-        cache_enabled = (
-            ("openrouter" in (result.base_url or "").lower() and "claude" in result.new_model.lower())
-            or result.api_mode == "anthropic_messages"
-        )
-        if cache_enabled:
-            _cprint("    Prompt caching: enabled")
-
-        # Warning from validation
-        if result.warning_message:
-            _cprint(f"    ⚠ {result.warning_message}")
-
-        # Persistence
-        if persist_global:
-            save_config_value("model.default", result.new_model)
-            if result.provider_changed:
-                save_config_value("model.provider", result.target_provider)
-            _cprint("    Saved to config.yaml (--global)")
-        else:
-            _cprint("    (session only — add --global to persist)")
+        self._apply_model_switch_result(result, persist_global=persist_global)
 
     def _show_model_and_providers(self):
         """Show current model + provider and list all authenticated providers.
@@ -7688,6 +7866,7 @@ class HermesCLI:
         # Secure secret capture state for skill setup
         self._secret_state = None       # dict with var_name, prompt, metadata, response_queue
         self._secret_deadline = 0
+        self._model_selection_controller = None
 
         # Clipboard image attachments (paste images into the CLI)
         self._attached_images: list[Path] = []
@@ -7789,9 +7968,22 @@ class HermesCLI:
                     event.app.invalidate()
                 return
 
+            if self._model_selection_active():
+                self._commit_model_selection(event.app.current_buffer)
+                event.app.invalidate()
+                return
+
+            if self._maybe_accept_slash_completion_on_enter(event.app.current_buffer):
+                event.app.invalidate()
+                return
+
             # --- Normal input routing ---
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
+            if text == "/model" and not has_images:
+                self._open_model_selection(event.app.current_buffer)
+                event.app.invalidate()
+                return
             if text or has_images:
                 # Snapshot and clear attached images
                 images = list(self._attached_images)
@@ -7845,6 +8037,10 @@ class HermesCLI:
             immediately.
             """
             buf = event.current_buffer
+            if self._model_selection_active():
+                self._commit_model_selection(buf)
+                event.app.invalidate()
+                return
             if buf.complete_state:
                 # Completion menu is open — accept the selection
                 completion = buf.complete_state.current_completion
@@ -7862,6 +8058,15 @@ class HermesCLI:
             else:
                 # No menu and no suggestion — start completions from scratch
                 buf.start_completion()
+
+        @kb.add(' ', eager=True)
+        def handle_space(event):
+            """Space should commit/advance /model in the same dropdown surface."""
+            buf = event.current_buffer
+            if self._maybe_accept_model_selection_on_space(buf):
+                event.app.invalidate()
+                return
+            buf.insert_text(' ')
 
         # --- Clarify tool: arrow-key navigation for multiple-choice questions ---
 
@@ -7896,12 +8101,40 @@ class HermesCLI:
                 self._approval_state["selected"] = min(max_idx, self._approval_state["selected"] + 1)
                 event.app.invalidate()
 
+        _model_selection_filter = Condition(lambda: self._model_selection_active())
+
+        @kb.add('up', filter=_model_selection_filter)
+        def model_selection_up(event):
+            self._move_model_selection(-1, event.current_buffer)
+            event.app.invalidate()
+
+        @kb.add('down', filter=_model_selection_filter)
+        def model_selection_down(event):
+            self._move_model_selection(1, event.current_buffer)
+            event.app.invalidate()
+
+        @kb.add('backspace', filter=_model_selection_filter)
+        def model_selection_backspace(event):
+            self._back_model_selection(event.current_buffer)
+            event.app.invalidate()
+
+        @kb.add('left', filter=_model_selection_filter)
+        def model_selection_left(event):
+            self._back_model_selection(event.current_buffer)
+            event.app.invalidate()
+
         # --- History navigation: up/down browse history in normal input mode ---
         # The TextArea is multiline, so by default up/down only move the cursor.
         # Buffer.auto_up/auto_down handle both: cursor movement when multi-line,
         # history browsing when on the first/last line (or single-line input).
         _normal_input = Condition(
-            lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state
+            lambda: (
+                not self._clarify_state
+                and not self._approval_state
+                and not self._sudo_state
+                and not self._secret_state
+                and not self._model_selection_active()
+            )
         )
 
         @kb.add('up', filter=_normal_input)
@@ -7975,6 +8208,11 @@ class HermesCLI:
                 self._clarify_state = None
                 self._clarify_freetext = False
                 event.app.current_buffer.reset()
+                event.app.invalidate()
+                return
+
+            if self._model_selection_active():
+                self._close_model_selection(event.app.current_buffer, clear_text=True)
                 event.app.invalidate()
                 return
 
@@ -8175,6 +8413,7 @@ class HermesCLI:
         _completer = SlashCommandCompleter(
             skill_commands_provider=lambda: _skill_commands,
             command_filter=cli_ref._command_available,
+            model_selection_provider=lambda: getattr(cli_ref, "_model_selection_controller", None),
         )
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),
@@ -8347,6 +8586,18 @@ class HermesCLI:
                     ('class:clarify-countdown', f'  ({remaining}s)'),
                 ]
 
+            if cli_ref._model_selection_active():
+                controller = cli_ref._model_selection_controller
+                breadcrumb = ""
+                try:
+                    if controller is not None:
+                        breadcrumb = controller.current_view().breadcrumb or "Select model source"
+                except Exception:
+                    breadcrumb = "Select model source"
+                return [
+                    ('class:hint', f'  /model · {breadcrumb} · ↑/↓ move, Enter/Space/Tab select, Backspace back'),
+                ]
+
             if cli_ref._clarify_state:
                 remaining = max(0, int(cli_ref._clarify_deadline - _time.monotonic()))
                 countdown = f'  ({remaining}s)' if cli_ref._clarify_deadline else ''
@@ -8369,7 +8620,7 @@ class HermesCLI:
             return []
 
         def get_hint_height():
-            if cli_ref._sudo_state or cli_ref._secret_state or cli_ref._approval_state or cli_ref._clarify_state or cli_ref._command_running:
+            if cli_ref._sudo_state or cli_ref._secret_state or cli_ref._approval_state or cli_ref._clarify_state or cli_ref._command_running or cli_ref._model_selection_active():
                 return 1
             # Keep a spacer while the agent runs on roomy terminals, but reclaim
             # the row on narrow/mobile screens where every line matters.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3953,16 +3953,21 @@ class GatewayRunner:
         custom_provs = None
         config_path = _hermes_home / "config.yaml"
         try:
+            cfg = {}
             if config_path.exists():
                 with open(config_path, encoding="utf-8") as f:
                     cfg = yaml.safe_load(f) or {}
-                model_cfg = cfg.get("model", {})
-                if isinstance(model_cfg, dict):
-                    current_model = model_cfg.get("default", "")
-                    current_provider = model_cfg.get("provider", current_provider)
-                    current_base_url = model_cfg.get("base_url", "")
-                user_provs = cfg.get("providers")
-                custom_provs = cfg.get("custom_providers")
+            model_cfg = cfg.get("model", {})
+            if isinstance(model_cfg, dict):
+                current_model = model_cfg.get("default", "") or model_cfg.get("model", "")
+                current_provider = model_cfg.get("provider", "") or cfg.get("provider", current_provider)
+                current_base_url = model_cfg.get("base_url", "") or cfg.get("base_url", "")
+            elif isinstance(model_cfg, str):
+                current_model = model_cfg
+                current_provider = cfg.get("provider", current_provider)
+                current_base_url = cfg.get("base_url", current_base_url)
+            user_provs = cfg.get("providers")
+            custom_provs = cfg.get("custom_providers")
         except Exception:
             pass
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -648,9 +648,11 @@ class SlashCommandCompleter(Completer):
         self,
         skill_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
         command_filter: Callable[[str], bool] | None = None,
+        model_selection_provider: Callable[[], Any] | None = None,
     ) -> None:
         self._skill_commands_provider = skill_commands_provider
         self._command_filter = command_filter
+        self._model_selection_provider = model_selection_provider
 
     def _command_allowed(self, slash_command: str) -> bool:
         if self._command_filter is None:
@@ -668,6 +670,17 @@ class SlashCommandCompleter(Completer):
         except Exception:
             return {}
 
+    def _model_selection_view(self):
+        if self._model_selection_provider is None:
+            return None
+        try:
+            controller = self._model_selection_provider()
+            if controller is None:
+                return None
+            return controller.current_view()
+        except Exception:
+            return None
+
     @staticmethod
     def _completion_text(cmd_name: str, word: str) -> str:
         """Return replacement text for a completion.
@@ -677,6 +690,8 @@ class SlashCommandCompleter(Completer):
         menu. Appending a trailing space keeps the dropdown visible and makes
         backspacing retrigger it naturally.
         """
+        if cmd_name == "model" and cmd_name == word:
+            return cmd_name
         return f"{cmd_name} " if cmd_name == word else cmd_name
 
     @staticmethod
@@ -923,6 +938,22 @@ class SlashCommandCompleter(Completer):
                 yield from self._path_completions(path_word)
             return
 
+        if text.lower().startswith("/model"):
+            view = self._model_selection_view()
+            if view is not None:
+                from hermes_cli.model_selection import selection_item_meta_text
+
+                for item in view.items:
+                    meta = selection_item_meta_text(item) or None
+                    yield Completion(
+                        item.token,
+                        start_position=0,
+                        display=item.label,
+                        display_meta=meta,
+                        style="fg:#7a7a7a" if not item.enabled else "",
+                    )
+                return
+
         # Check if we're completing a subcommand (base command already typed)
         parts = text.split(maxsplit=1)
         base_cmd = parts[0].lower()
@@ -1001,6 +1032,10 @@ class SlashCommandAutoSuggest(AutoSuggest):
             if self._history:
                 return self._history.get_suggestion(buffer, document)
             return None
+
+        if text.lower().startswith("/model") and self._completer is not None:
+            if self._completer._model_selection_view() is not None:
+                return None
 
         parts = text.split(maxsplit=1)
         base_cmd = parts[0].lower()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -882,7 +882,22 @@ def select_provider_and_model(args=None):
     )
     from hermes_cli.config import load_config, get_env_value
 
-    config = load_config()
+    def _load_model_selector_config():
+        config_path = get_hermes_home() / "config.yaml"
+        if config_path.exists():
+            return load_config()
+
+        project_config_path = PROJECT_ROOT / "cli-config.yaml"
+        if project_config_path.exists():
+            import yaml
+
+            with open(project_config_path, encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            return loaded if isinstance(loaded, dict) else {}
+
+        return load_config()
+
+    config = _load_model_selector_config()
     current_model = config.get("model")
     if isinstance(current_model, dict):
         current_model = current_model.get("default", "")
@@ -1105,7 +1120,7 @@ def select_provider_and_model(args=None):
     elif selected_provider == "custom":
         _model_flow_custom(config)
     elif selected_provider.startswith("custom:"):
-        provider_info = _named_custom_provider_map(load_config()).get(selected_provider)
+        provider_info = _named_custom_provider_map(_load_model_selector_config()).get(selected_provider)
         if provider_info is None:
             print(
                 "Warning: the selected saved custom provider is no longer available. "
@@ -1121,6 +1136,26 @@ def select_provider_and_model(args=None):
         _model_flow_kimi(config, current_model)
     elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
+    elif selected_provider:
+        current_model_value = "" if current_model == "(not set)" else current_model
+        current_base_url = model_cfg.get("base_url", "") if isinstance(model_cfg, dict) else ""
+        current_api_key = model_cfg.get("api_key", "") if isinstance(model_cfg, dict) else ""
+        result = switch_model(
+            raw_input="",
+            current_provider=active or "",
+            current_model=current_model_value,
+            current_base_url=current_base_url,
+            current_api_key=current_api_key,
+            explicit_provider=selected_provider,
+            user_providers=config.get("providers"),
+            custom_providers=config.get("custom_providers"),
+        )
+        if not result.success:
+            print(f"Could not switch model: {result.error_message}")
+            return
+        _persist_selected_model_result(result)
+        provider_label = result.provider_label or result.target_provider
+        print(f"Default model set to: {result.new_model} (via {provider_label})")
 
 
 def _persist_selected_model_result(result) -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -943,31 +943,6 @@ def select_provider_and_model(args=None):
     print(f"  Active provider:  {active_label}")
     print()
 
-    # Step 1: Provider selection — top providers shown first, rest behind "More..."
-    top_providers = [
-        ("nous", "Nous Portal (Nous Research subscription)"),
-        ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
-        ("anthropic", "Anthropic (Claude models — API key or Claude Code)"),
-        ("openai-codex", "OpenAI Codex"),
-        ("qwen-oauth", "Qwen OAuth (reuses local Qwen CLI login)"),
-        ("copilot", "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
-        ("huggingface", "Hugging Face Inference Providers (20+ open models)"),
-    ]
-
-    extended_providers = [
-        ("copilot-acp", "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
-        ("gemini", "Google AI Studio (Gemini models — OpenAI-compatible endpoint)"),
-        ("zai", "Z.AI / GLM (Zhipu AI direct API)"),
-        ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
-        ("minimax", "MiniMax (global direct API)"),
-        ("minimax-cn", "MiniMax China (domestic direct API)"),
-        ("kilocode", "Kilo Code (Kilo Gateway API)"),
-        ("opencode-zen", "OpenCode Zen (35+ curated models, pay-as-you-go)"),
-        ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
-        ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
-        ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
-    ]
-
     def _named_custom_provider_map(cfg) -> dict[str, dict[str, str]]:
         custom_providers_cfg = cfg.get("custom_providers") or []
         custom_provider_map = {}
@@ -991,61 +966,128 @@ def select_provider_and_model(args=None):
 
     # Add user-defined custom providers from config.yaml
     _custom_provider_map = _named_custom_provider_map(config)  # key → {name, base_url, api_key}
-    for key, provider_info in _custom_provider_map.items():
-        name = provider_info["name"]
-        base_url = provider_info["base_url"]
-        short_url = base_url.replace("https://", "").replace("http://", "").rstrip("/")
-        saved_model = provider_info.get("model", "")
-        model_hint = f" — {saved_model}" if saved_model else ""
-        top_providers.append((key, f"{name} ({short_url}){model_hint}"))
 
-    top_keys = {k for k, _ in top_providers}
-    extended_keys = {k for k, _ in extended_providers}
+    def _with_status(label: str, status_label: str = "") -> str:
+        return f"{label}  [{status_label}]" if status_label else label
 
-    # If the active provider is in the extended list, promote it into top
-    if active and active in extended_keys:
-        promoted = [(k, l) for k, l in extended_providers if k == active]
-        extended_providers = [(k, l) for k, l in extended_providers if k != active]
-        top_providers = promoted + top_providers
-        top_keys.add(active)
+    def _selection_choice_label(item) -> str:
+        from hermes_cli.model_selection import selection_item_meta_text
 
-    # Build the primary menu
-    ordered = []
-    default_idx = 0
-    for key, label in top_providers:
-        if active and key == active:
-            ordered.append((key, f"{label}  ← currently active"))
-            default_idx = len(ordered) - 1
-        else:
-            ordered.append((key, label))
+        meta = selection_item_meta_text(item)
+        return f"{item.label} — {meta}" if meta else item.label
 
-    ordered.append(("more", "More providers..."))
-    ordered.append(("cancel", "Cancel"))
+    from hermes_cli.model_selection import build_model_selection_tree, ModelSelectionController
+    from hermes_cli.model_switch import switch_model
 
-    provider_idx = _prompt_provider_choice(
-        [label for _, label in ordered], default=default_idx,
+    tree = build_model_selection_tree(
+        current_provider=active or "",
+        current_model="" if current_model == "(not set)" else current_model,
+        user_providers=config.get("providers"),
+        custom_providers=config.get("custom_providers"),
     )
-    if provider_idx is None or ordered[provider_idx][0] == "cancel":
+    root_ordered: list[tuple[str, str]] = [
+        (f"source:{source.id}", _with_status(source.label, source.status_label))
+        for source in tree.sources
+    ]
+    if active:
+        current_source_key = f"source:{'openrouter' if active == 'openrouter' else ('oauth' if active in {'openai-codex', 'nous', 'qwen-oauth'} else 'other')}"
+        source_items = [item for item in root_ordered if item[0].startswith("source:")]
+        source_items.sort(key=lambda item: (item[0] != current_source_key, item[0]))
+        root_ordered = source_items
+    root_ordered.append(("custom", "Custom endpoint (enter URL manually)"))
+    if _custom_provider_map:
+        root_ordered.append(("remove-custom", "Remove a saved custom provider"))
+    root_ordered.append(("cancel", "Cancel"))
+
+    default_root_idx = next(
+        (idx for idx, (key, _label) in enumerate(root_ordered) if key == "source:other"),
+        0,
+    )
+    for idx, (key, _label) in enumerate(root_ordered):
+        if key == "source:openrouter" and active == "openrouter":
+            default_root_idx = idx
+        elif key == "source:oauth" and active in {"openai-codex", "nous", "qwen-oauth"}:
+            default_root_idx = idx
+        elif key == "source:other" and active not in {"openrouter", "openai-codex", "nous", "qwen-oauth"} and active:
+            default_root_idx = idx
+
+    root_idx = _prompt_provider_choice(
+        [label for _, label in root_ordered],
+        default=default_root_idx,
+    )
+    if root_idx is None or root_ordered[root_idx][0] == "cancel":
         print("No change.")
         return
 
-    selected_provider = ordered[provider_idx][0]
+    selected_root = root_ordered[root_idx][0]
+    selected_provider = ""
+    selected_request = None
 
-    # "More providers..." — show the extended list
-    if selected_provider == "more":
-        ext_ordered = list(extended_providers)
-        ext_ordered.append(("custom", "Custom endpoint (enter URL manually)"))
-        if _custom_provider_map:
-            ext_ordered.append(("remove-custom", "Remove a saved custom provider"))
-        ext_ordered.append(("cancel", "Cancel"))
-
-        ext_idx = _prompt_provider_choice(
-            [label for _, label in ext_ordered], default=0,
-        )
-        if ext_idx is None or ext_ordered[ext_idx][0] == "cancel":
+    if selected_root.startswith("source:"):
+        source_id = selected_root.split(":", 1)[1]
+        provider_nodes = list(tree.providers(source_id))
+        provider_nodes.sort(key=lambda node: (not node.current, node.label))
+        provider_choices = [
+            _with_status(node.label, node.status_label)
+            for node in provider_nodes
+        ]
+        provider_choices.append("Cancel")
+        default_provider_idx = 0
+        for idx, node in enumerate(provider_nodes):
+            if node.current:
+                default_provider_idx = idx
+                break
+        provider_idx = _prompt_provider_choice(provider_choices, default=default_provider_idx)
+        if provider_idx is None or provider_idx >= len(provider_nodes):
             print("No change.")
             return
-        selected_provider = ext_ordered[ext_idx][0]
+        selected_provider_node = provider_nodes[provider_idx]
+        selected_provider = selected_provider_node.provider_slug
+
+        controller = ModelSelectionController(tree)
+        controller.set_provider(selected_provider_node.id)
+        model_view = controller.current_view()
+        if model_view.items and any(item.enabled for item in model_view.items):
+            model_choices = [
+                _selection_choice_label(item)
+                for item in model_view.items
+            ]
+            model_choices.append("Cancel")
+            model_idx = _prompt_provider_choice(
+                model_choices,
+                default=model_view.default_cursor(),
+            )
+            if model_idx is None or model_idx >= len(model_view.items):
+                print("No change.")
+                return
+            selected_request = controller.activate_index(model_idx)
+            if selected_request is None:
+                print("No change.")
+                return
+    else:
+        selected_provider = selected_root
+
+    if selected_request is not None:
+        current_model_value = "" if current_model == "(not set)" else current_model
+        current_base_url = model_cfg.get("base_url", "") if isinstance(model_cfg, dict) else ""
+        current_api_key = model_cfg.get("api_key", "") if isinstance(model_cfg, dict) else ""
+        result = switch_model(
+            raw_input=selected_request.model_id,
+            current_provider=active or "",
+            current_model=current_model_value,
+            current_base_url=current_base_url,
+            current_api_key=current_api_key,
+            explicit_provider=selected_request.provider_slug,
+            user_providers=config.get("providers"),
+            custom_providers=config.get("custom_providers"),
+        )
+        if not result.success:
+            print(f"Could not switch model: {result.error_message}")
+            return
+        _persist_selected_model_result(result)
+        provider_label = result.provider_label or result.target_provider
+        print(f"Default model set to: {result.new_model} (via {provider_label})")
+        return
 
     # Step 2: Provider-specific setup + model selection
     if selected_provider == "openrouter":
@@ -1079,6 +1121,50 @@ def select_provider_and_model(args=None):
         _model_flow_kimi(config, current_model)
     elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
+
+
+def _persist_selected_model_result(result) -> None:
+    """Persist a model switch result using the same provider semantics as setup flows."""
+    from hermes_cli.auth import (
+        _save_model_choice,
+        _update_config_for_provider,
+        deactivate_provider,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    oauth_providers = {"nous", "openai-codex", "qwen-oauth"}
+    if result.target_provider in oauth_providers:
+        _update_config_for_provider(
+            result.target_provider,
+            result.base_url,
+            default_model=result.new_model,
+        )
+        _save_model_choice(result.new_model)
+        return
+
+    cfg = load_config()
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        model_section = dict(model_cfg)
+    elif isinstance(model_cfg, str) and model_cfg.strip():
+        model_section = {"default": model_cfg.strip()}
+    else:
+        model_section = {}
+
+    model_section["default"] = result.new_model
+    model_section["provider"] = result.target_provider
+    if result.base_url:
+        model_section["base_url"] = result.base_url.rstrip("/")
+    else:
+        model_section.pop("base_url", None)
+    if result.api_mode:
+        model_section["api_mode"] = result.api_mode
+    else:
+        model_section.pop("api_mode", None)
+    model_section.pop("api_key", None)
+    cfg["model"] = model_section
+    save_config(cfg)
+    deactivate_provider()
 
 
 def _prompt_provider_choice(choices, *, default=0):
@@ -4447,7 +4533,7 @@ For more help on a command:
     gateway_subparsers = gateway_parser.add_subparsers(dest="gateway_command")
     
     # gateway run (default)
-    gateway_run = gateway_subparsers.add_parser("run", help="Run gateway in foreground (recommended for WSL, Docker, Termux)")
+    gateway_run = gateway_subparsers.add_parser("run", help="Run gateway in foreground")
     gateway_run.add_argument("-v", "--verbose", action="count", default=0,
                              help="Increase stderr log verbosity (-v=INFO, -vv=DEBUG)")
     gateway_run.add_argument("-q", "--quiet", action="store_true",
@@ -4456,7 +4542,7 @@ For more help on a command:
                              help="Replace any existing gateway instance (useful for systemd)")
     
     # gateway start
-    gateway_start = gateway_subparsers.add_parser("start", help="Start the installed systemd/launchd background service")
+    gateway_start = gateway_subparsers.add_parser("start", help="Start gateway service")
     gateway_start.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
     
     # gateway stop
@@ -4474,7 +4560,7 @@ For more help on a command:
     gateway_status.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
     
     # gateway install
-    gateway_install = gateway_subparsers.add_parser("install", help="Install gateway as a systemd/launchd background service")
+    gateway_install = gateway_subparsers.add_parser("install", help="Install gateway as service")
     gateway_install.add_argument("--force", action="store_true", help="Force reinstall")
     gateway_install.add_argument("--system", action="store_true", help="Install as a Linux system-level service (starts at boot)")
     gateway_install.add_argument("--run-as-user", dest="run_as_user", help="User account the Linux system service should run as")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1134,7 +1134,7 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
+    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "deepseek", "xai"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
     elif selected_provider:
         current_model_value = "" if current_model == "(not set)" else current_model
@@ -1198,6 +1198,22 @@ def _persist_selected_model_result(result) -> None:
         model_section.pop("api_mode", None)
     model_section.pop("api_key", None)
     cfg["model"] = model_section
+    providers_cfg = cfg.get("providers")
+    if isinstance(providers_cfg, dict) and result.target_provider in providers_cfg:
+        provider_entry = providers_cfg.get(result.target_provider)
+        if isinstance(provider_entry, dict):
+            provider_entry["default_model"] = result.new_model
+    custom_cfg = cfg.get("custom_providers")
+    if isinstance(custom_cfg, list) and result.target_provider.startswith("custom:"):
+        from hermes_cli.providers import custom_provider_slug
+
+        for entry in custom_cfg:
+            if not isinstance(entry, dict):
+                continue
+            display_name = str(entry.get("name") or "").strip()
+            if display_name and custom_provider_slug(display_name) == result.target_provider:
+                entry["model"] = result.new_model
+                break
     save_config(cfg)
     deactivate_provider()
 

--- a/hermes_cli/model_selection.py
+++ b/hermes_cli/model_selection.py
@@ -617,12 +617,14 @@ def build_model_selection_tree(
 
     oauth_providers: list[ProviderNode] = []
     oauth_defs = (
-        ("openai", "openai-codex", "OpenAI", get_codex_auth_status(), get_codex_model_ids(access_token=None)),
-        ("nous", "nous", "Nous", get_nous_auth_status(), list(_PROVIDER_MODELS.get("nous", ()))),
-        ("qwen", "qwen-oauth", "Qwen", get_qwen_auth_status(), list(_QWEN_OAUTH_MODELS)),
+        ("openai", "openai-codex", "OpenAI", get_codex_auth_status, lambda configured: get_codex_model_ids(access_token=None) if configured else []),
+        ("nous", "nous", "Nous", get_nous_auth_status, lambda configured: list(_PROVIDER_MODELS.get("nous", ())) if configured else []),
+        ("qwen", "qwen-oauth", "Qwen", get_qwen_auth_status, lambda configured: list(_QWEN_OAUTH_MODELS) if configured else []),
     )
-    for token, provider_slug, label, status, model_ids in oauth_defs:
+    for token, provider_slug, label, status_fn, model_ids_fn in oauth_defs:
+        status = status_fn()
         configured = bool(status.get("logged_in") or status.get("configured"))
+        model_ids = model_ids_fn(configured)
         status_label, status_kind = _status_label(configured)
         provider_id = f"oauth:{token}"
         oauth_providers.append(

--- a/hermes_cli/model_selection.py
+++ b/hermes_cli/model_selection.py
@@ -359,16 +359,6 @@ def _openrouter_has_credentials() -> bool:
         return False
 
 
-def _oauth_status(provider_slug: str) -> dict:
-    if provider_slug == "openai-codex":
-        return get_codex_auth_status()
-    if provider_slug == "nous":
-        return get_nous_auth_status()
-    if provider_slug == "qwen-oauth":
-        return get_qwen_auth_status()
-    return {"logged_in": False}
-
-
 def _vendor_label(vendor_slug: str) -> str:
     label = _OPENROUTER_VENDOR_LABELS.get(vendor_slug)
     if label:
@@ -617,15 +607,18 @@ def build_model_selection_tree(
 
     oauth_providers: list[ProviderNode] = []
     oauth_defs = (
-        ("openai", "openai-codex", "OpenAI", get_codex_auth_status, lambda configured: get_codex_model_ids(access_token=None) if configured else []),
-        ("nous", "nous", "Nous", get_nous_auth_status, lambda configured: list(_PROVIDER_MODELS.get("nous", ())) if configured else []),
-        ("qwen", "qwen-oauth", "Qwen", get_qwen_auth_status, lambda configured: list(_QWEN_OAUTH_MODELS) if configured else []),
+        ("openai", "openai-codex", "OpenAI", lambda configured: get_codex_model_ids(access_token=None) if configured else []),
+        ("nous", "nous", "Nous", lambda configured: list(_PROVIDER_MODELS.get("nous", ())) if configured else []),
+        ("qwen", "qwen-oauth", "Qwen", lambda configured: list(_QWEN_OAUTH_MODELS) if configured else []),
     )
-    for token, provider_slug, label, status_fn, model_ids_fn in oauth_defs:
-        status = status_fn()
-        configured = bool(status.get("logged_in") or status.get("configured"))
+    for token, provider_slug, label, model_ids_fn in oauth_defs:
+        status_label, status_kind = _provider_configured_status(
+            provider_slug,
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+        )
+        configured = status_kind != "error"
         model_ids = model_ids_fn(configured)
-        status_label, status_kind = _status_label(configured)
         provider_id = f"oauth:{token}"
         oauth_providers.append(
             ProviderNode(

--- a/hermes_cli/model_selection.py
+++ b/hermes_cli/model_selection.py
@@ -1,0 +1,790 @@
+"""Canonical model-selection primitives shared across Hermes surfaces.
+
+Stable hierarchy:
+
+  source -> provider -> model
+
+Where source is one of the long-lived top-level categories:
+
+  - ``openrouter``
+  - ``oauth``
+  - ``other``
+
+Providers and models are dynamic data beneath those stable categories.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional
+
+from agent.credential_pool import load_pool
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    get_codex_auth_status,
+    get_auth_status,
+    get_nous_auth_status,
+    get_qwen_auth_status,
+)
+from hermes_cli.codex_models import get_codex_model_ids
+from hermes_cli.model_normalize import normalize_model_for_provider
+from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS, normalize_provider
+from hermes_cli.providers import custom_provider_slug, get_label
+
+StatusKind = Literal["none", "success", "error"]
+
+_QWEN_OAUTH_MODELS: tuple[str, ...] = (
+    "qwen3-coder-plus",
+    "qwen3-coder",
+)
+
+_OTHER_PROVIDER_ORDER: tuple[str, ...] = (
+    "anthropic",
+    "copilot",
+    "copilot-acp",
+    "gemini",
+    "zai",
+    "kimi-coding",
+    "minimax",
+    "minimax-cn",
+    "deepseek",
+    "xai",
+    "kilocode",
+    "opencode-zen",
+    "opencode-go",
+    "ai-gateway",
+    "alibaba",
+    "huggingface",
+)
+
+_OPENROUTER_VENDOR_LABELS: dict[str, str] = {
+    "anthropic": "Anthropic",
+    "arcee-ai": "Arcee",
+    "deepseek": "DeepSeek",
+    "google": "Google",
+    "meta-llama": "Meta Llama",
+    "minimax": "MiniMax",
+    "moonshotai": "Moonshot",
+    "nvidia": "Nvidia",
+    "openai": "OpenAI",
+    "qwen": "Qwen",
+    "stepfun": "StepFun",
+    "x-ai": "X.AI",
+    "xiaomi": "Xiaomi",
+    "z-ai": "Z.AI",
+}
+
+
+@dataclass(frozen=True)
+class SourceCategory:
+    id: str
+    label: str
+    status_label: str = ""
+    status_kind: StatusKind = "none"
+    current: bool = False
+
+
+@dataclass(frozen=True)
+class ProviderNode:
+    id: str
+    source_id: str
+    provider_slug: str
+    token: str
+    label: str
+    status_label: str = ""
+    status_kind: StatusKind = "none"
+    current: bool = False
+
+
+@dataclass(frozen=True)
+class ModelNode:
+    id: str
+    provider_id: str
+    provider_slug: str
+    model_id: str
+    token: str
+    label: str
+    enabled: bool
+    current: bool = False
+
+
+@dataclass(frozen=True)
+class ModelSwitchRequest:
+    provider_slug: str
+    model_id: str
+
+
+@dataclass(frozen=True)
+class SelectionItem:
+    kind: Literal["source", "provider", "model"]
+    id: str
+    token: str
+    label: str
+    status_label: str = ""
+    status_kind: StatusKind = "none"
+    enabled: bool = True
+    current: bool = False
+    request: Optional[ModelSwitchRequest] = None
+
+
+@dataclass(frozen=True)
+class SelectionView:
+    level: Literal["source", "provider", "model"]
+    breadcrumb: str
+    items: tuple[SelectionItem, ...]
+
+    def default_cursor(self) -> int:
+        for idx, item in enumerate(self.items):
+            if item.current and item.enabled:
+                return idx
+        for idx, item in enumerate(self.items):
+            if item.enabled:
+                return idx
+        return 0
+
+
+@dataclass(frozen=True)
+class ModelSelectionTree:
+    sources: tuple[SourceCategory, ...]
+    providers_by_source: dict[str, tuple[ProviderNode, ...]]
+    models_by_provider: dict[str, tuple[ModelNode, ...]]
+
+    def source(self, source_id: str) -> Optional[SourceCategory]:
+        for source in self.sources:
+            if source.id == source_id:
+                return source
+        return None
+
+    def providers(self, source_id: str) -> tuple[ProviderNode, ...]:
+        return self.providers_by_source.get(source_id, ())
+
+    def provider(self, provider_id: str) -> Optional[ProviderNode]:
+        for providers in self.providers_by_source.values():
+            for provider in providers:
+                if provider.id == provider_id:
+                    return provider
+        return None
+
+    def models(self, provider_id: str) -> tuple[ModelNode, ...]:
+        return self.models_by_provider.get(provider_id, ())
+
+
+class ModelSelectionController:
+    """Stateful navigator for the canonical selection tree."""
+
+    def __init__(self, tree: ModelSelectionTree):
+        self.tree = tree
+        self.source_id: Optional[str] = None
+        self.provider_id: Optional[str] = None
+        self.cursor: int = 0
+        self._sync_cursor()
+
+    @property
+    def active(self) -> bool:
+        return True
+
+    @property
+    def level(self) -> Literal["source", "provider", "model"]:
+        if self.provider_id is not None:
+            return "model"
+        if self.source_id is not None:
+            return "provider"
+        return "source"
+
+    def current_view(self) -> SelectionView:
+        if self.provider_id is not None:
+            provider = self.tree.provider(self.provider_id)
+            assert provider is not None
+            source = self.tree.source(provider.source_id)
+            breadcrumb = f"{source.label} / {provider.label}" if source is not None else provider.label
+            items = tuple(
+                SelectionItem(
+                    kind="model",
+                    id=model.id,
+                    token=model.token,
+                    label=model.label,
+                    status_label=(
+                        provider.status_label
+                        or (source.status_label if source is not None else "")
+                    ) if not model.enabled else "",
+                    status_kind=(
+                        provider.status_kind
+                        if provider.status_kind != "none"
+                        else (source.status_kind if source is not None else "none")
+                    ) if not model.enabled else "none",
+                    enabled=model.enabled,
+                    current=model.current,
+                    request=ModelSwitchRequest(
+                        provider_slug=model.provider_slug,
+                        model_id=model.model_id,
+                    ),
+                )
+                for model in self.tree.models(self.provider_id)
+            )
+            return SelectionView(level="model", breadcrumb=breadcrumb, items=items)
+
+        if self.source_id is not None:
+            source = self.tree.source(self.source_id)
+            breadcrumb = source.label if source is not None else ""
+            items = tuple(
+                SelectionItem(
+                    kind="provider",
+                    id=provider.id,
+                    token=provider.token,
+                    label=provider.label,
+                    status_label=provider.status_label,
+                    status_kind=provider.status_kind,
+                    current=provider.current,
+                )
+                for provider in self.tree.providers(self.source_id)
+            )
+            return SelectionView(level="provider", breadcrumb=breadcrumb, items=items)
+
+        items = tuple(
+            SelectionItem(
+                kind="source",
+                id=source.id,
+                token=source.id,
+                label=source.label,
+                status_label=source.status_label,
+                status_kind=source.status_kind,
+                current=source.current,
+            )
+            for source in self.tree.sources
+        )
+        return SelectionView(level="source", breadcrumb="", items=items)
+
+    def move_up(self) -> None:
+        view = self.current_view()
+        if not view.items:
+            return
+        self.cursor = (self.cursor - 1) % len(view.items)
+
+    def move_down(self) -> None:
+        view = self.current_view()
+        if not view.items:
+            return
+        self.cursor = (self.cursor + 1) % len(view.items)
+
+    def set_source(self, source_id: str) -> bool:
+        if self.tree.source(source_id) is None:
+            return False
+        self.source_id = source_id
+        self.provider_id = None
+        self._sync_cursor()
+        return True
+
+    def set_provider(self, provider_id: str) -> bool:
+        provider = self.tree.provider(provider_id)
+        if provider is None:
+            return False
+        self.source_id = provider.source_id
+        self.provider_id = provider_id
+        self._sync_cursor()
+        return True
+
+    def selected_item(self) -> Optional[SelectionItem]:
+        view = self.current_view()
+        if not view.items:
+            return None
+        return view.items[max(0, min(self.cursor, len(view.items) - 1))]
+
+    def activate_index(self, index: int) -> Optional[ModelSwitchRequest]:
+        view = self.current_view()
+        if not view.items:
+            return None
+        self.cursor = max(0, min(index, len(view.items) - 1))
+        return self.enter()
+
+    def enter(self) -> Optional[ModelSwitchRequest]:
+        item = self.selected_item()
+        if item is None:
+            return None
+        if item.kind == "source":
+            self.source_id = item.id
+            self.provider_id = None
+            self._sync_cursor()
+            return None
+        if item.kind == "provider":
+            provider = self.tree.provider(item.id)
+            if provider is None:
+                return None
+            if not self.tree.models(item.id):
+                if provider.status_kind == "error":
+                    return None
+                return ModelSwitchRequest(
+                    provider_slug=provider.provider_slug,
+                    model_id="",
+                )
+            self.provider_id = item.id
+            self._sync_cursor()
+            return None
+        if not item.enabled:
+            return None
+        return item.request
+
+    def back(self) -> bool:
+        if self.provider_id is not None:
+            self.provider_id = None
+            self._sync_cursor()
+            return True
+        if self.source_id is not None:
+            self.source_id = None
+            self._sync_cursor()
+            return True
+        return False
+
+    def _sync_cursor(self) -> None:
+        self.cursor = self.current_view().default_cursor()
+
+
+def _status_label(configured: bool) -> tuple[str, StatusKind]:
+    return ("configured", "success") if configured else ("login", "error")
+
+
+def selection_item_meta_text(item: SelectionItem) -> str:
+    parts: list[str] = []
+    if item.current:
+        parts.append("current")
+    if item.status_label:
+        parts.append(item.status_label)
+    return " · ".join(parts)
+
+
+def _openrouter_has_credentials() -> bool:
+    try:
+        pool = load_pool("openrouter")
+        return bool(pool and pool.has_credentials())
+    except Exception:
+        return False
+
+
+def _oauth_status(provider_slug: str) -> dict:
+    if provider_slug == "openai-codex":
+        return get_codex_auth_status()
+    if provider_slug == "nous":
+        return get_nous_auth_status()
+    if provider_slug == "qwen-oauth":
+        return get_qwen_auth_status()
+    return {"logged_in": False}
+
+
+def _vendor_label(vendor_slug: str) -> str:
+    label = _OPENROUTER_VENDOR_LABELS.get(vendor_slug)
+    if label:
+        return label
+    bits = [part for part in vendor_slug.replace("_", "-").split("-") if part]
+    return " ".join(part[:1].upper() + part[1:] for part in bits) or vendor_slug
+
+
+def _append_variant(label: str, variant: str) -> str:
+    known = {
+        "free": "Free",
+        "fast": "Fast",
+        "extended": "Extended",
+    }
+    suffix = known.get(variant.lower(), variant.replace("-", " ").title())
+    return f"{label} {suffix}".strip()
+
+
+def _humanize_generic_model(model_id: str) -> str:
+    bare = model_id.split("/", 1)[1] if "/" in model_id else model_id
+    variant = ""
+    if ":" in bare:
+        bare, variant = bare.split(":", 1)
+    tokens = []
+    for part in bare.split("-"):
+        if not part:
+            continue
+        lower = part.lower()
+        if lower in {"gpt", "glm", "qwen"}:
+            tokens.append(lower.upper())
+        elif lower in {"x", "ai"}:
+            tokens.append(lower.upper())
+        elif lower == "mimo":
+            tokens.append("MiMo")
+        elif lower.replace(".", "").isdigit():
+            tokens.append(part)
+        else:
+            tokens.append(part[:1].upper() + part[1:])
+    label = " ".join(tokens) or bare
+    return _append_variant(label, variant) if variant else label
+
+
+def _humanize_openai_model(model_id: str) -> str:
+    bare = model_id.split("/", 1)[1] if "/" in model_id else model_id
+    variant = ""
+    if ":" in bare:
+        bare, variant = bare.split(":", 1)
+    if bare.startswith("gpt-"):
+        remainder = bare[len("gpt-"):]
+        parts = remainder.split("-")
+        label = f"GPT-{parts[0]}"
+        if len(parts) > 1:
+            label += " " + " ".join(part.upper() if part == "o" else part.capitalize() for part in parts[1:])
+        return _append_variant(label, variant) if variant else label
+    if bare.startswith(("o1-", "o3-", "o4-")):
+        family, *rest = bare.split("-")
+        label = family.upper()
+        if rest:
+            label += " " + " ".join(part.capitalize() for part in rest)
+        return _append_variant(label, variant) if variant else label
+    return _humanize_generic_model(model_id)
+
+
+def _humanize_anthropic_model(model_id: str) -> str:
+    bare = model_id.split("/", 1)[1] if "/" in model_id else model_id
+    variant = ""
+    if ":" in bare:
+        bare, variant = bare.split(":", 1)
+    for prefix, family in (
+        ("claude-opus-", "Opus"),
+        ("claude-sonnet-", "Sonnet"),
+        ("claude-haiku-", "Haiku"),
+    ):
+        if bare.startswith(prefix):
+            version = bare[len(prefix):].replace("-", ".")
+            label = f"{family} {version}".strip()
+            return _append_variant(label, variant) if variant else label
+    return _humanize_generic_model(model_id)
+
+
+def humanize_model_label(model_id: str, *, provider_slug: str = "") -> str:
+    bare = model_id.split("/", 1)[1] if "/" in model_id else model_id
+    if provider_slug == "openai-codex" or bare.startswith(("gpt-", "o1-", "o3-", "o4-")):
+        return _humanize_openai_model(model_id)
+    if bare.startswith("claude-"):
+        return _humanize_anthropic_model(model_id)
+    return _humanize_generic_model(model_id)
+
+
+def _oauth_current_model_matches(current_model: str, model_id: str) -> bool:
+    normalized = (current_model or "").strip()
+    return normalized == model_id or normalized.endswith(f"/{model_id}")
+
+
+def _provider_configured_status(
+    provider_slug: str,
+    *,
+    user_providers: Optional[dict[str, Any]] = None,
+    custom_providers: Optional[list[dict[str, Any]]] = None,
+) -> tuple[str, StatusKind]:
+    if provider_slug.startswith("custom:"):
+        if isinstance(custom_providers, list):
+            for entry in custom_providers:
+                if not isinstance(entry, dict):
+                    continue
+                display_name = (entry.get("name") or "").strip()
+                api_url = (
+                    entry.get("base_url", "")
+                    or entry.get("url", "")
+                    or entry.get("api", "")
+                    or ""
+                ).strip()
+                if display_name and api_url and custom_provider_slug(display_name) == provider_slug:
+                    return _status_label(True)
+        return _status_label(False)
+
+    if user_providers and provider_slug in user_providers:
+        entry = user_providers.get(provider_slug)
+        configured = isinstance(entry, dict) and bool(
+            (entry.get("api") or entry.get("url") or entry.get("base_url") or "").strip()
+        )
+        return _status_label(configured)
+
+    status = get_auth_status(provider_slug)
+    configured = bool(status.get("configured") or status.get("logged_in"))
+    return _status_label(configured)
+
+
+def _provider_token(provider_slug: str) -> str:
+    return provider_slug.strip().lower().replace(" ", "-")
+
+
+def _provider_display_name(provider_slug: str) -> str:
+    pconfig = PROVIDER_REGISTRY.get(provider_slug)
+    if pconfig is not None and getattr(pconfig, "name", ""):
+        return pconfig.name
+    return get_label(provider_slug)
+
+
+def _provider_model_rows(
+    *,
+    provider_id: str,
+    provider_slug: str,
+    model_ids: list[str],
+    configured: bool,
+    normalized_provider: str,
+    current_model: str,
+) -> tuple[ModelNode, ...]:
+    normalized_current = (
+        normalize_model_for_provider(current_model, provider_slug)
+        if normalized_provider == provider_slug
+        else ""
+    )
+    return tuple(
+        ModelNode(
+            id=f"{provider_id}:{model_id}",
+            provider_id=provider_id,
+            provider_slug=provider_slug,
+            model_id=model_id,
+            token=model_id,
+            label=humanize_model_label(model_id, provider_slug=provider_slug),
+            enabled=configured,
+            current=_oauth_current_model_matches(normalized_current, model_id),
+        )
+        for model_id in model_ids
+    )
+
+
+def build_model_selection_tree(
+    current_provider: str = "",
+    current_model: str = "",
+    user_providers: Optional[dict[str, Any]] = None,
+    custom_providers: Optional[list[dict[str, Any]]] = None,
+) -> ModelSelectionTree:
+    normalized_provider = normalize_provider(current_provider) if current_provider else ""
+    oauth_provider_slugs = {"openai-codex", "nous", "qwen-oauth"}
+    current_source = "openrouter" if normalized_provider == "openrouter" else (
+        "oauth" if normalized_provider in oauth_provider_slugs else (
+            "other" if normalized_provider else ""
+        )
+    )
+
+    openrouter_configured = _openrouter_has_credentials()
+    openrouter_status_label, openrouter_status_kind = _status_label(openrouter_configured)
+
+    sources = (
+        SourceCategory(
+            id="openrouter",
+            label="OpenRouter",
+            status_label=openrouter_status_label,
+            status_kind=openrouter_status_kind,
+            current=current_source == "openrouter",
+        ),
+        SourceCategory(
+            id="oauth",
+            label="OAuth",
+            current=current_source == "oauth",
+        ),
+    )
+
+    current_openrouter_model = normalize_model_for_provider(current_model, "openrouter")
+    grouped: dict[str, list[str]] = {}
+    ordered_vendors: list[str] = []
+    for model_id, _desc in OPENROUTER_MODELS:
+        if "/" not in model_id:
+            continue
+        vendor, _bare = model_id.split("/", 1)
+        if vendor not in grouped:
+            grouped[vendor] = []
+            ordered_vendors.append(vendor)
+        grouped[vendor].append(model_id)
+
+    openrouter_providers: list[ProviderNode] = []
+    models_by_provider: dict[str, tuple[ModelNode, ...]] = {}
+    for vendor in ordered_vendors:
+        provider_id = f"openrouter:{vendor}"
+        openrouter_providers.append(
+            ProviderNode(
+                id=provider_id,
+                source_id="openrouter",
+                provider_slug="openrouter",
+                token=vendor,
+                label=_vendor_label(vendor),
+                current=(
+                    normalized_provider == "openrouter"
+                    and current_openrouter_model.startswith(f"{vendor}/")
+                ),
+            )
+        )
+        models_by_provider[provider_id] = tuple(
+            ModelNode(
+                id=f"{provider_id}:{model_id}",
+                provider_id=provider_id,
+                provider_slug="openrouter",
+                model_id=model_id,
+                token=model_id.split("/", 1)[1] if "/" in model_id else model_id,
+                label=humanize_model_label(model_id),
+                enabled=openrouter_configured,
+                current=(
+                    normalized_provider == "openrouter"
+                    and current_openrouter_model == model_id
+                ),
+            )
+            for model_id in grouped[vendor]
+        )
+
+    oauth_providers: list[ProviderNode] = []
+    oauth_defs = (
+        ("openai", "openai-codex", "OpenAI", get_codex_auth_status(), get_codex_model_ids(access_token=None)),
+        ("nous", "nous", "Nous", get_nous_auth_status(), list(_PROVIDER_MODELS.get("nous", ()))),
+        ("qwen", "qwen-oauth", "Qwen", get_qwen_auth_status(), list(_QWEN_OAUTH_MODELS)),
+    )
+    for token, provider_slug, label, status, model_ids in oauth_defs:
+        configured = bool(status.get("logged_in") or status.get("configured"))
+        status_label, status_kind = _status_label(configured)
+        provider_id = f"oauth:{token}"
+        oauth_providers.append(
+            ProviderNode(
+                id=provider_id,
+                source_id="oauth",
+                provider_slug=provider_slug,
+                token=token,
+                label=label,
+                status_label=status_label,
+                status_kind=status_kind,
+                current=normalized_provider == provider_slug,
+            )
+        )
+        normalized_current = normalize_model_for_provider(current_model, provider_slug) if normalized_provider == provider_slug else ""
+        models_by_provider[provider_id] = tuple(
+            ModelNode(
+                id=f"{provider_id}:{model_id}",
+                provider_id=provider_id,
+                provider_slug=provider_slug,
+                model_id=model_id,
+                token=model_id.split("/", 1)[1] if "/" in model_id and provider_slug == "nous" else model_id,
+                label=humanize_model_label(model_id, provider_slug=provider_slug),
+                enabled=configured,
+                current=_oauth_current_model_matches(normalized_current, model_id),
+            )
+            for model_id in model_ids
+        )
+
+    other_providers: list[ProviderNode] = []
+    seen_other_slugs: set[str] = set()
+
+    for provider_slug in _OTHER_PROVIDER_ORDER:
+        model_ids = list(_PROVIDER_MODELS.get(provider_slug, ()))
+        if not model_ids:
+            continue
+        status_label, status_kind = _provider_configured_status(
+            provider_slug,
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+        )
+        configured = status_kind != "error"
+        provider_id = f"other:{provider_slug}"
+        other_providers.append(
+            ProviderNode(
+                id=provider_id,
+                source_id="other",
+                provider_slug=provider_slug,
+                token=_provider_token(provider_slug),
+                label=_provider_display_name(provider_slug),
+                status_label=status_label,
+                status_kind=status_kind,
+                current=normalized_provider == provider_slug,
+            )
+        )
+        models_by_provider[provider_id] = _provider_model_rows(
+            provider_id=provider_id,
+            provider_slug=provider_slug,
+            model_ids=model_ids,
+            configured=configured,
+            normalized_provider=normalized_provider,
+            current_model=current_model,
+        )
+        seen_other_slugs.add(provider_slug)
+
+    if user_providers and isinstance(user_providers, dict):
+        for provider_slug, entry in user_providers.items():
+            if provider_slug in seen_other_slugs or not isinstance(entry, dict):
+                continue
+            default_model = (entry.get("default_model") or "").strip()
+            model_ids: list[str] = []
+            if default_model:
+                model_ids.append(default_model)
+            elif normalized_provider == provider_slug and current_model:
+                model_ids.append(current_model)
+            status_label, status_kind = _provider_configured_status(
+                provider_slug,
+                user_providers=user_providers,
+                custom_providers=custom_providers,
+            )
+            configured = status_kind != "error"
+            provider_id = f"other:{provider_slug}"
+            other_providers.append(
+                ProviderNode(
+                    id=provider_id,
+                    source_id="other",
+                    provider_slug=provider_slug,
+                    token=_provider_token(provider_slug),
+                    label=(entry.get("name") or provider_slug).strip() or provider_slug,
+                    status_label=status_label,
+                    status_kind=status_kind,
+                    current=normalized_provider == provider_slug,
+                )
+            )
+            models_by_provider[provider_id] = _provider_model_rows(
+                provider_id=provider_id,
+                provider_slug=provider_slug,
+                model_ids=model_ids,
+                configured=configured,
+                normalized_provider=normalized_provider,
+                current_model=current_model,
+            )
+            seen_other_slugs.add(provider_slug)
+
+    if custom_providers and isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            display_name = (entry.get("name") or "").strip()
+            if not display_name:
+                continue
+            provider_slug = custom_provider_slug(display_name)
+            if provider_slug in seen_other_slugs:
+                continue
+            model_id = (entry.get("model") or "").strip() or (
+                current_model if normalized_provider == provider_slug and current_model else ""
+            )
+            status_label, status_kind = _provider_configured_status(
+                provider_slug,
+                user_providers=user_providers,
+                custom_providers=custom_providers,
+            )
+            configured = status_kind != "error"
+            provider_id = f"other:{provider_slug}"
+            other_providers.append(
+                ProviderNode(
+                    id=provider_id,
+                    source_id="other",
+                    provider_slug=provider_slug,
+                    token=_provider_token(provider_slug),
+                    label=display_name,
+                    status_label=status_label,
+                    status_kind=status_kind,
+                    current=normalized_provider == provider_slug,
+                )
+            )
+            models_by_provider[provider_id] = _provider_model_rows(
+                provider_id=provider_id,
+                provider_slug=provider_slug,
+                model_ids=[model_id] if model_id else [],
+                configured=configured,
+                normalized_provider=normalized_provider,
+                current_model=current_model,
+            )
+            seen_other_slugs.add(provider_slug)
+
+    sources = (
+        sources[0],
+        sources[1],
+        SourceCategory(
+            id="other",
+            label="Other providers",
+            current=current_source == "other",
+        ),
+    )
+
+    return ModelSelectionTree(
+        sources=sources,
+        providers_by_source={
+            "openrouter": tuple(openrouter_providers),
+            "oauth": tuple(oauth_providers),
+            "other": tuple(other_providers),
+        },
+        models_by_provider=models_by_provider,
+    )

--- a/hermes_cli/model_selection.py
+++ b/hermes_cli/model_selection.py
@@ -692,7 +692,12 @@ def build_model_selection_tree(
         for provider_slug, entry in user_providers.items():
             if provider_slug in seen_other_slugs or not isinstance(entry, dict):
                 continue
-            default_model = (entry.get("default_model") or "").strip()
+            default_model = (
+                entry.get("default_model")
+                or entry.get("model")
+                or entry.get("default")
+                or ""
+            ).strip()
             model_ids: list[str] = []
             if default_model:
                 model_ids.append(default_model)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -387,6 +387,7 @@ def switch_model(
     explicit_provider: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
+    skip_validation: bool = False,
 ) -> ModelSwitchResult:
     """Core model-switching pipeline shared between CLI and gateway.
 
@@ -653,20 +654,28 @@ def switch_model(
     new_model = normalize_model_for_provider(new_model, target_provider)
 
     # --- Validate ---
-    try:
-        validation = validate_requested_model(
-            new_model,
-            target_provider,
-            api_key=api_key,
-            base_url=base_url,
-        )
-    except Exception:
+    if skip_validation:
         validation = {
             "accepted": True,
             "persist": True,
-            "recognized": False,
+            "recognized": True,
             "message": None,
         }
+    else:
+        try:
+            validation = validate_requested_model(
+                new_model,
+                target_provider,
+                api_key=api_key,
+                base_url=base_url,
+            )
+        except Exception:
+            validation = {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": None,
+            }
 
     if not validation.get("accepted"):
         msg = validation.get("message", "Invalid model")
@@ -940,5 +949,4 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -433,6 +433,7 @@ def switch_model(
     )
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
+    pdef = None
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
@@ -616,22 +617,32 @@ def switch_model(
     api_mode = ""
 
     if provider_changed or explicit_provider:
-        try:
-            runtime = resolve_runtime_provider(requested=target_provider)
-            api_key = runtime.get("api_key", "")
-            base_url = runtime.get("base_url", "")
-            api_mode = runtime.get("api_mode", "")
-        except Exception as e:
-            return ModelSwitchResult(
-                success=False,
-                target_provider=target_provider,
-                provider_label=provider_label,
-                is_global=is_global,
-                error_message=(
-                    f"Could not resolve credentials for provider "
-                    f"'{provider_label}': {e}"
-                ),
-            )
+        if pdef is not None and pdef.source == "user-config":
+            base_url = pdef.base_url.rstrip("/")
+            api_mode = determine_api_mode(target_provider, base_url)
+            api_key = ""
+            for env_var in pdef.api_key_env_vars:
+                value = os.getenv(env_var, "").strip()
+                if value:
+                    api_key = value
+                    break
+        else:
+            try:
+                runtime = resolve_runtime_provider(requested=target_provider)
+                api_key = runtime.get("api_key", "")
+                base_url = runtime.get("base_url", "")
+                api_mode = runtime.get("api_mode", "")
+            except Exception as e:
+                return ModelSwitchResult(
+                    success=False,
+                    target_provider=target_provider,
+                    provider_label=provider_label,
+                    is_global=is_global,
+                    error_message=(
+                        f"Could not resolve credentials for provider "
+                        f"'{provider_label}': {e}"
+                    ),
+                )
     else:
         try:
             runtime = resolve_runtime_provider(requested=current_provider)
@@ -949,4 +960,3 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-

--- a/tests/cli/test_cli_model_picker.py
+++ b/tests/cli/test_cli_model_picker.py
@@ -1,0 +1,232 @@
+"""Tests for the canonical /model selector in the CLI."""
+
+from __future__ import annotations
+
+import queue
+from unittest.mock import MagicMock
+
+from prompt_toolkit.completion import Completion
+
+from hermes_cli.model_switch import ModelSwitchResult
+from hermes_cli.model_selection import ModelSwitchRequest
+
+
+def _make_cli():
+    from cli import HermesCLI
+
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "anthropic/claude-sonnet-4.6"
+    cli_obj.provider = "openrouter"
+    cli_obj.base_url = "https://openrouter.ai/api/v1"
+    cli_obj.api_key = "sk-test"
+    cli_obj.api_mode = "chat_completions"
+    cli_obj.requested_provider = "openrouter"
+    cli_obj._explicit_api_key = ""
+    cli_obj._explicit_base_url = ""
+    cli_obj._pending_input = queue.Queue()
+    cli_obj.agent = None
+    cli_obj._model_selection_controller = None
+    return cli_obj
+
+
+def test_handle_model_switch_no_args_shows_inline_menu_hint(monkeypatch):
+    cli_obj = _make_cli()
+    printed = []
+    monkeypatch.setattr("cli._cprint", lambda msg: printed.append(str(msg)))
+
+    cli_obj._handle_model_switch("/model")
+
+    assert any("inline slash menu" in line for line in printed)
+
+
+class _FakeCompletionState:
+    def __init__(self, completion):
+        self.current_completion = completion
+
+
+class _FakeBuffer:
+    def __init__(self, text: str, completion: Completion):
+        self.text = text
+        self.complete_state = _FakeCompletionState(completion)
+        self.reset_called = False
+        self.started_completion = False
+        self.document_text = text
+
+    def go_to_completion(self, index: int) -> None:
+        return None
+
+    def apply_completion(self, completion: Completion) -> None:
+        self.text = "/model"
+
+    def reset(self, append_to_history: bool = False) -> None:
+        self.text = ""
+        self.reset_called = append_to_history
+
+    def set_document(self, document, bypass_readonly: bool = False) -> None:
+        self.document_text = document.text
+        self.text = document.text
+
+    def start_completion(self, select_first: bool = False) -> None:
+        self.started_completion = select_first
+
+
+def test_maybe_accept_slash_completion_on_enter_opens_selector_in_same_surface():
+    cli_obj = _make_cli()
+    completion = Completion("model", start_position=-3, display="/model")
+    buffer = _FakeBuffer("/mo", completion)
+    opened = {"called": False, "buffer_text": None}
+    cli_obj._open_model_selection = lambda buf=None: (
+        opened.__setitem__("called", True),
+        opened.__setitem__("buffer_text", getattr(buf, "text", None)),
+    )
+
+    handled = cli_obj._maybe_accept_slash_completion_on_enter(buffer)
+
+    assert handled is True
+    assert buffer.reset_called is False
+    assert opened["called"] is True
+    assert opened["buffer_text"] == "/mo"
+
+
+def test_space_on_exact_model_opens_selector_in_same_surface():
+    cli_obj = _make_cli()
+    buffer = _FakeBuffer("/model", Completion("model", start_position=0, display="/model"))
+    opened = {"called": False, "buffer_text": None}
+    cli_obj._open_model_selection = lambda buf=None: (
+        opened.__setitem__("called", True),
+        opened.__setitem__("buffer_text", getattr(buf, "text", None)),
+    )
+
+    handled = cli_obj._maybe_accept_model_selection_on_space(buffer)
+
+    assert handled is True
+    assert opened["called"] is True
+    assert opened["buffer_text"] == "/model"
+
+
+class _Controller:
+    def __init__(self, request):
+        self._request = request
+        self.moved = []
+        self.back_calls = 0
+        self.source_id = "oauth"
+        self.provider_id = "oauth:openai"
+
+    def current_view(self):
+        class _View:
+            level = "model"
+            breadcrumb = "OAuth / OpenAI"
+            items = ()
+        return _View()
+
+    def move_up(self):
+        self.moved.append("up")
+
+    def move_down(self):
+        self.moved.append("down")
+
+    def back(self):
+        self.back_calls += 1
+        return self.back_calls == 1
+
+    def enter(self):
+        return self._request
+
+
+def test_activate_model_selection_executes_final_switch(monkeypatch):
+    cli_obj = _make_cli()
+    printed = []
+    captured = {}
+    monkeypatch.setattr("cli._cprint", lambda msg: printed.append(str(msg)))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    cli_obj._model_selection_controller = _Controller(
+        ModelSwitchRequest(provider_slug="openai-codex", model_id="gpt-5.4")
+    )
+
+    def _fake_switch_model(**kwargs):
+        captured.update(kwargs)
+        return ModelSwitchResult(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openai-codex",
+            provider_changed=True,
+            api_key="oauth-token",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+            provider_label="OpenAI Codex",
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_switch_model)
+    buffer = _FakeBuffer("/model", Completion("dummy", start_position=0))
+    handled = cli_obj._activate_model_selection(buffer)
+
+    assert handled is True
+    assert cli_obj._model_selection_controller is None
+    assert buffer.reset_called is True
+    assert cli_obj.model == "gpt-5.4"
+    assert cli_obj.provider == "openai-codex"
+    assert captured.get("skip_validation", False) is False
+    assert any("Model switched" in line for line in printed)
+
+
+def test_space_advances_active_model_selection(monkeypatch):
+    cli_obj = _make_cli()
+    cli_obj._model_selection_controller = _Controller(None)
+    buffer = _FakeBuffer("/model ", Completion("dummy", start_position=0))
+
+    called = {"activated": False}
+    cli_obj._activate_model_selection = lambda buf=None: called.__setitem__("activated", True) or True
+
+    handled = cli_obj._maybe_accept_model_selection_on_space(buffer)
+
+    assert handled is True
+    assert called["activated"] is True
+
+
+def test_commit_model_selection_forwards_buffer():
+    cli_obj = _make_cli()
+    buffer = _FakeBuffer("/model ", Completion("dummy", start_position=0))
+    captured = {"buffer": None}
+    cli_obj._activate_model_selection = lambda buf=None: captured.__setitem__("buffer", buf) or True
+
+    handled = cli_obj._commit_model_selection(buffer)
+
+    assert handled is True
+    assert captured["buffer"] is buffer
+
+
+def test_move_and_back_model_selection():
+    cli_obj = _make_cli()
+    controller = _Controller(None)
+    cli_obj._model_selection_controller = controller
+
+    buffer = _FakeBuffer("/model", Completion("dummy", start_position=0))
+    assert cli_obj._move_model_selection(-1, buffer) is True
+    assert cli_obj._move_model_selection(1, buffer) is True
+    assert controller.moved == ["up", "down"]
+
+    assert cli_obj._back_model_selection(buffer) is True
+    assert cli_obj._model_selection_controller is controller
+    assert cli_obj._back_model_selection(buffer) is True
+    assert cli_obj._model_selection_controller is None
+
+
+def test_sync_model_selection_buffer_writes_inline_path():
+    cli_obj = _make_cli()
+    from hermes_cli.model_selection import ModelSelectionController, build_model_selection_tree
+
+    tree = build_model_selection_tree(current_provider="openrouter", current_model="openai/gpt-5.4")
+    controller = ModelSelectionController(tree)
+    cli_obj._model_selection_controller = controller
+    buffer = _FakeBuffer("/model", Completion("dummy", start_position=0))
+
+    cli_obj._sync_model_selection_buffer(buffer)
+    assert buffer.text == "/model "
+
+    controller.enter()  # openrouter
+    cli_obj._sync_model_selection_buffer(buffer)
+    assert buffer.text == "/model openrouter "
+
+    controller.enter()  # default provider under openrouter
+    cli_obj._sync_model_selection_buffer(buffer)
+    assert buffer.text.startswith("/model openrouter ")

--- a/tests/gateway/test_model_picker_integration.py
+++ b/tests/gateway/test_model_picker_integration.py
@@ -1,0 +1,148 @@
+"""Tests for gateway /model interactive picker integration."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _FakePickerAdapter:
+    def __init__(self):
+        self._send_model_picker = AsyncMock(side_effect=self._send)
+        self.calls = []
+        self.on_model_selected = None
+
+    async def send_model_picker(self, **kwargs):
+        return await self._send_model_picker(**kwargs)
+
+    async def _send(self, **kwargs):
+        self.calls.append(kwargs)
+        self.on_model_selected = kwargs["on_model_selected"]
+        return SimpleNamespace(success=True)
+
+
+def _make_runner(platform: Platform):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {platform: _FakePickerAdapter()}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    return runner
+
+
+def _make_event(platform: Platform, text: str = "/model"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=platform, chat_id="12345", chat_type="dm"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", [Platform.TELEGRAM, Platform.DISCORD])
+async def test_handle_model_command_uses_platform_native_picker(tmp_path, monkeypatch, platform):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"model": {"default": "gpt-5.4", "provider": "openai-codex", "base_url": "https://chatgpt.com/backend-api/codex"}}
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **_kwargs: [
+            {
+                "slug": "openrouter",
+                "name": "OpenRouter",
+                "models": ["anthropic/claude-sonnet-4.6"],
+                "total_models": 1,
+                "is_current": False,
+            }
+        ],
+    )
+
+    runner = _make_runner(platform)
+    adapter = runner.adapters[platform]
+
+    result = await runner._handle_model_command(_make_event(platform))
+
+    assert result is None
+    adapter._send_model_picker.assert_awaited_once()
+    assert adapter.calls[0]["providers"][0]["slug"] == "openrouter"
+    assert adapter.calls[0]["current_model"] == "gpt-5.4"
+    assert adapter.calls[0]["current_provider"] == "openai-codex"
+
+
+@pytest.mark.asyncio
+async def test_model_picker_callback_uses_shared_switch_pipeline(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"model": {"default": "gpt-5.4", "provider": "openai-codex", "base_url": "https://chatgpt.com/backend-api/codex"}}
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **_kwargs: [
+            {
+                "slug": "openrouter",
+                "name": "OpenRouter",
+                "models": ["anthropic/claude-sonnet-4.6"],
+                "total_models": 1,
+                "is_current": False,
+            }
+        ],
+    )
+
+    captured = {}
+
+    def _fake_switch_model(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            success=True,
+            new_model=kwargs["raw_input"],
+            target_provider=kwargs["explicit_provider"],
+            provider_label="OpenRouter",
+            api_key="picker-key",
+            base_url="",
+            api_mode="chat_completions",
+            model_info=None,
+            warning_message=None,
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_switch_model)
+
+    runner = _make_runner(Platform.TELEGRAM)
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._handle_model_command(_make_event(Platform.TELEGRAM))
+    confirmation = await adapter.on_model_selected(
+        "12345", "anthropic/claude-sonnet-4.6", "openrouter"
+    )
+
+    assert captured["raw_input"] == "anthropic/claude-sonnet-4.6"
+    assert captured["explicit_provider"] == "openrouter"
+    assert captured["current_model"] == "gpt-5.4"
+    assert captured["current_provider"] == "openai-codex"
+    assert "Model switched to `anthropic/claude-sonnet-4.6`" in confirmation
+    session_key = runner._session_key_for_source(_make_event(Platform.TELEGRAM).source)
+    assert runner._session_model_overrides[session_key]["model"] == "anthropic/claude-sonnet-4.6"

--- a/tests/hermes_cli/test_model_selection.py
+++ b/tests/hermes_cli/test_model_selection.py
@@ -146,3 +146,31 @@ def test_other_source_marks_current_provider_when_runtime_provider_is_canonical(
     models = tree.models(provider.id)
     assert len(models) == 1
     assert models[0].current is True
+
+
+def test_user_provider_uses_model_field_when_default_model_missing(monkeypatch):
+    monkeypatch.setattr(ms, "load_pool", lambda provider: _Pool(False))
+    monkeypatch.setattr(ms, "get_codex_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_nous_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_qwen_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_auth_status", lambda provider_id=None: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_codex_model_ids", lambda access_token=None: [])
+    monkeypatch.setattr(ms, "OPENROUTER_MODELS", [])
+
+    tree = ms.build_model_selection_tree(
+        current_provider="openrouter",
+        current_model="openai/gpt-5.4",
+        user_providers={
+            "lab-provider": {
+                "name": "Lab Provider",
+                "api": "http://lab.example/v1",
+                "model": "lab-model",
+            }
+        },
+    )
+
+    provider = next(
+        provider for provider in tree.providers("other") if provider.provider_slug == "lab-provider"
+    )
+    models = tree.models(provider.id)
+    assert [item.model_id for item in models] == ["lab-model"]

--- a/tests/hermes_cli/test_model_selection.py
+++ b/tests/hermes_cli/test_model_selection.py
@@ -1,0 +1,148 @@
+"""Tests for canonical model-selection primitives."""
+
+from __future__ import annotations
+
+import hermes_cli.model_selection as ms
+
+
+class _Pool:
+    def __init__(self, has_credentials: bool):
+        self._has_credentials = has_credentials
+
+    def has_credentials(self) -> bool:
+        return self._has_credentials
+
+
+def test_build_tree_groups_openrouter_and_oauth(monkeypatch):
+    monkeypatch.setattr(ms, "load_pool", lambda provider: _Pool(True))
+    monkeypatch.setattr(ms, "get_codex_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ms, "get_nous_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_qwen_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_auth_status", lambda provider_id=None: {"logged_in": provider_id == "minimax"})
+    monkeypatch.setattr(ms, "get_codex_model_ids", lambda access_token=None: ["gpt-5.4", "gpt-5.4-mini"])
+    monkeypatch.setattr(ms, "OPENROUTER_MODELS", [
+        ("openai/gpt-5.4", ""),
+        ("openai/gpt-5.4-mini", ""),
+        ("anthropic/claude-opus-4.6", ""),
+    ])
+
+    tree = ms.build_model_selection_tree(current_provider="openrouter", current_model="openai/gpt-5.4")
+
+    assert [source.label for source in tree.sources] == ["OpenRouter", "OAuth", "Other providers"]
+    assert tree.sources[0].status_label == "configured"
+    assert [provider.label for provider in tree.providers("openrouter")] == ["OpenAI", "Anthropic"]
+    assert [provider.label for provider in tree.providers("oauth")] == ["OpenAI", "Nous", "Qwen"]
+    assert any(provider.label == "MiniMax" for provider in tree.providers("other"))
+    assert [provider.token for provider in tree.providers("openrouter")] == ["openai", "anthropic"]
+    assert [provider.token for provider in tree.providers("oauth")] == ["openai", "nous", "qwen"]
+
+
+def test_controller_navigates_source_provider_model(monkeypatch):
+    monkeypatch.setattr(ms, "load_pool", lambda provider: _Pool(True))
+    monkeypatch.setattr(ms, "get_codex_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ms, "get_nous_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_qwen_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_auth_status", lambda provider_id=None: {"logged_in": provider_id == "minimax"})
+    monkeypatch.setattr(ms, "get_codex_model_ids", lambda access_token=None: ["gpt-5.4", "gpt-5.4-mini"])
+    monkeypatch.setattr(ms, "OPENROUTER_MODELS", [
+        ("openai/gpt-5.4", ""),
+        ("anthropic/claude-opus-4.6", ""),
+    ])
+
+    controller = ms.ModelSelectionController(
+        ms.build_model_selection_tree(
+            current_provider="openrouter",
+            current_model="openai/gpt-5.4",
+        )
+    )
+
+    assert controller.current_view().level == "source"
+    assert [item.label for item in controller.current_view().items] == ["OpenRouter", "OAuth", "Other providers"]
+
+    request = controller.enter()
+    assert request is None
+    assert controller.current_view().level == "provider"
+    assert controller.current_view().breadcrumb == "OpenRouter"
+
+    controller.move_down()
+    request = controller.enter()
+    assert request is None
+    assert controller.current_view().level == "model"
+    assert controller.current_view().breadcrumb == "OpenRouter / Anthropic"
+
+    request = controller.enter()
+    assert request == ms.ModelSwitchRequest(
+        provider_slug="openrouter",
+        model_id="anthropic/claude-opus-4.6",
+    )
+
+
+def test_controller_back_pops_levels(monkeypatch):
+    monkeypatch.setattr(ms, "load_pool", lambda provider: _Pool(True))
+    monkeypatch.setattr(ms, "get_codex_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ms, "get_nous_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_qwen_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_auth_status", lambda provider_id=None: {"logged_in": provider_id == "minimax"})
+    monkeypatch.setattr(ms, "get_codex_model_ids", lambda access_token=None: ["gpt-5.4"])
+    monkeypatch.setattr(ms, "OPENROUTER_MODELS", [("openai/gpt-5.4", "")])
+
+    controller = ms.ModelSelectionController(ms.build_model_selection_tree())
+    controller.enter()
+    controller.enter()
+
+    assert controller.current_view().level == "model"
+    assert controller.back() is True
+    assert controller.current_view().level == "provider"
+    assert controller.back() is True
+    assert controller.current_view().level == "source"
+    assert controller.back() is False
+
+
+def test_other_source_exposes_minimax_models(monkeypatch):
+    monkeypatch.setattr(ms, "load_pool", lambda provider: _Pool(False))
+    monkeypatch.setattr(ms, "get_codex_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_nous_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_qwen_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_auth_status", lambda provider_id=None: {"logged_in": provider_id == "minimax"})
+    monkeypatch.setattr(ms, "get_codex_model_ids", lambda access_token=None: [])
+
+    tree = ms.build_model_selection_tree(current_provider="minimax", current_model="MiniMax-M2.7")
+    controller = ms.ModelSelectionController(tree)
+
+    controller.set_source("other")
+    provider_labels = [item.label for item in controller.current_view().items]
+    assert "MiniMax" in provider_labels
+
+    minimax_provider = next(provider for provider in tree.providers("other") if provider.provider_slug == "minimax")
+    controller.set_provider(minimax_provider.id)
+    assert controller.current_view().breadcrumb == "Other providers / MiniMax"
+    assert any(item.label == "MiniMax M2.7" for item in controller.current_view().items)
+
+
+def test_other_source_marks_current_provider_when_runtime_provider_is_canonical(monkeypatch):
+    monkeypatch.setattr(ms, "load_pool", lambda provider: _Pool(False))
+    monkeypatch.setattr(ms, "get_codex_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_nous_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(ms, "get_qwen_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(
+        ms,
+        "get_auth_status",
+        lambda provider_id=None: {"logged_in": provider_id == "copilot"},
+    )
+    monkeypatch.setattr(ms, "get_codex_model_ids", lambda access_token=None: [])
+    monkeypatch.setattr(ms, "OPENROUTER_MODELS", [])
+    monkeypatch.setattr(ms, "_PROVIDER_MODELS", {"copilot": ["claude-sonnet-4.6"]})
+
+    tree = ms.build_model_selection_tree(
+        current_provider="github-copilot",
+        current_model="claude-sonnet-4.6",
+    )
+
+    provider = next(
+        provider for provider in tree.providers("other") if provider.provider_slug == "copilot"
+    )
+    assert provider.current is True
+
+    models = tree.models(provider.id)
+    assert len(models) == 1
+    assert models[0].current is True

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -323,6 +323,58 @@ def test_select_provider_and_model_uses_canonical_request_for_openrouter_branch(
     assert captured["persisted"] == "openai/gpt-5.4"
 
 
+def test_select_provider_and_model_reads_repo_fallback_config_for_user_providers(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _clear_provider_env(monkeypatch)
+    (tmp_path / ".hermes").mkdir()
+    (tmp_path / "cli-config.yaml").write_text(
+        "model:\n  provider: auto\n  default: ''\nproviders:\n  lab-provider:\n    name: Lab Provider\n    api: http://lab.example/v1\n    model: lab-model\n",
+        encoding="utf-8",
+    )
+
+    prompt_calls = {"count": 0}
+    captured = {}
+
+    def fake_prompt_provider_choice(choices, default=0):
+        prompt_calls["count"] += 1
+        if prompt_calls["count"] == 1:
+            return next(i for i, choice in enumerate(choices) if choice == "Other providers")
+        if prompt_calls["count"] == 2:
+            return next(i for i, choice in enumerate(choices) if choice.startswith("Lab Provider"))
+        return next(i for i, choice in enumerate(choices) if choice.startswith("Lab Model"))
+
+    def fake_switch_model(**kwargs):
+        captured.update(kwargs)
+        from hermes_cli.model_switch import ModelSwitchResult
+
+        return ModelSwitchResult(
+            success=True,
+            new_model="lab-model",
+            target_provider="lab-provider",
+            provider_changed=True,
+            api_key="",
+            base_url="http://lab.example/v1",
+            api_mode="chat_completions",
+            provider_label="Lab Provider",
+        )
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda provider: None)
+    monkeypatch.setattr("hermes_cli.main.PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr("hermes_cli.main._prompt_provider_choice", fake_prompt_provider_choice)
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
+    monkeypatch.setattr("hermes_cli.main._persist_selected_model_result", lambda result: None)
+
+    from hermes_cli.main import select_provider_and_model
+
+    select_provider_and_model()
+
+    assert captured["explicit_provider"] == "lab-provider"
+    assert captured["raw_input"] == "lab-model"
+    assert captured["user_providers"]["lab-provider"]["api"] == "http://lab.example/v1"
+
+
 def test_codex_setup_uses_runtime_access_token_for_live_model_list(tmp_path, monkeypatch):
     """Codex model list fetching uses the runtime access token."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -237,11 +237,16 @@ def test_select_provider_and_model_warns_if_named_custom_provider_disappears(
     cfg["custom_providers"] = [{"name": "Local", "base_url": "http://localhost:8080/v1"}]
     save_config(cfg)
 
+    prompt_calls = {"count": 0}
+
     def fake_prompt_provider_choice(choices, default=0):
+        prompt_calls["count"] += 1
+        if prompt_calls["count"] == 1:
+            return next(i for i, label in enumerate(choices) if label == "Other providers")
         current = load_config()
         current["custom_providers"] = []
         save_config(current)
-        return next(i for i, label in enumerate(choices) if label.startswith("Local (localhost:8080/v1)"))
+        return next(i for i, label in enumerate(choices) if label.startswith("Local"))
 
     monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda provider: None)
     monkeypatch.setattr("hermes_cli.main._prompt_provider_choice", fake_prompt_provider_choice)
@@ -256,6 +261,66 @@ def test_select_provider_and_model_warns_if_named_custom_provider_disappears(
 
     out = capsys.readouterr().out
     assert "selected saved custom provider is no longer available" in out
+
+
+def test_select_provider_and_model_uses_canonical_request_for_openrouter_branch(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+    cfg = load_config()
+    cfg["model"] = {
+        "provider": "openrouter",
+        "default": "openai/gpt-5.4",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+    save_config(cfg)
+
+    captured = {}
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda provider: "openrouter")
+
+    def fake_prompt_provider_choice(choices, default=0):
+        if "Other providers..." in choices:
+            return 0
+        for idx, choice in enumerate(choices):
+            if choice.startswith("OpenAI"):
+                return idx
+        for idx, choice in enumerate(choices):
+            if choice.startswith("GPT-5.4"):
+                return idx
+        return default
+
+    monkeypatch.setattr("hermes_cli.main._prompt_provider_choice", fake_prompt_provider_choice)
+
+    def fake_switch_model(**kwargs):
+        captured.update(kwargs)
+        from hermes_cli.model_switch import ModelSwitchResult
+
+        return ModelSwitchResult(
+            success=True,
+            new_model="openai/gpt-5.4",
+            target_provider="openrouter",
+            provider_changed=False,
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
+    monkeypatch.setattr("hermes_cli.main._persist_selected_model_result", lambda result: captured.setdefault("persisted", result.new_model))
+
+    from hermes_cli.main import select_provider_and_model
+
+    select_provider_and_model()
+
+    assert captured["explicit_provider"] == "openrouter"
+    assert captured["raw_input"] == "openai/gpt-5.4"
+    assert captured.get("skip_validation", False) is False
+    assert captured["persisted"] == "openai/gpt-5.4"
 
 
 def test_codex_setup_uses_runtime_access_token_for_live_model_list(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

This PR contains the canonical model selector work and now explicitly covers the gateway `/model` picker integration too.

- add `hermes_cli/model_selection.py` as the shared selector/controller layer for the CLI
- wire CLI `/model` interactions onto the canonical picker flow
- reuse the same model-selection primitives in setup and command surfaces
- keep model switching routed through the existing shared `model_switch` pipeline
- add gateway tests proving Telegram/Discord `/model` picker flows use the shared `model_switch` backend rather than a separate platform-specific switch path

## Why it changed

Model selection logic was split across command parsing, setup prompts, and inline UI behavior. The CLI picker needed a canonical controller, and the gateway picker path needed explicit coverage so the shared backend contract is not just implicit.

## User and developer impact

Users get a cleaner inline model picker in the CLI, while Telegram and Discord continue to use platform-native picker UI backed by the same switch pipeline.

Developers get one controller-driven selection path for the CLI and explicit tests that gateway pickers are sharing the backend model switch logic.

## Root cause

Provider/model selection semantics and interaction behavior were spread across non-canonical UI and setup flows rather than a shared controller. The gateway picker path already used the shared backend, but that contract was not directly tested.

## Validation

- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m py_compile cli.py hermes_cli/commands.py hermes_cli/model_selection.py hermes_cli/main.py hermes_cli/model_switch.py tests/cli/test_cli_model_picker.py tests/hermes_cli/test_model_selection.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_commands.py`
- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m pytest -o addopts='' tests/cli/test_cli_model_picker.py tests/hermes_cli/test_model_selection.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_commands.py -q`
  - `130 passed in 4.75s`
- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m pytest -o addopts='' tests/gateway/test_model_picker_integration.py -q`
  - `3 passed in 0.15s`

## Notes

- the backend model-switch path is shared across CLI and gateway
- the picker UI remains platform-specific: CLI uses the inline selector, Telegram/Discord use native picker surfaces
