### PR TITLE
feat: add Nebius Token Factory to reasoning providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5977,6 +5977,8 @@ class AIAgent:
         """
         if "nousresearch" in self._base_url_lower:
             return True
+        if "tokenfactory.nebius" in self._base_url_lower:
+            return True
         if "ai-gateway.vercel.sh" in self._base_url_lower:
             return True
         if "models.github.ai" in self._base_url_lower or "api.githubcopilot.com" in self._base_url_lower:


### PR DESCRIPTION
## What does this PR do?

Adds Nebius Token Factory (tokenfactory.nebius.com) to the list of providers recognized by _supports_reasoning_extra_body() in run_agent.py. Without this, models hosted on Nebius (like Qwen3-235B) that support thinking/reasoning tokens never receive thinking_budget or reasoning_effort parameters. This causes thinking tokens to silently consume the output token budget, leading to truncated tool calls (finish_reason='length').

## Related Issue
Laisse vide ou crée une issue d'abord si tu veux être propre.
## Type of Change
Coche : 🐛 Bug fix
## Changes Made


run_agent.py: Added if "tokenfactory.nebius" in self._base_url_lower: return True in _supports_reasoning_extra_body() (line ~5980)


## How to Test


Configure a custom provider with base_url: https://api.tokenfactory.nebius.com/v1/
Set model to Qwen/Qwen3-235B-A22B-Instruct-2507 with thinking_budget: 2048
Run any tool-calling prompt (e.g. /search something)
Without patch: response truncates at ~8K tokens (finish_reason='length')
With patch: clean tool call completion, thinking tokens properly bounded


## Checklist
Coche :

✅ Commit follows Conventional Commits
✅ Searched existing PRs
✅ PR contains only related changes
✅ Tested on: Ubuntu 24.04 aarch64 (DGX Spark)