### PR TITLE
fix(provider): recognize open.bigmodel.cn as Zhipu/ZAI provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -196,6 +196,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
     "api.z.ai": "zai",
+    "open.bigmodel.cn": "zai",
     "api.moonshot.ai": "kimi-coding",
     "api.kimi.com": "kimi-coding",
     "api.minimax": "minimax",


### PR DESCRIPTION
## Summary

Zhipu AI (智谱) provides two API endpoints:
- **International**: `api.z.ai` — already mapped in `_URL_TO_PROVIDER`
- **China domestic**: `open.bigmodel.cn` — **not mapped** (this PR fixes it)

The domestic endpoint is used by both:
- Standard API: `https://open.bigmodel.cn/api/paas/v4`
- Coding Plan: `https://open.bigmodel.cn/api/coding/paas/v4`

## Problem

Without this mapping, `_infer_provider_from_url()` returns `None` for `open.bigmodel.cn` URLs. This causes `get_model_context_length()` to treat the endpoint as an unknown custom provider at step 2 and fall back to `DEFAULT_FALLBACK_CONTEXT` (128K) before ever reaching:

- Step 7: models.dev registry lookup (`"zai"` provider → correct GLM context)
- Step 8: Hardcoded `"glm": 202752` default

As a result, domestic Zhipu users see **128K context** instead of the correct **200K+** in the banner and context compressor.

## Fix

Add `"open.bigmodel.cn": "zai"` to `_URL_TO_PROVIDER` in `agent/model_metadata.py`.

One line, zero behavioral change for any other provider.

## Testing

- All 80 existing tests in `tests/agent/test_model_metadata.py` pass
- Verified `_infer_provider_from_url("https://open.bigmodel.cn/api/coding/paas/v4")` returns `"zai"`
- Verified `_infer_provider_from_url("https://api.z.ai/api/paas/v4")` still returns `"zai"`