### PR TITLE
fix(cli): validate structural integrity of skill snapshots during import

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -934,11 +934,21 @@ def do_snapshot_import(input_path: str, force: bool = False,
         c.print(f"[bold red]Error:[/] Invalid JSON in {inp}\n")
         return
 
+    if not isinstance(snapshot, dict):
+        c.print(f"[bold red]Error:[/] Invalid snapshot format in {inp}\n")
+        return
+
     # Restore taps first
     taps = snapshot.get("taps", [])
+    if not isinstance(taps, list):
+        c.print(f"[bold red]Error:[/] Invalid snapshot format in {inp}\n")
+        return
     if taps:
         mgr = TapsManager()
         for tap in taps:
+            if not isinstance(tap, dict):
+                c.print(f"[yellow]Skipping malformed tap entry in {inp}[/]")
+                continue
             repo = tap.get("repo", "")
             if repo:
                 mgr.add(repo, tap.get("path", "skills/"))
@@ -946,12 +956,18 @@ def do_snapshot_import(input_path: str, force: bool = False,
 
     # Install skills
     skills = snapshot.get("skills", [])
+    if not isinstance(skills, list):
+        c.print(f"[bold red]Error:[/] Invalid snapshot format in {inp}\n")
+        return
     if not skills:
         c.print("[dim]No skills in snapshot to install.[/]\n")
         return
 
     c.print(f"[bold]Importing {len(skills)} skill(s) from snapshot...[/]\n")
     for entry in skills:
+        if not isinstance(entry, dict):
+            c.print(f"[yellow]Skipping malformed skill entry in {inp}[/]")
+            continue
         identifier = entry.get("identifier", "")
         category = entry.get("category", "")
         if not identifier:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,9 +1,17 @@
+import json
 from io import StringIO
 
 import pytest
 from rich.console import Console
 
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    do_check,
+    do_install,
+    do_list,
+    do_snapshot_import,
+    do_update,
+    handle_skills_slash,
+)
 
 
 class _DummyLockFile:
@@ -231,3 +239,46 @@ def test_do_install_scans_with_resolved_identifier(monkeypatch, tmp_path, hub_en
     do_install("skils-sh/anthropics/skills/frontend-design", console=console, skip_confirm=True)
 
     assert scanned["source"] == canonical_identifier
+
+
+def test_do_snapshot_import_rejects_non_object_snapshot(tmp_path):
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text("[]", encoding="utf-8")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    do_snapshot_import(str(snapshot), console=console)
+
+    assert "Invalid snapshot format" in sink.getvalue()
+
+
+def test_do_snapshot_import_skips_malformed_skill_entries(monkeypatch, tmp_path):
+    import hermes_cli.skills_hub as cli_hub
+
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text(json.dumps({
+        "skills": [
+            "bad-entry",
+            {"name": "missing-id"},
+            {"name": "ok-skill", "identifier": "github/example/ok-skill", "category": "tools"},
+        ],
+        "taps": [],
+    }), encoding="utf-8")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    installs = []
+
+    monkeypatch.setattr(
+        cli_hub,
+        "do_install",
+        lambda identifier, category="", force=False, console=None: installs.append((identifier, category, force)),
+    )
+
+    do_snapshot_import(str(snapshot), force=True, console=console)
+
+    output = sink.getvalue()
+    assert "Skipping malformed skill entry" in output
+    assert "Skipping entry with no identifier: missing-id" in output
+    assert installs == [("github/example/ok-skill", "tools", True)]


### PR DESCRIPTION
# Summary

hermes skills snapshot import only validated JSON syntax, not snapshot structure. That meant a syntactically valid but malformed snapshot file could crash the command with AttributeError instead of returning a user-facing error or skipping bad entries.

This patch adds narrow structure validation to the snapshot import path and keeps the import flow resilient when individual entries are malformed.

## Problem

Before this change, these payloads could crash import:

* top-level JSON array instead of an object
* non-list skills / taps
* malformed entries inside skills / taps

Example:

```json
[]
```

or:

```json
{
  "skills": [
    "bad-entry",
    { "name": "missing-id" },
    { "name": "ok-skill", "identifier": "github/example/ok-skill", "category": "tools" }
  ],
  "taps": []
}
```

In both cases, import could raise at runtime because the code assumed snapshot and each entry were dict-shaped.

## Fix

* reject non-object snapshots with a clear error
* reject non-list skills / taps with a clear error
* skip malformed list entries instead of crashing
* preserve existing behavior for valid entries

The patch is intentionally scoped to input validation in do_snapshot_import().

## Tests

Added coverage for:

* rejecting a non-object snapshot
* skipping malformed skill entries while still importing valid ones

## Verification

Ran:

```bash
python -m pytest tests/hermes_cli/test_skills_hub.py -q
```

Result: 11 passed
