### PR TITLE
feat(resume): add "expanded" resume display mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1603,7 +1603,8 @@ class HermesCLI:
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
         _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
         self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
-        # resume_display: "full" (show history) | "minimal" (one-liner only)
+        # resume_display: "full" (show recap) | "expanded" (recap + last
+        # assistant response) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
@@ -3036,18 +3037,84 @@ class HermesCLI:
 
         return True
 
+    @staticmethod
+    def _strip_resume_reasoning(text: str) -> str:
+        """Remove hidden reasoning blocks from resume display text."""
+        import re
+
+        cleaned = re.sub(
+            r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
+            "", text, flags=re.DOTALL,
+        )
+        cleaned = re.sub(
+            r"<REASONING_SCRATCHPAD>.*$",
+            "", cleaned, flags=re.DOTALL,
+        )
+        return cleaned.strip()
+
+    def _render_response_panel(self, response: str, title_suffix: str = "") -> None:
+        """Render assistant text in the standard Hermes response panel style."""
+        if not response:
+            return
+
+        try:
+            from hermes_cli.skin_engine import get_active_skin
+            _skin = get_active_skin()
+            label = _skin.get_branding("response_label", "⚕ Hermes")
+            _resp_color = _skin.get_color("response_border", "#CD7F32")
+            _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+        except Exception:
+            label = "⚕ Hermes"
+            _resp_color = "#CD7F32"
+            _resp_text = "#FFF8DC"
+
+        console = ChatConsole() if self._app else self.console
+        console.print(Panel(
+            _rich_text_from_ansi(response),
+            title=f"[{_resp_color} bold]{label}{title_suffix}[/]",
+            title_align="left",
+            border_style=_resp_color,
+            style=_resp_text,
+            box=rich_box.HORIZONTALS,
+            padding=(1, 2),
+        ))
+
+    def _get_last_resume_assistant_response(self) -> str:
+        """Return the latest visible assistant text from the resumed history."""
+        for msg in reversed(self.conversation_history or []):
+            if msg.get("role") != "assistant":
+                continue
+            content = msg.get("content")
+            text = "" if content is None else str(content)
+            text = self._strip_resume_reasoning(text)
+            if text:
+                return text
+        return ""
+
+    def _display_post_resume_context(self):
+        """Show post-resume context according to ``display.resume_display``."""
+        if not self.conversation_history or self.resume_display == "minimal":
+            return
+
+        self._display_resumed_history()
+
+        if self.resume_display != "expanded":
+            return
+
+        last_response = self._get_last_resume_assistant_response()
+        if last_response:
+            self._render_response_panel(last_response, title_suffix=" (previous response)")
+
     def _display_resumed_history(self):
         """Render a compact recap of previous conversation messages.
 
         Uses Rich markup with dim/muted styling so the recap is visually
-        distinct from the active conversation.  Caps the display at the
+        distinct from the active conversation. Caps the display at the
         last ``MAX_DISPLAY_EXCHANGES`` user/assistant exchanges and shows
         an indicator for earlier hidden messages.
         """
         if not self.conversation_history:
             return
-
-        # Check config: resume_display setting
         if self.resume_display == "minimal":
             return
 
@@ -3055,21 +3122,6 @@ class HermesCLI:
         MAX_USER_LEN = 300           # truncate user messages
         MAX_ASST_LEN = 200           # truncate assistant text
         MAX_ASST_LINES = 3           # max lines of assistant text
-
-        def _strip_reasoning(text: str) -> str:
-            """Remove <REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD> blocks
-            from displayed text (reasoning model internal thoughts)."""
-            import re
-            cleaned = re.sub(
-                r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
-                "", text, flags=re.DOTALL,
-            )
-            # Also strip unclosed reasoning tags at the end
-            cleaned = re.sub(
-                r"<REASONING_SCRATCHPAD>.*$",
-                "", cleaned, flags=re.DOTALL,
-            )
-            return cleaned.strip()
 
         # Collect displayable entries (skip system, tool-result messages)
         entries = []  # list of (role, display_text)
@@ -3100,7 +3152,7 @@ class HermesCLI:
 
             elif role == "assistant":
                 text = "" if content is None else str(content)
-                text = _strip_reasoning(text)
+                text = self._strip_resume_reasoning(text)
                 parts = []
                 if text:
                     lines = text.splitlines()
@@ -3111,7 +3163,6 @@ class HermesCLI:
                     parts.append(text)
                 if tool_calls:
                     tc_count = len(tool_calls)
