### PR TITLE
feat: auto-ingest Telegram PDF drops into KB

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1763,6 +1763,80 @@ class GatewayRunner:
         if config and hasattr(config, "get_unauthorized_dm_behavior"):
             return config.get_unauthorized_dm_behavior(platform)
         return "pair"
+
+    @staticmethod
+    def _is_auto_ingest_pdf_drop(event: MessageEvent, source: SessionSource) -> bool:
+        if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
+            return False
+        if event.message_type != MessageType.DOCUMENT or not event.media_urls:
+            return False
+        for i, path in enumerate(event.media_urls):
+            mtype = event.media_types[i] if i < len(event.media_types) else ""
+            if mtype == "application/pdf" or str(path).lower().endswith(".pdf"):
+                return True
+        return False
+
+    async def _auto_ingest_pdf_drop(self, event: MessageEvent, source: SessionSource) -> Optional[str]:
+        if not self._is_auto_ingest_pdf_drop(event, source):
+            return None
+
+        pdf_path = None
+        for i, path in enumerate(event.media_urls):
+            mtype = event.media_types[i] if i < len(event.media_types) else ""
+            if mtype == "application/pdf" or str(path).lower().endswith(".pdf"):
+                pdf_path = path
+                break
+        if not pdf_path:
+            return None
+
+        adapter = self.adapters.get(source.platform)
+        metadata = {"thread_id": source.thread_id} if getattr(source, "thread_id", None) else None
+        if adapter:
+            await adapter.send(source.chat_id, "Received PDF. Staging and parsing now.", metadata=metadata)
+
+        def _run_ingest() -> dict[str, Any]:
+            hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+            scripts_dir = str(hermes_home / "scripts")
+            if scripts_dir not in sys.path:
+                sys.path.insert(0, scripts_dir)
+            from telegram_pdf_drop_ingest import ingest_telegram_pdf
+            return ingest_telegram_pdf(
+                cached_path=Path(pdf_path),
+                chat_id=str(source.chat_id or ""),
+                message_id=str(event.message_id or ""),
+                original_filename=Path(pdf_path).name,
+                caption=event.text or "",
+            )
+
+        loop = asyncio.get_running_loop()
+        try:
+            result = await loop.run_in_executor(None, _run_ingest)
+        except Exception as exc:
+            logger.exception("Telegram PDF auto-ingest failed for %s", pdf_path)
+            return f"PDF received, but ingest failed: {exc}"
+
+        status = result.get("status", "unknown")
+        parser_selected = result.get("parser_selected", "unknown")
+        route_reason = result.get("route_reason", "unknown")
+        record_id = result.get("record_id") or result.get("source_id") or "unknown"
+        staged_path = result.get("staged_path") or result.get("staging_path") or pdf_path
+
+        if status == "skipped_duplicate":
+            return (
+                f"PDF ingested already.\n"
+                f"record_id: {record_id}\n"
+                f"parser: {parser_selected}\n"
+                f"route_reason: {route_reason}\n"
+                f"staged_path: {staged_path}"
+            )
+
+        return (
+            f"PDF received and ingested.\n"
+            f"record_id: {record_id}\n"
+            f"parser: {parser_selected}\n"
+            f"route_reason: {route_reason}\n"
+            f"staged_path: {staged_path}"
+        )
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -2309,6 +2383,10 @@ class GatewayRunner:
             _platform_name, source.user_name or source.user_id or "unknown",
             source.chat_id or "unknown", _msg_preview,
         )
+
+        _pdf_auto_ingest_result = await self._auto_ingest_pdf_drop(event, source)
+        if _pdf_auto_ingest_result is not None:
+            return _pdf_auto_ingest_result
 
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -247,6 +247,15 @@ def _normalize_whatsapp_identifier(value: str) -> str:
     )
 
 
+def _resolve_pdf_ingest_scripts_dir() -> Path:
+    """Return the repo skill scripts directory for KB PDF ingest, with legacy fallback."""
+    project_root = Path(__file__).resolve().parents[1]
+    repo_skill_dir = project_root / "skills" / "productivity" / "docling-kb-pdf-ingest" / "scripts"
+    if repo_skill_dir.exists():
+        return repo_skill_dir
+    return _hermes_home / "scripts"
+
+
 def _expand_whatsapp_auth_aliases(identifier: str) -> set:
     """Resolve WhatsApp phone/LID aliases using bridge session mapping files."""
     normalized = _normalize_whatsapp_identifier(identifier)
@@ -1795,8 +1804,7 @@ class GatewayRunner:
             await adapter.send(source.chat_id, "Received PDF. Staging and parsing now.", metadata=metadata)
 
         def _run_ingest() -> dict[str, Any]:
-            hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
-            scripts_dir = str(hermes_home / "scripts")
+            scripts_dir = str(_resolve_pdf_ingest_scripts_dir())
             if scripts_dir not in sys.path:
                 sys.path.insert(0, scripts_dir)
             from telegram_pdf_drop_ingest import ingest_telegram_pdf

