### PR TITLE
fix(gateway): trigger memory provider shutdown on /new and /reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3765,6 +3765,11 @@ class GatewayRunner:
                 _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
             if _old_agent is not None:
                 try:
+                    if hasattr(_old_agent, "shutdown_memory_provider"):
+                        _old_agent.shutdown_memory_provider()
+                except Exception:
+                    pass
+                try:
                     if hasattr(_old_agent, "close"):
                         _old_agent.close()
                 except Exception:


### PR DESCRIPTION
Fixes #7759

### Problem
The `/new` and `/reset` commands were not calling `shutdown_memory_provider()` on the cached agent before eviction. This caused OpenViking (and any memory provider that relies on session-end shutdown) to skip commit, leaving memories un-indexed until idle timeout or gateway shutdown.

### Root Cause
In `_handle_reset_command()`, the code flushed memories and closed tool resources, but it never shut down the memory provider. The session expiry watcher already does this correctly.

### Fix
Add the missing `shutdown_memory_provider()` call in `_handle_reset_command()`, matching the behavior already present in the session expiry watcher (lines ~1600–1625).

### Verification
- `tests/gateway/test_session_reset_notify.py` — 13 passed ✅
- `tests/gateway/test_gateway_inactivity_timeout.py` — 8 passed ✅
- `tests/gateway/test_voice_command.py` — 168 passed ✅