### PR TITLE
feat: add image input policy for gateway and API image handling

### DIFF
--- a/agent/multimodal.py
+++ b/agent/multimodal.py
@@ -1,0 +1,287 @@
+"""Shared multimodal helpers for native image passthrough.
+
+The first implementation slice is image input only. The helpers here are
+written so Hermes can later grow into per-modality policy handling without
+copy-pasting gateway/API-server/runtime logic all over the codebase.
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+from urllib.parse import urlparse
+
+from agent.models_dev import get_model_info
+
+MAX_INLINE_IMAGE_BYTES = 2_000_000
+
+
+def message_content_has_image_parts(content: Any) -> bool:
+    if not isinstance(content, list):
+        return False
+    for part in content:
+        if isinstance(part, dict) and str(part.get("type", "") or "") in {"image_url", "input_image"}:
+            return True
+    return False
+
+
+def prepend_text_to_message_content(prefix: str, content: Any) -> Any:
+    text = str(prefix or "").strip()
+    if not text:
+        return content
+    if isinstance(content, list):
+        return [{"type": "text", "text": text}, *content]
+    body = str(content or "").strip()
+    return f"{text}\n\n{body}" if body else text
+
+
+def normalize_image_input_policy(policy: Optional[str]) -> str:
+    """Normalize config values to fallback|auto|strict.
+
+    Backward compatibility:
+    - describe -> fallback
+    - passthrough -> strict
+    """
+    value = str(policy or "").strip().lower()
+    if value in {"", "fallback", "describe"}:
+        return "fallback"
+    if value == "auto":
+        return "auto"
+    if value in {"strict", "passthrough"}:
+        return "strict"
+    return "fallback"
+
+
+def resolve_image_input_policy(config: Optional[dict]) -> str:
+    """Resolve the configured image input policy from config dict."""
+    cfg = config or {}
+    multimodal = cfg.get("multimodal") or {}
+    if isinstance(multimodal, dict) and multimodal.get("image_input_policy") is not None:
+        return normalize_image_input_policy(multimodal.get("image_input_policy"))
+
+    # Back-compat for the older image-specific setting from abandoned drafts.
+    auxiliary = cfg.get("auxiliary") or {}
+    vision = auxiliary.get("vision") or {}
+    if isinstance(vision, dict) and vision.get("gateway_mode") is not None:
+        return normalize_image_input_policy(vision.get("gateway_mode"))
+
+    return "fallback"
+
+
+def _normalize_runtime_provider(
+    provider: Optional[str],
+    base_url: Optional[str],
+    api_mode: Optional[str],
+) -> Optional[str]:
+    raw_provider = str(provider or "").strip().lower()
+    if raw_provider:
+        return raw_provider
+
+    if str(api_mode or "").strip().lower() == "anthropic_messages":
+        return "anthropic"
+
+    url = str(base_url or "").strip().lower()
+    if not url:
+        return None
+
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    host = (parsed.netloc or parsed.path or "").lower()
+
+    if "openrouter.ai" in host:
+        return "openrouter"
+    if "chatgpt.com" in host or "api.openai.com" in host:
+        return "openai"
+    if "api.githubcopilot.com" in host or "models.github.ai" in host:
+        return "copilot"
+    if "anthropic.com" in host or url.rstrip("/").endswith("/anthropic"):
+        return "anthropic"
+    if "googleapis.com" in host:
+        return "gemini"
+    if "api.deepseek.com" in host:
+        return "deepseek"
+    return None
+
+
+def runtime_supports_native_image_input(
+    *,
+    model: Optional[str],
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_mode: Optional[str] = None,
+) -> Optional[bool]:
+    """Conservatively determine whether the active runtime supports native images.
+
+    Returns:
+    - True when we have a strong signal that native image input is supported
+    - False when we have a strong signal that it is not
+    - None when support is unknown
+    """
+    model_id = str(model or "").strip()
+    if not model_id:
+        return None
+
+    runtime_provider = _normalize_runtime_provider(provider, base_url, api_mode)
+
+    candidates: list[str] = []
+    if runtime_provider:
+        candidates.append(runtime_provider)
+    if runtime_provider == "openai-codex":
+        candidates.append("openai")
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        info = get_model_info(candidate, model_id)
+        if info is not None:
+            return info.supports_vision()
+
+    model_lower = model_id.lower()
+    if runtime_provider in {"anthropic"} and model_lower.startswith("claude"):
+        return True
+    if runtime_provider in {"openai", "openai-codex"} and model_lower.startswith(("gpt-4o", "gpt-4.1", "gpt-5", "codex")):
+        return True
+    if runtime_provider == "openrouter":
+        if any(token in model_lower for token in ("/claude", "/gemini", "gpt-4o", "gpt-4.1", "gpt-5", "/vision", "mimo-v2-omni")):
+            return True
+    if runtime_provider == "gemini" and "gemini" in model_lower:
+        return True
+
+    # We intentionally do not guess for arbitrary custom/local endpoints.
+    return None
+
+
+def image_paths_within_inline_limit(
+    image_paths: Sequence[str],
+    *,
+    max_inline_bytes: int = MAX_INLINE_IMAGE_BYTES,
+) -> tuple[bool, list[str]]:
+    """Return (all_within_limit, oversized_paths)."""
+    oversized: list[str] = []
+    for raw_path in image_paths:
+        path = Path(str(raw_path)).expanduser()
+        try:
+            size = path.stat().st_size
+        except OSError:
+            oversized.append(str(path))
+            continue
+        if size > max_inline_bytes:
+            oversized.append(str(path))
+    return (len(oversized) == 0), oversized
+
+
+def local_image_path_to_data_url(path: str) -> str:
+    image_path = Path(path).expanduser()
+    data = image_path.read_bytes()
+    mime_type, _ = mimetypes.guess_type(str(image_path))
+    mime_type = mime_type or "image/jpeg"
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def build_native_image_message_content(
+    user_text: str,
+    image_paths: Sequence[str],
+) -> list[dict[str, Any]]:
+    """Build chat.completions-style content blocks with inline data URLs."""
+    parts: list[dict[str, Any]] = []
+    text = str(user_text or "").strip()
+    if text:
+        parts.append({"type": "text", "text": text})
+    for raw_path in image_paths:
+        parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": local_image_path_to_data_url(str(raw_path))},
+            }
+        )
+    return parts
+
+
+def build_gateway_image_shadow_text(user_text: str, image_paths: Sequence[str]) -> str:
+    """Text-only shadow message for persisted gateway transcripts."""
+    chunks: list[str] = []
+    text = str(user_text or "").strip()
+    if text:
+        chunks.append(text)
+    for raw_path in image_paths:
+        path = Path(str(raw_path)).expanduser()
+        chunks.append(f"Attached image: {path.name} (cached path: {path})")
+    return "\n\n".join(chunk for chunk in chunks if chunk).strip() or "Attached image"
+
+
+def build_file_image_shadow_text(user_text: str, image_descriptors: Iterable[str]) -> str:
+    """Text shadow for uploaded image/file references."""
+    chunks: list[str] = []
+    text = str(user_text or "").strip()
+    if text:
+        chunks.append(text)
+    for descriptor in image_descriptors:
+        label = str(descriptor or "").strip()
+        if label:
+            chunks.append(f"Attached image: {label}")
+    return "\n\n".join(chunk for chunk in chunks if chunk).strip() or "Attached image"
+
+
+def preview_text_for_message_content(content: Any) -> str:
+    """Compact text preview for list/string message content."""
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return str(content or "").strip()
+
+    chunks: list[str] = []
+    for part in content:
+        if isinstance(part, str) and part.strip():
+            chunks.append(part.strip())
+            continue
+        if not isinstance(part, dict):
+            continue
+        ptype = str(part.get("type", "") or "")
+        if ptype in {"text", "input_text", "output_text"}:
+            text = str(part.get("text", "") or "").strip()
+            if text:
+                chunks.append(text)
+        elif ptype in {"image_url", "input_image"}:
+            chunks.append("Attached image")
+        elif ptype in {"input_file", "file_url"}:
+            filename = str(part.get("filename", "") or "attachment").strip()
+            chunks.append(f"Attached: {filename}" if filename else "Attached file")
+    return " ".join(chunks).strip()
+
+
+def chat_content_to_responses_input(content: Any) -> Any:
+    """Convert chat-style content blocks to Responses API content blocks."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content) if content else ""
+
+    converted: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        ptype = str(part.get("type", "") or "")
+        if ptype in {"text", "input_text"}:
+            converted.append({"type": "input_text", "text": str(part.get("text", "") or "")})
+            continue
+        if ptype in {"image_url", "input_image"}:
+            image_data = part.get("image_url", {})
+            if isinstance(image_data, dict):
+                url = str(image_data.get("url", "") or "")
+                detail = image_data.get("detail")
+            else:
+                url = str(image_data or "")
+                detail = None
+            entry: dict[str, Any] = {"type": "input_image", "image_url": url}
+            if detail:
+                entry["detail"] = detail
+            converted.append(entry)
+            continue
+        text = str(part.get("text", "") or "").strip()
+        if text:
+            converted.append({"type": "input_text", "text": text})
+    return converted or ""