--- a/skills/productivity/docling-kb-pdf-ingest/SKILL.md
+++ b/skills/productivity/docling-kb-pdf-ingest/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: docling-kb-pdf-ingest
+description: Docling-first local PDF ingest into the Hermes KB evidence layer with PyMuPDF4LLM fast path, Telegram drop handling, OCR fallback, and optional wiki/source promotion.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [PDF, Docling, OCR, KB, Telegram, Evidence, Wiki]
+    related_skills: [ocr-and-documents]
+---
+
+# Docling KB PDF Ingest
+
+Use this when a PDF should be routed into the Hermes KB evidence layer instead of being merely read once.
+
+It provides a Docling-first ingest path with:
+- PyMuPDF4LLM fast path for small born-digital PDFs
+- OCR fallback for image-like or scan-like PDFs when Docling output is too thin
+- immutable raw-PDF storage under the KB
+- evidence/source/chunk/transform records
+- optional promotion into `wiki/sources/`
+- Telegram PDF drop ingestion
+
+Linked scripts in `scripts/` are the canonical repo copy of the pipeline.
+
+## Layout
+
+The scripts write under the active `HERMES_HOME`:
+- `kb/raw/pdf/`
+- `kb/evidence/`
+- `kb/wiki/sources/`
+- `kb/wiki/queries/`
+- `kb/staging/telegram/`
+
+## Core scripts
+
+- `scripts/pdf_ingest_pipeline.py` — main ingest entry point
+- `scripts/telegram_pdf_drop_ingest.py` — Telegram-specific wrapper
+- `scripts/pdf_extract_docling.py` — Docling extraction with OCR fallback
+- `scripts/pdf_extract_pymupdf4llm.py` — fast-path extractor
+- `scripts/pdf_promote_to_wiki.py` — promotion candidate and source-page writer
+- `scripts/pdf_pilot_report.py` — pilot/evaluation report writer
+
+## Typical usage
+
+Run from repo root with the virtualenv active:
+
+```bash
+source venv/bin/activate
+python skills/productivity/docling-kb-pdf-ingest/scripts/pdf_ingest_pipeline.py /absolute/path/to/file.pdf --ingress-channel manual_pilot --promote-source-page
+```
+
+Telegram drop wrapper:
+
+```bash
+source venv/bin/activate
+python skills/productivity/docling-kb-pdf-ingest/scripts/telegram_pdf_drop_ingest.py /tmp/cached.pdf --chat-id 1632061707 --message-id 42 --original-filename drop.pdf
+```
+
+Pilot report:
+
+```bash
+source venv/bin/activate
+python skills/productivity/docling-kb-pdf-ingest/scripts/pdf_pilot_report.py
+```
+
+## Routing rules
+
+- If a text layer is present, page count is within the fast-path limit, and OCR is not needed: use PyMuPDF4LLM.
+- Otherwise default to Docling.
+- If Docling markdown is too thin, render page images and run local OCR via `ocrmac`, appending the recovered text under `OCR Fallback Supplement` instead of overwriting Docling output.
+
+## Promotion rule
+
+Promotion candidates can always be written into the derived evidence folder.
+Only promote into `wiki/sources/` when the extracted markdown is genuinely promotion-ready. Weak OCR or identity-card style scans should stay in evidence only.
+
+## Verification
+
+After changes, run the targeted tests:
+
+```bash
+source venv/bin/activate
+python -m pytest tests/tools/test_pdf_ingest_pipeline.py tests/tools/test_pdf_extract_docling.py tests/gateway/test_telegram_pdf_ingest_flow.py tests/gateway/test_telegram_documents.py -q
+```

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_extract_docling.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_extract_docling.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import fitz
+from docling.document_converter import DocumentConverter
+from ocrmac.ocrmac import text_from_image
+
+from pdf_ingest_config import CHUNKS_FILENAME, DOCLING_JSON_FILENAME, DOCLING_MARKDOWN_FILENAME
+from pdf_ingest_lib import split_markdown_chunks, write_json
+
+PARSER_NAME = "docling"
+OCR_FALLBACK_MIN_TEXT_CHARS = 120
+
+
+def parser_version() -> str:
+    try:
+        import docling
+        return getattr(docling, "__version__", "unknown")
+    except Exception:
+        return "unknown"
+
+
+def _ocr_fallback_markdown(pdf_path: Path, output_dir: Path) -> tuple[str, list[dict[str, Any]]]:
+    ocr_dir = output_dir / "ocr-fallback"
+    ocr_dir.mkdir(parents=True, exist_ok=True)
+
+    doc = fitz.open(pdf_path)
+    page_blocks: list[str] = []
+    ocr_chunks: list[dict[str, Any]] = []
+    for page_index, page in enumerate(doc, start=1):
+        image_path = ocr_dir / f"page-{page_index}.png"
+        pix = page.get_pixmap(matrix=fitz.Matrix(3, 3), alpha=False)
+        pix.save(str(image_path))
+        lines = text_from_image(str(image_path), recognition_level="accurate", detail=False)
+        line_text = "\n".join(line.strip() for line in lines if line and line.strip())
+        if not line_text:
+            continue
+        page_blocks.append(f"## OCR Fallback — Page {page_index}\n\n{line_text}")
+        ocr_chunks.append(
+            {
+                "ordinal": page_index,
+                "section_heading": f"OCR Fallback — Page {page_index}",
+                "page_start": page_index,
+                "page_end": page_index,
+                "parser_chunk_id": f"ocr-fallback-page-{page_index}",
+                "provenance_refs": [page_index],
+                "text": line_text,
+            }
+        )
+    doc.close()
+    return "\n\n".join(page_blocks).strip(), ocr_chunks
+
+
+def extract_pdf(pdf_path: Path, output_dir: Path, page_count: int) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    converter = DocumentConverter()
+    result = converter.convert(str(pdf_path))
+    document = result.document
+    markdown_text = document.export_to_markdown().strip()
+    document_dict = document.export_to_dict()
+    chunks = split_markdown_chunks(markdown_text, page_count)
+
+    ocr_fallback_used = False
+    if len(markdown_text) < OCR_FALLBACK_MIN_TEXT_CHARS:
+        fallback_markdown, fallback_chunks = _ocr_fallback_markdown(pdf_path, output_dir)
+        if fallback_markdown and len(fallback_markdown) > len(markdown_text):
+            if markdown_text:
+                markdown_text = f"{markdown_text}\n\n## OCR Fallback Supplement\n\n{fallback_markdown}"
+                chunks.extend(fallback_chunks)
+            else:
+                markdown_text = fallback_markdown
+                chunks = fallback_chunks
+            document_dict["ocr_fallback"] = {
+                "used": True,
+                "pages_with_text": [chunk["page_start"] for chunk in fallback_chunks],
+            }
+            ocr_fallback_used = True
+        else:
+            document_dict["ocr_fallback"] = {"used": False, "pages_with_text": []}
+    else:
+        document_dict["ocr_fallback"] = {"used": False, "pages_with_text": []}
+
+    markdown_path = output_dir / DOCLING_MARKDOWN_FILENAME
+    json_path = output_dir / DOCLING_JSON_FILENAME
+    chunks_path = output_dir / CHUNKS_FILENAME
+
+    markdown_path.write_text(markdown_text, encoding="utf-8")
+    write_json(json_path, document_dict)
+    write_json(chunks_path, chunks)
+
+    return {
+        "parser_name": PARSER_NAME,
+        "parser_version": parser_version(),
+        "markdown_text": markdown_text,
+        "markdown_path": markdown_path,
+        "json_path": json_path,
+        "chunk_path": chunks_path,
+        "chunks": chunks,
+        "ocr_fallback_used": ocr_fallback_used,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract a PDF with Docling")
+    parser.add_argument("pdf_path")
+    parser.add_argument("output_dir")
+    parser.add_argument("--page-count", type=int, default=1)
+    args = parser.parse_args()
+
+    payload = extract_pdf(Path(args.pdf_path), Path(args.output_dir), args.page_count)
+    print(
+        json.dumps(
+            {
+                "parser_name": payload["parser_name"],
+                "parser_version": payload["parser_version"],
+                "markdown_path": str(payload["markdown_path"]),
+                "json_path": str(payload["json_path"]),
+                "chunk_path": str(payload["chunk_path"]),
+                "chunk_count": len(payload["chunks"]),
+                "ocr_fallback_used": payload["ocr_fallback_used"],
+            },
+            indent=2,
+        )
+    )

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_extract_pymupdf4llm.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_extract_pymupdf4llm.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pymupdf4llm
+
+from pdf_ingest_config import CHUNKS_FILENAME, PYMUPDF_JSON_FILENAME, PYMUPDF_MARKDOWN_FILENAME
+from pdf_ingest_lib import write_json
+
+PARSER_NAME = "pymupdf4llm"
+
+
+def parser_version() -> str:
+    try:
+        import pymupdf4llm as mod
+        return getattr(mod, "__version__", "unknown")
+    except Exception:
+        return "unknown"
+
+
+def extract_pdf(pdf_path: Path, output_dir: Path, page_count: int) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    markdown_text = pymupdf4llm.to_markdown(str(pdf_path))
+    page_chunks = pymupdf4llm.to_markdown(str(pdf_path), page_chunks=True)
+
+    chunks: list[dict[str, Any]] = []
+    for idx, chunk in enumerate(page_chunks, start=1):
+        text = (chunk.get("text") or "").strip()
+        if not text:
+            continue
+        chunks.append(
+            {
+                "ordinal": idx,
+                "section_heading": None,
+                "page_start": idx,
+                "page_end": idx,
+                "parser_chunk_id": f"page-{idx}",
+                "provenance_refs": [idx],
+                "text": text,
+            }
+        )
+
+    markdown_path = output_dir / PYMUPDF_MARKDOWN_FILENAME
+    json_path = output_dir / PYMUPDF_JSON_FILENAME
+    chunks_path = output_dir / CHUNKS_FILENAME
+
+    markdown_path.write_text(markdown_text, encoding="utf-8")
+    write_json(json_path, {"page_chunks": page_chunks, "page_count": page_count})
+    write_json(chunks_path, chunks)
+
+    return {
+        "parser_name": PARSER_NAME,
+        "parser_version": parser_version(),
+        "markdown_text": markdown_text,
+        "markdown_path": markdown_path,
+        "json_path": json_path,
+        "chunk_path": chunks_path,
+        "chunks": chunks,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract a PDF with PyMuPDF4LLM")
+    parser.add_argument("pdf_path")
+    parser.add_argument("output_dir")
+    parser.add_argument("--page-count", type=int, default=1)
+    args = parser.parse_args()
+
+    payload = extract_pdf(Path(args.pdf_path), Path(args.output_dir), args.page_count)
+    print(
+        json.dumps(
+            {
+                "parser_name": payload["parser_name"],
+                "parser_version": payload["parser_version"],
+                "markdown_path": str(payload["markdown_path"]),
+                "json_path": str(payload["json_path"]),
+                "chunk_path": str(payload["chunk_path"]),
+                "chunk_count": len(payload["chunks"]),
+            },
+            indent=2,
+        )
+    )

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_ingest_config.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_ingest_config.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+
+HERMES_HOME = get_hermes_home()
+KB_HOME = HERMES_HOME / "kb"
+STAGING_HOME = KB_HOME / "staging"
+RAW_PDF_HOME = KB_HOME / "raw" / "pdf"
+EVIDENCE_HOME = KB_HOME / "evidence"
+DERIVED_PDF_HOME = EVIDENCE_HOME / "derived" / "pdf"
+WIKI_HOME = KB_HOME / "wiki"
+WIKI_SOURCES_HOME = WIKI_HOME / "sources"
+WIKI_QUERIES_HOME = WIKI_HOME / "queries"
+
+INBOX_STAGING_HOME = STAGING_HOME / "inbox"
+TELEGRAM_STAGING_HOME = STAGING_HOME / "telegram"
+PILOT_STAGING_HOME = STAGING_HOME / "pilot"
+
+SOURCES_JSONL = EVIDENCE_HOME / "sources.jsonl"
+CHUNKS_JSONL = EVIDENCE_HOME / "chunks.jsonl"
+STATEMENTS_JSONL = EVIDENCE_HOME / "statements.jsonl"
+ENTITIES_JSONL = EVIDENCE_HOME / "entities.jsonl"
+LINKS_JSONL = EVIDENCE_HOME / "links.jsonl"
+TRANSFORMS_JSONL = EVIDENCE_HOME / "transforms.jsonl"
+INGEST_STATE_JSON = EVIDENCE_HOME / "ingest-state.json"
+
+PROMOTION_CANDIDATE_FILENAME = "promotion-candidate.md"
+RESULT_FILENAME = "result.json"
+DOCLING_MARKDOWN_FILENAME = "docling.md"
+DOCLING_JSON_FILENAME = "docling.json"
+PYMUPDF_MARKDOWN_FILENAME = "pymupdf4llm.md"
+PYMUPDF_JSON_FILENAME = "pymupdf4llm.json"
+CHUNKS_FILENAME = "chunks.json"
+
+PYMUPDF_FAST_PATH_MAX_PAGES = 9
+
+INGRESS_MANUAL_PILOT = "manual_pilot"
+INGRESS_TELEGRAM = "telegram_document"
+INGRESS_GMAIL = "gmail_attachment"
+
+PILOT_BATCH_ID = "pdf-pilot-april-2026"
+PILOT_FILES = {
+    "simple-born-digital": "/Users/quark/Library/CloudStorage/Dropbox/00_Quark_MAIN/00_SHARED_INBOX/2026-02-27 interactive session log.pdf",
+    "complex-layout-figures": "/Users/quark/Library/CloudStorage/Dropbox/00_Quark_MAIN/00_SHARED_INBOX/screencapture-x-gkisokay-article-2041129801516458090-2026-04-06-10_11_28.pdf",
+    "scanned-ocr-needed": "/Users/quark/Library/CloudStorage/Dropbox/00_Quark_MAIN/00_SHARED_INBOX/US_SocialSecurity_TBO_250602.pdf",
+}
+
+
+def ensure_pdf_ingest_dirs() -> None:
+    for path in [
+        KB_HOME,
+        STAGING_HOME,
+        RAW_PDF_HOME,
+        EVIDENCE_HOME,
+        DERIVED_PDF_HOME,
+        WIKI_HOME,
+        WIKI_SOURCES_HOME,
+        WIKI_QUERIES_HOME,
+        INBOX_STAGING_HOME,
+        TELEGRAM_STAGING_HOME,
+        PILOT_STAGING_HOME,
+    ]:
+        path.mkdir(parents=True, exist_ok=True)
+
+    for file_path in [
+        SOURCES_JSONL,
+        CHUNKS_JSONL,
+        STATEMENTS_JSONL,
+        ENTITIES_JSONL,
+        LINKS_JSONL,
+        TRANSFORMS_JSONL,
+    ]:
+        if not file_path.exists():
+            file_path.write_text("", encoding="utf-8")
+
+    if not INGEST_STATE_JSON.exists():
+        INGEST_STATE_JSON.write_text('{"processed": {}}', encoding="utf-8")

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_ingest_lib.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_ingest_lib.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import fitz
+
+from pdf_ingest_config import (
+    CHUNKS_JSONL,
+    DERIVED_PDF_HOME,
+    EVIDENCE_HOME,
+    INGEST_STATE_JSON,
+    PILOT_BATCH_ID,
+    PYMUPDF_FAST_PATH_MAX_PAGES,
+    RAW_PDF_HOME,
+    SOURCES_JSONL,
+    TELEGRAM_STAGING_HOME,
+    TRANSFORMS_JSONL,
+    ensure_pdf_ingest_dirs,
+)
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return default
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def slugify(value: str) -> str:
+    text = re.sub(r"[^a-zA-Z0-9._ -]+", "-", value).strip().lower()
+    text = re.sub(r"\s+", "-", text)
+    text = re.sub(r"-+", "-", text)
+    return text or "document"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def stable_source_id(source_sha256: str) -> str:
+    return f"src_pdf_{source_sha256[:12]}"
+
+
+def stable_transform_id(source_id: str, started_at: str) -> str:
+    token = hashlib.sha256(f"{source_id}:{started_at}".encode("utf-8")).hexdigest()[:12]
+    return f"xform_pdf_{token}"
+
+
+def sanitize_filename(name: str) -> str:
+    base = Path(name).name.strip() or "document.pdf"
+    safe = re.sub(r"[^\w.\- ]+", "_", base)
+    safe = re.sub(r"\s+", "-", safe)
+    return safe or "document.pdf"
+
+
+def inspect_pdf(path: Path) -> dict[str, Any]:
+    doc = fitz.open(path)
+    page_count = doc.page_count
+    text_pages = 0
+    total_text_chars = 0
+    for page in doc:
+        text = page.get_text("text") or ""
+        stripped = text.strip()
+        if stripped:
+            text_pages += 1
+            total_text_chars += len(stripped)
+    doc.close()
+    text_layer_present = text_pages > 0
+    ocr_needed = not text_layer_present
+    return {
+        "page_count": page_count,
+        "text_layer_present": text_layer_present,
+        "ocr_needed": ocr_needed,
+        "text_pages": text_pages,
+        "text_chars": total_text_chars,
+        "file_size_bytes": path.stat().st_size,
+    }
+
+
+def choose_parser(*, page_count: int, text_layer_present: bool, ocr_needed: bool) -> tuple[str, str]:
+    if text_layer_present and page_count <= PYMUPDF_FAST_PATH_MAX_PAGES and not ocr_needed:
+        return (
+            "pymupdf4llm",
+            f"born-digital text layer present, {page_count} page(s), OCR not needed",
+        )
+    reason_bits = [f"default Docling path"]
+    if not text_layer_present:
+        reason_bits.append("no text layer detected")
+    if ocr_needed:
+        reason_bits.append("OCR likely needed")
+    if page_count > PYMUPDF_FAST_PATH_MAX_PAGES:
+        reason_bits.append(f"page count {page_count} exceeds fast-path limit")
+    return ("docling", "; ".join(reason_bits))
+
+
+def immutable_raw_pdf_path(*, source_sha256: str, original_filename: str, observed_at: str) -> Path:
+    date_prefix = observed_at[:10]
+    return RAW_PDF_HOME / date_prefix / f"{source_sha256}__{sanitize_filename(original_filename)}"
+
+
+def copy_to_raw_if_needed(*, source_path: Path, source_sha256: str, original_filename: str, observed_at: str) -> Path:
+    raw_path = immutable_raw_pdf_path(
+        source_sha256=source_sha256,
+        original_filename=original_filename,
+        observed_at=observed_at,
+    )
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    if not raw_path.exists():
+        shutil.copy2(source_path, raw_path)
+    return raw_path
+
+
+def copy_to_telegram_staging(path: Path, original_filename: str | None = None) -> Path:
+    ensure_pdf_ingest_dirs()
+    name = sanitize_filename(original_filename or path.name)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    dest = TELEGRAM_STAGING_HOME / f"{stamp}-{name}"
+    shutil.copy2(path, dest)
+    return dest
+
+
+def derived_dir(source_id: str) -> Path:
+    target = DERIVED_PDF_HOME / source_id
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def read_ingest_state() -> dict[str, Any]:
+    ensure_pdf_ingest_dirs()
+    state = read_json(INGEST_STATE_JSON, {"processed": {}})
+    if "processed" not in state:
+        state = {"processed": {}}
+    return state
+
+
+def write_ingest_state(state: dict[str, Any]) -> None:
+    write_json(INGEST_STATE_JSON, state)
+
+
+def dedup_key(*, ingress_channel: str, source_sha256: str) -> str:
+    return f"{ingress_channel}:{source_sha256}"
+
+
+def ensure_evidence_layout() -> None:
+    ensure_pdf_ingest_dirs()
+
+
+def split_markdown_chunks(markdown_text: str, page_count: int) -> list[dict[str, Any]]:
+    text = markdown_text.strip()
+    if not text:
+        return []
+    sections = re.split(r"\n(?=##?\s)", text)
+    chunks: list[dict[str, Any]] = []
+    for idx, section in enumerate(sections, start=1):
+        heading = None
+        first_line = section.strip().splitlines()[0] if section.strip().splitlines() else ""
+        if first_line.startswith("#"):
+            heading = re.sub(r"^#+\s*", "", first_line).strip() or None
+        chunks.append(
+            {
+                "ordinal": idx,
+                "section_heading": heading,
+                "page_start": 1,
+                "page_end": max(1, page_count),
+                "text": section.strip(),
+            }
+        )
+    return chunks
+
+
+def build_source_record(
+    *,
+    source_id: str,
+    original_filename: str,
+    staging_path: Path,
+    raw_path: Path,
+    source_sha256: str,
+    ingress_channel: str,
+    inspected: dict[str, Any],
+    parser_selected: str,
+    route_reason: str,
+    parse_started_at: str,
+    parse_completed_at: str,
+    latency_ms_total: int,
+    latency_ms_parse: int,
+    markdown_artifact_path: Path,
+    json_artifact_path: Path,
+    chunk_artifact_path: Path,
+    parser_version: str,
+    source_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "lineage_version": 1,
+        "record_type": "source",
+        "source_type": "pdf",
+        "source_id": source_id,
+        "record_id": source_id,
+        "ingress_channel": ingress_channel,
+        "original_filename": original_filename,
+        "staging_path": str(staging_path),
+        "raw_path": str(raw_path),
+        "source_sha256": source_sha256,
+        "page_count": inspected["page_count"],
+        "file_size_bytes": inspected["file_size_bytes"],
+        "text_layer_present": inspected["text_layer_present"],
+        "ocr_needed": inspected["ocr_needed"],
+        "parser_selected": parser_selected,
+        "route_reason": route_reason,
+        "parser_version": parser_version,
+        "parse_started_at": parse_started_at,
+        "parse_completed_at": parse_completed_at,
+        "latency_ms_total": latency_ms_total,
+        "latency_ms_parse": latency_ms_parse,
+        "markdown_artifact_path": str(markdown_artifact_path),
+        "json_artifact_path": str(json_artifact_path),
+        "chunk_artifact_path": str(chunk_artifact_path),
+        "pilot_batch_id": PILOT_BATCH_ID,
+        "source_context": source_context or {},
+    }
+
+
+def build_chunk_records(*, source_id: str, source_sha256: str, chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for chunk in chunks:
+        ordinal = int(chunk["ordinal"])
+        chunk_text = chunk["text"].strip()
+        text_hash = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+        chunk_id = f"chunk_pdf_{source_sha256[:12]}_{ordinal:03d}"
+        records.append(
+            {
+                "lineage_version": 1,
+                "record_type": "chunk",
+                "source_id": source_id,
+                "chunk_id": chunk_id,
+                "ordinal": ordinal,
+                "page_start": chunk.get("page_start", 1),
+                "page_end": chunk.get("page_end", 1),
+                "section_heading": chunk.get("section_heading"),
+                "parser_chunk_id": chunk.get("parser_chunk_id"),
+                "text": chunk_text,
+                "text_hash": text_hash,
+                "provenance_refs": chunk.get("provenance_refs", []),
+            }
+        )
+    return records
+
+
+def build_transform_record(
+    *,
+    transform_id: str,
+    source_id: str,
+    ingress_channel: str,
+    parser_selected: str,
+    route_reason: str,
+    started_at: str,
+    completed_at: str,
+    status: str,
+    output_counts: dict[str, int],
+    error_message: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "lineage_version": 1,
+        "record_type": "transform",
+        "transform_id": transform_id,
+        "transform_type": "pdf_ingest",
+        "source_id": source_id,
+        "ingress_channel": ingress_channel,
+        "parser_selected": parser_selected,
+        "route_reason": route_reason,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "status": status,
+        "error_message": error_message,
+        "output_counts": output_counts,
+    }
+
+
+def record_success(state: dict[str, Any], *, key: str, source_record: dict[str, Any], transform_record: dict[str, Any]) -> None:
+    state["processed"][key] = {
+        "status": "success",
+        "source_id": source_record["source_id"],
+        "record_id": source_record["record_id"],
+        "raw_path": source_record["raw_path"],
+        "parser_selected": source_record["parser_selected"],
+        "route_reason": source_record["route_reason"],
+        "parse_completed_at": source_record["parse_completed_at"],
+        "transform_id": transform_record["transform_id"],
+    }
+
+
+def record_duplicate_transform(*, source_id: str, ingress_channel: str, parser_selected: str, route_reason: str) -> dict[str, Any]:
+    started_at = iso_now()
+    transform_id = stable_transform_id(source_id, started_at)
+    transform = build_transform_record(
+        transform_id=transform_id,
+        source_id=source_id,
+        ingress_channel=ingress_channel,
+        parser_selected=parser_selected,
+        route_reason=route_reason,
+        started_at=started_at,
+        completed_at=started_at,
+        status="skipped_duplicate",
+        error_message=None,
+        output_counts={
+            "chunks_written": 0,
+            "statements_written": 0,
+            "entities_written": 0,
+            "links_written": 0,
+            "promotion_candidates_written": 0,
+        },
+    )
+    append_jsonl(TRANSFORMS_JSONL, transform)
+    return transform
+
+
+def persist_records(source_record: dict[str, Any], chunk_records: list[dict[str, Any]], transform_record: dict[str, Any]) -> None:
+    append_jsonl(SOURCES_JSONL, source_record)
+    for chunk in chunk_records:
+        append_jsonl(CHUNKS_JSONL, chunk)
+    append_jsonl(TRANSFORMS_JSONL, transform_record)
+
+
+def find_source_record(source_id: str) -> dict[str, Any] | None:
+    if not SOURCES_JSONL.exists():
+        return None
+    for line in SOURCES_JSONL.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        if record.get("source_id") == source_id:
+            return record
+    return None
+
+
+class Timer:
+    def __init__(self) -> None:
+        self.started = time.perf_counter()
+
+    def ms(self) -> int:
+        return int((time.perf_counter() - self.started) * 1000)

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_ingest_pipeline.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_ingest_pipeline.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from pdf_extract_docling import extract_pdf as extract_docling
+from pdf_extract_pymupdf4llm import extract_pdf as extract_pymupdf4llm
+from pdf_ingest_config import RESULT_FILENAME, ensure_pdf_ingest_dirs
+from pdf_ingest_lib import (
+    Timer,
+    build_chunk_records,
+    build_source_record,
+    build_transform_record,
+    choose_parser,
+    copy_to_raw_if_needed,
+    dedup_key,
+    derived_dir,
+    find_source_record,
+    inspect_pdf,
+    iso_now,
+    persist_records,
+    read_ingest_state,
+    read_json,
+    record_duplicate_transform,
+    record_success,
+    sanitize_filename,
+    sha256_file,
+    stable_source_id,
+    stable_transform_id,
+    write_ingest_state,
+    write_json,
+)
+from pdf_promote_to_wiki import promote_source_summary, write_promotion_candidate
+
+
+PARSER_MAP = {
+    "docling": extract_docling,
+    "pymupdf4llm": extract_pymupdf4llm,
+}
+
+
+def ingest_pdf(
+    *,
+    pdf_path: Path,
+    ingress_channel: str,
+    source_context: dict[str, Any] | None = None,
+    dry_run_promotion: bool = True,
+    promote_source_page: bool = False,
+) -> dict[str, Any]:
+    ensure_pdf_ingest_dirs()
+    timer_total = Timer()
+    staged_path = pdf_path.resolve()
+    original_filename = sanitize_filename(staged_path.name)
+    source_sha256 = sha256_file(staged_path)
+    state = read_ingest_state()
+    key = dedup_key(ingress_channel=ingress_channel, source_sha256=source_sha256)
+
+    existing = state["processed"].get(key)
+    if existing:
+        source_id = existing["source_id"]
+        transform = record_duplicate_transform(
+            source_id=source_id,
+            ingress_channel=ingress_channel,
+            parser_selected=existing.get("parser_selected", "unknown"),
+            route_reason=existing.get("route_reason", "duplicate reuse"),
+        )
+        result_path = derived_dir(source_id) / RESULT_FILENAME
+        result = read_json(result_path, {}) if result_path.exists() else {}
+        if not result:
+            result = {
+                "source_id": source_id,
+                "record_id": existing.get("record_id", source_id),
+                "raw_path": existing["raw_path"],
+                "parser_selected": existing.get("parser_selected"),
+                "route_reason": existing.get("route_reason"),
+            }
+        result["status"] = "skipped_duplicate"
+        result["transform_id"] = transform["transform_id"]
+
+        if promote_source_page:
+            source_record = find_source_record(source_id)
+            markdown_path = Path(result.get("markdown_artifact_path", ""))
+            if source_record and markdown_path.exists():
+                result["source_page_path"] = str(
+                    promote_source_summary(
+                        source_record=source_record,
+                        markdown_text=markdown_path.read_text(encoding="utf-8"),
+                    )
+                )
+
+        write_json(result_path, result)
+        return result
+
+    inspected = inspect_pdf(staged_path)
+    parser_selected, route_reason = choose_parser(
+        page_count=inspected["page_count"],
+        text_layer_present=inspected["text_layer_present"],
+        ocr_needed=inspected["ocr_needed"],
+    )
+
+    observed_at = iso_now()
+    raw_path = copy_to_raw_if_needed(
+        source_path=staged_path,
+        source_sha256=source_sha256,
+        original_filename=original_filename,
+        observed_at=observed_at,
+    )
+
+    source_id = stable_source_id(source_sha256)
+    source_output_dir = derived_dir(source_id)
+    parse_started_at = iso_now()
+    timer_parse = Timer()
+    parser_payload = PARSER_MAP[parser_selected](raw_path, source_output_dir, inspected["page_count"])
+    latency_ms_parse = timer_parse.ms()
+    parse_completed_at = iso_now()
+
+    chunk_records = build_chunk_records(
+        source_id=source_id,
+        source_sha256=source_sha256,
+        chunks=parser_payload["chunks"],
+    )
+
+    source_record = build_source_record(
+        source_id=source_id,
+        original_filename=original_filename,
+        staging_path=staged_path,
+        raw_path=raw_path,
+        source_sha256=source_sha256,
+        ingress_channel=ingress_channel,
+        inspected=inspected,
+        parser_selected=parser_selected,
+        route_reason=route_reason,
+        parse_started_at=parse_started_at,
+        parse_completed_at=parse_completed_at,
+        latency_ms_total=timer_total.ms(),
+        latency_ms_parse=latency_ms_parse,
+        markdown_artifact_path=parser_payload["markdown_path"],
+        json_artifact_path=parser_payload["json_path"],
+        chunk_artifact_path=parser_payload["chunk_path"],
+        parser_version=parser_payload["parser_version"],
+        source_context=source_context,
+    )
+
+    transform_id = stable_transform_id(source_id, parse_started_at)
+    promotion_candidate_path = None
+    source_page_path = None
+    if dry_run_promotion:
+        promotion_candidate_path = write_promotion_candidate(
+            output_dir=source_output_dir,
+            source_record=source_record,
+            markdown_text=parser_payload["markdown_text"],
+        )
+    if promote_source_page:
+        source_page_path = promote_source_summary(
+            source_record=source_record,
+            markdown_text=parser_payload["markdown_text"],
+        )
+
+    transform_record = build_transform_record(
+        transform_id=transform_id,
+        source_id=source_id,
+        ingress_channel=ingress_channel,
+        parser_selected=parser_selected,
+        route_reason=route_reason,
+        started_at=parse_started_at,
+        completed_at=parse_completed_at,
+        status="success",
+        error_message=None,
+        output_counts={
+            "chunks_written": len(chunk_records),
+            "statements_written": 0,
+            "entities_written": 0,
+            "links_written": 0,
+            "promotion_candidates_written": 1 if promotion_candidate_path else 0,
+            "source_pages_written": 1 if source_page_path else 0,
+        },
+    )
+
+    persist_records(source_record, chunk_records, transform_record)
+    record_success(state, key=key, source_record=source_record, transform_record=transform_record)
+    write_ingest_state(state)
+
+    result = {
+        "status": "success",
+        "source_id": source_id,
+        "record_id": source_id,
+        "raw_path": str(raw_path),
+        "staging_path": str(staged_path),
+        "parser_selected": parser_selected,
+        "route_reason": route_reason,
+        "page_count": inspected["page_count"],
+        "text_layer_present": inspected["text_layer_present"],
+        "ocr_needed": inspected["ocr_needed"],
+        "latency_ms_total": timer_total.ms(),
+        "latency_ms_parse": latency_ms_parse,
+        "transform_id": transform_id,
+        "markdown_artifact_path": str(parser_payload["markdown_path"]),
+        "json_artifact_path": str(parser_payload["json_path"]),
+        "chunk_artifact_path": str(parser_payload["chunk_path"]),
+        "promotion_candidate_path": str(promotion_candidate_path) if promotion_candidate_path else None,
+        "source_page_path": str(source_page_path) if source_page_path else None,
+    }
+    write_json(source_output_dir / RESULT_FILENAME, result)
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Ingest a staged PDF into the Hermes evidence layer")
+    parser.add_argument("pdf_path")
+    parser.add_argument("--ingress-channel", default="manual_pilot")
+    parser.add_argument("--source-context-json", default="{}")
+    parser.add_argument("--no-dry-run-promotion", action="store_true")
+    parser.add_argument("--promote-source-page", action="store_true")
+    args = parser.parse_args()
+
+    source_context = json.loads(args.source_context_json)
+    result = ingest_pdf(
+        pdf_path=Path(args.pdf_path),
+        ingress_channel=args.ingress_channel,
+        source_context=source_context,
+        dry_run_promotion=not args.no_dry_run_promotion,
+        promote_source_page=args.promote_source_page,
+    )
+    print(json.dumps(result, indent=2, ensure_ascii=False))

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_pilot_report.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_pilot_report.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pdf_ingest_config import PILOT_BATCH_ID, PILOT_FILES, WIKI_QUERIES_HOME
+from pdf_ingest_lib import read_json, slugify
+from pdf_ingest_pipeline import ingest_pdf
+
+
+def _score(markdown_text: str, parser_selected: str, ocr_needed: bool) -> dict[str, int]:
+    text = markdown_text.strip()
+    has_headings = "#" in text
+    reading_order = 2 if len(text) > 200 else 1 if text else 0
+    heading_structure = 2 if has_headings else 1 if text else 0
+    table_figure_preservation = 1 if parser_selected == "docling" else 0
+    if ocr_needed:
+        ocr_accuracy = 2 if len(text) > 40 else 1 if text else 0
+    else:
+        ocr_accuracy = 2
+    promotion_readiness = 2 if len(text) > 400 else 1 if text else 0
+    return {
+        "reading_order": reading_order,
+        "heading_structure": heading_structure,
+        "table_figure_preservation": table_figure_preservation,
+        "ocr_text_accuracy": ocr_accuracy,
+        "promotion_readiness": promotion_readiness,
+    }
+
+
+def run_pilot() -> dict[str, Any]:
+    rows = []
+    for label, file_path in PILOT_FILES.items():
+        result = ingest_pdf(
+            pdf_path=Path(file_path),
+            ingress_channel="manual_pilot",
+            source_context={"pilot_label": label},
+            dry_run_promotion=True,
+            promote_source_page=(label != "scanned-ocr-needed"),
+        )
+        markdown_path = Path(result["markdown_artifact_path"])
+        markdown_text = markdown_path.read_text(encoding="utf-8") if markdown_path.exists() else ""
+        scores = _score(markdown_text, result["parser_selected"], result["ocr_needed"])
+        rows.append(
+            {
+                "label": label,
+                "file_path": file_path,
+                "record_id": result["record_id"],
+                "parser_selected": result["parser_selected"],
+                "route_reason": result["route_reason"],
+                "latency_ms_total": result["latency_ms_total"],
+                "latency_ms_parse": result["latency_ms_parse"],
+                "page_count": result["page_count"],
+                "text_layer_present": result["text_layer_present"],
+                "ocr_needed": result["ocr_needed"],
+                "scores": scores,
+                "markdown_artifact_path": result["markdown_artifact_path"],
+                "promotion_candidate_path": result.get("promotion_candidate_path"),
+                "source_page_path": result.get("source_page_path"),
+            }
+        )
+    return {"pilot_batch_id": PILOT_BATCH_ID, "rows": rows}
+
+
+def write_query_page(report: dict[str, Any]) -> Path:
+    WIKI_QUERIES_HOME.mkdir(parents=True, exist_ok=True)
+    target = WIKI_QUERIES_HOME / "pdf-ingest-pilot-april-2026.md"
+    lines = [
+        "---",
+        'title: PDF Ingest Pilot — April 2026',
+        'created: 2026-04-11',
+        'updated: 2026-04-11',
+        'type: query',
+        'tags: [pdf, ingest, pilot, docling, kb]',
+        'sources: ["raw/pdf pilot corpus"]',
+        '---',
+        '',
+        '# PDF Ingest Pilot — April 2026',
+        '',
+        '> Pilot report for the Docling-first Hermes KB PDF ingest path.',
+        '',
+        '## Findings',
+        '',
+    ]
+    for row in report["rows"]:
+        lines.extend([
+            f"- `{row['label']}` → `{row['parser_selected']}` ({row['route_reason']}); total {row['latency_ms_total']} ms; record `{row['record_id']}`",
+        ])
+    lines.extend([
+        '',
+        '## Recommendation',
+        '',
+        '- Keep Docling as the default parser.',
+        '- Keep the PyMuPDF4LLM fast path only if the simple born-digital sample shows a meaningful latency win without fidelity loss.',
+    ])
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return target
+
+
+if __name__ == "__main__":
+    report = run_pilot()
+    query_path = write_query_page(report)
+    report["query_page_path"] = str(query_path)
+    print(json.dumps(report, indent=2, ensure_ascii=False))

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_promote_to_wiki.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/pdf_promote_to_wiki.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from pdf_ingest_config import PROMOTION_CANDIDATE_FILENAME, WIKI_SOURCES_HOME
+from pdf_ingest_lib import slugify
+
+
+def _clean_lines(markdown_text: str) -> list[str]:
+    return [line.strip() for line in markdown_text.splitlines() if line.strip() and line.strip() != "<!-- image -->"]
+
+
+def _summary(markdown_text: str) -> str:
+    for line in _clean_lines(markdown_text):
+        if not line.startswith("#"):
+            return line[:220]
+    return "No summary available."
+
+
+def _highlights(markdown_text: str, limit: int = 5) -> list[str]:
+    picks: list[str] = []
+    for line in _clean_lines(markdown_text):
+        if line.startswith("#"):
+            picks.append(line.lstrip("#").strip())
+        elif len(line) > 40:
+            picks.append(line[:180])
+        if len(picks) >= limit:
+            break
+    return picks or ["No reliable highlights extracted."]
+
+
+def source_page_slug(source_record: dict) -> str:
+    return slugify(Path(source_record["original_filename"]).stem)
+
+
+def source_page_path(source_record: dict) -> Path:
+    return WIKI_SOURCES_HOME / f"{source_page_slug(source_record)}.md"
+
+
+def build_promotion_candidate(*, source_record: dict, markdown_text: str) -> str:
+    title = Path(source_record["original_filename"]).stem.replace("-", " ").replace("_", " ").strip() or source_record["original_filename"]
+    summary = _summary(markdown_text)
+    raw_rel = Path(source_record["raw_path"])
+    return (
+        f"# {title}\n\n"
+        f"> {summary}\n\n"
+        f"## Source metadata\n"
+        f"- source_id: `{source_record['source_id']}`\n"
+        f"- parser: `{source_record['parser_selected']}`\n"
+        f"- route_reason: {source_record['route_reason']}\n"
+        f"- raw_path: `{raw_rel}`\n\n"
+        f"## Suggested action\n"
+        f"- Source summary target: `wiki/sources/{source_page_slug(source_record)}.md`\n"
+        f"- Review extracted markdown for citation-safe facts before promoting into concepts/entities.\n"
+    )
+
+
+def build_source_summary_page(*, source_record: dict, markdown_text: str) -> str:
+    slug = source_page_slug(source_record)
+    title = slug.replace("-", " ").strip().title()
+    summary = _summary(markdown_text)
+    highlights = _highlights(markdown_text)
+    raw_rel = Path(source_record["raw_path"])
+    lines = [
+        "---",
+        f"title: \"{title}\"",
+        f"created: {source_record['parse_completed_at'][:10]}",
+        f"updated: {source_record['parse_completed_at'][:10]}",
+        "type: source",
+        f"tags: [source, pdf, kb-ingest, {source_record['parser_selected']}]",
+        f"sources: [\"{raw_rel}\"]",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        f"> {summary}",
+        "",
+        "## Content",
+        "",
+        f"This source page was auto-promoted from the PDF evidence layer. Parser: {source_record['parser_selected']}. Route reason: {source_record['route_reason']}",
+        "",
+        "## Highlights",
+        "",
+    ]
+    for item in highlights:
+        lines.append(f"- {item}")
+    lines.extend([
+        "",
+        "## Related",
+        "",
+        "- [[research-cycle-log]]",
+        "",
+        "## Sources",
+        "",
+        f"- [{raw_rel.name}](../../raw/pdf/{raw_rel.parent.name}/{raw_rel.name})",
+        f"- Evidence record: `{source_record['source_id']}`",
+        "",
+        "## Changelog",
+        "",
+        f"- {source_record['parse_completed_at'][:10]}: Auto-promoted source summary from PDF evidence ingest using {source_record['parser_selected']}.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def write_promotion_candidate(*, output_dir: Path, source_record: dict, markdown_text: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = output_dir / PROMOTION_CANDIDATE_FILENAME
+    target.write_text(build_promotion_candidate(source_record=source_record, markdown_text=markdown_text), encoding="utf-8")
+    return target
+
+
+def promote_source_summary(*, source_record: dict, markdown_text: str) -> Path:
+    WIKI_SOURCES_HOME.mkdir(parents=True, exist_ok=True)
+    target = source_page_path(source_record)
+    target.write_text(build_source_summary_page(source_record=source_record, markdown_text=markdown_text), encoding="utf-8")
+    return target
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Write PDF promotion artifacts")
+    parser.add_argument("source_record_json")
+    parser.add_argument("markdown_path")
+    parser.add_argument("output_dir")
+    parser.add_argument("--promote", action="store_true")
+    args = parser.parse_args()
+
+    source_record = json.loads(Path(args.source_record_json).read_text(encoding="utf-8"))
+    markdown_text = Path(args.markdown_path).read_text(encoding="utf-8")
+    payload = {
+        "promotion_candidate_path": str(write_promotion_candidate(output_dir=Path(args.output_dir), source_record=source_record, markdown_text=markdown_text))
+    }
+    if args.promote:
+        payload["source_page_path"] = str(promote_source_summary(source_record=source_record, markdown_text=markdown_text))
+    print(json.dumps(payload, indent=2))

--- a/skills/productivity/docling-kb-pdf-ingest/scripts/telegram_pdf_drop_ingest.py
+++ b/skills/productivity/docling-kb-pdf-ingest/scripts/telegram_pdf_drop_ingest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from pdf_ingest_config import INGRESS_TELEGRAM
+from pdf_ingest_lib import copy_to_telegram_staging
+from pdf_ingest_pipeline import ingest_pdf
+
+
+def ingest_telegram_pdf(*, cached_path: Path, chat_id: str, message_id: str, original_filename: str | None = None, caption: str | None = None) -> dict:
+    staged_path = copy_to_telegram_staging(cached_path, original_filename=original_filename)
+    source_context = {
+        "telegram_chat_id": chat_id,
+        "telegram_message_id": message_id,
+        "telegram_file_name": original_filename or cached_path.name,
+        "telegram_caption": caption or "",
+    }
+    result = ingest_pdf(
+        pdf_path=staged_path,
+        ingress_channel=INGRESS_TELEGRAM,
+        source_context=source_context,
+        dry_run_promotion=True,
+    )
+    result["staged_path"] = str(staged_path)
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Ingest a Telegram PDF drop into the Hermes evidence layer")
+    parser.add_argument("cached_path")
+    parser.add_argument("--chat-id", required=True)
+    parser.add_argument("--message-id", required=True)
+    parser.add_argument("--original-filename")
+    parser.add_argument("--caption", default="")
+    args = parser.parse_args()
+
+    payload = ingest_telegram_pdf(
+        cached_path=Path(args.cached_path),
+        chat_id=args.chat_id,
+        message_id=args.message_id,
+        original_filename=args.original_filename,
+        caption=args.caption,
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False))

--- a/tests/gateway/test_telegram_pdf_ingest_flow.py
+++ b/tests/gateway/test_telegram_pdf_ingest_flow.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="1632061707",
+        chat_id="1632061707",
+        user_name="Thiago",
+        chat_type="dm",
+    )
+
+
+def _make_event(pdf_path: str = "/tmp/doc.pdf") -> MessageEvent:
+    return MessageEvent(
+        text="",
+        source=_make_source(),
+        message_id="m1",
+        message_type=MessageType.DOCUMENT,
+        media_urls=[pdf_path],
+        media_types=["application/pdf"],
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner.pairing_store = MagicMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_pdf_dm_triggers_auto_ingest_and_skips_agent(monkeypatch):
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("agent should not run for auto-ingest pdf drops"))
+    runner._auto_ingest_pdf_drop = AsyncMock(return_value="PDF received and ingested.\nrecord_id: src_pdf_123")
+
+    result = await runner._handle_message(_make_event())
+
+    assert result is not None
+    assert "record_id: src_pdf_123" in result
+    runner._run_agent.assert_not_called()
+    runner._auto_ingest_pdf_drop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pdf_drop_sends_receipt_message(monkeypatch):
+    runner = _make_runner()
+
+    async def _fake_send(chat_id, content, metadata=None):
+        return None
+
+    runner.adapters[Platform.TELEGRAM].send = AsyncMock(side_effect=_fake_send)
+
+    async def _fake_run_in_executor(_executor, func):
+        return {
+            "status": "success",
+            "record_id": "src_pdf_deadbeef",
+            "parser_selected": "docling",
+            "route_reason": "default Docling path",
+            "staged_path": "/tmp/staged.pdf",
+        }
+
+    loop = MagicMock()
+    loop.run_in_executor = AsyncMock(side_effect=_fake_run_in_executor)
+    monkeypatch.setattr("gateway.run.asyncio.get_running_loop", lambda: loop)
+
+    result = await runner._auto_ingest_pdf_drop(_make_event(), _make_source())
+
+    runner.adapters[Platform.TELEGRAM].send.assert_awaited_once()
+    sent_args = runner.adapters[Platform.TELEGRAM].send.await_args.args
+    assert sent_args[1] == "Received PDF. Staging and parsing now."
+    assert "record_id: src_pdf_deadbeef" in result
+
+
+@pytest.mark.asyncio
+async def test_non_pdf_document_does_not_auto_ingest():
+    from gateway.run import GatewayRunner
+
+    event = MessageEvent(
+        text="",
+        source=_make_source(),
+        message_id="m1",
+        message_type=MessageType.DOCUMENT,
+        media_urls=["/tmp/file.docx"],
+        media_types=["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+    )
+    assert GatewayRunner._is_auto_ingest_pdf_drop(event, _make_source()) is False

--- a/tests/tools/test_pdf_extract_docling.py
+++ b/tests/tools/test_pdf_extract_docling.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path("/Users/quark/.hermes/scripts")
+
+
+def load_module(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    for name in ["pdf_ingest_config", "pdf_ingest_lib", "pdf_extract_docling"]:
+        sys.modules.pop(name, None)
+    return importlib.import_module("pdf_extract_docling")
+
+
+def test_docling_uses_ocr_fallback_when_markdown_is_too_short(monkeypatch, tmp_path):
+    module = load_module(monkeypatch, tmp_path)
+
+    class _FakeDocument:
+        def export_to_markdown(self):
+            return "<!-- image -->"
+
+        def export_to_dict(self):
+            return {"kind": "fake"}
+
+    class _FakeResult:
+        document = _FakeDocument()
+
+    class _FakeConverter:
+        def convert(self, _src):
+            return _FakeResult()
+
+    monkeypatch.setattr(module, "DocumentConverter", lambda: _FakeConverter())
+    monkeypatch.setattr(
+        module,
+        "_ocr_fallback_markdown",
+        lambda _pdf_path, _output_dir: (
+            "## OCR Fallback — Page 1\n\nVALID FOR WORK ONLY WITH DHS AUTHORIZATION",
+            [
+                {
+                    "ordinal": 1,
+                    "section_heading": "OCR Fallback — Page 1",
+                    "page_start": 1,
+                    "page_end": 1,
+                    "parser_chunk_id": "ocr-fallback-page-1",
+                    "provenance_refs": [1],
+                    "text": "VALID FOR WORK ONLY WITH DHS AUTHORIZATION",
+                }
+            ],
+        ),
+    )
+
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"%PDF-scan")
+    output_dir = tmp_path / "out"
+
+    payload = module.extract_pdf(pdf_path, output_dir, 1)
+
+    assert payload["ocr_fallback_used"] is True
+    assert "VALID FOR WORK ONLY WITH DHS AUTHORIZATION" in payload["markdown_text"]
+    saved_json = json.loads((output_dir / "docling.json").read_text(encoding="utf-8"))
+    assert saved_json["ocr_fallback"]["used"] is True

--- a/tests/tools/test_pdf_extract_docling.py
+++ b/tests/tools/test_pdf_extract_docling.py
@@ -6,7 +6,13 @@ import sys
 from pathlib import Path
 
 
-SCRIPTS_DIR = Path("/Users/quark/.hermes/scripts")
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "productivity"
+    / "docling-kb-pdf-ingest"
+    / "scripts"
+)
 
 
 def load_module(monkeypatch, tmp_path):

--- a/tests/tools/test_pdf_ingest_pipeline.py
+++ b/tests/tools/test_pdf_ingest_pipeline.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS_DIR = Path("/Users/quark/.hermes/scripts")
+
+
+def load_pipeline_modules(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    for name in [
+        "pdf_ingest_config",
+        "pdf_ingest_lib",
+        "pdf_extract_docling",
+        "pdf_extract_pymupdf4llm",
+        "pdf_promote_to_wiki",
+        "pdf_ingest_pipeline",
+        "telegram_pdf_drop_ingest",
+        "pdf_pilot_report",
+    ]:
+        sys.modules.pop(name, None)
+    config = importlib.import_module("pdf_ingest_config")
+    lib = importlib.import_module("pdf_ingest_lib")
+    pipeline = importlib.import_module("pdf_ingest_pipeline")
+    telegram = importlib.import_module("telegram_pdf_drop_ingest")
+    return config, lib, pipeline, telegram
+
+
+@pytest.fixture()
+def loaded(monkeypatch, tmp_path):
+    return load_pipeline_modules(monkeypatch, tmp_path)
+
+
+def fake_extractor_factory(parser_name: str):
+    def _extract(pdf_path: Path, output_dir: Path, page_count: int):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        markdown_path = output_dir / f"{parser_name}.md"
+        json_path = output_dir / f"{parser_name}.json"
+        chunk_path = output_dir / "chunks.json"
+        markdown_text = f"# {parser_name} extraction\n\nParsed {pdf_path.name}"
+        chunks = [
+            {
+                "ordinal": 1,
+                "section_heading": f"{parser_name} heading",
+                "page_start": 1,
+                "page_end": page_count,
+                "parser_chunk_id": f"{parser_name}-1",
+                "provenance_refs": [1],
+                "text": markdown_text,
+            }
+        ]
+        markdown_path.write_text(markdown_text, encoding="utf-8")
+        json_path.write_text(json.dumps({"parser": parser_name}), encoding="utf-8")
+        chunk_path.write_text(json.dumps(chunks), encoding="utf-8")
+        return {
+            "parser_name": parser_name,
+            "parser_version": "test-1",
+            "markdown_text": markdown_text,
+            "markdown_path": markdown_path,
+            "json_path": json_path,
+            "chunk_path": chunk_path,
+            "chunks": chunks,
+        }
+
+    return _extract
+
+
+def test_routes_short_text_pdf_to_pymupdf4llm(loaded, monkeypatch, tmp_path):
+    config, lib, pipeline, _telegram = loaded
+    staged = tmp_path / "input.pdf"
+    staged.write_bytes(b"%PDF-short-text")
+
+    monkeypatch.setattr(
+        pipeline,
+        "inspect_pdf",
+        lambda _path: {
+            "page_count": 3,
+            "text_layer_present": True,
+            "ocr_needed": False,
+            "text_pages": 3,
+            "text_chars": 900,
+            "file_size_bytes": staged.stat().st_size,
+        },
+    )
+    pipeline.PARSER_MAP["pymupdf4llm"] = fake_extractor_factory("pymupdf4llm")
+    pipeline.PARSER_MAP["docling"] = fake_extractor_factory("docling")
+
+    result = pipeline.ingest_pdf(pdf_path=staged, ingress_channel="manual_pilot", source_context={"pilot_label": "simple"})
+
+    assert result["status"] == "success"
+    assert result["parser_selected"] == "pymupdf4llm"
+    assert result["record_id"].startswith("src_pdf_")
+    assert Path(result["raw_path"]).exists()
+
+
+def test_routes_non_text_pdf_to_docling(loaded, monkeypatch, tmp_path):
+    _config, _lib, pipeline, _telegram = loaded
+    staged = tmp_path / "scan.pdf"
+    staged.write_bytes(b"%PDF-scan")
+
+    monkeypatch.setattr(
+        pipeline,
+        "inspect_pdf",
+        lambda _path: {
+            "page_count": 2,
+            "text_layer_present": False,
+            "ocr_needed": True,
+            "text_pages": 0,
+            "text_chars": 0,
+            "file_size_bytes": staged.stat().st_size,
+        },
+    )
+    pipeline.PARSER_MAP["pymupdf4llm"] = fake_extractor_factory("pymupdf4llm")
+    pipeline.PARSER_MAP["docling"] = fake_extractor_factory("docling")
+
+    result = pipeline.ingest_pdf(pdf_path=staged, ingress_channel="manual_pilot", source_context={"pilot_label": "scan"})
+
+    assert result["parser_selected"] == "docling"
+    assert "no text layer detected" in result["route_reason"]
+
+
+def test_duplicate_pdf_reuses_existing_record(loaded, monkeypatch, tmp_path):
+    _config, _lib, pipeline, _telegram = loaded
+    staged = tmp_path / "dup.pdf"
+    staged.write_bytes(b"%PDF-dup")
+
+    monkeypatch.setattr(
+        pipeline,
+        "inspect_pdf",
+        lambda _path: {
+            "page_count": 1,
+            "text_layer_present": True,
+            "ocr_needed": False,
+            "text_pages": 1,
+            "text_chars": 100,
+            "file_size_bytes": staged.stat().st_size,
+        },
+    )
+    pipeline.PARSER_MAP["pymupdf4llm"] = fake_extractor_factory("pymupdf4llm")
+    pipeline.PARSER_MAP["docling"] = fake_extractor_factory("docling")
+
+    first = pipeline.ingest_pdf(pdf_path=staged, ingress_channel="manual_pilot", source_context={})
+    second = pipeline.ingest_pdf(pdf_path=staged, ingress_channel="manual_pilot", source_context={})
+
+    assert first["record_id"] == second["record_id"]
+    assert second["status"] == "skipped_duplicate"
+
+
+def test_pipeline_writes_evidence_records(loaded, monkeypatch, tmp_path):
+    config, _lib, pipeline, _telegram = loaded
+    staged = tmp_path / "evidence.pdf"
+    staged.write_bytes(b"%PDF-evidence")
+
+    monkeypatch.setattr(
+        pipeline,
+        "inspect_pdf",
+        lambda _path: {
+            "page_count": 4,
+            "text_layer_present": True,
+            "ocr_needed": False,
+            "text_pages": 4,
+            "text_chars": 400,
+            "file_size_bytes": staged.stat().st_size,
+        },
+    )
+    pipeline.PARSER_MAP["pymupdf4llm"] = fake_extractor_factory("pymupdf4llm")
+    pipeline.PARSER_MAP["docling"] = fake_extractor_factory("docling")
+
+    result = pipeline.ingest_pdf(pdf_path=staged, ingress_channel="manual_pilot", source_context={"pilot_label": "evidence"})
+
+    sources_lines = [line for line in config.SOURCES_JSONL.read_text(encoding="utf-8").splitlines() if line.strip()]
+    chunks_lines = [line for line in config.CHUNKS_JSONL.read_text(encoding="utf-8").splitlines() if line.strip()]
+    transforms_lines = [line for line in config.TRANSFORMS_JSONL.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    assert len(sources_lines) == 1
+    assert len(chunks_lines) == 1
+    assert len(transforms_lines) >= 1
+
+    source_record = json.loads(sources_lines[0])
+    assert source_record["record_id"] == result["record_id"]
+    assert source_record["parser_selected"] == result["parser_selected"]
+    assert Path(result["promotion_candidate_path"]).exists()
+
+
+def test_telegram_ingest_copies_to_staging_and_runs_pipeline(loaded, monkeypatch, tmp_path):
+    config, _lib, _pipeline, telegram = loaded
+    cached = tmp_path / "doc_cached.pdf"
+    cached.write_bytes(b"%PDF-telegram")
+
+    def _fake_ingest(**kwargs):
+        return {
+            "status": "success",
+            "record_id": "src_pdf_deadbeefcafe",
+            "source_id": "src_pdf_deadbeefcafe",
+            "parser_selected": "docling",
+            "route_reason": "default Docling path",
+            "staging_path": str(kwargs["pdf_path"]),
+        }
+
+    monkeypatch.setattr(telegram, "ingest_pdf", _fake_ingest)
+
+    result = telegram.ingest_telegram_pdf(
+        cached_path=cached,
+        chat_id="1632061707",
+        message_id="42",
+        original_filename="drop.pdf",
+        caption="",
+    )
+
+    assert result["record_id"] == "src_pdf_deadbeefcafe"
+    assert Path(result["staged_path"]).exists()
+    assert str(Path(result["staged_path"]).parent).startswith(str(config.TELEGRAM_STAGING_HOME))
+
+
+def test_pipeline_can_promote_source_summary_page(loaded, monkeypatch, tmp_path):
+    config, _lib, pipeline, _telegram = loaded
+    staged = tmp_path / "promote.pdf"
+    staged.write_bytes(b"%PDF-promote")
+
+    monkeypatch.setattr(
+        pipeline,
+        "inspect_pdf",
+        lambda _path: {
+            "page_count": 2,
+            "text_layer_present": True,
+            "ocr_needed": False,
+            "text_pages": 2,
+            "text_chars": 300,
+            "file_size_bytes": staged.stat().st_size,
+        },
+    )
+    pipeline.PARSER_MAP["pymupdf4llm"] = fake_extractor_factory("pymupdf4llm")
+    pipeline.PARSER_MAP["docling"] = fake_extractor_factory("docling")
+
+    result = pipeline.ingest_pdf(
+        pdf_path=staged,
+        ingress_channel="manual_pilot",
+        source_context={"pilot_label": "promote"},
+        dry_run_promotion=True,
+        promote_source_page=True,
+    )
+
+    assert result["source_page_path"] is not None
+    source_page = Path(result["source_page_path"])
+    assert source_page.exists()
+    assert "type: source" in source_page.read_text(encoding="utf-8")

--- a/tests/tools/test_pdf_ingest_pipeline.py
+++ b/tests/tools/test_pdf_ingest_pipeline.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import pytest
 
 
-SCRIPTS_DIR = Path("/Users/quark/.hermes/scripts")
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "productivity"
+    / "docling-kb-pdf-ingest"
+    / "scripts"
+)
 
 
 def load_pipeline_modules(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- auto-ingest Telegram PDF drops into the KB evidence layer and acknowledge routing/results in the gateway
- add a Docling-first PDF ingest pipeline with PyMuPDF4LLM fast path, OCR fallback, duplicate reuse, and optional wiki source promotion tests
- vendor the KB PDF ingest scripts into a repo skill so gateway/runtime and tests stop depending on ~/.hermes/scripts

## Test Plan
- source venv/bin/activate
- python -m pytest tests/tools/test_pdf_ingest_pipeline.py tests/tools/test_pdf_extract_docling.py tests/gateway/test_telegram_pdf_ingest_flow.py tests/gateway/test_telegram_documents.py -q

## Notes
- gateway now resolves the repo skill scripts first and falls back to legacy ~/.hermes/scripts for compatibility