### PR TITLE
ci: pin test workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Set up Python 3.11
         run: uv python install 3.11


### PR DESCRIPTION
## Summary
- pin `actions/checkout` in `.github/workflows/tests.yml` to an immutable SHA
- pin `astral-sh/setup-uv` in the same workflow to an immutable SHA
- preserve the existing test workflow behavior and job structure

## Why
- reduces supply-chain drift in a security-relevant workflow surface
- keeps the change intentionally tiny and contributor-safe
- avoids overlapping existing open PRs on other Hermes workflow files

## Validation
- `git diff --check`
- `python -c "import pathlib, yaml; p=pathlib.Path(r'C:\Users\Eddie\.codex\worktrees\hermes-agent-tests-ci-pin\.github\workflows\tests.yml'); yaml.safe_load(p.read_text(encoding='utf-8')); print('yaml_ok', p)"`
- queued local PC Control review-coder preflight before push on the staged diff

## Risk Notes
- one-file change only
- no workflow logic changes
- no dependency or code-path changes