--- a/docs/plans/2026-04-11-native-multimodal-passthrough-policy.md
+++ b/docs/plans/2026-04-11-native-multimodal-passthrough-policy.md
@@ -1,0 +1,338 @@
+# Native Multimodal Passthrough Policy
+
+Date: 2026-04-11
+
+## Goal
+
+Introduce a professional, future-proof multimodal policy layer in Hermes so omni-capable models can receive native media inputs when the runtime safely supports them, while Hermes still has explicit fallback behavior when it does not.
+
+The first implementation slice is image input only.
+
+## Why this plan exists
+
+We do not want another muddled “image passthrough” patch that quietly mixes together:
+- Telegram/gateway image enrichment
+- API server uploaded-file behavior
+- Anthropic fallback quirks
+- documentation that overclaims native multimodal support
+- unrelated fast-mode or provider-routing churn
+
+This plan resets the work on a clean `main` and keeps the change surgical.
+
+## Source of truth
+
+For this work, the source of truth is:
+1. this plan document for scope and naming
+2. code behavior in `main`
+3. website docs for user-facing behavior
+4. concise GitHub issue + PR descriptions derived from this plan
+
+Do not let issue text or stale PR history become the source of truth.
+
+## Terms to use
+
+Use this terminology consistently in code comments, docs, issue text, and PR text:
+- omni model
+- native multimodal passthrough
+- fallback preprocessing
+- per-modality policy
+- omni runtime support
+
+Avoid image-specific naming like `gateway_mode` in the new design.
+
+## Policy names
+
+Use these mode names:
+- `fallback`
+  - always preprocess before handing off to the main model
+- `auto`
+  - use native passthrough when the active runtime is known to support the modality; otherwise fallback
+- `strict`
+  - require native passthrough; fail clearly if runtime support is unknown or unsupported
+
+## Scope for the first PR
+
+In scope:
+- native image passthrough for gateway inputs
+- native image passthrough for API server uploaded-image/file inputs where safe
+- transcript-safe shadow persistence for multimodal inputs
+- conditional Anthropic downgrade only when native image passthrough is not safe
+- documentation correction so claimed behavior matches real behavior
+
+Out of scope:
+- native audio passthrough
+- native video passthrough
+- generic document/PDF multimodal redesign
+- fast mode / service tier work
+- broad CLI multimodal redesign unless required for correctness of docs or shared helpers
+
+## Design principles
+
+1. Keep the default conservative.
+2. Do not silently degrade in `strict` mode.
+3. Keep persistence text-only unless there is an explicit storage redesign.
+4. Reuse shared helpers instead of open-coding modality handling in multiple places.
+5. Do not hardcode a giant provider:model allowlist in gateway code.
+6. Keep issue and PR copy short and blunt.
+
+## Proposed config shape
+
+Add a new top-level config section:
+
+```yaml
+multimodal:
+  image_input_policy: fallback   # fallback | auto | strict
+```
+
+Rationale:
+- this avoids burying multimodal behavior under `auxiliary.vision`
+- it is future-proof for later `audio_input_policy`, `video_input_policy`, etc.
+- it keeps the first PR surgical because only one key is implemented
+
+Default for upstream should be `fallback`.
+
+Do not flip the default to `auto` in this first PR.
+
+## Current code surfaces that matter
+
+### Gateway image ingestion
+- `gateway/run.py`
+  - currently collects image paths and unconditionally calls `_enrich_message_with_vision()`
+  - this is the main legacy image-to-description path
+
+### Gateway audio ingestion
+- `gateway/run.py`
+  - currently uses `_enrich_message_with_transcription()`
+  - this remains untouched in the first PR
+
+### API server uploaded files
+- `gateway/platforms/api_server.py`
+  - `_normalize_message_content()` currently inlines small images as `image_url`
+  - larger images become a text note via `_file_note()`
+  - `MAX_INLINE_IMAGE_ATTACHMENT_BYTES = 2_000_000` is the current threshold
+
+### Agent runtime multimodal handling
+- `run_agent.py`
+  - must preserve structured multimodal content through provider preflight
+  - must only downgrade image blocks to text when the active runtime actually needs fallback
+
+### Anthropic compatibility path
+- `run_agent.py`
+- `agent/anthropic_adapter.py`
+  - native image support exists at the adapter layer
+  - fallback behavior should be conditional, not unconditional
+
+### Config defaults and docs
+- `hermes_cli/config.py`
+- `website/docs/user-guide/configuration.md`
+- `website/docs/user-guide/features/vision.md`
+- `website/docs/user-guide/features/api-server.md`
+
+## File plan
+
+### 1. New shared helper
+Create:
+- `agent/multimodal.py`
+
+Responsibilities:
+- central `image_input_policy` parsing
+- helper(s) to decide whether native image passthrough is safe for the active runtime
+- helper(s) to build provider-facing image parts from local files / URLs / uploaded assets
+- helper(s) to create transcript-safe shadow text for persisted message history
+
+Why:
+- keeps gateway, API server, and runtime logic aligned
+- prevents a second round of duplicated “can this runtime take images?” logic
+
+### 2. Config
+Modify:
+- `hermes_cli/config.py`
+
+Changes:
+- add `multimodal.image_input_policy`
+- default it to `fallback`
+- include comments that explicitly describe `fallback | auto | strict`
+- bump config version only if required by the repo’s migration rules
+
+### 3. Gateway runtime path
+Modify:
+- `gateway/run.py`
+
+Changes:
+- replace unconditional `_enrich_message_with_vision()` usage with mode-aware logic
+- in `fallback`, keep current behavior
+- in `auto`, pass native image parts when safe; otherwise call `_enrich_message_with_vision()`
+- in `strict`, fail clearly rather than silently enriching
+- preserve text-only `persist_user_message` / transcript-friendly shadow content
+
+Important:
+- do not touch audio behavior in this PR
+- do not mix in fast mode or unrelated gateway config changes
+
+### 4. API server path
+Modify:
+- `gateway/platforms/api_server.py`
+
+Changes:
+- route uploaded image/file inputs through the same image policy semantics
+- avoid the current “small images native, large images text note” split as the only decision rule
+- keep size limits, but make policy and failure behavior explicit
+- make large-image behavior consistent with `fallback | auto | strict`
+- preserve persisted message content in a storage-safe form
+
+Important:
+- the API server must not advertise capabilities the runtime path cannot actually honor
+- file upload docs must match the real behavior after the change
+
+### 5. Agent runtime preflight
+Modify:
+- `run_agent.py`
+
+Changes:
+- preserve structured image parts through the live API path
+- keep shadow text separate from provider-facing content
+- downgrade Anthropics image blocks only when required by runtime capability checks
+- ensure previews/logging do not explode on list-based content
+
+### 6. Anthropic runtime compatibility
+Modify only if necessary:
+- `agent/anthropic_adapter.py`
+- possibly `agent/auxiliary_client.py`
+
+Changes:
+- only if the shared helper needs a small adapter-level hook or capability bridge
+- avoid broad refactors here
+
+### 7. Documentation
+Modify:
+- `website/docs/user-guide/configuration.md`
+- `website/docs/user-guide/features/vision.md`
+- `website/docs/user-guide/features/api-server.md`
+- optionally `website/docs/developer-guide/provider-runtime.md` if the runtime decision rules need developer-facing explanation
+
+Documentation goals:
+- stop overclaiming native multimodal support where the code still falls back
+- document the new `multimodal.image_input_policy`
+- explain `fallback | auto | strict` clearly
+- make explicit that audio/video remain follow-up work
+
+## Impact assessment
+
+### Expected user-facing impact
+Positive:
+- clearer behavior for image inputs
+- fewer surprising auxiliary-vision hops in supported runtimes
+- better alignment between omni-capable model expectations and Hermes runtime behavior
+- better docs
+
+Risk:
+- runtime capability detection mistakes could cause false passthrough or false fallback
+- large-image handling in API server could regress if not tested carefully
+- provider-specific paths could break if structured content is mutated incorrectly
+
+### Backward compatibility
+- default `fallback` preserves current behavior for existing users
+- `auto` and `strict` are opt-in behavior changes
+- transcript/session persistence remains text-only
+
+### Styling / professionalism guardrails
+- follow existing Hermes naming and config comment style
+- keep user-facing descriptions concise
+- do not add speculative config for audio/video yet
+- no emoji-heavy docs or noisy PR prose
+- no dead compatibility aliases unless absolutely necessary
+
+## Test plan
+
+### New tests to add
+Create:
+- `tests/gateway/test_gateway_multimodal_passthrough.py`
+
+Cover:
+- `fallback` keeps current enrichment path
+- `auto` uses native passthrough when runtime supports images
+- `auto` falls back when runtime support is unknown/unsupported
+- `strict` raises a clear error instead of silently enriching
+- persisted shadow message remains text-only
+
+### Existing tests to extend
+Modify:
+- `tests/gateway/test_api_server.py`
+  - uploaded image handling under `fallback | auto | strict`
+  - large uploaded image behavior
+- `tests/run_agent/test_run_agent.py`
+  - structured image content survives provider preflight
+  - persist-user shadow behavior remains stable
+  - Anthropic fallback is conditional
+- `tests/agent/test_anthropic_adapter.py`
+  - only if adapter expectations need explicit multimodal coverage
+- `tests/agent/test_auxiliary_config_bridge.py`
+  - config shape / bridge assertions if needed
+
+### Test commands
+Run at minimum:
+
+```bash
+source venv/bin/activate
+python -m pytest \
+  tests/gateway/test_gateway_multimodal_passthrough.py \
+  tests/gateway/test_api_server.py \
+  tests/run_agent/test_run_agent.py \
+  tests/agent/test_anthropic_adapter.py \
+  tests/agent/test_auxiliary_config_bridge.py -q
+```
+
+Then run a focused secondary pass around existing provider/runtime behavior:
+
+```bash
+source venv/bin/activate
+python -m pytest \
+  tests/run_agent/test_provider_parity.py \
+  tests/gateway/test_fast_command.py \
+  tests/gateway/test_agent_cache.py -q
+```
+
+Finally, if the change lands cleanly, run the full suite before PR finalization.
+
+## Implementation sequence
+
+1. Create the plan and keep it as the source of truth.
+2. Create a fresh branch from `main`.
+3. Add `agent/multimodal.py` and config wiring.
+4. Make gateway image handling mode-aware.
+5. Make API server uploaded-image handling follow the same policy.
+6. Tighten `run_agent.py` runtime preservation and conditional fallback.
+7. Update docs so behavior claims match reality.
+8. Run targeted tests.
+9. Only then open a new issue and PR.
+
+## Branch and PR strategy
+
+Start from:
+- `main` only
+
+Suggested branch name:
+- `feat/native-multimodal-image-policy`
+
+Suggested issue title:
+- `[Feature]: Native multimodal passthrough with per-modality fallback policy (image slice)`
+
+Suggested PR title:
+- `feat(multimodal): add native image passthrough policy for gateway and API server`
+
+## Commit strategy
+
+Prefer small commits:
+1. `docs: add native multimodal passthrough plan`
+2. `feat(config): add multimodal image input policy`
+3. `feat(gateway): make image handling policy-aware`
+4. `feat(api-server): apply image input policy to uploaded images`
+5. `fix(agent): preserve native image parts and conditional anthropic fallback`
+6. `docs: align multimodal docs with runtime behavior`
+7. `test(multimodal): add gateway and runtime passthrough coverage`
+
+## Explicit non-bullshit note
+
+This first PR does not make Hermes fully omni.
+
+It creates the right language and policy model, then implements the first clean slice for images. Audio, video, and broader document/file multimodal behavior should follow as separate work once this foundation is stable.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -45,6 +45,12 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from agent.multimodal import (
+    message_content_has_image_parts,
+    preview_text_for_message_content,
+    resolve_image_input_policy,
+    runtime_supports_native_image_input,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -496,6 +502,26 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         return agent
 
+    async def _normalize_request_content(self, content: Any, *, model: str, runtime_kwargs: Dict[str, Any]) -> Any:
+        if not message_content_has_image_parts(content):
+            return content
+
+        from gateway.run import _load_gateway_config
+
+        policy = resolve_image_input_policy(_load_gateway_config())
+        native_support = runtime_supports_native_image_input(
+            model=model,
+            provider=runtime_kwargs.get("provider"),
+            base_url=runtime_kwargs.get("base_url"),
+            api_mode=runtime_kwargs.get("api_mode"),
+        )
+
+        if policy == "strict" and native_support is not True:
+            raise ValueError("Native image passthrough is unavailable for the active runtime in strict multimodal mode.")
+        if policy == "auto" and native_support is True:
+            return content
+        return preview_text_for_message_content(content)
+
     # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
@@ -544,11 +570,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_model = _resolve_gateway_model()
+
         stream = body.get("stream", False)
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: List[Dict[str, Any]] = []
 
         for msg in messages:
             role = msg.get("role", "")
@@ -560,6 +590,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 else:
                     system_prompt = system_prompt + "\n" + content
             elif role in ("user", "assistant"):
+                if isinstance(content, list):
+                    try:
+                        content = await self._normalize_request_content(
+                            content,
+                            model=runtime_model,
+                            runtime_kwargs=runtime_kwargs,
+                        )
+                    except ValueError as exc:
+                        return web.json_response(_openai_error(str(exc)), status=400)
                 conversation_messages.append({"role": role, "content": content})
 
         # Extract the last user message as the primary input
@@ -619,7 +658,7 @@ class APIServerAdapter(BasePlatformAdapter):
             first_user = ""
             for cm in conversation_messages:
                 if cm.get("role") == "user":
-                    first_user = cm.get("content", "")
+                    first_user = preview_text_for_message_content(cm.get("content", ""))
                     break
             session_id = _derive_chat_session_id(system_prompt, first_user)
             # history already set from request body above
@@ -904,8 +943,12 @@ class APIServerAdapter(BasePlatformAdapter):
             previous_response_id = self._response_store.get_conversation(conversation)
             # No error if conversation doesn't exist yet — it's a new conversation
 
+        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_model = _resolve_gateway_model()
+
         # Normalize input to message list
-        input_messages: List[Dict[str, str]] = []
+        input_messages: List[Dict[str, Any]] = []
         if isinstance(raw_input, str):
             input_messages = [{"role": "user", "content": raw_input}]
         elif isinstance(raw_input, list):
@@ -915,17 +958,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 elif isinstance(item, dict):
                     role = item.get("role", "user")
                     content = item.get("content", "")
-                    # Handle content that may be a list of content parts
                     if isinstance(content, list):
-                        text_parts = []
-                        for part in content:
-                            if isinstance(part, dict) and part.get("type") == "input_text":
-                                text_parts.append(part.get("text", ""))
-                            elif isinstance(part, dict) and part.get("type") == "output_text":
-                                text_parts.append(part.get("text", ""))
-                            elif isinstance(part, str):
-                                text_parts.append(part)
-                        content = "\n".join(text_parts)
+                        try:
+                            content = await self._normalize_request_content(
+                                content,
+                                model=runtime_model,
+                                runtime_kwargs=runtime_kwargs,
+                            )
+                        except ValueError as exc:
+                            return web.json_response(_openai_error(str(exc)), status=400)
                     input_messages.append({"role": role, "content": content})
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
@@ -934,7 +975,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # This lets stateless clients supply their own history instead of
         # relying on server-side response chaining via previous_response_id.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -1397,8 +1438,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _run_agent(
         self,
-        user_message: str,
-        conversation_history: List[Dict[str, str]],
+        user_message: Any,
+        conversation_history: List[Dict[str, Any]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
@@ -1542,7 +1583,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -252,6 +252,16 @@ from gateway.restart import (
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     parse_restart_drain_timeout,
 )
+from agent.multimodal import (
+    MAX_INLINE_IMAGE_BYTES,
+    build_gateway_image_shadow_text,
+    build_native_image_message_content,
+    image_paths_within_inline_limit,
+    prepend_text_to_message_content,
+    preview_text_for_message_content,
+    resolve_image_input_policy,
+    runtime_supports_native_image_input,
+)
 
 
 def _normalize_whatsapp_identifier(value: str) -> str:
@@ -3206,6 +3216,9 @@ class GatewayRunner:
         if _is_shared_thread and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
+        agent_message: Any = message_text
+        persist_user_message: Optional[str] = None
+
         if event.media_urls:
             image_paths = []
             for i, path in enumerate(event.media_urls):
@@ -3218,10 +3231,22 @@ class GatewayRunner:
                 if is_image:
                     image_paths.append(path)
             if image_paths:
-                message_text = await self._enrich_message_with_vision(
-                    message_text, image_paths
+                agent_message, persist_user_message, image_error = await self._resolve_gateway_image_message(
+                    user_text=message_text,
+                    image_paths=image_paths,
+                    source=source,
+                    session_key=session_key,
                 )
-        
+                if image_error:
+                    _adapter = self.adapters.get(source.platform)
+                    if _adapter:
+                        await _adapter.send(
+                            source.chat_id,
+                            image_error,
+                            metadata={"thread_id": source.thread_id} if source.thread_id else None,
+                        )
+                    return
+
         # -----------------------------------------------------------------
         # Auto-transcribe voice/audio messages sent by the user
         # -----------------------------------------------------------------
@@ -3368,13 +3393,14 @@ class GatewayRunner:
 
             # Run the agent
             agent_result = await self._run_agent(
-                message=message_text,
+                message=agent_message,
                 context_prompt=context_prompt,
                 history=history,
                 source=source,
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                persist_user_message=persist_user_message,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -6604,6 +6630,58 @@ class GatewayRunner:
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
     
+    async def _resolve_gateway_image_message(
+        self,
+        *,
+        user_text: str,
+        image_paths: List[str],
+        source: SessionSource,
+        session_key: str,
+    ) -> tuple[Any, Optional[str], Optional[str]]:
+        if not image_paths:
+            return user_text, None, None
+
+        user_config = _load_gateway_config()
+        image_policy = resolve_image_input_policy(user_config)
+        model, runtime_kwargs = self._resolve_session_agent_runtime(
+            source=source,
+            session_key=session_key,
+            user_config=user_config,
+        )
+        turn_route = self._resolve_turn_agent_config(user_text, model, runtime_kwargs)
+        native_support = runtime_supports_native_image_input(
+            model=turn_route.get("model"),
+            provider=(turn_route.get("runtime") or {}).get("provider"),
+            base_url=(turn_route.get("runtime") or {}).get("base_url"),
+            api_mode=(turn_route.get("runtime") or {}).get("api_mode"),
+        )
+        within_limit, oversized = image_paths_within_inline_limit(
+            image_paths,
+            max_inline_bytes=MAX_INLINE_IMAGE_BYTES,
+        )
+
+        if image_policy == "fallback":
+            enriched = await self._enrich_message_with_vision(user_text, image_paths)
+            return enriched, None, None
+
+        if native_support is True and within_limit:
+            return (
+                build_native_image_message_content(user_text, image_paths),
+                build_gateway_image_shadow_text(user_text, image_paths),
+                None,
+            )
+
+        if image_policy == "strict":
+            if native_support is not True:
+                return user_text, None, "❌ Native image passthrough is unavailable for the active runtime in strict multimodal mode."
+            oversized_names = ", ".join(Path(p).name for p in oversized)
+            return user_text, None, (
+                f"❌ Native image passthrough refused in strict multimodal mode because inline images exceed {MAX_INLINE_IMAGE_BYTES} bytes: {oversized_names}"
+            )
+
+        enriched = await self._enrich_message_with_vision(user_text, image_paths)
+        return enriched, None, None
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,
@@ -7004,7 +7082,7 @@ class GatewayRunner:
 
     async def _run_agent(
         self,
-        message: str,
+        message: Any,
         context_prompt: str,
         history: List[Dict[str, Any]],
         source: SessionSource,
@@ -7012,6 +7090,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -7327,13 +7406,11 @@ class GatewayRunner:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
         def run_sync():
-            # The conditional re-assignment of `message` further below
-            # (prepending model-switch notes) makes Python treat it as a
-            # local variable in the entire function.  `nonlocal` lets us
-            # read *and* reassign the outer `_run_agent` parameter without
-            # triggering an UnboundLocalError on the earlier read at
-            # `_resolve_turn_agent_config(message, …)`.
-            nonlocal message
+            # The conditional re-assignment of `message` / `persist_user_message`
+            # further below (prepending model-switch notes) makes Python treat
+            # them as local variables in the entire function. `nonlocal` lets
+            # us read *and* reassign the outer `_run_agent` parameters safely.
+            nonlocal message, persist_user_message
 
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
@@ -7407,7 +7484,8 @@ class GatewayRunner:
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            routing_message = persist_user_message or preview_text_for_message_content(message)
+            turn_route = self._resolve_turn_agent_config(routing_message, model, runtime_kwargs)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -7635,13 +7713,15 @@ class GatewayRunner:
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                message = prepend_text_to_message_content(_msn, message)
+                if isinstance(persist_user_message, str) and persist_user_message.strip():
+                    persist_user_message = _msn + "\n\n" + persist_user_message
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id, persist_user_message=persist_user_message)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -499,6 +499,14 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Multimodal passthrough policy. The first slice is image input only.
+    # fallback = use auxiliary vision preprocessing first (or downgrade to text-safe preview),
+    # auto = passthrough when runtime safely supports it, else auxiliary preprocessing,
+    # strict = require native passthrough and fail when unsupported/unknown.
+    "multimodal": {
+        "image_input_policy": "fallback",  # fallback | auto | strict
+    },
+
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,

--- a/run_agent.py
+++ b/run_agent.py
@@ -106,6 +106,11 @@ from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
+from agent.multimodal import (
+    chat_content_to_responses_input,
+    preview_text_for_message_content,
+    runtime_supports_native_image_input,
+)
 from utils import atomic_json_write, env_var_enabled
 
 
@@ -3330,7 +3335,7 @@ class AIAgent:
 
             if role in {"user", "assistant"}:
                 content = msg.get("content", "")
-                content_text = str(content) if content is not None else ""
+                converted_content = chat_content_to_responses_input(content)
 
                 if role == "assistant":
                     # Replay encrypted reasoning items from previous turns
@@ -3343,15 +3348,22 @@ class AIAgent:
                                 items.append(ri)
                                 has_codex_reasoning = True
 
-                    if content_text.strip():
-                        items.append({"role": "assistant", "content": content_text})
-                    elif has_codex_reasoning:
-                        # The Responses API requires a following item after each
-                        # reasoning item (otherwise: missing_following_item error).
-                        # When the assistant produced only reasoning with no visible
-                        # content, emit an empty assistant message as the required
-                        # following item.
-                        items.append({"role": "assistant", "content": ""})
+                    if isinstance(converted_content, list):
+                        if converted_content:
+                            items.append({"role": "assistant", "content": converted_content})
+                        elif has_codex_reasoning:
+                            items.append({"role": "assistant", "content": ""})
+                    else:
+                        content_text = str(converted_content or "")
+                        if content_text.strip():
+                            items.append({"role": "assistant", "content": content_text})
+                        elif has_codex_reasoning:
+                            # The Responses API requires a following item after each
+                            # reasoning item (otherwise: missing_following_item error).
+                            # When the assistant produced only reasoning with no visible
+                            # content, emit an empty assistant message as the required
+                            # following item.
+                            items.append({"role": "assistant", "content": ""})
 
                     tool_calls = msg.get("tool_calls")
                     if isinstance(tool_calls, list):
@@ -3396,7 +3408,7 @@ class AIAgent:
                             })
                     continue
 
-                items.append({"role": role, "content": content_text})
+                items.append({"role": role, "content": converted_content})
                 continue
 
             if role == "tool":
@@ -3489,7 +3501,8 @@ class AIAgent:
                 content = item.get("content", "")
                 if content is None:
                     content = ""
-                if not isinstance(content, str):
+                content = chat_content_to_responses_input(content)
+                if not isinstance(content, (str, list)):
                     content = str(content)
 
                 normalized.append({"role": role, "content": content})
@@ -3878,7 +3891,6 @@ class AIAgent:
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
         if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
             from agent.copilot_acp_client import CopilotACPClient
-
             client = CopilotACPClient(**client_kwargs)
             logger.info(
                 "Copilot ACP client created (%s, shared=%s) %s",
@@ -5622,6 +5634,15 @@ class AIAgent:
             isinstance(msg, dict) and self._content_has_image_parts(msg.get("content"))
             for msg in api_messages
         ):
+            return api_messages
+
+        native_support = runtime_supports_native_image_input(
+            model=self.model,
+            provider=self.provider,
+            base_url=self.base_url,
+            api_mode=self.api_mode,
+        )
+        if native_support is True:
             return api_messages
 
         transformed = copy.deepcopy(api_messages)
@@ -7413,6 +7434,12 @@ class AIAgent:
         if isinstance(persist_user_message, str):
             persist_user_message = _sanitize_surrogates(persist_user_message)
 
+        user_message_preview = (
+            persist_user_message
+            if isinstance(persist_user_message, str) and persist_user_message.strip()
+            else preview_text_for_message_content(user_message)
+        )
+
         # Store stream callback for _interruptible_api_call to pick up
         self._stream_callback = stream_callback
         self._persist_user_message_idx = None
@@ -7451,7 +7478,7 @@ class AIAgent:
         self.iteration_budget = IterationBudget(self.max_iterations)
 
         # Log conversation turn start for debugging/observability
-        _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
+        _msg_preview = (user_message_preview[:80] + "...") if len(user_message_preview) > 80 else user_message_preview
         _msg_preview = _msg_preview.replace("\n", " ")
         logger.info(
             "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
@@ -7507,7 +7534,9 @@ class AIAgent:
         self._persist_user_message_idx = current_turn_user_idx
         
         if not self.quiet_mode:
-            self._safe_print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
+            self._safe_print(
+                f"💬 Starting conversation: '{user_message_preview[:60]}{'...' if len(user_message_preview) > 60 else ''}'"
+            )
         
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -111,7 +111,7 @@ class TestResponseStore:
 
 class TestAdapterInit:
     def test_default_config(self):
-        config = PlatformConfig(enabled=True)
+        config = PlatformConfig(enabled=True, extra={"key": ""})
         adapter = APIServerAdapter(config)
         assert adapter._host == "127.0.0.1"
         assert adapter._port == 8642
@@ -157,7 +157,7 @@ class TestAdapterInit:
 
 class TestAuth:
     def test_no_key_configured_allows_all(self):
-        config = PlatformConfig(enabled=True)
+        config = PlatformConfig(enabled=True, extra={"key": ""})
         adapter = APIServerAdapter(config)
         mock_request = MagicMock()
         mock_request.headers = {}
@@ -205,9 +205,7 @@ class TestAuth:
 
 def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
     """Create an adapter with optional API key."""
-    extra = {}
-    if api_key:
-        extra["key"] = api_key
+    extra = {"key": api_key}
     if cors_origins is not None:
         extra["cors_origins"] = cors_origins
     config = PlatformConfig(enabled=True, extra=extra)
@@ -1830,3 +1828,124 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+
+class TestApiServerMultimodalInputPolicy:
+    @pytest.mark.asyncio
+    async def test_chat_completions_auto_preserves_supported_image_parts(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_mode": "chat_completions", "api_key": "***"}),
+                patch("gateway.run._resolve_gateway_model", return_value="openai/gpt-5.4"),
+                patch("gateway.run._load_gateway_config", return_value={"multimodal": {"image_input_policy": "auto"}}),
+                patch("gateway.platforms.api_server.runtime_supports_native_image_input", return_value=True),
+                patch.object(adapter, "_run_agent", new=AsyncMock(return_value=({"final_response": "ok", "messages": []}, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}))) as mock_run,
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "Describe this"},
+                                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+            assert resp.status == 200
+            assert isinstance(mock_run.call_args.kwargs["user_message"], list)
+            assert mock_run.call_args.kwargs["user_message"][1]["type"] == "image_url"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_fallback_downgrades_image_parts_to_text(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_mode": "chat_completions", "api_key": "***"}),
+                patch("gateway.run._resolve_gateway_model", return_value="openai/gpt-5.4"),
+                patch("gateway.run._load_gateway_config", return_value={"multimodal": {"image_input_policy": "fallback"}}),
+                patch.object(adapter, "_run_agent", new=AsyncMock(return_value=({"final_response": "ok", "messages": []}, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}))) as mock_run,
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "Describe this"},
+                                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+            assert resp.status == 200
+            assert isinstance(mock_run.call_args.kwargs["user_message"], str)
+            assert "Describe this" in mock_run.call_args.kwargs["user_message"]
+            assert "Attached image" in mock_run.call_args.kwargs["user_message"]
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_strict_rejects_unsupported_image_runtime(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_mode": "chat_completions", "api_key": "***"}),
+                patch("gateway.run._resolve_gateway_model", return_value="openai/gpt-5.4"),
+                patch("gateway.run._load_gateway_config", return_value={"multimodal": {"image_input_policy": "strict"}}),
+                patch("gateway.platforms.api_server.runtime_supports_native_image_input", return_value=None),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "Describe this"},
+                                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+            assert resp.status == 400
+            payload = await resp.json()
+            assert "strict multimodal mode" in payload["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_responses_auto_preserves_supported_image_parts(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_mode": "chat_completions", "api_key": "***"}),
+                patch("gateway.run._resolve_gateway_model", return_value="openai/gpt-5.4"),
+                patch("gateway.run._load_gateway_config", return_value={"multimodal": {"image_input_policy": "auto"}}),
+                patch("gateway.platforms.api_server.runtime_supports_native_image_input", return_value=True),
+                patch.object(adapter, "_run_agent", new=AsyncMock(return_value=({"final_response": "ok", "messages": []}, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}))) as mock_run,
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_text", "text": "Describe this"},
+                                    {"type": "input_image", "image_url": "https://example.com/cat.png"},
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+            assert resp.status == 200
+            assert isinstance(mock_run.call_args.kwargs["user_message"], list)
+            assert mock_run.call_args.kwargs["user_message"][1]["type"] == "input_image"

