### PR TITLE
fix(hindsight): add missing hindsight-all dep for local_embedded mode (closes #7718)

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -500,6 +500,20 @@ class HindsightMemoryProvider(MemoryProvider):
         # "local" is a legacy alias for "local_embedded"
         if self._mode == "local":
             self._mode = "local_embedded"
+
+        # Validate local_embedded dependency before any further initialization.
+        # local_embedded requires hindsight-all (provides hindsight.HindsightEmbedded);
+        # the cloud/external modes only need hindsight-client (hindsight_client.Hindsight).
+        if self._mode == "local_embedded":
+            try:
+                from hindsight import HindsightEmbedded  # noqa: F401
+            except ImportError:
+                raise RuntimeError(
+                    "Hindsight local_embedded mode requires the 'hindsight-all' package, "
+                    "which is not installed. Run:\n\n"
+                    "    uv pip install --system hindsight-all\n\n"
+                    "Then restart the gateway."
+                )
         self._api_key = self._config.get("apiKey") or self._config.get("api_key") or os.environ.get("HINDSIGHT_API_KEY", "")
         default_url = _DEFAULT_LOCAL_URL if self._mode in ("local_embedded", "local_external") else _DEFAULT_API_URL
         self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,10 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
+  # hindsight-client: required for cloud and local_external modes
   - "hindsight-client>=0.4.22"
+  # hindsight-all: required for local_embedded mode (provides hindsight.HindsightEmbedded)
+  - "hindsight-all>=0.5.0"
 requires_env: []
 hooks:
   - on_session_end

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,6 +6,7 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import sys
 import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -596,3 +597,129 @@ class TestAvailability:
         monkeypatch.setenv("HINDSIGHT_MODE", "local")
         p = HindsightMemoryProvider()
         assert p.is_available()
+
+
+# ---------------------------------------------------------------------------
+# Tests for local_embedded dependency validation (GitHub issue #7718)
+# ---------------------------------------------------------------------------
+
+class TestLocalEmbeddedDependency:
+    """Verify local_embedded mode fails loudly when hindsight-all is missing.
+
+    These tests validate the fix for GitHub issue #7718:
+    https://github.com/NousResearch/Hermes-Agent/issues/7718
+
+    The root cause: ``local_embedded`` mode imports
+    ``from hindsight import HindsightEmbedded`` (requires hindsight-all
+    package) but ``plugin.yaml`` only declared ``hindsight-client`` as a
+    dependency.  Users selecting ``local_embedded`` therefore experienced a
+    silent AttributeError at runtime.  The fix has two parts:
+
+    1. plugin.yaml now declares both ``hindsight-client`` *and*
+       ``hindsight-all`` as dependencies.
+    2. ``initialize()`` now performs a guard import and raises a clear
+       ``RuntimeError`` with the install command if ``hindsight-all`` is
+       absent.
+    """
+
+    def _make_mock_hindsight_without_embedded(self):
+        """Return a sys.modules-compatible mock of the ``hindsight`` package
+        that raises ImportError for every attribute (simulating
+        ``hindsight-all`` not being installed)."""
+        from types import ModuleType
+
+        class _MockHindsightModule(ModuleType):
+            def __getattr__(self, name):
+                raise ImportError(
+                    f"module 'hindsight' has no attribute '{name}'. "
+                    "hint: run 'uv pip install --system hindsight-all'"
+                )
+
+        return _MockHindsightModule("hindsight")
+
+    def test_local_embedded_raises_when_hindsight_not_installed(
+        self, tmp_path, monkeypatch
+    ):
+        """``initialize()`` must raise ``RuntimeError`` (not silently skip)
+        when ``hindsight-all`` is absent and mode is ``local_embedded``."""
+        config = {
+            "mode": "local_embedded",
+            "llm_provider": "openai",
+            "llm_api_key": "sk-test",
+            "llm_model": "gpt-4o-mini",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+
+        p = HindsightMemoryProvider()
+        mock_h = self._make_mock_hindsight_without_embedded()
+        monkeypatch.setitem(sys.modules, "hindsight", mock_h)
+        with pytest.raises(RuntimeError, match="hindsight-all"):
+            p.initialize(
+                session_id="test-session",
+                hermes_home=str(tmp_path),
+                platform="cli",
+            )
+
+    def test_legacy_local_alias_also_checks_dependency(
+        self, tmp_path, monkeypatch
+    ):
+        """The legacy ``"local"`` alias must also trigger the dependency
+        check (it is silently remapped to ``local_embedded`` internally)."""
+        config = {
+            "mode": "local",
+            "llm_provider": "openai",
+            "llm_api_key": "sk-test",
+            "llm_model": "gpt-4o-mini",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+
+        p = HindsightMemoryProvider()
+        mock_h = self._make_mock_hindsight_without_embedded()
+        monkeypatch.setitem(sys.modules, "hindsight", mock_h)
+        with pytest.raises(RuntimeError, match="hindsight-all"):
+            p.initialize(
+                session_id="test-session",
+                hermes_home=str(tmp_path),
+                platform="cli",
+            )
+
+    def test_cloud_mode_does_not_require_hindsight_all(
+        self, tmp_path, monkeypatch
+    ):
+        """``cloud`` mode must NOT attempt to import from the ``hindsight``
+        top-level package; it uses ``hindsight_client.Hindsight`` which is
+        provided by ``hindsight-client``.  ``initialize()`` should complete
+        without checking for ``hindsight-all``."""
+        config = {
+            "mode": "cloud",
+            "apiKey": "sk-test",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "budget": "mid",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+
+        p = HindsightMemoryProvider()
+        mock_h = self._make_mock_hindsight_without_embedded()
+        monkeypatch.setitem(sys.modules, "hindsight", mock_h)
+        p.initialize(
+            session_id="test-session",
+            hermes_home=str(tmp_path),
+            platform="cli",
+        )
+        assert p._mode == "cloud"


### PR DESCRIPTION
Fixes #7718.

Root cause: local_embedded mode imports from hindsight.HindsightEmbedded (requires hindsight-all), but plugin.yaml only declared hindsight-client as a dependency. Users selecting local_embedded experienced a silent ModuleNotFoundError on every on_session_end hook.

Changes:
- plugin.yaml: declares both hindsight-client>=0.4.22 (cloud/external) and hindsight-all>=0.5.0 (local_embedded)
- plugins/memory/hindsight/__init__.py: initialize() now raises a clear RuntimeError with install command if hindsight-all is absent
- tests/plugins/memory/test_hindsight_provider.py: 3 new tests for guard, legacy alias, and cloud mode non-regression

## How to Test

```bash
# Verify 49/49 tests pass
python -m pytest tests/plugins/memory/test_hindsight_provider.py -v
```

Fixes #7718