### PR TITLE
fix(tts): make schema default output path profile-safe

### DIFF
--- a/tests/tools/test_tts_schema_paths.py
+++ b/tests/tools/test_tts_schema_paths.py
@@ -1,0 +1,20 @@
+import importlib
+
+from hermes_constants import display_hermes_home
+
+
+def test_text_to_speech_schema_uses_profile_safe_default_path():
+    """Tool schema should not hardcode ~/.hermes paths (breaks profiles)."""
+    # pytest's autouse fixture sets HERMES_HOME at runtime (after test collection),
+    # so reload the module to ensure any schema strings computed at import time
+    # reflect the isolated HERMES_HOME.
+    tts_tool = importlib.import_module("tools.tts_tool")
+    tts_tool = importlib.reload(tts_tool)
+
+    desc = tts_tool.TTS_SCHEMA["parameters"]["properties"]["output_path"]["description"]
+
+    # Should mention the active HERMES_HOME (or its ~/ shorthand) via display_hermes_home().
+    assert display_hermes_home() in desc
+    # Default directory should be the consolidated cache path for new installs.
+    assert ("cache/audio" in desc) or ("audio_cache" in desc)
+

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -14,7 +14,7 @@ Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
 - MP3 (.mp3) for everything else (CLI, Discord, WhatsApp)
 
-Configuration is loaded from ~/.hermes/config.yaml under the 'tts:' key.
+Configuration is loaded from HERMES_HOME/config.yaml under the 'tts:' key.
 The user chooses the provider and voice; the model just sends text.
 
 Usage:
@@ -101,11 +101,11 @@ MAX_TEXT_LENGTH = 4000
 
 
 # ===========================================================================
-# Config loader -- reads tts: section from ~/.hermes/config.yaml
+# Config loader -- reads tts: section from HERMES_HOME/config.yaml
 # ===========================================================================
 def _load_tts_config() -> Dict[str, Any]:
     """
-    Load TTS configuration from ~/.hermes/config.yaml.
+    Load TTS configuration from HERMES_HOME/config.yaml.
 
     Returns a dict with provider settings. Falls back to defaults
     for any missing fields.
@@ -509,7 +509,7 @@ def text_to_speech_tool(
     """
     Convert text to speech audio.
 
-    Reads provider/voice config from ~/.hermes/config.yaml (tts: section).
+    Reads provider/voice config from HERMES_HOME/config.yaml (tts: section).
     The model sends text; the user configures voice and provider.
 
     On messaging platforms, the returned MEDIA:<path> tag is intercepted
@@ -1028,6 +1028,23 @@ if __name__ == "__main__":
 # ---------------------------------------------------------------------------
 from tools.registry import registry, tool_error
 
+
+def _default_output_path_hint() -> str:
+    """Return a profile-safe, user-facing default output path hint for schemas."""
+    try:
+        from hermes_constants import get_hermes_home, display_hermes_home
+
+        out_dir = Path(DEFAULT_OUTPUT_DIR)
+        home = get_hermes_home()
+        try:
+            rel = out_dir.relative_to(home)
+            return f"{display_hermes_home()}/{rel}"
+        except ValueError:
+            # DEFAULT_OUTPUT_DIR is not under HERMES_HOME (unexpected/custom).
+            return str(out_dir)
+    except Exception:
+        return str(DEFAULT_OUTPUT_DIR)
+
 TTS_SCHEMA = {
     "name": "text_to_speech",
     "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as a voice message. On Telegram it plays as a voice bubble, on Discord/WhatsApp as an audio attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured, not model-selected.",
@@ -1040,7 +1057,10 @@ TTS_SCHEMA = {
             },
             "output_path": {
                 "type": "string",
-                "description": "Optional custom file path to save the audio. Defaults to ~/.hermes/audio_cache/<timestamp>.mp3"
+                "description": (
+                    "Optional custom file path to save the audio. "
+                    f"Defaults to {_default_output_path_hint()}/<timestamp>.mp3"
+                )
             }
         },
         "required": ["text"]


### PR DESCRIPTION
Fixes #7697

### What changed
- Make `text_to_speech` schema `output_path` default path hint HERMES_HOME/profile-aware.
- Add a unit test to prevent hardcoded `~/.hermes` defaults in schema strings.

### How to test
```bash

pytest tests/tools/test_tts_schema_paths.py -q