### PR TITLE
fix(gateway): normalize iOS unicode dashes in slash command args

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -660,7 +660,10 @@ class MessageEvent:
         if not self.is_command():
             return self.text
         parts = self.text.split(maxsplit=1)
-        return parts[1] if len(parts) > 1 else ""
+        args = parts[1] if len(parts) > 1 else ""
+        # iOS auto-corrects -- to — (em dash) and - to – (en dash)
+        args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
+        return args
 
 
 @dataclass 


### PR DESCRIPTION
## What does this PR do?

iOS keyboards auto-correct `--` to `—` (em dash, U+2014) and `-` to `–` (en dash, U+2013). This causes slash commands like `/model glm-4.7 —provider zai` to fail with `Error: Model names cannot contain spaces` because the `—provider` flag isn't recognized and the entire string is treated as the model name.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Normalize unicode dashes to ASCII in `MessageEvent.get_command_args()`, so all slash command `--flag` arguments work correctly regardless of input method.

## How to Test

1. On an iOS device (or simulate em-dash input), type: `/model glm-4.7 —provider zai`
2. Verify the model switches successfully instead of showing the spaces error.
3. Run: `pytest tests/ -q` — all tests pass.