### PR TITLE
fix weixin chunk delivery retries

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -981,6 +981,16 @@ class WeixinAdapter(BasePlatformAdapter):
         self._cdn_base_url = str(
             extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
+        self._send_chunk_delay_seconds = float(
+            extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "0.35")
+        )
+        self._send_chunk_retries = int(
+            extra.get("send_chunk_retries") or os.getenv("WEIXIN_SEND_CHUNK_RETRIES", "2")
+        )
+        self._send_chunk_retry_delay_seconds = float(
+            extra.get("send_chunk_retry_delay_seconds")
+            or os.getenv("WEIXIN_SEND_CHUNK_RETRY_DELAY_SECONDS", "1.0")
+        )
         self._dm_policy = str(extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "open")).strip().lower()
         self._group_policy = str(extra.get("group_policy") or os.getenv("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
         allow_from = extra.get("allow_from")
@@ -1332,6 +1342,46 @@ class WeixinAdapter(BasePlatformAdapter):
     def _split_text(self, content: str) -> List[str]:
         return _split_text_for_weixin_delivery(content, self.MAX_MESSAGE_LENGTH)
 
+    async def _send_text_chunk(
+        self,
+        *,
+        chat_id: str,
+        chunk: str,
+        context_token: Optional[str],
+        client_id: str,
+    ) -> None:
+        last_error: Optional[Exception] = None
+        for attempt in range(self._send_chunk_retries + 1):
+            try:
+                await _send_message(
+                    self._session,
+                    base_url=self._base_url,
+                    token=self._token,
+                    to=chat_id,
+                    text=chunk,
+                    context_token=context_token,
+                    client_id=client_id,
+                )
+                return
+            except Exception as exc:
+                last_error = exc
+                if attempt >= self._send_chunk_retries:
+                    break
+                wait = self._send_chunk_retry_delay_seconds * (attempt + 1)
+                logger.warning(
+                    "[%s] send chunk failed to=%s attempt=%d/%d, retrying in %.2fs: %s",
+                    self.name,
+                    _safe_id(chat_id),
+                    attempt + 1,
+                    self._send_chunk_retries + 1,
+                    wait,
+                    exc,
+                )
+                if wait > 0:
+                    await asyncio.sleep(wait)
+        assert last_error is not None
+        raise last_error
+
     async def send(
         self,
         chat_id: str,
@@ -1344,18 +1394,18 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
         try:
-            for chunk in self._split_text(self.format_message(content)):
+            chunks = self._split_text(self.format_message(content))
+            for idx, chunk in enumerate(chunks):
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
-                await _send_message(
-                    self._session,
-                    base_url=self._base_url,
-                    token=self._token,
-                    to=chat_id,
-                    text=chunk,
+                await self._send_text_chunk(
+                    chat_id=chat_id,
+                    chunk=chunk,
                     context_token=context_token,
                     client_id=client_id,
                 )
                 last_message_id = client_id
+                if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:
+                    await asyncio.sleep(self._send_chunk_delay_seconds)
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+from unittest.mock import ANY
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import PlatformConfig
@@ -199,6 +200,53 @@ class TestWeixinSendMessageIntegration:
             "hello",
             media_files=[("/tmp/demo.png", False)],
         )
+
+
+class TestWeixinChunkDelivery:
+    def _connected_adapter(self) -> WeixinAdapter:
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        return adapter
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_send_waits_between_multiple_chunks(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        adapter.MAX_MESSAGE_LENGTH = 12
+
+        result = asyncio.run(adapter.send("wxid_test123", "first\nsecond\nthird"))
+
+        assert result.success is True
+        assert send_message_mock.await_count == 3
+        assert sleep_mock.await_count == 2
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_send_retries_failed_chunk_before_continuing(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        adapter.MAX_MESSAGE_LENGTH = 12
+        calls = {"count": 0}
+
+        async def flaky_send(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 2:
+                raise RuntimeError("temporary iLink failure")
+
+        send_message_mock.side_effect = flaky_send
+
+        result = asyncio.run(adapter.send("wxid_test123", "first\nsecond\nthird"))
+
+        assert result.success is True
+        assert send_message_mock.await_count == 4
+        first_retry = send_message_mock.await_args_list[1].kwargs
+        second_retry = send_message_mock.await_args_list[2].kwargs
+        assert first_retry["text"] == "second"
+        assert second_retry["text"] == "second"
+        assert first_retry["client_id"] == second_retry["client_id"]
+        sleep_mock.assert_any_await(ANY)
 
 
 class TestWeixinRemoteMediaSafety:


### PR DESCRIPTION
## Summary

Adds per-chunk retry and pacing for Weixin text delivery so long replies split into multiple bubbles are less likely to lose trailing chunks silently.

## Root cause

The Weixin adapter sent all split text chunks in a tight loop and treated each `_send_message` call as a single-attempt operation. If iLink/WeChat temporarily rejected, throttled, or dropped a later chunk, the adapter had no retry/backoff around that specific chunk before moving through the turn lifecycle.

## Changes

- Add configurable Weixin chunk delivery settings for inter-chunk delay, retry count, and retry delay.
- Send each text chunk through a helper that retries failures before reporting the send as failed.
- Reuse the same `client_id` for retries of a given chunk so duplicate delivery can be de-duplicated by the backend when supported.
- Add regression coverage for pacing between chunks and retrying a failed middle chunk before continuing.

## Validation

- `python -m pytest tests/gateway/test_weixin.py tests/tools/test_send_message_tool.py -q -n0`
- `python -m py_compile gateway/platforms/weixin.py tests/gateway/test_weixin.py`
- `git diff --check`

Fixes #7836
