### PR TITLE
fix: /queue command silently discarded when agent is running

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1091,6 +1091,30 @@ class BasePlatformAdapter(ABC):
                     logger.error("[%s] Status dispatch failed: %s", self.name, e, exc_info=True)
                 return
 
+            # /queue must bypass the active-session guard so it reaches the
+            # gateway's /queue handler (which stores the text without triggering
+            # an interrupt).  Without this, the adapter intercepts /queue as a
+            # normal follow-up message, triggers an interrupt, and the safety
+            # net in run.py discards it as a known command.
+            if cmd in ("queue", "q"):
+                logger.debug(
+                    "[%s] Queue command '/%s' bypassing active-session guard for %s",
+                    self.name, cmd, session_key,
+                )
+                try:
+                    _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                    response = await self._message_handler(event)
+                    if response:
+                        await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=response,
+                            reply_to=event.message_id,
+                            metadata=_thread_meta,
+                        )
+                except Exception as e:
+                    logger.error("[%s] Queue dispatch failed: %s", self.name, e, exc_info=True)
+                return
+
             # Special case: photo bursts/albums frequently arrive as multiple near-
             # simultaneous messages. Queue them without interrupting the active run,
             # then process them immediately after the current task finishes.


### PR DESCRIPTION
## Bug

The `/queue` (alias `/q`) command is silently discarded when the agent is actively processing a message on any messaging platform (Telegram, Discord, etc.).

## Root Cause

When a user sends `/queue <prompt>` while the agent is running:

1. **Adapter intercepts** (`base.py`): The adapter's `handle_message()` detects an active session. It checks a bypass list for commands that need direct dispatch (`approve`, `deny`, `status`, `stop`, `new`, `reset`). `/queue` is **not** in this list.

2. **Falls through to interrupt path**: The adapter treats `/queue` as a normal follow-up message → stores it in `_pending_messages` → triggers an interrupt on the running agent.

3. **Safety net discards it** (`run.py` line ~7381): The agent finishes/is interrupted, dequeues the pending text `/queue <prompt>`, and the safety check sees it starts with `/` and is a known command → **discards it**.

4. **Gateway's /queue handler never runs**: The dedicated `/queue` handler in `run.py` (which creates a new event with just the text and stores it without interrupting) is never reached.

## Fix

Add `"queue"` and `"q"` to the active-session bypass list in `gateway/platforms/base.py`, following the same pattern used by `/status` (added in #5046). This allows `/queue` commands to bypass the active-session guard and reach the gateway's dedicated handler.

## Testing

1. Start a conversation that triggers a long agent run (e.g., a web search)
2. While the agent is processing, send `/queue remind me about this later`
3. **Before fix**: Command is silently discarded
4. **After fix**: Bot replies "Queued for the next turn." and the text is processed after the current run completes

## Files Changed

- `gateway/platforms/base.py` — Added `/queue` and `/q` bypass block after the `/status` bypass