### PR TITLE
fix(plugins/honcho): honor active HERMES_HOME during config path resolution

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -58,7 +58,7 @@ def resolve_config_path() -> Path:
 
     Resolution order:
       1. $HERMES_HOME/honcho.json      (profile-local, if it exists)
-      2. ~/.hermes/honcho.json          (default profile — shared host blocks live here)
+      2. <Hermes root>/honcho.json    (shared root config for the active deployment)
       3. ~/.honcho/config.json          (global, cross-app interop)
 
     Returns the global path if none exist (for first-time setup writes).
@@ -67,8 +67,11 @@ def resolve_config_path() -> Path:
     if local_path.exists():
         return local_path
 
-    # Default profile's config — host blocks accumulate here via setup/clone
-    default_path = Path.home() / ".hermes" / "honcho.json"
+    # Shared root config: default ~/.hermes for native installs, but a custom
+    # deployment root (including Docker/profile roots) when HERMES_HOME lives
+    # outside ~/.hermes. This avoids leaking host-user Honcho config into an
+    # isolated Hermes instance.
+    default_path = get_default_hermes_root() / "honcho.json"
     if default_path != local_path and default_path.exists():
         return default_path
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -342,6 +342,35 @@ class TestResolveConfigPath:
         assert config.api_key == "local-key"
         assert config.workspace_id == "local-ws"
 
+    def test_custom_hermes_root_does_not_fallback_to_native_default_profile(self, tmp_path):
+        """Custom HERMES_HOME deployments must stay isolated from ~/.hermes/honcho.json."""
+        fake_home = tmp_path / "fakehome"
+        native_default = fake_home / ".hermes"
+        native_default.mkdir(parents=True)
+        (native_default / "honcho.json").write_text(json.dumps({"apiKey": "native-key"}))
+
+        custom_root = tmp_path / "isolated-root"
+        custom_root.mkdir()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(custom_root)}), \
+             patch.object(Path, "home", return_value=fake_home):
+            result = resolve_config_path()
+
+        assert result == GLOBAL_CONFIG_PATH
+
+    def test_custom_profile_falls_back_to_custom_root_config(self, tmp_path):
+        """Profiles under a custom root should share that root's honcho.json."""
+        custom_root = tmp_path / "isolated-root"
+        profile_home = custom_root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        root_cfg = custom_root / "honcho.json"
+        root_cfg.write_text(json.dumps({"apiKey": "root-key"}))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(profile_home)}):
+            result = resolve_config_path()
+
+        assert result == root_cfg
+
 
 class TestResolveActiveHost:
     def test_default_returns_hermes(self):


### PR DESCRIPTION
## Summary

This fixes a path resolution issue in the Honcho memory plugin where `resolve_config_path()` would fall back to the host user's `~/.hermes/honcho.json` even when a custom `HERMES_HOME` was in use.

This caused unintended config leakage across environments, especially in isolated deployments or custom-root profiles.

## Problem

The plugin resolved shared Honcho config using:

- `Path.home() / ".hermes"`

This ignored the active Hermes root and could pull configuration from the host environment instead of the intended runtime context.

## Fix

- replaced `Path.home() / ".hermes"` with `get_default_hermes_root()`
- ensures shared Honcho config is resolved relative to the active Hermes root

Applied in:
- `plugins/memory/honcho/client.py` (around line 56)

## Behavior

- custom `HERMES_HOME` no longer inherits host-level `~/.hermes/honcho.json`
- shared Honcho config is now correctly scoped to the active Hermes root
- profile isolation is preserved across different environments

## Tests

Added regression coverage in:

- `tests/honcho_plugin/test_client.py` (around line 345)

Covers:
- custom root does **not** inherit host `~/.hermes/honcho.json`
- custom root correctly resolves shared config within its own root

## Verification

```bash
python -m pytest tests\honcho_plugin\test_client.py -q

56 passed

python -m pytest tests\test_hermes_constants.py -q
6 passed