### PR TITLE
fix(claw): handle OpenClaw TTS provider rename from "edge" to "microsoft"

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1324,8 +1324,9 @@ class Migrator:
         tts_data: Dict[str, Any] = {}
 
         provider = tts.get("provider")
-        if isinstance(provider, str) and provider in ("elevenlabs", "openai", "edge"):
-            tts_data["provider"] = provider
+        if isinstance(provider, str) and provider in ("elevenlabs", "openai", "edge", "microsoft"):
+            # OpenClaw renamed "edge" to "microsoft"; Hermes still uses "edge"
+            tts_data["provider"] = "edge" if provider == "microsoft" else provider
 
         # TTS provider settings live under messages.tts.providers.{provider}
         # in OpenClaw (not messages.tts.elevenlabs directly)
@@ -1374,9 +1375,9 @@ class Migrator:
                 tts_data["openai"] = oai_settings
 
         edge_tts = (
-            (providers.get("edge") or {})
-            if isinstance(providers.get("edge"), dict) else
-            (tts.get("edge") or {})
+            (providers.get("edge") or providers.get("microsoft") or {})
+            if isinstance(providers.get("edge"), dict) or isinstance(providers.get("microsoft"), dict) else
+            (tts.get("edge") or tts.get("microsoft") or {})
         )
         if isinstance(edge_tts, dict):
             edge_voice = edge_tts.get("voice")


### PR DESCRIPTION
## Summary

- OpenClaw renamed the "edge" TTS provider to "microsoft" (https://github.com/openclaw/openclaw/issues/56220)
- The migration tool only checked `providers.edge` / `tts.edge`, silently finding nothing when the source config used the new name

## Change

- Check both `"edge"` and `"microsoft"` provider keys when reading TTS config from `openclaw.json`
- Accept `"microsoft"` in the `provider` field and normalize it back to `"edge"` in the output (since Hermes still uses the original name)

**+6 / -5 lines, single file.**

## Testing

Given an `openclaw.json` with new-format TTS:
```json
{"messages": {"tts": {"provider": "microsoft", "providers": {"microsoft": {"voice": "en-US-GuyNeural"}}}}}
```
`hermes claw migrate` should import the voice setting and set `provider: edge` in Hermes config.

Refs #7847