### PR TITLE
fix: add xAI provider prefixes to _PROVIDER_PREFIXES

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -24,13 +24,13 @@ logger = logging.getLogger(__name__)
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
-    "gemini", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
+    "gemini", "zai", "xai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
     "qwen-oauth",
     "custom", "local",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
-    "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
+    "glm", "z-ai", "z.ai", "zhipu", "x-ai", "x.ai", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
     "qwen-portal",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -381,6 +381,11 @@ class TestStripProviderPrefix:
         assert _strip_provider_prefix("openrouter:anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
         assert _strip_provider_prefix("anthropic:claude-sonnet-4") == "claude-sonnet-4"
 
+    def test_xai_provider_prefixes_are_stripped(self):
+        assert _strip_provider_prefix("xai:grok-4") == "grok-4"
+        assert _strip_provider_prefix("x-ai:grok-4") == "grok-4"
+        assert _strip_provider_prefix("x.ai:grok-4") == "grok-4"
+
     def test_ollama_model_tag_preserved(self):
         """Ollama model:tag format must NOT be stripped."""
         assert _strip_provider_prefix("qwen3.5:27b") == "qwen3.5:27b"


### PR DESCRIPTION
## Summary
- Adds `"xai"`, `"x-ai"`, and `"x.ai"` to the `_PROVIDER_PREFIXES` frozenset in `agent/model_metadata.py`
- xAI model names prefixed with these values were not recognized by `_strip_provider_prefix()`, causing silent failures in context-length lookups and model metadata queries
- Follows the existing pattern for similar providers (e.g., `"zai"` / `"z-ai"` / `"z.ai"` for Zhipu)

Fixes #7575

## Test plan
- [x] Added tests verifying `_strip_provider_prefix("xai:grok-4")`, `_strip_provider_prefix("x-ai:grok-4")`, and `_strip_provider_prefix("x.ai:grok-4")` all return `"grok-4"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)