### PR TITLE
fix: sanitize hyphenated session-search FTS queries

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,7 +26,6 @@ from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
-
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
@@ -968,10 +967,19 @@ class SessionDB:
         sanitized = re.sub(r"\*+", "*", sanitized)
         sanitized = re.sub(r"(^|\s)\*", r"\1", sanitized)
 
-        # Step 4: Remove dangling boolean operators at start/end that would
-        # cause syntax errors (e.g. "hello AND" or "OR world")
+        # Step 4: Remove dangling or duplicated boolean operators that would
+        # cause syntax errors (e.g. "hello AND", "OR world", "a AND OR b")
         sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
         sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
+        while True:
+            collapsed = re.sub(
+                r"(?i)\b(?:AND|OR|NOT)\b\s+\b(?:AND|OR|NOT)\b",
+                lambda m: m.group(0).split()[-1],
+                sanitized,
+            )
+            if collapsed == sanitized:
+                break
+            sanitized = collapsed
 
         # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
         # quotes.  FTS5's tokenizer splits on dots and hyphens, turning

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2,7 +2,6 @@
 
 import time
 import pytest
-from pathlib import Path
 
 from hermes_state import SessionDB
 
@@ -390,6 +389,17 @@ class TestFTS5Search:
         assert isinstance(results2, list)
         assert len(results2) >= 1
 
+    def test_search_broad_or_query_with_hyphenated_term_still_runs(self, db):
+        broad_query = "错题本 OR 错题 OR wrong-book OR mistakes"
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="We built a wrong-book review workflow for mistakes.")
+
+        results = db.search_messages(broad_query)
+
+        assert isinstance(results, list)
+        assert len(results) >= 1
+        assert any(r["session_id"] == "s1" for r in results)
+
     def test_search_quoted_phrase_preserved(self, db):
         """User-provided quoted phrases should be preserved for exact matching."""
         db.create_session(session_id="s1", source="cli")
@@ -456,6 +466,10 @@ class TestFTS5Search:
         assert s('"chat-send"') == '"chat-send"'
         # Hyphenated inside a quoted phrase stays as-is
         assert s('"my chat-send thing"') == '"my chat-send thing"'
+        # Non-word hyphenated tokens must not be left bare, or FTS parses them as column filters
+        assert s('wrong-book') == '"wrong-book"'
+        result = s('错题本 OR 错题 OR wrong-book OR mistakes')
+        assert '"wrong-book"' in result
 
     def test_sanitize_fts5_quotes_dotted_terms(self):
         """Dotted terms should be wrapped in quotes to avoid FTS5 query parse edge cases."""


### PR DESCRIPTION
## Summary
Fix a session-search FTS edge case where a broad OR query can fail if one of the search terms is hyphenated.

## Linked issue
Closes #7824

## Problem
A query such as:
- `错题本 OR 错题 OR wrong-book OR mistakes`

can fail in SQLite FTS5 with:
- `sqlite3.OperationalError: no such column: book`

because a bare hyphenated token like `wrong-book` may be interpreted as a column-filter expression instead of a normal term.

## Fix
Keep the change narrow in the FTS sanitization path:
- collapse duplicated boolean operators that may remain after sanitization
- quote dotted/hyphenated tokens so FTS5 treats them as phrases during MATCH execution

## Why this scope
This PR intentionally stays at the query sanitization layer and adds only regression coverage for the reported failure mode. It does not add tool-layer retry/fallback behavior or unrelated search semantics changes.

## Verification
- `pytest -q tests/test_hermes_state.py::TestFTS5Search`
