### PR TITLE
fix(update): restart system gateway via sudo when non-root

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3843,8 +3843,12 @@ def cmd_update(args):
                                 capture_output=True, text=True, timeout=5,
                             )
                             if check.stdout.strip() == "active":
+                                restart_cmd = scope_cmd + ["restart", svc_name]
+                                if scope == "system" and os.geteuid() != 0 and shutil.which("sudo"):
+                                    restart_cmd = ["sudo", "-n"] + restart_cmd
+
                                 restart = subprocess.run(
-                                    scope_cmd + ["restart", svc_name],
+                                    restart_cmd,
                                     capture_output=True, text=True, timeout=15,
                                 )
                                 if restart.returncode == 0:

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -27,6 +27,7 @@ def _make_run_side_effect(
     systemd_active=False,
     system_service_active=False,
     system_restart_rc=0,
+    sudo_system_restart_rc=None,
     launchctl_loaded=False,
 ):
     """Build a subprocess.run side_effect that simulates git + service commands."""
@@ -78,8 +79,12 @@ def _make_run_side_effect(
         # systemctl restart — distinguish --user from system scope
         if "systemctl" in joined and "restart" in joined:
             if "--user" not in joined and system_service_active:
-                stderr = "" if system_restart_rc == 0 else "Failed to restart: Permission denied"
-                return subprocess.CompletedProcess(cmd, system_restart_rc, stdout="", stderr=stderr)
+                if "sudo -n" in joined:
+                    rc = system_restart_rc if sudo_system_restart_rc is None else sudo_system_restart_rc
+                else:
+                    rc = system_restart_rc
+                stderr = "" if rc == 0 else "Failed to restart: Permission denied"
+                return subprocess.CompletedProcess(cmd, rc, stdout="", stderr=stderr)
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
         # launchctl list ai.hermes.gateway
@@ -430,6 +435,7 @@ class TestCmdUpdateSystemService:
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr("os.geteuid", lambda: 0)
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",
@@ -448,6 +454,37 @@ class TestCmdUpdateSystemService:
             if "restart" in " ".join(str(a) for a in c.args[0])
             and "systemctl" in " ".join(str(a) for a in c.args[0])
             and "--user" not in " ".join(str(a) for a in c.args[0])
+        ]
+        assert len(restart_calls) == 1
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_detects_system_service_and_uses_sudo_when_non_root(
+        self, mock_run, _mock_which, mock_args, capsys, monkeypatch,
+    ):
+        """When system service is active and Hermes runs non-root, restart via sudo -n."""
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr("os.geteuid", lambda: 1000)
+        _mock_which.side_effect = lambda name: "/usr/bin/sudo" if name == "sudo" else None
+
+        mock_run.side_effect = _make_run_side_effect(
+            commit_count="3",
+            systemd_active=False,
+            system_service_active=True,
+            system_restart_rc=1,
+            sudo_system_restart_rc=0,
+        )
+
+        with patch.object(gateway_cli, "find_gateway_pids", return_value=[]):
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr().out
+        assert "Restarted hermes-gateway" in captured
+        restart_calls = [
+            c for c in mock_run.call_args_list
+            if c.args and c.args[0][:4] == ["sudo", "-n", "systemctl", "restart"]
         ]
         assert len(restart_calls) == 1
 


### PR DESCRIPTION
## Summary

Fixes `hermes update` / `/update` on Linux VPS setups where the Hermes gateway is installed as a system service and Hermes itself runs as a non-root user.

Previously, update would detect the active system service but try to restart it with plain `systemctl restart ...`, which could fail with:

`Interactive authentication required.`

This left the gateway running stale code until manually restarted.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- retry system-scoped gateway restarts during `cmd_update` with `sudo -n systemctl restart <service>` when Hermes is running non-root
- add a regression test covering the non-root + system-service restart path in `tests/hermes_cli/test_update_gateway_restart.py`

## How to Test

1. Install Hermes gateway as a Linux system service:
   - `sudo hermes gateway install --system --run-as-user <user>`
2. Run `hermes update` or `/update` as that non-root user.
3. Verify the gateway restarts successfully instead of failing with `Interactive authentication required.`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 VPS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Observed before fix on Ubuntu 24.04 VPS with a system-installed gateway:

`⚠ Failed to restart hermes-gateway: Failed to restart hermes-gateway.service: Interactive authentication required.`

After the fix, `/update` successfully restarted the live system service and Telegram reconnected normally.