### PR TITLE
Fix Copilot ACP relative file paths within session cwd

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -228,11 +228,11 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str
 
 
 def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
-    candidate = Path(path_text)
-    if not candidate.is_absolute():
-        raise PermissionError("ACP file-system paths must be absolute.")
-    resolved = candidate.resolve()
     root = Path(cwd).resolve()
+    candidate = Path(path_text).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve()
     try:
         resolved.relative_to(root)
     except ValueError as exc:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -1,0 +1,84 @@
+import io
+import json
+from types import SimpleNamespace
+
+from agent.copilot_acp_client import CopilotACPClient, _ensure_path_within_cwd
+
+
+def _fake_process():
+    return SimpleNamespace(stdin=io.StringIO())
+
+
+def test_ensure_path_within_cwd_accepts_relative_paths(tmp_path):
+    nested = tmp_path / "src" / "main.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("print('ok')", encoding="utf-8")
+
+    resolved = _ensure_path_within_cwd("src/main.py", str(tmp_path))
+
+    assert resolved == nested.resolve()
+
+
+def test_handle_server_message_reads_relative_file_path(tmp_path):
+    target = tmp_path / "notes.txt"
+    target.write_text("copilot context", encoding="utf-8")
+    client = CopilotACPClient(acp_cwd=str(tmp_path))
+    process = _fake_process()
+
+    handled = client._handle_server_message(
+        {
+            "id": 1,
+            "method": "fs/read_text_file",
+            "params": {"path": "notes.txt"},
+        },
+        process=process,
+        cwd=str(tmp_path),
+        text_parts=None,
+        reasoning_parts=None,
+    )
+
+    assert handled is True
+    response = json.loads(process.stdin.getvalue())
+    assert response["result"]["content"] == "copilot context"
+
+
+def test_handle_server_message_writes_relative_file_path(tmp_path):
+    client = CopilotACPClient(acp_cwd=str(tmp_path))
+    process = _fake_process()
+
+    handled = client._handle_server_message(
+        {
+            "id": 2,
+            "method": "fs/write_text_file",
+            "params": {"path": "out/result.txt", "content": "done"},
+        },
+        process=process,
+        cwd=str(tmp_path),
+        text_parts=None,
+        reasoning_parts=None,
+    )
+
+    assert handled is True
+    assert (tmp_path / "out" / "result.txt").read_text(encoding="utf-8") == "done"
+
+
+def test_handle_server_message_rejects_relative_traversal(tmp_path):
+    client = CopilotACPClient(acp_cwd=str(tmp_path))
+    process = _fake_process()
+
+    client._handle_server_message(
+        {
+            "id": 3,
+            "method": "fs/write_text_file",
+            "params": {"path": "../escape.txt", "content": "nope"},
+        },
+        process=process,
+        cwd=str(tmp_path),
+        text_parts=None,
+        reasoning_parts=None,
+    )
+
+    response = json.loads(process.stdin.getvalue())
+    assert response["error"]["code"] == -32602
+    assert "outside the session cwd" in response["error"]["message"]
+    assert not (tmp_path.parent / "escape.txt").exists()


### PR DESCRIPTION
## Summary

This fixes a Copilot ACP integration bug where Hermes rejected safe relative file paths for ACP file-system requests.

Before this change, `agent/copilot_acp_client.py` required `fs/read_text_file` and `fs/write_text_file` paths to be absolute. In practice, ACP clients may send paths like `notes.txt` or `src/main.py` relative to the active session cwd. Those requests were incorrectly rejected with a permission error even when the target stayed inside the session workspace.

## Root cause

`_ensure_path_within_cwd()` rejected non-absolute paths before applying the existing containment check.

## Fix

Relative paths are now resolved against the session cwd and then validated with the existing `relative_to(root)` containment check.

This preserves traversal protection while allowing normal ACP relative-path behavior.

## Tests

Added coverage for:

* accepting relative paths inside the session cwd
* reading a relative file path
* writing a relative file path
* rejecting relative traversal such as `../escape.txt`

Test file:

* `tests/agent/test_copilot_acp_client.py`
