### PR TITLE
fix(weixin): keep short multiline content in one bubble

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -756,13 +756,15 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
 
 
 def _split_text_for_weixin_delivery(content: str, max_length: int) -> List[str]:
-    """Split content into sequential Weixin messages.
+    """Split content into Weixin messages only when necessary.
 
-    Prefer one message per top-level line/markdown unit when the author used
-    explicit line breaks. Oversized units fall back to block-aware packing so
-    long code fences still split safely.
+    Preference order:
+    1. If the whole message fits, keep it as a single bubble even if it
+       contains multiple lines. This gives the most card-like experience.
+    2. If it exceeds the platform limit, split it into readable blocks while
+       preserving markdown/code fence boundaries as much as possible.
     """
-    if len(content) <= max_length and "\n" not in content:
+    if len(content) <= max_length:
         return [content]
 
     chunks: List[str] = []
@@ -1425,12 +1427,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -62,15 +62,15 @@ class TestWeixinFormatting:
 
 
 class TestWeixinChunking:
-    def test_split_text_sends_top_level_newlines_as_separate_messages(self):
+    def test_split_text_keeps_multiline_message_as_single_bubble_when_within_limit(self):
         adapter = _make_adapter()
 
         content = adapter.format_message("第一行\n第二行\n第三行")
         chunks = adapter._split_text(content)
 
-        assert chunks == ["第一行", "第二行", "第三行"]
+        assert chunks == ["第一行\n第二行\n第三行"]
 
-    def test_split_text_keeps_indented_followup_with_previous_line(self):
+    def test_split_text_keeps_table_message_as_single_bubble_when_within_limit(self):
         adapter = _make_adapter()
 
         content = adapter.format_message(
@@ -82,8 +82,7 @@ class TestWeixinChunking:
         chunks = adapter._split_text(content)
 
         assert chunks == [
-            "- Setting: Timeout\n  Value: 30s",
-            "- Setting: Retries\n  Value: 3",
+            "- Setting: Timeout\n  Value: 30s\n- Setting: Retries\n  Value: 3"
         ]
 
     def test_split_text_keeps_complete_code_block_together_when_possible(self):


### PR DESCRIPTION
## What Changed
- keep short multiline Weixin messages in a single bubble when they fit within the platform limit
- keep the existing block-aware fallback for oversized content so markdown and code fences still split safely
- align the Weixin gateway tests with the new chunking behavior

## Why
- splitting every top-level newline into separate messages made short multiline replies feel fragmented in Weixin
- when the full payload already fits, preserving one bubble gives a more readable card-like result without relaxing the size guardrails

## How to Test
- [x] source venv/bin/activate && python -m pytest tests/gateway/test_weixin.py -q

## Risk & Rollback
- Risk level: Low
- Rollback: revert commit 9d959744

## Checklist
- [x] Config/env changes needed: no
- [x] Database migration required: no
- [x] API contract changes: no
- [x] Feature flag involved: no
- [x] Tests added / updated: yes