### PR TITLE
fix(zai): preserve dots in GLM model names on Anthropic-compatible endpoints

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -130,6 +130,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemma-4-26b-it",
     ],
     "zai": [
+        "glm-5.1",
         "glm-5",
         "glm-5-turbo",
         "glm-4.7",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -104,7 +104,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
         "gemma-4-31b-it", "gemma-4-26b-it",
     ],
-    "zai": ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],

--- a/run_agent.py
+++ b/run_agent.py
@@ -5856,11 +5856,12 @@ class AIAgent:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
-        OpenCode Go keeps dots (e.g. minimax-m2.7)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go"}:
+        OpenCode Go keeps dots (e.g. minimax-m2.7).
+        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "zai"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
+        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base or "bigmodel.cn" in base
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/cli/test_cli_interrupt_subagent.py
+++ b/tests/cli/test_cli_interrupt_subagent.py
@@ -63,6 +63,7 @@ class TestCLISubagentInterrupt(unittest.TestCase):
         parent._delegate_depth = 0
         parent._delegate_spinner = None
         parent.tool_progress_callback = None
+        parent._execution_thread_id = None
 
         # We'll track what happens with _active_children
         original_children = parent._active_children

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import pytest
 
@@ -33,6 +34,13 @@ def _clear_provider_env(monkeypatch):
         "CLAUDE_CODE_OAUTH_TOKEN",
     ):
         monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _block_codex_import():
+    """Prevent _seed_from_singletons from importing real ~/.codex/ credentials."""
+    with patch("hermes_cli.auth._import_codex_cli_tokens", return_value=None):
+        yield
 
 
 def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):

--- a/tests/run_agent/test_real_interrupt_subagent.py
+++ b/tests/run_agent/test_real_interrupt_subagent.py
@@ -77,6 +77,7 @@ class TestRealSubagentInterrupt(unittest.TestCase):
         parent.tool_progress_callback = None
         parent.iteration_budget = IterationBudget(max_total=100)
         parent._client_kwargs = {"api_key": "test", "base_url": "http://localhost:1"}
+        parent._execution_thread_id = None
 
         from tools.delegate_tool import _run_single_child
 
@@ -86,100 +87,97 @@ class TestRealSubagentInterrupt(unittest.TestCase):
 
         def run_delegate():
             try:
-                # Patch the OpenAI client creation inside AIAgent.__init__
                 with patch('run_agent.OpenAI') as MockOpenAI:
                     mock_client = MagicMock()
-                    # API call takes 5 seconds — should be interrupted before that
                     mock_client.chat.completions.create = _make_slow_api_response(delay=5.0)
                     mock_client.close = MagicMock()
                     MockOpenAI.return_value = mock_client
 
-                    # Patch the instance method so it skips prompt assembly
-                    with patch.object(AIAgent, '_build_system_prompt', return_value="You are a test agent"):
-                        # Signal when child starts
-                        original_run = AIAgent.run_conversation
+                    original_run = AIAgent.run_conversation
 
-                        def patched_run(self_agent, *args, **kwargs):
-                            child_started.set()
-                            return original_run(self_agent, *args, **kwargs)
+                    def patched_run(self_agent, *args, **kwargs):
+                        child_started.set()
+                        return original_run(self_agent, *args, **kwargs)
 
-                        with patch.object(AIAgent, 'run_conversation', patched_run):
-                            # Build a real child agent (AIAgent is NOT patched here,
-                            # only run_conversation and _build_system_prompt are)
-                            child = AIAgent(
-                                base_url="http://localhost:1",
-                                api_key="test-key",
-                                model="test/model",
-                                provider="test",
-                                api_mode="chat_completions",
-                                max_iterations=5,
-                                enabled_toolsets=["terminal"],
-                                quiet_mode=True,
-                                skip_context_files=True,
-                                skip_memory=True,
-                                platform="cli",
-                            )
-                            child._delegate_depth = 1
-                            parent._active_children.append(child)
-                            result = _run_single_child(
-                                task_index=0,
-                                goal="Test task",
-                                child=child,
-                                parent_agent=parent,
-                            )
-                            result_holder[0] = result
+                    with patch.object(AIAgent, 'run_conversation', patched_run):
+                        child = AIAgent(
+                            base_url="http://localhost:1",
+                            api_key="test-key",
+                            model="test/model",
+                            provider="test",
+                            api_mode="chat_completions",
+                            max_iterations=5,
+                            enabled_toolsets=["terminal"],
+                            quiet_mode=True,
+                            skip_context_files=True,
+                            skip_memory=True,
+                            platform="cli",
+                        )
+                        child._delegate_depth = 1
+                        parent._active_children.append(child)
+                        result = _run_single_child(
+                            task_index=0,
+                            goal="Test task",
+                            child=child,
+                            parent_agent=parent,
+                        )
+                        result_holder[0] = result
             except Exception as e:
                 import traceback
                 traceback.print_exc()
                 error_holder[0] = e
 
