### PR TITLE
fix(cron): skip context files for scheduled jobs

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -663,6 +663,7 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
+        assert kwargs["skip_context_files"] is True
         assert kwargs["session_id"].startswith("cron_test-job_")
         fake_db.end_session.assert_called_once()
         call_args = fake_db.end_session.call_args


### PR DESCRIPTION
Fixes https://github.com/NousResearch/hermes-agent/issues/5209 (at least, fixes "cron jobs fail timeout", which is a reported symptom)


Problem
- The overnight cron jobs failed instead of delivering their reports.

Why 1
- Because the scheduler killed them for inactivity timeout.

Why 2
- Because the jobs spent too long doing non-essential context/workspace discovery instead of the actual task.

Why 3
- Because cron-created agents were still allowed to load or chase local project context:
  - repo-local AGENTS.md / SOUL / memory-file discovery
  - and in one news run, an AGENTS.md file search escalated all the way to path "/"

Why 4
- Because the cron agent setup did not set:
  - skip_context_files=True
- so scheduled jobs inherited normal interactive agent behavior that makes sense for coding sessions, but not for tiny scheduled tasks.

Why 5
- Because cron was using the same broad default agent posture as normal conversations, without sufficiently constraining startup context behavior for automation.

Root cause
- Cron jobs were not isolated from interactive project-context discovery.
- That allowed wasteful local context/tool behavior, which led to long stalls and inactivity timeouts.

Two concrete manifestations
- Watcher cron:
  - wandered into AGENTS/SOUL/local memory-style inspection before checking GitHub Actions
- News cron:
  - explicitly searched "/" for AGENTS.md, which is a terrible idea in a cron run

Fix:
- Skip the context files for cron jobs, light and breezy lemon squeezy

