### PR TITLE
fix: use dynamic OpenAI Codex model catalog in /model

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -856,8 +856,19 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list — look up by Hermes slug, fall back to overlay key
-        model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
+        # Use dynamic catalogs for providers that can discover their live model
+        # list (notably openai-codex), otherwise fall back to curated defaults.
+        if hermes_slug == "openai-codex":
+            try:
+                from hermes_cli.models import provider_model_ids
+
+                model_ids = provider_model_ids(hermes_slug)
+            except Exception:
+                model_ids = []
+        else:
+            model_ids = []
+        if not model_ids:
+            model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
         total = len(model_ids)
         top = model_ids[:max_models]
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1150,6 +1150,36 @@ def _resolve_copilot_catalog_api_key() -> str:
         return ""
 
 
+def _resolve_codex_catalog_token() -> Optional[str]:
+    """Best-effort token resolution for Codex model discovery.
+
+    Uses the same credential sources as runtime resolution, but quietly falls back
+    when no token is available so catalog callers can still use local cache /
+    curated defaults.
+    """
+    try:
+        from hermes_cli.auth import get_codex_auth_status
+
+        status = get_codex_auth_status()
+        token = status.get("api_key") if isinstance(status, dict) else None
+        if isinstance(token, str) and token.strip():
+            return token.strip()
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.auth import resolve_codex_runtime_credentials
+
+        creds = resolve_codex_runtime_credentials()
+        token = creds.get("api_key") if isinstance(creds, dict) else None
+        if isinstance(token, str) and token.strip():
+            return token.strip()
+    except Exception:
+        pass
+
+    return None
+
+
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -1162,7 +1192,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     if normalized == "openai-codex":
         from hermes_cli.codex_models import get_codex_model_ids
 
-        return get_codex_model_ids()
+        return get_codex_model_ids(access_token=_resolve_codex_catalog_token())
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())
@@ -1795,6 +1825,31 @@ def validate_requested_model(
             "recognized": False,
             "message": message,
         }
+
+    if normalized == "openai-codex":
+        codex_models = provider_model_ids(normalized)
+        if requested_for_lookup in set(codex_models):
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        if codex_models:
+            suggestions = get_close_matches(requested, codex_models, n=3, cutoff=0.5)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in the OpenAI Codex model listing. "
+                    f"It may still work if your account exposes hidden or newly rolled out models."
+                    f"{suggestion_text}"
+                ),
+            }
 
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -187,6 +187,13 @@ class TestProviderModelIds:
         assert len(ids) > 0
         assert all("/" in mid for mid in ids)
 
+    def test_openai_codex_uses_dynamic_catalog_with_runtime_token(self):
+        with patch("hermes_cli.auth.get_codex_auth_status", return_value={"api_key": "tok", "logged_in": True}), \
+             patch("hermes_cli.codex_models.get_codex_model_ids", return_value=["gpt-5.4", "gpt-5.3-codex-spark"]):
+            ids = provider_model_ids("openai-codex")
+
+        assert ids == ["gpt-5.4", "gpt-5.3-codex-spark"]
+
     def test_unknown_provider_returns_empty(self):
         assert provider_model_ids("some-unknown-provider") == []
 
@@ -194,12 +201,12 @@ class TestProviderModelIds:
         assert "glm-5" in provider_model_ids("zai")
 
     def test_copilot_prefers_live_catalog(self):
-        with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "gh-token"}), \
+        with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "***"}), \
              patch("hermes_cli.models._fetch_github_models", return_value=["gpt-5.4", "claude-sonnet-4.6"]):
             assert provider_model_ids("copilot") == ["gpt-5.4", "claude-sonnet-4.6"]
 
     def test_copilot_acp_reuses_copilot_catalog(self):
-        with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "gh-token"}), \
+        with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "***"}), \
              patch("hermes_cli.models._fetch_github_models", return_value=["gpt-5.4", "claude-sonnet-4.6"]):
             assert provider_model_ids("copilot-acp") == ["gpt-5.4", "claude-sonnet-4.6"]
 
@@ -446,6 +453,36 @@ class TestValidateApiFallback:
         result = _validate("anthropic/claude-opus-4.6", api_models=None)
         assert result["accepted"] is True
         assert result["persist"] is True
+
+    def test_openai_codex_uses_codex_catalog_when_generic_probe_is_unavailable(self):
+        with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+             patch("hermes_cli.models.provider_model_ids", return_value=["gpt-5.4", "gpt-5.3-codex-spark"]):
+            result = validate_requested_model(
+                "gpt-5.3-codex-spark",
+                "openai-codex",
+                api_key="tok",
+                base_url="https://chatgpt.com/backend-api/codex",
+            )
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_openai_codex_invalid_name_warns_from_codex_catalog(self):
+        with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+             patch("hermes_cli.models.provider_model_ids", return_value=["gpt-5.4", "gpt-5.3-codex-spark"]):
+            result = validate_requested_model(
+                "gpt-5.3-Codex-Spark",
+                "openai-codex",
+                api_key="tok",
+                base_url="https://chatgpt.com/backend-api/codex",
+            )
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "OpenAI Codex model listing" in result["message"]
 
     def test_unknown_model_also_accepted_when_api_down(self):
         """No hardcoded catalog gatekeeping — accept, persist, and warn."""

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -4,14 +4,11 @@ HERMES_OVERLAYS keys may be models.dev IDs (e.g. "github-copilot") while
 _PROVIDER_MODELS and config.yaml use Hermes IDs ("copilot").  The slug
 resolution in list_authenticated_providers() Section 2 must bridge this gap.
 
