### PR TITLE
fix: add gpt-5.4 to openai-codex model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -87,6 +87,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-nano",
     ],
     "openai-codex": [
+        "gpt-5.4",
+        "gpt-5.4-mini",
         "gpt-5.3-codex",
         "gpt-5.2-codex",
         "gpt-5.1-codex-mini",


### PR DESCRIPTION
## Summary

ChatGPT OAuth users couldn't see gpt-5.4 or gpt-5.4-mini in the `/model` picker on Telegram/Discord.

**Root cause:** `_PROVIDER_MODELS['openai-codex']` in `hermes_cli/models.py` was never updated when gpt-5.4 became available. It only had the older codex-specific models (gpt-5.3-codex, gpt-5.2-codex, etc.). Meanwhile, `codex_models.py`'s `DEFAULT_CODEX_MODELS` already included gpt-5.4 and gpt-5.4-mini.

The `/model` interactive picker (Telegram inline keyboards, Discord buttons) calls `list_authenticated_providers()` which pulls from the `_PROVIDER_MODELS` curated list — not from `codex_models.py`.

**Fix:** Add `gpt-5.4` and `gpt-5.4-mini` to the top of the openai-codex curated list, matching what `codex_models.py` already has.

## Test plan
- 161 model-related tests pass (test_models, test_codex_models, test_model_switch, test_model_command, test_model_validation, test_model_normalize)
- Verified import: `_PROVIDER_MODELS['openai-codex']` now returns `['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', ...]`

Reported by @chongdashu