### PR TITLE
fix(gateway): skip systemd check when systemctl is absent

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -317,6 +317,9 @@ def supports_systemd_services() -> bool:
         return False
     if is_wsl():
         return _wsl_systemd_operational()
+    # Docker / container environments typically lack systemd
+    if shutil.which("systemctl") is None:
+        return False
     return True
 
 


### PR DESCRIPTION
## Summary
- `hermes gateway setup` crashes with `FileNotFoundError` in Docker containers because `supports_systemd_services()` returns `True` on all Linux, but Docker lacks `systemctl`
- Added a `shutil.which("systemctl")` guard before assuming systemd support

## Test plan
- [x] Verified `hermes gateway setup` completes successfully inside Docker container
- [x] Verified Weixin QR login flow works end-to-end after fix
- [ ] Existing systemd-based Linux installs should be unaffected (guard only triggers when `systemctl` binary is missing)