### PR TITLE
fix(launchd): --force now bootouts existing service before reinstall

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1255,6 +1255,10 @@ def launchd_install(force: bool = False):
         print(f"Service already installed at: {plist_path}")
         print("Use --force to reinstall")
         return
+
+    if force and plist_path.exists():
+        label = get_launchd_label()
+        subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
     
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     print(f"Installing launchd service to: {plist_path}")


### PR DESCRIPTION
## Summary

- `hermes gateway install --force` on macOS would fail with exit code 5 if the service was already loaded in launchd
- `launchctl bootstrap` cannot overwrite a running service — must bootout first

## Fix

When `--force` is passed and a plist already exists, call `launchctl bootout` before `bootstrap` to cleanly unload the old service.

```python
if force and plist_path.exists():
    label = get_launchd_label()
    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
```

## Testing

- Manual: `hermes -p pi gateway install --force` on macOS with a service already running no longer fails