### PR TITLE
Fix /model provider-prefixed direct endpoints routing to OpenRouter

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4391,7 +4391,7 @@ class GatewayRunner:
             lines.append(f"{auth} `{p['id']}` — {p['label']}{aliases}{marker}")
 
         lines.append("")
-        lines.append("Switch: `/model provider:model-name`")
+        lines.append("Switch: `/model <name> --provider <slug>`")
         lines.append("Setup: `hermes setup`")
         return "\n".join(lines)
     

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -373,6 +373,50 @@ def _resolve_alias_fallback(
     return None
 
 
+def _extract_unambiguous_provider_prefix(
+    raw_input: str,
+    user_providers: dict = None,
+    custom_providers: list | None = None,
+) -> tuple[str, str] | None:
+    """Extract ``provider/model`` for unambiguous non-aggregator provider slugs.
+
+    ``/model`` historically only treated ``--provider`` as an explicit provider
+    selector. That made inputs such as ``minimax-cn/MiniMax-M2.7`` fall through to
+    generic model detection, which could incorrectly route them to aggregators like
+    OpenRouter. To avoid breaking common aggregator slugs like
+    ``anthropic/claude-sonnet-*``, this helper only accepts provider prefixes that
+    are unambiguous in practice: hyphenated/built-in non-aggregator slugs and
+    user-defined/custom provider slugs.
+    """
+    stripped = (raw_input or "").strip()
+    if not stripped or "/" not in stripped:
+        return None
+    if stripped.startswith(("http://", "https://")):
+        return None
+
+    left, right = stripped.split("/", 1)
+    provider_part = left.strip().lower()
+    model_part = right.strip()
+    if not provider_part or not model_part:
+        return None
+
+    pdef = resolve_provider_full(provider_part, user_providers, custom_providers)
+    if pdef is None:
+        return None
+    if is_aggregator(pdef.id):
+        return None
+
+    is_unambiguous_prefix = (
+        "-" in provider_part
+        or ":" in provider_part
+        or getattr(pdef, "source", "") == "user-config"
+    )
+    if not is_unambiguous_prefix:
+        return None
+
+    return (pdef.id, model_part)
+
+
 # ---------------------------------------------------------------------------
 # Core model-switching pipeline
 # ---------------------------------------------------------------------------
@@ -435,6 +479,18 @@ def switch_model(
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
+
+    # Support unambiguous provider/model prefixes for non-aggregator slugs such
+    # as ``minimax-cn/MiniMax-M2.7`` without stealing common OpenRouter-style
+    # vendor/model IDs like ``anthropic/claude-sonnet-*``.
+    if not explicit_provider:
+        prefixed = _extract_unambiguous_provider_prefix(
+            raw_input,
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+        )
+        if prefixed is not None:
+            explicit_provider, new_model = prefixed
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -940,5 +996,4 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -102,3 +102,34 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.new_model == "rotator-openrouter-coding"
     assert result.base_url == "http://127.0.0.1:4141/v1"
     assert result.api_key == "no-key-required"
+
+
+def test_switch_model_accepts_unambiguous_provider_prefix(monkeypatch):
+    """Hyphenated provider/model prefixes should not fall through to OpenRouter."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "mm-key",
+            "base_url": "https://api.minimaxi.com/anthropic",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="minimax-cn/MiniMax-M2.7",
+        current_provider="openrouter",
+        current_model="anthropic/claude-sonnet-4.6",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="or-key",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "minimax-cn"
+    assert result.new_model == "MiniMax-M2.7"
+    assert result.base_url == "https://api.minimaxi.com/anthropic"
+    assert result.api_mode == "anthropic_messages"


### PR DESCRIPTION
## What does this PR do?

This fixes a `/model` parsing bug where provider-prefixed direct-provider inputs like `minimax-cn/MiniMax-M2.7` were treated as plain model strings instead of an explicit provider switch.

Before this patch, that input could fall through to `detect_provider_for_model()` and get re-routed to OpenRouter, which then produced session output like:

```text
Model switched to minimax-cn/MiniMax-M2.7
Provider: OpenRouter
Warning: minimax-cn/MiniMax-M2.7 was not found in this provider's model listing.
```

and then failed with an OpenRouter auth error.

This PR adds a narrow parser for unambiguous `provider/model` prefixes before generic provider detection runs. The parser intentionally only handles prefixes that are unlikely to collide with OpenRouter-style vendor/model slugs, such as:
- `minimax-cn/MiniMax-M2.7`
- `custom:local-provider/my-model`

It does not try to reinterpret general aggregator IDs like `anthropic/claude-sonnet-4.6`.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] ? New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] ? Tests (adding or improving test coverage)
- [ ] ?? Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `_extract_unambiguous_provider_prefix()` in `hermes_cli/model_switch.py`
- Updated `switch_model()` in `hermes_cli/model_switch.py` to treat unambiguous `provider/model` prefixes as an explicit provider switch
- Updated the gateway `/model` hint in `gateway/run.py` to recommend the syntax the shared implementation actually supports
- Added a regression test in `tests/hermes_cli/test_model_switch_custom_providers.py` for the MiniMax China case

## How to Test

1. Start from a session currently using an aggregator provider such as OpenRouter.
2. Run `/model minimax-cn/MiniMax-M2.7`.
3. Confirm the switch resolves to `minimax-cn` instead of OpenRouter and that the new regression test covers this path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) ? or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys ? or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows ? or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) ? or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior ? or N/A

## Screenshots / Logs

Reproduction before the fix:

```text
[2026/4/12 1:52] /model minimax-cn/MiniMax-M2.7
Model switched to minimax-cn/MiniMax-M2.7
Provider: OpenRouter
...
HTTP 401: No cookie auth credentials found
```

Validation performed for this branch:
- added regression test `test_switch_model_accepts_unambiguous_provider_prefix`
- `python -m py_compile hermes_cli/model_switch.py gateway/run.py tests/hermes_cli/test_model_switch_custom_providers.py`

I could not run the full pytest suite in this Windows checkout because the local interpreter here did not have the repo test dependencies installed.
