### PR TITLE
fix(memory): pass session and user context to on_turn_start

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -378,7 +378,8 @@ class MemoryManager:
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         """Notify all providers of a new turn.
 
-        kwargs may include: remaining_tokens, model, platform, tool_count.
+        kwargs may include: remaining_tokens, model, platform, tool_count,
+        user_id, user_name, and session_title.
         """
         for provider in self._providers:
             try:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -260,7 +260,8 @@ class MemoryManager:
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         """Notify all providers of a new turn.
 
-        kwargs may include: remaining_tokens, model, platform, tool_count.
+        kwargs may include: remaining_tokens, model, platform, tool_count,
+        session_id, session_title, user_id, and user_name.
         """
         for provider in self._providers:
             try:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -144,9 +144,10 @@ class MemoryProvider(ABC):
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         """Called at the start of each turn with the user message.
 
-        Use for turn-counting, scope management, periodic maintenance.
+        Use for turn-counting, scope management, attribution, and periodic maintenance.
 
-        kwargs may include: remaining_tokens, model, platform, tool_count.
+        kwargs may include: remaining_tokens, model, platform, tool_count,
+        user_id, user_name, and session_title.
         Providers use what they need; extras are ignored.
         """
 

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -146,7 +146,8 @@ class MemoryProvider(ABC):
 
         Use for turn-counting, scope management, periodic maintenance.
 
-        kwargs may include: remaining_tokens, model, platform, tool_count.
+        kwargs may include: remaining_tokens, model, platform, tool_count,
+        session_id, session_title, user_id, and user_name.
         Providers use what they need; extras are ignored.
         """
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10302,6 +10302,8 @@ class GatewayRunner:
                     return agent.run_conversation(
                         user_message=prompt,
                         task_id=task_id,
+                        turn_user_id=source.user_id,
+                        turn_user_name=source.user_name,
                     )
                 finally:
                     self._cleanup_agent_resources(agent)
@@ -15327,7 +15329,13 @@ class GatewayRunner:
                 else:
                     _run_message = message
 
-                result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(
+                    _run_message,
+                    conversation_history=agent_history,
+                    task_id=session_id,
+                    turn_user_id=source.user_id,
+                    turn_user_name=source.user_name,
+                )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5122,6 +5122,8 @@ class GatewayRunner:
                 return agent.run_conversation(
                     user_message=prompt,
                     task_id=task_id,
+                    turn_user_id=source.user_id,
+                    turn_user_name=source.user_name,
                 )
 
             loop = asyncio.get_event_loop()
@@ -7641,7 +7643,13 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(
+                    message,
+                    conversation_history=agent_history,
+                    task_id=session_id,
+                    turn_user_id=source.user_id,
+                    turn_user_name=source.user_name,
+                )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5658,6 +5658,35 @@ class AIAgent:
         except Exception:
             pass
 
+    def _build_memory_turn_context(
+        self,
+        *,
+        turn_user_id: Optional[str] = None,
+        turn_user_name: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Collect per-turn attribution context for external memory providers."""
+        context: Dict[str, str] = {}
+
+        if self.platform:
+            context["platform"] = str(self.platform)
+
+        user_id = turn_user_id or self._user_id
+        if user_id:
+            context["user_id"] = str(user_id)
+
+        if turn_user_name:
+            context["user_name"] = str(turn_user_name)
+
+        if self._session_db and self.session_id:
+            try:
+                session_title = self._session_db.get_session_title(self.session_id)
+            except Exception:
+                session_title = None
+            if session_title:
+                context["session_title"] = str(session_title)
+
+        return context
+
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.
 
@@ -11690,6 +11719,8 @@ class AIAgent:
         task_id: str = None,
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
+        turn_user_id: Optional[str] = None,
+        turn_user_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -11705,7 +11736,12 @@ class AIAgent:
             persist_user_message: Optional clean user message to store in
                 transcripts/history when user_message contains API-only
                 synthetic prefixes.
-                    or queuing follow-up prefetch work.
+                or queuing follow-up prefetch work.
+            turn_user_id: Optional per-message user identifier supplied by the
+                host. This can differ from the cached agent user in shared
+                thread sessions.
+            turn_user_name: Optional per-message display name supplied by the
+                host for memory-provider attribution in shared sessions.
 
         Returns:
             Dict: Complete conversation result with final response and message history
@@ -12098,9 +12134,13 @@ class AIAgent:
         if self._memory_manager:
             try:
                 _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
-                self._memory_manager.on_turn_start(self._user_turn_count, _turn_msg)
-            except Exception:
-                pass
+                _turn_context = self._build_memory_turn_context(
+                    turn_user_id=turn_user_id,
+                    turn_user_name=turn_user_name,
+                )
+                self._memory_manager.on_turn_start(self._user_turn_count, _turn_msg, **_turn_context)
+            except Exception as e:
+                logger.debug("External memory provider turn-start hook failed: %s", e)
 
         # External memory provider: prefetch once before the tool loop.
         # Reuse the cached result on every iteration to avoid re-calling

