### PR TITLE
fix: correct Discord audio attachment and voice message duration handling

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -76,6 +76,58 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _probe_audio_duration_seconds(audio_path: str, file_size_bytes: Optional[int] = None) -> float:
+    """Best-effort duration probe for Discord voice-message metadata.
+
+    Accurate duration is important for native Discord voice messages: if the
+    metadata duration is longer than the Opus file's real duration, Discord's
+    UI shows the inflated duration and playback stops early when the stream
+    ends. Prefer ffprobe, then mutagen if available, then fall back to a rough
+    byte-size heuristic.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=nw=1:nk=1",
+                audio_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        duration_text = result.stdout.strip()
+        if duration_text:
+            duration = float(duration_text)
+            if duration > 0:
+                return duration
+    except Exception:
+        pass
+
+    try:
+        from mutagen import File as MutagenFile
+
+        info = MutagenFile(audio_path)
+        length = getattr(getattr(info, "info", None), "length", None)
+        if length and length > 0:
+            return float(length)
+    except Exception:
+        pass
+
+    if file_size_bytes is None:
+        try:
+            file_size_bytes = os.path.getsize(audio_path)
+        except OSError:
+            file_size_bytes = 0
+    return max(1.0, file_size_bytes / 2000.0)
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available."""
     return DISCORD_AVAILABLE
@@ -965,13 +1017,10 @@ class DiscordAdapter(BasePlatformAdapter):
             try:
                 import base64
 
-                duration_secs = 5.0
-                try:
-                    from mutagen.oggopus import OggOpus
-                    info = OggOpus(audio_path)
-                    duration_secs = info.info.length
-                except Exception:
-                    duration_secs = max(1.0, len(file_data) / 2000.0)
+                duration_secs = _probe_audio_duration_seconds(
+                    audio_path,
+                    file_size_bytes=len(file_data),
+                )
 
                 waveform_bytes = bytes([128] * 256)
                 waveform_b64 = base64.b64encode(waveform_bytes).decode()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4819,11 +4819,18 @@ class GatewayRunner:
                 try:
                     ext = Path(media_path).suffix.lower()
                     if ext in _AUDIO_EXTS:
-                        await adapter.send_voice(
-                            chat_id=event.source.chat_id,
-                            audio_path=media_path,
-                            metadata=_thread_meta,
-                        )
+                        if is_voice:
+                            await adapter.send_voice(
+                                chat_id=event.source.chat_id,
+                                audio_path=media_path,
+                                metadata=_thread_meta,
+                            )
+                        else:
+                            await adapter.send_document(
+                                chat_id=event.source.chat_id,
+                                file_path=media_path,
+                                metadata=_thread_meta,
+                            )
                     elif ext in _VIDEO_EXTS:
                         await adapter.send_video(
                             chat_id=event.source.chat_id,

--- a/tests/gateway/test_discord_voice_duration.py
+++ b/tests/gateway/test_discord_voice_duration.py
@@ -1,0 +1,89 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _ensure_discord_mock():
+    """Install a lightweight discord mock when discord.py isn't available."""
+    import sys
+
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    discord_mod.opus = SimpleNamespace(is_loaded=lambda: True, load_opus=lambda *_args, **_kwargs: None)
+    discord_mod.FFmpegPCMAudio = MagicMock
+    discord_mod.PCMVolumeTransformer = MagicMock
+    discord_mod.http = SimpleNamespace(Route=MagicMock)
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from gateway.platforms.discord import DiscordAdapter, _probe_audio_duration_seconds
+
+
+def test_probe_audio_duration_prefers_ffprobe():
+    completed = MagicMock(stdout="6.4865\n")
+    with patch("gateway.platforms.discord.subprocess.run", return_value=completed) as run_mock:
+        duration = _probe_audio_duration_seconds("/tmp/sample.ogg", file_size_bytes=52651)
+
+    assert duration == pytest.approx(6.4865)
+    run_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_voice_uses_probed_duration_in_discord_payload(tmp_path):
+    audio_path = tmp_path / "sample.ogg"
+    audio_path.write_bytes(b"OggS" + b"\x00" * 128)
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = SimpleNamespace(value="discord")
+
+    channel = SimpleNamespace(id=123)
+    captured = {}
+
+    async def fake_request(route, *, form):
+        captured["form"] = form
+        return {"id": "msg-123"}
+
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(return_value=channel),
+        http=SimpleNamespace(request=fake_request),
+    )
+
+    with patch("gateway.platforms.discord._probe_audio_duration_seconds", return_value=6.4865), \
+         patch("gateway.platforms.discord.discord.http.Route", return_value=object()):
+        result = await DiscordAdapter.send_voice(adapter, chat_id="123", audio_path=str(audio_path))
+
+    assert result.success is True
+    payload_json = next(item["value"] for item in captured["form"] if item["name"] == "payload_json")
+    payload = json.loads(payload_json)
+    assert payload["attachments"][0]["duration_secs"] == pytest.approx(6.49)

