### PR TITLE
fix: guard build_plan_path against whitespace-only input

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -33,7 +33,8 @@ def build_plan_path(
     daytona, and similar terminal backends. That keeps the plan with the active
     workspace instead of the Hermes host's global home directory.
     """
-    slug_source = (user_instruction or "").strip().splitlines()[0] if user_instruction else ""
+    stripped = (user_instruction or "").strip()
+    slug_source = stripped.splitlines()[0] if stripped else ""
     slug = _PLAN_SLUG_RE.sub("-", slug_source.lower()).strip("-")
     if slug:
         slug = "-".join(part for part in slug.split("-")[:8] if part)[:48].strip("-")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -382,6 +382,18 @@ class TestPlanSkillHelpers:
 
         assert path == Path(".hermes") / "plans" / "2026-03-15_093045-implement-oauth-login-refresh-tokens.md"
 
+    def test_build_plan_path_whitespace_newlines_no_index_error(self):
+        path = build_plan_path("  \n  ")
+        assert str(path).endswith("conversation-plan.md")
+
+    def test_build_plan_path_spaces_only_no_index_error(self):
+        path = build_plan_path("   ")
+        assert str(path).endswith("conversation-plan.md")
+
+    def test_build_plan_path_empty_string(self):
+        path = build_plan_path("")
+        assert str(path).endswith("conversation-plan.md")
+
     def test_plan_skill_message_can_include_runtime_save_path_note(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(


### PR DESCRIPTION
## Summary
- Fixes `IndexError` when `build_plan_path()` receives whitespace-only input (e.g., `"  \n  "`)
- The bug: whitespace-only strings are truthy, so `if user_instruction` passes, but after `.strip()` the result is `""`, and `.splitlines()` returns `[]`, causing `[0]` to raise `IndexError`
- Fix: check the stripped result before indexing into `splitlines()`

Fixes #7576

## Test plan
- [x] Added tests for whitespace-with-newlines, spaces-only, and empty string inputs
- [x] All return a path ending with `conversation-plan.md` (the default slug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)