### PR TITLE
fix(gateway): propagate user identity to notify_on_complete watchers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6494,6 +6494,8 @@ class GatewayRunner:
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            user_id=str(context.source.user_id) if context.source.user_id else "",
+            user_name=str(context.source.user_name) if context.source.user_name else "",
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -6676,6 +6678,8 @@ class GatewayRunner:
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
         thread_id = watcher.get("thread_id", "")
+        user_id = watcher.get("user_id", "")
+        user_name = watcher.get("user_name", "")
         agent_notify = watcher.get("notify_on_complete", False)
         notify_mode = self._load_background_notifications_mode()
 
@@ -6731,6 +6735,8 @@ class GatewayRunner:
                                 platform=_platform_enum,
                                 chat_id=chat_id,
                                 thread_id=thread_id or None,
+                                user_id=user_id or None,
+                                user_name=user_name or None,
                             )
                             synth_event = MessageEvent(
                                 text=synth_text,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -46,12 +46,16 @@ _SESSION_PLATFORM: ContextVar[str] = ContextVar("HERMES_SESSION_PLATFORM", defau
 _SESSION_CHAT_ID: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_ID", default="")
 _SESSION_CHAT_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_NAME", default="")
 _SESSION_THREAD_ID: ContextVar[str] = ContextVar("HERMES_SESSION_THREAD_ID", default="")
+_SESSION_USER_ID: ContextVar[str] = ContextVar("HERMES_SESSION_USER_ID", default="")
+_SESSION_USER_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_USER_NAME", default="")
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
+    "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
+    "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
 }
 
 
@@ -60,6 +64,8 @@ def set_session_vars(
     chat_id: str = "",
     chat_name: str = "",
     thread_id: str = "",
+    user_id: str = "",
+    user_name: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -74,6 +80,8 @@ def set_session_vars(
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
+        _SESSION_USER_ID.set(user_id),
+        _SESSION_USER_NAME.set(user_name),
     ]
     return tokens
 
@@ -87,6 +95,8 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,
+        _SESSION_USER_ID,
+        _SESSION_USER_NAME,
     ]
     for var, token in zip(vars_in_order, tokens):
         var.reset(token)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -82,6 +82,8 @@ class ProcessSession:
     watcher_chat_id: str = ""
     watcher_thread_id: str = ""
     watcher_interval: int = 0                   # 0 = no watcher configured
+    watcher_user_id: str = ""
+    watcher_user_name: str = ""
     notify_on_complete: bool = False             # Queue agent notification on exit
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
@@ -871,6 +873,8 @@ class ProcessRegistry:
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_thread_id": s.watcher_thread_id,
                             "watcher_interval": s.watcher_interval,
+                            "watcher_user_id": s.watcher_user_id,
+                            "watcher_user_name": s.watcher_user_name,
                             "notify_on_complete": s.notify_on_complete,
                         })
             
@@ -931,6 +935,8 @@ class ProcessRegistry:
                     watcher_chat_id=entry.get("watcher_chat_id", ""),
                     watcher_thread_id=entry.get("watcher_thread_id", ""),
                     watcher_interval=entry.get("watcher_interval", 0),
+                    watcher_user_id=entry.get("watcher_user_id", ""),
+                    watcher_user_name=entry.get("watcher_user_name", ""),
                     notify_on_complete=entry.get("notify_on_complete", False),
                 )
                 with self._lock:
@@ -947,6 +953,8 @@ class ProcessRegistry:
                         "platform": session.watcher_platform,
                         "chat_id": session.watcher_chat_id,
                         "thread_id": session.watcher_thread_id,
+                        "user_id": session.watcher_user_id,
+                        "user_name": session.watcher_user_name,
                         "notify_on_complete": session.notify_on_complete,
                     })
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1425,9 +1425,13 @@ def terminal_tool(
                     if _gw_platform and not check_interval:
                         _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
                         _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
+                        _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
+                        _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
                         proc_session.watcher_platform = _gw_platform
                         proc_session.watcher_chat_id = _gw_chat_id
                         proc_session.watcher_thread_id = _gw_thread_id
+                        proc_session.watcher_user_id = _gw_user_id
+                        proc_session.watcher_user_name = _gw_user_name
                         proc_session.watcher_interval = 5
                         process_registry.pending_watchers.append({
                             "session_id": proc_session.id,
@@ -1436,6 +1440,8 @@ def terminal_tool(
                             "platform": _gw_platform,
                             "chat_id": _gw_chat_id,
                             "thread_id": _gw_thread_id,
+                            "user_id": _gw_user_id,
+                            "user_name": _gw_user_name,
                             "notify_on_complete": True,
                         })
 
@@ -1450,11 +1456,15 @@ def terminal_tool(
                     watcher_platform = _gse2("HERMES_SESSION_PLATFORM", "")
                     watcher_chat_id = _gse2("HERMES_SESSION_CHAT_ID", "")
                     watcher_thread_id = _gse2("HERMES_SESSION_THREAD_ID", "")
+                    watcher_user_id = _gse2("HERMES_SESSION_USER_ID", "")
+                    watcher_user_name = _gse2("HERMES_SESSION_USER_NAME", "")
 
                     # Store on session for checkpoint persistence
                     proc_session.watcher_platform = watcher_platform
                     proc_session.watcher_chat_id = watcher_chat_id
                     proc_session.watcher_thread_id = watcher_thread_id
+                    proc_session.watcher_user_id = watcher_user_id
+                    proc_session.watcher_user_name = watcher_user_name
                     proc_session.watcher_interval = effective_interval
 
                     process_registry.pending_watchers.append({
@@ -1464,6 +1474,8 @@ def terminal_tool(
                         "platform": watcher_platform,
                         "chat_id": watcher_chat_id,
                         "thread_id": watcher_thread_id,
+                        "user_id": watcher_user_id,
+                        "user_name": watcher_user_name,
                     })
 
                 return json.dumps(result_data, ensure_ascii=False)


### PR DESCRIPTION
## Problem

Fixes #7643

When a background process with `notify_on_complete=true` finishes, `_run_process_watcher()` constructs a `SessionSource` without `user_id`/`user_name`. This causes `_is_user_authorized()` to reject the synthetic message (`if not user_id: return False`), triggering the pairing flow instead of delivering the agent notification.

## Root Cause

User identity is not propagated through the watcher pipeline:
1. `_set_session_env()` doesn't export `HERMES_SESSION_USER_ID`/`HERMES_SESSION_USER_NAME`
2. `terminal_tool.py` watcher creation doesn't capture user identity
3. `ProcessSession` has no `watcher_user_id`/`watcher_user_name` fields
4. `_run_process_watcher()` can't populate `SessionSource` with user info

## Fix

Propagate user identity through the full chain (4 files, 36 lines added):

| File | Change |
|---|---|
| `gateway/session_context.py` | Add `_SESSION_USER_ID`/`_SESSION_USER_NAME` ContextVars |
| `gateway/run.py` | Pass user identity in `_set_session_env()`; read it in `_run_process_watcher()` |
| `tools/process_registry.py` | Add `watcher_user_id`/`watcher_user_name` to `ProcessSession` + checkpoint serialization/recovery |
| `tools/terminal_tool.py` | Read user identity from session context, include in watcher dicts |

## Testing

- All 2419 existing tests pass (9 failures are pre-existing on main)
- Backward-compatible: new fields default to empty string, checkpoint recovery uses `.get(key, "")`