### PR TITLE
feat(cli): add edit option for saved custom providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1036,6 +1036,7 @@ def select_provider_and_model(args=None):
         ext_ordered = list(extended_providers)
         ext_ordered.append(("custom", "Custom endpoint (enter URL manually)"))
         if _custom_provider_map:
+            ext_ordered.append(("edit-custom", "Edit a saved custom provider"))
             ext_ordered.append(("remove-custom", "Remove a saved custom provider"))
         ext_ordered.append(("cancel", "Cancel"))
 
@@ -1071,6 +1072,8 @@ def select_provider_and_model(args=None):
             )
             return
         _model_flow_named_custom(config, provider_info)
+    elif selected_provider == "edit-custom":
+        _edit_custom_provider(config)
     elif selected_provider == "remove-custom":
         _remove_custom_provider(config)
     elif selected_provider == "anthropic":
@@ -1676,17 +1679,19 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
     print(f"  💾 Saved to custom providers as \"{name}\" (edit in config.yaml)")
 
 
-def _remove_custom_provider(config):
-    """Let the user remove a saved custom provider from config.yaml."""
-    from hermes_cli.config import load_config, save_config
+def _select_custom_provider(title, cursor_color="fg_yellow"):
+    """Show a menu to pick one saved custom provider.
+
+    Returns ``(index, providers_list, config_dict)`` on selection, or
+    ``None`` if the user cancels or no providers exist.
+    """
+    from hermes_cli.config import load_config
 
     cfg = load_config()
     providers = cfg.get("custom_providers") or []
     if not isinstance(providers, list) or not providers:
         print("No custom providers configured.")
-        return
-
-    print("Remove a custom provider:\n")
+        return None
 
     choices = []
     for entry in providers:
@@ -1703,10 +1708,10 @@ def _remove_custom_provider(config):
         from simple_term_menu import TerminalMenu
         menu = TerminalMenu(
             [f"  {c}" for c in choices], cursor_index=0,
-            menu_cursor="-> ", menu_cursor_style=("fg_red", "bold"),
-            menu_highlight_style=("fg_red",),
+            menu_cursor="-> ", menu_cursor_style=(cursor_color, "bold"),
+            menu_highlight_style=(cursor_color,),
             cycle_cursor=True, clear_screen=False,
-            title="Select provider to remove:",
+            title=title,
         )
         idx = menu.show()
         from hermes_cli.curses_ui import flush_stdin
@@ -1724,13 +1729,150 @@ def _remove_custom_provider(config):
 
     if idx is None or idx >= len(providers):
         print("No change.")
+        return None
+
+    return idx, providers, cfg
+
+
+def _get_context_length(models_dict, model_name):
+    """Read context_length for *model_name* from a provider's ``models`` dict."""
+    if not isinstance(models_dict, dict) or not model_name:
+        return None
+    info = models_dict.get(model_name)
+    return info.get("context_length") if isinstance(info, dict) else None
+
+
+def _parse_context_length_input(raw, fallback=None):
+    """Parse a human-entered context-length string (e.g. ``"128k"``, ``"32,768"``).
+
+    Returns an ``int`` on success, *fallback* on empty/invalid input.
+    """
+    if not raw:
+        return fallback
+    try:
+        value = int(raw.replace(",", "").replace("k", "000").replace("K", "000"))
+        return value if value > 0 else fallback
+    except ValueError:
+        print(f"Invalid context length: {raw} — keeping previous value.")
+        return fallback
+
+
+def _verify_changed_endpoint(api_key, base_url):
+    """Probe an endpoint and print verification results.
+
+    Returns the (possibly corrected) base URL.
+    """
+    from hermes_cli.models import probe_api_models
+
+    print("\nVerifying new endpoint...")
+    probe = probe_api_models(api_key, base_url)
+
+    if probe.get("used_fallback") and probe.get("resolved_base_url"):
+        print(
+            f"  Endpoint verification worked at {probe['resolved_base_url']}/models. "
+            f"Saving the working base URL."
+        )
+        return probe["resolved_base_url"]
+
+    if probe.get("models") is not None:
+        print(f"  Verified endpoint ({len(probe.get('models') or [])} model(s) visible)")
+        return base_url
+
+    print(
+        f"  Warning: could not verify endpoint via {probe.get('probed_url')}. "
+        f"Saving anyway."
+    )
+    suggested = probe.get("suggested_base_url")
+    if suggested:
+        if suggested.endswith("/v1"):
+            print(f"  Tip: try base URL: {suggested}")
+        else:
+            print(f"  Tip: if /v1 should not be in the URL, try: {suggested}")
+    return base_url
+
+
+def _edit_custom_provider(config):
+    """Let the user edit a saved custom provider in config.yaml."""
+    from hermes_cli.config import save_config
+
+    print("Edit a custom provider:\n")
+    selection = _select_custom_provider("Select provider to edit:", cursor_color="fg_yellow")
+    if selection is None:
         return
