### PR TITLE
fix(chat): require interactive TTY for cmd_chat

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -656,7 +656,19 @@ def cmd_chat(args):
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
-    
+
+    # Interactive chat (no single-shot -q/--query, no -i/--image) needs a real
+    # TTY. Otherwise prompt_toolkit's add_reader on stdin can crash with
+    # OSError [Errno 22] from kqueue on macOS (Vt100Input only catches
+    # PermissionError, which is the epoll-equivalent on Linux).
+    if not kwargs.get("query") and not kwargs.get("image") and not sys.stdin.isatty():
+        print(
+            "Error: 'hermes chat' requires an interactive terminal when no -q/--query is given.\n"
+            "Run it directly in your terminal, or pass -q for single-shot mode.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     try:
         cli_main(**kwargs)
     except ValueError as e:


### PR DESCRIPTION
Without this guard, running `hermes chat` in any environment where stdin
is not a real TTY (pipe, detached parent, kqueue-unfriendly fd, etc.)
crashes inside prompt_toolkit's `Vt100Input._attached_input` with:

    OSError: [Errno 22] Invalid argument
      at loop.add_reader(fd, callback_wrapper)

prompt_toolkit only catches `PermissionError` there (which epoll raises
on Linux for /dev/null); the macOS kqueue selector raises `OSError`
instead, and nothing in the chat run() try/except handles it, so the
process dies after printing the welcome banner and exit summary.

This mirrors the existing `_require_tty()` guards already used by the
other interactive commands (`setup`, `model`, `whatsapp`, `uninstall`,
`tools`, `skills config`). Single-shot mode (`-q/--query` or
`-i/--image`) still works without a TTY, since those paths never enter
prompt_toolkit's interactive loop.

