### PR TITLE
feat: add chat-specific model defaults

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -45,6 +45,45 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
     return default
 
 
+def _normalize_chat_model_overrides(value: Any) -> Dict[str, Dict[str, str]]:
+    """Normalize chat-specific model overrides from config/gateway.json.
+
+    Expected shape::
+
+        {
+          "telegram:-100123": {"model": "gpt-5.4-mini", "provider": "openai-codex"},
+          "telegram:-100123:17585": {"model": "claude-sonnet-4", "provider": "anthropic"},
+        }
+
+    Unknown keys are ignored. Empty entries are dropped.
+    """
+    if not isinstance(value, dict):
+        return {}
+
+    normalized: Dict[str, Dict[str, str]] = {}
+    for raw_target, raw_entry in value.items():
+        if not isinstance(raw_target, str) or not isinstance(raw_entry, dict):
+            continue
+
+        target = raw_target.strip()
+        if not target:
+            continue
+
+        entry: Dict[str, str] = {}
+        for field_name in ("model", "provider", "base_url", "api_key", "api_mode"):
+            raw_field = raw_entry.get(field_name)
+            if raw_field is None:
+                continue
+            field_value = str(raw_field).strip()
+            if field_value:
+                entry[field_name] = field_value
+
+        if entry:
+            normalized[target] = entry
+
+    return normalized
+
+
 class Platform(Enum):
     """Supported messaging platforms."""
     LOCAL = "local"
@@ -236,6 +275,9 @@ class GatewayConfig:
 
     # User-defined quick commands (slash commands that bypass the agent loop)
     quick_commands: Dict[str, Any] = field(default_factory=dict)
+
+    # Chat-specific model defaults keyed by platform:chat_id or platform:chat_id:thread_id
+    chat_model_overrides: Dict[str, Dict[str, str]] = field(default_factory=dict)
     
     # Storage paths
     sessions_dir: Path = field(default_factory=lambda: get_hermes_home() / "sessions")
@@ -305,6 +347,33 @@ class GatewayConfig:
         if config:
             return config.home_channel
         return None
+
+    def get_chat_model_override(self, source: Any) -> Optional[Dict[str, str]]:
+        """Return the configured model override for a chat or thread, if any.
+
+        Resolution order:
+        1. exact thread target: ``platform:chat_id:thread_id``
+        2. parent chat target: ``platform:chat_id``
+        """
+        if not source:
+            return None
+
+        platform = getattr(getattr(source, "platform", None), "value", "")
+        chat_id = str(getattr(source, "chat_id", "") or "").strip()
+        thread_id = str(getattr(source, "thread_id", "") or "").strip()
+        if not platform or not chat_id:
+            return None
+
+        candidates = []
+        if thread_id:
+            candidates.append(f"{platform}:{chat_id}:{thread_id}")
+        candidates.append(f"{platform}:{chat_id}")
+
+        for target in candidates:
+            override = self.chat_model_overrides.get(target)
+            if override:
+                return dict(override)
+        return None
     
     def get_reset_policy(
         self, 
@@ -340,6 +409,7 @@ class GatewayConfig:
             },
             "reset_triggers": self.reset_triggers,
             "quick_commands": self.quick_commands,
+            "chat_model_overrides": self.chat_model_overrides,
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
             "stt_enabled": self.stt_enabled,
@@ -383,6 +453,10 @@ class GatewayConfig:
         if not isinstance(quick_commands, dict):
             quick_commands = {}
 
+        chat_model_overrides = _normalize_chat_model_overrides(
+            data.get("chat_model_overrides", {})
+        )
+
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
@@ -401,6 +475,7 @@ class GatewayConfig:
             reset_by_platform=reset_by_platform,
             reset_triggers=data.get("reset_triggers", ["/new", "/reset"]),
             quick_commands=quick_commands,
+            chat_model_overrides=chat_model_overrides,
             sessions_dir=sessions_dir,
             always_log_local=data.get("always_log_local", True),
             stt_enabled=_coerce_bool(stt_enabled, True),
