### PR TITLE
feat: add internal /sessions management command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3757,6 +3757,201 @@ class HermesCLI:
         print()
         return True
 
+    def _resolve_cli_session_target(self, target: str) -> Optional[str]:
+        """Resolve a historical session by exact ID, unique prefix, or title."""
+        if not self._session_db or not target:
+            return None
+        resolved = self._session_db.resolve_session_id(target)
+        if resolved:
+            session = self._session_db.get_session(resolved)
+            if session and session.get("source") != "tool":
+                return resolved
+        resolved = self._session_db.resolve_session_by_title(target)
+        if resolved:
+            session = self._session_db.get_session(resolved)
+            if session and session.get("source") != "tool":
+                return resolved
+        return None
+
+    @staticmethod
+    def _session_preview_entries(messages: list[dict[str, Any]], max_entries: int = 8) -> list[tuple[str, str]]:
+        """Build compact visible preview entries for a historical session."""
+        import re
+
+        entries: list[tuple[str, str]] = []
+        for msg in messages or []:
+            role = msg.get("role") or ""
+            if role in {"system", "tool", "session_meta"}:
+                continue
+
+            content = msg.get("content")
+            tool_calls = msg.get("tool_calls") or []
+            text = ""
+            if isinstance(content, list):
+                parts = []
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        parts.append(part.get("text", ""))
+                    elif isinstance(part, dict) and part.get("type") == "image_url":
+                        parts.append("[image]")
+                text = " ".join(p for p in parts if p)
+            elif content is not None:
+                text = str(content)
+
+            if role == "assistant" and tool_calls:
+                names = []
+                for tc in tool_calls:
+                    fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                    name = fn.get("name", "unknown") if isinstance(fn, dict) else "unknown"
+                    if name not in names:
+                        names.append(name)
+                label = ", ".join(names[:4]) if names else "tool"
+                if len(names) > 4:
+                    label += ", ..."
+                tool_suffix = f"[{len(tool_calls)} tool call{'s' if len(tool_calls) != 1 else ''}: {label}]"
+                text = f"{text} {tool_suffix}".strip()
+
+            text = re.sub(
+                r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
+                "",
+                text,
+                flags=re.DOTALL,
+            )
+            text = re.sub(r"<REASONING_SCRATCHPAD>.*$", "", text, flags=re.DOTALL).strip()
+            if not text:
+                continue
+            text = re.sub(r"\s+", " ", text).strip()
+            if len(text) > 180:
+                text = text[:180] + "..."
+            entries.append((role, text))
+
+        return entries[-max_entries:]
+
+    def _handle_sessions_command(self, cmd_original: str) -> None:
+        """Handle /sessions [list|view|resume|rename|delete|stats] for CLI."""
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        import shlex
+
+        try:
+            parts = shlex.split(cmd_original)
+        except ValueError as e:
+            _cprint(f"  Could not parse /sessions command: {e}")
+            return
+
+        subcommand = parts[1].lower() if len(parts) > 1 else "list"
+        if subcommand not in {"list", "view", "resume", "rename", "delete", "stats"}:
+            _cprint("  Usage: /sessions [list|view|resume|rename|delete|stats]")
+            return
+
+        if subcommand == "list":
+            limit = 10
+            if len(parts) > 2:
+                try:
+                    limit = max(1, int(parts[2]))
+                except ValueError:
+                    _cprint("  Usage: /sessions list [limit]")
+                    return
+            sessions = self._session_db.list_sessions_rich(
+                exclude_sources=["tool"],
+                limit=limit,
+            )
+            sessions = [s for s in sessions if s.get("id") != self.session_id]
+            if not sessions:
+                _cprint("  No historical sessions found.")
+                return
+            from hermes_cli.main import _relative_time
+            print()
+            print("  Historical sessions:")
+            print()
+            print(f"  {'Title':<26} {'Source':<10} {'Preview':<32} {'Last Active':<13} {'ID'}")
+            print(f"  {'─' * 26} {'─' * 10} {'─' * 32} {'─' * 13} {'─' * 24}")
+            for session in sessions:
+                title = (session.get("title") or "—")[:24]
+                src = (session.get("source") or "?")[:10]
+                preview = (session.get("preview") or "")[:30]
+                last_active = _relative_time(session.get("last_active"))
+                print(f"  {title:<26} {src:<10} {preview:<32} {last_active:<13} {session['id']}")
+            print()
+            print("  Use /sessions view <session> for details or /sessions resume <session> to switch.")
+            print()
+            return
+
+        if subcommand == "stats":
+            sessions = [s for s in self._session_db.search_sessions(limit=100000) if s.get("source") != "tool"]
+            msgs = sum((s.get("message_count") or 0) for s in sessions)
+            _cprint(f"  Sessions: {len(sessions)}")
+            _cprint(f"  Stored messages: {msgs}")
+            return
+
+        if subcommand == "resume":
+            target = " ".join(parts[2:]).strip()
+            self._handle_resume_command(f"/resume {target}" if target else "/resume")
+            return
+
+        if len(parts) < 3:
+            _cprint(f"  Usage: /sessions {subcommand} <session id|prefix|title>" + (" <new title>" if subcommand == "rename" else ""))
+            return
+
+        target = parts[2].strip()
+        resolved = self._resolve_cli_session_target(target)
+        if not resolved:
+            _cprint(f"  Session not found: {target}")
+            return
+
+        if subcommand == "view":
+            session_meta = self._session_db.get_session(resolved) or {}
+            messages = self._session_db.get_messages_as_conversation(resolved)
+            entries = self._session_preview_entries(messages)
+            title = session_meta.get("title") or "—"
+            print()
+            print(f"  Session ID: {resolved}")
+            print(f"  Title: {title}")
+            print(f"  Messages: {session_meta.get('message_count', 0)}")
+            print(f"  Source: {session_meta.get('source', 'cli')}")
+            if entries:
+                print("  Preview:")
+                for role, text in entries:
+                    speaker = "You" if role == "user" else "Hermes"
+                    print(f"    - {speaker}: {text}")
+            else:
+                print("  Preview: (no visible messages)")
+            print()
+            return
+
+        if resolved == self.session_id:
+            if subcommand == "rename":
+                _cprint("  That is the active session — use /title <new name> instead.")
+            elif subcommand == "delete":
+                _cprint("  Refusing to delete the active session. Switch away first with /resume or /new.")
+            return
+
+        if subcommand == "rename":
+            if len(parts) < 4:
+                _cprint("  Usage: /sessions rename <session id|prefix|title> <new title>")
+                return
+            new_title = " ".join(parts[3:]).strip()
+            try:
+                if self._session_db.set_session_title(resolved, new_title):
+                    _cprint(f"  Renamed session {resolved} to: {new_title}")
+                else:
+                    _cprint(f"  Session not found: {target}")
+            except ValueError as e:
+                _cprint(f"  {e}")
+            return
+
+        if subcommand == "delete":
+            if "--yes" not in parts[3:]:
+                print("  Refusing to delete without confirmation. Re-run with: /sessions delete <session> --yes")
+                return
+            if self._session_db.delete_session(resolved):
+                _cprint(f"  Deleted session: {resolved}")
+            else:
+                _cprint(f"  Session not found: {target}")
+            return
+
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
@@ -4919,6 +5114,8 @@ class HermesCLI:
             self.new_session()
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
+        elif canonical == "sessions":
+            self._handle_sessions_command(cmd_original)
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
         elif canonical == "provider":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2520,6 +2520,9 @@ class GatewayRunner:
         if canonical == "resume":
             return await self._handle_resume_command(event)
 