--- a/run_agent.py
+++ b/run_agent.py
@@ -2785,12 +2785,12 @@ class AIAgent:
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("External memory provider session-end hook failed: %s", e)
             try:
                 self._memory_manager.shutdown_all()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("External memory provider shutdown hook failed: %s", e)
         # Notify context engine of session end (flush DAG, close DBs, etc.)
         if hasattr(self, "context_compressor") and self.context_compressor:
             try:
@@ -4413,6 +4413,37 @@ class AIAgent:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         else:
             self._client_kwargs.pop("default_headers", None)
+
+    def _build_memory_turn_context(
+        self,
+        *,
+        turn_user_id: str | None = None,
+        turn_user_name: str | None = None,
+    ) -> Dict[str, str]:
+        """Collect narrow per-turn context for external memory providers."""
+        context: Dict[str, str] = {}
+
+        if self.session_id:
+            context["session_id"] = self.session_id
+        if self.platform:
+            context["platform"] = self.platform
+
+        user_id = self._user_id if turn_user_id is None else turn_user_id
+        if user_id:
+            context["user_id"] = str(user_id)
+
+        if turn_user_name:
+            context["user_name"] = str(turn_user_name)
+
+        if self._session_db and self.session_id:
+            try:
+                session_title = self._session_db.get_session_title(self.session_id)
+            except Exception:
+                session_title = None
+            if session_title:
+                context["session_title"] = str(session_title)
+
+        return context
 
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
@@ -6386,8 +6417,8 @@ class AIAgent:
         if self._memory_manager:
             try:
                 self._memory_manager.on_pre_compress(messages)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("External memory provider pre-compress hook failed: %s", e)
 
         compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
 
@@ -7376,6 +7407,8 @@ class AIAgent:
         task_id: str = None,
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
+        turn_user_id: Optional[str] = None,
+        turn_user_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -7391,7 +7424,12 @@ class AIAgent:
             persist_user_message: Optional clean user message to store in
                 transcripts/history when user_message contains API-only
                 synthetic prefixes.
-                    or queuing follow-up prefetch work.
+                or queuing follow-up prefetch work.
+            turn_user_id: Optional per-message user identifier supplied by the
+                host. This may differ from the cached agent's original user in
+                shared thread sessions.
+            turn_user_name: Optional per-message display name supplied by the
+                host for attribution in shared sessions.
 
         Returns:
             Dict: Complete conversation result with final response and message history
@@ -7487,6 +7525,21 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+        _memory_turn_context = self._build_memory_turn_context(
+            turn_user_id=turn_user_id,
+            turn_user_name=turn_user_name,
+        )
+
+        if self._memory_manager:
+            try:
+                _turn_message = original_user_message if isinstance(original_user_message, str) else ""
+                self._memory_manager.on_turn_start(
+                    self._user_turn_count,
+                    _turn_message,
+                    **_memory_turn_context,
+                )
+            except Exception as e:
+                logger.debug("External memory provider turn-start hook failed: %s", e)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
@@ -9978,8 +10031,8 @@ class AIAgent:
             try:
                 self._memory_manager.sync_all(original_user_message, final_response)
                 self._memory_manager.queue_prefetch_all(original_user_message)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("External memory provider post-turn hooks failed: %s", e)
 
         # Background memory/skill review — runs AFTER the response is delivered
         # so it never competes with the user's task for model attention.

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -64,8 +64,8 @@ class FakeMemoryProvider(MemoryProvider):
     def shutdown(self):
         self.shutdown_called = True
 
-    def on_turn_start(self, turn_number, message):
-        self.turn_starts.append((turn_number, message))
+    def on_turn_start(self, turn_number, message, **kwargs):
+        self.turn_starts.append((turn_number, message, kwargs))
 
     def on_session_end(self, messages):
         self.session_end_called = True
@@ -310,7 +310,30 @@ class TestMemoryManager:
         p = FakeMemoryProvider("p")
         mgr.add_provider(p)
         mgr.on_turn_start(3, "hello")
-        assert p.turn_starts == [(3, "hello")]
+        assert p.turn_starts == [(3, "hello", {})]
+
+    def test_on_turn_start_passes_turn_context(self):
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("p")
+        mgr.add_provider(p)
+        mgr.on_turn_start(
+            4,
+            "hello",
+            session_title="Research Thread",
+            user_id="u-42",
+            user_name="Alice",
+        )
+        assert p.turn_starts == [
+            (
+                4,
+                "hello",
+                {
+                    "session_title": "Research Thread",
+                    "user_id": "u-42",
+                    "user_name": "Alice",
+                },
+            )
+        ]
 
     def test_on_session_end(self):
         mgr = MemoryManager()

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -64,8 +64,8 @@ class FakeMemoryProvider(MemoryProvider):
     def shutdown(self):
         self.shutdown_called = True
 
