### PR TITLE
fix(claw): find source files in workspace-main/ when workspace/ is empty

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -617,6 +617,19 @@ class Migrator:
             candidate = self.source_root / rel
             if candidate.exists():
                 return candidate
+            # OpenClaw renamed workspace/ to workspace-main/ (and workspace-{agentId}
+            # for multi-agent).  Try the new path as a fallback.
+            if rel.startswith("workspace/"):
+                suffix = rel[len("workspace/"):]
+                for variant in ("workspace-main", "workspace-assistant"):
+                    alt = self.source_root / variant / suffix
+                    if alt.exists():
+                        return alt
+            elif rel.startswith("workspace.default/"):
+                suffix = rel[len("workspace.default/"):]
+                alt = self.source_root / "workspace-main" / suffix
+                if alt.exists():
+                    return alt
         return None
 
     def resolve_skill_destination(self, destination: Path) -> Path:


### PR DESCRIPTION
## Summary

Multiple users report that memories, persona, and skills are not migrated. The root cause: OpenClaw renamed `workspace/` to `workspace-main/` (and `workspace-{agentId}` for multi-agent setups). Users who upgraded OpenClaw before migrating to Hermes have their files at the new path, but the migration tool only checks the old one.

## Change

`source_candidate()` now checks `workspace-main/` and `workspace-assistant/` as automatic fallbacks when the original `workspace/` path doesn't exist. This applies to all 12 existing callers without changing any call sites:

- `MEMORY.md`, `USER.md`, `SOUL.md` (persona + memory)
- `AGENTS.md` (workspace instructions)
- `skills/` directory
- `memory/` directory (daily notes)
- `tts/` directory
- `IDENTITY.md`, `TOOLS.md`, `HEARTBEAT.md`, `BOOTSTRAP.md` (archived docs)

**+13 lines, single function.**

### Known limitation

OpenClaw multi-agent setups can use arbitrary agent IDs (e.g. `workspace-ceo/`, `workspace-work/`). This fix only checks the two most common IDs (`main`, `assistant`). A more complete fix would read `config["agents"]["list"]` to discover all agent workspace directories, but that's a larger change better suited for multi-agent migration support.

## Testing

Given an OpenClaw setup where `~/.openclaw/workspace/` is empty or missing but `~/.openclaw/workspace-main/MEMORY.md` exists:

```
hermes claw migrate --dry-run
```

Should now report `MEMORY.md` as "migrated" instead of "skipped (source file not found)".

Refs #7847