### PR TITLE
fix(auth): add User-Agent header to Qwen OAuth refresh (closes #7746)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -76,6 +76,10 @@ CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56"
 QWEN_OAUTH_TOKEN_URL = "https://chat.qwen.ai/api/v1/oauth2/token"
 QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+# User-Agent sent with Qwen OAuth refresh requests.
+# Matches the format used by qwen-code-api so the OAuth server
+# returns a JSON token response instead of a redirect/non-JSON body.
+_QWEN_USER_AGENT = "HermesAgent/1.0"
 
 
 # =============================================================================
@@ -1098,6 +1102,7 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "application/json",
+                "User-Agent": _QWEN_USER_AGENT,
             },
             data={
                 "grant_type": "refresh_token",
@@ -1125,8 +1130,14 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
     try:
         payload = response.json()
     except Exception as exc:
+        # Surface diagnostics so users can report the actual server response
+        diag = (
+            f"status={response.status_code}, "
+            f"content-type={response.headers.get('content-type', 'unknown')}, "
+            f"body={response.text[:200]!r}"
+        )
         raise AuthError(
-            f"Qwen OAuth refresh returned invalid JSON: {exc}",
+            f"Qwen OAuth refresh returned invalid JSON ({diag}): {exc}",
             provider="qwen-oauth",
             code="qwen_refresh_invalid_json",
         ) from exc

--- a/tests/hermes_cli/test_auth_qwen_provider.py
+++ b/tests/hermes_cli/test_auth_qwen_provider.py
@@ -397,3 +397,53 @@ def test_get_qwen_auth_status_not_logged_in(qwen_env):
     status = get_qwen_auth_status()
     assert status["logged_in"] is False
     assert "error" in status
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for User-Agent fix (GitHub issue #7746)
+# ---------------------------------------------------------------------------
+
+def test_refresh_qwen_cli_tokens_sends_user_agent_header(qwen_env):
+    """Verify that the OAuth refresh request includes a User-Agent header
+    so the Qwen server returns JSON instead of an HTML/non-JSON response."""
+    tokens = _make_qwen_tokens(refresh_token="rt")
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+    with patch("hermes_cli.auth.httpx") as mock_httpx:
+        mock_httpx.post.return_value = resp
+        _refresh_qwen_cli_tokens(tokens)
+
+    call_kwargs = mock_httpx.post.call_args.kwargs
+    headers = call_kwargs.get("headers", {})
+    assert "User-Agent" in headers, (
+        f"User-Agent header missing. Headers sent: {headers}"
+    )
+    assert headers["User-Agent"] == "HermesAgent/1.0"
+
+
+def test_refresh_qwen_cli_tokens_invalid_json_error_includes_diagnostics(qwen_env):
+    """When the server returns a non-JSON response, the error message must
+    include status code, content-type, and response body preview so the
+    failure is diagnosable without needing network capture tools."""
+    tokens = _make_qwen_tokens(refresh_token="rt")
+
+    resp = MagicMock()
+    resp.status_code = 200
+    # Must configure the MagicMock for .headers so .get() returns a string
+    resp.headers = MagicMock()
+    resp.headers.get.return_value = "text/html"
+    resp.text = "<html><body>Please enable JS</body></html>"
+    resp.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+
+    with patch("hermes_cli.auth.httpx") as mock_httpx:
+        mock_httpx.post.return_value = resp
+        with pytest.raises(AuthError) as exc:
+            _refresh_qwen_cli_tokens(tokens)
+    assert exc.value.code == "qwen_refresh_invalid_json"
+    msg = str(exc.value)
+    assert "status=200" in msg, f"Error message should include status code. Got: {msg}"
+    assert "text/html" in msg, f"Error message should include content-type. Got: {msg}"
+    assert "Please enable JS" in msg, f"Error message should include body preview. Got: {msg}"


### PR DESCRIPTION
## What does this PR do?

Fixes #7746 — Qwen OAuth token refresh silently fails with `invalid JSON` because the refresh request is missing a `User-Agent` header. The Qwen OAuth server returns a non-JSON response (HTML / redirect) when the header is absent.

## Root Cause

Reported by @gxmst in issue #7746:
- `qwen-code-api` sends `User-Agent: QwenCode/0.14.0 (linux; x64)` during token refresh and works fine
- Hermes `_refresh_qwen_cli_tokens()` sends no `User-Agent`, causing the OAuth server to return a non-JSON response
- Hermes then calls `response.json()` on that response and raises a confusing `invalid JSON` error

## Changes

**hermes_cli/auth.py:**
- Added `_QWEN_USER_AGENT = "HermesAgent/1.0"` constant
- Added `User-Agent: HermesAgent/1.0` to the httpx.post headers in `_refresh_qwen_cli_tokens()`
- Improved the `qwen_refresh_invalid_json` error message to include:
  - HTTP status code
  - Content-Type header
  - Response body preview (first 200 chars)

**tests/hermes_cli/test_auth_qwen_provider.py:**
- `test_refresh_qwen_cli_tokens_sends_user_agent_header`: verifies the User-Agent header is sent with the correct value
- `test_refresh_qwen_cli_tokens_invalid_json_error_includes_diagnostics`: verifies diagnostics are surfaced in the error message

## How to Test

```bash
# 31/31 tests pass (29 existing + 2 new)
uv venv .venv --python 3.11 && source .venv/bin/activate
uv pip install -e ".[all,dev]"
python -m pytest tests/hermes_cli/test_auth_qwen_provider.py -v

# Manual test (requires real Qwen credentials):
hermes qwen auth qwen-oauth
hermes chat  # trigger token refresh
```

## Related Issue

Fixes #7746