### PR TITLE
fix(honcho): fully shut down async writer + close HTTP client on exit

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -697,12 +697,24 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
+        # Gracefully flush + join the async writer thread, then close the
+        # underlying HTTP client. Without this, the background writer and
+        # httpx connection pool can still be live during interpreter teardown,
+        # which caused crashes at exit.
         if self._manager:
             try:
-                self._manager.flush_all()
-            except Exception:
-                pass
+                self._manager.shutdown()
+            except Exception as e:
+                logger.debug("Honcho manager shutdown error: %s", e)
+            try:
+                client = getattr(self._manager, "_honcho", None) or getattr(
+                    self._manager, "honcho", None
+                )
+                http = getattr(client, "_http", None) if client else None
+                if http is not None and hasattr(http, "close"):
+                    http.close()
+            except Exception as e:
+                logger.debug("Honcho HTTP client close error: %s", e)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`HonchoMemoryProvider.shutdown()` only called `flush_all()`, which leaves two things alive at interpreter teardown:

1. The `honcho-async-writer` background thread (owned by `HonchoSessionManager`) — `flush_all()` drains the queue but never sends `_ASYNC_SHUTDOWN` and never joins the thread.
2. The underlying `httpx.Client` inside the Honcho SDK (`honcho._http._client`) — its connection pool is still open when Python finalizes.

This race caused intermittent crashes during clean exit.

## Fix

`HonchoMemoryProvider.shutdown()` now:

1. Calls `HonchoSessionManager.shutdown()` (which already does flush → `_ASYNC_SHUTDOWN` → `join`).
2. Explicitly closes `honcho._http` so the httpx pool is torn down before finalization.

Both wrapped in `try/except` with debug logging — shutdown must never raise.

## Verification

Offline smoke test with a mocked Honcho client:

```
async thread: <Thread(honcho-async-writer, started daemon ...)>
alive before: True
alive after : False
http.close called: True
```

Full honcho test suite: **141 passed, 3 skipped**.

Sibling memory plugins (byterover, hindsight, holographic) were audited for the same pattern — none affected. supermemory is not installed in this environment.