+        if canonical == "sessions":
+            return await self._handle_sessions_command(event)
+
         if canonical == "branch":
             return await self._handle_branch_command(event)
 
@@ -5600,6 +5603,237 @@ class GatewayRunner:
             else:
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
+    @staticmethod
+    def _session_preview_entries(messages: list[dict[str, Any]], max_entries: int = 8) -> list[tuple[str, str]]:
+        """Build compact visible preview entries for gateway /sessions views."""
+        entries: list[tuple[str, str]] = []
+        for msg in messages or []:
+            role = msg.get("role") or ""
+            if role in {"system", "tool", "session_meta"}:
+                continue
+
+            content = msg.get("content")
+            tool_calls = msg.get("tool_calls") or []
+            text = ""
+            if isinstance(content, list):
+                parts = []
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        parts.append(part.get("text", ""))
+                    elif isinstance(part, dict) and part.get("type") == "image_url":
+                        parts.append("[image]")
+                text = " ".join(p for p in parts if p)
+            elif content is not None:
+                text = str(content)
+
+            if role == "assistant" and tool_calls:
+                names = []
+                for tc in tool_calls:
+                    fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                    name = fn.get("name", "unknown") if isinstance(fn, dict) else "unknown"
+                    if name not in names:
+                        names.append(name)
+                label = ", ".join(names[:4]) if names else "tool"
+                if len(names) > 4:
+                    label += ", ..."
+                tool_suffix = f"[{len(tool_calls)} tool call{'s' if len(tool_calls) != 1 else ''}: {label}]"
+                text = f"{text} {tool_suffix}".strip()
+
+            text = re.sub(
+                r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
+                "",
+                text,
+                flags=re.DOTALL,
+            )
+            text = re.sub(r"<REASONING_SCRATCHPAD>.*$", "", text, flags=re.DOTALL).strip()
+            if not text:
+                continue
+            text = re.sub(r"\s+", " ", text).strip()
+            if len(text) > 180:
+                text = text[:180] + "..."
+            entries.append((role, text))
+        return entries[-max_entries:]
+
+    def _list_gateway_historical_sessions(self, source, limit: int = 10) -> list[dict[str, Any]]:
+        """List sessions for this sender, with a legacy fallback for NULL user_id rows."""
+        if not self._session_db:
+            return []
+        platform_name = source.platform.value if source.platform else None
+        sessions = self._session_db.list_sessions_rich(source=platform_name, limit=max(limit, 50))
+        scoped = [s for s in sessions if s.get("user_id") == source.user_id]
+        if scoped:
+            return scoped[:limit]
+        legacy = [s for s in sessions if s.get("user_id") in (None, "")]
+        return legacy[:limit]
+
+    def _resolve_scoped_gateway_session_target(self, source, target: str) -> Optional[str]:
+        """Resolve an exact ID, unique prefix, or title within the sender's scope."""
+        if not self._session_db or not target:
+            return None
+        platform_name = source.platform.value if source.platform else None
+        user_id = source.user_id
+        resolved = self._session_db.resolve_session_id(target, source=platform_name, user_id=user_id)
+        if resolved:
+            return resolved
+        resolved = self._session_db.resolve_session_by_title(target, source=platform_name, user_id=user_id)
+        if resolved:
+            return resolved
+
+        # Legacy fallback: older gateway rows may not have user_id populated.
+        legacy_resolved = self._session_db.resolve_session_id(target, source=platform_name)
+        if legacy_resolved:
+            legacy_session = self._session_db.get_session(legacy_resolved)
+            if legacy_session and legacy_session.get("user_id") in (None, ""):
+                return legacy_resolved
+
+        legacy_resolved = self._session_db.resolve_session_by_title(target, source=platform_name)
+        if legacy_resolved:
+            legacy_session = self._session_db.get_session(legacy_resolved)
+            if legacy_session and legacy_session.get("user_id") in (None, ""):
+                return legacy_resolved
+        return None
+
+    async def _handle_sessions_command(self, event: MessageEvent) -> str:
+        """Handle /sessions [list|view|resume|rename|delete|stats] in gateway chats."""
+        if not self._session_db:
+            return "Session database not available."
+
+        import shlex
+
+        try:
+            parts = shlex.split(event.text or "/sessions")
+        except ValueError as e:
+            return f"Could not parse /sessions command: {e}"
+
+        subcommand = parts[1].lower() if len(parts) > 1 else "list"
+        if subcommand not in {"list", "view", "resume", "rename", "delete", "stats"}:
+            return "Usage: `/sessions [list|view|resume|rename|delete|stats]`"
+
+        source = event.source
+        platform_name = source.platform.value if source.platform else None
+        user_id = source.user_id
+        current_entry = self.session_store.get_or_create_session(source)
+
+        if subcommand == "list":
+            limit = 10
+            if len(parts) > 2:
+                try:
+                    limit = max(1, int(parts[2]))
+                except ValueError:
+                    return "Usage: `/sessions list [limit]`"
+            sessions = self._list_gateway_historical_sessions(source, limit=limit)
+            sessions = [s for s in sessions if s.get("id") != current_entry.session_id]
+            if not sessions:
+                return "No historical sessions found for this chat yet."
+            lines = ["📚 **Historical Sessions**", ""]
+            for session in sessions:
+                title = session.get("title") or session["id"]
+                preview = session.get("preview") or ""
+                preview_part = f" — _{preview}_" if preview else ""
+                lines.append(f"• **{title}** `{session['id']}`{preview_part}")
+            lines.append("\nUse `/sessions view <session>` for details or `/sessions resume <session>` to switch.")
+            return "\n".join(lines)
+
+        if subcommand == "stats":
+            sessions = self._session_db.search_sessions(source=platform_name, limit=100000)
+            scoped = [s for s in sessions if s.get("user_id") == user_id]
+            message_count = sum((s.get("message_count") or 0) for s in scoped)
+            return (
+                "📊 **Session Stats**\n"
+                f"Sessions: **{len(scoped)}**\n"
+                f"Messages: **{message_count}**"
+            )
+
+        if subcommand == "resume":
+            target = " ".join(parts[2:]).strip()
+            if target:
+                resume_event = MessageEvent(
+                    text=f"/resume {target}",
+                    source=event.source,
+                    message_type=event.message_type,
+                    raw_message=event.raw_message,
+                    message_id=event.message_id,
+                    media_urls=list(event.media_urls),
+                    media_types=list(event.media_types),
+                    reply_to_message_id=event.reply_to_message_id,
+                    reply_to_text=event.reply_to_text,
+                    auto_skill=event.auto_skill,
+                    internal=event.internal,
+                    timestamp=event.timestamp,
+                )
+            else:
+                resume_event = MessageEvent(
+                    text="/resume",
+                    source=event.source,
+                    message_type=event.message_type,
+                    raw_message=event.raw_message,
+                    message_id=event.message_id,
+                    media_urls=list(event.media_urls),
+                    media_types=list(event.media_types),
+                    reply_to_message_id=event.reply_to_message_id,
+                    reply_to_text=event.reply_to_text,
+                    auto_skill=event.auto_skill,
+                    internal=event.internal,
+                    timestamp=event.timestamp,
+                )
+            return await self._handle_resume_command(resume_event)
+
+        if len(parts) < 3:
+            return (
+                f"Usage: `/sessions {subcommand} <session id|prefix|title>`"
+                + (" `<new title>`" if subcommand == "rename" else "")
+            )
+
+        target = parts[2].strip()
+        resolved = self._resolve_scoped_gateway_session_target(source, target)
+        if not resolved:
+            return f"Session not found: `{target}`"
+
+        if subcommand == "view":
+            session_meta = self._session_db.get_session(resolved) or {}
+            messages = self._session_db.get_messages_as_conversation(resolved)
+            entries = self._session_preview_entries(messages)
+            title = session_meta.get("title") or resolved
+            lines = [
+                "📄 **Session Details**",
+                f"**Session ID:** `{resolved}`",
+                f"**Title:** {title}",
+                f"**Messages:** {session_meta.get('message_count', 0)}",
+            ]
+            if entries:
+                lines.append("")
+                lines.append("**Preview:**")
+                for role, text in entries:
+                    speaker = "You" if role == "user" else "Hermes"
+                    lines.append(f"• **{speaker}:** {text}")
+            return "\n".join(lines)
+
+        if resolved == current_entry.session_id:
+            if subcommand == "rename":
+                return "That is the active session — use `/title <new name>` instead."
+            if subcommand == "delete":
+                return "Refusing to delete the active session. Switch away first with `/resume` or `/new`."
+
+        if subcommand == "rename":
+            if len(parts) < 4:
+                return "Usage: `/sessions rename <session id|prefix|title> <new title>`"
+            new_title = " ".join(parts[3:]).strip()
+            try:
+                if self._session_db.set_session_title(resolved, new_title):
+                    return f"Renamed session `{resolved}` to **{new_title}**."
+                return f"Session not found: `{target}`"
+            except ValueError as e:
+                return f"Error: {e}"
+
+        if subcommand == "delete":
+            if "--yes" not in parts[3:]:
+                return "Refusing to delete without confirmation. Re-run with `/sessions delete <session> --yes`."
+            if self._session_db.delete_session(resolved):
+                return f"Deleted session `{resolved}`."
+            return f"Session not found: `{target}`"
+
+        return "Usage: `/sessions [list|view|resume|rename|delete|stats]`"
+
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — switch to a previously-named session."""
         if not self._session_db:
@@ -5612,10 +5846,7 @@ class GatewayRunner:
         if not name:
             # List recent titled sessions for this user/platform
             try:
-                user_source = source.platform.value if source.platform else None
-                sessions = self._session_db.list_sessions_rich(
-                    source=user_source, limit=10
-                )
+                sessions = self._list_gateway_historical_sessions(source, limit=10)
                 titled = [s for s in sessions if s.get("title")]
                 if not titled:
                     return (
@@ -5635,8 +5866,8 @@ class GatewayRunner:
                 logger.debug("Failed to list titled sessions: %s", e)
                 return f"Could not list sessions: {e}"
 
-        # Resolve the name to a session ID
-        target_id = self._session_db.resolve_session_by_title(name)
+        # Resolve the name to a session ID inside this sender's scope
+        target_id = self._resolve_scoped_gateway_session_target(source, name)
         if not target_id:
             return (
                 f"No session found matching '**{name}**'.\n"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -89,6 +89,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("sessions", "View and manage historical sessions", "Session",
+               args_hint="[list|view|resume|rename|delete|stats]",
+               subcommands=("list", "view", "resume", "rename", "delete", "stats")),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -529,16 +529,44 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
+    @staticmethod
+    def _session_scope_sql(source: str = None, user_id: str = None) -> tuple[str, list[Any]]:
+        """Build reusable SQL fragments for optional session scoping."""
+        clauses = []
+        params: list[Any] = []
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+        if user_id is not None:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+        return (" AND ".join(clauses), params)
+
+    def resolve_session_id(
+        self,
+        session_id_or_prefix: str,
+        source: str = None,
+        user_id: str = None,
+    ) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 
-        Returns the exact ID when it exists. Otherwise treats the input as a
-        prefix and returns the single matching session ID if the prefix is
-        unambiguous. Returns None for no matches or ambiguous prefixes.
+        Optional ``source``/``user_id`` filters scope the lookup to a subset of
+        sessions. Returns the exact ID when it exists inside the scope.
+        Otherwise treats the input as a prefix and returns the single matching
+        session ID if the prefix is unambiguous. Returns None for no matches or
+        ambiguous prefixes.
         """
