### PR TITLE
fix(claw): warn about unresolvable SecretRefs, skills reload, and WhatsApp re-pairing

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1161,6 +1161,16 @@ class Migrator:
                 raw_key = provider_cfg.get("apiKey")
                 api_key = resolve_secret_input(raw_key, openclaw_env)
                 if not api_key:
+                    # Warn if a SecretRef with file/exec source was silently unresolvable
+                    if isinstance(raw_key, dict) and raw_key.get("source") in ("file", "exec"):
+                        self.record(
+                            "provider-keys",
+                            self.source_root / "openclaw.json",
+                            None,
+                            "skipped",
+                            f"Provider '{provider_name}' uses a {raw_key['source']}-backed SecretRef "
+                            f"that cannot be auto-migrated. Add this key to ~/.hermes/.env manually.",
+                        )
                     continue
 
                 base_url = provider_cfg.get("baseUrl", "")
@@ -2494,6 +2504,33 @@ class Migrator:
             notes.append("- Run `hermes cron` to recreate scheduled tasks (see archive/cron-config.json)")
         elif has_cron_store_archive:
             notes.append("- Run `hermes cron` to recreate scheduled tasks (see archived cron-store)")
+
+        # Check if skills were imported
+        has_skills = any(i.kind == "skills" and i.status == "migrated" for i in self.items)
+        if has_skills:
+            notes.extend([
+                "",
+                "## Imported Skills",
+                "",
+                "Imported skills require a new session to take effect. After migration,",
+                "restart your agent or start a new chat session, then run `/skills`",
+                "to verify they loaded correctly.",
+                "",
+            ])
+
+        # Check if WhatsApp was detected
+        has_whatsapp = any(i.kind == "whatsapp-settings" and i.status == "migrated" for i in self.items)
+        if has_whatsapp:
+            notes.extend([
+                "",
+                "## WhatsApp Requires Re-Pairing",
+                "",
+                "WhatsApp uses QR-code pairing, not token-based auth. Your allowlist",
+                "was migrated, but you must re-pair the device by running:",
+                "",
+                "    hermes whatsapp",
+                "",
+            ])
 
         notes.extend([
             "- Run `hermes gateway install` if you need the gateway service",


### PR DESCRIPTION
## Summary

Three post-migration UX improvements that address silent failure modes reported by users migrating from OpenClaw.

### 1. SecretRef file/exec sources now produce a warning

When a provider API key uses a file- or exec-backed `SecretRef` (e.g. `{"source": "file", "id": "/path/to/key"}`), `resolve_secret_input()` returns `None` and the key is silently dropped. Now a `"skipped"` record is created with an actionable message:

> Provider 'openrouter' uses a file-backed SecretRef that cannot be auto-migrated. Add this key to ~/.hermes/.env manually.

### 2. Skills reload note added to MIGRATION_NOTES.md

When skills are imported, a note is appended explaining that a new session is required for them to take effect. Users were reporting "skills aren't loading" after migration.

### 3. WhatsApp re-pairing note added to MIGRATION_NOTES.md

When WhatsApp settings are **successfully migrated**, a note explains that QR-code re-pairing is required and provides the command (`hermes whatsapp`). WhatsApp uses QR pairing, not token-based auth, so token migration is inherently impossible. The note only appears when whatsapp-settings has status "migrated" (not when skipped).

**+37 lines, single file, purely additive.**

Refs #7847