--- a/tests/gateway/test_media_delivery_audio.py
+++ b/tests/gateway/test_media_delivery_audio.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.platforms.base import SessionSource, MessageEvent, MessageType
+from gateway.run import GatewayRunner
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    return runner
+
+
+def _make_event(chat_id: str = "123", thread_id: str | None = None) -> MessageEvent:
+    source = SessionSource(chat_id=chat_id, user_id="user1", platform=SimpleNamespace(value="discord"))
+    source.thread_id = thread_id
+    return MessageEvent(text="", message_type=MessageType.TEXT, source=source)
+
+
+@pytest.mark.asyncio
+async def test_audio_media_without_voice_directive_is_sent_as_document():
+    runner = _make_runner()
+    event = _make_event(thread_id="thread-1")
+    adapter = SimpleNamespace(
+        name="discord",
+        extract_media=lambda response: ([("/tmp/plain.ogg", False)], response),
+        extract_images=lambda response: ([], response),
+        extract_local_files=lambda response: ([], response),
+        send_voice=AsyncMock(),
+        send_document=AsyncMock(),
+        send_video=AsyncMock(),
+        send_image_file=AsyncMock(),
+    )
+
+    await GatewayRunner._deliver_media_from_response(runner, "MEDIA:/tmp/plain.ogg", event, adapter)
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="123",
+        file_path="/tmp/plain.ogg",
+        metadata={"thread_id": "thread-1"},
+    )
+    adapter.send_voice.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_audio_media_with_voice_directive_is_sent_as_voice():
+    runner = _make_runner()
+    event = _make_event()
+    adapter = SimpleNamespace(
+        name="discord",
+        extract_media=lambda response: ([("/tmp/voice.ogg", True)], response),
+        extract_images=lambda response: ([], response),
+        extract_local_files=lambda response: ([], response),
+        send_voice=AsyncMock(),
+        send_document=AsyncMock(),
+        send_video=AsyncMock(),
+        send_image_file=AsyncMock(),
+    )
+
+    await GatewayRunner._deliver_media_from_response(runner, "[[audio_as_voice]]\nMEDIA:/tmp/voice.ogg", event, adapter)
+
+    adapter.send_voice.assert_awaited_once_with(
+        chat_id="123",
+        audio_path="/tmp/voice.ogg",
+        metadata=None,
+    )
+    adapter.send_document.assert_not_called()


### PR DESCRIPTION
## Summary
- use `ffprobe` to populate Discord native voice-message duration metadata when available
- fall back to mutagen, then the existing byte-size heuristic
- send plain audio attachments through the normal file attachment path instead of always forcing the Discord voice-message path
- add regression tests for both cases

## Why
While testing Hermes TTS output on Discord, I ran into two separate audio delivery issues.

First, native Discord voice messages could advertise the wrong `duration_secs` value when `mutagen` wasn't available. In that case Hermes fell back to a rough byte-size estimate, which can overshoot badly on short Opus files. That produced cases where Discord showed a much longer duration than the actual file, so playback stopped early.

Second, plain audio attachments were also being routed through `send_voice(...)` during post-response media delivery. That meant audio intended to be sent as a normal attachment could still go through Discord's voice-message path and inherit the same confusing metadata/UI behavior.

## Fix
This change does two things:

1. For actual Discord voice messages, prefer real duration probing in this order:
   - `ffprobe`
   - mutagen
   - byte-size heuristic as a last resort

2. For post-response media delivery, only call `send_voice(...)` when the response explicitly includes `[[audio_as_voice]]`. Plain `MEDIA:/path/file.ogg` audio now goes out through the normal file attachment path.

## Testing
Added regression coverage for:
- duration probing
- Discord payload using the probed duration
- plain audio media being sent as a normal attachment
- voice-tagged audio media still being sent as a voice message

Ran:
- `python -m pytest tests/gateway/test_discord_voice_duration.py tests/gateway/test_media_delivery_audio.py -q`
- `python -m pytest tests/gateway/test_discord_media_metadata.py tests/gateway/test_voice_command.py tests/gateway/test_platform_base.py -q`

## Repro
Before this change I saw two failure modes on Discord:
- a voice note displaying a much longer duration than the actual file, causing playback to stop early
- an audio attachment displaying one duration before playback, then jumping to a different time after pressing play because it was still being handled as a voice-message-style send
