### PR TITLE
feat: add ask_advisor tool for multi-model strategic guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -170,6 +170,17 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+ADVISOR_GUIDANCE = (
+    "\n## Advisor Tool\n"
+    "You have access to an 'ask_advisor' tool that consults a more capable model "
+    "for strategic guidance. Use it when:\n"
+    "- You're unsure about the best approach for a complex task\n"
+    "- You need help with architectural or design decisions\n"
+    "- You've been stuck or making errors for multiple iterations\n"
+    "The advisor sees your question and provides a concise strategic plan. "
+    "Follow the plan yourself using your available tools.\n"
+)
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -530,6 +530,19 @@ DEFAULT_CONFIG = {
                                # independent of the parent's max_iterations)
     },
 
+    # Advisor — consult a more capable model for strategic guidance.
+    # The executor model (e.g., local Ollama) calls ask_advisor to get a
+    # concise plan from a stronger model (e.g., Claude Opus) and then
+    # executes the plan using its own tools.
+    "advisor": {
+        "enabled": False,
+        "provider": "",       # e.g. "anthropic", "openrouter", "openai" (empty + no base_url = disabled)
+        "model": "",          # e.g. "claude-sonnet-4-20250514"
+        "base_url": "",       # direct OpenAI-compatible endpoint (takes precedence over provider)
+        "api_key": "",        # API key for base_url or provider auth
+        "max_tokens": 700,    # max tokens for advisor response (400-700 recommended)
+    },
+
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.
@@ -1449,7 +1462,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
+    "agent", "terminal", "display", "compression", "delegation", "advisor",
     "auxiliary", "custom_providers", "memory", "gateway",
 }
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -154,6 +154,7 @@ def _discover_tools():
         "tools.clarify_tool",
         "tools.code_execution_tool",
         "tools.delegate_tool",
+        "tools.advisor_tool",
         "tools.process_registry",
         "tools.send_message_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin

--- a/run_agent.py
+++ b/run_agent.py
@@ -81,6 +81,7 @@ from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    ADVISOR_GUIDANCE,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
@@ -2728,6 +2729,8 @@ class AIAgent:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
+        if "ask_advisor" in self.valid_tool_names:
+            tool_guidance.append(ADVISOR_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
 

--- a/tests/tools/test_advisor_tool.py
+++ b/tests/tools/test_advisor_tool.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Tests for the advisor tool.
+
+Verifies:
+- Tool registration in the registry
+- check_fn behavior (enabled/disabled states)
+- Handler validation (missing question, empty config)
+- Message building for the advisor model
+
+Run with:  python -m pytest tests/tools/test_advisor_tool.py -v
+"""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tools.advisor_tool import (
+    ASK_ADVISOR_SCHEMA,
+    check_advisor_requirements,
+    ask_advisor_handler,
+    _build_advisor_messages,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_fn tests
+# ---------------------------------------------------------------------------
+
+class TestCheckAdvisorRequirements:
+    """Tests for check_advisor_requirements."""
+
+    def test_returns_false_when_disabled(self):
+        """Should return False when advisor.enabled is False."""
+        with patch("tools.advisor_tool.load_config") as mock_cfg:
+            mock_cfg.return_value = {
+                "advisor": {"enabled": False, "provider": "anthropic"}
+            }
+            assert check_advisor_requirements() is False
+
+    def test_returns_false_when_no_provider_or_base_url(self):
+        """Should return False when neither provider nor base_url is set."""
+        with patch("tools.advisor_tool.load_config") as mock_cfg:
+            mock_cfg.return_value = {
+                "advisor": {"enabled": True, "provider": "", "base_url": ""}
+            }
+            assert check_advisor_requirements() is False
+
+    def test_returns_true_when_enabled_with_provider(self):
+        """Should return True when enabled with a provider."""
+        with patch("tools.advisor_tool.load_config") as mock_cfg:
+            mock_cfg.return_value = {
+                "advisor": {"enabled": True, "provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+            }
+            assert check_advisor_requirements() is True
+
+    def test_returns_true_when_enabled_with_base_url(self):
+        """Should return True when enabled with a base_url (even without provider)."""
+        with patch("tools.advisor_tool.load_config") as mock_cfg:
+            mock_cfg.return_value = {
+                "advisor": {"enabled": True, "base_url": "http://localhost:11434/v1"}
+            }
+            assert check_advisor_requirements() is True
+
+    def test_returns_false_when_advisor_missing_from_config(self):
+        """Should return False when advisor section is missing."""
+        with patch("tools.advisor_tool.load_config") as mock_cfg:
+            mock_cfg.return_value = {}
+            assert check_advisor_requirements() is False
+
+    def test_returns_false_when_advisor_not_dict(self):
+        """Should return False when advisor is not a dict."""
+        with patch("tools.advisor_tool.load_config") as mock_cfg:
+            mock_cfg.return_value = {"advisor": "invalid"}
+            assert check_advisor_requirements() is False
+
+    def test_returns_false_on_config_load_error(self):
+        """Should return False (not raise) when load_config fails."""
+        with patch("tools.advisor_tool.load_config", side_effect=Exception("boom")):
+            assert check_advisor_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+class TestToolRegistration:
+    """Verify the tool is correctly registered in the registry."""
+
+    def test_registered_in_registry(self):
+        from tools.registry import registry
+        entry = registry._tools.get("ask_advisor")
+        assert entry is not None, "ask_advisor should be registered"
+
+    def test_toolset_is_advisor(self):
+        from tools.registry import registry
+        entry = registry._tools.get("ask_advisor")
+        assert entry.toolset == "advisor"
+
+    def test_has_check_fn(self):
+        from tools.registry import registry
+        entry = registry._tools.get("ask_advisor")
+        assert entry.check_fn is not None
+
+    def test_has_handler(self):
+        from tools.registry import registry
+        entry = registry._tools.get("ask_advisor")
+        assert entry.handler is not None
+
+    def test_emoji_is_brain(self):
+        from tools.registry import registry
+        entry = registry._tools.get("ask_advisor")
+        assert entry.emoji == "🧠"
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    """Verify the tool schema is well-formed."""
+
+    def test_schema_has_name(self):
+        assert ASK_ADVISOR_SCHEMA["name"] == "ask_advisor"
+
+    def test_schema_has_description(self):
+        assert "strategic guidance" in ASK_ADVISOR_SCHEMA["description"]
+
+    def test_schema_required_params(self):
+        required = ASK_ADVISOR_SCHEMA["parameters"]["required"]
+        assert "question" in required
+
+    def test_schema_question_param(self):
+        props = ASK_ADVISOR_SCHEMA["parameters"]["properties"]
+        assert "question" in props
+        assert props["question"]["type"] == "string"
+
+    def test_schema_context_param(self):
+        props = ASK_ADVISOR_SCHEMA["parameters"]["properties"]
+        assert "context" in props
+        assert props["context"]["type"] == "string"
+        # context should NOT be required
+        assert "context" not in ASK_ADVISOR_SCHEMA["parameters"]["required"]
+
+
+# ---------------------------------------------------------------------------
+# Handler tests
+# ---------------------------------------------------------------------------
+
+class TestHandler:
+    """Tests for ask_advisor_handler."""
+
+    def test_missing_question_returns_error(self):
+        result = json.loads(ask_advisor_handler({}))
+        assert "error" in result
+
+    def test_empty_question_returns_error(self):
+        result = json.loads(ask_advisor_handler({"question": ""}))
+        assert "error" in result
+
+    def test_whitespace_question_returns_error(self):
+        result = json.loads(ask_advisor_handler({"question": "   "}))
+        assert "error" in result
+
+    def test_no_provider_or_base_url_returns_error(self):
+        with patch("tools.advisor_tool.load_config") as mock_cfg:
+            mock_cfg.return_value = {
+                "advisor": {
+                    "enabled": True,
+                    "provider": "",
+                    "base_url": "",
+                    "model": "",
+                }
+            }
+            result = json.loads(ask_advisor_handler({"question": "How do I fix this?"}))
+            assert "error" in result
+            assert "not configured" in result["error"]
+
+    def test_successful_call(self):
+        """Verify handler calls call_llm and returns structured result."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Here is your plan: step 1, step 2."
+
+        with patch("tools.advisor_tool.load_config") as mock_cfg, \
+             patch("tools.advisor_tool.call_llm", return_value=mock_response) as mock_llm:
+            mock_cfg.return_value = {
+                "advisor": {
+                    "enabled": True,
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-20250514",
+                    "base_url": "",
+                    "api_key": "",
+                    "max_tokens": 700,
+                }
+            }
+            result = json.loads(ask_advisor_handler({
+                "question": "How should I approach this?",
+                "context": "I'm working on a Python project.",
+            }))
+
+        assert "advisor_response" in result
+        assert "Here is your plan" in result["advisor_response"]
+        assert result["model"] == "claude-sonnet-4-20250514"
+        mock_llm.assert_called_once()
+
+    def test_call_llm_receives_correct_args(self):
+        """Verify call_llm receives provider, model, messages, max_tokens."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Plan"
+
+        with patch("tools.advisor_tool.load_config") as mock_cfg, \
+             patch("tools.advisor_tool.call_llm", return_value=mock_response) as mock_llm:
+            mock_cfg.return_value = {
+                "advisor": {
+                    "enabled": True,
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "base_url": "",
+                    "api_key": "",
+                    "max_tokens": 500,
+                }
+            }
+            ask_advisor_handler({"question": "test"})
+
+        call_kwargs = mock_llm.call_args
+        assert call_kwargs.kwargs["provider"] == "openrouter"
+        assert call_kwargs.kwargs["model"] == "anthropic/claude-3.5-sonnet"
+        assert call_kwargs.kwargs["max_tokens"] == 500
+        assert isinstance(call_kwargs.kwargs["messages"], list)
+        assert len(call_kwargs.kwargs["messages"]) == 2  # system + user
+
+
+# ---------------------------------------------------------------------------
+# Message building tests
+# ---------------------------------------------------------------------------
+
+class TestBuildAdvisorMessages:
+    """Tests for _build_advisor_messages."""
+
+    def test_basic_messages(self):
+        msgs = _build_advisor_messages("What should I do?")
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "system"
+        assert "expert advisor" in msgs[0]["content"]
+        assert msgs[1]["role"] == "user"
+        assert "What should I do?" in msgs[1]["content"]
+
+    def test_with_context(self):
+        msgs = _build_advisor_messages("What should I do?", context="Extra info")
+        assert "Extra info" in msgs[1]["content"]
+        assert "Additional Context" in msgs[1]["content"]
+
+    def test_without_context(self):
+        msgs = _build_advisor_messages("What should I do?")
+        assert "Additional Context" not in msgs[1]["content"]
+
+    def test_empty_context_ignored(self):
+        msgs = _build_advisor_messages("Q", context="  ")
+        assert "Additional Context" not in msgs[1]["content"]

--- a/tools/advisor_tool.py
+++ b/tools/advisor_tool.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Advisor Tool -- Strategic Guidance from a More Capable Model
+
+An application-level advisor pattern tool. The executor model (e.g., local
+Ollama gemma4) can call this tool to get strategic guidance from a more
+capable advisor model (e.g., Claude Opus via API). This is inspired by
+Claude's advisor tool but implemented at the application level so it works
+with ANY executor model.
+
+Flow:
+    Executor (any model, e.g., local gemma4 via Ollama)
+        ↓ tool_call: ask_advisor(question="How should I approach this?")
+        ↓ sends conversation context + question
+    Advisor (e.g., Claude Opus via API)
+        ↓ returns 400-700 token strategic plan
+    Executor receives plan and continues executing
+
+The advisor is configured via config.yaml:
+    advisor:
+        enabled: true
+        provider: anthropic
+        model: claude-sonnet-4-20250514
+        base_url: ""
+        api_key: ""
+        max_tokens: 700
+"""
+
+import json
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
+from tools.registry import registry, tool_error, tool_result
+
+
+# ---------------------------------------------------------------------------
+# Config check
+# ---------------------------------------------------------------------------
+
+def check_advisor_requirements() -> bool:
+    """Return True when the advisor is enabled and has a provider configured."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        advisor = config.get("advisor", {})
+        if not isinstance(advisor, dict):
+            return False
+        if not advisor.get("enabled", False):
+            return False
+        # Need at least a provider or base_url to know where to send the request
+        if not advisor.get("provider") and not advisor.get("base_url"):
+            return False
+        return True
+    except Exception:
+        logger.debug("advisor check_fn raised", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+ASK_ADVISOR_SCHEMA = {
+    "name": "ask_advisor",
+    "description": (
+        "Consult a more capable model for strategic guidance on a complex task. "
+        "The advisor sees your question and returns a concise plan (400-700 tokens). "
+        "Use this when:\n"
+        "- You're unsure about the best approach for a complex task\n"
+        "- You need help with architectural or design decisions\n"
+        "- You've been stuck or making errors for multiple iterations\n"
+        "The advisor provides a strategic plan — follow it yourself using your available tools."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "Your strategic question for the advisor. Be specific about what you need help with.",
+            },
+            "context": {
+                "type": "string",
+                "description": (
+                    "Optional extra context to include. The advisor already sees "
+                    "your conversation history; use this for additional details "
+                    "or constraints not captured in the conversation."
+                ),
+            },
+        },
+        "required": ["question"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def _build_advisor_messages(question: str, context: str = None) -> list:
+    """Build the message list sent to the advisor model."""
+    system_prompt = (
+        "You are an expert advisor providing strategic guidance to another AI "
+        "assistant (the executor). The executor has access to terminal, file, "
+        "web, and other tools and will carry out your plan.\n\n"
+        "Guidelines:\n"
+        "- Provide a clear, actionable plan (400-700 tokens)\n"
+        "- Be specific: mention exact commands, file paths, or approaches\n"
+        "- Consider edge cases and potential pitfalls\n"
+        "- Prioritize the most effective approach over the most obvious one\n"
+        "- If multiple steps are needed, order them logically\n"
+        "- Don't just describe what to do — explain *how* to do it\n"
+        "- The executor will follow your plan using its own tools\n"
+    )
+    user_parts = [f"## Question\n\n{question}"]
+    if context and context.strip():
+        user_parts.append(f"\n## Additional Context\n\n{context}")
+    user_parts.append(
+        "\nProvide a concise strategic plan that the executor can follow "
+        "using its available tools (terminal, file operations, web search, etc.)."
+    )
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": "\n".join(user_parts)},
+    ]
+
+
+def ask_advisor_handler(args: dict, **kwargs) -> str:
+    """Handle the ask_advisor tool call.
+
+    Reads advisor config, builds a prompt, calls the advisor model, and
+    returns the response as a JSON string.
+    """
+    question = args.get("question", "")
+    context = args.get("context")
+
+    if not question or not question.strip():
+        return tool_error("question is required and must be a non-empty string.")
+
+    question = question.strip()
+
+    # Load advisor configuration
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except Exception as exc:
+        return tool_error(f"Failed to load config: {exc}")
+
+    advisor = config.get("advisor", {})
+    if not isinstance(advisor, dict):
+        return tool_error("Advisor configuration is invalid (expected a dict).")
+
+    provider = advisor.get("provider", "").strip()
+    model = advisor.get("model", "").strip()
+    base_url = advisor.get("base_url", "").strip()
+    api_key = advisor.get("api_key", "").strip()
+    max_tokens = advisor.get("max_tokens", 700)
+
+    if not provider and not base_url:
+        return tool_error(
+            "Advisor is not configured. Set advisor.provider or "
+            "advisor.base_url in config.yaml."
+        )
+
+    # Build messages
+    messages = _build_advisor_messages(question, context)
+
+    # Call the advisor model using call_llm with explicit provider/model
+    try:
+        from agent.auxiliary_client import call_llm
+        response = call_llm(
+            provider=provider or None,
+            model=model or None,
+            base_url=base_url or None,
+            api_key=api_key or None,
+            messages=messages,
+            max_tokens=int(max_tokens),
+            temperature=0.3,
+        )
+    except Exception as exc:
+        logger.error("Advisor call failed: %s\n%s", exc, traceback.format_exc())
+        return tool_error(f"Advisor call failed: {type(exc).__name__}: {exc}")
+
+    # Extract response content
+    try:
+        content = None
+        if hasattr(response, "choices") and response.choices:
+            content = response.choices[0].message.content
+        elif hasattr(response, "content"):
+            content = response.content
+        elif isinstance(response, dict):
+            content = response.get("content") or response.get("text")
+
+        if not content or not content.strip():
+            return tool_error("Advisor returned an empty response.")
+
+        return tool_result({
+            "advisor_response": content.strip(),
+            "model": model or provider or "unknown",
+        })
+    except Exception as exc:
+        return tool_error(f"Failed to parse advisor response: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="ask_advisor",
+    toolset="advisor",
+    schema=ASK_ADVISOR_SCHEMA,
+    handler=ask_advisor_handler,
+    check_fn=check_advisor_requirements,
+    emoji="🧠",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -192,6 +192,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "advisor": {
+        "description": "Consult a more capable model for strategic guidance on complex tasks",
+        "tools": ["ask_advisor"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 


### PR DESCRIPTION
## Summary

Implements an **application-level advisor pattern** that allows any executor model (including local models via Ollama) to consult a more capable advisor model (e.g., Claude Opus) for strategic planning.

Inspired by Claude's advisor tool, but implemented at the application level so it works with **any executor model** — not limited to Claude-only combinations.

## How it works

```
Executor (e.g., local gemma4 via Ollama)
    ↓ tool_call: ask_advisor(question="How should I approach this?")
Advisor (e.g., Claude Opus via API)
    ↓ returns 400-700 token strategic plan
Executor receives plan and continues executing
```

This combines the cost efficiency of local models (free) with the strategic reasoning of frontier models, since the advisor is only called when needed.

## Changes

### New files
- **`tools/advisor_tool.py`** — Tool implementation with registry registration, config-driven provider/model selection, conversation context sharing via `call_llm()`
- **`tests/tools/test_advisor_tool.py`** — 20 unit tests covering check_fn, registration, schema, handler logic, and message building

### Modified files
- **`hermes_cli/config.py`** — Add `advisor` config section (`enabled`, `provider`, `model`, `base_url`, `api_key`, `max_tokens`)
- **`agent/prompt_builder.py`** — Add `ADVISOR_GUIDANCE` constant for system prompt
- **`run_agent.py`** — Conditionally inject advisor guidance when tool is available
- **`toolsets.py`** — Register `advisor` toolset
- **`model_tools.py`** — Add `tools.advisor_tool` to discovery imports

## Configuration

```yaml
advisor:
  enabled: true
  provider: anthropic
  model: claude-opus-4-20250514
  max_tokens: 700
```

Or with any provider (OpenRouter, local Ollama, etc.):

```yaml
advisor:
  enabled: true
  provider: openrouter
  model: anthropic/claude-opus-4-20250514
```

## Use cases

- **Local model + cloud advisor**: Run a free local model (Ollama) for most turns, call Claude/GPT for strategic decisions
- **Cheap model + expensive advisor**: Use Sonnet as executor, Opus as advisor — near-Opus quality at Sonnet cost
- **Any provider combination**: Works with all 18+ providers Hermes supports

Closes none. First iteration — future enhancements could include auto-trigger (e.g., after N failed iterations) and context compression before sending to advisor.