### PR TITLE
feat(weixin): add compact message splitting mode with config toggle

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1017,6 +1017,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         weixin_group_allowed_users = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "").strip()
         if weixin_group_allowed_users:
             extra["group_allow_from"] = weixin_group_allowed_users
+        weixin_split_multiline = os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES", "").strip()
+        if weixin_split_multiline:
+            extra["split_multiline_messages"] = weixin_split_multiline
         weixin_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
         if weixin_home:
             config.platforms[Platform.WEIXIN].home_channel = HomeChannel(

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -755,23 +755,57 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
     return packed
 
 
-def _split_text_for_weixin_delivery(content: str, max_length: int) -> List[str]:
+def _split_text_for_weixin_delivery(content: str, max_length: int, split_per_line: bool = False) -> List[str]:
     """Split content into sequential Weixin messages.
 
-    Prefer one message per top-level line/markdown unit when the author used
-    explicit line breaks. Oversized units fall back to block-aware packing so
-    long code fences still split safely.
-    """
-    if len(content) <= max_length and "\n" not in content:
-        return [content]
+    *compact* (default): Prefer a single message whenever it fits within the
+    platform limit, even when the author used explicit line breaks. Only fall
+    back to block-aware packing when the formatted payload exceeds
+    ``max_length``.
 
-    chunks: List[str] = []
-    for unit in _split_delivery_units_for_weixin(content):
-        if len(unit) <= max_length:
-            chunks.append(unit)
-            continue
-        chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
+    *per_line*: Legacy behavior — top-level line breaks become separate chat
+    messages; oversized units still use block-aware packing.
+
+    The active mode is controlled via ``config.yaml`` ->
+    ``platforms.weixin.extra.split_multiline_messages`` (``true`` / ``false``)
+    or the env var ``WEIXIN_SPLIT_MULTILINE_MESSAGES``.
+
+    ``true``  → per_line (legacy)
+    ``false`` → compact (default)
+    """
+    if split_per_line:
+        if len(content) <= max_length and "\n" not in content:
+            return [content]
+        chunks: List[str] = []
+        for unit in _split_delivery_units_for_weixin(content):
+            if len(unit) <= max_length:
+                chunks.append(unit)
+                continue
+            chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
+        return chunks or [content]
+
+    # compact (default)
+    if len(content) <= max_length:
+        return [content]
+    chunks = _pack_markdown_blocks_for_weixin(content, max_length)
     return chunks or [content]
+
+
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return default
 
 
 def _extract_text(item_list: List[Dict[str, Any]]) -> str:
@@ -991,6 +1025,10 @@ class WeixinAdapter(BasePlatformAdapter):
             group_allow_from = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "")
         self._allow_from = self._coerce_list(allow_from)
         self._group_allow_from = self._coerce_list(group_allow_from)
+        self._split_multiline_messages = _coerce_bool(
+            extra.get("split_multiline_messages") or os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES"),
+            default=False,
+        )
 
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
@@ -1330,7 +1368,11 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.debug("[%s] getConfig failed for %s: %s", self.name, _safe_id(user_id), exc)
 
     def _split_text(self, content: str) -> List[str]:
-        return _split_text_for_weixin_delivery(content, self.MAX_MESSAGE_LENGTH)
+        return _split_text_for_weixin_delivery(
+            content,
+            self.MAX_MESSAGE_LENGTH,
+            self._split_multiline_messages,
+        )
 
     async def send(
         self,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -62,15 +62,15 @@ class TestWeixinFormatting:
 
 
 class TestWeixinChunking:
-    def test_split_text_sends_top_level_newlines_as_separate_messages(self):
+    def test_split_text_keeps_short_multiline_message_in_single_chunk(self):
         adapter = _make_adapter()
 
         content = adapter.format_message("第一行\n第二行\n第三行")
         chunks = adapter._split_text(content)
 
-        assert chunks == ["第一行", "第二行", "第三行"]
+        assert chunks == ["第一行\n第二行\n第三行"]
 
-    def test_split_text_keeps_indented_followup_with_previous_line(self):
+    def test_split_text_keeps_short_reformatted_table_in_single_chunk(self):
         adapter = _make_adapter()
 
         content = adapter.format_message(
@@ -81,10 +81,7 @@ class TestWeixinChunking:
         )
         chunks = adapter._split_text(content)
 
-        assert chunks == [
-            "- Setting: Timeout\n  Value: 30s",
-            "- Setting: Retries\n  Value: 3",
-        ]
+        assert chunks == ["- Setting: Timeout\n  Value: 30s\n- Setting: Retries\n  Value: 3"]
 
     def test_split_text_keeps_complete_code_block_together_when_possible(self):
         adapter = _make_adapter()
@@ -114,6 +111,23 @@ class TestWeixinChunking:
         assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in chunks)
         assert all(chunk.count("```") >= 2 for chunk in chunks)
 
+    def test_split_text_can_restore_legacy_multiline_splitting_via_config(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "account_id": "acct",
+                    "token": "token",
+                    "split_multiline_messages": True,
+                },
+            )
+        )
+
+        content = adapter.format_message("第一行\n第二行\n第三行")
+        chunks = adapter._split_text(content)
+
+        assert chunks == ["第一行", "第二行", "第三行"]
+
 
 class TestWeixinConfig:
     def test_apply_env_overrides_configures_weixin(self):
@@ -127,6 +141,7 @@ class TestWeixinConfig:
                 "WEIXIN_BASE_URL": "https://ilink.example.com/",
                 "WEIXIN_CDN_BASE_URL": "https://cdn.example.com/c2c/",
                 "WEIXIN_DM_POLICY": "allowlist",
+                "WEIXIN_SPLIT_MULTILINE_MESSAGES": "true",
                 "WEIXIN_ALLOWED_USERS": "wxid_1,wxid_2",
                 "WEIXIN_HOME_CHANNEL": "wxid_1",
                 "WEIXIN_HOME_CHANNEL_NAME": "Primary DM",
@@ -142,6 +157,7 @@ class TestWeixinConfig:
         assert platform_config.extra["base_url"] == "https://ilink.example.com"
         assert platform_config.extra["cdn_base_url"] == "https://cdn.example.com/c2c"
         assert platform_config.extra["dm_policy"] == "allowlist"
+        assert platform_config.extra["split_multiline_messages"] == "true"
         assert platform_config.extra["allow_from"] == "wxid_1,wxid_2"
         assert platform_config.home_channel == HomeChannel(Platform.WEIXIN, "wxid_1", "Primary DM")
 

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -66,6 +66,9 @@ WEIXIN_ACCOUNT_ID=your-account-id
 WEIXIN_DM_POLICY=open
 WEIXIN_ALLOWED_USERS=user_id_1,user_id_2
 
+# Optional: restore legacy multiline splitting behavior
+# WEIXIN_SPLIT_MULTILINE_MESSAGES=true
+
 # Optional: home channel for cron/notifications
 WEIXIN_HOME_CHANNEL=chat_id
 WEIXIN_HOME_CHANNEL_NAME=Home
@@ -108,6 +111,7 @@ Set these in `config.yaml` under `platforms.weixin.extra`:
 | `group_policy` | `disabled` | Group access: `open`, `allowlist`, `disabled` |
 | `allow_from` | `[]` | User IDs allowed for DMs (when dm_policy=allowlist) |
 | `group_allow_from` | `[]` | Group IDs allowed (when group_policy=allowlist) |
+| `split_multiline_messages` | `false` | When `true`, split multi-line replies into multiple chat messages (legacy behavior). When `false`, keep multi-line replies as one message unless they exceed the length limit. |
 
 ## Access Policies
 
@@ -211,12 +215,12 @@ WeChat's personal chat does not natively render full Markdown. The adapter refor
 
 ## Message Chunking
 
-Long messages are split intelligently for chat delivery:
+Messages are delivered as a single chat message whenever they fit within the platform limit. Only oversized payloads are split for delivery:
 
 - Maximum message length: **4000 characters**
-- Split points prefer paragraph boundaries and blank lines
-- Code fences are kept intact (never split mid-block)
-- Indented continuation lines (sub-items in reformatted tables/lists) stay with their parent
+- Messages under the limit stay intact even when they contain multiple paragraphs or line breaks
+- Oversized messages split at logical boundaries (paragraphs, blank lines, code fences)
+- Code fences are kept intact whenever possible (never split mid-block unless the fence itself exceeds the limit)
 - Oversized individual blocks fall back to the base adapter's truncation logic
 
 ## Typing Indicators


### PR DESCRIPTION
## What does this PR do?

The Weixin adapter previously split every top-level line break into a separate chat message, which triggered WeChat rate limits and hurt readability. This PR adds a compact delivery mode that keeps multi-line replies as a single chat message unless they exceed the 4000-char platform limit, with a config toggle to restore legacy per-line splitting behavior.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/weixin.py` — Changed `_split_text_for_weixin_delivery()` to accept a `split_per_line` flag; defaults to compact mode (single message when within length limit). Updated `WeixinAdapter._split_text()` to pass `self._split_multiline_messages` through.
- `gateway/config.py` — Added `WEIXIN_SPLIT_MULTILINE_MESSAGES` environment variable, mapped to `split_multiline_messages` in `platforms.weixin.extra`.
- `tests/gateway/test_weixin.py` — Updated existing chunking tests to reflect compact defaults. Added `test_split_text_can_restore_legacy_multiline_splitting_via_config` to verify the toggle.
- `website/docs/user-guide/messaging/weixin.md` — Added `split_multiline_messages` to the Configuration Options table. Updated the Message Chunking section to describe compact behavior.

## How to Test

1. Run `pytest tests/gateway/test_weixin.py -q` — all 15 tests should pass.
2. Send a multi-line message via Weixin — it should arrive as a single message (compact mode).
3. Set `platforms.weixin.extra.split_multiline_messages: true` in config.yaml — multi-line messages should split per line again (legacy mode).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/weixin.md`)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (platform extra, not top-level config)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Weixin adapter only)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A