### PR TITLE
fix(wecom): handle appmsg attachments (PDF/Word/Excel) from WeCom AI Bot

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -636,6 +636,13 @@ class WeComAdapter(BasePlatformAdapter):
                 if voice_text:
                     text_parts.append(voice_text)
 
+            # Extract appmsg title (filename) for WeCom AI Bot attachments
+            if msgtype == "appmsg":
+                appmsg = body.get("appmsg") if isinstance(body.get("appmsg"), dict) else {}
+                title = str(appmsg.get("title") or "").strip()
+                if title:
+                    text_parts.append(title)
+
         quote = body.get("quote") if isinstance(body.get("quote"), dict) else {}
         quote_type = str(quote.get("msgtype") or "").lower()
         if quote_type == "text":
@@ -668,6 +675,13 @@ class WeComAdapter(BasePlatformAdapter):
                 refs.append(("image", body["image"]))
             if msgtype == "file" and isinstance(body.get("file"), dict):
                 refs.append(("file", body["file"]))
+            # Handle appmsg (WeCom AI Bot attachments with PDF/Word/Excel)
+            if msgtype == "appmsg" and isinstance(body.get("appmsg"), dict):
+                appmsg = body["appmsg"]
+                if isinstance(appmsg.get("file"), dict):
+                    refs.append(("file", appmsg["file"]))
+                elif isinstance(appmsg.get("image"), dict):
+                    refs.append(("image", appmsg["image"]))
 
         quote = body.get("quote") if isinstance(body.get("quote"), dict) else {}
         quote_type = str(quote.get("msgtype") or "").lower()


### PR DESCRIPTION
## Summary

WeCom AI Bot sends file attachments with `msgtype="appmsg"`, not `msgtype="file"`. Previously file content was silently discarded.

### Changes

1. **_extract_text()**: Extract appmsg title (filename) for display
2. **_extract_media()**: Handle `appmsg` type with file/image content

### Before
- User sends PDF via WeCom AI Bot
- Hermes receives only text: `"filename.pdf"` (no file content)

### After  
- Hermes receives both filename title AND file content for processing

## Fixes
Fixes #7750

## Test plan
- [ ] Send PDF/Word/Excel file via WeCom AI Bot
- [ ] Verify file content is downloaded and passed to agent
- [ ] Verify filename title is still extracted

🤖 Generated with [Claude Code](https://claude.ai)