### PR TITLE
fix(skills): follow symlinks with cycle guard across all skill discovery paths

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -207,7 +207,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_external_skills_dirs, walk_skill_files
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
@@ -218,9 +218,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
-            for skill_md in scan_dir.rglob("SKILL.md"):
-                if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
-                    continue
+            for skill_md in walk_skill_files(scan_dir, "SKILL.md"):
                 try:
                     content = skill_md.read_text(encoding='utf-8')
                     frontmatter, body = _parse_frontmatter(content)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -429,15 +429,40 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 # ── File iteration ────────────────────────────────────────────────────────
 
 
+def walk_skill_files(base_dir: Path, filename: str) -> List[Path]:
+    """Walk *base_dir* returning sorted paths matching *filename*.
+
+    Follows symlinked directories so that skills installed via ``ln -s``
+    are discovered.  Uses ``(st_dev, st_ino)`` to detect directory cycles
+    and avoid infinite recursion.
+
+    Excludes ``.git``, ``.github``, ``.hub`` directories.
+    """
+    results: List[Path] = []
+    seen_real: set = set()
+    for root, dirs, files in os.walk(base_dir, followlinks=True):
+        # Cycle guard: skip directories we have already traversed
+        try:
+            st = os.stat(root)
+            ident = (st.st_dev, st.st_ino)
+        except OSError:
+            dirs[:] = []
+            continue
+        if ident in seen_real:
+            dirs[:] = []
+            continue
+        seen_real.add(ident)
+        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+        if filename in files:
+            results.append(Path(root) / filename)
+    return sorted(results, key=lambda p: str(p))
+
+
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
     Excludes ``.git``, ``.github``, ``.hub`` directories.
