### PR TITLE
[TESTED] fix: cache audio documents (.wav) and normalize Whisper model names

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2345,6 +2345,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 # If it's an audio file sent as a document, cache it as audio for STT
                 AUDIO_EXTS = {".wav", ".mp3", ".ogg", ".aac", ".flac", ".m4a", ".opus"}
                 if ext in AUDIO_EXTS:
+                    # Check file size before downloading (Telegram Bot API limit: 20 MB)
+                    MAX_DOC_BYTES = 20 * 1024 * 1024
+                    if not doc.file_size or doc.file_size > MAX_DOC_BYTES:
+                        event.text = (
+                            "The audio file is too large or its size could not be verified. "
+                            "Maximum: 20 MB."
+                        )
+                        logger.info("[Telegram] Audio document too large: %s bytes", doc.file_size)
+                        await self.handle_message(event)
+                        return
                     file_obj = await doc.get_file()
                     audio_bytes = await file_obj.download_as_bytearray()
                     audio_ext = ext if ext else ".wav"
@@ -2357,7 +2367,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     }
                     event.media_types = [audio_mime_types.get(audio_ext, "audio/wav")]
                     logger.info("[Telegram] Cached audio document (%s) at %s", ext, cached_path)
-                # Check if supported
+                    # Audio path is complete — skip document handling below
+                    if mediagroup_id:=getattr(msg, "media_group_id", None):
+                        await self._queue_media_group_event(str(mediagroup_id), event)
+                        return
+                    await self.handle_message(event)
+                    return
+                # Non-audio document: check if supported
                 elif ext not in SUPPORTED_DOCUMENT_TYPES:
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
                     event.text = (

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2342,8 +2342,23 @@ class TelegramAdapter(BasePlatformAdapter):
                     mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
                     ext = mime_to_ext.get(doc.mime_type, "")
 
+                # If it's an audio file sent as a document, cache it as audio for STT
+                AUDIO_EXTS = {".wav", ".mp3", ".ogg", ".aac", ".flac", ".m4a", ".opus"}
+                if ext in AUDIO_EXTS:
+                    file_obj = await doc.get_file()
+                    audio_bytes = await file_obj.download_as_bytearray()
+                    audio_ext = ext if ext else ".wav"
+                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=audio_ext)
+                    event.media_urls = [cached_path]
+                    audio_mime_types = {
+                        ".wav": "audio/wav", ".mp3": "audio/mpeg", ".ogg": "audio/ogg",
+                        ".aac": "audio/aac", ".flac": "audio/flac", ".m4a": "audio/mp4",
+                        ".opus": "audio/opus",
+                    }
+                    event.media_types = [audio_mime_types.get(audio_ext, "audio/wav")]
+                    logger.info("[Telegram] Cached audio document (%s) at %s", ext, cached_path)
                 # Check if supported
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                elif ext not in SUPPORTED_DOCUMENT_TYPES:
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
                     event.text = (
                         f"Unsupported document type '{ext or 'unknown'}'. "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2064,13 +2064,13 @@ class GatewayRunner:
 
         # Intercept numeric replies to /sessions list
         import time as _time
-        if session_key in self._sessions_list_cache:
-            ts_key = f"_ts_{session_key}"
+        if _quick_key in self._sessions_list_cache:
+            ts_key = f"_ts_{_quick_key}"
             ts = self._sessions_list_cache.get(ts_key, 0)
             if _time.time() - ts < 300:  # 5-minute window
                 text = (event.text or "").strip()
                 if text.isdigit() and 1 <= int(text) <= 10:
-                    cache = self._sessions_list_cache[session_key]
+                    cache = self._sessions_list_cache[_quick_key]
                     target_id = cache.get(text)
                     if target_id:
                         # Flush and switch
@@ -2086,20 +2086,20 @@ class GatewayRunner:
                                 _flush_task.add_done_callback(self._background_tasks.discard)
                             except Exception:
                                 pass
-                            if session_key in self._running_agents:
-                                del self._running_agents[session_key]
-                            new_entry = self.session_store.switch_session(session_key, target_id)
+                            if _quick_key in self._running_agents:
+                                del self._running_agents[_quick_key]
+                            new_entry = self.session_store.switch_session(_quick_key, target_id)
                             history = self.session_store.load_transcript(target_id)
                             msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
                             title = self._session_db.get_session_title(target_id) if self._session_db else None
                             name = title or "switched session"
                             result = f"Switched to session (was on #{len(history) if history else 0} messages back). Conversing in: {name}."
-                        del self._sessions_list_cache[session_key]
+                        del self._sessions_list_cache[_quick_key]
                         del self._sessions_list_cache[ts_key]
                         return result
             # Expired or invalid — clear
-            self._sessions_list_cache.pop(session_key, None)
-            self._sessions_list_cache.pop(f"_ts_{session_key}", None)
+            self._sessions_list_cache.pop(_quick_key, None)
+            self._sessions_list_cache.pop(f"_ts_{_quick_key}", None)
 
         # Check for commands
         command = event.get_command()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -336,6 +336,25 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
+def _format_relative_time(dt) -> str:
+    """Return a human-readable relative time string."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    diff = now - dt.replace(tzinfo=None)
+    total_seconds = diff.total_seconds()
+    if total_seconds < 60:
+        return "just now"
+    elif total_seconds < 3600:
+        mins = int(total_seconds / 60)
+        return f"{mins}m ago"
+    elif total_seconds < 86400:
+        hours = int(total_seconds / 3600)
+        return f"{hours}h ago"
+    else:
+        days = int(total_seconds / 86400)
+        return f"{days}d ago"
+
+
 def _dequeue_pending_text(adapter, session_key: str) -> str | None:
     """Consume and return the text of a pending queued message.
 
@@ -526,6 +545,11 @@ class GatewayRunner:
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+
+        # Sessions list cache for /sessions command — ephemeral, per-chat
+        # Key: session_key -> {index_str: session_id}
+        # Separate _ts_{session_key} -> float timestamp for expiry
+        self._sessions_list_cache: Dict[str, Any] = {}
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
@@ -2038,6 +2062,45 @@ class GatewayRunner:
                 self._pending_messages[_quick_key] = event.text
             return None
 
+        # Intercept numeric replies to /sessions list
+        import time as _time
+        if session_key in self._sessions_list_cache:
+            ts_key = f"_ts_{session_key}"
+            ts = self._sessions_list_cache.get(ts_key, 0)
+            if _time.time() - ts < 300:  # 5-minute window
+                text = (event.text or "").strip()
+                if text.isdigit() and 1 <= int(text) <= 10:
+                    cache = self._sessions_list_cache[session_key]
+                    target_id = cache.get(text)
+                    if target_id:
+                        # Flush and switch
+                        current_entry = self.session_store.get_or_create_session(source)
+                        if current_entry.session_id == target_id:
+                            result = f"Already on that session."
+                        else:
+                            try:
+                                _flush_task = asyncio.create_task(
+                                    self._async_flush_memories(current_entry.session_id)
+                                )
+                                self._background_tasks.add(_flush_task)
+                                _flush_task.add_done_callback(self._background_tasks.discard)
+                            except Exception:
+                                pass
+                            if session_key in self._running_agents:
+                                del self._running_agents[session_key]
+                            new_entry = self.session_store.switch_session(session_key, target_id)
+                            history = self.session_store.load_transcript(target_id)
+                            msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
+                            title = self._session_db.get_session_title(target_id) if self._session_db else None
+                            name = title or "switched session"
+                            result = f"Switched to session (was on #{len(history) if history else 0} messages back). Conversing in: {name}."
+                        del self._sessions_list_cache[session_key]
+                        del self._sessions_list_cache[ts_key]
+                        return result
+            # Expired or invalid — clear
+            self._sessions_list_cache.pop(session_key, None)
+            self._sessions_list_cache.pop(f"_ts_{session_key}", None)
+
         # Check for commands
         command = event.get_command()
         
@@ -2153,6 +2216,9 @@ class GatewayRunner:
 
         if canonical == "branch":
             return await self._handle_branch_command(event)
+
+        if canonical == "sessions":
+            return await self._handle_sessions_command(event)
 
         if canonical == "rollback":
             return await self._handle_rollback_command(event)
@@ -5182,6 +5248,51 @@ class GatewayRunner:
         msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
 
         return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
+
+    async def _handle_sessions_command(self, event: MessageEvent) -> str:
+        """Handle /sessions — show recent sessions as a numbered list to switch between them."""
+        if not self._session_db:
+            return "Session database not available."
+
+        source = event.source
+        user_source = source.platform.value if source.platform else None
+        session_key = self._session_key_for_source(source)
+
+        try:
+            sessions = self._session_db.list_sessions_rich(
+                source=user_source, limit=10, include_children=False
+            )
+        except Exception as e:
+            return f"Could not list sessions: {e}"
+
+        if not sessions:
+            return "No recent sessions found."
+
+        # Store sessions list for this chat so we can intercept numeric replies
+        import time as _time
+        self._sessions_list_cache[session_key] = {
+            str(i): s["id"] for i, s in enumerate(sessions)
+        }
+        # Also store the timestamp so we can expire this after 5 minutes
+        self._sessions_list_cache[f"_ts_{session_key}"] = _time.time()
+
+        lines = ["📋 **Recent Sessions** (reply with a number to switch)\n"]
+        for i, s in enumerate(sessions):
+            title = s.get("title") or "Untitled"
+            preview = (s.get("preview") or "—")[:55]
+            last_active = s.get("last_active", s.get("started_at", ""))
+            try:
+                from datetime import datetime
+                dt = datetime.fromisoformat(last_active.replace("Z", "+00:00"))
+                age = _format_relative_time(dt)
+            except Exception:
+                age = ""
+            age_str = f" ({age})" if age else ""
+            lines.append(f"{i+1}. **{title}**{age_str}")
+            lines.append(f"   {preview}")
+
+        lines.append("\nReply with a number (1-10) to switch.")
+        return "\n".join(lines)
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -80,6 +80,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("sessions", "Browse and switch between recent sessions", "Session",
+               gateway_only=True),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -248,6 +248,71 @@ class TestDocumentDownloadBlock:
         assert event.media_types == ["application/zip"]
 
     @pytest.mark.asyncio
+    async def test_audio_document_wav_routed_to_audio_cache(self, adapter, tmp_path, monkeypatch):
+        """A .wav sent as msg.document is cached with audio/* mime for the STT pipeline."""
+        audio_bytes = b"RIFFfakewavdata"
+        file_obj = _make_file_obj(audio_bytes)
+        doc = _make_document(
+            file_name="recording.wav", mime_type="audio/wav",
+            file_size=len(audio_bytes), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        monkeypatch.setattr(
+            "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+        )
+        import importlib, gateway.platforms.base as base_mod
+        importlib.reload(base_mod)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls
+        assert event.media_types == ["audio/wav"]
+        assert event.media_urls[0].endswith(".wav")
+
+    @pytest.mark.asyncio
+    async def test_audio_document_oversized_rejected_before_download(self, adapter):
+        """Oversized audio is rejected before download — no network I/O for big files."""
+        oversized_doc = _make_document(
+            file_name="large.mp3", mime_type="audio/mpeg",
+            file_size=25 * 1024 * 1024,
+        )
+        msg = _make_message(document=oversized_doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert "too large" in event.text.lower()
+        # Size check must happen before get_file() is called
+        assert oversized_doc.get_file.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_audio_document_short_circuits_document_cache(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        """Audio documents complete in the audio branch and do not reach the document cache."""
+        audio_bytes = b"oggdata"
+        file_obj = _make_file_obj(audio_bytes)
+        doc = _make_document(
+            file_name="voice.ogg", mime_type="audio/ogg",
+            file_size=len(audio_bytes), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        monkeypatch.setattr(
+            "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+        )
+        import importlib, gateway.platforms.base as base_mod
+        importlib.reload(base_mod)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        # Must have audio mime, not application/octet-stream from generic document path
+        assert event.media_types == ["audio/ogg"]
+
+    @pytest.mark.asyncio
     async def test_oversized_file_rejected(self, adapter):
         doc = _make_document(file_name="huge.pdf", file_size=25 * 1024 * 1024)
         msg = _make_message(document=doc)

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -184,6 +184,47 @@ class TestTranscribeOpenAI:
 
 
 # ---------------------------------------------------------------------------
+# Model normalization (OpenAI/GroQ → local faster-whisper)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLocalCommandModel:
+    """_normalize_local_command_model() maps cloud model IDs to faster-whisper names."""
+
+    def _call_normalize(self, model_name):
+        from tools.transcription_tools import _normalize_local_command_model
+        return _normalize_local_command_model(model_name)
+
+    def test_whisper_1_returns_base(self):
+        assert self._call_normalize("whisper-1") == "base"
+
+    def test_gpt_4o_mini_transcribe_returns_base(self):
+        assert self._call_normalize("gpt-4o-mini-transcribe") == "base"
+
+    def test_gpt_4o_transcribe_returns_base(self):
+        assert self._call_normalize("gpt-4o-transcribe") == "base"
+
+    def test_groq_whisper_large_v3_returns_base(self):
+        assert self._call_normalize("whisper-large-v3") == "base"
+
+    def test_groq_whisper_large_v3_turbo_returns_base(self):
+        assert self._call_normalize("whisper-large-v3-turbo") == "base"
+
+    def test_groq_distil_whisper_returns_base(self):
+        assert self._call_normalize("distil-whisper-large-v3-en") == "base"
+
+    def test_local_model_name_passed_through(self):
+        assert self._call_normalize("medium") == "medium"
+        assert self._call_normalize("large-v3") == "large-v3"
+
+    def test_none_returns_base(self):
+        assert self._call_normalize(None) == "base"
+
+    def test_empty_string_returns_base(self):
+        assert self._call_normalize("") == "base"
+
+
+# ---------------------------------------------------------------------------
 # Main transcribe_audio() dispatch
 # ---------------------------------------------------------------------------
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -171,6 +171,12 @@ def _has_local_command() -> bool:
 
 def _normalize_local_command_model(model_name: Optional[str]) -> str:
     if not model_name or model_name in OPENAI_MODELS or model_name in GROQ_MODELS:
+        if model_name and model_name not in (None, ""):
+            logger.info(
+                "Normalizing STT model '%s' to '%s' (OpenAI/GroQ model not supported "
+                "by faster-whisper — see stt.local.model in config to set a faster-whisper model name).",
+                model_name, DEFAULT_LOCAL_MODEL,
+            )
         return DEFAULT_LOCAL_MODEL
     return model_name
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -301,6 +301,9 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
     if not _HAS_FASTER_WHISPER:
         return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
 
+    # Normalize OpenAI/GroQ model identifiers to faster-whisper model names
+    model_name = _normalize_local_command_model(model_name)
+
     try:
         from faster_whisper import WhisperModel
         # Lazy-load the model (downloads on first use, ~150 MB for 'base')


### PR DESCRIPTION
Three fixes bundled in this PR:

### Fix 1: tools/transcription_tools.py
_transcribe_local() now calls _normalize_local_command_model() before passing the model name to faster_whisper.WhisperModel. Previously, STT_OPENAI_MODEL=whisper-1 was passed directly to WhisperModel(), which only accepts its own identifiers (base, small, large-v3, etc.), causing a crash on every local transcription.

### Fix 2: gateway/platforms/telegram.py
Route audio document extensions (wav, mp3, ogg, aac, flac, m4a, opus) to cache_audio_from_bytes() instead of rejecting them as unsupported document types. Telegram sends these as msg.document rather than msg.voice/msg.audio.

### Feature: gateway/run.py — /sessions command
New /sessions gateway command (gateway_only) shows numbered list of 10 most recent sessions with title, age, and first-message preview. Numeric replies (1-10) within 5 minutes are intercepted as session switches.

### Test result (production)
A .wav file sent as a Telegram document was cached and transcribed successfully after fixes 1+2 applied.
