### PR TITLE
[codex] Read CLI skill commands from the live registry

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -262,9 +262,13 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     return _skill_commands
 
 
-def get_skill_commands() -> Dict[str, Dict[str, Any]]:
-    """Return the current skill commands mapping (scan first if empty)."""
-    if not _skill_commands:
+def get_skill_commands(*, force_refresh: bool = False) -> Dict[str, Dict[str, Any]]:
+    """Return the current skill commands mapping.
+
+    When ``force_refresh`` is true, rescan the skill directories even if a
+    previous result is cached.
+    """
+    if force_refresh or not _skill_commands:
         scan_skill_commands()
     return _skill_commands
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
+_skill_commands_dirty: bool = True
 _PLAN_SLUG_RE = re.compile(r"[^a-z0-9]+")
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
@@ -203,7 +204,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands
+    global _skill_commands, _skill_commands_dirty
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
@@ -259,6 +260,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     continue
     except Exception:
         pass
+    _skill_commands_dirty = False
     return _skill_commands
 
 
@@ -268,9 +270,15 @@ def get_skill_commands(*, force_refresh: bool = False) -> Dict[str, Dict[str, An
     When ``force_refresh`` is true, rescan the skill directories even if a
     previous result is cached.
     """
-    if force_refresh or not _skill_commands:
+    if force_refresh or _skill_commands_dirty or not _skill_commands:
         scan_skill_commands()
     return _skill_commands
+
+
+def mark_skill_commands_dirty() -> None:
+    """Mark cached slash skill commands stale so the next lookup rescans."""
+    global _skill_commands_dirty
+    _skill_commands_dirty = True
 
 
 def resolve_skill_command_key(command: str) -> Optional[str]:

--- a/cli.py
+++ b/cli.py
@@ -1365,13 +1365,18 @@ def _looks_like_slash_command(text: str) -> bool:
 # ============================================================================
 
 from agent.skill_commands import (
-    scan_skill_commands,
+    get_skill_commands,
     build_skill_invocation_message,
     build_plan_path,
     build_preloaded_skills_prompt,
 )
 
-_skill_commands = scan_skill_commands()
+_skill_commands = None
+
+
+def _current_skill_commands() -> dict:
+    """Return live skill commands unless a test/override has patched them in."""
+    return _skill_commands if _skill_commands is not None else get_skill_commands()
 
 
 def _get_plugin_cmd_handler_names() -> set:
@@ -3503,9 +3508,10 @@ class HermesCLI:
                     continue
                 ChatConsole().print(f"    [bold {_accent_hex()}]{cmd:<15}[/] [dim]-[/] {_escape(desc)}")
 
-        if _skill_commands:
-            _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed):")
-            for cmd, info in sorted(_skill_commands.items()):
+        skill_commands = _current_skill_commands()
+        if skill_commands:
+            _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(skill_commands)} installed):")
+            for cmd, info in sorted(skill_commands.items()):
                 ChatConsole().print(
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"
                 )
@@ -5025,6 +5031,7 @@ class HermesCLI:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]
             quick_commands = self.config.get("quick_commands", {})
+            skill_commands = _current_skill_commands()
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
                 if qcmd.get("type") == "exec":
@@ -5071,13 +5078,13 @@ class HermesCLI:
                     except Exception as e:
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
-            elif base_cmd in _skill_commands:
+            elif base_cmd in skill_commands:
                 user_instruction = cmd_original[len(base_cmd):].strip()
                 msg = build_skill_invocation_message(
                     base_cmd, user_instruction, task_id=self.session_id
                 )
                 if msg:
-                    skill_name = _skill_commands[base_cmd]["name"]
+                    skill_name = skill_commands[base_cmd]["name"]
                     print(f"\n⚡ Loading skill: {skill_name}")
                     if hasattr(self, '_pending_input'):
                         self._pending_input.put(msg)
@@ -5089,7 +5096,7 @@ class HermesCLI:
                 # that execution-time resolution agrees with tab-completion.
                 from hermes_cli.commands import COMMANDS
                 typed_base = cmd_lower.split()[0]
-                all_known = set(COMMANDS) | set(_skill_commands)
+                all_known = set(COMMANDS) | set(skill_commands)
                 matches = [c for c in all_known if c.startswith(typed_base)]
                 if len(matches) > 1:
                     # Prefer an exact match (typed the full command name)
@@ -8173,7 +8180,7 @@ class HermesCLI:
 
 
         _completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: _skill_commands,
+            skill_commands_provider=_current_skill_commands,
             command_filter=cli_ref._command_available,
         )
         input_area = TextArea(

--- a/cli.py
+++ b/cli.py
@@ -1376,7 +1376,7 @@ _skill_commands = None
 
 def _current_skill_commands() -> dict:
     """Return live skill commands unless a test/override has patched them in."""
-    return _skill_commands if _skill_commands is not None else get_skill_commands()
+    return _skill_commands if _skill_commands is not None else get_skill_commands(force_refresh=True)
 
 
 def _get_plugin_cmd_handler_names() -> set:

--- a/cli.py
+++ b/cli.py
@@ -1366,6 +1366,7 @@ def _looks_like_slash_command(text: str) -> bool:
 
 from agent.skill_commands import (
     get_skill_commands,
+    mark_skill_commands_dirty,
     build_skill_invocation_message,
     build_plan_path,
     build_preloaded_skills_prompt,
@@ -1376,7 +1377,7 @@ _skill_commands = None
 
 def _current_skill_commands() -> dict:
     """Return live skill commands unless a test/override has patched them in."""
-    return _skill_commands if _skill_commands is not None else get_skill_commands(force_refresh=True)
+    return _skill_commands if _skill_commands is not None else get_skill_commands()
 
 
 def _get_plugin_cmd_handler_names() -> set:
@@ -4738,6 +4739,14 @@ class HermesCLI:
         """Handle /skills slash command — delegates to hermes_cli.skills_hub."""
         from hermes_cli.skills_hub import handle_skills_slash
         handle_skills_slash(cmd, ChatConsole())
+        cmd_lower = cmd.lower().strip()
+        if (
+            cmd_lower.startswith("/skills install")
+            or cmd_lower.startswith("/skills uninstall")
+            or cmd_lower.startswith("/skills update")
+            or cmd_lower.startswith("/skills snapshot import")
+        ):
+            mark_skill_commands_dirty()
 
     def _show_gateway_status(self):
         """Show status of the gateway and connected messaging platforms."""

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -107,6 +107,21 @@ class TestSlashCommandPrefixMatching:
         unknown = any("Unknown command" in p for p in printed)
         assert not unknown, f"Expected skill prefix to match, got: {printed}"
 
+    def test_skill_commands_are_read_live_when_snapshot_is_unset(self):
+        cli_obj = _make_cli()
+        printed = []
+        cli_obj.console.print = lambda *a, **kw: printed.append(str(a))
+
+        import cli as cli_mod
+        with patch.object(cli_mod, "_skill_commands", None), patch(
+            "cli.get_skill_commands",
+            return_value={"/live-skill": {"name": "Live Skill", "description": "test"}},
+        ):
+            cli_obj.process_command("/live-ski")
+
+        unknown = any("Unknown command" in p for p in printed)
+        assert not unknown, f"Expected live skill registry to match, got: {printed}"
+
     def test_ambiguous_between_builtin_and_skill(self):
         """Ambiguous prefix spanning builtin + skill commands shows suggestions."""
         cli_obj = _make_cli()

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -116,9 +116,10 @@ class TestSlashCommandPrefixMatching:
         with patch.object(cli_mod, "_skill_commands", None), patch(
             "cli.get_skill_commands",
             return_value={"/live-skill": {"name": "Live Skill", "description": "test"}},
-        ):
+        ) as mock_get_skill_commands:
             cli_obj.process_command("/live-ski")
 
+        mock_get_skill_commands.assert_any_call(force_refresh=True)
         unknown = any("Unknown command" in p for p in printed)
         assert not unknown, f"Expected live skill registry to match, got: {printed}"
 

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -119,7 +119,7 @@ class TestSlashCommandPrefixMatching:
         ) as mock_get_skill_commands:
             cli_obj.process_command("/live-ski")
 
-        mock_get_skill_commands.assert_any_call(force_refresh=True)
+        mock_get_skill_commands.assert_called()
         unknown = any("Unknown command" in p for p in printed)
         assert not unknown, f"Expected live skill registry to match, got: {printed}"
 


### PR DESCRIPTION
## What changed

This PR removes the stale CLI snapshot of installed skill commands.

- stop capturing `scan_skill_commands()` once at `cli.py` import time
- route CLI help, slash dispatch, prefix matching, and autocomplete through a live skill-command lookup helper
- keep `_skill_commands` as an explicit override hook for tests and targeted monkeypatching

## Why it changed

The CLI was the one path still freezing skill command state at startup while other surfaces re-read live state. Installing or changing skills during a session could leave CLI help and slash dispatch behind until restart.

## Impact

- skill command availability in the CLI stays aligned with the live skill registry
- existing tests that patch `_skill_commands` continue to work

## Validation

- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m py_compile cli.py tests/cli/test_cli_prefix_matching.py`
- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m pytest -o addopts='' tests/cli/test_cli_prefix_matching.py tests/hermes_cli/test_commands.py -q`
  - `116 passed in 2.20s`
