### PR TITLE
fix(hindsight): clarify pip dependency per mode in README

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -131,4 +131,16 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.4.22`. The plugin auto-upgrades on session start if an older version is detected.
+Different modes require different packages:
+
+| Mode | Package | Minimum Version |
+|------|---------|----------------|
+| `cloud` | `hindsight-client` | `>= 0.4.22` |
+| `local_external` | `hindsight-client` | `>= 0.4.22` |
+| `local_embedded` | `hindsight-all` | `>= 0.5.0` |
+
+The plugin auto-upgrades `hindsight-client` on session start if an older version is detected, but does **not** auto-install `hindsight-all`. If you are using `local_embedded` mode and see `No module named 'hindsight'` errors, run:
+
+```bash
+uv pip install --system hindsight-all
+```


### PR DESCRIPTION
## What does this PR do?

Fixes a documentation gap in `plugins/memory/hindsight/README.md` — the "Client Version" section implied that `hindsight-client` is the only required package, but `local_embedded` mode actually requires `hindsight-all`.

## Changes

**plugins/memory/hindsight/README.md**:

Before:
\`\`\`
Requires `hindsight-client >= 0.4.22`. The plugin auto-upgrades on session start if an older version is detected.
\`\`\`

After: A dependency table is added:

| Mode | Package | Minimum Version |
|------|---------|----------------|
| `cloud` | `hindsight-client` | `>= 0.4.22` |
| `local_external` | `hindsight-client` | `>= 0.4.22` |
| `local_embedded` | `hindsight-all` | `>= 0.5.0` |

With a clear note that `hindsight-all` is **not** auto-upgraded, and the install command to fix it.

## Related Issue

Partially addresses the documentation concern raised in #7718 (the code fix for #7718 is submitted separately as PR #7745).