-        exact = self.get_session(session_id_or_prefix)
-        if exact:
-            return exact["id"]
+        scope_sql, scope_params = self._session_scope_sql(source=source, user_id=user_id)
+        query = "SELECT id FROM sessions WHERE id = ?"
+        params: list[Any] = [session_id_or_prefix]
+        if scope_sql:
+            query += f" AND {scope_sql}"
+            params.extend(scope_params)
+        with self._lock:
+            cursor = self._conn.execute(query, params)
+            row = cursor.fetchone()
+        if row:
+            return row["id"]
 
         escaped = (
             session_id_or_prefix
@@ -546,11 +574,14 @@ class SessionDB:
             .replace("%", "\\%")
             .replace("_", "\\_")
         )
+        query = "SELECT id FROM sessions WHERE id LIKE ? ESCAPE '\\'"
+        params = [f"{escaped}%"]
+        if scope_sql:
+            query += f" AND {scope_sql}"
+            params.extend(scope_params)
+        query += " ORDER BY started_at DESC LIMIT 2"
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id FROM sessions WHERE id LIKE ? ESCAPE '\\' ORDER BY started_at DESC LIMIT 2",
-                (f"{escaped}%",),
-            )
+            cursor = self._conn.execute(query, params)
             matches = [row["id"] for row in cursor.fetchall()]
         if len(matches) == 1:
             return matches[0]
