### PR TITLE
 fix(weixin): preserve structured markdown delivery

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -107,8 +107,6 @@ MSG_STATE_FINISH = 2
 TYPING_START = 1
 TYPING_STOP = 2
 
-_HEADER_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
-_TABLE_RULE_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$")
 _FENCE_RE = re.compile(r"^```([^\n`]*)\s*$")
 
 
@@ -559,98 +557,8 @@ def _mime_from_filename(filename: str) -> str:
     return mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
 
-def _split_table_row(line: str) -> List[str]:
-    row = line.strip()
-    if row.startswith("|"):
-        row = row[1:]
-    if row.endswith("|"):
-        row = row[:-1]
-    return [cell.strip() for cell in row.split("|")]
-
-
-def _rewrite_headers_for_weixin(line: str) -> str:
-    match = _HEADER_RE.match(line)
-    if not match:
-        return line.rstrip()
-    level = len(match.group(1))
-    title = match.group(2).strip()
-    if level == 1:
-        return f"【{title}】"
-    return f"**{title}**"
-
-
-def _rewrite_table_block_for_weixin(lines: List[str]) -> str:
-    if len(lines) < 2:
-        return "\n".join(lines)
-    headers = _split_table_row(lines[0])
-    body_rows = [_split_table_row(line) for line in lines[2:] if line.strip()]
-    if not headers or not body_rows:
-        return "\n".join(lines)
-
-    formatted_rows: List[str] = []
-    for row in body_rows:
-        pairs = []
-        for idx, header in enumerate(headers):
-            if idx >= len(row):
-                break
-            label = header or f"Column {idx + 1}"
-            value = row[idx].strip()
-            if value:
-                pairs.append((label, value))
-        if not pairs:
-            continue
-        if len(pairs) == 1:
-            label, value = pairs[0]
-            formatted_rows.append(f"- {label}: {value}")
-            continue
-        if len(pairs) == 2:
-            label, value = pairs[0]
-            other_label, other_value = pairs[1]
-            formatted_rows.append(f"- {label}: {value}")
-            formatted_rows.append(f"  {other_label}: {other_value}")
-            continue
-        summary = " | ".join(f"{label}: {value}" for label, value in pairs)
-        formatted_rows.append(f"- {summary}")
-    return "\n".join(formatted_rows) if formatted_rows else "\n".join(lines)
-
-
 def _normalize_markdown_blocks(content: str) -> str:
-    lines = content.splitlines()
-    result: List[str] = []
-    i = 0
-    in_code_block = False
-
-    while i < len(lines):
-        line = lines[i].rstrip()
-        fence_match = _FENCE_RE.match(line.strip())
-        if fence_match:
-            in_code_block = not in_code_block
-            result.append(line)
-            i += 1
-            continue
-
-        if in_code_block:
-            result.append(line)
-            i += 1
-            continue
-
-        if (
-            i + 1 < len(lines)
-            and "|" in lines[i]
-            and _TABLE_RULE_RE.match(lines[i + 1].rstrip())
-        ):
-            table_lines = [lines[i].rstrip(), lines[i + 1].rstrip()]
-            i += 2
-            while i < len(lines) and "|" in lines[i]:
-                table_lines.append(lines[i].rstrip())
-                i += 1
-            result.append(_rewrite_table_block_for_weixin(table_lines))
-            continue
-
-        result.append(_rewrite_headers_for_weixin(line))
-        i += 1
-
-    normalized = "\n".join(item.rstrip() for item in result)
+    normalized = "\n".join(line.rstrip() for line in content.splitlines())
     normalized = re.sub(r"\n{3,}", "\n\n", normalized)
     return normalized.strip()
 
@@ -693,45 +601,6 @@ def _split_markdown_blocks(content: str) -> List[str]:
     return [block for block in blocks if block]
 
 
