### PR TITLE
[codex] Handle fork PR comment failures in supply chain audit

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -185,8 +185,13 @@ jobs:
 
           printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
 
-          if ! gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"; then
-            echo "::warning::Unable to post PR comment (likely fork PR token restrictions). Findings were written to the job summary instead."
+          if ! COMMENT_ERR="$(gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" 2>&1)"; then
+            if printf '%s' "$COMMENT_ERR" | grep -Eqi 'resource not accessible by integration|http 403|forbidden'; then
+              echo "::warning::Unable to post PR comment due to token restrictions. Findings were written to the job summary instead."
+            else
+              echo "$COMMENT_ERR" >&2
+              exit 1
+            fi
           fi
 
       - name: Fail on critical findings

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -183,9 +183,8 @@ jobs:
           ---
           *Automated scan triggered by [supply-chain-audit](/.github/workflows/supply-chain-audit.yml). If this is a false positive, a maintainer can approve after manual review.*"
 
-          printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
-
           if ! COMMENT_ERR="$(gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" 2>&1)"; then
+            printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
             if printf '%s' "$COMMENT_ERR" | grep -Eqi 'resource not accessible by integration|http 403|forbidden'; then
               echo "::warning::Unable to post PR comment due to token restrictions. Findings were written to the job summary instead."
             else

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -183,10 +183,14 @@ jobs:
           ---
           *Automated scan triggered by [supply-chain-audit](/.github/workflows/supply-chain-audit.yml). If this is a false positive, a maintainer can approve after manual review.*"
 
-          gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
+          printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
+
+          if ! gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"; then
+            echo "::warning::Unable to post PR comment (likely fork PR token restrictions). Findings were written to the job summary instead."
+          fi
 
       - name: Fail on critical findings
         if: steps.scan.outputs.critical == 'true'
         run: |
-          echo "::error::CRITICAL supply chain risk patterns detected in this PR. See the PR comment for details."
+          echo "::error::CRITICAL supply chain risk patterns detected in this PR. See the PR comment or job summary for details."
           exit 1


### PR DESCRIPTION
## What changed

- guard the supply-chain audit PR comment path so fork PR comment failures do not break the workflow

## Why it changed

Fork PRs do not always have permission to post the same write-side review/comment artifacts as same-repo branches. The workflow should keep auditing instead of failing on that secondary path.

## Impact

Fork PRs keep the supply-chain audit signal without spurious workflow failures from the comment step.

## Validation

- `ruby -e 'require "yaml"; data = YAML.load_file(".github/workflows/supply-chain-audit.yml"); raise "missing jobs" unless data.is_a?(Hash) && data["jobs"]'`
