### PR TITLE
fix(slack): handle file_shared events to suppress Bolt 404 errors

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -200,6 +200,20 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_app_mention(event, say):
                 pass
 
+            # Acknowledge file_shared events to prevent Bolt 404 errors.
+            # When a user uploads a file, Slack fires both a "message" event
+            # (which includes the files array and is already handled above)
+            # and a separate "file_shared" event.  Without this handler the
+            # framework returns HTTP 404 for every file_shared delivery,
+            # causing Slack to retry up to three times per upload and
+            # flooding logs with "Unhandled request" warnings.  See #7384.
+            @self._app.event("file_shared")
+            async def handle_file_shared(event, say):
+                logger.debug(
+                    "[Slack] Acknowledged file_shared event (file_id=%s)",
+                    event.get("file_id", "unknown"),
+                )
+
             @self._app.event("assistant_thread_started")
             async def handle_assistant_thread_started(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -145,6 +145,7 @@ class TestAppMentionHandler:
 
         assert "message" in registered_events
         assert "app_mention" in registered_events
+        assert "file_shared" in registered_events
         assert "assistant_thread_started" in registered_events
         assert "assistant_thread_context_changed" in registered_events
         assert "/hermes" in registered_commands


### PR DESCRIPTION
## What does this PR do?

When a user uploads a file in Slack, the platform fires two independent events: a `message` event (which includes the `files` array) and a separate `file_shared` event. The existing `message` handler already processes file attachments correctly (images, audio, documents), but there was no handler registered for `file_shared`. This caused the Bolt framework to return HTTP 404 for every `file_shared` delivery, and Slack would retry up to three times per upload — flooding logs with `Unhandled request` warnings.

This PR registers a lightweight `file_shared` acknowledgment handler so the framework returns 200 and Slack stops retrying.

## Related Issue

Fixes #7384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/slack.py`: Register a `@self._app.event("file_shared")` handler that acknowledges the event with a `logger.debug()` call — identical in pattern to the existing `app_mention` no-op handler (which suppresses the same class of Bolt 404 errors for mention events)
- `tests/gateway/test_slack.py`: Add assertion that `file_shared` is included in the registered event types during `connect()`

## How to Test

1. `pytest tests/gateway/test_slack.py -v` — all 125 tests pass
2. `pytest tests/gateway/test_slack_mention.py tests/gateway/test_slack_approval_buttons.py -v` — all 44 tests pass
3. With a Slack workspace: upload a file in a DM to the bot — the `Unhandled request: file_shared` warning should no longer appear in logs, and file processing should continue to work as before via the `message` event handler

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A