+    Follows symlinks with cycle detection (delegates to :func:`walk_skill_files`).
     """
-    matches = []
-    for root, dirs, files in os.walk(skills_dir):
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
-        if filename in files:
-            matches.append(Path(root) / filename)
-    for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):
+    for path in walk_skill_files(skills_dir, filename):
         yield path

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -377,16 +377,14 @@ def _check_unavailable_skill(command_name: str) -> str | None:
     normalized = command_name.lower().replace("_", "-")
     try:
         from tools.skills_tool import _get_disabled_skill_names
-        from agent.skill_utils import get_all_skills_dirs
+        from agent.skill_utils import get_all_skills_dirs, walk_skill_files
         disabled = _get_disabled_skill_names()
 
         # Check disabled skills across all dirs (local + external)
         for skills_dir in get_all_skills_dirs():
             if not skills_dir.exists():
                 continue
-            for skill_md in skills_dir.rglob("SKILL.md"):
-                if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
-                    continue
+            for skill_md in walk_skill_files(skills_dir, "SKILL.md"):
                 name = skill_md.parent.name.lower().replace("_", "-")
                 if name == normalized and name in disabled:
                     return (
@@ -399,7 +397,7 @@ def _check_unavailable_skill(command_name: str) -> str | None:
         repo_root = Path(__file__).resolve().parent.parent
         optional_dir = get_optional_skills_dir(repo_root / "optional-skills")
         if optional_dir.exists():
-            for skill_md in optional_dir.rglob("SKILL.md"):
+            for skill_md in walk_skill_files(optional_dir, "SKILL.md"):
                 name = skill_md.parent.name.lower().replace("_", "-")
                 if name == normalized:
                     # Build install path: official/<category>/<name>

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -321,11 +321,8 @@ def _count_skills(profile_dir: Path) -> int:
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return 0
-    count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if "/.hub/" not in str(md) and "/.git/" not in str(md):
-            count += 1
-    return count
+    from agent.skill_utils import walk_skill_files
+    return len(walk_skill_files(skills_dir, "SKILL.md"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -46,6 +46,35 @@ class TestScanSkillCommands:
         assert "/my-skill" in result
         assert result["/my-skill"]["name"] == "my-skill"
 
+    def test_finds_symlinked_skill(self, tmp_path):
+        """Skills installed via symlink should be discovered."""
+        real_dir = tmp_path / "real" / "linked-skill"
+        real_dir.mkdir(parents=True)
+        (real_dir / "SKILL.md").write_text(
+            "---\nname: linked-skill\ndescription: A symlinked skill.\n---\n\nBody.\n"
+        )
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "linked-skill").symlink_to(real_dir, target_is_directory=True)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            result = scan_skill_commands()
+        assert "/linked-skill" in result
+        assert result["/linked-skill"]["name"] == "linked-skill"
+
+    def test_symlink_cycle_does_not_hang(self, tmp_path):
+        """A symlink cycle inside the skills dir must not cause infinite recursion."""
+        skill_dir = tmp_path / "cyclic-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: cyclic-skill\ndescription: Has a cycle.\n---\n\nBody.\n"
+        )
+        # Create a directory symlink that points back to the skills root
+        (skill_dir / "loop").symlink_to(tmp_path, target_is_directory=True)
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = scan_skill_commands()
+        # Should still find the skill without hanging
+        assert "/cyclic-skill" in result
+
     def test_empty_dir(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             result = scan_skill_commands()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -204,11 +204,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs
+    from agent.skill_utils import get_all_skills_dirs, walk_skill_files
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in walk_skill_files(skills_dir, "SKILL.md"):
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -529,7 +529,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs
+    from agent.skill_utils import get_external_skills_dirs, walk_skill_files
 
     skills = []
     seen_names: set = set()
@@ -544,9 +544,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
-        for skill_md in scan_dir.rglob("SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
-                continue
+        for skill_md in walk_skill_files(scan_dir, "SKILL.md"):
 
             skill_dir = skill_md.parent
 
@@ -671,12 +669,11 @@ def skills_categories(verbose: bool = False, task_id: str = None) -> str:
                 ensure_ascii=False,
             )
 
+        from agent.skill_utils import walk_skill_files as _walk
         category_dirs = {}
         category_counts: Dict[str, int] = {}
         for scan_dir in all_dirs:
-            for skill_md in scan_dir.rglob("SKILL.md"):
-                if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
-                    continue
+            for skill_md in _walk(scan_dir, "SKILL.md"):
 
                 try:
                     frontmatter, _ = _parse_frontmatter(
@@ -832,8 +829,9 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
 
         # Search by directory name across all dirs
         if not skill_md:
+            from agent.skill_utils import walk_skill_files as _walk
             for search_dir in all_dirs:
-                for found_skill_md in search_dir.rglob("SKILL.md"):
+                for found_skill_md in _walk(search_dir, "SKILL.md"):
                     if found_skill_md.parent.name == name:
                         skill_dir = found_skill_md.parent
                         skill_md = found_skill_md


### PR DESCRIPTION
## Summary

Skills installed via directory symlink (e.g. `ln -s /path/to/skill ~/.hermes/skills/my-skill`) are silently ignored because Python's `pathlib.Path.rglob()` does **not follow symlinked directories** by default. This affects **all** skill discovery paths — not just slash command registration but also `skills list`, `skills categories`, `skill_view` fallback search, `skill_manager` operations, and gateway unavailable-skill hints.

## Root Cause

`Path.rglob()` skips symlinked directories during traversal (documented Python behavior). When a skill directory itself is a symlink, `rglob("SKILL.md")` never enters it, so the skill is invisible to the entire system.

## Fix

Introduce a single shared `walk_skill_files()` function in `agent/skill_utils.py` that:
1. Uses `os.walk(followlinks=True)` to traverse into symlinked directories
2. Maintains a `(st_dev, st_ino)` visited set to **detect and break symlink cycles**
3. Excludes `.git`, `.github`, `.hub` directories (consistent with existing behavior)

Then replace all `rglob("SKILL.md")` calls across the skill discovery surface:

| File | Function | Change |
|------|----------|--------|
| `agent/skill_utils.py` | `iter_skill_index_files` | Delegates to `walk_skill_files` |
| `agent/skill_commands.py` | `scan_skill_commands` | `rglob` → `walk_skill_files` |
| `tools/skills_tool.py` | `_find_all_skills` | `rglob` → `walk_skill_files` |
| `tools/skills_tool.py` | `skills_categories` | `rglob` → `walk_skill_files` |
| `tools/skills_tool.py` | `skill_view` (name search) | `rglob` → `walk_skill_files` |
| `tools/skill_manager_tool.py` | `_find_skill` | `rglob` → `walk_skill_files` |
| `gateway/run.py` | `_check_unavailable_skill` | `rglob` → `walk_skill_files` |
| `hermes_cli/profiles.py` | `_count_skills` | `rglob` → `walk_skill_files` |

**Not changed** (repo-internal dirs, no user symlinks expected):
- `tools/skills_hub.py` — scans `optional-skills/` bundled in repo
- `tools/skills_sync.py` — scans bundled skills
- `hermes_cli/dump.py` — export utility

## Reproduction

```bash
# Create a symlinked skill
ln -s /path/to/my-skill ~/.hermes/skills/my-skill

# Before fix: skill invisible everywhere
# After fix: skill discovered in all paths (slash commands, list, categories, etc.)
```

## Cycle Safety

A symlink cycle (e.g. `skill-dir/loop -> ~/.hermes/skills/`) would cause `os.walk(followlinks=True)` to recurse infinitely. The `walk_skill_files` function tracks visited directories by `(st_dev, st_ino)` and prunes already-seen directories, preventing infinite loops.

## Test Plan

Two new tests added to `tests/agent/test_skill_commands.py`:
- **`test_finds_symlinked_skill`** — symlinked skill directory is discovered by `scan_skill_commands()`
- **`test_symlink_cycle_does_not_hang`** — directory cycle does not cause infinite recursion

Existing 26 tests continue to pass.

## Known Limitation

Symlinked skills whose resolved path falls outside `~/.hermes/skills/` will trigger a security warning log ("skill file is outside the trusted skills directory"). This is cosmetic and does not affect functionality. Addressing this is out of scope for this PR.