@@ -483,6 +558,9 @@ def load_gateway_config() -> GatewayConfig:
 
             if "thread_sessions_per_user" in yaml_cfg:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
+
+            if "chat_model_overrides" in yaml_cfg:
+                gw_data["chat_model_overrides"] = yaml_cfg["chat_model_overrides"]
 
             streaming_cfg = yaml_cfg.get("streaming")
             if isinstance(streaming_cfg, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -848,7 +848,11 @@ class GatewayRunner:
         session_key: Optional[str] = None,
         user_config: Optional[dict] = None,
     ) -> tuple[str, dict]:
-        """Resolve model/runtime for a session, honoring session-scoped /model overrides.
+        """Resolve model/runtime for a session.
+
+        Precedence:
+        1. chat-specific configured defaults from ``chat_model_overrides``
+        2. session-scoped ``/model`` overrides
 
         If the session override already contains a complete provider bundle
         (provider/api_key/base_url/api_mode), prefer it directly instead of
@@ -875,11 +879,77 @@ class GatewayRunner:
                 return override_model, override_runtime
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        if source is not None:
+            model, runtime_kwargs = self._apply_configured_chat_model_override(
+                source,
+                model,
+                runtime_kwargs,
+                user_config=user_config,
+            )
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
             )
         return model, runtime_kwargs
+
+    def _apply_configured_chat_model_override(
+        self,
+        source: SessionSource,
+        model: str,
+        runtime_kwargs: dict,
+        user_config: Optional[dict] = None,
+    ) -> tuple[str, dict]:
+        """Apply a configured chat/thread model default if one exists."""
+        config = getattr(self, "config", None)
+        if config is None or not hasattr(config, "get_chat_model_override"):
+            return model, runtime_kwargs
+
+        override = config.get_chat_model_override(source)
+        if not override:
+            return model, runtime_kwargs
+
+        override_model = override.get("model", "")
+        explicit_provider = override.get("provider", "")
+        if not override_model and not explicit_provider:
+            return model, runtime_kwargs
+
+        from hermes_cli.model_switch import switch_model as _switch_model
+
+        cfg = user_config if isinstance(user_config, dict) else _load_gateway_config()
+        if not isinstance(cfg, dict):
+            cfg = {}
+
+        result = _switch_model(
+            raw_input=override_model or model,
+            current_provider=runtime_kwargs.get("provider", ""),
+            current_model=model,
+            current_base_url=runtime_kwargs.get("base_url", ""),
+            current_api_key=runtime_kwargs.get("api_key", ""),
+            is_global=False,
+            explicit_provider=explicit_provider,
+            user_providers=cfg.get("providers"),
+            custom_providers=cfg.get("custom_providers"),
+        )
+        if not result.success:
+            logger.warning(
+                "Ignoring invalid chat model override for %s:%s: %s",
+                getattr(getattr(source, "platform", None), "value", "unknown"),
+                getattr(source, "chat_id", "unknown"),
+                result.error_message,
+            )
+            return model, runtime_kwargs
+
+        updated_runtime = dict(runtime_kwargs)
+        resolved_runtime = {
+            "provider": override.get("provider", result.target_provider),
+            "api_key": override.get("api_key", result.api_key),
+            "base_url": override.get("base_url", result.base_url),
+            "api_mode": override.get("api_mode", result.api_mode),
+        }
+        for key, value in resolved_runtime.items():
+            if value is not None:
+                updated_runtime[key] = value
+        return result.new_model, updated_runtime
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         from agent.smart_model_routing import resolve_turn_route
@@ -4053,6 +4123,7 @@ class GatewayRunner:
         current_api_key = ""
         user_provs = None
         custom_provs = None
+        cfg = None
         config_path = _hermes_home / "config.yaml"
         try:
             if config_path.exists():
@@ -4068,8 +4139,25 @@ class GatewayRunner:
         except Exception:
             pass
 
-        # Check for session override
         source = event.source