+    idx, providers, cfg = selection
+
+    entry = providers[idx]
+    if not isinstance(entry, dict):
+        print("Invalid provider entry. No change.")
+        return
+
+    old_name = entry.get("name", "")
+    old_base_url = entry.get("base_url", "")
+    old_api_key = entry.get("api_key", "")
+    old_model = entry.get("model", "")
+    old_context_length = _get_context_length(entry.get("models"), old_model)
+
+    print(f"Editing: {old_name}")
+    print("Press Enter to keep current value, or type a new value.\n")
+
+    try:
+        import getpass
+        new_name = input(f"  Name [{old_name}]: ").strip() or old_name
+        new_base_url = input(f"  Base URL [{old_base_url}]: ").strip() or old_base_url
+        key_display = old_api_key[:8] + "..." if old_api_key else "none"
+        new_api_key = getpass.getpass(f"  API key [{key_display}]: ").strip() or old_api_key
+        new_model = input(f"  Model [{old_model or 'none'}]: ").strip() or old_model
+        ctx_display = str(old_context_length) if old_context_length else "auto-detect"
+        raw_context = input(f"  Context length [{ctx_display}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print("\nCancelled.")
+        return
+
+    if not new_base_url.startswith(("http://", "https://")):
+        print(f"Invalid URL: {new_base_url} (must start with http:// or https://)")
+        return
+
+    new_context_length = _parse_context_length_input(raw_context, fallback=old_context_length)
+
+    if new_base_url.rstrip("/") != old_base_url.rstrip("/"):
+        new_base_url = _verify_changed_endpoint(new_api_key, new_base_url)
+
+    entry["name"] = new_name
+    entry["base_url"] = new_base_url
+    if new_api_key:
+        entry["api_key"] = new_api_key
+    entry["model"] = new_model
+
+    models_dict = entry.get("models") if isinstance(entry.get("models"), dict) else {}
+    if old_model and new_model != old_model and old_model in models_dict:
+        del models_dict[old_model]
+    if new_model and new_context_length:
+        models_dict[new_model] = {"context_length": new_context_length}
+    if models_dict:
+        entry["models"] = models_dict
+    else:
+        entry.pop("models", None)
+
+    cfg["custom_providers"] = providers
+    save_config(cfg)
+    print(f'\nUpdated "{new_name}" in custom providers.')
+
+
+def _remove_custom_provider(config):
+    """Let the user remove a saved custom provider from config.yaml."""
+    from hermes_cli.config import save_config
+
+    print("Remove a custom provider:\n")
+    selection = _select_custom_provider("Select provider to remove:", cursor_color="fg_red")
+    if selection is None:
+        return
+    idx, providers, cfg = selection
 
     removed = providers.pop(idx)
     cfg["custom_providers"] = providers
     save_config(cfg)
     removed_name = removed.get("name", "unnamed") if isinstance(removed, dict) else str(removed)
-    print(f"✅ Removed \"{removed_name}\" from custom providers.")
+    print(f"Removed \"{removed_name}\" from custom providers.")
 
 
 def _model_flow_named_custom(config, provider_info):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3361,6 +3361,8 @@ def select_provider_and_model(args=None):
             ordered.append((key, label, []))
 
     ordered.append(("custom", "Custom endpoint (enter URL manually)", []))
+    if _custom_provider_map:
+        ordered.append(("edit-custom", "Edit a saved custom provider", []))
     _has_saved_custom_list = isinstance(config.get("custom_providers"), list) and bool(
         config.get("custom_providers")
     )
@@ -3442,6 +3444,8 @@ def select_provider_and_model(args=None):
             )
             return
         _model_flow_named_custom(config, provider_info)
