### PR TITLE
[codex] Unify provider alias resolution

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -38,6 +38,7 @@ import httpx
 import yaml
 
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
+from hermes_cli.providers import normalize_provider as normalize_provider_id
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
@@ -892,30 +893,7 @@ def resolve_provider(
     4. Provider-specific API keys (GLM, Kimi, MiniMax) -> that provider
     5. Fallback: "openrouter"
     """
-    normalized = (requested or "auto").strip().lower()
-
-    # Normalize provider aliases
-    _PROVIDER_ALIASES = {
-        "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
-        "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
-        "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
-        "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
-        "claude": "anthropic", "claude-code": "anthropic",
-        "github": "copilot", "github-copilot": "copilot",
-        "github-models": "copilot", "github-model": "copilot",
-        "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
-        "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
-        "opencode": "opencode-zen", "zen": "opencode-zen",
-        "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
-        "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
-        "go": "opencode-go", "opencode-go-sub": "opencode-go",
-        "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
-        # Local server aliases — route through the generic custom provider
-        "lmstudio": "custom", "lm-studio": "custom", "lm_studio": "custom",
-        "ollama": "custom", "vllm": "custom", "llamacpp": "custom",
-        "llama.cpp": "custom", "llama-cpp": "custom",
-    }
-    normalized = _PROVIDER_ALIASES.get(normalized, normalized)
+    normalized = normalize_provider_id((requested or "auto").strip().lower())
 
     if normalized == "openrouter":
         return "openrouter"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -894,6 +894,8 @@ def resolve_provider(
     5. Fallback: "openrouter"
     """
     normalized = normalize_provider_id((requested or "auto").strip().lower())
+    if normalized in {"lmstudio", "ollama-cloud", "local"}:
+        normalized = "custom"
 
     if normalized == "openrouter":
         return "openrouter"

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -14,6 +14,10 @@ import urllib.error
 from difflib import get_close_matches
 from typing import Any, Optional
 
+from hermes_cli.providers import ALIASES as PROVIDER_ALIASES
+from hermes_cli.providers import get_label as get_provider_label
+from hermes_cli.providers import normalize_provider as normalize_provider_id
+
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_EDITOR_VERSION = "vscode/1.104.1"
@@ -495,46 +499,7 @@ _PROVIDER_LABELS = {
     "custom": "Custom endpoint",
 }
 
-_PROVIDER_ALIASES = {
-    "glm": "zai",
-    "z-ai": "zai",
-    "z.ai": "zai",
-    "zhipu": "zai",
-    "github": "copilot",
-    "github-copilot": "copilot",
-    "github-models": "copilot",
-    "github-model": "copilot",
-    "github-copilot-acp": "copilot-acp",
-    "copilot-acp-agent": "copilot-acp",
-    "google": "gemini",
-    "google-gemini": "gemini",
-    "google-ai-studio": "gemini",
-    "kimi": "kimi-coding",
-    "moonshot": "kimi-coding",
-    "minimax-china": "minimax-cn",
-    "minimax_cn": "minimax-cn",
-    "claude": "anthropic",
-    "claude-code": "anthropic",
-    "deep-seek": "deepseek",
-    "opencode": "opencode-zen",
-    "zen": "opencode-zen",
-    "go": "opencode-go",
-    "opencode-go-sub": "opencode-go",
-    "aigateway": "ai-gateway",
-    "vercel": "ai-gateway",
-    "vercel-ai-gateway": "ai-gateway",
-    "kilo": "kilocode",
-    "kilo-code": "kilocode",
-    "kilo-gateway": "kilocode",
-    "dashscope": "alibaba",
-    "aliyun": "alibaba",
-    "qwen": "alibaba",
-    "alibaba-cloud": "alibaba",
-    "qwen-portal": "qwen-oauth",
-    "hf": "huggingface",
-    "hugging-face": "huggingface",
-    "huggingface-hub": "huggingface",
-}
+_PROVIDER_ALIASES = dict(PROVIDER_ALIASES)
 
 
 def _openrouter_model_is_free(pricing: Any) -> bool:
@@ -955,7 +920,7 @@ def detect_provider_for_model(
     # provider switch and pick the first model from that provider's catalog.
     # Skip "custom" and "openrouter" — custom has no model catalog, and
     # openrouter requires an explicit model name to be useful.
-    resolved_provider = _PROVIDER_ALIASES.get(name_lower, name_lower)
+    resolved_provider = normalize_provider(name_lower)
     if resolved_provider not in {"custom", "openrouter"}:
         default_models = _PROVIDER_MODELS.get(resolved_provider, [])
         if (
@@ -1057,7 +1022,7 @@ def normalize_provider(provider: Optional[str]) -> str:
     provider based on credentials and environment.
     """
     normalized = (provider or "openrouter").strip().lower()
-    return _PROVIDER_ALIASES.get(normalized, normalized)
+    return normalize_provider_id(normalized)
 
 
 def provider_label(provider: Optional[str]) -> str:
@@ -1067,7 +1032,8 @@ def provider_label(provider: Optional[str]) -> str:
     if normalized == "auto":
         return "Auto"
     normalized = normalize_provider(normalized)
-    return _PROVIDER_LABELS.get(normalized, original or "OpenRouter")
+    label = get_provider_label(normalized)
+    return label or _PROVIDER_LABELS.get(normalized, original or "OpenRouter")
 
 
 # Models that support OpenAI Priority Processing (service_tier="priority").

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -70,7 +70,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
-    "github-copilot": HermesOverlay(
+    "copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
     ),
@@ -83,7 +83,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         extra_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         base_url_env_var="GLM_BASE_URL",
     ),
-    "kimi-for-coding": HermesOverlay(
+    "kimi-coding": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="KIMI_BASE_URL",
     ),
@@ -103,11 +103,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
-    "vercel": HermesOverlay(
+    "ai-gateway": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
     ),
-    "opencode": HermesOverlay(
+    "opencode-zen": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
         base_url_env_var="OPENCODE_ZEN_BASE_URL",
@@ -117,7 +117,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
-    "kilo": HermesOverlay(
+    "kilocode": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
         base_url_env_var="KILOCODE_BASE_URL",
@@ -162,6 +162,11 @@ ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 
+    # gemini
+    "google": "gemini",
+    "google-gemini": "gemini",
+    "google-ai-studio": "gemini",
+
     # zai
     "glm": "zai",
     "z-ai": "zai",
@@ -172,10 +177,10 @@ ALIASES: Dict[str, str] = {
     "x-ai": "xai",
     "x.ai": "xai",
 
-    # kimi-for-coding (models.dev ID)
-    "kimi": "kimi-for-coding",
-    "kimi-coding": "kimi-for-coding",
-    "moonshot": "kimi-for-coding",
+    # kimi-coding
+    "kimi": "kimi-coding",
+    "kimi-for-coding": "kimi-coding",
+    "moonshot": "kimi-coding",
 
     # minimax-cn
     "minimax-china": "minimax-cn",
@@ -185,28 +190,31 @@ ALIASES: Dict[str, str] = {
     "claude": "anthropic",
     "claude-code": "anthropic",
 
-    # github-copilot (models.dev ID)
-    "copilot": "github-copilot",
-    "github": "github-copilot",
+    # copilot
+    "github": "copilot",
+    "github-copilot": "copilot",
+    "github-models": "copilot",
+    "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
+    "copilot-acp-agent": "copilot-acp",
 
-    # vercel (models.dev ID for AI Gateway)
-    "ai-gateway": "vercel",
-    "aigateway": "vercel",
-    "vercel-ai-gateway": "vercel",
+    # ai-gateway
+    "aigateway": "ai-gateway",
+    "vercel": "ai-gateway",
+    "vercel-ai-gateway": "ai-gateway",
 
-    # opencode (models.dev ID for OpenCode Zen)
-    "opencode-zen": "opencode",
-    "zen": "opencode",
+    # opencode-zen
+    "opencode": "opencode-zen",
+    "zen": "opencode-zen",
 
     # opencode-go
     "go": "opencode-go",
     "opencode-go-sub": "opencode-go",
 
-    # kilo (models.dev ID for KiloCode)
-    "kilocode": "kilo",
-    "kilo-code": "kilo",
-    "kilo-gateway": "kilo",
+    # kilocode
+    "kilo": "kilocode",
+    "kilo-code": "kilocode",
+    "kilo-gateway": "kilocode",
 
     # deepseek
     "deep-seek": "deepseek",
@@ -216,21 +224,23 @@ ALIASES: Dict[str, str] = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "qwen-portal": "qwen-oauth",
+    "qwen-cli": "qwen-oauth",
 
     # huggingface
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
 
-    # Local server aliases → virtual "local" concept (resolved via user config)
-    "lmstudio": "lmstudio",
-    "lm-studio": "lmstudio",
-    "lm_studio": "lmstudio",
-    "ollama": "ollama-cloud",
-    "vllm": "local",
-    "llamacpp": "local",
-    "llama.cpp": "local",
-    "llama-cpp": "local",
+    # Local server aliases → generic custom endpoint
+    "lmstudio": "custom",
+    "lm-studio": "custom",
+    "lm_studio": "custom",
+    "ollama": "custom",
+    "vllm": "custom",
+    "llamacpp": "custom",
+    "llama.cpp": "custom",
+    "llama-cpp": "custom",
 }
 
 
@@ -241,8 +251,18 @@ ALIASES: Dict[str, str] = {
 _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
+    "copilot": "GitHub Copilot",
     "copilot-acp": "GitHub Copilot ACP",
-    "local": "Local endpoint",
+    "gemini": "Google AI Studio",
+    "zai": "Z.AI / GLM",
+    "kimi-coding": "Kimi / Moonshot",
+    "minimax-cn": "MiniMax (China)",
+    "deepseek": "DeepSeek",
+    "opencode-zen": "OpenCode Zen",
+    "opencode-go": "OpenCode Go",
+    "ai-gateway": "AI Gateway",
+    "kilocode": "Kilo Code",
+    "custom": "Custom endpoint",
 }
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -232,15 +232,15 @@ ALIASES: Dict[str, str] = {
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
 
-    # Local server aliases → generic custom endpoint
-    "lmstudio": "custom",
-    "lm-studio": "custom",
-    "lm_studio": "custom",
-    "ollama": "custom",
-    "vllm": "custom",
-    "llamacpp": "custom",
-    "llama.cpp": "custom",
-    "llama-cpp": "custom",
+    # Local server aliases → preserve Hermes-facing IDs for /model flows
+    "lmstudio": "lmstudio",
+    "lm-studio": "lmstudio",
+    "lm_studio": "lmstudio",
+    "ollama": "ollama-cloud",
+    "vllm": "local",
+    "llamacpp": "local",
+    "llama.cpp": "local",
+    "llama-cpp": "local",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -266,7 +266,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     # ``custom:local`` always target the saved custom provider.
     if requested_norm == "auto":
         return None
-    if not requested_norm.startswith("custom:"):
+    local_aliases = {"local", "lmstudio", "ollama-cloud"}
+    if not requested_norm.startswith("custom:") and requested_norm not in local_aliases:
         try:
             auth_mod.resolve_provider(requested_norm)
         except AuthError:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -27,6 +27,7 @@ from hermes_cli.auth import (
     has_usable_secret,
 )
 from hermes_cli.config import load_config
+from hermes_cli.providers import normalize_provider as normalize_provider_id
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -97,8 +98,8 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     persisted mode when the config's provider matches the runtime
     provider (or when no configured provider is recorded).
     """
-    normalized_provider = (provider or "").strip().lower()
-    normalized_configured = (configured_provider or "").strip().lower()
+    normalized_provider = normalize_provider_id((provider or "").strip().lower()) if provider else ""
+    normalized_configured = normalize_provider_id((configured_provider or "").strip().lower()) if configured_provider else ""
     if not normalized_configured:
         return True
     if normalized_provider == "custom":
@@ -107,7 +108,7 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
 
 
 def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
-    configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+    configured_provider = normalize_provider_id(str(model_cfg.get("provider") or "").strip().lower()) if model_cfg.get("provider") else ""
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
@@ -156,7 +157,7 @@ def _resolve_runtime_from_pool_entry(
         base_url = base_url or DEFAULT_QWEN_BASE_URL
     elif provider == "anthropic":
         api_mode = "anthropic_messages"
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_provider = normalize_provider_id(str(model_cfg.get("provider") or "").strip().lower()) if model_cfg.get("provider") else ""
         cfg_base_url = ""
         if cfg_provider == "anthropic":
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
@@ -168,7 +169,7 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
     else:
-        configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+        configured_provider = normalize_provider_id(str(model_cfg.get("provider") or "").strip().lower()) if model_cfg.get("provider") else ""
         # Honour model.base_url from config.yaml when the configured provider
         # matches this provider — same pattern as the Anthropic branch above.
         # Only override when the pool entry has no explicit base_url (i.e. it
@@ -366,8 +367,8 @@ def _resolve_openrouter_runtime(
         if isinstance(v, str) and v.strip():
             cfg_api_key = v.strip()
             break
-    requested_norm = (requested_provider or "").strip().lower()
-    cfg_provider = cfg_provider.strip().lower()
+    requested_norm = normalize_provider_id((requested_provider or "").strip().lower()) if requested_provider else ""
+    cfg_provider = normalize_provider_id(cfg_provider.strip().lower()) if cfg_provider else ""
 
     env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
 
@@ -462,7 +463,7 @@ def _resolve_explicit_runtime(
         return None
 
     if provider == "anthropic":
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_provider = normalize_provider_id(str(model_cfg.get("provider") or "").strip().lower()) if model_cfg.get("provider") else ""
         cfg_base_url = ""
         if cfg_provider == "anthropic":
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
@@ -616,7 +617,7 @@ def resolve_runtime_provider(
 
     should_use_pool = provider != "openrouter"
     if provider == "openrouter":
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_provider = normalize_provider_id(str(model_cfg.get("provider") or "").strip().lower()) if model_cfg.get("provider") else ""
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
         env_openai_base_url = os.getenv("OPENAI_BASE_URL", "").strip()
         env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
@@ -787,7 +788,7 @@ def resolve_runtime_provider(
         if provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
         else:
-            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+            configured_provider = normalize_provider_id(str(model_cfg.get("provider") or "").strip().lower()) if model_cfg.get("provider") else ""
             # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -155,6 +155,8 @@ class TestNormalizeProvider:
         assert normalize_provider("kimi") == "kimi-coding"
         assert normalize_provider("moonshot") == "kimi-coding"
         assert normalize_provider("github-copilot") == "copilot"
+        assert normalize_provider("lmstudio") == "lmstudio"
+        assert normalize_provider("ollama") == "ollama-cloud"
 
     def test_case_insensitive(self):
         assert normalize_provider("OpenRouter") == "openrouter"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1066,6 +1066,12 @@ def test_resolve_provider_custom_returns_custom():
     assert resolve_provider("custom") == "custom"
 
 
+def test_resolve_provider_local_aliases_still_route_to_custom():
+    from hermes_cli.auth import resolve_provider
+    assert resolve_provider("lmstudio") == "custom"
+    assert resolve_provider("ollama") == "custom"
+
+
 def test_resolve_provider_openrouter_unchanged():
     """resolve_provider('openrouter') must still return 'openrouter'."""
     from hermes_cli.auth import resolve_provider


### PR DESCRIPTION
## What changed

This PR narrows provider identity to one shared alias resolver and one Hermes-facing canonical ID namespace.

- make `hermes_cli.providers` canonicalize aliases to the Hermes provider IDs already used by auth and model-selection code
- update `hermes_cli.auth.resolve_provider()` to use the shared resolver instead of its own alias table
- update `hermes_cli.models.normalize_provider()` and related provider parsing paths to use the same shared resolver
- preserve Hermes-facing provider labels in the shared provider layer so adopting the resolver does not silently churn UI labels

## Why it changed

Provider alias normalization had drifted across `providers.py`, `auth.py`, and `models.py`. The same input string could normalize to different internal IDs depending on which subsystem touched it first.

## Impact

- provider additions and alias changes now have one primary normalization path
- auth, model parsing, and provider labels agree on Hermes provider IDs more consistently
- the models.dev integration remains behind `providers.py` instead of leaking its naming directly into auth/model UX

## Validation

- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m py_compile hermes_cli/providers.py hermes_cli/auth.py hermes_cli/models.py`
- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_gemini_provider.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_overlay_slug_resolution.py tests/hermes_cli/test_runtime_provider_resolution.py -q`
  - `292 passed in 7.55s`