--- a/tests/gateway/test_gateway_multimodal_passthrough.py
+++ b/tests/gateway/test_gateway_multimodal_passthrough.py
@@ -1,0 +1,98 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner._resolve_session_agent_runtime = lambda **kwargs: (
+        "openai/gpt-5.4",
+        {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    runner._resolve_turn_agent_config = lambda user_message, model, runtime_kwargs: {
+        "model": model,
+        "runtime": runtime_kwargs,
+    }
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+
+
+@pytest.mark.asyncio
+async def test_resolve_gateway_image_message_auto_returns_native_multimodal(tmp_path):
+    runner = _make_runner()
+    image_path = tmp_path / "cat.png"
+    image_path.write_bytes(b"fake-png")
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={"multimodal": {"image_input_policy": "auto"}}),
+        patch("gateway.run.runtime_supports_native_image_input", return_value=True),
+    ):
+        agent_message, persist_user_message, image_error = await runner._resolve_gateway_image_message(
+            user_text="What is in this image?",
+            image_paths=[str(image_path)],
+            source=_make_source(),
+            session_key="session-1",
+        )
+
+    assert image_error is None
+    assert isinstance(agent_message, list)
+    assert agent_message[0] == {"type": "text", "text": "What is in this image?"}
+    assert agent_message[1]["type"] == "image_url"
+    assert agent_message[1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert "Attached image: cat.png" in persist_user_message
+    runner._enrich_message_with_vision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_gateway_image_message_fallback_uses_vision_enrichment(tmp_path):
+    runner = _make_runner()
+    image_path = tmp_path / "cat.png"
+    image_path.write_bytes(b"fake-png")
+
+    with patch("gateway.run._load_gateway_config", return_value={"multimodal": {"image_input_policy": "fallback"}}):
+        agent_message, persist_user_message, image_error = await runner._resolve_gateway_image_message(
+            user_text="Describe it",
+            image_paths=[str(image_path)],
+            source=_make_source(),
+            session_key="session-1",
+        )
+
+    assert agent_message == "ENRICHED"
+    assert persist_user_message is None
+    assert image_error is None
+    runner._enrich_message_with_vision.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_gateway_image_message_strict_returns_error_for_unsupported_runtime(tmp_path):
+    runner = _make_runner()
+    image_path = tmp_path / "cat.png"
+    image_path.write_bytes(b"fake-png")
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={"multimodal": {"image_input_policy": "strict"}}),
+        patch("gateway.run.runtime_supports_native_image_input", return_value=None),
+    ):
+        agent_message, persist_user_message, image_error = await runner._resolve_gateway_image_message(
+            user_text="Describe it",
+            image_paths=[str(image_path)],
+            source=_make_source(),
+            session_key="session-1",
+        )
+
+    assert agent_message == "Describe it"
+    assert persist_user_message is None
+    assert image_error == "❌ Native image passthrough is unavailable for the active runtime in strict multimodal mode."
+    runner._enrich_message_with_vision.assert_not_awaited()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3891,3 +3891,79 @@ class TestDeadRetryCode:
             f"Expected 2 occurrences of 'if retry_count >= max_retries:' "
             f"but found {occurrences}"
         )
