### PR TITLE
fix: preserve dots in model IDs for OpenCode Zen provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/hermes

--- a/run_agent.py
+++ b/run_agent.py
@@ -5819,11 +5819,11 @@ class AIAgent:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
-        OpenCode Go keeps dots (e.g. minimax-m2.7)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go"}:
+        OpenCode Go/Zen keeps dots for MiniMax models (e.g. minimax-m2.5-free)."""
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
+        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -302,11 +302,27 @@ class TestMinimaxPreserveDots:
         from run_agent import AIAgent
         assert AIAgent._anthropic_preserve_dots(agent) is True
 
+    def test_opencode_zen_provider_preserves_dots(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="opencode-zen", base_url="")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_opencode_zen_url_preserves_dots(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="custom", base_url="https://opencode.ai/zen/v1")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
     def test_anthropic_does_not_preserve_dots(self):
         from types import SimpleNamespace
         agent = SimpleNamespace(provider="anthropic", base_url="https://api.anthropic.com")
         from run_agent import AIAgent
         assert AIAgent._anthropic_preserve_dots(agent) is False
+
+    def test_normalize_preserves_m25_free_dot(self):
+        from agent.anthropic_adapter import normalize_model_name
+        assert normalize_model_name("minimax-m2.5-free", preserve_dots=True) == "minimax-m2.5-free"
 
     def test_normalize_preserves_m27_dot(self):
         from agent.anthropic_adapter import normalize_model_name


### PR DESCRIPTION
## Summary

- Fixes HTTP 400 when using OpenCode Zen with MiniMax models (e.g. `minimax-m2.5-free`)
- `_anthropic_preserve_dots()` didn't recognize `opencode-zen` provider or its URL pattern, causing `normalize_model_name()` to convert dots to hyphens (`minimax-m2-5-free`), which the API rejects
- Adds `"opencode-zen"` to the provider allowlist and broadens URL check from `"opencode.ai/zen/go"` to `"opencode.ai/zen/"` to cover both Go and Zen endpoints

Closes #7710

## Test plan

- [x] Added tests for `opencode-zen` provider detection (`test_opencode_zen_provider_preserves_dots`)
- [x] Added tests for URL-based detection (`test_opencode_zen_url_preserves_dots`)
- [x] Added test for dot preservation in `minimax-m2.5-free` model name
- [x] All 42 existing tests in `test_minimax_provider.py` pass