### PR TITLE
fix(terminal): honor configured cwd at session init

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -130,6 +130,27 @@ class TestEmbedStdinHeredoc:
 
 
 class TestInitSessionFailure:
+    def test_init_session_bootstrap_changes_to_configured_cwd(self):
+        env = _TestableEnv(cwd="/tmp/configured")
+
+        calls = []
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            calls.append({"cmd": cmd, "login": login})
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 0
+            mock.stdout = iter([])
+            return mock
+
+        env._run_bash = mock_run_bash
+        env.init_session()
+
+        assert len(calls) == 1
+        assert calls[0]["login"] is True
+        assert "cd /tmp/configured" in calls[0]["cmd"] or "cd '/tmp/configured'" in calls[0]["cmd"]
+        assert env._snapshot_ready is True
+
     def test_snapshot_ready_false_on_failure(self):
         env = _TestableEnv()
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -245,6 +245,11 @@ class BaseEnvironment(ABC):
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
 
+    @staticmethod
+    def _quote_cwd_for_shell(cwd: str) -> str:
+        """Quote a cwd for shell ``cd`` while preserving ``~`` expansion."""
+        return shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
+
     # ------------------------------------------------------------------
     # Abstract methods
     # ------------------------------------------------------------------
@@ -281,6 +286,7 @@ class BaseEnvironment(ABC):
         instead of running with ``bash -l``.
         """
         # Full capture: env vars, functions (filtered), aliases, shell options.
+        quoted_cwd = self._quote_cwd_for_shell(self.cwd)
         bootstrap = (
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
@@ -288,6 +294,7 @@ class BaseEnvironment(ABC):
             f"echo 'shopt -s expand_aliases' >> {self._snapshot_path}\n"
             f"echo 'set +e' >> {self._snapshot_path}\n"
             f"echo 'set +u' >> {self._snapshot_path}\n"
+            f"cd {quoted_cwd} || exit 126\n"
             f"pwd -P > {self._cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )
@@ -326,9 +333,7 @@ class BaseEnvironment(ABC):
             parts.append(f"source {self._snapshot_path} 2>/dev/null || true")
 
         # cd to working directory — let bash expand ~ natively
-        quoted_cwd = (
-            shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
-        )
+        quoted_cwd = self._quote_cwd_for_shell(cwd)
         parts.append(f"cd {quoted_cwd} || exit 126")
 
         # Run the actual command


### PR DESCRIPTION
## Summary                                                                                                                                                                      
                                                                                                                                                                                  
  Fixes a gateway / messaging working-directory bug where Telegram sessions ignored the configured profile `cwd` and kept starting in the gateway process launch directory        
  instead.                                                                                                                                                                        
                                                                                                                                                                                  
  In affected setups, env/config values such as `terminal.cwd`, `TERMINAL_CWD`, and `MESSAGING_CWD` were present and correct, but commands like `pwd` still resolved to           
  `~/.hermes/hermes-agent`.                                                                                                                                                       
                                                                                                                                                                                  
  Fixes #7663                                                                                                                                                                     
                                                                                                                                                                                  
  ## Root Cause
                                                                                                                                                                                  
  The config/env bridge in `gateway/run.py` was working correctly and did set `TERMINAL_CWD`.                                                                                     
                                                                                                                                                                                  
  The actual problem was lower in the terminal environment lifecycle:                                                                                                             
                                                                                                                                                                                  
  - `BaseEnvironment.init_session()` creates the shell snapshot used by later terminal commands                                                                                   
  - during that initialization, it captured the shell state and current directory                                                                                                 
  - but it did **not** first `cd` into the configured working directory
  - so the snapshot locked in the gateway process startup directory instead of the configured terminal cwd                                                                        
                                                                                                                                                                                  
  That made later commands inherit the wrong default directory even though the env vars were correct.                                                                             
                                                                                                                                                                                  
  ## What Changed                                                                                                                                                                 
                                                                                                                                                                                  
  - update `BaseEnvironment.init_session()` to `cd` into the configured cwd before capturing the shell snapshot                                                                   
  - reuse the same cwd quoting logic for both init-time and normal command execution                                                                                              
  - add a regression test to verify init-session bootstrap honors configured cwd                                                                                                  
                                                                                                                                                                                  
  ## Behavior Before                                                                                                                                                              
                                                                                                                                                                                  
  Configured profile/gateway cwd could be visible in env vars, but new messaging terminal sessions still started in the gateway launch directory:                                 
                                                                                                                                                                                  
  - `MESSAGING_CWD` correct                                                                                                                                                       
  - `TERMINAL_CWD` correct                                                                                                                                                        
  - `pwd` wrong                                                                                                                                                                   
                                                                                                                                                                                  
  ## Behavior After                                                                                                                                                               
                                                                                                                                                                                  
  When a terminal environment is initialized for messaging/gateway use, its initial shell snapshot now starts in the configured cwd, so subsequent commands like `pwd` reflect the
  configured profile working directory.                                                                                                                                           
                                                                                                                                                                                  
  ## Testing                                                                                                                                                                      
                                                                                                                                                                                  
  Ran:                                                                                                                                                                            
                                                                                                                                                                                  
  - `.\venv\Scripts\python -m pytest tests\tools\test_base_environment.py tests\gateway\test_config_cwd_bridge.py -q` 