### PR TITLE
fix(gateway): add HERMES_SESSION_KEY to session_context contextvars

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6597,6 +6597,7 @@ class GatewayRunner:
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            session_key=context.session_key,
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -7335,8 +7336,8 @@ class GatewayRunner:
             # `_resolve_turn_agent_config(message, …)`.
             nonlocal message
 
-            # Pass session_key to process registry via env var so background
-            # processes can be mapped back to this gateway session
+            # session_key is now set via contextvars in _set_session_env()
+            # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
             # Read from env var or use default (same as CLI)

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -46,12 +46,14 @@ _SESSION_PLATFORM: ContextVar[str] = ContextVar("HERMES_SESSION_PLATFORM", defau
 _SESSION_CHAT_ID: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_ID", default="")
 _SESSION_CHAT_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_NAME", default="")
 _SESSION_THREAD_ID: ContextVar[str] = ContextVar("HERMES_SESSION_THREAD_ID", default="")
+_SESSION_KEY: ContextVar[str] = ContextVar("HERMES_SESSION_KEY", default="")
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
+    "HERMES_SESSION_KEY": _SESSION_KEY,
 }
 
 
@@ -60,6 +62,7 @@ def set_session_vars(
     chat_id: str = "",
     chat_name: str = "",
     thread_id: str = "",
+    session_key: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -74,6 +77,7 @@ def set_session_vars(
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
+        _SESSION_KEY.set(session_key),
     ]
     return tokens
 
@@ -87,6 +91,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,
+        _SESSION_KEY,
     ]
     for var, token in zip(vars_in_order, tokens):
         var.reset(token)

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 from gateway.config import Platform
@@ -117,3 +118,99 @@ def test_set_session_env_handles_missing_optional_fields():
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
 
     runner._clear_session_env(tokens)
+
+
+# ---------------------------------------------------------------------------
+# SESSION_KEY contextvars tests
+# ---------------------------------------------------------------------------
+
+
+def test_session_key_set_via_contextvars(monkeypatch):
+    """set_session_vars should set HERMES_SESSION_KEY via contextvars."""
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id="-1001",
+        session_key="tg:-1001:17585",
+    )
+    assert get_session_env("HERMES_SESSION_KEY") == "tg:-1001:17585"
+
+    clear_session_vars(tokens)
+    assert get_session_env("HERMES_SESSION_KEY") == ""
+
+
+def test_session_key_falls_back_to_os_environ(monkeypatch):
+    """get_session_env for SESSION_KEY should fall back to os.environ."""
+    monkeypatch.setenv("HERMES_SESSION_KEY", "env-session-123")
+
+    # No contextvar set — should read from os.environ
+    assert get_session_env("HERMES_SESSION_KEY") == "env-session-123"
+
+    # Set contextvar — should prefer it
+    tokens = set_session_vars(session_key="ctx-session-456")
+    assert get_session_env("HERMES_SESSION_KEY") == "ctx-session-456"
+
+    # Restore — should fall back to os.environ
+    clear_session_vars(tokens)
+    assert get_session_env("HERMES_SESSION_KEY") == "env-session-123"
+
+
+def test_set_session_env_includes_session_key():
+    """_set_session_env should propagate session_key from SessionContext."""
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="Group",
+        chat_type="group",
+        thread_id="17585",
+    )
+    context = SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_key="tg:-1001:17585",
+    )
+
+    tokens = runner._set_session_env(context)
+    assert get_session_env("HERMES_SESSION_KEY") == "tg:-1001:17585"
+    runner._clear_session_env(tokens)
+    assert get_session_env("HERMES_SESSION_KEY") == ""
+
+
+def test_session_key_no_race_condition_with_contextvars(monkeypatch):
+    """Prove contextvars isolates SESSION_KEY across concurrent async tasks.
+
+    Two tasks set different session keys. With contextvars each task
+    reads back its own value. With os.environ the second task would
+    overwrite the first (the old bug).
+    """
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+
+    results = {}
+
+    async def handler(key: str, delay: float):
+        tokens = set_session_vars(session_key=key)
+        try:
+            await asyncio.sleep(delay)
+            read_back = get_session_env("HERMES_SESSION_KEY")
+            results[key] = read_back
+        finally:
+            clear_session_vars(tokens)
+
+    async def run():
+        task_a = asyncio.create_task(handler("session-A", 0.15))
+        await asyncio.sleep(0.05)
+        task_b = asyncio.create_task(handler("session-B", 0.05))
+        await asyncio.gather(task_a, task_b)
+
+    asyncio.run(run())
+
+    # Both tasks must read back their own session key
+    assert results["session-A"] == "session-A", (
+        f"Session A got '{results['session-A']}' instead of 'session-A' — race condition!"
+    )
+    assert results["session-B"] == "session-B", (
+        f"Session B got '{results['session-B']}' instead of 'session-B' — race condition!"
+    )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -17,6 +17,8 @@ import threading
 import unicodedata
 from typing import Optional
 