-                    # Extract tool names
                     names = []
                     for tc in tool_calls:
                         fn = tc.get("function", {})
@@ -3124,21 +3175,17 @@ class HermesCLI:
                     noun = "call" if tc_count == 1 else "calls"
                     parts.append(f"[{tc_count} tool {noun}: {names_str}]")
                 if not parts:
-                    # Skip pure-reasoning messages that have no visible output
                     continue
                 entries.append(("assistant", " ".join(parts)))
 
         if not entries:
             return
 
-        # Determine if we need to truncate
         skipped = 0
         if len(entries) > MAX_DISPLAY_EXCHANGES * 2:
             skipped = len(entries) - MAX_DISPLAY_EXCHANGES * 2
             entries = entries[skipped:]
 
-        # Build the display using Rich
-        from rich.panel import Panel
         from rich.text import Text
 
         try:
@@ -3164,7 +3211,6 @@ class HermesCLI:
         for i, (role, text) in enumerate(entries):
             if role == "user":
                 lines.append("  ● You: ", style=f"dim bold {_session_label_c}")
-                # Show first line inline, indent rest
                 msg_lines = text.splitlines()
                 lines.append(msg_lines[0] + "\n", style="dim")
                 for ml in msg_lines[1:]:
@@ -3176,16 +3222,15 @@ class HermesCLI:
                 for ml in msg_lines[1:]:
                     lines.append(f"            {ml}\n", style="dim")
             if i < len(entries) - 1:
-                lines.append("")  # small gap
+                lines.append("")
 
-        panel = Panel(
+        self.console.print(Panel(
             lines,
             title=f"[dim {_session_label_c}]Previous Conversation[/]",
             border_style=f"dim {_session_border_c}",
             padding=(0, 1),
             style=_history_text_c,
-        )
-        self.console.print(panel)
+        ))
 
     def _try_attach_clipboard_image(self) -> bool:
         """Check clipboard for an image and attach it if found.
@@ -4074,6 +4119,7 @@ class HermesCLI:
                 f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
                 f" {len(self.conversation_history)} total)"
             )
+            self._display_post_resume_context()
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 
@@ -7389,18 +7435,6 @@ class HermesCLI:
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")
 
             if response and not response_previewed:
-                # Use skin engine for label/color with fallback
-                try:
-                    from hermes_cli.skin_engine import get_active_skin
-                    _skin = get_active_skin()
-                    label = _skin.get_branding("response_label", "⚕ Hermes")
-                    _resp_color = _skin.get_color("response_border", "#CD7F32")
-                    _resp_text = _skin.get_color("banner_text", "#FFF8DC")
-                except Exception:
-                    label = "⚕ Hermes"
-                    _resp_color = "#CD7F32"
-                    _resp_text = "#FFF8DC"
-
                 is_error_response = result and (result.get("failed") or result.get("partial"))
                 already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
                 if use_streaming_tts and _streaming_box_opened and not is_error_response:
@@ -7412,16 +7446,7 @@ class HermesCLI:
                     # _flush_stream() already closed the box. Skip Rich Panel.
                     pass
                 else:
-                    _chat_console = ChatConsole()
-                    _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
-                        title=f"[{_resp_color} bold]{label}[/]",
-                        title_align="left",
-                        border_style=_resp_color,
-                        style=_resp_text,
-                        box=rich_box.HORIZONTALS,
-                        padding=(1, 2),
-                    ))
+                    self._render_response_panel(response)
 
 
             # Play terminal bell when agent finishes (if enabled).
@@ -7726,7 +7751,7 @@ class HermesCLI:
         # so the user has context before typing their first message.
         if self._resumed:
             if self._preload_resumed_session():
-                self._display_resumed_history()
+                self._display_post_resume_context()
 
         try:
             from hermes_cli.skin_engine import get_active_skin

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -126,6 +126,13 @@ class TestDisplayResumedHistory:
         cli_obj._display_resumed_history()
         return buf.getvalue()
 
+    def _capture_post_resume_display(self, cli_obj):
+        """Run _display_post_resume_context and capture console output."""
+        buf = StringIO()
+        cli_obj.console.file = buf
+        cli_obj._display_post_resume_context()
+        return buf.getvalue()
+
     def test_simple_history_shows_user_and_assistant(self):
         cli = _make_cli()
         cli.conversation_history = _simple_history()
@@ -247,6 +254,31 @@ class TestDisplayResumedHistory:
         output = self._capture_display(cli)
 
         assert "Previous Conversation" in output
+
+    def test_expanded_mode_shows_full_last_assistant_response(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "expanded"}})
+        multi = "\n".join([f"Line {i}" for i in range(20)])
+        cli.conversation_history = [
+            {"role": "user", "content": "Show me lines."},
+            {"role": "assistant", "content": multi},
+        ]
+        output = self._capture_post_resume_display(cli)
+
+        assert "Previous Conversation" in output
+        assert "previous response" in output.lower()
+        assert "Line 0" in output
+        assert "Line 19" in output
+
+    def test_expanded_mode_skips_extra_panel_when_no_visible_assistant_text(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "expanded"}})
+        cli.conversation_history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": None},
+        ]
+        output = self._capture_post_resume_display(cli)
+
+        assert "Previous Conversation" in output
+        assert "previous response" not in output.lower()
 
     def test_assistant_with_no_content_no_tools_skipped(self):
         """Assistant messages with no visible output (e.g. pure reasoning)
