### PR TITLE
fix(tools): enforce ID uniqueness in TODO store during replace operations

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -24,6 +24,18 @@ class TestWriteAndRead:
         items[0]["content"] = "MUTATED"
         assert store.read()[0]["content"] == "Task"
 
+    def test_write_deduplicates_duplicate_ids(self):
+        store = TodoStore()
+        result = store.write([
+            {"id": "1", "content": "First version", "status": "pending"},
+            {"id": "2", "content": "Other task", "status": "pending"},
+            {"id": "1", "content": "Latest version", "status": "in_progress"},
+        ])
+        assert result == [
+            {"id": "2", "content": "Other task", "status": "pending"},
+            {"id": "1", "content": "Latest version", "status": "in_progress"},
+        ]
+
 
 class TestHasItems:
     def test_empty_store(self):

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -46,11 +46,11 @@ class TodoStore:
         """
         if not merge:
             # Replace mode: new list entirely
-            self._items = [self._validate(t) for t in todos]
+            self._items = [self._validate(t) for t in self._dedupe_by_id(todos)]
         else:
             # Merge mode: update existing items by id, append new ones
             existing = {item["id"]: item for item in self._items}
-            for t in todos:
+            for t in self._dedupe_by_id(todos):
                 item_id = str(t.get("id", "")).strip()
                 if not item_id:
                     continue  # Can't merge without an id
@@ -142,6 +142,22 @@ class TodoStore:
             status = "pending"
 
         return {"id": item_id, "content": content, "status": status}
+
+    @classmethod
+    def _dedupe_by_id(cls, todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Collapse duplicate ids while preserving the last occurrence and its position."""
+        normalized: List[Optional[Dict[str, Any]]] = []
+        latest_index_by_id: Dict[str, int] = {}
+        for raw_item in todos:
+            item = dict(raw_item)
+            item_id = str(item.get("id", "")).strip() or "?"
+            item["id"] = item_id
+            previous_index = latest_index_by_id.get(item_id)
+            if previous_index is not None:
+                normalized[previous_index] = None
+            latest_index_by_id[item_id] = len(normalized)
+            normalized.append(item)
+        return [item for item in normalized if item is not None]
 
 
 def todo_tool(


### PR DESCRIPTION
## Summary

This fixes a data consistency issue in the todo store where entries with the same `id` could be duplicated during replace operations.

When the same `id` was written multiple times, the store could keep multiple records instead of maintaining a single canonical entry. This made subsequent `merge=True` updates ambiguous and unpredictable.

## Root cause

The write path did not enforce uniqueness on the `id` field in replace mode, allowing duplicate entries to coexist in the store.

## Fix

- deduplicate entries by `id` before writing
- keep the **last occurrence** as the canonical record
- apply this logic in `tools/todo_tool.py` (around line 49)

## Tests

Added regression coverage in:

- `tests/tools/test_todo_tool.py` (around line 27)

## Verification

```bash
python -m pytest tests\tools\test_todo_tool.py tests\tools\test_read_loop_detection.py -q

Result:

47 passed