### PR TITLE
fix(qwen): add User-Agent to OAuth refresh request

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import platform
 import shutil
 import shlex
 import ssl
@@ -92,6 +93,11 @@ CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56"
 QWEN_OAUTH_TOKEN_URL = "https://chat.qwen.ai/api/v1/oauth2/token"
 QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+QWEN_OAUTH_USER_AGENT = "QwenCode/{version} ({system}; {machine})".format(
+    version="0.14.0",
+    system=platform.system().lower(),
+    machine=platform.machine(),
+)
 DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL = "https://accounts.spotify.com"
 DEFAULT_SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"
@@ -1390,6 +1396,7 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "application/json",
+                "User-Agent": QWEN_OAUTH_USER_AGENT,
             },
             data={
                 "grant_type": "refresh_token",
@@ -1417,8 +1424,11 @@ def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20
     try:
         payload = response.json()
     except Exception as exc:
+        ct = response.headers.get("content-type", "")
+        preview = response.text[:500] if response.text else "(empty)"
         raise AuthError(
-            f"Qwen OAuth refresh returned invalid JSON: {exc}",
+            f"Qwen OAuth refresh returned invalid JSON: {exc}"
+            f" (status={response.status_code}, content-type={ct!r}, body={preview!r})",
             provider="qwen-oauth",
             code="qwen_refresh_invalid_json",
         ) from exc

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -5,6 +5,16 @@ import os
 import pytest
 
 
+_ANTHROPIC_ENV_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+
+
+@pytest.fixture(autouse=True)
+def _clean_anthropic_env(monkeypatch):
+    """Remove anthropic env vars so CI secrets don't leak into tests."""
+    for var in _ANTHROPIC_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
 def _write_config(tmp_path, config: dict) -> None:
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_auth_qwen_provider.py
+++ b/tests/hermes_cli/test_auth_qwen_provider.py
@@ -200,6 +200,12 @@ def test_refresh_qwen_cli_tokens_success(qwen_env):
     assert result["refresh_token"] == "new-refresh"
     assert "expiry_date" in result
 
+    # Verify User-Agent header is sent
+    call_kwargs = mock_httpx.post.call_args
+    headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+    assert "User-Agent" in headers
+    assert headers["User-Agent"].startswith("QwenCode/")
+
 
 def test_refresh_qwen_cli_tokens_preserves_old_refresh_if_not_in_response(qwen_env):
     tokens = _make_qwen_tokens(refresh_token="keep-me")
@@ -256,12 +262,16 @@ def test_refresh_qwen_cli_tokens_invalid_json_response(qwen_env):
     resp = MagicMock()
     resp.status_code = 200
     resp.json.side_effect = ValueError("bad json")
+    resp.headers = {"content-type": "text/html"}
+    resp.text = "<html>Not Found</html>"
 
     with patch("hermes_cli.auth.httpx") as mock_httpx:
         mock_httpx.post.return_value = resp
         with pytest.raises(AuthError) as exc:
             _refresh_qwen_cli_tokens(tokens)
     assert exc.value.code == "qwen_refresh_invalid_json"
+    assert "status=200" in str(exc.value)
+    assert "text/html" in str(exc.value)
 
 
 def test_refresh_qwen_cli_tokens_missing_access_token_in_response(qwen_env):

--- a/tests/run_agent/test_real_interrupt_subagent.py
+++ b/tests/run_agent/test_real_interrupt_subagent.py
@@ -42,9 +42,13 @@ class TestRealSubagentInterrupt(unittest.TestCase):
     def setUp(self):
         set_interrupt(False)
         os.environ.setdefault("OPENAI_API_KEY", "test-key")
+        from run_agent import AIAgent
+        self._orig_build_system_prompt = AIAgent._build_system_prompt
 
     def tearDown(self):
         set_interrupt(False)
+        from run_agent import AIAgent
+        AIAgent._build_system_prompt = self._orig_build_system_prompt
 
     def test_interrupt_child_during_api_call(self):
         """Real AIAgent child interrupted while making API call."""
@@ -54,6 +58,7 @@ class TestRealSubagentInterrupt(unittest.TestCase):
         parent = AIAgent.__new__(AIAgent)
         parent._interrupt_requested = False
         parent._interrupt_message = None
+        parent._execution_thread_id = None
         parent._active_children = []
         parent._active_children_lock = threading.Lock()
         parent.quiet_mode = True

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -35,6 +35,15 @@ def _reset_logging_state():
             h.close()
         else:
             pre_existing.append(h)
+    # Reset child logger levels that AIAgent(quiet_mode=True) or
+    # setup_logging() may have set in the same xdist worker process.
+    _LOGGERS_TO_RESET = (
+        *hermes_logging._NOISY_LOGGERS,
+        "tools", "run_agent", "trajectory_compressor", "cron", "hermes_cli",
+    )
+    saved_levels = {name: logging.getLogger(name).level for name in _LOGGERS_TO_RESET}
+    for name in _LOGGERS_TO_RESET:
+        logging.getLogger(name).setLevel(logging.NOTSET)
     # Ensure the record factory is installed (it's idempotent).
     hermes_logging._install_session_record_factory()
     yield
@@ -43,6 +52,8 @@ def _reset_logging_state():
         if h not in pre_existing:
             root.removeHandler(h)
             h.close()
+    for name, lvl in saved_levels.items():
+        logging.getLogger(name).setLevel(lvl)
     hermes_logging._logging_initialized = False
     hermes_logging.clear_session_context()
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -138,9 +138,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, watch_patterns: list = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "watch_patterns": watch_patterns}',
     ),
 }
 


### PR DESCRIPTION
## Summary

Fixes #7746

- Add a Qwen-compatible `User-Agent` header (`QwenCode/0.14.0 (linux; x64)`) to the OAuth token refresh POST request. Without this header, Qwen's endpoint may return an empty or non-JSON response, causing `response.json()` to fail with `Expecting value: line 1 column 1`.
- Improve the `qwen_refresh_invalid_json` error message to include HTTP status code, `Content-Type`, and a body preview — making future auth failures much easier to diagnose.

## Test plan

- All 29 existing Qwen OAuth tests pass, including updated assertions that verify the `User-Agent` header is present and the enhanced error message includes diagnostics.