### PR TITLE
Fix config version detection for versionless legacy configs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1463,8 +1463,13 @@ def check_config_version() -> Tuple[int, int]:
     
     Returns (current_version, latest_version).
     """
-    config = load_config()
+    config = read_raw_config()
     current = config.get("_config_version", 0)
+    if not isinstance(current, int):
+        try:
+            current = int(current)
+        except (TypeError, ValueError):
+            current = 0
     latest = DEFAULT_CONFIG.get("_config_version", 1)
     return current, latest
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -8,6 +8,7 @@ import yaml
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
+    check_config_version,
     get_hermes_home,
     ensure_hermes_home,
     load_config,
@@ -421,3 +422,20 @@ class TestAnthropicTokenMigration:
         }):
             migrate_config(interactive=False, quiet=True)
             assert load_env().get("ANTHROPIC_TOKEN") == "current-token"
+
+
+class TestConfigVersionDetection:
+    def test_missing_version_is_treated_as_legacy_and_runs_migrations(self, tmp_path):
+        """Configs missing _config_version must still run versioned migrations."""
+        (tmp_path / "config.yaml").write_text("model: test-model\n")
+        (tmp_path / ".env").write_text("ANTHROPIC_TOKEN=old-token\n")
+        with patch.dict(os.environ, {
+            "HERMES_HOME": str(tmp_path),
+            "ANTHROPIC_TOKEN": "old-token",
+        }):
+            current, latest = check_config_version()
+            assert current == 0
+            assert latest == DEFAULT_CONFIG["_config_version"]
+
+            migrate_config(interactive=False, quiet=True)
+            assert load_env().get("ANTHROPIC_TOKEN") == ""


### PR DESCRIPTION

## Summary

This fixes config version detection so legacy `config.yaml` files without `_config_version` are treated as outdated instead of being silently considered current.

## Problem

`check_config_version()` was reading the merged config via `load_config()`. Because `load_config()` overlays `DEFAULT_CONFIG`, configs missing `_config_version` inherited the latest version number and skipped version-gated migrations.

## Fix

* read the version from `read_raw_config()` instead of the default-merged config
* safely coerce non-integer `_config_version` values
* fall back to version `0` when the field is missing or invalid

## Impact

This restores expected migration behavior for older or hand-edited configs, including cleanup steps that depend on version checks.

## Tests

Added regression coverage for:

* versionless configs
* missing `_config_version` reporting `0`
* legacy migrations running again and clearing stale `ANTHROPIC_TOKEN`
