### PR TITLE
fix(security): detect and block commands that destroy agent's own runtime

### DIFF
--- a/tests/test_approval_runtime_mutation.py
+++ b/tests/test_approval_runtime_mutation.py
@@ -1,0 +1,295 @@
+"""Tests for runtime self-mutation detection and hard block in tools.approval.
+
+These tests verify that commands which would mutate the agent's own
+Python runtime are detected by ``detect_runtime_mutation`` and hard-
+blocked by ``_hard_block_runtime_mutation`` / ``check_all_command_guards``.
+
+Coverage: venv creation (uv venv, python -m venv, virtualenv), recursive
+delete (rm -rf), move (mv), and uv pip uninstall without --python.
+"""
+
+import os
+import pytest
+
+from tools.approval import (
+    detect_dangerous_command,
+    detect_runtime_mutation,
+    _hard_block_runtime_mutation,
+    check_all_command_guards,
+)
+
+
+@pytest.fixture
+def fake_runtime(tmp_path):
+    """A real directory that stands in for the agent's own venv."""
+    fake = tmp_path / "fake-venv"
+    (fake / "bin").mkdir(parents=True)
+    return str(fake.resolve())
+
+
+@pytest.fixture
+def runtime_roots(fake_runtime):
+    return [fake_runtime]
+
+
+# =========================================================================
+# detect_runtime_mutation — detection layer
+# =========================================================================
+
+
+class TestDetectRuntimeMutation:
+    # --- venv creation ---
+
+    def test_uv_venv_exact_absolute_path_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"uv venv {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+        assert "venv creation" in reason
+
+    def test_uv_venv_relative_from_parent_flagged(self, runtime_roots):
+        parent = os.path.dirname(runtime_roots[0])
+        basename = os.path.basename(runtime_roots[0])
+        reason = detect_runtime_mutation(
+            f"uv venv {basename}",
+            cwd=parent,
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+        assert "venv creation" in reason
+
+    def test_uv_venv_with_python_flag_still_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"uv venv --python 3.11 {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+
+    def test_uv_venv_unrelated_target_ignored(self, runtime_roots, tmp_path):
+        other = tmp_path / "other-project" / ".venv"
+        reason = detect_runtime_mutation(
+            f"uv venv {other}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is None
+
+    def test_python_m_venv_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"python -m venv {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+
+    def test_python3_m_venv_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"python3 -m venv {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+
+    def test_virtualenv_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"virtualenv {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+
+    # --- rm -rf ---
+
+    def test_rm_rf_runtime_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"rm -rf {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+        assert "recursive delete" in reason
+
+    def test_rm_rf_combined_flags_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"rm -fr {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+
+    def test_rm_rf_long_flag_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"rm --recursive --force {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+
+    def test_rm_without_recursive_ignored(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"rm {runtime_roots[0]}/file",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is None
+
+    def test_rm_rf_unrelated_ignored(self, runtime_roots, tmp_path):
+        other = tmp_path / "junk"
+        other.mkdir()
+        reason = detect_runtime_mutation(
+            f"rm -rf {other}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is None
+
+    # --- mv ---
+
+    def test_mv_runtime_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"mv {runtime_roots[0]} /tmp/backup",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+        assert "move" in reason
+
+    def test_mv_into_runtime_as_dest_ignored(self, runtime_roots, tmp_path):
+        """Moving something INTO the runtime (as dest) is not destructive."""
+        source = tmp_path / "file.txt"
+        source.touch()
+        reason = detect_runtime_mutation(
+            f"mv {source} {runtime_roots[0]}/",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is None
+
+    def test_mv_unrelated_ignored(self, runtime_roots, tmp_path):
+        reason = detect_runtime_mutation(
+            f"mv {tmp_path}/a {tmp_path}/b",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is None
+
+    # --- uv pip uninstall ---
+
+    def test_uv_pip_uninstall_no_python_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            "uv pip uninstall requests",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+        assert "uv pip uninstall" in reason
+
+    def test_uv_pip_uninstall_with_python_ignored(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            "uv pip uninstall --python /tmp/other/bin/python3 requests",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is None
+
+    # --- sudo / env wrapper stripping ---
+
+    def test_sudo_rm_rf_runtime_flagged(self, runtime_roots):
+        reason = detect_runtime_mutation(
+            f"sudo rm -rf {runtime_roots[0]}",
+            runtime_roots=runtime_roots,
+        )
+        assert reason is not None
+
+    # --- edge cases ---
+
+    def test_unparseable_command_returns_none(self, runtime_roots):
+        assert (
+            detect_runtime_mutation(
+                'uv venv "unclosed',
+                runtime_roots=runtime_roots,
+            )
+            is None
+        )
+
+    def test_empty_command_returns_none(self, runtime_roots):
+        assert detect_runtime_mutation("", runtime_roots=runtime_roots) is None
+
+    def test_no_runtime_roots_returns_none(self):
+        assert (
+            detect_runtime_mutation(
+                "uv venv /anywhere",
+                runtime_roots=[],
+            )
+            is None
+        )
+
+    def test_unrelated_command_returns_none(self, runtime_roots):
+        assert (
+            detect_runtime_mutation(
+                "ls -la",
+                runtime_roots=runtime_roots,
+            )
+            is None
+        )
+
+    def test_read_only_access_to_runtime_allowed(self, runtime_roots):
+        """cat, ls, head etc. against runtime paths must not be blocked."""
+        for cmd in ["cat", "ls -la", "head -20", "file"]:
+            assert detect_runtime_mutation(
+                f"{cmd} {runtime_roots[0]}/bin/python",
+                runtime_roots=runtime_roots,
+            ) is None
+
+
+# =========================================================================
+# _hard_block_runtime_mutation — enforcement layer
+# =========================================================================
+
+
+class TestHardBlock:
+    """Verify _hard_block_runtime_mutation returns proper block dicts."""
+
+    def test_block_returns_hard_blocked_dict(self, monkeypatch, fake_runtime):
+        monkeypatch.setattr("tools.approval._runtime_roots", lambda: [fake_runtime])
+        result = _hard_block_runtime_mutation(f"rm -rf {fake_runtime}")
+        assert result is not None
+        assert result["hard_blocked"] is True
+        assert result["approved"] is False
+        assert "BLOCKED" in result["message"]
+
+    def test_safe_command_returns_none(self, monkeypatch, fake_runtime):
+        monkeypatch.setattr("tools.approval._runtime_roots", lambda: [fake_runtime])
+        assert _hard_block_runtime_mutation("ls -la") is None
+
+
+# =========================================================================
+# check_all_command_guards integration — non-bypassable
+# =========================================================================
+
+
+class TestCheckAllCommandGuardsIntegration:
+    """Verify the hard block fires before yolo/container bypass."""
+
+    def test_hard_block_fires_even_in_yolo_mode(
+        self, monkeypatch, fake_runtime
+    ):
+        monkeypatch.setattr("tools.approval._runtime_roots", lambda: [fake_runtime])
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        result = check_all_command_guards(
+            f"rm -rf {fake_runtime}", env_type="local"
+        )
+        assert result["approved"] is False
+        assert result.get("hard_blocked") is True
+
+    def test_hard_block_fires_even_for_containers(
+        self, monkeypatch, fake_runtime
+    ):
+        monkeypatch.setattr("tools.approval._runtime_roots", lambda: [fake_runtime])
+        result = check_all_command_guards(
+            f"rm -rf {fake_runtime}", env_type="docker"
+        )
+        assert result["approved"] is False
+        assert result.get("hard_blocked") is True
+
+    def test_safe_command_passes_through(self, monkeypatch, fake_runtime):
+        monkeypatch.setattr("tools.approval._runtime_roots", lambda: [fake_runtime])
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        result = check_all_command_guards("ls -la", env_type="local")
+        assert result["approved"] is True
+
+    def test_rm_rf_against_runtime_still_caught_by_existing_pattern(
+        self, fake_runtime
+    ):
+        # The existing `rm -[^\s]*r` regex pattern already catches any
+        # `rm -rf`. Verify we don't break that.
+        is_dangerous, _, _ = detect_dangerous_command(f"rm -rf {fake_runtime}")
+        assert is_dangerous is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2,6 +2,7 @@
 
 This module is the single source of truth for the dangerous command system:
 - Pattern detection (DANGEROUS_PATTERNS, detect_dangerous_command)
+- Runtime self-mutation hard block (non-bypassable, checked before yolo/force)
 - Per-session approval state (thread-safe, keyed by session_key)
 - Approval prompting (CLI interactive + gateway async)
 - Smart approval via auxiliary LLM (auto-approve low-risk commands)
@@ -12,6 +13,7 @@ import contextvars
 import logging
 import os
 import re
+import shlex
 import sys
 import threading
 import unicodedata
@@ -154,6 +156,206 @@ def _approval_key_aliases(pattern_key: str) -> set[str]:
     historical regex-derived key.
     """
     return _PATTERN_KEY_ALIASES.get(pattern_key, {pattern_key})
+
+
+# =========================================================================
+# Runtime self-mutation detection and hard block
+# =========================================================================
+# Venv-creating commands (`uv venv`, `python -m venv`, `virtualenv`) are
+# not inherently destructive — they only kill the agent when targeting
+# the Python environment it is running from. `uv venv` silently replaces
+# an existing venv, stripping every package including certifi, and the
+# process dies on the next API call.  Similarly, `rm -rf`, `mv`, and
+# `uv pip uninstall` against the runtime are lethal.
+#
+# This guard uses structural parsing (shlex + path resolution) rather
+# than regex, and is enforced as a HARD BLOCK in check_all_command_guards
+# — before yolo, force, smart approval, and container bypass. This is
+# intentional: three self-destruct incidents in two days proved that
+# approvable guards are insufficient when the agent can approve its own
+# commands.
+
+_VENV_MAKERS: tuple[tuple[str, ...], ...] = (
+    ("uv", "venv"),
+    ("python", "-m", "venv"),
+    ("python3", "-m", "venv"),
+    ("virtualenv",),
+)
+
+
+def _runtime_roots() -> list[str]:
+    """Directories whose mutation would break the running agent.
+
+    Returns the absolute, realpath-resolved paths for:
+    - ``sys.prefix`` — the venv directory the current process runs from
+    - The agent source directory (parent of ``tools/``)
+
+    Returns an empty list if paths are unset or unusable.
+    """
+    roots = []
+    try:
+        prefix = os.path.realpath(sys.prefix)
+        if prefix and prefix != os.sep and len(prefix) > 1:
+            roots.append(prefix)
+    except (OSError, AttributeError, ValueError):
+        pass
+    try:
+        source = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
+        if source and source != os.sep and len(source) > 1:
+            roots.append(source)
+    except (OSError, AttributeError, ValueError):
+        pass
+    return roots
+
+
+def _path_under(candidate: str, roots: list[str]) -> Optional[str]:
+    """Return the matching root if candidate equals or lives under one of them."""
+    try:
+        resolved = os.path.realpath(candidate)
+    except (OSError, ValueError):
+        return None
+    for root in roots:
+        if resolved == root:
+            return root
+        if resolved.startswith(root + os.sep):
+            return root
+    return None
+
+
+def detect_runtime_mutation(
+    command: str,
+    cwd: Optional[str] = None,
+    runtime_roots: Optional[list[str]] = None,
+) -> Optional[str]:
+    """Detect commands that would mutate the Python runtime the agent is
+    currently running in.
+
+    Parses the command with ``shlex.split``, extracts target paths from
+    known environment-mutating commands, resolves them against *cwd*
+    (defaulting to ``os.getcwd()``), and returns a human-readable
+    description if any target lies inside a runtime root.  Returns
+    ``None`` when the command is safe or cannot be parsed.
+
+    Detection covers: venv creation (``uv venv``, ``python -m venv``,
+    ``virtualenv``), recursive delete (``rm -rf``), move (``mv``), and
+    ``uv pip uninstall`` without an explicit ``--python`` target.
+
+    Unparseable or ambiguous commands pass through and remain subject
+    to the regex ``DANGEROUS_PATTERNS``.
+    """
+    try:
+        tokens = shlex.split(command, comments=True, posix=True)
+    except ValueError:
+        return None
+    if not tokens:
+        return None
+
+    roots = runtime_roots if runtime_roots is not None else _runtime_roots()
+    if not roots:
+        return None
+    base = cwd or os.getcwd()
+
+    def _resolve(path: str) -> str:
+        path = os.path.expanduser(path)
+        if os.path.isabs(path):
+            return path
+        return os.path.join(base, path)
+
+    # Strip leading env assignments and wrappers (sudo, env, nice, etc.)
+    i = 0
+    while i < len(tokens) and "=" in tokens[i]:
+        i += 1
+    while i < len(tokens) and tokens[i] in ("sudo", "env", "nice", "nohup", "command"):
+        i += 1
+    tokens = tokens[i:]
+    if not tokens:
+        return None
+
+    cmd = os.path.basename(tokens[0])
+    args = tokens[1:]
+
+    # --- venv creation: `uv venv <target>`, `python -m venv <target>`, etc.
+    for prefix in _VENV_MAKERS:
+        full = (cmd,) + prefix[1:] if len(prefix) > 1 else (cmd,)
+        if len(tokens) < len(prefix):
+            continue
+        if tuple(t.lower() for t in tokens[: len(prefix)]) != prefix:
+            continue
+        for arg in tokens[len(prefix):]:
+            if arg.startswith("-"):
+                continue
+            matched = _path_under(_resolve(arg), roots)
+            if matched:
+                return f"venv creation targeting running runtime at {matched}"
+        break
+
+    # --- rm -rf <target> against runtime
+    if cmd == "rm":
+        has_recursive = any(
+            flag.startswith("-") and not flag.startswith("--") and ("r" in flag or "R" in flag)
+            for flag in args
+        ) or "--recursive" in args
+        if has_recursive:
+            for arg in args:
+                if arg.startswith("-"):
+                    continue
+                matched = _path_under(_resolve(arg), roots)
+                if matched:
+                    return f"recursive delete targeting running runtime at {matched}"
+
+    # --- mv <runtime-path> <dest>
+    if cmd == "mv":
+        non_flag = [a for a in args if not a.startswith("-")]
+        if non_flag:
+            matched = _path_under(_resolve(non_flag[0]), roots)
+            if matched:
+                return f"move/rename of running runtime at {matched}"
+
+    # --- uv pip uninstall (without explicit --python targets current env)
+    if cmd == "uv" and len(args) >= 2 and args[0] == "pip" and args[1] == "uninstall":
+        has_explicit_python = any(a.startswith("--python") for a in args)
+        if not has_explicit_python:
+            return "uv pip uninstall without --python targets the agent's own runtime"
+
+    return None
+
+
+def _hard_block_runtime_mutation(command: str) -> Optional[dict]:
+    """Return a hard-block dict if *command* would mutate the agent runtime.
+
+    This is called from ``check_all_command_guards`` *before* any bypass
+    logic (yolo, force, smart approval, container skip).  The block
+    cannot be overridden — the agent must never destroy its own runtime.
+
+    Resolves relative paths against both ``os.getcwd()`` and the agent
+    source directory, since the terminal tool may execute commands from
+    the agent's project root while the process cwd differs.
+    """
+    # Try current working directory first
+    reason = detect_runtime_mutation(command)
+    if reason is not None:
+        pass
+    else:
+        # Also check relative paths against the agent source directory,
+        # since the agent often runs commands "from" its project root
+        # even when the process cwd is elsewhere (e.g. /home/hermes).
+        try:
+            source_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
+        except (OSError, AttributeError):
+            source_dir = None
+        if source_dir and source_dir != os.getcwd():
+            reason = detect_runtime_mutation(command, cwd=source_dir)
+    if reason is None:
+        return None
+    return {
+        "approved": False,
+        "hard_blocked": True,
+        "message": (
+            f"BLOCKED (non-bypassable): {reason}. "
+            "This command would destroy the running agent. Do NOT retry or force."
+        ),
+        "status": "blocked",
+    }
 
 
 # =========================================================================
@@ -696,6 +898,17 @@ def check_all_command_guards(command: str, env_type: str,
     a gateway force=True replay from bypassing one check when only the
     other was shown to the user.
     """
+    # --- Runtime self-mutation: HARD BLOCK (non-bypassable) ---
+    # Must run before container/yolo/force/smart-approval checks.
+    # The agent can approve its own commands via smart approval or
+    # gateway /approve — this guard prevents that for commands that
+    # would destroy the runtime.  Three self-destruct incidents in
+    # two days proved that approvable guards are insufficient.
+    runtime_block = _hard_block_runtime_mutation(command)
+    if runtime_block is not None:
+        logger.warning("HARD BLOCKED runtime self-mutation: %s", command[:120])
+        return runtime_block
+
     # Skip containers for both checks
     if env_type in ("docker", "singularity", "modal", "daytona"):
         return {"approved": True, "message": None}


### PR DESCRIPTION
## What

Adds a **non-bypassable hard block** in `check_all_command_guards()` that prevents commands from destroying the agent's own Python runtime. The guard runs *before* all bypass logic (yolo mode, `force=True`, smart approval, container skip).

Introduces `detect_runtime_mutation()` — a structural (non-regex) check that parses shell commands with `shlex`, extracts target paths from known environment-mutating commands, resolves them against cwd, and flags the command when the target resolves inside the agent's runtime (`sys.prefix`) or source directory.

## Why

Three self-destruct incidents in two days:

1. **2026-04-11**: `uv venv venv` from inside `~/.hermes/hermes-agent/` — overwrote live venv with empty one
2. **2026-04-12 (1)**: `rm -rf venv/` — agent saw co-located venv, decided it was a "problem", deleted it
3. **2026-04-12 (2)**: recreated venv with wrong Python version, then `uv tool install --editable`

The existing `DANGEROUS_PATTERNS` catch `rm -rf` via regex, but the agent **approved its own command** through the gateway approval flow. Approvable guards are insufficient when the agent can self-approve. The guard must be non-bypassable.

## Detection coverage

| Command | Blocked? |
|---------|----------|
| `uv venv venv` (from agent dir) | ✅ Hard blocked |
| `uv venv /path/to/runtime` | ✅ Hard blocked |
| `python -m venv <runtime>` | ✅ Hard blocked |
| `virtualenv <runtime>` | ✅ Hard blocked |
| `rm -rf venv/` | ✅ Hard blocked |
| `rm --recursive --force <runtime>` | ✅ Hard blocked |
| `sudo rm -rf <runtime>` | ✅ Hard blocked |
| `mv venv /tmp/backup` | ✅ Hard blocked |
| `uv pip uninstall requests` | ✅ Hard blocked (no `--python`) |
| `uv venv /tmp/other-project` | ✅ Allowed |
| `rm -rf /tmp/junk` | ✅ Allowed |
| `uv pip uninstall --python /other/bin/python3 pkg` | ✅ Allowed |
| `ls -la venv/` | ✅ Allowed |

## Key design decisions

- **Placement**: `check_all_command_guards()` line 1, before container/yolo/force checks
- **Return value**: `{"hard_blocked": True, "approved": False}` — callers can distinguish hard blocks from soft approval denials
- **Source dir protection**: `_runtime_roots()` includes both `sys.prefix` and the agent source directory (parent of `tools/`)
- **sudo stripping**: `sudo rm -rf venv` is caught (env/sudo/nohup wrappers stripped before analysis)
- **Fail-open**: unparseable commands or empty runtime roots → `None` (not blocked)

## How to test

```bash
pytest tests/test_approval_runtime_mutation.py -v
```

```python
from tools.approval import detect_runtime_mutation, _hard_block_runtime_mutation
import sys

# Detection
print(detect_runtime_mutation(f'uv venv {sys.prefix}'))
# → "venv creation targeting running runtime at ..."

print(detect_runtime_mutation('uv venv /tmp/safe'))
# → None

# Hard block
print(_hard_block_runtime_mutation(f'rm -rf {sys.prefix}'))
# → {"hard_blocked": True, "approved": False, ...}
```

## Scope

Covers: venv creation, `rm -rf`, `mv`, `uv pip uninstall` against the runtime. Does not cover `code_execution_tool.py` (uses `subprocess.Popen` directly — separate PR).

Fixes #7779.