### PR TITLE
fix(aux): honor api_mode for custom auxiliary endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -928,6 +928,14 @@ def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
     if custom_mode == "codex_responses":
         real_client = OpenAI(api_key=custom_key, base_url=custom_base)
         return CodexAuxiliaryClient(real_client, model), model
+    if custom_mode == "anthropic_messages":
+        try:
+            from agent.anthropic_adapter import build_anthropic_client
+            real_client = build_anthropic_client(custom_key, custom_base)
+            return AnthropicAuxiliaryClient(real_client, model, custom_key, custom_base), model
+        except ImportError:
+            logger.warning("anthropic_messages mode requires the anthropic package")
+            return None, None
     return OpenAI(api_key=custom_key, base_url=custom_base), model
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -672,6 +672,21 @@ class TestGetTextAuxiliaryClient:
         assert mock_openai.call_args.kwargs["api_key"] == "sk-test"
 
 
+    def test_custom_endpoint_uses_anthropic_wrapper_when_runtime_requests_anthropic_messages(self):
+        mock_anthropic_client = MagicMock()
+        with patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("https://custom.example.com", "sk-ant-test", "anthropic_messages")), \
+             patch("agent.auxiliary_client._read_main_model", return_value="claude-opus-4.6"), \
+             patch("agent.anthropic_adapter.build_anthropic_client",
+                   return_value=mock_anthropic_client) as mock_build:
+            client, model = get_text_auxiliary_client()
+
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+        assert isinstance(client, AnthropicAuxiliaryClient)
+        assert model == "claude-opus-4.6"
+        mock_build.assert_called_once_with("sk-ant-test", "https://custom.example.com")
+
+
 class TestVisionClientFallback:
     """Vision client auto mode resolves known-good multimodal backends."""
 


### PR DESCRIPTION
## Summary
- When users configure `api_mode: anthropic_messages` for custom endpoints, `_try_custom_endpoint()` now creates an `AnthropicAuxiliaryClient` instead of always defaulting to the OpenAI SDK
- Fixes vision_analyze and other auxiliary tasks failing with "Your request was blocked" on Anthropic-compatible endpoints
- Added test coverage for the new `anthropic_messages` branch

Closes #7661

## Test plan
- [x] Existing tests pass (`pytest tests/agent/test_auxiliary_client.py`)
- [x] New test `test_custom_endpoint_uses_anthropic_wrapper_when_runtime_requests_anthropic_messages` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)