+
+        configured_runtime = {
+            "provider": current_provider,
+            "api_key": current_api_key,
+            "base_url": current_base_url,
+            "api_mode": "",
+        }
+        current_model, configured_runtime = self._apply_configured_chat_model_override(
+            source,
+            current_model,
+            configured_runtime,
+            user_config=cfg if isinstance(cfg, dict) else None,
+        )
+        current_provider = configured_runtime.get("provider", current_provider)
+        current_base_url = configured_runtime.get("base_url", current_base_url)
+        current_api_key = configured_runtime.get("api_key", current_api_key)
+
+        # Check for session override
         session_key = self._session_key_for_source(source)
         override = self._session_model_overrides.get(session_key, {})
         if override:

--- a/tests/gateway/test_chat_model_overrides.py
+++ b/tests/gateway/test_chat_model_overrides.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def _make_source(chat_id: str = "c1", thread_id: str | None = None) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        thread_id=thread_id,
+        user_id="u1",
+        user_name="tester",
+    )
+
+
+def _make_runner(config: GatewayConfig):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner._session_model_overrides = {}
+    runner.session_store = MagicMock()
+    return runner
+
+
+class TestGatewayConfigChatModelOverrides:
+    def test_thread_override_beats_parent_chat_override(self):
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")},
+            chat_model_overrides={
+                "telegram:c1": {"model": "gpt-5.4-mini", "provider": "openai-codex"},
+                "telegram:c1:t42": {"model": "claude-sonnet-4", "provider": "anthropic"},
+            },
+        )
+
+        override = config.get_chat_model_override(_make_source(thread_id="t42"))
+
+        assert override == {"model": "claude-sonnet-4", "provider": "anthropic"}
+
+    def test_parent_chat_override_falls_back_for_threads(self):
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")},
+            chat_model_overrides={
+                "telegram:c1": {"model": "gpt-5.4-mini", "provider": "openai-codex"},
+            },
+        )
+
+        override = config.get_chat_model_override(_make_source(thread_id="t42"))
+
+        assert override == {"model": "gpt-5.4-mini", "provider": "openai-codex"}
+
+
+class TestApplyConfiguredChatModelOverride:
+    def test_applies_configured_override_via_model_switch(self):
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")},
+            chat_model_overrides={
+                "telegram:c1": {"model": "gpt-5.4-mini", "provider": "openai-codex"},
+            },
+        )
+        runner = _make_runner(config)
+
+        with patch("gateway.run._load_gateway_config", return_value={"providers": {}, "custom_providers": []}), patch(
+            "hermes_cli.model_switch.switch_model",
+            return_value=SimpleNamespace(
+                success=True,
+                new_model="gpt-5.4-mini",
+                target_provider="openai-codex",
+                api_key="chat-key",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_mode="responses",
+            ),
+        ) as switch_model:
+            model, runtime_kwargs = runner._apply_configured_chat_model_override(
+                _make_source(),
+                "gpt-5.4",
+                {
+                    "provider": "openai-codex",
+                    "api_key": "global-key",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "api_mode": "responses",
+                },
+            )
+
+        assert model == "gpt-5.4-mini"
+        assert runtime_kwargs["provider"] == "openai-codex"
+        assert runtime_kwargs["api_key"] == "chat-key"
+        assert runtime_kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert runtime_kwargs["api_mode"] == "responses"
+        switch_model.assert_called_once()
+
+    def test_session_override_wins_over_configured_chat_default(self):
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")},
+            chat_model_overrides={
+                "telegram:c1": {"model": "gpt-5.4-mini", "provider": "openai-codex"},
+            },
+        )
+        runner = _make_runner(config)
+        session_key = "agent:main:telegram:group:c1:u1"
+        runner._session_key_for_source = MagicMock(return_value=session_key)
+        runner._session_model_overrides[session_key] = {
+            "model": "claude-sonnet-4",
+            "provider": "anthropic",
+            "api_key": "anthropic-key",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        }
+
+        with patch("gateway.run._resolve_gateway_model", return_value="gpt-5.4"), patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={
+                "provider": "openai-codex",
+                "api_key": "global-key",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_mode": "responses",
+            },
+        ), patch.object(
+            runner,
+            "_apply_configured_chat_model_override",
+            return_value=(
+                "gpt-5.4-mini",
+                {
+                    "provider": "openai-codex",
+                    "api_key": "chat-key",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "api_mode": "responses",
+                },
+            ),
+        ):
+            model, runtime_kwargs = runner._resolve_session_agent_runtime(source=_make_source())
+
+        assert model == "claude-sonnet-4"
+        assert runtime_kwargs["provider"] == "anthropic"
+        assert runtime_kwargs["api_key"] == "anthropic-key"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -108,6 +108,9 @@ class TestGatewayConfigRoundtrip:
             },
             reset_triggers=["/new"],
             quick_commands={"limits": {"type": "exec", "command": "echo ok"}},