+from gateway.session_context import get_session_env
+
 logger = logging.getLogger(__name__)
 
 # Per-thread/per-task gateway session identity.
@@ -40,11 +42,17 @@ def reset_current_session_key(token: contextvars.Token[str]) -> None:
 
 
 def get_current_session_key(default: str = "default") -> str:
-    """Return the active session key, preferring context-local state."""
+    """Return the active session key, preferring context-local state.
+
+    Resolution order:
+    1. approval-specific contextvars (set by gateway before agent.run)
+    2. session_context contextvars (set by _set_session_env)
+    3. os.environ fallback (CLI, cron, tests)
+    """
     session_key = _approval_session_key.get()
     if session_key:
         return session_key
-    return os.getenv("HERMES_SESSION_KEY", default)
+    return get_session_env("HERMES_SESSION_KEY", default)
 
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME.


### PR DESCRIPTION
## Summary

- `HERMES_SESSION_KEY` was missing from the `session_context.py` contextvars migration — still set via `os.environ` (process-global), which is racy under concurrent gateway messages
- The approval system had its own contextvars workaround (`_approval_session_key`), but any new code using `os.getenv("HERMES_SESSION_KEY")` would hit the same race
- This PR completes the migration by adding `SESSION_KEY` to the unified `_VAR_MAP` and wiring it through `set_session_vars()` / `_set_session_env()`

## Race condition proof

Two concurrent gateway handlers set `os.environ["HERMES_SESSION_KEY"]`. Handler A (slow) reads back Handler B's key:

```
[TEST] os.environ — two concurrent async handlers
  session-A-telegram-12345:
    expected: session-A-telegram-12345
    actual:   session-B-discord-67890
    result:   RACE CONDITION

[TEST] contextvars — two concurrent async handlers (FIXED)
  session-A-telegram-12345:
    expected: session-A-telegram-12345
    actual:   session-A-telegram-12345
    result:   OK
```

## Changes

- **`gateway/session_context.py`**: Add `_SESSION_KEY` ContextVar to `_VAR_MAP`, add `session_key` param to `set_session_vars()` / `clear_session_vars()`
- **`gateway/run.py`**: Pass `context.session_key` through `_set_session_env()` (kept `os.environ` set as CLI/cron fallback)
- **`tools/approval.py`**: Replace `os.getenv` fallback with `get_session_env()` for unified resolution chain (approval contextvars -> session_context contextvars -> os.environ)
- **`tests/gateway/test_session_env.py`**: 4 new tests covering SESSION_KEY contextvars, os.environ fallback, SessionContext propagation, and concurrent task isolation

## Test plan

- [x] `pytest tests/gateway/test_session_env.py` — 9/9 passed (5 existing + 4 new)
- [x] No circular import (`from tools.approval import get_current_session_key` verified)
- [ ] Verify gateway handles concurrent messages correctly with this change