### PR TITLE
fix: correct MiniMax API endpoint URL from deprecated api.minimax.io

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@
 # MiniMax provides access to MiniMax models (global endpoint)
 # Get your key at: https://www.minimax.io
 # MINIMAX_API_KEY=
-# MINIMAX_BASE_URL=https://api.minimax.io/v1  # Override default base URL
+# MINIMAX_BASE_URL=https://api.minimax.chat/v1  # Override default base URL
 
 # MiniMax China endpoint (for users in mainland China)
 # MINIMAX_CN_API_KEY=

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -224,7 +224,7 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     if not normalized:
         return False
     normalized = normalized.rstrip("/").lower()
-    return normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+    return normalized.startswith(("https://api.minimax.chat", "https://api.minimaxi.com/anthropic"))
 
 
 def _common_betas_for_base_url(base_url: str | None) -> list[str]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -163,7 +163,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="minimax",
         name="MiniMax",
         auth_type="api_key",
-        inference_base_url="https://api.minimax.io/anthropic",
+        inference_base_url="https://api.minimax.chat/v1",
         api_key_env_vars=("MINIMAX_API_KEY",),
         base_url_env_var="MINIMAX_BASE_URL",
     ),

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -723,7 +723,7 @@ def run_doctor(args):
         ("Hugging Face",     ("HF_TOKEN",),                                   "https://router.huggingface.co/v1/models", "HF_BASE_URL", True),
         ("Alibaba/DashScope", ("DASHSCOPE_API_KEY",),                         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
         # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
-        ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
+        ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.chat/v1/models",    "MINIMAX_BASE_URL", True),
         ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),
         ("AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -776,7 +776,7 @@ def resolve_runtime_provider(
         # Honour model.base_url from config.yaml when the configured provider
         # matches this provider — mirrors the Anthropic path above.  Without
         # this, users who set model.base_url to e.g. api.minimaxi.com/anthropic
-        # (China endpoint) still get the hardcoded api.minimax.io default (#6039).
+        # (China endpoint) still get the hardcoded api.minimax.chat default (#6039).
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = ""
         if cfg_provider == provider:
@@ -795,7 +795,7 @@ def resolve_runtime_provider(
                 from hermes_cli.models import opencode_model_api_mode
                 api_mode = opencode_model_api_mode(provider, model_cfg.get("default", ""))
             # Auto-detect Anthropic-compatible endpoints by URL convention
-            # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
+            # (e.g. https://api.minimax.chat/anthropic, https://dashscope.../anthropic)
             elif base_url.rstrip("/").endswith("/anthropic"):
                 api_mode = "anthropic_messages"
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -32,7 +32,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `KIMI_API_KEY` | Kimi / Moonshot AI API key ([moonshot.ai](https://platform.moonshot.ai)) |
 | `KIMI_BASE_URL` | Override Kimi base URL (default: `https://api.moonshot.ai/v1`) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)) |
-| `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/v1`) |
+| `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.chat/v1`) |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)) |
 | `MINIMAX_CN_BASE_URL` | Override MiniMax China base URL (default: `https://api.minimaxi.com/v1`) |
 | `KILOCODE_API_KEY` | Kilo Code API key ([kilo.ai](https://kilo.ai)) |


### PR DESCRIPTION
## Summary

Updates the hardcoded MiniMax inference base URL from the deprecated `https://api.minimax.io/anthropic` (which returns 401) to the current official endpoint `https://api.minimax.chat/v1`.

## Root Cause

The endpoint `api.minimax.io` is stale and returns 401 errors. MiniMax's current OpenAI-compatible endpoint is `https://api.minimax.chat/v1`. This was verified via direct API test during investigation.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/auth.py` | `inference_base_url`: `api.minimax.io/anthropic` -> `api.minimax.chat/v1` |
| `hermes_cli/doctor.py` | Health check endpoint updated |
| `agent/anthropic_adapter.py` | `_requires_bearer_auth()` URL recognition updated |
| `hermes_cli/runtime_provider.py` | Comment references (2 locations) |
| `.env.example` | Default base URL documentation |
| `website/docs/reference/environment-variables.md` | Default value documentation |

## Testing

Verified that `https://api.minimax.chat/v1/chat/completions` returns 200 with a valid MiniMax subscription key.

**Note:** TTS endpoint (`tools/tts_tool.py`) was not changed as it uses a separate `/v1/t2a_v2` path that requires separate verification.
