### PR TITLE
fix(context): preserve multimodal content during compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -191,7 +191,7 @@ class ContextCompressor(ContextEngine):
             min_protect = min(protect_tail_count, len(result) - 1)
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                content_len = len(msg.get("content") or "")
+                content_len = len(self._coerce_content_to_text(msg.get("content")))
                 msg_tokens = content_len // _CHARS_PER_TOKEN + 10
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
@@ -210,7 +210,7 @@ class ContextCompressor(ContextEngine):
             msg = result[i]
             if msg.get("role") != "tool":
                 continue
-            content = msg.get("content", "")
+            content = self._coerce_content_to_text(msg.get("content"))
             if not content or content == _PRUNED_TOOL_PLACEHOLDER:
                 continue
             # Only prune if the content is substantial (>200 chars)
@@ -235,6 +235,52 @@ class ContextCompressor(ContextEngine):
         budget = int(content_tokens * _SUMMARY_RATIO)
         return max(_MIN_SUMMARY_TOKENS, min(budget, self.max_summary_tokens))
 
+    @staticmethod
+    def _coerce_content_to_text(content: Any) -> str:
+        """Convert structured or multimodal message content into readable text."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: List[str] = []
+            for part in content:
+                text = ContextCompressor._coerce_content_to_text(part)
+                if text and text.strip():
+                    parts.append(text)
+            return "\n".join(parts)
+        if isinstance(content, dict):
+            ptype = str(content.get("type") or "")
+            if ptype in {"text", "input_text"}:
+                return ContextCompressor._coerce_content_to_text(content.get("text"))
+            if ptype in {"image_url", "input_image"}:
+                image_data = content.get("image_url") or content.get("url") or {}
+                if isinstance(image_data, dict):
+                    image_url = str(image_data.get("url") or "")
+                else:
+                    image_url = str(image_data or "")
+                return f"[image:{image_url}]" if image_url else "[image]"
+            if ptype == "image":
+                source = content.get("source", {})
+                if isinstance(source, dict):
+                    media_type = str(source.get("media_type") or "")
+                    return f"[image:{media_type}]" if media_type else "[image]"
+                return "[image]"
+            if ptype in {"input_audio", "audio"}:
+                transcript = ContextCompressor._coerce_content_to_text(
+                    content.get("transcript") or content.get("text"),
+                )
+                return transcript or "[audio]"
+
+            for key in ("text", "content"):
+                if key in content:
+                    text = ContextCompressor._coerce_content_to_text(content.get(key))
+                    if text:
+                        return text
+
+            return str(content)
+        return str(content)
+
     # Truncation limits for the summarizer input.  These bound how much of
     # each message the summary model sees — the budget is the *summary*
     # model's context window, not the main model's.
@@ -254,7 +300,7 @@ class ContextCompressor(ContextEngine):
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = msg.get("content") or ""
+            content = self._coerce_content_to_text(msg.get("content"))
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":
@@ -588,7 +634,7 @@ Write only the summary body. Do not include any preamble or prefix."""
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
-            content = msg.get("content") or ""
+            content = self._coerce_content_to_text(msg.get("content"))
             msg_tokens = len(content) // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
             # Include tool call arguments in estimate
             for tc in msg.get("tool_calls") or []:
@@ -697,7 +743,7 @@ Write only the summary body. Do not include any preamble or prefix."""
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system" and self.compression_count == 0:
                 msg["content"] = (
-                    (msg.get("content") or "")
+                    self._coerce_content_to_text(msg.get("content"))
                     + "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
                 )
             compressed.append(msg)
@@ -743,8 +789,11 @@ Write only the summary body. Do not include any preamble or prefix."""
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
             if _merge_summary_into_tail and i == compress_end:
-                original = msg.get("content") or ""
-                msg["content"] = summary + "\n\n" + original
+                original = msg.get("content")
+                if isinstance(original, list):
+                    msg["content"] = [{"type": "text", "text": summary + "\n\n"}] + list(original)
+                else:
+                    msg["content"] = summary + "\n\n" + self._coerce_content_to_text(original)
                 _merge_summary_into_tail = False
             compressed.append(msg)
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3,7 +3,11 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.context_compressor import (
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    _PRUNED_TOOL_PLACEHOLDER,
+)
 
 
 @pytest.fixture()