-def _split_delivery_units_for_weixin(content: str) -> List[str]:
-    """Split formatted content into chat-friendly delivery units.
-
-    Weixin can render Markdown, but chat readability is better when top-level
-    line breaks become separate messages. Keep fenced code blocks intact and
-    attach indented continuation lines to the previous top-level line so
-    transformed tables/lists do not get torn apart.
-    """
-    units: List[str] = []
-
-    for block in _split_markdown_blocks(content):
-        if _FENCE_RE.match(block.splitlines()[0].strip()):
-            units.append(block)
-            continue
-
-        current: List[str] = []
-        for raw_line in block.splitlines():
-            line = raw_line.rstrip()
-            if not line.strip():
-                if current:
-                    units.append("\n".join(current).strip())
-                    current = []
-                continue
-
-            is_continuation = bool(current) and raw_line.startswith((" ", "\t"))
-            if is_continuation:
-                current.append(line)
-                continue
-
-            if current:
-                units.append("\n".join(current).strip())
-            current = [line]
-
-        if current:
-            units.append("\n".join(current).strip())
-
-    return [unit for unit in units if unit]
-
-
 def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]:
     if len(content) <= max_length:
         return [content]
@@ -758,19 +627,14 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
 def _split_text_for_weixin_delivery(content: str, max_length: int) -> List[str]:
     """Split content into sequential Weixin messages.
 
-    Prefer one message per top-level line/markdown unit when the author used
-    explicit line breaks. Oversized units fall back to block-aware packing so
-    long code fences still split safely.
+    Preserve the original markdown structure whenever it already fits in a
+    single Weixin message. Oversized payloads fall back to block-aware packing
+    so long paragraphs and code fences still split safely.
     """
-    if len(content) <= max_length and "\n" not in content:
+    if len(content) <= max_length:
         return [content]
 
-    chunks: List[str] = []
-    for unit in _split_delivery_units_for_weixin(content):
-        if len(unit) <= max_length:
-            chunks.append(unit)
-            continue
-        chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
+    chunks = _pack_markdown_blocks_for_weixin(content, max_length)
     return chunks or [content]
 
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -21,17 +21,14 @@ def _make_adapter() -> WeixinAdapter:
 
 
 class TestWeixinFormatting:
-    def test_format_message_preserves_markdown_and_rewrites_headers(self):
+    def test_format_message_preserves_markdown_headers(self):
         adapter = _make_adapter()
 
         content = "# Title\n\n## Plan\n\nUse **bold** and [docs](https://example.com)."
 
-        assert (
-            adapter.format_message(content)
-            == "【Title】\n\n**Plan**\n\nUse **bold** and [docs](https://example.com)."
-        )
+        assert adapter.format_message(content) == content
 
-    def test_format_message_rewrites_markdown_tables(self):
+    def test_format_message_preserves_markdown_tables(self):
         adapter = _make_adapter()
 
         content = (
@@ -41,19 +38,14 @@ class TestWeixinFormatting:
             "| Retries | 3 |\n"
         )
 
-        assert adapter.format_message(content) == (
-            "- Setting: Timeout\n"
-            "  Value: 30s\n"
-            "- Setting: Retries\n"
-            "  Value: 3"
-        )
+        assert adapter.format_message(content) == content.strip()
 
     def test_format_message_preserves_fenced_code_blocks(self):
         adapter = _make_adapter()
 
         content = "## Snippet\n\n```python\nprint('hi')\n```"
 
-        assert adapter.format_message(content) == "**Snippet**\n\n```python\nprint('hi')\n```"
+        assert adapter.format_message(content) == content
 
     def test_format_message_returns_empty_string_for_none(self):
         adapter = _make_adapter()
@@ -62,15 +54,15 @@ class TestWeixinFormatting:
 
 
 class TestWeixinChunking:
-    def test_split_text_sends_top_level_newlines_as_separate_messages(self):
+    def test_split_text_keeps_under_limit_content_in_single_message(self):
         adapter = _make_adapter()
 
         content = adapter.format_message("第一行\n第二行\n第三行")
         chunks = adapter._split_text(content)
 
-        assert chunks == ["第一行", "第二行", "第三行"]
+        assert chunks == ["第一行\n第二行\n第三行"]
 
-    def test_split_text_keeps_indented_followup_with_previous_line(self):
+    def test_split_text_keeps_tables_together_when_under_limit(self):
         adapter = _make_adapter()
 
         content = adapter.format_message(
@@ -81,10 +73,7 @@ class TestWeixinChunking:
         )
         chunks = adapter._split_text(content)
 
