### PR TITLE
fix: skip sudo prompt when sudo -n already works

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -5,10 +5,12 @@ import tools.terminal_tool as terminal_tool
 
 def setup_function():
     terminal_tool._cached_sudo_password = ""
+    terminal_tool._sudo_nopasswd_available = None
 
 
 def teardown_function():
     terminal_tool._cached_sudo_password = ""
+    terminal_tool._sudo_nopasswd_available = None
 
 
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):
@@ -88,3 +90,19 @@ def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
 
     assert transformed == "echo ok && sudo -S -p '' whoami"
     assert sudo_stdin == "cached-pass\n"
+
+
+def test_sudo_nopasswd_skips_prompt_and_rewrite(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    def _fail_prompt(*args, **kwargs):
+        raise AssertionError("interactive sudo prompt should not run when sudo -n already works")
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: True)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo whoami")
+
+    assert transformed == "sudo whoami"
+    assert sudo_stdin is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -113,6 +113,8 @@ def _check_disk_usage_warning():
 
 # Session-cached sudo password (persists until CLI exits)
 _cached_sudo_password: str = ""
+# Cache whether this host/user can run sudo without a password. None = unknown.
+_sudo_nopasswd_available: bool | None = None
 
 # Optional UI callbacks for interactive prompts. When set, these are called
 # instead of the default /dev/tty or input() readers. The CLI registers these
@@ -445,6 +447,29 @@ def _rewrite_real_sudo_invocations(command: str) -> tuple[str, bool]:
     return "".join(out), found
 
 
+def _sudo_nopasswd_works() -> bool:
+    """Return True when the current user can run sudo without a password."""
+    global _sudo_nopasswd_available
+
+    if _sudo_nopasswd_available is not None:
+        return _sudo_nopasswd_available
+
+    try:
+        probe = subprocess.run(
+            ["sudo", "-n", "true"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+            check=False,
+        )
+        _sudo_nopasswd_available = (probe.returncode == 0)
+    except Exception:
+        _sudo_nopasswd_available = False
+
+    return _sudo_nopasswd_available
+
+
 def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None]:
     """
     Transform sudo commands to use -S flag if SUDO_PASSWORD is available.
@@ -489,6 +514,10 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
     has_configured_password = "SUDO_PASSWORD" in os.environ
     sudo_password = os.environ.get("SUDO_PASSWORD", "") if has_configured_password else _cached_sudo_password
+
+    # If the host is already configured with sudo NOPASSWD, do not prompt.
+    if not has_configured_password and not sudo_password and _sudo_nopasswd_works():
+        return command, None
 
     if not has_configured_password and not sudo_password and os.getenv("HERMES_INTERACTIVE"):
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)


### PR DESCRIPTION
## Summary
- detect when the current user already has passwordless sudo via `sudo -n true`
- skip the interactive sudo password prompt in that case
- add a regression test covering the NOPASSWD path

## Problem
Hermes currently prompts for a sudo password whenever it sees a sudo command in interactive mode unless `SUDO_PASSWORD` is set. That happens even when the host is already configured with sudo NOPASSWD, so YOLO/approval settings can be off and the user still gets an unnecessary password prompt.

## Test Plan
- [x] `./venv/bin/python -m pytest tests/tools/test_terminal_tool.py -q`
- [x] local smoke test of `_transform_sudo_command('sudo whoami')` returning `('sudo whoami', None)` when `sudo -n` works
