### PR TITLE
feat(gateway): add per-channel model override for Discord channel_skill_bindings

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -592,6 +592,10 @@ class MessageEvent:
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.
     auto_skill: Optional[str | list[str]] = None
+
+    # Auto-applied model override for channel bindings (e.g., Discord channel_skill_bindings).
+    # Supports model alias names defined in config.yaml model_aliases.
+    auto_model: Optional[str] = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1894,12 +1894,14 @@ class DiscordAdapter(BasePlatformAdapter):
 
         _parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
+        _model = self._resolve_channel_model(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
             source=source,
             raw_message=interaction,
             auto_skill=_skills,
+            auto_model=_model,
         )
         await self.handle_message(event)
 
@@ -1926,6 +1928,30 @@ class DiscordAdapter(BasePlatformAdapter):
                     return [skills]
                 if isinstance(skills, list) and skills:
                     return list(dict.fromkeys(skills))  # dedup, preserve order
+        return None
+
+    def _resolve_channel_model(self, channel_id: str, parent_id: str | None = None) -> str | None:
+        """Look up optional model override for a Discord channel/forum thread.
+
+        Config format (in platform extra):
+            channel_skill_bindings:
+              - id: "123456"
+                skills: ["skill-a"]
+                model: "kiro-opus"   # optional model alias or full model id
+        Also checks parent_id so forum threads inherit the forum's bindings.
+        """
+        bindings = self.config.extra.get("channel_skill_bindings", [])
+        if not bindings:
+            return None
+        ids_to_check = {channel_id}
+        if parent_id:
+            ids_to_check.add(parent_id)
+        for entry in bindings:
+            entry_id = str(entry.get("id", ""))
+            if entry_id in ids_to_check:
+                model = entry.get("model")
+                if model:
+                    return str(model)
         return None
 
     def _thread_parent_channel(self, channel: Any) -> Any:
@@ -2516,6 +2542,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_chan, "parent_id", "") or "")
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
+        _model = self._resolve_channel_model(_chan_id, _parent_id or None)
         event = MessageEvent(
             text=event_text,
             message_type=msg_type,
@@ -2527,6 +2554,7 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_message_id=str(message.reference.message_id) if message.reference else None,
             timestamp=message.created_at,
             auto_skill=_skills,
+            auto_model=_model,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2510,6 +2510,52 @@ class GatewayRunner:
             except Exception as e:
                 logger.warning("[Gateway] Failed to auto-load skill(s) %s: %s", _skill_names, e)
 
+        # Auto-apply model override for channel bindings (e.g., Discord channel_skill_bindings).
+        # Only apply on new sessions — ongoing sessions keep their current model.
+        _auto_model = getattr(event, "auto_model", None)
+        if _is_new_session and _auto_model:
+            try:
+                from hermes_cli.model_switch import _switch_model
+                from hermes_cli.auth import list_authenticated_providers
+                _cfg = self._load_config()
+                _user_provs = _cfg.get("providers", {})
+                _custom_provs = _cfg.get("custom_providers", [])
+                _cur_model = _cfg.get("model", {}).get("default", "")
+                _cur_provider = _cfg.get("model", {}).get("provider", "")
+                _cur_base_url = _cfg.get("model", {}).get("base_url", "")
+                _cur_api_key = _cfg.get("model", {}).get("api_key", "")
+                _result = _switch_model(
+                    raw_input=_auto_model,
+                    current_provider=_cur_provider,
+                    current_model=_cur_model,
+                    current_base_url=_cur_base_url,
+                    current_api_key=_cur_api_key,
+                    is_global=False,
+                    user_providers=_user_provs,
+                    custom_providers=_custom_provs,
+                )
+                if _result.success:
+                    if not hasattr(self, "_session_model_overrides"):
+                        self._session_model_overrides = {}
+                    self._session_model_overrides[session_key] = {
+                        "model": _result.new_model,
+                        "provider": _result.target_provider,
+                        "api_key": _result.api_key,
+                        "base_url": _result.base_url,
+                        "api_mode": _result.api_mode,
+                    }
+                    logger.info(
+                        "[Gateway] Auto-applied model override '%s' -> '%s' for session %s",
+                        _auto_model, _result.new_model, session_key,
+                    )
+                else:
+                    logger.warning(
+                        "[Gateway] Failed to resolve auto_model '%s': %s",
+                        _auto_model, _result.error_message,
+                    )
+            except Exception as e:
+                logger.warning("[Gateway] Failed to apply auto_model '%s': %s", _auto_model, e)
+
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
         
@@ -6971,7 +7017,7 @@ class GatewayRunner:
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
-            agent.request_overrides = turn_route.get("request_overrides")
+            agent.request_overrides = turn_route.get("request_overrides") or {}
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:


### PR DESCRIPTION
## Summary

Allow Discord `channel_skill_bindings` to specify an optional `model` field that automatically switches the model for new sessions in that channel.

## Config Example

```yaml
channel_skill_bindings:
  - id: '1234567890'
    skills: ['my-skill']
    model: 'claude-opus-4-6'   # model alias or full model id
```

## Changes

- `gateway/platforms/base.py`: add `auto_model` field to `MessageEvent`
- `gateway/platforms/discord.py`: add `_resolve_channel_model()`, populate `auto_model` on events (both slash command and regular message paths)
- `gateway/run.py`: apply `auto_model` override on new session creation via `_switch_model()`

## Behavior

- Only applies on **new sessions** — ongoing sessions keep their current model
- Supports model aliases defined in `config.yaml model_aliases`
- Falls back gracefully with a warning log if the model can't be resolved
- Forum threads inherit the parent forum's binding (same as skill bindings)