### PR TITLE
fix(weixin): convert markdown links to plain text format

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -110,6 +110,7 @@ TYPING_STOP = 2
 _HEADER_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 _TABLE_RULE_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$")
 _FENCE_RE = re.compile(r"^```([^\n`]*)\s*$")
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
 
 def check_weixin_requirements() -> bool:
@@ -647,7 +648,9 @@ def _normalize_markdown_blocks(content: str) -> str:
             result.append(_rewrite_table_block_for_weixin(table_lines))
             continue
 
-        result.append(_rewrite_headers_for_weixin(line))
+        rewritten = _rewrite_headers_for_weixin(line)
+        rewritten = _MARKDOWN_LINK_RE.sub(r"\1 (\2)", rewritten)
+        result.append(rewritten)
         i += 1
 
     normalized = "\n".join(item.rstrip() for item in result)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -28,8 +28,24 @@ class TestWeixinFormatting:
 
         assert (
             adapter.format_message(content)
-            == "【Title】\n\n**Plan**\n\nUse **bold** and [docs](https://example.com)."
+            == "【Title】\n\n**Plan**\n\nUse **bold** and docs (https://example.com)."
         )
+
+    def test_format_message_converts_markdown_links_to_plain_text(self):
+        adapter = _make_adapter()
+
+        content = "Check [the docs](https://example.com) and [GitHub](https://github.com) for details"
+        assert (
+            adapter.format_message(content)
+            == "Check the docs (https://example.com) and GitHub (https://github.com) for details"
+        )
+
+    def test_format_message_preserves_links_inside_code_blocks(self):
+        adapter = _make_adapter()
+
+        content = "See below:\n\n```\n[link](https://example.com)\n```\n\nDone."
+        result = adapter.format_message(content)
+        assert "[link](https://example.com)" in result
 
     def test_format_message_rewrites_markdown_tables(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- Markdown link syntax `[text](url)` was passed through unmodified to WeChat's plain text renderer, causing URLs to be lost
- Now converts to `text (url)` format, matching the Feishu adapter's approach
- Link conversion respects code block boundaries — links inside fenced code blocks are preserved

Fixes #7617

## Test plan
- [x] Updated existing test to expect converted link format
- [x] Added test for multiple links in one line
- [x] Added test verifying links inside code blocks are NOT converted

🤖 Generated with [Claude Code](https://claude.com/claude-code)