-        agent_thread = threading.Thread(target=run_delegate, daemon=True)
-        agent_thread.start()
+        # Keep class-level patch in the test method scope so it is always
+        # restored even when the test fails — a daemon thread holding this
+        # patch would poison other tests in the same xdist worker.
+        with patch.object(AIAgent, '_build_system_prompt', return_value="You are a test agent"):
+            agent_thread = threading.Thread(target=run_delegate, daemon=True)
+            agent_thread.start()
 
-        # Wait for child to start run_conversation
-        started = child_started.wait(timeout=10)
-        if not started:
-            agent_thread.join(timeout=1)
+            # Wait for child to start run_conversation
+            started = child_started.wait(timeout=10)
+            if not started:
+                agent_thread.join(timeout=1)
+                if error_holder[0]:
+                    raise error_holder[0]
+                self.fail("Child never started run_conversation")
+
+            # Give child time to enter main loop and start API call
+            time.sleep(0.5)
+
+            # Verify child is registered
+            print(f"Active children: {len(parent._active_children)}")
+            self.assertGreaterEqual(len(parent._active_children), 1,
+                                    "Child not registered in _active_children")
+
+            # Interrupt! (simulating what CLI does)
+            start = time.monotonic()
+            parent.interrupt("User typed a new message")
+
+            # Check propagation
+            child = parent._active_children[0] if parent._active_children else None
+            if child:
+                print(f"Child._interrupt_requested after parent.interrupt(): {child._interrupt_requested}")
+                self.assertTrue(child._interrupt_requested,
+                               "Interrupt did not propagate to child!")
+
+            # Wait for delegate to finish (should be fast since interrupted)
+            agent_thread.join(timeout=5)
+            elapsed = time.monotonic() - start
+
             if error_holder[0]:
                 raise error_holder[0]
-            self.fail("Child never started run_conversation")
 
-        # Give child time to enter main loop and start API call
-        time.sleep(0.5)
+            result = result_holder[0]
+            self.assertIsNotNone(result, "Delegate returned no result")
+            print(f"Result status: {result['status']}, elapsed: {elapsed:.2f}s")
+            print(f"Full result: {result}")
 
-        # Verify child is registered
-        print(f"Active children: {len(parent._active_children)}")
-        self.assertGreaterEqual(len(parent._active_children), 1,
-                                "Child not registered in _active_children")
-
-        # Interrupt! (simulating what CLI does)
-        start = time.monotonic()
-        parent.interrupt("User typed a new message")
-
-        # Check propagation
-        child = parent._active_children[0] if parent._active_children else None
-        if child:
-            print(f"Child._interrupt_requested after parent.interrupt(): {child._interrupt_requested}")
-            self.assertTrue(child._interrupt_requested,
-                           "Interrupt did not propagate to child!")
-
-        # Wait for delegate to finish (should be fast since interrupted)
-        agent_thread.join(timeout=5)
-        elapsed = time.monotonic() - start
-
-        if error_holder[0]:
-            raise error_holder[0]
-
-        result = result_holder[0]
-        self.assertIsNotNone(result, "Delegate returned no result")
-        print(f"Result status: {result['status']}, elapsed: {elapsed:.2f}s")
-        print(f"Full result: {result}")
-
-        # The child should have been interrupted, not completed the full 5s API call
-        self.assertLess(elapsed, 3.0,
-                       f"Took {elapsed:.2f}s — interrupt was not detected quickly enough")
-        self.assertEqual(result["status"], "interrupted",
-                        f"Expected 'interrupted', got '{result['status']}'")
+            # The child should have been interrupted, not completed the full 5s API call
+            self.assertLess(elapsed, 3.0,
+                           f"Took {elapsed:.2f}s — interrupt was not detected quickly enough")
+            self.assertEqual(result["status"], "interrupted",
+                            f"Expected 'interrupted', got '{result['status']}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- When using ZAI's Anthropic-compatible endpoint (`open.bigmodel.cn/api/anthropic`), model names like `glm-4.7` and `glm-5.1` had their dots replaced with hyphens (`glm-4-7`, `glm-5-1`) by `normalize_model_name()` in the Anthropic adapter, causing ZAI's API to return "模型不存在" (model not found)
- Add `"zai"` provider and `"bigmodel.cn"` URL to `_anthropic_preserve_dots()` so dots are preserved for ZAI models
- Add `glm-5.1` to the native ZAI curated model list in both `models.py` and `setup.py`

Closes #7475

## Test plan
- [x] Existing model normalization tests pass (144 passed)
