### PR TITLE
fix(cli): add ChatConsole.status compatibility for /skills search

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1355,6 +1355,19 @@ class ChatConsole:
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 
+    @contextmanager
+    def status(self, *_args, **_kwargs):
+        """Provide a no-op Rich-compatible status context.
+
+        Some slash command helpers use ``console.status(...)`` when running in
+        the standalone CLI. Interactive chat routes those helpers through
+        ``ChatConsole()``, which historically only implemented ``print()``.
+        Returning a silent context manager keeps slash commands compatible
+        without duplicating the higher-level busy indicator already shown by
+        ``HermesCLI._busy_command()``.
+        """
+        yield self
+
 # ASCII Art - HERMES-AGENT logo (full width, single line - requires ~95 char terminal)
 HERMES_AGENT_LOGO = """[bold #FFD700]██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗       █████╗  ██████╗ ███████╗███╗   ██╗████████╗[/]
 [bold #FFD700]██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝      ██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝[/]

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,8 +1,10 @@
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 from rich.console import Console
 
+from cli import ChatConsole
 from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
 
 
@@ -177,6 +179,21 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():
+    results = [type("R", (), {
+        "name": "kubernetes",
+        "description": "Cluster orchestration",
+        "source": "skills.sh",
+        "trust_level": "community",
+        "identifier": "skills-sh/example/kubernetes",
+    })()]
+
+    with patch("tools.skills_hub.unified_search", return_value=results), \
+         patch("tools.skills_hub.create_source_router", return_value={}), \
+         patch("tools.skills_hub.GitHubAuth"):
+        handle_skills_slash("/skills search kubernetes", console=ChatConsole())
 
 
 def test_do_install_scans_with_resolved_identifier(monkeypatch, tmp_path, hub_env):


### PR DESCRIPTION
## Summary

Related to #6262, but not a duplicate.

This PR fixes an interactive CLI regression where `/skills search <query>` fails with:

`Error: 'ChatConsole' object has no attribute 'status'`

The issue was introduced after `hermes_cli/skills_hub.py` started using `console.status(...)` in #7301. The interactive slash-command path passes `ChatConsole`, which previously implemented `print()` but not `status()`.

## Root cause

- `hermes_cli/skills_hub.py` now uses:
  - `with c.status("[bold]Searching registries..."):`
  - `with c.status("[bold]Fetching skills from registries..."):`
- Interactive CLI routes `/skills ...` through `ChatConsole`
- `ChatConsole` did not implement `status()`
- As a result, `hermes skills search ...` worked, but `/skills search ...` in interactive CLI crashed

## Changes

- Add `ChatConsole.status()` as a no-op Rich-compatible context manager
- Keep the implementation silent because `HermesCLI._busy_command()` already shows command progress
- Add a regression test covering:
  - `handle_skills_slash("/skills search kubernetes", console=ChatConsole())`

## Why this is not covered by #6262

#6262 improves ChatConsole usage by reusing `self.chat_console`, but it does not add `ChatConsole.status()` compatibility. Without this change, the interactive `/skills search ...` path can still fail when helpers call `console.status(...)`.

## Testing

Ran:

```bash
python -m pytest tests/hermes_cli/test_skills_hub.py tests/cli/test_cli_loading_indicator.py tests/hermes_cli/test_skills_skip_confirm.py -q -o 'addopts='
```

Result:

- 27 passed

Also verified manually in interactive CLI (tmux):
- `/skills search kubernetes` now shows results correctly
- no `ChatConsole.status` error
