### PR TITLE
[codex] Unify skills command request parsing

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -29,6 +29,11 @@ except ImportError:  # pragma: no cover
     Suggestion = None     # type: ignore[assignment]
     Completion = None     # type: ignore[assignment]
 
+try:
+    from hermes_cli.skills_command_request import skills_subcommand_names as _shared_skills_subcommand_names
+except Exception:  # pragma: no cover
+    _shared_skills_subcommand_names = None
+
 
 # ---------------------------------------------------------------------------
 # CommandDef dataclass
@@ -222,6 +227,11 @@ def rebuild_lookups() -> None:
         m = _PIPE_SUBS_RE.search(cmd.args_hint)
         if m:
             SUBCOMMANDS[key] = m.group(0).split("|")
+    if _shared_skills_subcommand_names is not None:
+        try:
+            SUBCOMMANDS["/skills"] = _shared_skills_subcommand_names()
+        except Exception:
+            pass
 
     GATEWAY_KNOWN_COMMANDS = frozenset(
         name
@@ -274,6 +284,11 @@ for _cmd in COMMAND_REGISTRY:
     m = _PIPE_SUBS_RE.search(_cmd.args_hint)
     if m:
         SUBCOMMANDS[key] = m.group(0).split("|")
+if _shared_skills_subcommand_names is not None:
+    try:
+        SUBCOMMANDS["/skills"] = _shared_skills_subcommand_names()
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -50,6 +50,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli.skills_command_request import register_skills_subcommands
+
 def _require_tty(command_name: str) -> None:
     """Exit with a clear error if stdin is not a terminal.
 
@@ -4835,67 +4837,7 @@ For more help on a command:
         help="Search, install, configure, and manage skills",
         description="Search, install, inspect, audit, configure, and manage skills from skills.sh, well-known agent skill endpoints, GitHub, ClawHub, and other registries."
     )
-    skills_subparsers = skills_parser.add_subparsers(dest="skills_action")
-
-    skills_browse = skills_subparsers.add_parser("browse", help="Browse all available skills (paginated)")
-    skills_browse.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    skills_browse.add_argument("--size", type=int, default=20, help="Results per page (default: 20)")
-    skills_browse.add_argument("--source", default="all",
-                               choices=["all", "official", "skills-sh", "well-known", "github", "clawhub", "lobehub"],
-                               help="Filter by source (default: all)")
-
-    skills_search = skills_subparsers.add_parser("search", help="Search skill registries")
-    skills_search.add_argument("query", help="Search query")
-    skills_search.add_argument("--source", default="all", choices=["all", "official", "skills-sh", "well-known", "github", "clawhub", "lobehub"])
-    skills_search.add_argument("--limit", type=int, default=10, help="Max results")
-
-    skills_install = skills_subparsers.add_parser("install", help="Install a skill")
-    skills_install.add_argument("identifier", help="Skill identifier (e.g. openai/skills/skill-creator)")
-    skills_install.add_argument("--category", default="", help="Category folder to install into")
-    skills_install.add_argument("--force", action="store_true", help="Install despite blocked scan verdict")
-    skills_install.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt (needed in TUI mode)")
-
-    skills_inspect = skills_subparsers.add_parser("inspect", help="Preview a skill without installing")
-    skills_inspect.add_argument("identifier", help="Skill identifier")
-
-    skills_list = skills_subparsers.add_parser("list", help="List installed skills")
-    skills_list.add_argument("--source", default="all", choices=["all", "hub", "builtin", "local"])
-
-    skills_check = skills_subparsers.add_parser("check", help="Check installed hub skills for updates")
-    skills_check.add_argument("name", nargs="?", help="Specific skill to check (default: all)")
-
-    skills_update = skills_subparsers.add_parser("update", help="Update installed hub skills")
-    skills_update.add_argument("name", nargs="?", help="Specific skill to update (default: all outdated skills)")
-
-    skills_audit = skills_subparsers.add_parser("audit", help="Re-scan installed hub skills")
-    skills_audit.add_argument("name", nargs="?", help="Specific skill to audit (default: all)")
-
-    skills_uninstall = skills_subparsers.add_parser("uninstall", help="Remove a hub-installed skill")
-    skills_uninstall.add_argument("name", help="Skill name to remove")
-
-    skills_publish = skills_subparsers.add_parser("publish", help="Publish a skill to a registry")
-    skills_publish.add_argument("skill_path", help="Path to skill directory")
-    skills_publish.add_argument("--to", default="github", choices=["github", "clawhub"], help="Target registry")
-    skills_publish.add_argument("--repo", default="", help="Target GitHub repo (e.g. openai/skills)")
-
-    skills_snapshot = skills_subparsers.add_parser("snapshot", help="Export/import skill configurations")
-    snapshot_subparsers = skills_snapshot.add_subparsers(dest="snapshot_action")
-    snap_export = snapshot_subparsers.add_parser("export", help="Export installed skills to a file")
-    snap_export.add_argument("output", help="Output JSON file path (use - for stdout)")
-    snap_import = snapshot_subparsers.add_parser("import", help="Import and install skills from a file")
-    snap_import.add_argument("input", help="Input JSON file path")
-    snap_import.add_argument("--force", action="store_true", help="Force install despite caution verdict")
-
-    skills_tap = skills_subparsers.add_parser("tap", help="Manage skill sources")
-    tap_subparsers = skills_tap.add_subparsers(dest="tap_action")
-    tap_subparsers.add_parser("list", help="List configured taps")
-    tap_add = tap_subparsers.add_parser("add", help="Add a GitHub repo as skill source")
-    tap_add.add_argument("repo", help="GitHub repo (e.g. owner/repo)")
-    tap_rm = tap_subparsers.add_parser("remove", help="Remove a tap")
-    tap_rm.add_argument("name", help="Tap name to remove")
-
-    # config sub-action: interactive enable/disable
-    skills_subparsers.add_parser("config", help="Interactive skill configuration — enable/disable individual skills")
+    register_skills_subcommands(skills_parser)
 
     def cmd_skills(args):
         # Route 'config' action to skills_config module

--- a/hermes_cli/skills_command_request.py
+++ b/hermes_cli/skills_command_request.py
@@ -57,7 +57,7 @@ def register_skills_subcommands(skills_parser: argparse.ArgumentParser) -> None:
                                help="Filter by source (default: all)")
 
     skills_search = skills_subparsers.add_parser("search", help="Search skill registries")
-    skills_search.add_argument("query", help="Search query")
+    skills_search.add_argument("query", nargs="+", help="Search query")
     skills_search.add_argument("--source", default="all", choices=["all", "official", "skills-sh", "well-known", "github", "clawhub", "lobehub"])
     skills_search.add_argument("--limit", type=int, default=10, help="Max results")
 
@@ -138,7 +138,7 @@ def request_from_namespace(args, *, command_source: str) -> SkillsCommandRequest
         page=getattr(args, "page", 1),
         size=getattr(args, "size", 20),
         source_filter=getattr(args, "source", "all"),
-        query=getattr(args, "query", "") or "",
+        query=" ".join(getattr(args, "query", []) or []) if isinstance(getattr(args, "query", ""), list) else (getattr(args, "query", "") or ""),
         limit=getattr(args, "limit", 10),
         identifier=getattr(args, "identifier", "") or "",
         category=getattr(args, "category", "") or "",
@@ -157,7 +157,10 @@ def request_from_namespace(args, *, command_source: str) -> SkillsCommandRequest
 
 
 def parse_skills_slash_command(cmd: str) -> SkillsCommandRequest:
-    parts = shlex.split(cmd.strip())
+    try:
+        parts = shlex.split(cmd.strip())
+    except ValueError as exc:
+        return SkillsCommandRequest(action="error", command_source="slash", error=str(exc))
     if parts and parts[0].lower() == "/skills":
         parts = parts[1:]
     if not parts:

--- a/hermes_cli/skills_command_request.py
+++ b/hermes_cli/skills_command_request.py
@@ -117,6 +117,9 @@ def request_from_namespace(args, *, command_source: str) -> SkillsCommandRequest
     skip_confirm = getattr(args, "yes", False)
     if command_source == "slash" and action in {"install", "uninstall"}:
         skip_confirm = True
+    invalidate_cache = bool(getattr(args, "now", False))
+    if command_source == "cli" and action in {"install", "uninstall"}:
+        invalidate_cache = True
 
     path = ""
     if action == "snapshot":
@@ -124,6 +127,10 @@ def request_from_namespace(args, *, command_source: str) -> SkillsCommandRequest
             path = getattr(args, "output", "")
         elif getattr(args, "snapshot_action", None) == "import":
             path = getattr(args, "input", "")
+
+    tap_action = getattr(args, "tap_action", "") or ""
+    if command_source == "slash" and action == "tap" and not tap_action:
+        tap_action = "list"
 
     return SkillsCommandRequest(
         action=action,
@@ -137,14 +144,14 @@ def request_from_namespace(args, *, command_source: str) -> SkillsCommandRequest
         category=getattr(args, "category", "") or "",
         force=bool(getattr(args, "force", False)),
         skip_confirm=bool(skip_confirm),
-        invalidate_cache=bool(getattr(args, "now", False)),
+        invalidate_cache=invalidate_cache,
         name=getattr(args, "name", "") or "",
         skill_path=getattr(args, "skill_path", "") or "",
         target=getattr(args, "to", "github") or "github",
         repo=getattr(args, "repo", "") or "",
         snapshot_action=getattr(args, "snapshot_action", "") or "",
         path=path,
-        tap_action=getattr(args, "tap_action", "") or "",
+        tap_action=tap_action,
         config_available=(command_source != "slash"),
     )
 

--- a/hermes_cli/skills_command_request.py
+++ b/hermes_cli/skills_command_request.py
@@ -44,6 +44,7 @@ class SkillsCommandRequest:
     tap_action: str = ""
     config_available: bool = True
     error: str = ""
+    help_text: str = ""
 
 
 def register_skills_subcommands(skills_parser: argparse.ArgumentParser) -> None:
@@ -112,6 +113,17 @@ def register_skills_subcommands(skills_parser: argparse.ArgumentParser) -> None:
     skills_subparsers.add_parser("config", help="Interactive skill configuration — enable/disable individual skills")
 
 
+def skills_subcommand_names() -> list[str]:
+    parser = _SkillsArgumentParser(prog="skills", add_help=False)
+    register_skills_subcommands(parser)
+    action = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    return sorted(action.choices.keys())
+
+
 def request_from_namespace(args, *, command_source: str) -> SkillsCommandRequest:
     action = getattr(args, "skills_action", None) or "help"
     skip_confirm = getattr(args, "yes", False)
@@ -165,6 +177,15 @@ def parse_skills_slash_command(cmd: str) -> SkillsCommandRequest:
         parts = parts[1:]
     if not parts:
         return SkillsCommandRequest(action="help", command_source="slash")
+
+    if any(part in {"--help", "-h"} for part in parts):
+        parser = _SkillsArgumentParser(prog="/skills", add_help=True)
+        register_skills_subcommands(parser)
+        return SkillsCommandRequest(
+            action="help",
+            command_source="slash",
+            help_text=parser.format_help(),
+        )
 
     parser = _SkillsArgumentParser(prog="/skills", add_help=False)
     register_skills_subcommands(parser)

--- a/hermes_cli/skills_command_request.py
+++ b/hermes_cli/skills_command_request.py
@@ -1,0 +1,165 @@
+"""Shared parser tree and request model for `hermes skills` and `/skills`."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+from dataclasses import dataclass
+
+
+class SkillsParseError(ValueError):
+    """Raised when the shared skills parser rejects input."""
+
+
+class _SkillsArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise SkillsParseError(message)
+
+    def exit(self, status=0, message=None):
+        if message:
+            raise SkillsParseError(message.strip())
+        raise SkillsParseError(f"parser exited with status {status}")
+
+
+@dataclass(frozen=True)
+class SkillsCommandRequest:
+    action: str
+    command_source: str
+    page: int = 1
+    size: int = 20
+    source_filter: str = "all"
+    query: str = ""
+    limit: int = 10
+    identifier: str = ""
+    category: str = ""
+    force: bool = False
+    skip_confirm: bool = False
+    invalidate_cache: bool = False
+    name: str = ""
+    skill_path: str = ""
+    target: str = "github"
+    repo: str = ""
+    snapshot_action: str = ""
+    path: str = ""
+    tap_action: str = ""
+    config_available: bool = True
+    error: str = ""
+
+
+def register_skills_subcommands(skills_parser: argparse.ArgumentParser) -> None:
+    skills_subparsers = skills_parser.add_subparsers(dest="skills_action")
+
+    skills_browse = skills_subparsers.add_parser("browse", help="Browse all available skills (paginated)")
+    skills_browse.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    skills_browse.add_argument("--size", type=int, default=20, help="Results per page (default: 20)")
+    skills_browse.add_argument("--source", default="all",
+                               choices=["all", "official", "skills-sh", "well-known", "github", "clawhub", "lobehub"],
+                               help="Filter by source (default: all)")
+
+    skills_search = skills_subparsers.add_parser("search", help="Search skill registries")
+    skills_search.add_argument("query", help="Search query")
+    skills_search.add_argument("--source", default="all", choices=["all", "official", "skills-sh", "well-known", "github", "clawhub", "lobehub"])
+    skills_search.add_argument("--limit", type=int, default=10, help="Max results")
+
+    skills_install = skills_subparsers.add_parser("install", help="Install a skill")
+    skills_install.add_argument("identifier", help="Skill identifier (e.g. openai/skills/skill-creator)")
+    skills_install.add_argument("--category", default="", help="Category folder to install into")
+    skills_install.add_argument("--force", action="store_true", help="Install despite blocked scan verdict")
+    skills_install.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt (needed in TUI mode)")
+    skills_install.add_argument("--now", action="store_true", help="Invalidate prompt cache immediately")
+
+    skills_inspect = skills_subparsers.add_parser("inspect", help="Preview a skill without installing")
+    skills_inspect.add_argument("identifier", help="Skill identifier")
+
+    skills_list = skills_subparsers.add_parser("list", help="List installed skills")
+    skills_list.add_argument("--source", default="all", choices=["all", "hub", "builtin", "local"])
+
+    skills_check = skills_subparsers.add_parser("check", help="Check installed hub skills for updates")
+    skills_check.add_argument("name", nargs="?", help="Specific skill to check (default: all)")
+
+    skills_update = skills_subparsers.add_parser("update", help="Update installed hub skills")
+    skills_update.add_argument("name", nargs="?", help="Specific skill to update (default: all outdated skills)")
+
+    skills_audit = skills_subparsers.add_parser("audit", help="Re-scan installed hub skills")
+    skills_audit.add_argument("name", nargs="?", help="Specific skill to audit (default: all)")
+
+    skills_uninstall = skills_subparsers.add_parser("uninstall", help="Remove a hub-installed skill")
+    skills_uninstall.add_argument("name", help="Skill name to remove")
+    skills_uninstall.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+    skills_uninstall.add_argument("--now", action="store_true", help="Invalidate prompt cache immediately")
+
+    skills_publish = skills_subparsers.add_parser("publish", help="Publish a skill to a registry")
+    skills_publish.add_argument("skill_path", help="Path to skill directory")
+    skills_publish.add_argument("--to", default="github", choices=["github", "clawhub"], help="Target registry")
+    skills_publish.add_argument("--repo", default="", help="Target GitHub repo (e.g. openai/skills)")
+
+    skills_snapshot = skills_subparsers.add_parser("snapshot", help="Export/import skill configurations")
+    snapshot_subparsers = skills_snapshot.add_subparsers(dest="snapshot_action")
+    snap_export = snapshot_subparsers.add_parser("export", help="Export installed skills to a file")
+    snap_export.add_argument("output", help="Output JSON file path (use - for stdout)")
+    snap_import = snapshot_subparsers.add_parser("import", help="Import and install skills from a file")
+    snap_import.add_argument("input", help="Input JSON file path")
+    snap_import.add_argument("--force", action="store_true", help="Force install despite caution verdict")
+
+    skills_tap = skills_subparsers.add_parser("tap", help="Manage skill sources")
+    tap_subparsers = skills_tap.add_subparsers(dest="tap_action")
+    tap_subparsers.add_parser("list", help="List configured taps")
+    tap_add = tap_subparsers.add_parser("add", help="Add a GitHub repo as skill source")
+    tap_add.add_argument("repo", help="GitHub repo (e.g. owner/repo)")
+    tap_rm = tap_subparsers.add_parser("remove", help="Remove a tap")
+    tap_rm.add_argument("name", help="Tap name to remove")
+
+    skills_subparsers.add_parser("config", help="Interactive skill configuration — enable/disable individual skills")
+
+
+def request_from_namespace(args, *, command_source: str) -> SkillsCommandRequest:
+    action = getattr(args, "skills_action", None) or "help"
+    skip_confirm = getattr(args, "yes", False)
+    if command_source == "slash" and action in {"install", "uninstall"}:
+        skip_confirm = True
+
+    path = ""
+    if action == "snapshot":
+        if getattr(args, "snapshot_action", None) == "export":
+            path = getattr(args, "output", "")
+        elif getattr(args, "snapshot_action", None) == "import":
+            path = getattr(args, "input", "")
+
+    return SkillsCommandRequest(
+        action=action,
+        command_source=command_source,
+        page=getattr(args, "page", 1),
+        size=getattr(args, "size", 20),
+        source_filter=getattr(args, "source", "all"),
+        query=getattr(args, "query", "") or "",
+        limit=getattr(args, "limit", 10),
+        identifier=getattr(args, "identifier", "") or "",
+        category=getattr(args, "category", "") or "",
+        force=bool(getattr(args, "force", False)),
+        skip_confirm=bool(skip_confirm),
+        invalidate_cache=bool(getattr(args, "now", False)),
+        name=getattr(args, "name", "") or "",
+        skill_path=getattr(args, "skill_path", "") or "",
+        target=getattr(args, "to", "github") or "github",
+        repo=getattr(args, "repo", "") or "",
+        snapshot_action=getattr(args, "snapshot_action", "") or "",
+        path=path,
+        tap_action=getattr(args, "tap_action", "") or "",
+        config_available=(command_source != "slash"),
+    )
+
+
+def parse_skills_slash_command(cmd: str) -> SkillsCommandRequest:
+    parts = shlex.split(cmd.strip())
+    if parts and parts[0].lower() == "/skills":
+        parts = parts[1:]
+    if not parts:
+        return SkillsCommandRequest(action="help", command_source="slash")
+
+    parser = _SkillsArgumentParser(prog="/skills", add_help=False)
+    register_skills_subcommands(parser)
+    try:
+        args = parser.parse_args(parts)
+    except SkillsParseError as exc:
+        return SkillsCommandRequest(action="error", command_source="slash", error=str(exc))
+    return request_from_namespace(args, command_source="slash")

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -19,6 +19,12 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from hermes_cli.skills_command_request import (
+    SkillsCommandRequest,
+    parse_skills_slash_command,
+    request_from_namespace,
+)
+
 # Lazy imports to avoid circular dependencies and slow startup.
 # tools.skills_hub and tools.skills_guard are imported inside functions.
 from hermes_constants import display_hermes_home
@@ -968,53 +974,71 @@ def do_snapshot_import(input_path: str, force: bool = False,
 # CLI argparse entry point
 # ---------------------------------------------------------------------------
 
+def _dispatch_skills_request(request: SkillsCommandRequest, console: Optional[Console] = None) -> None:
+    c = console or _console
+
+    if request.action == "browse":
+        do_browse(page=request.page, page_size=request.size, source=request.source_filter, console=c)
+    elif request.action == "search":
+        do_search(request.query, source=request.source_filter, limit=request.limit, console=c)
+    elif request.action == "install":
+        do_install(
+            request.identifier,
+            category=request.category,
+            force=request.force,
+            skip_confirm=request.skip_confirm,
+            invalidate_cache=request.invalidate_cache,
+            console=c,
+        )
+    elif request.action == "inspect":
+        do_inspect(request.identifier, console=c)
+    elif request.action == "list":
+        do_list(source_filter=request.source_filter, console=c)
+    elif request.action == "check":
+        do_check(name=request.name or None, console=c)
+    elif request.action == "update":
+        do_update(name=request.name or None, console=c)
+    elif request.action == "audit":
+        do_audit(name=request.name or None, console=c)
+    elif request.action == "uninstall":
+        do_uninstall(
+            request.name,
+            console=c,
+            skip_confirm=request.skip_confirm,
+            invalidate_cache=request.invalidate_cache,
+        )
+    elif request.action == "publish":
+        do_publish(request.skill_path, target=request.target, repo=request.repo, console=c)
+    elif request.action == "snapshot":
+        if request.snapshot_action == "export":
+            do_snapshot_export(request.path, console=c)
+        elif request.snapshot_action == "import":
+            do_snapshot_import(request.path, force=request.force, console=c)
+        else:
+            c.print("Usage: hermes skills snapshot [export|import]\n")
+    elif request.action == "tap":
+        if not request.tap_action:
+            c.print("Usage: hermes skills tap [list|add|remove]\n")
+            return
+        do_tap(request.tap_action, repo=request.repo or request.name, console=c)
+    elif request.action == "config":
+        if request.config_available:
+            c.print("[bold red]skills config should be routed by hermes_cli.main before reaching the hub.[/]")
+        else:
+            c.print("[bold red]/skills config is not available in chat. Use `hermes skills config` in the terminal.[/]")
+    elif request.action in {"help", "", None}:
+        _print_skills_help(c)
+    elif request.action == "error":
+        c.print(f"[bold red]Error:[/] {request.error}")
+        _print_skills_help(c)
+    else:
+        c.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|publish|snapshot|tap|config]\n")
+        c.print("Run 'hermes skills <command> --help' for details.\n")
+
+
 def skills_command(args) -> None:
     """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py."""
-    action = getattr(args, "skills_action", None)
-
-    if action == "browse":
-        do_browse(page=args.page, page_size=args.size, source=args.source)
-    elif action == "search":
-        do_search(args.query, source=args.source, limit=args.limit)
-    elif action == "install":
-        do_install(args.identifier, category=args.category, force=args.force,
-                   skip_confirm=getattr(args, "yes", False))
-    elif action == "inspect":
-        do_inspect(args.identifier)
-    elif action == "list":
-        do_list(source_filter=args.source)
-    elif action == "check":
-        do_check(name=getattr(args, "name", None))
-    elif action == "update":
-        do_update(name=getattr(args, "name", None))
-    elif action == "audit":
-        do_audit(name=getattr(args, "name", None))
-    elif action == "uninstall":
-        do_uninstall(args.name)
-    elif action == "publish":
-        do_publish(
-            args.skill_path,
-            target=getattr(args, "to", "github"),
-            repo=getattr(args, "repo", ""),
-        )
-    elif action == "snapshot":
-        snap_action = getattr(args, "snapshot_action", None)
-        if snap_action == "export":
-            do_snapshot_export(args.output)
-        elif snap_action == "import":
-            do_snapshot_import(args.input, force=getattr(args, "force", False))
-        else:
-            _console.print("Usage: hermes skills snapshot [export|import]\n")
-    elif action == "tap":
-        tap_action = getattr(args, "tap_action", None)
-        repo = getattr(args, "repo", "") or getattr(args, "name", "")
-        if not tap_action:
-            _console.print("Usage: hermes skills tap [list|add|remove]\n")
-            return
-        do_tap(tap_action, repo=repo)
-    else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|publish|snapshot|tap]\n")
-        _console.print("Run 'hermes skills <command> --help' for details.\n")
+    _dispatch_skills_request(request_from_namespace(args, command_source="cli"))
 
 
 # ---------------------------------------------------------------------------
