### PR TITLE
fix(custom-providers): propagate model field from config so API receives the correct model name

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2710,6 +2710,15 @@ class HermesCLI:
         self.api_key = api_key
         self.base_url = base_url
 
+        # When a custom_provider entry carries an explicit `model` field,
+        # use it as the effective model name.  Without this, running
+        # `hermes chat --model <provider-name>` sends the provider name
+        # (e.g. "my-provider") as the model string to the API instead of
+        # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
+        runtime_model = runtime.get("model")
+        if runtime_model and isinstance(runtime_model, str):
+            self.model = runtime_model
+
         # Normalize model for the resolved provider (e.g. swap non-Codex
         # models when provider is openai-codex).  Fixes #651.
         model_changed = self._normalize_model_for_provider(resolved_provider)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -304,6 +304,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
             result["api_mode"] = api_mode
+        model_name = str(entry.get("model", "") or "").strip()
+        if model_name:
+            result["model"] = model_name
         return result
 
     return None
@@ -339,7 +342,7 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
-    return {
+    result = {
         "provider": "custom",
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
@@ -348,6 +351,11 @@ def _resolve_named_custom_runtime(
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
+    # Propagate the model name so callers can override self.model when the
+    # provider name differs from the actual model string the API expects.
+    if custom_provider.get("model"):
+        result["model"] = custom_provider["model"]
+    return result
 
 
 def _resolve_openrouter_runtime(


### PR DESCRIPTION
## Problem

Fixes #7828

When a `custom_providers` entry in `config.yaml` defines a `model` field, that value was silently discarded:

```yaml
custom_providers:
  - name: my-dashscope
    base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
    api_key: ${ALI_API_KEY}
    api_mode: chat_completions
    model: qwen3.6-plus   # ← this was ignored
```

Running `hermes chat --model my-dashscope` failed with:

```
Error code: 400 - {'error': {'message': 'Model Not Exist'}}
```

because the agent sent the string `"my-dashscope"` (the provider name) as the model to the API instead of `"qwen3.6-plus"` (the configured model). Setting the provider as the *default* model worked around the bug because that path reads `model.default` directly and never goes through `_resolve_named_custom_runtime`.

## Root Cause

`_get_named_custom_provider()` built its result dict from `entry.get("name")`, `entry.get("base_url")`, `entry.get("api_key")`, and `entry.get("api_mode")` — but never touched `entry.get("model")`. The field was present in `config.yaml` but dropped before any caller could see it.

`_resolve_named_custom_runtime()` therefore had no model to propagate, and `cli.py`'s `_ensure_runtime_credentials()` never updated `self.model` from the runtime result.

## Fix

Three small, surgical changes:

### 1. `hermes_cli/runtime_provider.py` — `_get_named_custom_provider()`
```python
model_name = str(entry.get("model", "") or "").strip()
if model_name:
    result["model"] = model_name
```
Reads the `model` field from the config entry and stores it in the result dict so callers can access it.

### 2. `hermes_cli/runtime_provider.py` — `_resolve_named_custom_runtime()`
```python
if custom_provider.get("model"):
    result["model"] = custom_provider["model"]
```
Propagates the model name into the dict returned by `resolve_runtime_provider()`.

### 3. `cli.py` — `_ensure_runtime_credentials()`
```python
runtime_model = runtime.get("model")
if runtime_model and isinstance(runtime_model, str):
    self.model = runtime_model
```
After resolving credentials, overrides `self.model` with the configured model name so the AIAgent is initialised with the value the API actually expects, not the provider name the user typed.

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| `name == model` in config | ✅ works (coincidence) | ✅ works |
| `name != model` in config | ❌ 400 Model Not Exist | ✅ correct model sent |
| Provider set as default model | ✅ works | ✅ works (unaffected) |
| No `model` field in entry | ✅ unchanged | ✅ unchanged |