### PR TITLE
fix(mcp): honor explicit include filters in MCP tool enable/disable flow

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -416,7 +416,7 @@ def cmd_mcp_list(args=None):
         if isinstance(tools_cfg, dict):
             include = tools_cfg.get("include")
             exclude = tools_cfg.get("exclude")
-            if include and isinstance(include, list):
+            if "include" in tools_cfg and isinstance(include, list):
                 tools_str = f"{len(include)} selected"
             elif exclude and isinstance(exclude, list):
                 tools_str = f"-{len(exclude)} excluded"
@@ -552,7 +552,7 @@ def cmd_mcp_configure(args):
 
     tool_names = [t[0] for t in all_tools]
 
-    if include and isinstance(include, list):
+    if isinstance(tools_cfg, dict) and "include" in tools_cfg and isinstance(include, list):
         include_set = set(include)
         pre_selected = {
             i for i, tn in enumerate(tool_names) if tn in include_set

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1610,8 +1610,9 @@ def _configure_mcp_tools_interactive(config: dict):
 
         srv_cfg = mcp_servers.get(server_name, {})
         tools_cfg = srv_cfg.get("tools") or {}
-        include_list = tools_cfg.get("include") or []
-        exclude_list = tools_cfg.get("exclude") or []
+        has_include_filter = "include" in tools_cfg
+        include_list = list(tools_cfg.get("include") or [])
+        exclude_list = list(tools_cfg.get("exclude") or [])
 
         # Build checklist labels
         labels = []
@@ -1626,7 +1627,7 @@ def _configure_mcp_tools_interactive(config: dict):
         pre_selected: Set[int] = set()
         tool_names = [t[0] for t in tools]
         for i, tool_name in enumerate(tool_names):
-            if include_list:
+            if has_include_filter:
                 # Include mode: only included tools are selected
                 if tool_name in include_list:
                     pre_selected.add(i)
@@ -1694,7 +1695,7 @@ def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str],
 
 
 def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:
-    """Add or remove specific MCP tools from a server's exclude list.
+    """Add or remove specific MCP tool filters for configured servers.
 
     Returns the set of server names that were not found in config.
     """
@@ -1707,13 +1708,24 @@ def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]
             failed_servers.add(server_name)
             continue
         tools_cfg = mcp_servers[server_name].setdefault("tools", {})
-        exclude = list(tools_cfg.get("exclude") or [])
-        if action == "disable":
-            if tool_name not in exclude:
-                exclude.append(tool_name)
+        has_include_filter = "include" in tools_cfg
+
+        if has_include_filter:
+            include = list(tools_cfg.get("include") or [])
+            if action == "disable":
+                include = [t for t in include if t != tool_name]
+            elif tool_name not in include:
+                include.append(tool_name)
+            tools_cfg["include"] = include
+            tools_cfg.pop("exclude", None)
         else:
-            exclude = [t for t in exclude if t != tool_name]
-        tools_cfg["exclude"] = exclude
+            exclude = list(tools_cfg.get("exclude") or [])
+            if action == "disable":
+                if tool_name not in exclude:
+                    exclude.append(tool_name)
+            else:
+                exclude = [t for t in exclude if t != tool_name]
+            tools_cfg["exclude"] = exclude
 
     return failed_servers
 
@@ -1746,10 +1758,11 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
         print("MCP servers:")
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
-            exclude = tools_cfg.get("exclude") or []
-            include = tools_cfg.get("include") or []
-            if include:
-                _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
+            exclude = list(tools_cfg.get("exclude") or [])
+            include = list(tools_cfg.get("include") or [])
+            if "include" in tools_cfg:
+                summary = ", ".join(include) if include else "none"
+                _print_info(f"{srv_name}  [include only: {summary}]")
             elif exclude:
                 _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
             else:

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -95,6 +95,22 @@ class TestToolsDisableMcp:
         out = capsys.readouterr().out
         assert "MCP server 'unknown' not found in config" in out
 
+    def test_disable_updates_existing_include_filter(self):
+        config = {
+            "mcp_servers": {
+                "github": {"tools": {"include": ["create_issue", "delete_branch"]}}
+            }
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        tools_cfg = saved["mcp_servers"]["github"]["tools"]
+        assert tools_cfg["include"] == ["delete_branch"]
+        assert "exclude" not in tools_cfg
+
 
 # ── MCP tool enable ──────────────────────────────────────────────────────────
 
@@ -111,6 +127,18 @@ class TestToolsEnableMcp:
         saved = mock_save.call_args[0][0]
         assert "create_issue" not in saved["mcp_servers"]["github"]["tools"]["exclude"]
         assert "delete_branch" in saved["mcp_servers"]["github"]["tools"]["exclude"]
+
+    def test_enable_updates_existing_include_filter(self):
+        config = {"mcp_servers": {"github": {"tools": {"include": ["delete_branch"]}}}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["github:create_issue"], platform="cli")
+            )
+        saved = mock_save.call_args[0][0]
+        tools_cfg = saved["mcp_servers"]["github"]["tools"]
+        assert tools_cfg["include"] == ["delete_branch", "create_issue"]
+        assert "exclude" not in tools_cfg
 
 
 # ── Mixed targets ────────────────────────────────────────────────────────────

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2603,6 +2603,20 @@ class TestMCPSelectiveToolLoading:
         assert registered == ["mcp_ink_no_caps_create_service"]
         assert set(mock_registry.get_all_tool_names()) == {"mcp_ink_no_caps_create_service"}
 
+    def test_empty_include_filter_registers_no_tools(self):
+        config = {
+            "url": "https://mcp.example.com",
+            "tools": {"include": []},
+        }
+        registered, mock_registry = self._run_discover(
+            "ink_empty_include",
+            ["create_service", "delete_service"],
+            config,
+            session=SimpleNamespace(),
+        )
+        assert registered == []
+        assert mock_registry.get_all_tool_names() == []
+
     def test_no_filter_registers_all_server_tools_when_no_utilities_supported(self):
         registered, _ = self._run_discover(
             "ink_no_filter",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1653,16 +1653,20 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
     ]
 
 
-def _normalize_name_filter(value: Any, label: str) -> set[str]:
-    """Normalize include/exclude config to a set of tool names."""
+def _normalize_name_filter(value: Any, label: str) -> Optional[set[str]]:
+    """Normalize include/exclude config to a set of tool names.
+
+    Returns ``None`` when the filter is absent so callers can distinguish
+    "no filter configured" from an explicit empty include list.
+    """
     if value is None:
-        return set()
+        return None
     if isinstance(value, str):
         return {value}
     if isinstance(value, (list, tuple, set)):
         return {str(item) for item in value}
     logger.warning("MCP config %s must be a string or list of strings; ignoring %r", label, value)
-    return set()
+    return None
 
 
 def _parse_boolish(value: Any, default: bool = True) -> bool:
@@ -1759,7 +1763,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     exclude_set = _normalize_name_filter(tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude")
 
     def _should_register(tool_name: str) -> bool:
-        if include_set:
+        if include_set is not None:
             return tool_name in include_set
         if exclude_set:
             return tool_name not in exclude_set


### PR DESCRIPTION
Context

This patch fixes a mismatch between CLI-side MCP tool filtering and runtime tool resolution.

When mcp_servers.<name>.tools.include was in use, hermes tools enable/disable server:tool could update config without the change being applied consistently at runtime. In practice, disabling a tool under include-mode could be ignored, and include=[] could be interpreted as if all tools were enabled.

What was wrong

The issue affected three connected areas:

the CLI enable/disable flow did not always mutate the existing include filter correctly
runtime MCP tool resolution did not consistently treat include=[] as an explicit “enable nothing” state
MCP listing/config UI could misread an empty include filter and present the wrong effective state

That made the behavior of filtered MCP servers ambiguous, especially after toggling tools through the CLI.

What changed

The fix updates the MCP filtering path across:

hermes_cli/tools_config.py
hermes_cli/mcp_config.py
tools/mcp_tool.py

Behavior after this patch:

hermes tools enable/disable server:tool now updates existing include filters correctly
explicit include=[] is now respected at runtime as 0 enabled tools
MCP config/listing flows now interpret an empty include filter correctly
Tests

Added regression coverage in:

tests/hermes_cli/test_tools_disable_enable.py
tests/tools/test_mcp_tool.py

Also validated the surrounding config behavior with:

& .\venv\Scripts\Activate.ps1; python -m pytest tests\hermes_cli\test_tools_disable_enable.py tests\hermes_cli\test_mcp_tools_config.py tests\tools\test_mcp_tool.py -q
& .\venv\Scripts\Activate.ps1; python -m pytest tests\hermes_cli\test_tools_config.py tests\hermes_cli\test_mcp_config.py -q

Results
197 passed
44 passed