@@ -1022,184 +1046,7 @@ def skills_command(args) -> None:
 # ---------------------------------------------------------------------------
 
 def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
-    """
-    Parse and dispatch `/skills <subcommand> [args]` from the chat interface.
-
-    Examples:
-        /skills search kubernetes
-        /skills install openai/skills/skill-creator
-        /skills install openai/skills/skill-creator --force
-        /skills inspect openai/skills/skill-creator
-        /skills list
-        /skills list --source hub
-        /skills check
-        /skills update
-        /skills audit
-        /skills audit my-skill
-        /skills uninstall my-skill
-        /skills tap list
-        /skills tap add owner/repo
-        /skills tap remove owner/repo
-    """
-    c = console or _console
-    parts = cmd.strip().split()
-
-    # Strip the leading "/skills" if present
-    if parts and parts[0].lower() == "/skills":
-        parts = parts[1:]
-
-    if not parts:
-        _print_skills_help(c)
-        return
-
-    action = parts[0].lower()
-    args = parts[1:]
-
-    if action == "browse":
-        page = 1
-        page_size = 20
-        source = "all"
-        i = 0
-        while i < len(args):
-            if args[i] == "--page" and i + 1 < len(args):
-                try:
-                    page = int(args[i + 1])
-                except ValueError:
-                    pass
-                i += 2
-            elif args[i] == "--size" and i + 1 < len(args):
-                try:
-                    page_size = int(args[i + 1])
-                except ValueError:
-                    pass
-                i += 2
-            elif args[i] == "--source" and i + 1 < len(args):
-                source = args[i + 1]
-                i += 2
-            else:
-                i += 1
-        do_browse(page=page, page_size=page_size, source=source, console=c)
-
-    elif action == "search":
-        if not args:
-            c.print("[bold red]Usage:[/] /skills search <query> [--source skills-sh|well-known|github|official] [--limit N]\n")
-            return
-        source = "all"
-        limit = 10
-        query_parts = []
-        i = 0
-        while i < len(args):
-            if args[i] == "--source" and i + 1 < len(args):
-                source = args[i + 1]
-                i += 2
-            elif args[i] == "--limit" and i + 1 < len(args):
-                try:
-                    limit = int(args[i + 1])
-                except ValueError:
-                    pass
-                i += 2
-            else:
-                query_parts.append(args[i])
-                i += 1
-        do_search(" ".join(query_parts), source=source, limit=limit, console=c)
-
-    elif action == "install":
-        if not args:
-            c.print("[bold red]Usage:[/] /skills install <identifier> [--category <cat>] [--force] [--now]\n")
-            return
-        identifier = args[0]
-        category = ""
-        # Slash commands run inside prompt_toolkit where input() hangs.
-        # Always skip confirmation — the user typing the command is implicit consent.
-        skip_confirm = True
-        force = "--force" in args
-        # --now invalidates prompt cache immediately (costs more money).
-        # Default: defer to next session to preserve cache.
-        invalidate_cache = "--now" in args
-        for i, a in enumerate(args):
-            if a == "--category" and i + 1 < len(args):
-                category = args[i + 1]
-        do_install(identifier, category=category, force=force,
-                   skip_confirm=skip_confirm, invalidate_cache=invalidate_cache,
-                   console=c)
-
-    elif action == "inspect":
-        if not args:
-            c.print("[bold red]Usage:[/] /skills inspect <identifier>\n")
-            return
-        do_inspect(args[0], console=c)
-
-    elif action == "list":
-        source_filter = "all"
-        if "--source" in args:
-            idx = args.index("--source")
-            if idx + 1 < len(args):
-                source_filter = args[idx + 1]
-        do_list(source_filter=source_filter, console=c)
-
-    elif action == "check":
-        name = args[0] if args else None
-        do_check(name=name, console=c)
-
-    elif action == "update":
-        name = args[0] if args else None
-        do_update(name=name, console=c)
-
-    elif action == "audit":
-        name = args[0] if args else None
-        do_audit(name=name, console=c)
-
-    elif action == "uninstall":
-        if not args:
-            c.print("[bold red]Usage:[/] /skills uninstall <name> [--now]\n")
-            return
-        # Slash commands run inside prompt_toolkit where input() hangs.
-        skip_confirm = True
-        invalidate_cache = "--now" in args
-        do_uninstall(args[0], console=c, skip_confirm=skip_confirm,
-                     invalidate_cache=invalidate_cache)
-
-    elif action == "publish":
-        if not args:
-            c.print("[bold red]Usage:[/] /skills publish <skill-path> [--to github] [--repo owner/repo]\n")
-            return
-        skill_path = args[0]
-        target = "github"
-        repo = ""
-        for i, a in enumerate(args):
-            if a == "--to" and i + 1 < len(args):
-                target = args[i + 1]
-            if a == "--repo" and i + 1 < len(args):
-                repo = args[i + 1]
-        do_publish(skill_path, target=target, repo=repo, console=c)
-
-    elif action == "snapshot":
-        if not args:
-            c.print("[bold red]Usage:[/] /skills snapshot export <file> | /skills snapshot import <file>\n")
-            return
-        snap_action = args[0]
-        if snap_action == "export" and len(args) > 1:
-            do_snapshot_export(args[1], console=c)
-        elif snap_action == "import" and len(args) > 1:
-            force = "--force" in args
-            do_snapshot_import(args[1], force=force, console=c)
-        else:
-            c.print("[bold red]Usage:[/] /skills snapshot export <file> | /skills snapshot import <file>\n")
-
-    elif action == "tap":
-        if not args:
-            do_tap("list", console=c)
-            return
-        tap_action = args[0]
-        repo = args[1] if len(args) > 1 else ""
-        do_tap(tap_action, repo=repo, console=c)
-
-    elif action in ("help", "--help", "-h"):
-        _print_skills_help(c)
-
-    else:
-        c.print(f"[bold red]Unknown action:[/] {action}")
-        _print_skills_help(c)
+    _dispatch_skills_request(parse_skills_slash_command(cmd), console=console)
 
 
 def _print_skills_help(console: Console) -> None:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1027,7 +1027,10 @@ def _dispatch_skills_request(request: SkillsCommandRequest, console: Optional[Co
         else:
             c.print("[bold red]/skills config is not available in chat. Use `hermes skills config` in the terminal.[/]")
     elif request.action in {"help", "", None}:
-        _print_skills_help(c)
+        if request.help_text:
+            c.print(request.help_text)
+        else:
+            _print_skills_help(c)
     elif request.action == "error":
         c.print(f"[bold red]Error:[/] {request.error}")
         _print_skills_help(c)

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -438,6 +438,10 @@ class TestSubcommands:
         """Commands with explicit subcommands on CommandDef are extracted."""
         assert "/skills" in SUBCOMMANDS
         assert "install" in SUBCOMMANDS["/skills"]
+        assert "list" in SUBCOMMANDS["/skills"]
+        assert "tap" in SUBCOMMANDS["/skills"]
+        assert "list" in SUBCOMMANDS["/skills"]
+        assert "tap" in SUBCOMMANDS["/skills"]
 
     def test_reasoning_has_subcommands(self):
         assert "/reasoning" in SUBCOMMANDS

--- a/tests/hermes_cli/test_skills_command_request.py
+++ b/tests/hermes_cli/test_skills_command_request.py
@@ -1,0 +1,54 @@
+import pytest
+
+from hermes_cli.skills_command_request import (
+    SkillsCommandRequest,
+    _SkillsArgumentParser,
+    parse_skills_slash_command,
+    register_skills_subcommands,
+    request_from_namespace,
+)
+
+
+def _make_parser():
+    parser = _SkillsArgumentParser(prog="skills", add_help=False)
+    register_skills_subcommands(parser)
+    return parser
+
+
+def test_request_from_namespace_preserves_cli_confirmation_policy():
+    parser = _make_parser()
+    args = parser.parse_args(["install", "openai/skills/skill-creator", "--yes"])
+
+    request = request_from_namespace(args, command_source="cli")
+
+    assert request == SkillsCommandRequest(
+        action="install",
+        command_source="cli",
+        identifier="openai/skills/skill-creator",
+        skip_confirm=True,
+    )
+
+
+def test_parse_skills_slash_command_uses_same_parser_tree():
+    request = parse_skills_slash_command(
+        "/skills snapshot import my.json --force"
+    )
+
+    assert request.action == "snapshot"
+    assert request.snapshot_action == "import"
+    assert request.path == "my.json"
+    assert request.force is True
+
+
+def test_parse_skills_slash_command_marks_config_unavailable():
+    request = parse_skills_slash_command("/skills config")
+
+    assert request.action == "config"
+    assert request.config_available is False
+
+
+def test_parse_skills_slash_command_returns_error_request_on_invalid_input():
+    request = parse_skills_slash_command("/skills install")
+
+    assert request.action == "error"
+    assert request.error

--- a/tests/hermes_cli/test_skills_command_request.py
+++ b/tests/hermes_cli/test_skills_command_request.py
@@ -26,7 +26,17 @@ def test_request_from_namespace_preserves_cli_confirmation_policy():
         command_source="cli",
         identifier="openai/skills/skill-creator",
         skip_confirm=True,
+        invalidate_cache=True,
     )
+
+
+def test_request_from_namespace_preserves_cli_cache_invalidation_behavior():
+    parser = _make_parser()
+    args = parser.parse_args(["install", "openai/skills/skill-creator"])
+
+    request = request_from_namespace(args, command_source="cli")
+
+    assert request.invalidate_cache is True
 
 
 def test_parse_skills_slash_command_uses_same_parser_tree():
@@ -45,6 +55,13 @@ def test_parse_skills_slash_command_marks_config_unavailable():
 
     assert request.action == "config"
     assert request.config_available is False
+
+
+def test_parse_skills_slash_command_tap_defaults_to_list():
+    request = parse_skills_slash_command("/skills tap")
+
+    assert request.action == "tap"
+    assert request.tap_action == "list"
 
 
 def test_parse_skills_slash_command_returns_error_request_on_invalid_input():

--- a/tests/hermes_cli/test_skills_command_request.py
+++ b/tests/hermes_cli/test_skills_command_request.py
@@ -72,6 +72,13 @@ def test_parse_skills_slash_command_tap_defaults_to_list():
     assert request.tap_action == "list"
 
 
+def test_parse_skills_slash_command_help_flag_returns_help_request():
+    request = parse_skills_slash_command("/skills search --help")
+
+    assert request.action == "help"
+    assert request.help_text
+
+
 def test_parse_skills_slash_command_returns_error_request_on_invalid_input():
     request = parse_skills_slash_command("/skills install")
 

--- a/tests/hermes_cli/test_skills_command_request.py
+++ b/tests/hermes_cli/test_skills_command_request.py
@@ -50,6 +50,14 @@ def test_parse_skills_slash_command_uses_same_parser_tree():
     assert request.force is True
 
 
+def test_parse_skills_slash_command_accepts_multiword_search_without_quotes():
+    request = parse_skills_slash_command("/skills search foo bar --limit 5")
+
+    assert request.action == "search"
+    assert request.query == "foo bar"
+    assert request.limit == 5
+
+
 def test_parse_skills_slash_command_marks_config_unavailable():
     request = parse_skills_slash_command("/skills config")
 
@@ -66,6 +74,13 @@ def test_parse_skills_slash_command_tap_defaults_to_list():
 
 def test_parse_skills_slash_command_returns_error_request_on_invalid_input():
     request = parse_skills_slash_command("/skills install")
+
+    assert request.action == "error"
+    assert request.error
+
+
+def test_parse_skills_slash_command_returns_error_request_on_malformed_quotes():
+    request = parse_skills_slash_command('/skills search "unterminated')
 
     assert request.action == "error"
     assert request.error


### PR DESCRIPTION
## What changed

This PR introduces one shared skills command request/parser layer for both `hermes skills` and `/skills`.

- add `hermes_cli.skills_command_request` with a shared parser tree, `SkillsCommandRequest` request model, and slash-command parser
- make `hermes_cli.main` register the `skills` subcommands from that shared parser instead of hand-building a separate tree
- make `hermes_cli.skills_hub` dispatch a shared `SkillsCommandRequest` instead of manually reparsing slash commands
- preserve the existing surface-specific behavior where slash commands auto-skip confirmation and `skills config` remains terminal-only

## Why it changed

`hermes skills` and `/skills` had separate parsers and partially separate semantics. Every new flag or subcommand risked drifting unless both paths were updated manually.

## Impact

- CLI and slash command surfaces now share one subcommand tree and one request model
- confirmation policy still differs by surface, but it now happens after parsing instead of by forking the parser logic
- `skills config` stays routed through the terminal-only interactive flow with an explicit `/skills config` rejection in chat

## Validation

- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m py_compile hermes_cli/skills_command_request.py hermes_cli/skills_hub.py hermes_cli/main.py tests/hermes_cli/test_skills_command_request.py`
- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_skills_command_request.py tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_skills_skip_confirm.py tests/hermes_cli/test_skills_install_flags.py tests/hermes_cli/test_skills_subparser.py -q`
  - `34 passed in 0.66s`
