### PR TITLE
fix: is_local_endpoint misses Docker/Podman DNS names

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -241,8 +241,28 @@ def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
 
 
+def _load_local_endpoints() -> set:
+    """Load additional local endpoint hostnames from config.
+
+    Reads ``model.local_endpoints`` from config.yaml — a list of hostnames
+    that should be treated as local even though they aren't IPs or localhost.
+    Typical use: Docker/Podman DNS names for LiteLLM or other local proxies.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, dict):
+            entries = model_cfg.get("local_endpoints", [])
+            if isinstance(entries, list):
+                return {str(e).strip().lower() for e in entries if e}
+    except Exception:
+        pass
+    return set()
+
+
 def is_local_endpoint(base_url: str) -> bool:
-    """Return True if base_url points to a local machine (localhost / RFC-1918 / WSL)."""
+    """Return True if base_url points to a local machine (localhost / RFC-1918 / WSL / configured hostnames)."""
     normalized = _normalize_base_url(base_url)
     if not normalized:
         return False
@@ -254,12 +274,28 @@ def is_local_endpoint(base_url: str) -> bool:
         return False
     if host in _LOCAL_HOSTS:
         return True
-    # RFC-1918 private ranges and link-local
+    # Unqualified hostnames (no dots) are local — Docker/Podman DNS, mDNS,
+    # /etc/hosts entries. A hostname like "hermes-litellm" or "ollama" is
+    # always on the local network.
+    if "." not in host:
+        return True
+    # Check configured local endpoints (e.g. custom DNS names)
+    if host.lower() in _load_local_endpoints():
+        return True
+    # Try resolving hostname to IP and check if it's private
     import ipaddress
     try:
         addr = ipaddress.ip_address(host)
         return addr.is_private or addr.is_loopback or addr.is_link_local
     except ValueError:
+        pass
+    # DNS resolution fallback — resolve hostname and check if IP is private
+    import socket
+    try:
+        resolved_ip = socket.gethostbyname(host)
+        addr = ipaddress.ip_address(resolved_ip)
+        return addr.is_private or addr.is_loopback or addr.is_link_local
+    except (socket.gaierror, ValueError):
         pass
     # Bare IP that looks like a private range (e.g. 172.26.x.x for WSL)
     parts = host.split(".")


### PR DESCRIPTION
## Summary

Extends `is_local_endpoint()` in `agent/model_metadata.py` to detect local LLM proxies accessed via container DNS names (e.g. `ollama`, `litellm`, `hermes-litellm`).

Without this fix, the stale stream timeout (180s, added in #6368) is NOT auto-disabled for local providers accessed via Docker/Podman DNS, causing the infinite retry loop described in #7069.

## Changes

Three additions to `is_local_endpoint()`:

1. **Unqualified hostnames (no dots) → always local.** A hostname like `ollama` or `litellm` is always a local network name (Docker/Podman DNS, mDNS, `/etc/hosts`). This is the most common case and requires zero configuration.

2. **DNS resolution fallback** — resolve the hostname to an IP with `socket.gethostbyname()`, check if the resolved address is private/loopback/link-local. Catches qualified local hostnames like `ollama.local`.

3. **Configurable `model.local_endpoints`** — a list of hostnames in `config.yaml` to explicitly mark as local. Useful for edge cases where DNS resolution isn't available or the hostname doesn't resolve to a private IP.

## Test plan

- [ ] Verify `is_local_endpoint("http://ollama:11434/v1")` returns `True` (unqualified hostname)
- [ ] Verify `is_local_endpoint("http://my-litellm-proxy:4000/v1")` returns `True` (unqualified hostname)
- [ ] Verify `is_local_endpoint("http://api.openai.com/v1")` returns `False` (qualified, public)
- [ ] Verify `is_local_endpoint("http://localhost:11434/v1")` still returns `True` (existing behavior)
- [ ] Verify `is_local_endpoint("http://192.168.1.100:8000/v1")` still returns `True` (existing behavior)
- [ ] Verify DNS resolution: `is_local_endpoint("http://my-host.local:8000/v1")` resolves and checks IP
- [ ] Verify `model.local_endpoints` config is read when set
- [ ] Verify graceful degradation when config is unavailable (no crash)

Fixes #7905
Related: #7069, #6368

🤖 Generated with [Claude Code](https://claude.com/claude-code)