+
+
+class TestNativeMultimodalInput:
+    def test_chat_messages_to_responses_input_preserves_image_parts(self, agent):
+        items = agent._chat_messages_to_responses_input([
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUFBQQ=="}},
+                ],
+            }
+        ])
+
+        assert items == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "What is in this image?"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,QUFBQQ=="},
+                ],
+            }
+        ]
+
+    def test_preflight_codex_input_items_preserves_multimodal_user_content(self, agent):
+        normalized = agent._preflight_codex_input_items([
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Look"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUFBQQ=="}},
+                ],
+            }
+        ])
+
+        assert normalized == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Look"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,QUFBQQ=="},
+                ],
+            }
+        ]
+
+    def test_build_api_kwargs_preserves_multimodal_user_image_for_anthropic_when_runtime_supports_vision(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent.base_url = "https://api.anthropic.com/v1"
+        agent.model = "claude-sonnet-4-20250514"
+        agent.reasoning_config = None
+
+        api_messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Can you see this now?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ],
+        }]
+
+        with (
+            patch("run_agent.runtime_supports_native_image_input", return_value=True),
+            patch("agent.anthropic_adapter.build_anthropic_kwargs") as mock_build,
+        ):
+            mock_build.return_value = {"model": "claude-sonnet-4-20250514", "messages": [], "max_tokens": 4096}
+            agent._build_api_kwargs(api_messages)
+
+        kwargs = mock_build.call_args.kwargs or dict(zip(
+            ["model", "messages", "tools", "max_tokens", "reasoning_config"],
+            mock_build.call_args.args,
+        ))
+        transformed = kwargs["messages"]
+        assert isinstance(transformed[0]["content"], list)
+        assert transformed[0]["content"][0]["type"] == "text"
+        assert transformed[0]["content"][1]["type"] == "image_url"
+        assert transformed[0]["content"][1]["image_url"]["url"] == "https://example.com/cat.png"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -667,6 +667,21 @@ Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 
 Context compression has its own top-level `compression:` block with `summary_provider`, `summary_model`, and `summary_base_url` — see [Context Compression](#context-compression) above. The fallback model uses a `fallback_model:` block — see [Fallback Model](/docs/integrations/providers#fallback-model). All three follow the same provider/model/base_url pattern.
 :::
 
+### Multimodal Image Input Policy
+
+Use `multimodal.image_input_policy` to control how Hermes handles incoming images before they reach the main model:
+
+```yaml
+multimodal:
+  image_input_policy: fallback   # fallback | auto | strict
+```
+
+- `fallback` — use Hermes' auxiliary vision preprocessing first (or downgrade to text-safe preview) before the main model sees the image
+- `auto` — use native image passthrough when the active runtime safely supports it; otherwise fall back to auxiliary vision preprocessing
+- `strict` — require native image passthrough and fail clearly instead of silently falling back to auxiliary preprocessing
+
+This first slice applies to image input only. Audio, video, and broader file/document multimodal handling are follow-up work.
+
 ### Changing the Vision Model
 
 To use GPT-4o instead of Gemini Flash for image analysis:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -276,5 +276,6 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 ## Limitations
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
-- **No file upload** — vision/document analysis via uploaded files is not yet supported through the API.
+- **No file upload** — raw uploaded files are still not supported through the API server.
+- **Inline image parts only** — multimodal image input currently works through inline `image_url` / `input_image` message content, and follows `multimodal.image_input_policy` (`fallback | auto | strict`), where `fallback` means auxiliary vision preprocessing rather than native passthrough.
 - **Model field is cosmetic** — the `model` field in requests is accepted but the actual LLM model used is configured server-side in config.yaml.

--- a/website/docs/user-guide/features/vision.md
+++ b/website/docs/user-guide/features/vision.md
@@ -21,6 +21,16 @@ You can attach multiple images before sending — each gets its own badge. Press
 
 Images are saved to `~/.hermes/images/` as PNG files with timestamped filenames.
 
+## Gateway and API Server Behavior
+
+CLI image paste is only one multimodal entry path. Gateway and API-server requests can now be configured separately from auxiliary vision via `multimodal.image_input_policy`:
+
+- `fallback` — use auxiliary vision preprocessing first, or downgrade to text-safe preview before the main model sees the image
+- `auto` — pass images through natively when the routed runtime safely supports them; otherwise use auxiliary vision preprocessing
+- `strict` — require native image passthrough and fail clearly when unsupported instead of silently using auxiliary vision
+
+This policy currently covers image input only. Audio, video, and broader omni-media support remain follow-up work.
+
 ## Paste Methods
 
 How you attach an image depends on your terminal environment. Not all methods work everywhere — here's the full breakdown:


### PR DESCRIPTION
## Summary
Add a configurable image input policy for gateway and API-server image requests.

## What changed
- added `multimodal.image_input_policy` with `fallback | auto | strict`
- gateway image handling now follows the configured policy
- API-server inline image handling follows the same policy
- native image parts are preserved when runtime support is known to be safe
- strict mode now fails clearly instead of degrading silently
- docs updated to describe the actual image-handling behavior
- targeted tests added for gateway, API-server, and runtime compatibility paths

## Why
Hermes previously handled image input implicitly across different paths. This change makes the behavior explicit and gives users control over whether they want compatibility-first handling or native passthrough when supported.

## User impact
- default remains conservative: `fallback`
- users can opt into native-first behavior with `auto`
- users who require true native behavior can use `strict`

## Test plan
- `source venv/bin/activate && python -m pytest tests/gateway/test_gateway_multimodal_passthrough.py tests/gateway/test_api_server.py tests/run_agent/test_run_agent.py tests/agent/test_anthropic_adapter.py tests/agent/test_auxiliary_config_bridge.py -q`

Closes #7872