### PR TITLE
security(approval): close launchctl / hermes CLI self-termination gaps

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -580,6 +580,86 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    # --- macOS launchctl self-termination ----------------------------------
+    # `launchctl kickstart -k` sends SIGTERM to the target service. If the
+    # agent targets its own gateway service, launchd KeepAlive respawns the
+    # gateway, the resumed session sees the pending (uncompleted) tool call,
+    # and the model retries the same command — producing an infinite self-kill
+    # loop. See the 2026-04-11 ade profile incident.
+
+    def test_launchctl_kickstart_detected(self):
+        cmd = "launchctl kickstart -k gui/501/ai.hermes.gateway-ade"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "launchctl" in desc.lower()
+
+    def test_launchctl_kickstart_with_id_expansion_detected(self):
+        """The real-world form uses $(id -u) rather than a literal uid."""
+        cmd = "launchctl kickstart -k gui/$(id -u)/ai.hermes.gateway-ade"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_kill_detected(self):
+        cmd = "launchctl kill SIGTERM gui/501/ai.hermes.gateway-ade"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_bootout_detected(self):
+        cmd = "launchctl bootout gui/501/ai.hermes.gateway-ade"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_unload_hermes_detected(self):
+        cmd = "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway-ade.plist"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "hermes" in desc.lower()
+
+    def test_launchctl_list_not_flagged(self):
+        """Inspection-only launchctl subcommands must remain allowed."""
+        cmd = "launchctl list | grep ai.hermes.gateway-ade"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_launchctl_print_not_flagged(self):
+        cmd = "launchctl print gui/501"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # --- hermes CLI self-termination ---------------------------------------
+    # `hermes gateway restart/stop/kill` from inside the gateway triggers the
+    # same class of self-kill loop on any platform. Upstream commit a55c044c
+    # also detects this at the CLI layer and routes to SIGUSR1 graceful
+    # restart, but defense-in-depth at the approval layer is still valuable
+    # for the raw `hermes ... gateway restart` pattern in agent tool calls.
+
+    def test_hermes_gateway_restart_detected(self):
+        cmd = "hermes -p ade gateway restart"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "hermes" in desc.lower()
+
+    def test_hermes_gateway_stop_detected(self):
+        cmd = "hermes gateway stop"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_hermes_gateway_kill_detected(self):
+        cmd = "hermes -p cocoa gateway kill"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_hermes_gateway_start_not_flagged(self):
+        """`hermes gateway start` is safe — starting a non-running gateway."""
+        cmd = "hermes gateway start"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_hermes_gateway_status_not_flagged(self):
+        cmd = "hermes gateway status"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
 
 class TestNormalizationBypass:
     """Obfuscation techniques must not bypass dangerous command detection."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -105,6 +105,12 @@ DANGEROUS_PATTERNS = [
     # to regex at detection time. Catch the structural pattern instead.
     (r'\bkill\b.*\$\(\s*pgrep\b', "kill process via pgrep expansion (self-termination)"),
     (r'\bkill\b.*`\s*pgrep\b', "kill process via backtick pgrep expansion (self-termination)"),
+    # macOS launchctl self-termination: kickstart -k SIGTERMs the service,
+    # KeepAlive respawns it, resumed session retries the same call → infinite loop
+    (r'\blaunchctl\s+(kickstart|kill|bootout|bootstrap)\b', "macOS launchctl service control (self-termination risk)"),
+    (r'\blaunchctl\s+(load|unload)\b.*hermes', "launchctl manipulate hermes service"),
+    # hermes CLI gateway control from inside the agent → same self-termination risk
+    (r'\bhermes\b.*\bgateway\s+(restart|stop|kill)\b', "hermes CLI gateway control (self-termination risk)"),
     # File copy/move/edit into sensitive system paths
     (r'\b(cp|mv|install)\b.*\s/etc/', "copy/move file into /etc/"),
     (r'\bsed\s+-[^\s]*i.*\s/etc/', "in-place edit of system config"),


### PR DESCRIPTION
Three additional `DANGEROUS_PATTERNS` entries closing self-termination vectors
not covered by the existing `pkill/killall` name-based pattern or the
`pgrep`-expansion patterns from #aedf6c79.

### What

1. **macOS `launchctl` service control** — `launchctl kickstart -k <target>`
   sends SIGTERM to the target service. If the agent targets its own gateway
   service, `launchd` KeepAlive (`SuccessfulExit: false`) respawns the process,
   the resumed session sees a pending tool call with exit 130, and the model
   retries the same command. Result: infinite self-kill loop.

   Covers `launchctl kickstart`, `kill`, `bootout`, `bootstrap`, plus
   `launchctl load/unload` when the argument references a hermes service.

2. **`hermes` CLI gateway control** — `hermes -p <profile> gateway
   restart/stop/kill` is the same class of self-termination when invoked
   from inside the gateway.

   Note: #a55c044c already addresses this at the CLI layer by detecting
   gateway ancestry and routing `hermes gateway restart` to a SIGUSR1 graceful
   restart. This PR adds defense-in-depth at the approval layer so that:

   - The raw pattern is flagged before it reaches the CLI path
   - `stop`/`kill` subcommands (which the CLI path doesn't turn into
     graceful restart) are also caught

### Why — motivating incident

On 2026-04-11, an `ade` profile agent on macOS added a new Discord slash
command and included this step in its todo plan:

```
Restart ade Discord gateway so slash commands resync
```

The agent then executed:

```bash
launchctl kickstart -k gui/$(id -u)/ai.hermes.gateway-ade
```

`launchctl` sent SIGTERM to the running gateway. launchd respawned the gateway
(`KeepAlive.SuccessfulExit = false`). The new gateway loaded the session from
SQLite, saw the pending launchctl tool call with exit 130, and the codex model
decided to retry — reasoning (not unreasonably) that the command had been
interrupted and should be tried again.

This ran in a tight loop for ~14 hours. Each human message that arrived during
the loop was persisted into the session, giving the resumed model additional
context, but the model consistently returned to the same todo step and ran the
same command. The existing `DANGEROUS_PATTERNS` did not catch `launchctl
kickstart` (not a `pkill`/`killall`) or `hermes gateway restart` (doesn't
match the `hermes|gateway|cli.py` name-in-body pattern in a `pkill/killall`
context).

The incident is a cousin of the one that motivated #aedf6c79 —
same "self-termination" category, different primitive.

### Why not `systemctl`

`systemctl --user restart hermes-gateway` is intentionally **not** added to
`DANGEROUS_PATTERNS`. The existing test `test_systemctl_restart_not_flagged`
treats it as the supported Linux restart path, and #a55c044c already handles
self-invocation via SIGUSR1 at the CLI layer for `systemctl`. Adding a
`DANGEROUS_PATTERNS` entry would require removing that test, which would be
a behavior change rather than a pure gap fix.

If maintainers disagree and would prefer `systemctl restart hermes-*` to be
flagged symmetric with `launchctl`, I'm happy to add the pattern + update the
existing test in a follow-up commit.

### Tests

12 new cases in `TestGatewayProtection`, following the same positive + negative
pattern as `TestPgrepKillExpansion`:

- 7 launchctl cases: `kickstart`, `kickstart` with `$(id -u)`, `kill`,
  `bootout`, `unload+hermes`, `list` (negative), `print` (negative)
- 5 hermes-CLI cases: `restart`, `stop`, `kill`, `start` (negative),
  `status` (negative)

Full suite: `131 passed, 0 failed` (119 before → 131 after).

### Checklist

- [x] `pytest tests/tools/test_approval.py` passes
- [x] No changes to existing tests or patterns
- [x] Commit message follows #aedf6c79 format
- [x] Real-world incident referenced with concrete command
- [x] Defense-in-depth rationale explained (does not duplicate #a55c044c)