@@ -641,35 +672,56 @@ class SessionDB:
             row = cursor.fetchone()
         return row["title"] if row else None
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(
+        self,
+        title: str,
+        source: str = None,
+        user_id: str = None,
+    ) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
+        scope_sql, scope_params = self._session_scope_sql(source=source, user_id=user_id)
+        query = "SELECT * FROM sessions WHERE title = ?"
+        params: list[Any] = [title]
+        if scope_sql:
+            query += f" AND {scope_sql}"
+            params.extend(scope_params)
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
-            )
+            cursor = self._conn.execute(query, params)
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self,
+        title: str,
+        source: str = None,
+        user_id: str = None,
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
         If not, searches for "title #N" variants and returns the latest one.
         If the exact title exists AND numbered variants exist, returns the
         latest numbered variant (the most recent continuation).
+        Optional ``source``/``user_id`` filters scope the lookup.
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, source=source, user_id=user_id)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        scope_sql, scope_params = self._session_scope_sql(source=source, user_id=user_id)
+        query = (
+            "SELECT id, title, started_at FROM sessions "
+            "WHERE title LIKE ? ESCAPE '\\'"
+        )
+        params: list[Any] = [f"{escaped} #%"]
+        if scope_sql:
+            query += f" AND {scope_sql}"
+            params.extend(scope_params)
+        query += " ORDER BY started_at DESC"
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
-            )
+            cursor = self._conn.execute(query, params)
             numbered = cursor.fetchall()
 
         if numbered:
@@ -721,6 +773,7 @@ class SessionDB:
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
+        user_id: str = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -742,6 +795,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if user_id is not None:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")

--- a/tests/cli/test_sessions_command.py
+++ b/tests/cli/test_sessions_command.py
@@ -1,0 +1,103 @@
+from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+from hermes_state import SessionDB
+from tests.cli.test_cli_init import _make_cli
+
+
+def _seed_session(db: SessionDB, session_id: str, *, title: str | None = None, user_message: str | None = None):
+    db.create_session(session_id=session_id, source="cli")
+    if title:
+        db.set_session_title(session_id, title)
+    if user_message:
+        db.append_message(session_id, role="user", content=user_message)
+        db.append_message(session_id, role="assistant", content=f"Reply to {user_message}")
+
+
+def test_sessions_command_is_registered_for_cli_and_gateway():
+    command = resolve_command("/sessions")
+    assert command is not None
+    assert command.name == "sessions"
+    assert "sessions" in GATEWAY_KNOWN_COMMANDS
+
+
+def test_sessions_list_shows_historical_sessions(capsys, tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _seed_session(db, "current", title="Current Session", user_message="current preview")
+        _seed_session(db, "old_cli_001", title="Old Session", user_message="hello from the past")
+
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = db
+
+        cli.process_command("/sessions")
+        output = capsys.readouterr().out
+
+        assert "Old Session" in output
+        assert "old_cli_001" in output
+        assert "Current Session" not in output
+    finally:
+        db.close()
+
+
+def test_sessions_view_accepts_unique_id_prefix(capsys, tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _seed_session(
+            db,
+            "20260411_010101_abcd12",
+            title="Deep Work",
+            user_message="show me the transcript preview",
+        )
+
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = db
+
+        cli.process_command("/sessions view 20260411_010101_abcd")
+        output = capsys.readouterr().out
+
+        assert "Deep Work" in output
+        assert "20260411_010101_abcd12" in output
+        assert "show me the transcript preview" in output
+    finally:
+        db.close()
+
+
+def test_sessions_rename_updates_historical_session_title(capsys, tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _seed_session(db, "current", title="Current Session", user_message="current preview")
+        _seed_session(db, "old_cli_001", title="Old Session", user_message="old preview")
+
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = db
+
+        cli.process_command("/sessions rename old_cli_001 Renamed Session")
+        _ = capsys.readouterr().out
+
+        assert db.get_session_title("old_cli_001") == "Renamed Session"
+    finally:
+        db.close()
+
+
+def test_sessions_delete_requires_yes_then_deletes(capsys, tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _seed_session(db, "current", title="Current Session", user_message="current preview")
+        _seed_session(db, "old_cli_001", title="Old Session", user_message="old preview")
+
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = db
+
+        cli.process_command("/sessions delete old_cli_001")
+        output = capsys.readouterr().out
+        assert "--yes" in output
+        assert db.get_session("old_cli_001") is not None
+
+        cli.process_command("/sessions delete old_cli_001 --yes")
+        _ = capsys.readouterr().out
+        assert db.get_session("old_cli_001") is None
+    finally:
+        db.close()

--- a/tests/gateway/test_sessions_command.py
+++ b/tests/gateway/test_sessions_command.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, build_session_key
+from hermes_state import SessionDB
+
+
+def _make_event(text="/sessions", platform=Platform.TELEGRAM, user_id="alice", chat_id="chat-1"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        user_name=user_id,
+        chat_id=chat_id,
+        chat_type="dm",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(session_db=None, current_session_id="current_session_001", event=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = session_db
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    runner._evict_cached_agent = MagicMock()
+    runner._async_flush_memories = AsyncMock()
+
+    session_key = build_session_key(event.source) if event else "agent:main:telegram:dm"
+    mock_session_entry = MagicMock()
+    mock_session_entry.session_id = current_session_id
+    mock_session_entry.session_key = session_key
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = mock_session_entry
+    mock_store.load_transcript.return_value = []
+    mock_store.switch_session.return_value = mock_session_entry
+    runner.session_store = mock_store
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_only_shows_current_users_sessions(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("alice_history_001", "telegram", user_id="alice")
+        db.set_session_title("alice_history_001", "Alice History")
+        db.append_message("alice_history_001", role="user", content="alice transcript")
+
+        db.create_session("bob_history_001", "telegram", user_id="bob")
+        db.set_session_title("bob_history_001", "Bob History")
+        db.append_message("bob_history_001", role="user", content="bob transcript")
+
+        event = _make_event(text="/sessions", user_id="alice")
+        runner = _make_runner(session_db=db, event=event)
+
+        result = await runner._handle_sessions_command(event)
+
+        assert "Alice History" in result
+        assert "Bob History" not in result
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_sessions_view_rejects_other_users_session_id(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("bob_history_001", "telegram", user_id="bob")
+        db.set_session_title("bob_history_001", "Bob History")
+        db.append_message("bob_history_001", role="user", content="bob transcript")
+
+        event = _make_event(text="/sessions view bob_history_001", user_id="alice")
+        runner = _make_runner(session_db=db, event=event)
+
+        result = await runner._handle_sessions_command(event)
+
+        assert "not found" in result.lower()
+        assert "Bob History" not in result
+    finally:
+        db.close()

--- a/tests/test_hermes_state_sessions_scope.py
+++ b/tests/test_hermes_state_sessions_scope.py
@@ -1,0 +1,38 @@
+from hermes_state import SessionDB
+
+
+def test_list_sessions_rich_can_scope_by_source_and_user_id(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("alice_tg", "telegram", user_id="alice")
+        db.set_session_title("alice_tg", "Alice Telegram")
+        db.create_session("alice_cli", "cli", user_id="alice")
+        db.set_session_title("alice_cli", "Alice CLI")
+        db.create_session("bob_tg", "telegram", user_id="bob")
+        db.set_session_title("bob_tg", "Bob Telegram")
+
+        sessions = db.list_sessions_rich(source="telegram", user_id="alice", limit=20)
+        ids = [session["id"] for session in sessions]
+
+        assert ids == ["alice_tg"]
+    finally:
+        db.close()
+
+
+def test_resolve_session_id_and_title_respect_scope(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("alice_secret_001", "telegram", user_id="alice")
+        db.set_session_title("alice_secret_001", "Alice Secret")
+
+        db.create_session("bob_secret_001", "telegram", user_id="bob")
+        db.set_session_title("bob_secret_001", "Bob Secret")
+
+        assert db.resolve_session_id("bob_secret_001", source="telegram", user_id="alice") is None
+        assert db.resolve_session_id("bob_secret", source="telegram", user_id="alice") is None
+        assert db.resolve_session_by_title("Bob Secret", source="telegram", user_id="alice") is None
+
+        assert db.resolve_session_id("bob_secret", source="telegram", user_id="bob") == "bob_secret_001"
+        assert db.resolve_session_by_title("Bob Secret", source="telegram", user_id="bob") == "bob_secret_001"
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add a built-in `/sessions` management command for internal Hermes conversations in both CLI and gateway chats
- support `list`, `view`, `resume`, `rename`, `delete`, and `stats` actions from inside the chat experience
- scope gateway session browsing to the current platform/user while preserving legacy fallback behavior for older records
- add regression coverage for command registration, CLI flows, gateway scoping, and session filtering

## Motivation
Managing internal sessions previously required dropping out to separate workflows or manual browsing. This change makes common session management tasks available directly inside Hermes, which is especially helpful for reviewing, resuming, renaming, and cleaning up prior conversations without leaving the current interface.

## Attribution
- I proposed the feature idea and intended workflow
- Hermes edited the code, ran verification, and submitted this PR on my behalf

## Test Plan
- `pytest -q tests/hermes_cli/test_commands.py tests/gateway/test_resume_command.py tests/gateway/test_sessions_command.py tests/cli/test_cli_init.py tests/cli/test_sessions_command.py tests/hermes_cli/test_sessions_delete.py tests/test_hermes_state.py tests/test_hermes_state_sessions_scope.py`
- Local targeted test run result: `289 passed`
