### PR TITLE
logging: ensure proper teardown of stale file handlers on force re-initialization

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -109,6 +109,8 @@ def setup_logging(
     from agent.redact import RedactingFormatter
 
     root = logging.getLogger()
+    if force:
+        _remove_managed_handlers(root, {"agent.log", "errors.log"})
 
     # --- agent.log (INFO+) — the main activity log -------------------------
     _add_rotating_handler(
@@ -237,6 +239,19 @@ def _add_rotating_handler(
     handler.setLevel(level)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+
+def _remove_managed_handlers(logger: logging.Logger, filenames: set[str]) -> None:
+    """Remove Hermes-managed rotating handlers for the given filenames."""
+    targets = {name.lower() for name in filenames}
+    for existing in list(logger.handlers):
+        if not isinstance(existing, RotatingFileHandler):
+            continue
+        base_filename = getattr(existing, "baseFilename", "")
+        if Path(base_filename).name.lower() not in targets:
+            continue
+        logger.removeHandler(existing)
+        existing.close()
 
 
 def _read_logging_config():

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -99,10 +99,10 @@ class TestSetupLogging:
         assert len(agent_handlers) == 1
 
     def test_force_reinitializes(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home)
-        # Force still won't add duplicate handlers because _add_rotating_handler
-        # checks by resolved path.
-        hermes_logging.setup_logging(hermes_home=hermes_home, force=True)
+        hermes_logging.setup_logging(hermes_home=hermes_home, log_level="INFO")
+        hermes_logging.setup_logging(
+            hermes_home=hermes_home, log_level="DEBUG", force=True
+        )
 
         root = logging.getLogger()
         agent_handlers = [
@@ -111,6 +111,24 @@ class TestSetupLogging:
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert len(agent_handlers) == 1
+        assert agent_handlers[0].level == logging.DEBUG
+
+    def test_force_replaces_old_log_directory(self, tmp_path):
+        home_a = tmp_path / "home-a"
+        home_b = tmp_path / "home-b"
+
+        hermes_logging.setup_logging(hermes_home=home_a)
+        hermes_logging.setup_logging(hermes_home=home_b, force=True)
+
+        root = logging.getLogger()
+        agent_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "agent.log" in getattr(h, "baseFilename", "")
+        ]
+
+        assert len(agent_handlers) == 1
+        assert Path(agent_handlers[0].baseFilename).resolve() == (home_b / "logs" / "agent.log").resolve()
 
     def test_custom_log_level(self, hermes_home):
         hermes_logging.setup_logging(hermes_home=hermes_home, log_level="DEBUG")


### PR DESCRIPTION
# Overview

This patch addresses a state-leakage issue in the setup_logging utility where invoking force=True failed to purge existing RotatingFileHandler instances from the root logger. This resulted in "phantom logging" scenarios where the agent continued writing to legacy paths or maintained stale log levels after a profile switch.

## Technical Breakdown

The current implementation of setup_logging(force=True) bypassed the initialization sentinel but did not perform a teardown of active Hermes-managed handlers. Consequently:

* **Level Mismatch:** Since _add_rotating_handler() is idempotent based on the file path, it would detect the existing handler and skip reconfiguration, leaving the old log_level (e.g., INFO) active even if DEBUG was requested.
* **Path Leakage:** When switching hermes_home, the old file handlers remained attached to the root logger. This caused concurrent logging to both the old and new log directories, leading to potential context bleed between different user profiles.

## Changes

* **Explicit Cleanup:** Modified setup_logging to iterate through and detach any RotatingFileHandler instances associated with agent.log and errors.log when force=True is passed.
* **Resource Release:** Ensured handlers are properly closed before removal to prevent file-lock issues, particularly on Windows environments.

## Validation Logic

Two regression scenarios were targeted:

* **Re-init Level Persistence:** Verified that an INFO -> DEBUG transition correctly updates the handler's internal level.
* **Profile Isolation:** Confirmed that re-initializing with a different hermes_home results in exactly one active handler set pointing to the new directory.
