### PR TITLE
fix(gateway): don't suppress error messages when streaming already_sent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3485,7 +3485,12 @@ class GatewayRunner:
             # post-processing in _process_message_background is skipped
             # when already_sent is True, so media files would never be
             # delivered without this.
-            if agent_result.get("already_sent"):
+            #
+            # Never skip when the agent failed — the error message is new
+            # content the user hasn't seen (streaming only sent earlier
+            # partial output before the failure).  Without this guard,
+            # users see the agent "stop responding without explanation."
+            if agent_result.get("already_sent") and not agent_result.get("failed"):
                 if response:
                     _media_adapter = self.adapters.get(source.platform)
                     if _media_adapter:
@@ -8012,9 +8017,13 @@ class GatewayRunner:
 
         # If streaming already delivered the response, mark it so the
         # caller's send() is skipped (avoiding duplicate messages).
+        # BUT: never suppress delivery when the agent failed — the error
+        # message is new content the user hasn't seen, and it must reach
+        # them even if streaming had sent earlier partial output.
         _sc = stream_consumer_holder[0]
         if _sc and _sc.already_sent and isinstance(response, dict):
-            response["already_sent"] = True
+            if not response.get("failed"):
+                response["already_sent"] = True
         
         return response
 


### PR DESCRIPTION
## Summary

When the stream consumer has sent at least one message (`already_sent=True`), the gateway skips sending the final response to avoid duplicates. But this also suppressed error messages when the agent **failed** mid-loop — rate limit exhaustion, context overflow, compression failure, etc.

**User-visible symptom:** The agent appears to "stop responding mid-loop without any explanation." The last streamed content stays on screen and nothing else arrives — no error, no timeout message, nothing.

**Root cause:** The `already_sent` flag is set unconditionally when the stream consumer has sent anything, even a single progressive edit early in the session. When the agent later fails (returning `{"failed": True, "error": "..."}`), the gateway generates a proper error message at line ~3050, but then the `already_sent` check at line ~3212 returns `None` — silently dropping the error.

**Fix:** Check the `failed` flag at both sites:
1. **Producer** (`_run_agent`, line ~7698): Don't mark `already_sent` on the response dict when the agent failed
2. **Consumer** (`_handle_message_with_agent`, line ~3212): Belt-and-suspenders — don't suppress delivery when `failed` is set

## Test plan
- 25/25 stream consumer tests pass
- 68/68 streaming + already_sent related gateway tests pass  
- 2465/2465 gateway tests pass (22 pre-existing failures unrelated to this change)