### PR TITLE
fix(gateway): route /queue through queue handlers

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1427,7 +1427,18 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart"):
+            if cmd in (
+                "approve",
+                "deny",
+                "status",
+                "stop",
+                "new",
+                "reset",
+                "background",
+                "queue",
+                "q",
+                "restart",
+            ):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2483,6 +2483,22 @@ class GatewayRunner:
                 "args": event.get_command_args().strip(),
             })
 
+        if command in ("queue", "q"):
+            queued_text = event.get_command_args().strip()
+            if not queued_text:
+                return "Usage: /queue <prompt>"
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                from gateway.platforms.base import MessageEvent as _ME, MessageType as _MT
+                queued_event = _ME(
+                    text=queued_text,
+                    message_type=_MT.TEXT,
+                    source=event.source,
+                    message_id=event.message_id,
+                )
+                adapter._pending_messages[_quick_key] = queued_event
+            return "Queued for the next turn."
+
         # Resolve aliases to canonical name so dispatch only checks canonicals.
         _cmd_def = _resolve_cmd(command) if command else None
         canonical = _cmd_def.name if _cmd_def else command

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -6,10 +6,11 @@ after the agent finishes its current task — not silently dropped.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.config import GatewayConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -17,6 +18,7 @@ from gateway.platforms.base import (
     PlatformConfig,
     Platform,
 )
+from gateway.session import SessionSource, build_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -163,3 +165,89 @@ class TestQueueConsumptionAfterCompletion:
 
         retrieved = adapter.get_pending_message(session_key)
         assert retrieved.text == "third"
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_runner(adapter: BasePlatformAdapter):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._pending_model_notes = {}
+    runner._update_prompt_pending = {}
+    runner._draining = False
+    runner._voice_mode = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._session_key_for_source = GatewayRunner._session_key_for_source.__get__(
+        runner, GatewayRunner
+    )
+    runner._handle_message_with_agent = AsyncMock(return_value="agent path")
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    return runner
+
+
+class TestQueueCommandRouting:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command_text", ["/queue after this", "/q after this"])
+    async def test_active_session_commands_bypass_adapter_interrupt_path(self, command_text):
+        adapter = _StubAdapter()
+        adapter._send_with_retry = AsyncMock()
+        adapter.set_message_handler(AsyncMock(return_value="Queued for the next turn."))
+
+        source = _make_source()
+        session_key = build_session_key(source)
+        interrupt_event = asyncio.Event()
+        adapter._active_sessions[session_key] = interrupt_event
+
+        event = MessageEvent(
+            text=command_text,
+            source=source,
+            message_id="m-active",
+            message_type=MessageType.COMMAND,
+        )
+
+        await adapter.handle_message(event)
+
+        adapter._message_handler.assert_awaited_once_with(event)
+        adapter._send_with_retry.assert_awaited_once()
+        assert not interrupt_event.is_set()
+        assert session_key not in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command_text", ["/queue after this", "/q after this"])
+    async def test_idle_queue_dispatches_to_queue_handler(self, command_text):
+        adapter = _StubAdapter()
+        runner = _make_runner(adapter)
+        source = _make_source()
+        event = MessageEvent(
+            text=command_text,
+            source=source,
+            message_id="m-idle",
+            message_type=MessageType.COMMAND,
+        )
+
+        result = await runner._handle_message(event)
+
+        session_key = runner._session_key_for_source(source)
+        queued_event = adapter._pending_messages[session_key]
+        assert result == "Queued for the next turn."
+        assert queued_event.text == "after this"
+        assert queued_event.message_type == MessageType.TEXT
+        runner._handle_message_with_agent.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes `/queue` being misrouted in the gateway command pipeline.

Before this change, there were two separate gaps:

1. Active-session path: `/queue` and `/q` did not bypass the Level 1 active-session guard in `gateway/platforms/base.py`, so they could be treated like normal follow-up/interrupt messages instead of reaching the dedicated queue handler.
2. Idle path: `/q` could be misresolved before reaching queue handling because shared command resolution also has a CLI-only `q` alias for `/quit`. The gateway needs to handle queue commands before that alias resolution step.

## Fix

- `gateway/platforms/base.py`
  - add `/queue` and `/q` to the active-session bypass set so they dispatch directly to the gateway runner, matching the existing `/approve`, `/deny`, `/stop`, `/new` style fixes
- `gateway/run.py`
  - handle `/queue` and `/q` on the normal command path before canonical alias resolution can misroute `/q`
  - queue the clean prompt text as a pending `MessageEvent` and return `Queued for the next turn.`
- `tests/gateway/test_queue_consumption.py`
  - add regression coverage for both active-session and idle routing

## Test Plan
- /home/pinion/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_queue_consumption.py -q
- /home/pinion/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_platform_base.py tests/gateway/test_status_command.py tests/gateway/test_queue_consumption.py -q

Closes #7220