-        assert chunks == [
-            "- Setting: Timeout\n  Value: 30s",
-            "- Setting: Retries\n  Value: 3",
-        ]
+        assert chunks == [content]
 
     def test_split_text_keeps_complete_code_block_together_when_possible(self):
         adapter = _make_adapter()

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -87,8 +87,8 @@ The adapter will restore saved credentials, connect to the iLink API, and begin 
 - **Media support** — images, video, files, and voice messages
 - **AES-128-ECB encrypted CDN** — automatic encryption/decryption for all media transfers
 - **Context token persistence** — disk-backed reply continuity across restarts
-- **Markdown formatting** — headers, tables, and code blocks are reformatted for WeChat readability
-- **Smart message chunking** — long messages are split at logical boundaries (paragraphs, code fences)
+- **Markdown formatting** — preserve authored Markdown, including tables and code blocks
+- **Smart message chunking** — only over-limit messages are split at logical boundaries (paragraphs, code fences)
 - **Typing indicators** — shows "typing…" status in the WeChat client while the agent processes
 - **SSRF protection** — outbound media URLs are validated before download
 - **Message deduplication** — 5-minute sliding window prevents double-processing
@@ -202,21 +202,21 @@ This ensures reply continuity even after gateway restarts.
 
 ## Markdown Formatting
 
-WeChat's personal chat does not natively render full Markdown. The adapter reformats content for better readability:
+The adapter preserves authored Markdown so structured output stays intact in a single message whenever possible:
 
-- **Headers** (`# Title`) → converted to `【Title】` (level 1) or `**Title**` (level 2+)
-- **Tables** → reformatted as labeled key-value lists (e.g., `- Column: Value`)
-- **Code fences** → preserved as-is (WeChat renders these adequately)
-- **Excessive blank lines** → collapsed to double newlines
+- **Headers** remain as authored
+- **Tables** remain as authored
+- **Code fences** remain as authored
+- **Excessive blank lines** are still collapsed to double newlines
 
 ## Message Chunking
 
 Long messages are split intelligently for chat delivery:
 
 - Maximum message length: **4000 characters**
+- Messages that already fit within the limit stay as a single message
 - Split points prefer paragraph boundaries and blank lines
 - Code fences are kept intact (never split mid-block)
-- Indented continuation lines (sub-items in reformatted tables/lists) stay with their parent
 - Oversized individual blocks fall back to the base adapter's truncation logic
 
 ## Typing Indicators


### PR DESCRIPTION
## Summary                                                                                                                                                                      
                                                                                                                                                                                  
  Fixes a Weixin/WeChat formatting regression where structured Markdown output was being fragmented into multiple chat bubbles.                                                   
                                                                                                                                                                                  
  This change restores the expected behavior by keeping authored Markdown intact in a single message whenever it fits within the Weixin message limit.                            
                                                                                                                                                                                  
  Fixes #7468                                                                                                                                                                     
                                                                                                                                                                                  
  ## What Changed                                                                                                                                                                 
                                                                                                                                                                                  
  - preserve authored Markdown in Weixin output instead of rewriting headers/tables                                                                                               
  - keep under-limit messages as a single Weixin message                                                                                                                          
  - only chunk over-limit messages                                                                                                                                                
  - retain block-aware splitting for oversized content so code fences still split safely                                                                                          
  - update Weixin docs to match the actual delivery behavior                                                                                                                      
  - update Weixin regression tests to cover preserved tables and single-message delivery                                                                                          
                                                                                                                                                                                  
  ## Behavior Before                                                                                                                                                              
                                                                                                                                                                                  
  Structured output like Markdown tables could be flattened and split into multiple top-level message bubbles, which made summaries and audits much harder to read.               
                                                                                                                                                                                  
  ## Behavior After                                                                                                                                                               
                                                                                                                                                                                  
  - Markdown tables remain as authored                                                                                                                                            
  - headers remain as authored                                                                                                                                                    
  - code fences remain as authored                                                                                                                                                
  - content under the 4000-character Weixin limit is sent as one message                                                                                                          
  - only oversized content is split                                                                                                                                               
                                                                                                                                                                                  
  ## Testing                                                                                                                                                                      
                                                                                                                                                                                  
  Ran:                                                                                                                                                                            
                                                                                                                                                                                  
  - `.\venv\Scripts\python -m pytest tests\gateway\test_weixin.py tests\gateway\test_text_batching.py tests\tools\test_send_message_tool.py -q` 