### PR TITLE
fix(claw): read API keys from openclaw.json "env" sub-object

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1224,6 +1224,21 @@ class Migrator:
             if val and hermes_key not in secret_additions:
                 secret_additions[hermes_key] = val
 
+        # Check the openclaw.json "env" sub-object — some OpenClaw setups
+        # store API keys here instead of in a separate .env file.
+        # Keys can be at env.<KEY> or env.vars.<KEY>.
+        json_env = config.get("env")
+        if isinstance(json_env, dict):
+            env_vars = json_env.get("vars")
+            sources = [json_env]
+            if isinstance(env_vars, dict):
+                sources.append(env_vars)
+            for src in sources:
+                for oc_key, hermes_key in env_key_mapping.items():
+                    val = src.get(oc_key)
+                    if isinstance(val, str) and val.strip() and hermes_key not in secret_additions:
+                        secret_additions[hermes_key] = val.strip()
+
         # Check per-agent auth-profiles.json for additional credentials
         auth_profiles_path = self.source_root / "agents" / "main" / "agent" / "auth-profiles.json"
         if auth_profiles_path.exists():


### PR DESCRIPTION
## Summary

- `migrate_provider_keys()` checks three sources for API keys: `config.models.providers`, `~/.openclaw/.env`, and `auth-profiles.json`
- Many OpenClaw installations store keys in the `openclaw.json` top-level `"env"` sub-object (e.g. `{"env": {"GEMINI_API_KEY": "..."}}`) or `"env.vars"` sub-object instead of a separate `.env` file
- This source was never checked, causing keys to be silently dropped during migration

## Change

Add a fourth source that reads both `config["env"]` and `config["env"]["vars"]` using the same `env_key_mapping`, slotted between the `.env` file check and the `auth-profiles.json` check. Existing higher-priority sources still take precedence.

**+15 lines, single file.**

## Testing

Given an `openclaw.json` containing:
```json
{"env": {"GEMINI_API_KEY": "AIza..."}}
```
or:
```json
{"env": {"vars": {"OPENROUTER_API_KEY": "sk-or-..."}}}
```
and no `~/.openclaw/.env` file, `hermes claw migrate --migrate-secrets` should now find and import both keys.

Fixes #4652
Refs #4030, #1580, #7847