### PR TITLE
fix(weixin): prevent excessive message splitting on WeChat platform

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -758,19 +758,21 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
 def _split_text_for_weixin_delivery(content: str, max_length: int) -> List[str]:
     """Split content into sequential Weixin messages.
 
-    Prefer one message per top-level line/markdown unit when the author used
-    explicit line breaks. Oversized units fall back to block-aware packing so
-    long code fences still split safely.
+    Prefer single message delivery to avoid truncation issues.
+    Only split when content exceeds max_length.
     """
-    if len(content) <= max_length and "\n" not in content:
+    # 优先尝试整条消息发送
+    if len(content) <= max_length:
         return [content]
 
+    # 超长时才分割，按段落块（而不是按空行）分割
     chunks: List[str] = []
-    for unit in _split_delivery_units_for_weixin(content):
-        if len(unit) <= max_length:
-            chunks.append(unit)
+    for block in _split_markdown_blocks(content):
+        if len(block) <= max_length:
+            chunks.append(block)
             continue
-        chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
+        # 单个块超长时才进一步拆分
+        chunks.extend(_pack_markdown_blocks_for_weixin(block, max_length))
     return chunks or [content]
 
 


### PR DESCRIPTION
## Problem

The original implementation of `_split_text_for_weixin_delivery()` in the WeChat (Weixin) platform adapter was splitting messages at **every newline character**. This caused messages that could have been delivered as a single unit to be fragmented into multiple separate messages, resulting in:

- Excessive notification spam for users
- Poor readability with content arriving in scattered pieces
- Unnecessary API calls to the WeChat platform

For example, a simple 3-paragraph message would be split into 3+ separate messages even if the total length was well under WeChat's 4000 character limit.

## Solution

Modified `_split_text_for_weixin_delivery()` (lines 758-778 in `gateway/platforms/weixin.py`) to:

1. **Prefer single-message delivery** - Only split when content actually exceeds the `max_length` (4000 chars)
2. **Remove the `and "\n" not in content` condition** - This was causing unnecessary splits for any content with newlines
3. **Use paragraph-based splitting** - When splitting is necessary, use `_split_markdown_blocks()` for intelligent paragraph-aware splitting instead of line-by-line splitting

## Changes

```diff
- if len(content) <= max_length and "\n" not in content:
+ if len(content) <= max_length:
      return [content]
```

The function now:
- Returns the entire content as a single message if it fits within 4000 chars
- Only splits when necessary using markdown-aware block splitting
- Preserves the safety mechanisms for oversized blocks

## Testing

- Manual testing confirmed that messages with multiple paragraphs are now delivered as a single message on WeChat
- Long messages exceeding 4000 chars still split correctly at paragraph boundaries

## Impact

- Improved user experience on WeChat platform
- Reduced notification spam
- No breaking changes - the function still respects the max_length limit