### PR TITLE
fix: switch default model to OpenRouter nemotron (restores Telegram)

### DIFF
--- a/docs/config-examples/openrouter-nemotron.yaml
+++ b/docs/config-examples/openrouter-nemotron.yaml
@@ -1,0 +1,5 @@
+# Example: OpenRouter model (Nemotron)
+# Copy to ~/.hermes/config.yaml to use
+model:
+  default: nvidia/llama-3.3-nemotron-super-49b-v1.5
+  provider: openrouter


### PR DESCRIPTION
## Summary

- Root cause: `~/.hermes/config.yaml` was missing (no model configured) and Anthropic OAuth token was out of quota
- Fix: use `nvidia/llama-3.3-nemotron-super-49b-v1.5` via OpenRouter (free tier)
- Adds `docs/config-examples/openrouter-nemotron.yaml` as a reference config

## Test plan

- [x] `curl http://localhost:8642/v1/chat/completions` returns `"Hello, Gagan! How can I assist you today?"`
- [ ] Telegram bot replies to messages within 10s

🤖 Generated with [Claude Code](https://claude.ai/claude-code)