@@ -434,6 +466,23 @@ class TestPreloadResumedSession:
         output = buf.getvalue()
         assert "1 user message," in output
         assert "1 user messages" not in output
+
+
+class TestResumeCommandDisplay:
+    """/resume should use the same post-resume display path as startup resume."""
+
+    def test_handle_resume_command_uses_post_resume_context(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "expanded"}})
+        cli.session_id = "current_session"
+        cli._session_db = MagicMock()
+        cli._session_db.get_session.return_value = {"id": "target_session", "title": "Target"}
+        cli._session_db.get_messages_as_conversation.return_value = _simple_history()
+        cli._display_post_resume_context = MagicMock()
+
+        with patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="target_session"):
+            cli._handle_resume_command("/resume target_session")
+
+        cli._display_post_resume_context.assert_called_once()
 
 
 # ── Integration: _init_agent skips when preloaded ────────────────────

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -847,7 +847,7 @@ display:
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
-  resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
+  resume_display: full    # full (compact recap) | expanded (recap + full last assistant response) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -115,12 +115,19 @@ The recap:
 - **Caps** at the last 10 exchanges with a "... N earlier messages ..." indicator
 - Uses **dim styling** to distinguish from the active conversation
 
-To disable the recap and keep the minimal one-liner behavior, set in `~/.hermes/config.yaml`:
+Resume display modes in `~/.hermes/config.yaml`:
 
 ```yaml
 display:
-  resume_display: minimal   # default: full
+  resume_display: full      # compact recap (default)
+  # resume_display: expanded  # recap + full previous assistant response
+  # resume_display: minimal   # one-line resume notice only
 ```
+
+`expanded` is useful when you want both orientation and actionability: you keep
+the recap panel, then Hermes also shows the full last visible assistant response
+in the normal response panel style so you can immediately continue from the last
+answer.
 
 :::tip
 Session IDs follow the format `YYYYMMDD_HHMMSS_<8-char-hex>`, e.g. `20250305_091523_a1b2c3d4`. You can resume by ID or by title — both work with `-c` and `-r`.


### PR DESCRIPTION
## Summary

Adds a new `expanded` resume display mode that shows users the full last assistant response alongside the existing compact recap when resuming a session.

Here's what it looks like:
<img width="708" height="551" alt="Screenshot 2026-04-11 at 12 44 16 PM" src="https://github.com/user-attachments/assets/b407345f-993b-4a43-a453-5c40141c5ed7" />


## Why

When resuming a Hermes CLI session, the compact recap truncates assistant replies. That is enough to remind users what the conversation was about, but often not enough to recover the actual answer or next-step guidance Hermes gave right before the session ended. In practice, this makes resume feel disorienting: users can see that Hermes said something useful, but not the full content they need to continue.

The full text is already present in session storage. This change makes the resume UX surface that information directly, so users can pick up where they left off without replaying the whole session or re-asking for the same guidance.

## What changed

- Introduced `display.resume_display = expanded` as a new mode alongside the existing `minimal` and `full` settings
- `expanded` renders the existing compact recap plus the complete last visible assistant response, giving users both orientation and actionable context
- Unified the post-resume display path so that startup `--resume` and in-session `/resume` now use the same rendering logic
- Preserved existing behavior for `minimal` and `full`, so this is an additive, backward-compatible change

## Testing

- `tests/cli/test_resume_display.py` — 30 passed (covers the new expanded mode and related edge cases)
- `tests/cli/test_cli_init.py` — 26 passed (covers resume initialization behavior)

## Notes

- Default remains `full`
- `expanded` is opt-in via config; no new CLI flag was added in this PR
- This change is intentionally targeted at resume UX: it improves session re-entry without changing how normal responses are displayed