-Covers: #5223, #6492
+Covers: #5223, #6492, #6595
 """
 
-import json
 import os
 from unittest.mock import patch
-
-import pytest
 
 from hermes_cli.model_switch import list_authenticated_providers
 
@@ -81,3 +78,24 @@ def test_kilo_overlay_uses_hermes_slug():
 
     kilo_mdev = next((p for p in providers if p["slug"] == "kilo"), None)
     assert kilo_mdev is None, "kilo slug should not appear (resolved to kilocode)"
+
+
+def test_openai_codex_overlay_uses_dynamic_catalog(monkeypatch):
+    """openai-codex should surface dynamically discovered models in /model listings."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {"openai-codex": {"tokens": {"access_token": "tok"}}}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda provider, force_refresh=False: ["gpt-5.4", "gpt-5.3-codex-spark"]
+        if provider == "openai-codex" else [],
+    )
+
+    providers = list_authenticated_providers(current_provider="openai-codex", max_models=10)
+
+    codex = next((p for p in providers if p["slug"] == "openai-codex"), None)
+    assert codex is not None, "openai-codex should appear when auth store contains credentials"
+    assert codex["models"] == ["gpt-5.4", "gpt-5.3-codex-spark"]
+    assert codex["total_models"] == 2


### PR DESCRIPTION
## Summary
- use the Codex credential-backed catalog when resolving `openai-codex` models instead of relying on the generic OpenAI-compatible `/models` probe path
- surface dynamically discovered Codex models in `/model` provider listings so new rollout slugs appear without waiting for a hardcoded catalog update
- add regression coverage for dynamic catalog lookup, Codex-specific validation, and the `/model` overlay listing path

(JA)
- `openai-codex` のモデル解決で、汎用の OpenAI 互換 `/models` プローブではなく Codex 認証付きカタログを使うようにしました
- `/model` の provider 一覧でも動的に発見した Codex モデルを表示し、新しいロールアウト済み slug をハードコード更新待ちにしないようにしました
- 動的カタログ参照、Codex 専用バリデーション、`/model` オーバーレイ一覧の回帰テストを追加しました

## Why
The current `openai-codex` flow already has a dedicated model catalog (`hermes_cli.codex_models.get_codex_model_ids()`), but `/model` still had two stale paths:
1. provider listings fell back to the curated static list in `_PROVIDER_MODELS`
2. explicit model validation fell back to the generic `fetch_api_models()` check, which cannot reliably validate `https://chatgpt.com/backend-api/codex`

That mismatch means Hermes can know about newer Codex slugs in one code path while still hiding or warning on the same slugs in `/model` flows.

(JA)
`openai-codex` には既に専用のモデルカタログ (`hermes_cli.codex_models.get_codex_model_ids()`) がありますが、`/model` には古い経路が 2 つ残っていました。
1. provider 一覧が `_PROVIDER_MODELS` の静的リストにフォールバックしていた
2. 明示的なモデル検証が、`https://chatgpt.com/backend-api/codex` を安定して検証できない汎用 `fetch_api_models()` にフォールバックしていた

この不一致のせいで、ある経路では新しい Codex slug を知っていても、`/model` の別経路では同じ slug を隠したり警告したりしていました。

## Testing
- `python3 -m pytest -n 0 tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_overlay_slug_resolution.py`
- `python3 -m pytest -n 0 tests/hermes_cli/test_model_validation.py::TestProviderModelIds::test_openai_codex_uses_dynamic_catalog_with_runtime_token tests/hermes_cli/test_model_validation.py::TestValidateApiFallback::test_openai_codex_uses_codex_catalog_when_generic_probe_is_unavailable tests/hermes_cli/test_overlay_slug_resolution.py::test_openai_codex_overlay_uses_dynamic_catalog`

(JA)
- `python3 -m pytest -n 0 tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_overlay_slug_resolution.py`
- `python3 -m pytest -n 0 tests/hermes_cli/test_model_validation.py::TestProviderModelIds::test_openai_codex_uses_dynamic_catalog_with_runtime_token tests/hermes_cli/test_model_validation.py::TestValidateApiFallback::test_openai_codex_uses_codex_catalog_when_generic_probe_is_unavailable tests/hermes_cli/test_overlay_slug_resolution.py::test_openai_codex_overlay_uses_dynamic_catalog`

## Related
- fixes the stale `/model` behavior reported in #6595
- narrows the mismatch between Codex-specific discovery and `/model` validation paths

(JA)
- #6595 で報告されていた古い `/model` 挙動を修正します
- Codex 専用の動的発見経路と `/model` のバリデーション経路の不一致を縮めます