+            chat_model_overrides={
+                "telegram:123": {"model": "gpt-5.4-mini", "provider": "openai-codex"},
+            },
             group_sessions_per_user=False,
             thread_sessions_per_user=True,
         )
@@ -118,6 +121,9 @@ class TestGatewayConfigRoundtrip:
         assert restored.platforms[Platform.TELEGRAM].token == "tok_123"
         assert restored.reset_triggers == ["/new"]
         assert restored.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
+        assert restored.chat_model_overrides == {
+            "telegram:123": {"model": "gpt-5.4-mini", "provider": "openai-codex"}
+        }
         assert restored.group_sessions_per_user is False
         assert restored.thread_sessions_per_user is True
 
@@ -180,6 +186,26 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.thread_sessions_per_user is True
+
+    def test_bridges_chat_model_overrides_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "chat_model_overrides:\n"
+            '  "telegram:-100123":\n'
+            '    model: gpt-5.4-mini\n'
+            '    provider: openai-codex\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.chat_model_overrides == {
+            "telegram:-100123": {"model": "gpt-5.4-mini", "provider": "openai-codex"}
+        }
 
     def test_thread_sessions_per_user_defaults_to_false(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -990,6 +990,30 @@ group_sessions_per_user: true  # true = per-user isolation in groups/channels, f
 
 For the behavior details and examples, see [Sessions](/docs/user-guide/sessions) and the [Discord guide](/docs/user-guide/messaging/discord).
 
+## Chat-Specific Model Defaults
+
+Set persistent model defaults for individual chats, channels, or topics without running a separate bot profile:
+
+```yaml
+chat_model_overrides:
+  "telegram:1046999283":
+    model: gpt-5.4
+    provider: openai-codex
+
+  "telegram:-1003938985116":
+    model: gpt-5.4-mini
+    provider: openai-codex
+
+  "telegram:-1003938985116:17585":
+    model: claude-sonnet-4
+    provider: anthropic
+```
+
+- Keys use `platform:chat_id` or `platform:chat_id:thread_id`.
+- Thread/topic overrides win over the parent chat override.
+- These are defaults for that chat. A user can still temporarily switch with `/model`, and `/new` resets back to the configured chat default.
+- This is useful when you want, for example, a cheaper/faster model in a knowledge-base intake channel but a stronger model in DMs.
+
 ## Unauthorized DM Behavior
 
 Control what Hermes does when an unknown user sends a direct message:


### PR DESCRIPTION
## Summary
- add `chat_model_overrides` to gateway config so specific chats or threads can have persistent default models
- apply configured chat defaults before session-scoped `/model` overrides, while keeping `/model` higher precedence
- document the config and add regression coverage for config loading, thread-vs-chat precedence, and runtime/session interactions

## Test Plan
- source .venv/bin/activate && python -m pytest tests/gateway/test_config.py tests/gateway/test_chat_model_overrides.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_session_model_reset.py tests/gateway/test_model_command_custom_providers.py -q -o 'addopts='