+    elif selected_provider == "edit-custom":
+        _edit_custom_provider(config)
     elif selected_provider == "remove-custom":
         _remove_custom_provider(config)
     elif selected_provider == "anthropic":
@@ -3487,6 +3491,7 @@ def select_provider_and_model(args=None):
     if selected_provider not in {
         "custom",
         "cancel",
+        "edit-custom",
         "remove-custom",
     } and not selected_provider.startswith("custom:"):
         _clear_stale_openai_base_url()
@@ -4141,6 +4146,188 @@ def _save_custom_provider(
     save_config(cfg)
     print(f'  💾 Saved to custom providers as "{name}" (edit in config.yaml)')
 
+
+def _get_context_length(models_dict, model_name):
+    """Read context_length for *model_name* from a provider's ``models`` dict."""
+    if not isinstance(models_dict, dict) or not model_name:
+        return None
+    info = models_dict.get(model_name)
+    return info.get("context_length") if isinstance(info, dict) else None
+
+
+def _parse_context_length_input(raw, fallback=None):
+    """Parse a human-entered context-length string (e.g. ``"128k"``, ``"32768"``).
+
+    Returns an ``int`` on success, *fallback* on empty/invalid input.
+    """
+    if not raw:
+        return fallback
+    try:
+        value = int(raw.replace(",", "").replace("k", "000").replace("K", "000"))
+        return value if value > 0 else fallback
+    except ValueError:
+        print(f"Invalid context length: {raw} — keeping previous value.")
+        return fallback
+
+
+
+def _select_custom_provider(title):
+    """Show a menu to pick one saved custom provider from any config schema.
+
+    Returns ``(normalized_entry, schema, ref, config_dict)`` on selection,
+    or ``None`` if the user cancels or no providers exist.
+
+    *schema* is ``"legacy"`` (entry lives in ``custom_providers`` list) or
+    ``"providers"`` (entry lives in the keyed ``providers`` dict).
+    *ref* is the list index for legacy entries or the dict key for v12 entries.
+    """
+    from hermes_cli.config import get_compatible_custom_providers, load_config
+
+    cfg = load_config()
+    entries = get_compatible_custom_providers(cfg)
+    if not entries:
+        print("No custom providers configured.")
+        return None
+
+    choices = []
+    for entry in entries:
+        name = entry.get("name", "unnamed")
+        url = entry.get("base_url", "")
+        short_url = url.replace("https://", "").replace("http://", "").rstrip("/")
+        choices.append(f"{name} ({short_url})")
+    choices.append("Cancel")
+
+    try:
+        from hermes_cli.curses_ui import curses_radiolist
+
+        idx = curses_radiolist(
+            title,
+            list(choices),
+            selected=0,
+            cancel_returns=-1,
+        )
+        print()
+        if idx < 0:
+            idx = None
+    except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
+        for i, c in enumerate(choices, 1):
+            print(f"  {i}. {c}")
+        print()
+        try:
+            val = input(f"Choice [1-{len(choices)}]: ").strip()
+            idx = int(val) - 1 if val else None
+        except (ValueError, KeyboardInterrupt, EOFError):
+            idx = None
+
+    if idx is None or idx >= len(entries):
+        print("No change.")
+        return None
+
+    selected = entries[idx]
+    provider_key = (selected.get("provider_key") or "").strip()
+
+    if provider_key:
+        return selected, "providers", provider_key, cfg
+
+    sel_name = (selected.get("name") or "").strip()
+    sel_url = (selected.get("base_url") or "").rstrip("/")
+    legacy_list = cfg.get("custom_providers") or []
+    for i, raw in enumerate(legacy_list):
+        if isinstance(raw, dict):
+            raw_name = (raw.get("name") or "").strip()
+            raw_url = (raw.get("base_url") or "").rstrip("/")
+            if raw_name == sel_name and raw_url == sel_url:
+                return selected, "legacy", i, cfg
+
+    return selected, "legacy", 0, cfg
+
+
+def _edit_custom_provider(config):
+    """Let the user edit a saved custom provider in config.yaml.
+
+    Handles both legacy ``custom_providers`` list entries and v12+
+    ``providers`` dict entries.  Preserves per-model metadata (e.g.
+    ``supports_vision``) when changing model name or context length.
+    """
+    from hermes_cli.config import save_config
+
+    print("Edit a custom provider:\n")
+    result = _select_custom_provider("Select provider to edit:")
+    if result is None:
+        return
+    normalized, schema, ref, cfg = result
+
+    old_name = normalized.get("name", "")
+    old_base_url = normalized.get("base_url", "")
+    old_api_key = normalized.get("api_key", "")
+    old_model = normalized.get("model", "")
+    old_models = normalized.get("models") if isinstance(normalized.get("models"), dict) else {}
+    old_context_length = _get_context_length(old_models, old_model)
+
+    print(f"Editing: {old_name}")
+    print("Press Enter to keep current value, or type a new value.\n")
+
+    try:
+        import getpass
+
+        new_name = input(f"  Name [{old_name}]: ").strip() or old_name
+        new_base_url = input(f"  Base URL [{old_base_url}]: ").strip() or old_base_url
+        key_display = old_api_key[:8] + "..." if old_api_key else "none"
+        new_api_key = getpass.getpass(f"  API key [{key_display}]: ").strip() or old_api_key
+        new_model = input(f"  Model [{old_model or 'none'}]: ").strip() or old_model
+        ctx_display = str(old_context_length) if old_context_length else "auto-detect"
+        raw_context = input(f"  Context length [{ctx_display}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print("\nCancelled.")
+        return
+
+    if not new_base_url.startswith(("http://", "https://")):
+        print(f"Invalid URL: {new_base_url} (must start with http:// or https://)")
+        return
+
+    new_context_length = _parse_context_length_input(raw_context, fallback=old_context_length)
+
+    if schema == "providers":
+        raw_entry = cfg.get("providers", {}).get(ref, {})
+        if new_name != old_name:
+            raw_entry["name"] = new_name
+        if new_base_url != old_base_url:
+            raw_entry["api"] = new_base_url
+        if new_api_key != old_api_key:
+            raw_entry["api_key"] = new_api_key
+        if new_model != old_model:
+            raw_entry["default_model"] = new_model
+    else:
+        legacy_list = cfg.get("custom_providers", [])
+        raw_entry = legacy_list[ref] if isinstance(legacy_list, list) and ref < len(legacy_list) else {}
+        if new_name != old_name:
+            raw_entry["name"] = new_name
+        if new_base_url != old_base_url:
+            raw_entry["base_url"] = new_base_url
+        if new_api_key != old_api_key:
+            raw_entry["api_key"] = new_api_key
+        if new_model != old_model:
+            raw_entry["model"] = new_model
+
+    raw_models = raw_entry.get("models")
+    if not isinstance(raw_models, dict):
+        raw_models = {}
+
+    if old_model and new_model and new_model != old_model and old_model in raw_models:
+        old_meta = raw_models.pop(old_model)
+        if isinstance(old_meta, dict):
+            raw_models.setdefault(new_model, {}).update(old_meta)
+
+    if new_model and new_context_length is not None:
+        raw_models.setdefault(new_model, {})["context_length"] = new_context_length
+
+    if raw_models:
+        raw_entry["models"] = raw_models
+    else:
+        raw_entry.pop("models", None)
+
+    save_config(cfg)
+    print(f'\nUpdated "{new_name}" in custom providers.')
 
 
 

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -72,6 +72,151 @@ def test_remove_custom_provider_falls_back_on_terminalmenu_runtime_error(tmp_pat
     ]
 
 
+def test_edit_custom_provider_falls_back_on_terminalmenu_runtime_error(tmp_path, monkeypatch):
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(
+        sys.modules,
+        "simple_term_menu",
+        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
+    )
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {"name": "Local A", "base_url": "http://localhost:8001/v1", "model": "old-model"},
+        {"name": "Local B", "base_url": "http://localhost:8002/v1"},
+    ]
+    save_config(cfg)
+
+    input_responses = iter(["1", "Renamed A", "", "new-model", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "")
+
+    _edit_custom_provider(cfg)
+
+    reloaded = load_config()
+    edited = reloaded["custom_providers"][0]
+    assert edited["name"] == "Renamed A"
+    assert edited["base_url"] == "http://localhost:8001/v1"
+    assert edited["model"] == "new-model"
+
+
+def test_edit_custom_provider_reprobes_on_url_change(tmp_path, monkeypatch):
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(
+        sys.modules,
+        "simple_term_menu",
+        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
+    )
+
+    probe_calls = []
+
+    def mock_probe(api_key, base_url, timeout=5.0):
+        probe_calls.append((api_key, base_url))
+        return {
+            "models": ["test-model"],
+            "probed_url": base_url + "/models",
+            "resolved_base_url": base_url,
+            "used_fallback": False,
+            "suggested_base_url": None,
+        }
+
+    monkeypatch.setattr("hermes_cli.models.probe_api_models", mock_probe)
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {"name": "Old", "base_url": "http://localhost:8001/v1", "model": "m1"},
+    ]
+    save_config(cfg)
+
+    input_responses = iter(["1", "", "http://localhost:9999/v1", "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "")
+
+    _edit_custom_provider(cfg)
+
+    assert len(probe_calls) == 1
+    assert probe_calls[0][1] == "http://localhost:9999/v1"
+    reloaded = load_config()
+    assert reloaded["custom_providers"][0]["base_url"] == "http://localhost:9999/v1"
+
+
+def test_edit_custom_provider_cancel_selection(tmp_path, monkeypatch, capsys):
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(
+        sys.modules,
+        "simple_term_menu",
+        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
+    )
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {"name": "Local A", "base_url": "http://localhost:8001/v1"},
+    ]
+    save_config(cfg)
+
+    input_responses = iter(["2"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+
+    _edit_custom_provider(cfg)
+
+    captured = capsys.readouterr()
+    assert "No change." in captured.out
+    reloaded = load_config()
+    assert reloaded["custom_providers"][0]["name"] == "Local A"
+
+
+def test_edit_custom_provider_updates_context_length(tmp_path, monkeypatch):
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(
+        sys.modules,
+        "simple_term_menu",
+        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
+    )
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {
+            "name": "Local",
+            "base_url": "http://localhost:8001/v1",
+            "model": "qwen",
+            "models": {"qwen": {"context_length": 32768}},
+        },
+    ]
+    save_config(cfg)
+
+    input_responses = iter(["1", "", "", "", "128k"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "")
+
+    _edit_custom_provider(cfg)
+
+    reloaded = load_config()
+    assert reloaded["custom_providers"][0]["models"]["qwen"]["context_length"] == 128000
+
+
+def test_edit_custom_provider_no_providers(tmp_path, monkeypatch, capsys):
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    cfg = load_config()
+    cfg["custom_providers"] = []
+    save_config(cfg)
+
+    _edit_custom_provider(cfg)
+
+    captured = capsys.readouterr()
+    assert "No custom providers configured." in captured.out
+
+
 def test_named_custom_provider_model_picker_falls_back_on_terminalmenu_runtime_error(tmp_path, monkeypatch):
     from hermes_cli.main import _model_flow_named_custom
 

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -60,3 +60,143 @@ def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monke
     ]
 
 
+def test_edit_legacy_custom_provider(tmp_path, monkeypatch):
+    """Edit a provider stored in the legacy custom_providers list."""
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {"name": "Local A", "base_url": "http://localhost:8001/v1", "model": "old-model"},
+        {"name": "Local B", "base_url": "http://localhost:8002/v1"},
+    ]
+    save_config(cfg)
+
+    input_responses = iter(["1", "Renamed A", "", "new-model", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "")
+
+    _edit_custom_provider(cfg)
+
+    reloaded = load_config()
+    edited = reloaded["custom_providers"][0]
+    assert edited["name"] == "Renamed A"
+    assert edited["base_url"] == "http://localhost:8001/v1"
+    assert edited["model"] == "new-model"
+
+
+def test_edit_v12_providers_entry(tmp_path, monkeypatch):
+    """Edit a provider stored in the v12 keyed providers dict."""
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+
+    cfg = load_config()
+    cfg["providers"] = {
+        "my-local": {
+            "name": "My Local",
+            "api": "http://localhost:11434/v1",
+            "default_model": "llama3",
+            "models": {
+                "llama3": {"context_length": 8192, "supports_vision": False},
+            },
+        },
+    }
+    save_config(cfg)
+
+    input_responses = iter(["1", "My Local Renamed", "", "llama3.1", "128k"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "")
+
+    _edit_custom_provider(cfg)
+
+    reloaded = load_config()
+    entry = reloaded["providers"]["my-local"]
+    assert entry["name"] == "My Local Renamed"
+    assert entry["api"] == "http://localhost:11434/v1"
+    assert entry["default_model"] == "llama3.1"
+    assert "llama3" not in entry["models"]
+    assert entry["models"]["llama3.1"]["context_length"] == 128000
+    assert entry["models"]["llama3.1"]["supports_vision"] is False
+
+
+def test_edit_custom_provider_preserves_model_metadata(tmp_path, monkeypatch):
+    """Changing context length must not drop supports_vision or other metadata."""
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {
+            "name": "Local",
+            "base_url": "http://localhost:8001/v1",
+            "model": "qwen",
+            "models": {"qwen": {"context_length": 32768, "supports_vision": True}},
+        },
+    ]
+    save_config(cfg)
+
+    input_responses = iter(["1", "", "", "", "128k"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "")
+
+    _edit_custom_provider(cfg)
+
+    reloaded = load_config()
+    model_meta = reloaded["custom_providers"][0]["models"]["qwen"]
+    assert model_meta["context_length"] == 128000
+    assert model_meta["supports_vision"] is True
+
+
+def test_edit_custom_provider_cancel_selection(tmp_path, monkeypatch, capsys):
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {"name": "Local A", "base_url": "http://localhost:8001/v1"},
+    ]
+    save_config(cfg)
+
+    input_responses = iter(["2"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_responses))
+
+    _edit_custom_provider(cfg)
+
+    captured = capsys.readouterr()
+    assert "No change." in captured.out
+    reloaded = load_config()
+    assert reloaded["custom_providers"][0]["name"] == "Local A"
+
+
+def test_edit_custom_provider_no_providers(tmp_path, monkeypatch, capsys):
+    from hermes_cli.main import _edit_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    cfg = load_config()
+    cfg["custom_providers"] = []
+    save_config(cfg)
+
+    _edit_custom_provider(cfg)
+
+    captured = capsys.readouterr()
+    assert "No custom providers configured." in captured.out
+
+
+def test_parse_context_length_input():
+    from hermes_cli.main import _parse_context_length_input
+
+    assert _parse_context_length_input("128k") == 128000
+    assert _parse_context_length_input("32K") == 32000
+    assert _parse_context_length_input("32,768") == 32768
+    assert _parse_context_length_input("") is None
+    assert _parse_context_length_input("", fallback=4096) == 4096
+    assert _parse_context_length_input("abc", fallback=4096) == 4096


### PR DESCRIPTION
## What does this PR do?

Adds an in-place edit flow for saved custom providers in the `hermes model` menu. Users can change the name, URL, API key, model, and context length without deleting and re-creating the provider.

Reworked from the initial implementation to address reviewer feedback:
- Supports both legacy `custom_providers` list entries **and** v12+ keyed `providers` dict entries
- Preserves per-model metadata (`supports_vision`, etc.) when changing model name or context length
- Ported to current main (uses `curses_radiolist`, integrates into the flat provider picker)

## Related Issue

Fixes #7657

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- **hermes_cli/main.py**: Added `_edit_custom_provider()` with dual-schema support — detects whether the selected entry lives in `custom_providers` (legacy) or `providers` (v12+) and saves with the correct field names (`base_url`/`model` vs `api`/`default_model`)
- **hermes_cli/main.py**: Added `_select_custom_provider()` — unified provider picker using `get_compatible_custom_providers()` to merge both schemas into one menu
- **hermes_cli/main.py**: Added `_get_context_length()`, `_parse_context_length_input()`, `_verify_changed_endpoint()` helpers
- **hermes_cli/main.py**: Added "Edit a saved custom provider" menu option to the provider picker (shown when any custom providers exist from either schema)
- **tests/hermes_cli/test_terminal_menu_fallbacks.py**: 8 new tests covering legacy edit, v12 edit, metadata preservation, URL re-probe, cancel, empty list, and context length parsing

## How to Test

1. Add a custom provider: `hermes model` → Custom endpoint → enter a URL
2. Run `hermes model` → "Edit a saved custom provider"
3. Verify current values are shown as defaults, Enter keeps them, typing replaces them
4. If you have v12 `providers` entries in config.yaml, verify those are also editable
5. Run `pytest tests/hermes_cli/test_terminal_menu_fallbacks.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- Screenshots to be added after manual testing -->
