### PR TITLE
fix(agent): prevent false thinking-exhaustion for non-reasoning models

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8144,8 +8144,24 @@ class AIAgent:
                                     _text_parts.append(getattr(_blk, "text", ""))
                             _trunc_content = "\n".join(_text_parts) if _text_parts else None
 
+                        # A response is "thinking exhausted" only when the model
+                        # actually produced reasoning blocks but no visible text after
+                        # them.  Models that do not use <think> tags (e.g. GLM-4.7 on
+                        # NVIDIA Build, minimax) may return content=None or an empty
+                        # string for unrelated reasons — treat those as normal
+                        # truncations that deserve continuation retries, not as
+                        # thinking-budget exhaustion.
+                        _has_think_tags = bool(
+                            _trunc_content and re.search(
+                                r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>',
+                                _trunc_content,
+                                re.IGNORECASE,
+                            )
+                        )
                         _thinking_exhausted = (
-                            not _trunc_has_tool_calls and (
+                            not _trunc_has_tool_calls
+                            and _has_think_tags
+                            and (
                                 (_trunc_content is not None and not self._has_content_after_think_block(_trunc_content))
                                 or _trunc_content is None
                             )


### PR DESCRIPTION
## Problem

Closes #7729

Models without think tags (e.g. GLM-4.7 on NVIDIA Build) always showed Thinking Budget Exhausted error when truncated.

## Root Cause

The `_thinking_exhausted` check fired for any model returning `content=None` on truncation, not just reasoning models.

## Fix

Gate the exhaustion check on `_has_think_tags` — only trigger when the model actually produced `<think>` / `<thinking>` / `<reasoning>` blocks. Non-reasoning models now fall through to the normal 3-attempt continuation retry.

Fixes #7729