### PR TITLE
fix(telegram): pass explicit proxy URL to HTTPXRequest

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -66,6 +66,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
+    resolve_proxy_url,
 )
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
@@ -552,10 +553,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
 
-            proxy_configured = any(
-                (os.getenv(k) or "").strip()
-                for k in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy")
-            )
+            proxy_url = resolve_proxy_url(platform_env_var="TELEGRAM_PROXY")
+            proxy_configured = bool(proxy_url)
+            if proxy_url:
+                request_kwargs["proxy"] = proxy_url
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in ("1", "true", "yes", "on"))
             fallback_ips = self._fallback_ips()
             if not fallback_ips:


### PR DESCRIPTION
## What does this PR do?

This fixes Telegram proxy handling so an explicitly configured proxy URL is actually forwarded to `HTTPXRequest`.

Before this patch, the Telegram adapter could detect proxy-related environment variables, but the resolved proxy URL was not passed through to the underlying request object. That meant Telegram traffic could still bypass the intended proxy even when proxy env vars were configured.

This patch switches the Telegram adapter to use `resolve_proxy_url("TELEGRAM_PROXY")` and passes the result to `request_kwargs["proxy"]` when present.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] ? New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] ? Tests (adding or improving test coverage)
- [ ] ?? Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Imported `resolve_proxy_url` from `gateway.platforms.base`
- Replaced the inline Telegram proxy detection logic with `resolve_proxy_url("TELEGRAM_PROXY")`
- Passed the resolved proxy URL into `HTTPXRequest` via `request_kwargs["proxy"]`
- Kept the change scoped to `gateway/platforms/telegram.py`

## How to Test

1. Configure a Telegram proxy, for example `TELEGRAM_PROXY=socks5h://127.0.0.1:10808`.
2. Start the gateway and connect the Telegram adapter.
3. Confirm Telegram traffic succeeds through the configured proxy instead of bypassing it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) ? or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys ? or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows ? or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) ? or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior ? or N/A

## Screenshots / Logs

Validated locally on WSL2 with a v2rayN SOCKS5 proxy.