-    def on_turn_start(self, turn_number, message):
-        self.turn_starts.append((turn_number, message))
+    def on_turn_start(self, turn_number, message, **kwargs):
+        self.turn_starts.append((turn_number, message, kwargs))
 
     def on_session_end(self, messages):
         self.session_end_called = True
@@ -303,7 +303,30 @@ class TestMemoryManager:
         p = FakeMemoryProvider("p")
         mgr.add_provider(p)
         mgr.on_turn_start(3, "hello")
-        assert p.turn_starts == [(3, "hello")]
+        assert p.turn_starts == [(3, "hello", {})]
+
+    def test_on_turn_start_passes_turn_context(self):
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("p")
+        mgr.add_provider(p)
+        mgr.on_turn_start(
+            4,
+            "hello",
+            session_id="sess-1",
+            session_title="Research Thread",
+            user_id="u-42",
+            user_name="Alice",
+        )
+        assert p.turn_starts == [(
+            4,
+            "hello",
+            {
+                "session_id": "sess-1",
+                "session_title": "Research Thread",
+                "user_id": "u-42",
+                "user_name": "Alice",
+            },
+        )]
 
     def test_on_session_end(self):
         mgr = MemoryManager()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -13,7 +13,7 @@ import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from agent.codex_responses_adapter import _chat_messages_to_responses_input, _normalize_codex_response, _preflight_codex_input_items
@@ -2475,6 +2475,68 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_turn_context_reaches_memory_manager_before_prefetch(self, agent):
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+        agent.platform = "telegram"
+        agent.session_id = "sess-123"
+        agent._user_id = "stale-user"
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.prefetch_all.return_value = ""
+        agent._session_db = MagicMock()
+        agent._session_db.get_session_title.return_value = "Thread Research"
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "hello",
+                turn_user_id="u-42",
+                turn_user_name="Alice",
+            )
+
+        assert result["final_response"] == "Final answer"
+        relevant_calls = [
+            c for c in agent._memory_manager.mock_calls
+            if c[0] in {"on_turn_start", "prefetch_all"}
+        ]
+        assert relevant_calls[:2] == [
+            call.on_turn_start(
+                1,
+                "hello",
+                platform="telegram",
+                user_id="u-42",
+                user_name="Alice",
+                session_title="Thread Research",
+            ),
+            call.prefetch_all("hello"),
+        ]
+
+    def test_empty_turn_user_id_falls_back_to_cached_user(self, agent):
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+        agent._user_id = "cached-user"
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.prefetch_all.return_value = ""
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", turn_user_id="")
+
+        assert result["final_response"] == "Final answer"
+        agent._memory_manager.on_turn_start.assert_any_call(
+            1,
+            "hello",
+            user_id="cached-user",
+        )
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -13,7 +13,7 @@ import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -1604,6 +1604,47 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_turn_context_reaches_memory_manager_before_prefetch(self, agent):
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+        agent.platform = "telegram"
+        agent.session_id = "sess-123"
+        agent._user_id = "stale-user"
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.prefetch_all.return_value = ""
+        agent._session_db = MagicMock()
+        agent._session_db.get_session_title.return_value = "Thread Research"
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "hello",
+                turn_user_id="u-42",
+                turn_user_name="Alice",
+            )
+
+        assert result["final_response"] == "Final answer"
+        relevant_calls = [
+            c for c in agent._memory_manager.mock_calls
+            if c[0] in {"on_turn_start", "prefetch_all"}
+        ]
+        assert relevant_calls[:2] == [
+            call.on_turn_start(
+                1,
+                "hello",
+                session_id="sess-123",
+                platform="telegram",
+                user_id="u-42",
+                user_name="Alice",
+                session_title="Thread Research",
+            ),
+            call.prefetch_all("hello"),
+        ]
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

- External memory providers receive per-turn context (user_id, user_name, session_title, platform) into `MemoryManager.on_turn_start` (in addition to the existing remaining_tokens/model/tool_count slots).
- Adds `turn_user_id` / `turn_user_name` to `run_conversation`; gateway forwards source.user_id/source.user_name so multi-user threads attribute correctly.

Fully backward compatible — the base class and all in-tree providers already accept `**kwargs`, so unknown keys are silently absorbed.

Fixes https://github.com/NousResearch/hermes-agent/issues/7193
Fixes https://github.com/NousResearch/hermes-agent/issues/7781
Fixes https://github.com/NousResearch/hermes-agent/issues/7777

## Test plan

- [x] `test_on_turn_start` — existing test updated to verify empty kwargs passthrough
- [x] `test_on_turn_start_passes_turn_context` — new test: all four context keys reach the provider
- [x] `test_turn_context_reaches_memory_manager_before_prefetch` — new test: verifies `on_turn_start` fires before `prefetch_all` with correct gateway user override