### PR TITLE
fix(cli): resolve npm path for Windows compatibility in post-setup hooks

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -377,13 +377,20 @@ def _run_post_setup(post_setup_key: str):
     import shutil
     if post_setup_key in ("agent_browser", "browserbase"):
         node_modules = PROJECT_ROOT / "node_modules" / "agent-browser"
-        if not node_modules.exists() and shutil.which("npm"):
+        npm_bin = shutil.which("npm")
+        if not node_modules.exists() and npm_bin:
             _print_info("    Installing Node.js dependencies for browser tools...")
             import subprocess
-            result = subprocess.run(
-                ["npm", "install", "--silent"],
-                capture_output=True, text=True, cwd=str(PROJECT_ROOT)
-            )
+            # Use the resolved path so Windows finds npm.cmd correctly;
+            # bare "npm" fails because CreateProcess does not search PATHEXT.
+            try:
+                result = subprocess.run(
+                    [npm_bin, "install", "--silent"],
+                    capture_output=True, text=True, cwd=str(PROJECT_ROOT),
+                )
+            except FileNotFoundError:
+                _print_warning("    npm could not be launched - run manually: npm install (in hermes-agent directory)")
+                return
             if result.returncode == 0:
                 _print_success("    Node.js dependencies installed")
             else:
@@ -394,17 +401,22 @@ def _run_post_setup(post_setup_key: str):
 
     elif post_setup_key == "camofox":
         camofox_dir = PROJECT_ROOT / "node_modules" / "@askjo" / "camoufox-browser"
-        if not camofox_dir.exists() and shutil.which("npm"):
+        npm_bin = shutil.which("npm")
+        if not camofox_dir.exists() and npm_bin:
             _print_info("    Installing Camofox browser server...")
             import subprocess
-            result = subprocess.run(
-                ["npm", "install", "--silent"],
-                capture_output=True, text=True, cwd=str(PROJECT_ROOT)
-            )
+            try:
+                result = subprocess.run(
+                    [npm_bin, "install", "--silent"],
+                    capture_output=True, text=True, cwd=str(PROJECT_ROOT),
+                )
+            except FileNotFoundError:
+                _print_warning("    npm could not be launched - run manually: npm install (in hermes-agent directory)")
+                return
             if result.returncode == 0:
                 _print_success("    Camofox installed")
             else:
-                _print_warning("    npm install failed - run manually: npm install")
+                _print_warning("    npm install failed - run manually: npm install (in hermes-agent directory)")
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camoufox-browser")


### PR DESCRIPTION
## What does this PR do?

On Windows, `npm` is installed as `npm.cmd` (a batch script). When `_run_post_setup()` calls `subprocess.run(["npm", "install", "--silent"])`, Python's `CreateProcess` does not search `PATHEXT`, so it cannot find `npm.cmd` from the bare name `"npm"` and raises `FileNotFoundError`, crashing the setup wizard.

This PR resolves the npm executable path via `shutil.which("npm")` before passing it to `subprocess.run()`, so `CreateProcess` receives the full path (e.g. `C:\Program Files\nodejs\npm.cmd`) and can launch it correctly. This follows the same pattern already used for `uv` in the same function (line 425: `uv_bin = shutil.which("uv")`).

Also adds a `FileNotFoundError` guard so setup degrades gracefully with a user-friendly warning instead of a traceback.

## Related Issue

Fixes #7252

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/tools_config.py`: In `_run_post_setup()`, resolve npm path via `shutil.which()` before calling `subprocess.run()` for both the `agent_browser`/`browserbase` and `camofox` branches. Add `try/except FileNotFoundError` with a user-friendly fallback message.

## How to Test

1. `pytest tests/ -q` — full suite passes (pre-existing flaky failures are unrelated)
2. On Windows with Node.js installed: run `hermes` → select "Local Browser" → setup should complete without crashing
3. On Windows without Node.js: setup should print a friendly warning instead of a traceback
4. On macOS/Linux: behavior is unchanged (`shutil.which("npm")` returns the full path just like before)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A