### PR TITLE
fix(agent): restore subdirectory hint discovery for terminal cd paths

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -41,6 +41,10 @@ _PATH_ARG_KEYS = {"path", "file_path", "workdir"}
 # Tools that take shell commands where we should extract paths
 _COMMAND_TOOLS = {"terminal"}
 
+_DIRECTORY_COMMANDS = {"cd", "pushd"}
+
+_SHELL_OPERATORS = {"&&", "||", "|", ";", "&", "(", ")"}
+
 # How many parent directories to walk up when looking for hints.
 # Prevents scanning all the way to / for deeply nested paths.
 _MAX_ANCESTOR_WALK = 5
@@ -141,21 +145,39 @@ class SubdirectoryHintTracker:
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
         """Extract path-like tokens from a shell command string."""
         try:
-            tokens = shlex.split(cmd)
+            tokens = shlex.split(cmd, posix=os.name != "nt")
         except ValueError:
             tokens = cmd.split()
 
+        previous_token: Optional[str] = None
         for token in tokens:
             # Skip flags
             if token.startswith("-"):
-                continue
-            # Must look like a path (contains / or .)
-            if "/" not in token and "." not in token:
+                previous_token = token
                 continue
             # Skip URLs
             if token.startswith(("http://", "https://", "git@")):
+                previous_token = token
+                continue
+            if token in _SHELL_OPERATORS:
+                previous_token = token
+                continue
+            if previous_token in _DIRECTORY_COMMANDS:
+                self._add_path_candidate(token, candidates)
+                previous_token = token
+                continue
+            # Must look like a path.
+            if (
+                "/" not in token
+                and "\\" not in token
+                and "." not in token
+                and not token.startswith("~")
+                and not (len(token) >= 2 and token[1] == ":")
+            ):
+                previous_token = token
                 continue
             self._add_path_candidate(token, candidates)
+            previous_token = token
 
     def _is_valid_subdir(self, path: Path) -> bool:
         """Check if path is a valid directory to scan for hints."""

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -113,6 +113,15 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Backend-specific instructions" in result
 
+    def test_terminal_cd_command_with_relative_directory(self, project):
+        """Relative cd targets should also trigger subdirectory hint discovery."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "terminal", {"command": "cd backend && ls"}
+        )
+        assert result is not None
+        assert "Backend-specific instructions" in result
+
     def test_relative_path(self, project):
         """Relative paths resolved against working_dir."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))


### PR DESCRIPTION
## Overview

This patch restores reliable progressive subdirectory context discovery for terminal-driven navigation in `SubdirectoryHintTracker`.

It fixes two bugs in `agent/subdirectory_hints.py` that caused path extraction to miss valid navigation targets:

- Windows-style paths in terminal commands were tokenized incorrectly because parsing always used POSIX `shlex.split()`
- relative directory transitions such as `cd backend && ls` were missed because bare directory arguments were not considered path candidates

In those cases, Hermes could fail to load subtree-specific instruction files such as `AGENTS.md`, `CLAUDE.md`, or `.cursorrules` after the agent moved into a new part of the repository.

## User impact

This was a real behavior gap in the progressive context-loading flow.

Before the fix, common terminal commands like:

- `cat C:\repo\frontend\index.ts`
- `cd backend && ls`

might not trigger subdirectory hint discovery. As a result, directory-specific guidance could be skipped even though the agent had already navigated into the relevant subtree.

## Implementation notes

Updated terminal command path extraction in `agent/subdirectory_hints.py` to:

- use platform-aware tokenization with `shlex.split(..., posix=os.name != "nt")`
- recognize shell operators and ignore them cleanly
- treat arguments to `cd` and `pushd` as directory path candidates
- continue handling normal explicit path tokens, including Windows-style paths

Also added a regression test for relative `cd backend && ls` behavior in `tests/agent/test_subdirectory_hints.py`.

## Validation

Ran:

```bash
python -m pytest tests/agent/test_subdirectory_hints.py -q   result : 19 passed