### PR TITLE
fix(feishu): infer receive_id_type from chat_id prefix

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3249,7 +3249,14 @@ class FeishuAdapter(BasePlatformAdapter):
             content=payload,
             uuid_value=str(uuid.uuid4()),
         )
-        request = self._build_create_message_request("chat_id", body)
+        # Infer receive_id_type from chat_id prefix to support open_id (ou_) and union_id (on_)
+        if chat_id.startswith("ou_"):
+            rid_type = "open_id"
+        elif chat_id.startswith("on_"):
+            rid_type = "union_id"
+        else:
+            rid_type = "chat_id"
+        request = self._build_create_message_request(rid_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Infer `receive_id_type` from `chat_id` prefix to support all Feishu ID types:
  - `ou_` prefix → `open_id`
  - `on_` prefix → `union_id`  
  - default → `chat_id`
- Previously hardcoded `receive_id_type="chat_id"` which caused Feishu API error `[230001] invalid receive_id` for open_id targets

## Fixes
Fixes #7685

## Test plan
- [ ] Create cron job with `deliver: "feishu:ou_xxxxx"` and verify delivery succeeds
- [ ] Verify chat_id (`oc_`) and union_id (`on_`) targets still work

🤖 Generated with [Claude Code](https://claude.ai)