@@ -171,6 +175,42 @@ class TestNonStringContent:
         # None content → empty string → standardized compaction handoff prefix added
         assert summary is not None
         assert summary == SUMMARY_PREFIX
+
+    def test_multimodal_list_content_is_serialized_readably(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "hello"},
+                {"type": "image_url", "image_url": {"url": "http://x"}},
+                {"type": "input_image", "url": "http://y"},
+                {"type": "input_audio"},
+                {"type": "image", "source": {"media_type": "image/png"}},
+            ]},
+        ]
+
+        serialized = c._serialize_for_summary(messages)
+        assert "hello" in serialized
+        assert "[image:http://x]" in serialized
+        assert "[image:http://y]" in serialized
+        assert "[audio]" in serialized
+        assert "[image:image/png]" in serialized
+        assert "{'type': 'text'" not in serialized
+
+    def test_prune_old_tool_results_handles_multimodal_content(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "tool", "content": [{"type": "text", "text": "x" * 250}], "tool_call_id": "call_1"},
+            {"role": "user", "content": "recent"},
+            {"role": "assistant", "content": "reply"},
+        ]
+
+        result, pruned = c._prune_old_tool_results(messages, protect_tail_count=2)
+        assert pruned == 1
+        assert result[0]["content"] == _PRUNED_TOOL_PLACEHOLDER
 
     def test_summary_call_does_not_force_temperature(self):
         mock_response = MagicMock()
@@ -428,6 +468,40 @@ class TestCompressWithClient:
         first_tail = [m for m in result if "msg 6" in (m.get("content") or "")]
         assert len(first_tail) == 1
         assert "summary text" in first_tail[0]["content"]
+
+    def test_double_collision_merges_summary_into_multimodal_tail(self):
+        """Regression: merge-into-tail must handle multimodal list content."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=2)
+
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "msg 1"},
+            {"role": "assistant", "content": "msg 2"},
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+            {"role": "user", "content": [
+                {"type": "text", "text": "msg 5"},
+                {"type": "image_url", "image_url": {"url": "http://x"}},
+            ]},
+            {"role": "assistant", "content": "msg 6"},
+            {"role": "user", "content": "msg 7"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        first_tail = [m for m in result if isinstance(m.get("content"), list)]
+        assert len(first_tail) == 1
+        content = first_tail[0]["content"]
+        assert content[0]["type"] == "text"
+        assert "summary text" in content[0]["text"]
+        assert content[0]["text"].endswith("\n\n")
+        assert content[1:] == msgs[5]["content"]
 
     def test_double_collision_user_head_assistant_tail(self):
         """Reverse double collision: head ends with 'user', tail starts with 'assistant'.


### PR DESCRIPTION
## What does this PR do?

Fixes a `ContextCompressor` bug when conversation history contains structured or multimodal `content` (e.g. list-valued message content with text/image blocks).

Before this change, `ContextCompressor` assumed `msg["content"]` was always a string in several compression paths. That caused two problems:

1. **Summary serialization emitted Python reprs** for multimodal content instead of readable text, degrading summary quality
2. **merge-summary-into-tail raised `TypeError`**: `can only concatenate str (not "list") to str` when the first tail message had list-valued content

This patch adds a `_coerce_content_to_text()` helper that normalizes structured content to readable text where text is needed, while preserving multimodal list structure when merging a summary into the tail message.

Manually verified against real multimodal request shapes from OpenAI-style chat completions, OpenAI-style responses, and an Anthropic-compatible messages endpoint.

## Related Issue

No existing issue — discovered during code review of the compression paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_coerce_content_to_text()` in `agent/context_compressor.py` to normalize structured / multimodal message content into readable text for compression logic.
- Updated compression paths in `agent/context_compressor.py` to use normalized text for summary serialization, tail token estimation, old tool-result pruning, and system-note appending.
- Fixed merge-summary-into-tail in `agent/context_compressor.py` so list-valued multimodal content keeps its original structure by prepending a new text block instead of flattening the whole message into a string.
- Added a compatibility fallback for `input_image` parts that use `url` instead of `image_url`.
- Added regression coverage in `tests/agent/test_context_compressor.py` for:
  - readable multimodal serialization (including `input_image.url` fallback)
  - pruning non-string tool content
  - merge-summary-into-tail with multimodal content while preserving structure

## How to Test

```bash
python3 -m pytest tests/agent/test_context_compressor.py -q
```

```
41 passed, 41 warnings in 20.94s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (WSL2 Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
