### PR TITLE
fix(cron): pass skip_context_files=True to AIAgent in run_job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -723,6 +723,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             disabled_toolsets=["cronjob", "messaging", "clarify"],
             quiet_mode=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_context_files=True,  # SOUL.md/AGENTS.md/.cursorrules pollute ephemeral cron prompts and waste tokens — match batch/subagent paths
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -664,6 +664,13 @@ class TestRunJobSessionPersistence:
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
         assert kwargs["session_id"].startswith("cron_test-job_")
+        # Cron jobs run in ephemeral sessions and must not pull SOUL.md /
+        # AGENTS.md / .cursorrules into the system prompt — the same guarantee
+        # batch_runner and subagent delegation already provide.  Without this
+        # flag, every cron tick burns thousands of tokens re-loading user
+        # persona files even for `[SILENT] exec: ...` script-only jobs.
+        assert kwargs["skip_memory"] is True
+        assert kwargs["skip_context_files"] is True
         fake_db.end_session.assert_called_once()
         call_args = fake_db.end_session.call_args
         assert call_args[0][0].startswith("cron_test-job_")


### PR DESCRIPTION
Closes #7876.

## Problem

`cron/scheduler.py` is the only `AIAgent` caller in the codebase that does not opt out of context-file injection. Every cron tick — including pure `[SILENT] exec: bash ...` script-only jobs — re-loads SOUL.md, AGENTS.md, and .cursorrules into the system prompt, burning thousands of input tokens per run for no benefit.

The other ephemeral execution paths already skip these files:

| caller | flag |
| --- | --- |
| `cli.py:5349` (`/btw` ephemeral side question) | ✅ `skip_context_files=True` |
| `batch_runner.py:332` (batch generation) | ✅ `skip_context_files=True` |
| `tools/delegate_tool.py:304` (subagent delegation) | ✅ `skip_context_files=True` |
| **`cron/scheduler.py:725`** | ❌ **missing** |

`skip_memory` is already passed (line 725); only the matching `skip_context_files` was missing.

## Fix

One-line addition to the `AIAgent(...)` call in `_run_cron_job_async` so cron jobs receive the same minimal-context treatment as the other ephemeral paths.

## Impact

Measured on an install with 6 script-only `[SILENT] exec` cron jobs (~196 ticks/day across `memory-session-scan`, `memory-micro-cycle`, `memory-monitor`, `pricing-backfill`, `self-review-scan`, `self-review-apply`):

- **~10M wasted input tokens/day eliminated** for users with non-trivial SOUL.md/AGENTS.md
- No behavior change for cron jobs that legitimately need an LLM (they still get tools, model routing, session_db persistence, delivery, etc.) — they just stop hauling user-persona files into every ephemeral session

## Test

Extends the existing `TestRunJobSessionPersistence::test_run_job_passes_session_db_and_cron_platform` to assert both `skip_memory` and `skip_context_files` are forwarded:

```bash
pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence -q
...                                                                      [100%]
3 passed in 1.45s
```

## Risk

Very low. `skip_context_files` is an existing, documented `AIAgent` parameter (added in 48b5cfd0 for batch processing). This change just plumbs it through the cron path to match the other ephemeral callers.