### PR TITLE
Add WeCom callback-mode adapter with multi-app routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -291,8 +291,10 @@ class GatewayConfig:
             # Feishu uses extra dict for app credentials
             elif platform == Platform.FEISHU and config.extra.get("app_id"):
                 connected.append(platform)
-            # WeCom uses extra dict for bot credentials
-            elif platform == Platform.WECOM and config.extra.get("bot_id"):
+            # WeCom uses extra dict for bot credentials or callback-mode app config
+            elif platform == Platform.WECOM and (
+                config.extra.get("bot_id") or config.extra.get("corp_id") or config.extra.get("apps")
+            ):
                 connected.append(platform)
             # BlueBubbles uses extra dict for local server config
             elif platform == Platform.BLUEBUBBLES and config.extra.get("server_url") and config.extra.get("password"):
@@ -986,6 +988,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 chat_id=wecom_home,
                 name=os.getenv("WECOM_HOME_CHANNEL_NAME", "Home"),
             )
+
+    wecom_callback_corp_id = os.getenv("WECOM_CALLBACK_CORP_ID")
+    wecom_callback_corp_secret = os.getenv("WECOM_CALLBACK_CORP_SECRET")
+    if wecom_callback_corp_id and wecom_callback_corp_secret:
+        if Platform.WECOM not in config.platforms:
+            config.platforms[Platform.WECOM] = PlatformConfig()
+        config.platforms[Platform.WECOM].enabled = True
+        config.platforms[Platform.WECOM].extra.update({
+            "mode": "callback",
+            "corp_id": wecom_callback_corp_id,
+            "corp_secret": wecom_callback_corp_secret,
+            "agent_id": os.getenv("WECOM_CALLBACK_AGENT_ID", ""),
+            "token": os.getenv("WECOM_CALLBACK_TOKEN", ""),
+            "encoding_aes_key": os.getenv("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
+            "host": os.getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
+            "port": int(os.getenv("WECOM_CALLBACK_PORT", "8645")),
+        })
 
     # Weixin (personal WeChat via iLink Bot API)
     weixin_token = os.getenv("WEIXIN_TOKEN")

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -1,0 +1,355 @@
+"""WeCom callback-mode adapter for self-built enterprise applications."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket as _socket
+import time
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree as ET
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:
+    httpx = None  # type: ignore[assignment]
+    HTTPX_AVAILABLE = False
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.wecom_crypto import WXBizMsgCrypt, WeComCryptoError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8645
+DEFAULT_PATH = "/wecom/callback"
+TOKEN_TTL_SECONDS = 7200
+REPLY_TIMEOUT_SECONDS = 4.5
+
+
+def check_wecom_callback_requirements() -> bool:
+    return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
+
+
+class WecomCallbackAdapter(BasePlatformAdapter):
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.WECOM)
+        extra = config.extra or {}
+        self._host = str(extra.get("host") or DEFAULT_HOST)
+        self._port = int(extra.get("port") or DEFAULT_PORT)
+        self._path = str(extra.get("path") or DEFAULT_PATH)
+        self._apps: List[Dict[str, Any]] = self._normalize_apps(extra)
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.TCPSite] = None
+        self._app: Optional[web.Application] = None
+        self._http_client: Optional[httpx.AsyncClient] = None
+        self._message_queue: asyncio.Queue[MessageEvent] = asyncio.Queue()
+        self._poll_task: Optional[asyncio.Task] = None
+        self._pending_replies: Dict[str, asyncio.Future[str]] = {}
+        self._seen_messages: Dict[str, float] = {}
+        self._user_app_map: Dict[str, str] = {}
+        self._access_tokens: Dict[str, Dict[str, Any]] = {}
+
+    @staticmethod
+    def _user_app_key(corp_id: str, user_id: str) -> str:
+        return f"{corp_id}:{user_id}" if corp_id else user_id
+
+    @staticmethod
+    def _normalize_apps(extra: Dict[str, Any]) -> List[Dict[str, Any]]:
+        apps = extra.get("apps")
+        if isinstance(apps, list) and apps:
+            return [dict(app) for app in apps if isinstance(app, dict)]
+        if extra.get("corp_id"):
+            return [
+                {
+                    "name": extra.get("name") or "default",
+                    "corp_id": extra.get("corp_id", ""),
+                    "corp_secret": extra.get("corp_secret", ""),
+                    "agent_id": str(extra.get("agent_id", "")),
+                    "token": extra.get("token", ""),
+                    "encoding_aes_key": extra.get("encoding_aes_key", ""),
+                }
+            ]
+        return []
+
+    async def connect(self) -> bool:
+        if not self._apps:
+            logger.warning("[WecomCallback] No callback apps configured")
+            return False
+        if not check_wecom_callback_requirements():
+            logger.warning("[WecomCallback] aiohttp/httpx not installed")
+            return False
+        try:
+            with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as sock:
+                sock.settimeout(1)
+                sock.connect(("127.0.0.1", self._port))
+            logger.error("[WecomCallback] Port %d already in use", self._port)
+            return False
+        except (ConnectionRefusedError, OSError):
+            pass
+
+        try:
+            self._http_client = httpx.AsyncClient(timeout=20.0)
+            self._app = web.Application()
+            self._app.router.add_get("/health", self._handle_health)
+            self._app.router.add_get(self._path, self._handle_verify)
+            self._app.router.add_post(self._path, self._handle_callback)
+            self._runner = web.AppRunner(self._app)
+            await self._runner.setup()
+            self._site = web.TCPSite(self._runner, self._host, self._port)
+            await self._site.start()
+            self._poll_task = asyncio.create_task(self._poll_loop())
+            self._mark_connected()
+            logger.info("[WecomCallback] HTTP server listening on %s:%s", self._host, self._port)
+            logger.info("[WecomCallback] Callback URL: http://YOUR_PUBLIC_IP:%s%s", self._port, self._path)
+            for app in self._apps:
+                await self._refresh_access_token(app)
+            return True
+        except Exception:
+            await self._cleanup()
+            logger.exception("[WecomCallback] Failed to start")
+            return False
+
+    async def disconnect(self) -> None:
+        self._running = False
+        if self._poll_task:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+            self._poll_task = None
+        await self._cleanup()
+        self._mark_disconnected()
+        logger.info("[WecomCallback] Disconnected")
+
+    async def _cleanup(self) -> None:
+        self._site = None
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        self._app = None
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        metadata = metadata or {}
+        reply_key = metadata.get("wecom_reply_key") or reply_to
+        if reply_key and reply_key in self._pending_replies:
+            fut = self._pending_replies.get(reply_key)
+            if fut and not fut.done():
+                fut.set_result(content)
+                return SendResult(success=True, message_id=str(reply_key))
+
+        app_name = self._user_app_map.get(chat_id)
+        effective_chat_id = chat_id
+        if not app_name and ":" not in chat_id:
+            matching_keys = [key for key in self._user_app_map.keys() if key.endswith(f":{chat_id}")]
+            if len(matching_keys) == 1:
+                effective_chat_id = matching_keys[0]
+                app_name = self._user_app_map.get(matching_keys[0])
+        app = self._get_app_by_name(app_name) if app_name else None
+        if not app:
+            app = self._apps[0]
+        touser = effective_chat_id.split(":", 1)[1] if ":" in effective_chat_id else effective_chat_id
+        try:
+            token = await self._get_access_token(app)
+            payload = {
+                "touser": touser,
+                "msgtype": "text",
+                "agentid": int(str(app.get("agent_id") or 0)),
+                "text": {"content": content[:2048]},
+                "safe": 0,
+            }
+            resp = await self._http_client.post(
+                f"https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token={token}",
+                json=payload,
+            )
+            data = resp.json()
+            if data.get("errcode") != 0:
+                return SendResult(success=False, error=str(data))
+            return SendResult(success=True, message_id=str(data.get("msgid", "")), raw_response=data)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        return web.json_response({"status": "ok", "platform": "wecom_callback"})
+
+    async def _handle_verify(self, request: web.Request) -> web.Response:
+        msg_signature = request.query.get("msg_signature", "")
+        timestamp = request.query.get("timestamp", "")
+        nonce = request.query.get("nonce", "")
+        echostr = request.query.get("echostr", "")
+        for app in self._apps:
+            try:
+                crypt = self._crypt_for_app(app)
+                plain = crypt.verify_url(msg_signature, timestamp, nonce, echostr)
+                return web.Response(text=plain, content_type="text/plain")
+            except Exception:
+                continue
+        return web.Response(status=403, text="signature verification failed")
+
+    async def _handle_callback(self, request: web.Request) -> web.Response:
+        msg_signature = request.query.get("msg_signature", "")
+        timestamp = request.query.get("timestamp", "")
+        nonce = request.query.get("nonce", "")
+        body = await request.text()
+        for app in self._apps:
+            try:
+                decrypted = self._decrypt_request(app, body, msg_signature, timestamp, nonce)
+                event = self._build_event(app, decrypted)
+                if event is None:
+                    return web.Response(
+                        text=self._encrypt_reply(app, "success", nonce, timestamp),
+                        content_type="application/xml",
+                    )
+                reply_future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+                reply_key = event.message_id or f"{event.source.chat_id}:{time.time()}"
+                self._pending_replies[reply_key] = reply_future
+                if event.source and event.source.user_id:
+                    map_key = self._user_app_key(str(app.get("corp_id") or ""), event.source.user_id)
+                    self._user_app_map[map_key] = app["name"]
+                await self._message_queue.put(event)
+                try:
+                    reply_text = await asyncio.wait_for(reply_future, timeout=REPLY_TIMEOUT_SECONDS)
+                except asyncio.TimeoutError:
+                    reply_text = "success"
+                finally:
+                    self._pending_replies.pop(reply_key, None)
+                return web.Response(
+                    text=self._encrypt_reply(
+                        app,
+                        self._build_text_reply_xml(event.source.user_id, app, reply_text),
+                        nonce,
+                        timestamp,
+                    ),
+                    content_type="application/xml",
+                )
+            except WeComCryptoError:
+                continue
+            except Exception:
+                logger.exception("[WecomCallback] Error handling message")
+                break
+        return web.Response(status=400, text="invalid callback payload")
+
+    async def _poll_loop(self) -> None:
+        while True:
+            event = await self._message_queue.get()
+            try:
+                task = asyncio.create_task(self.handle_message(event))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+            except Exception:
+                logger.exception("[WecomCallback] Failed to enqueue event")
+
+    def _decrypt_request(self, app: Dict[str, Any], body: str, msg_signature: str, timestamp: str, nonce: str) -> str:
+        root = ET.fromstring(body)
+        encrypt = root.findtext("Encrypt", default="")
+        crypt = self._crypt_for_app(app)
+        return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")
+
+    def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
+        root = ET.fromstring(xml_text)
+        msg_type = (root.findtext("MsgType") or "").lower()
+        if msg_type == "event":
+            event_name = (root.findtext("Event") or "").lower()
+            if event_name in {"enter_agent", "subscribe"}:
+                return None
+        if msg_type not in {"text", "event"}:
+            return None
+
+        user_id = root.findtext("FromUserName", default="")
+        corp_id = root.findtext("ToUserName", default=app.get("corp_id", ""))
+        scoped_chat_id = self._user_app_key(corp_id, user_id)
+        content = root.findtext("Content", default="").strip()
+        if not content and msg_type == "event":
+            content = "/start"
+        msg_id = root.findtext("MsgId") or f"{user_id}:{root.findtext('CreateTime', default='0')}"
+        source = self.build_source(
+            chat_id=scoped_chat_id,
+            chat_name=user_id,
+            chat_type="dm",
+            user_id=user_id,
+            user_name=user_id,
+        )
+        return MessageEvent(
+            text=content,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=xml_text,
+            message_id=msg_id,
+        )
+
+    def _build_text_reply_xml(self, user_id: str, app: Dict[str, Any], content: str) -> str:
+        root = ET.Element("xml")
+        ET.SubElement(root, "ToUserName").text = user_id
+        ET.SubElement(root, "FromUserName").text = str(app.get("corp_id") or "")
+        ET.SubElement(root, "CreateTime").text = str(int(time.time()))
+        ET.SubElement(root, "MsgType").text = "text"
+        ET.SubElement(root, "Content").text = content
+        return ET.tostring(root, encoding="unicode")
+
+    def _encrypt_reply(self, app: Dict[str, Any], plaintext_xml: str, nonce: str, timestamp: str) -> str:
+        return self._crypt_for_app(app).encrypt(plaintext_xml, nonce=nonce, timestamp=timestamp)
+
+    def _crypt_for_app(self, app: Dict[str, Any]) -> WXBizMsgCrypt:
+        return WXBizMsgCrypt(
+            token=str(app.get("token") or ""),
+            encoding_aes_key=str(app.get("encoding_aes_key") or ""),
+            receive_id=str(app.get("corp_id") or ""),
+        )
+
+    def _get_app_by_name(self, name: Optional[str]) -> Optional[Dict[str, Any]]:
+        if not name:
+            return None
+        for app in self._apps:
+            if app.get("name") == name:
+                return app
+        return None
+
+    async def _get_access_token(self, app: Dict[str, Any]) -> str:
+        cached = self._access_tokens.get(app["name"])
+        now = time.time()
+        if cached and cached.get("expires_at", 0) > now + 60:
+            return cached["token"]
+        return await self._refresh_access_token(app)
+
+    async def _refresh_access_token(self, app: Dict[str, Any]) -> str:
+        resp = await self._http_client.get(
+            "https://qyapi.weixin.qq.com/cgi-bin/gettoken",
+            params={"corpid": app.get("corp_id"), "corpsecret": app.get("corp_secret")},
+        )
+        data = resp.json()
+        if data.get("errcode") != 0:
+            raise RuntimeError(f"token refresh failed: {data}")
+        token = data["access_token"]
+        expires_in = int(data.get("expires_in", TOKEN_TTL_SECONDS))
+        self._access_tokens[app["name"]] = {"token": token, "expires_at": time.time() + expires_in}
+        logger.info(
+            "[WecomCallback] Token refreshed for app '%s' (corp=%s), expires in %ss",
+            app.get("name", "default"),
+            app.get("corp_id", ""),
+            expires_in,
+        )
+        return token

--- a/gateway/platforms/wecom_crypto.py
+++ b/gateway/platforms/wecom_crypto.py
@@ -1,0 +1,134 @@
+import base64
+import hashlib
+import os
+import random
+import socket
+import struct
+from typing import Optional
+from xml.etree import ElementTree as ET
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+
+
+class WeComCryptoError(Exception):
+    pass
+
+
+class SignatureError(WeComCryptoError):
+    pass
+
+
+class DecryptError(WeComCryptoError):
+    pass
+
+
+class EncryptError(WeComCryptoError):
+    pass
+
+
+class PKCS7Encoder:
+    block_size = 32
+
+    @classmethod
+    def encode(cls, text: bytes) -> bytes:
+        amount_to_pad = cls.block_size - (len(text) % cls.block_size)
+        if amount_to_pad == 0:
+            amount_to_pad = cls.block_size
+        pad = bytes([amount_to_pad]) * amount_to_pad
+        return text + pad
+
+    @classmethod
+    def decode(cls, decrypted: bytes) -> bytes:
+        if not decrypted:
+            raise DecryptError("empty decrypted payload")
+        pad = decrypted[-1]
+        if pad < 1 or pad > cls.block_size:
+            raise DecryptError("invalid PKCS7 padding")
+        if decrypted[-pad:] != bytes([pad]) * pad:
+            raise DecryptError("malformed PKCS7 padding")
+        return decrypted[:-pad]
+
+
+def _sha1_signature(token: str, timestamp: str, nonce: str, encrypt: str) -> str:
+    parts = sorted([token, timestamp, nonce, encrypt])
+    return hashlib.sha1("".join(parts).encode("utf-8")).hexdigest()
+
+
+class WXBizMsgCrypt:
+    """Minimal WeCom callback crypto helper compatible with BizMsgCrypt semantics."""
+
+    def __init__(self, token: str, encoding_aes_key: str, receive_id: str):
+        if not token:
+            raise ValueError("token is required")
+        if not encoding_aes_key:
+            raise ValueError("encoding_aes_key is required")
+        if len(encoding_aes_key) != 43:
+            raise ValueError("encoding_aes_key must be 43 chars")
+        if not receive_id:
+            raise ValueError("receive_id is required")
+
+        self.token = token
+        self.receive_id = receive_id
+        self.key = base64.b64decode(encoding_aes_key + "=")
+        self.iv = self.key[:16]
+
+    def verify_url(self, msg_signature: str, timestamp: str, nonce: str, echostr: str) -> str:
+        plain = self.decrypt(msg_signature, timestamp, nonce, echostr)
+        return plain.decode("utf-8")
+
+    def decrypt(self, msg_signature: str, timestamp: str, nonce: str, encrypt: str) -> bytes:
+        expected = _sha1_signature(self.token, timestamp, nonce, encrypt)
+        if expected != msg_signature:
+            raise SignatureError("signature mismatch")
+        try:
+            cipher_text = base64.b64decode(encrypt)
+        except Exception as exc:
+            raise DecryptError(f"invalid base64 payload: {exc}") from exc
+        try:
+            cipher = Cipher(algorithms.AES(self.key), modes.CBC(self.iv), backend=default_backend())
+            decryptor = cipher.decryptor()
+            padded = decryptor.update(cipher_text) + decryptor.finalize()
+            plain = PKCS7Encoder.decode(padded)
+            content = plain[16:]
+            xml_length = socket.ntohl(struct.unpack("I", content[:4])[0])
+            xml_content = content[4:4 + xml_length]
+            receive_id = content[4 + xml_length:].decode("utf-8")
+        except WeComCryptoError:
+            raise
+        except Exception as exc:
+            raise DecryptError(f"decrypt failed: {exc}") from exc
+
+        if receive_id != self.receive_id:
+            raise DecryptError("receive_id mismatch")
+        return xml_content
+
+    def encrypt(self, plaintext: str, nonce: Optional[str] = None, timestamp: Optional[str] = None) -> str:
+        nonce = nonce or self._random_nonce()
+        timestamp = timestamp or str(int(__import__('time').time()))
+        encrypt = self._encrypt_bytes(plaintext.encode("utf-8"))
+        signature = _sha1_signature(self.token, timestamp, nonce, encrypt)
+        root = ET.Element("xml")
+        ET.SubElement(root, "Encrypt").text = encrypt
+        ET.SubElement(root, "MsgSignature").text = signature
+        ET.SubElement(root, "TimeStamp").text = timestamp
+        ET.SubElement(root, "Nonce").text = nonce
+        return ET.tostring(root, encoding="unicode")
+
+    def _encrypt_bytes(self, raw: bytes) -> str:
+        try:
+            random_prefix = os.urandom(16)
+            msg_len = struct.pack("I", socket.htonl(len(raw)))
+            payload = random_prefix + msg_len + raw + self.receive_id.encode("utf-8")
+            padded = PKCS7Encoder.encode(payload)
+            cipher = Cipher(algorithms.AES(self.key), modes.CBC(self.iv), backend=default_backend())
+            encryptor = cipher.encryptor()
+            encrypted = encryptor.update(padded) + encryptor.finalize()
+            return base64.b64encode(encrypted).decode("utf-8")
+        except Exception as exc:
+            raise EncryptError(f"encrypt failed: {exc}") from exc
+
+    @staticmethod
+    def _random_nonce(length: int = 10) -> str:
+        alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        return "".join(random.choice(alphabet) for _ in range(length))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2038,6 +2038,16 @@ class GatewayRunner:
             return FeishuAdapter(config)
 
         elif platform == Platform.WECOM:
+            extra = getattr(config, "extra", {}) or {}
+            if extra.get("mode") == "callback" or extra.get("corp_id") or extra.get("apps"):
+                from gateway.platforms.wecom_callback import (
+                    WecomCallbackAdapter,
+                    check_wecom_callback_requirements,
+                )
+                if not check_wecom_callback_requirements():
+                    logger.warning("WeComCallback: aiohttp/httpx not installed")
+                    return None
+                return WecomCallbackAdapter(config)
             from gateway.platforms.wecom import WeComAdapter, check_wecom_requirements
             if not check_wecom_requirements():
                 logger.warning("WeCom: aiohttp not installed or WECOM_BOT_ID/SECRET not set")

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -1,0 +1,169 @@
+import asyncio
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.wecom_callback import WecomCallbackAdapter
+from gateway.platforms.wecom_crypto import WXBizMsgCrypt
+
+
+def _app(name="test-app", corp_id="ww1234567890", agent_id="1000002"):
+    return {
+        "name": name,
+        "corp_id": corp_id,
+        "corp_secret": "secret",
+        "agent_id": agent_id,
+        "token": "***",
+        "encoding_aes_key": "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG",
+    }
+
+
+def _config(apps=None):
+    return PlatformConfig(
+        enabled=True,
+        extra={"mode": "callback", "host": "127.0.0.1", "port": 0, "apps": apps or [_app()]},
+    )
+
+
+def test_crypto_roundtrip_encrypt_decrypt():
+    app = _app()
+    crypt = WXBizMsgCrypt(app["token"], app["encoding_aes_key"], app["corp_id"])
+    encrypted_xml = crypt.encrypt("<xml><Content>hello</Content></xml>", nonce="nonce123", timestamp="123456")
+    root = ET.fromstring(encrypted_xml)
+    decrypted = crypt.decrypt(
+        root.findtext("MsgSignature", default=""),
+        root.findtext("TimeStamp", default=""),
+        root.findtext("Nonce", default=""),
+        root.findtext("Encrypt", default=""),
+    )
+    assert b"<Content>hello</Content>" in decrypted
+
+
+@pytest.mark.asyncio
+async def test_send_resolves_pending_reply_future():
+    adapter = WecomCallbackAdapter(_config())
+    fut = asyncio.get_running_loop().create_future()
+    adapter._pending_replies["m1"] = fut
+    result = await adapter.send("user1", "hi", reply_to="m1")
+    assert result.success is True
+    assert result.message_id == "m1"
+    assert await fut == "hi"
+
+
+def test_build_event_uses_source_field_and_message_id():
+    adapter = WecomCallbackAdapter(_config())
+    xml_text = """
+    <xml>
+      <ToUserName>ww1234567890</ToUserName>
+      <FromUserName>zhangsan</FromUserName>
+      <CreateTime>1710000000</CreateTime>
+      <MsgType>text</MsgType>
+      <Content>你好</Content>
+      <MsgId>123456789</MsgId>
+    </xml>
+    """
+    event = adapter._build_event(_app(), xml_text)
+    assert event is not None
+    assert event.source is not None
+    assert event.source.user_id == "zhangsan"
+    assert event.source.chat_id == "ww1234567890:zhangsan"
+    assert event.message_id == "123456789"
+    assert event.text == "你好"
+
+
+def test_user_app_key_scopes_same_user_across_corps():
+    adapter = WecomCallbackAdapter(_config())
+    assert adapter._user_app_key("corpA", "alice") == "corpA:alice"
+    assert adapter._user_app_key("corpB", "alice") == "corpB:alice"
+    assert adapter._user_app_key("corpA", "alice") != adapter._user_app_key("corpB", "alice")
+
+
+@pytest.mark.asyncio
+async def test_send_uses_scoped_chat_id_to_select_correct_app():
+    apps = [
+        _app(name="corp-a", corp_id="corpA", agent_id="1001"),
+        _app(name="corp-b", corp_id="corpB", agent_id="2002"),
+    ]
+    adapter = WecomCallbackAdapter(_config(apps=apps))
+    adapter._user_app_map["corpB:alice"] = "corp-b"
+    adapter._access_tokens["corp-b"] = {"token": "tok-b", "expires_at": 9999999999}
+
+    calls = {}
+
+    class FakeResponse:
+        def json(self):
+            return {"errcode": 0, "msgid": "ok1"}
+
+    class FakeClient:
+        async def post(self, url, json):
+            calls["url"] = url
+            calls["json"] = json
+            return FakeResponse()
+
+    adapter._http_client = FakeClient()
+    result = await adapter.send("corpB:alice", "hello")
+
+    assert result.success is True
+    assert calls["json"]["touser"] == "alice"
+    assert calls["json"]["agentid"] == 2002
+    assert "tok-b" in calls["url"]
+
+
+@pytest.mark.asyncio
+async def test_send_falls_back_from_bare_user_id_when_unique():
+    apps = [
+        _app(name="corp-a", corp_id="corpA", agent_id="1001"),
+    ]
+    adapter = WecomCallbackAdapter(_config(apps=apps))
+    adapter._user_app_map["corpA:alice"] = "corp-a"
+    adapter._access_tokens["corp-a"] = {"token": "tok-a", "expires_at": 9999999999}
+
+    calls = {}
+
+    class FakeResponse:
+        def json(self):
+            return {"errcode": 0, "msgid": "ok2"}
+
+    class FakeClient:
+        async def post(self, url, json):
+            calls["url"] = url
+            calls["json"] = json
+            return FakeResponse()
+
+    adapter._http_client = FakeClient()
+    result = await adapter.send("alice", "hello")
+
+    assert result.success is True
+    assert calls["json"]["agentid"] == 1001
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_dispatches_handle_message(monkeypatch):
+    adapter = WecomCallbackAdapter(_config())
+    calls = []
+
+    async def fake_handle_message(event):
+        calls.append(event.text)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+    event = adapter._build_event(
+        _app(),
+        """
+        <xml>
+          <ToUserName>ww1234567890</ToUserName>
+          <FromUserName>lisi</FromUserName>
+          <CreateTime>1710000000</CreateTime>
+          <MsgType>text</MsgType>
+          <Content>test</Content>
+          <MsgId>m2</MsgId>
+        </xml>
+        """,
+    )
+    task = asyncio.create_task(adapter._poll_loop())
+    await adapter._message_queue.put(event)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert calls == ["test"]


### PR DESCRIPTION
## Summary
- add a callback-mode adapter for regular WeCom self-built apps
- route Platform.WECOM to callback mode when callback credentials are present
- recognize callback-mode configs as connected platforms
- support WECOM_CALLBACK_* environment overrides
- support multiple callback apps under platforms.wecom.extra.apps
- scope user routing by corp_id:user_id to avoid cross-corp collisions
- add regression tests for callback crypto and multi-corp routing

## Why
The existing WeCom integration path is centered on the bot/websocket-style setup. Regular self-built apps using callback mode need GET URL verification, POST encrypted XML callback handling, BizMsgCrypt-compatible AES decrypt/encrypt, and access_token-based outbound replies.

This patch adds a callback-mode adapter for that flow.

It also fixes a multi-corp routing issue: if user/app mapping is keyed only by user_id, replies can be routed through the wrong app when the same user identifier exists in multiple corp environments. This patch scopes the mapping to corp_id:user_id and keeps a compatibility fallback for legacy bare user_id sends.

## Tests
- crypto roundtrip encrypt/decrypt
- pending reply resolution in send()
- MessageEvent construction uses source=...
- poll loop dispatches queued events
- scoped corp_id:user_id chat ids
- cross-corp user key isolation
- scoped send path selects the correct app
- legacy bare user_id fallback still works when unique