### PR TITLE
fix(opencode-zen): preserve dotted MiniMax model ids

### DIFF
--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -208,6 +208,14 @@ class TestNormalizeModelForProvider:
         assert cli.model == "claude-sonnet-4-6"
         assert cli.api_mode == "anthropic_messages"
 
+    def test_opencode_zen_minimax_preserves_dots_and_uses_chat_completions(self):
+        cli = _make_cli(model="minimax-m2.5-free")
+        cli.api_mode = "anthropic_messages"
+        changed = cli._normalize_model_for_provider("opencode-zen")
+        assert changed is True
+        assert cli.model == "minimax-m2.5-free"
+        assert cli.api_mode == "chat_completions"
+
     def test_default_model_replaced(self):
         """No model configured (empty default) gets swapped for codex."""
         import cli as _cli_mod


### PR DESCRIPTION
 ## Summary                                                                                                                                                                      
                                                                                                                                                                                  
  Fixes a model normalization bug for `opencode-zen` where dotted model ids such as `minimax-m2.5-free` were incorrectly rewritten to hyphenated ids like `minimax-m2-5-free`,    
  causing OpenCode Zen requests to fail with 401 model-not-supported errors.                                                                                                      
                                                                                                                                                                                  
  Fixes #7674                                                                                                                                                                     
                                                                                                                                                                                  
  ## Root Cause                                                                                                                                                                   
                                                                                                                                                                                  
  `normalize_model_for_provider(..., "opencode-zen")` was applying Anthropic-style dot-to-hyphen normalization too broadly.                                                       
                                                                                                                                                                                  
  That behavior is only correct for Claude models on OpenCode Zen, which use the Anthropic-style `claude-sonnet-4-6` form. Non-Claude Zen models such as MiniMax, GPT, Gemini, and
  GLM should keep their native dotted ids.                                                                                                                                        
                                                                                                                                                                                  
  Because of that over-normalization:                                                                                                                                             
  - `minimax-m2.5-free` became `minimax-m2-5-free`                                                                                                                                
  - the request hit OpenCode Zen with an unsupported model id                                                                                                                     
  - the API returned `401` / `Model ... not supported`                                                                                                                            
                                                                                                                                                                                  
  ## What Changed                                                                                                                                                                 
                                                                                                                                                                                  
  - limit OpenCode Zen dot-to-hyphen rewriting to Claude / Anthropic-message models only                                                                                          
  - preserve dotted ids for non-Claude OpenCode Zen models                                                                                                                        
  - keep provider-prefix stripping behavior unchanged                                                                                                                             
  - update normalization docs/comments to reflect OpenCode Zen's mixed-mode behavior                                                                                              
  - add regression tests for `minimax-m2.5-free` and other non-Claude Zen models                                                                                                  
                                                                                                                                                                                  
  ## Behavior After                                                                                                                                                               
                                                                                                                                                                                  
  ### OpenCode Zen                                                                                                                                                                
  - `claude-sonnet-4.6` -> `claude-sonnet-4-6`                                                                                                                                    
  - `minimax-m2.5-free` -> `minimax-m2.5-free`                                                                                                                                    
  - `gpt-5.4` -> `gpt-5.4`                                                                                                                                                        
  - `gemini-2.5-flash` -> `gemini-2.5-flash`                                                                                                                                      
  - `glm-4.5` -> `glm-4.5`                                                                                                                                                        
                                                                                                                                                                                  
  ### OpenCode Go                                                                                                                                                                 
  - unchanged                                                                                                                                                                     
                                                                                                                                                                                  
  ## Testing                                                                                                                                                                      
                                                                                                                                                                                  
  Ran:                                                                                                                                                                            
                                                                                                                                                                                  
  - `.\venv\Scripts\python -m pytest tests\hermes_cli\test_model_normalize.py tests\hermes_cli\test_codex_models.py tests\hermes_cli\test_model_validation.py -q`                 
  - `.\venv\Scripts\python -m pytest tests\hermes_cli\test_runtime_provider_resolution.py -q` 