### PR TITLE
fix(matrix): pass required args to MemoryCryptoStore for mautrix ≥0.21

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -352,7 +352,16 @@ class MatrixAdapter(BasePlatformAdapter):
                 from mautrix.crypto import OlmMachine
                 from mautrix.crypto.store import MemoryCryptoStore
 
-                crypto_store = MemoryCryptoStore()
+                # account_id and pickle_key are required by mautrix ≥0.21.
+                # Use the Matrix user ID as account_id for stable identity.
+                # pickle_key secures in-memory serialisation; derive from
+                # the same user_id:device_id pair used for the on-disk HMAC.
+                _acct_id = self._user_id or "hermes"
+                _pickle_key = f"{self._user_id}:{self._device_id}"
+                crypto_store = MemoryCryptoStore(
+                    account_id=_acct_id,
+                    pickle_key=_pickle_key,
+                )
 
                 # Restore persisted crypto state from a previous run.
                 # Uses HMAC to verify integrity before unpickling.

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -357,7 +357,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 # pickle_key secures in-memory serialisation; derive from
                 # the same user_id:device_id pair used for the on-disk HMAC.
                 _acct_id = self._user_id or "hermes"
-                _pickle_key = f"{self._user_id}:{self._device_id}"
+                _pickle_key = f"{_acct_id}:{self._device_id}"
                 crypto_store = MemoryCryptoStore(
                     account_id=_acct_id,
                     pickle_key=_pickle_key,

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -157,7 +157,9 @@ def _make_fake_mautrix():
     mautrix_crypto_store = types.ModuleType("mautrix.crypto.store")
 
     class MemoryCryptoStore:
-        pass
+        def __init__(self, account_id="", pickle_key=""):
+            self.account_id = account_id
+            self.pickle_key = pickle_key
 
     mautrix_crypto_store.MemoryCryptoStore = MemoryCryptoStore
 


### PR DESCRIPTION
## Summary

Fixes #7803 — the mautrix-python migration (commit `1850747`) broke Matrix E2EE initialization because `MemoryCryptoStore.__init__()` gained two required positional arguments (`account_id`, `pickle_key`) in mautrix 0.21.

## Bug

```
MemoryCryptoStore.__init__() missing 2 required positional arguments: 'account_id' and 'pickle_key'
```

Gateway refuses to connect to Matrix when `MATRIX_ENCRYPTION=true`.

## Fix

- **`gateway/platforms/matrix.py`**: Pass `account_id=self._user_id` and `pickle_key=f"{self._user_id}:{self._device_id}"` to `MemoryCryptoStore()`. The pickle key reuses the same `user_id:device_id` derivation already used for the on-disk HMAC signature.
- **`tests/gateway/test_matrix.py`**: Update the `MemoryCryptoStore` test stub to accept the new parameters.

All 158 matrix-related tests pass.