### PR TITLE
feat: native AWS Bedrock provider via Converse API

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -298,6 +298,33 @@ def build_anthropic_client(api_key: str, base_url: str = None):
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
+def build_anthropic_bedrock_client(region: str):
+    """Create an AnthropicBedrock client for Bedrock Claude models.
+
+    Uses the Anthropic SDK's native Bedrock adapter, which provides full
+    Claude feature parity: prompt caching, thinking budgets, adaptive
+    thinking, fast mode — features not available via the Converse API.
+
+    Auth uses the boto3 default credential chain (IAM roles, SSO, env vars).
+    """
+    if _anthropic_sdk is None:
+        raise ImportError(
+            "The 'anthropic' package is required for the Bedrock provider. "
+            "Install it with: pip install 'anthropic>=0.39.0'"
+        )
+    if not hasattr(_anthropic_sdk, "AnthropicBedrock"):
+        raise ImportError(
+            "anthropic.AnthropicBedrock not available. "
+            "Upgrade with: pip install 'anthropic>=0.39.0'"
+        )
+    from httpx import Timeout
+
+    return _anthropic_sdk.AnthropicBedrock(
+        aws_region=region,
+        timeout=Timeout(timeout=900.0, connect=10.0),
+    )
+
+
 def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     """Read refreshable Claude Code OAuth credentials from ~/.claude/.credentials.json.
 

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -194,6 +194,57 @@ def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Tool-calling capability detection
+# ---------------------------------------------------------------------------
+# Some Bedrock models don't support tool/function calling. Sending toolConfig
+# to these models causes ValidationException. We maintain a denylist of known
+# non-tool-calling model patterns and strip tools for them.
+#
+# This is a conservative approach: unknown models are assumed to support tools.
+# If a model fails with a tool-related ValidationException, add it here.
+
+_NON_TOOL_CALLING_PATTERNS = [
+    "deepseek.r1",          # DeepSeek R1 — reasoning only, no tool support
+    "deepseek-r1",          # Alternate ID format
+    "stability.",           # Image generation models
+    "cohere.embed",         # Embedding models
+    "amazon.titan-embed",   # Embedding models
+]
+
+
+def _model_supports_tool_use(model_id: str) -> bool:
+    """Return True if the model is expected to support tool/function calling.
+
+    Models in the denylist are known to reject toolConfig in the Converse API.
+    Unknown models default to True (assume tool support).
+    """
+    model_lower = model_id.lower()
+    return not any(pattern in model_lower for pattern in _NON_TOOL_CALLING_PATTERNS)
+
+
+def is_anthropic_bedrock_model(model_id: str) -> bool:
+    """Return True if the model is an Anthropic Claude model on Bedrock.
+
+    These models should use the AnthropicBedrock SDK path for full feature
+    parity (prompt caching, thinking budgets, adaptive thinking).
+    Non-Claude models use the Converse API path.
+
+    Matches:
+      - ``anthropic.claude-*`` (foundation model IDs)
+      - ``us.anthropic.claude-*`` (US inference profiles)
+      - ``global.anthropic.claude-*`` (global inference profiles)
+      - ``eu.anthropic.claude-*`` (EU inference profiles)
+    """
+    model_lower = model_id.lower()
+    # Strip regional prefix if present
+    for prefix in ("us.", "global.", "eu.", "ap.", "jp."):
+        if model_lower.startswith(prefix):
+            model_lower = model_lower[len(prefix):]
+            break
+    return model_lower.startswith("anthropic.claude")
+
+
+# ---------------------------------------------------------------------------
 # Message format conversion: OpenAI → Bedrock Converse
 # ---------------------------------------------------------------------------
 
@@ -234,11 +285,15 @@ def _convert_content_to_converse(content) -> List[Dict]:
     Handles:
       - Plain text strings → [{"text": "..."}]
       - Content arrays with text/image_url parts → mixed text/image blocks
+
+    Filters out empty text blocks — Bedrock's Converse API rejects messages
+    where a text content block has an empty ``text`` field (ValidationException:
+    "text content blocks must be non-empty"). Ref: issue #9486.
     """
     if content is None:
-        return [{"text": ""}]
+        return [{"text": " "}]
     if isinstance(content, str):
-        return [{"text": content}] if content else [{"text": " "}]
+        return [{"text": content}] if content.strip() else [{"text": " "}]
     if isinstance(content, list):
         blocks = []
         for part in content:
@@ -686,7 +741,18 @@ def build_converse_kwargs(
     if tools:
         converse_tools = convert_tools_to_converse(tools)
         if converse_tools:
-            kwargs["toolConfig"] = {"tools": converse_tools}
+            # Some Bedrock models don't support tool/function calling (e.g.
+            # DeepSeek R1, reasoning-only models).  Sending toolConfig to
+            # these models causes a ValidationException → retry loop → failure.
+            # Strip tools for known non-tool-calling models and warn the user.
+            # Ref: PR #7920 feedback from @ptlally, pattern from PR #4346.
+            if _model_supports_tool_use(model):
+                kwargs["toolConfig"] = {"tools": converse_tools}
+            else:
+                logger.warning(
+                    "Model %s does not support tool calling — tools stripped. "
+                    "The agent will operate in text-only mode.", model
+                )
 
     if guardrail_config:
         kwargs["guardrailConfig"] = guardrail_config

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1,0 +1,1032 @@
+"""AWS Bedrock Converse API adapter for Hermes Agent.
+
+Provides native integration with Amazon Bedrock using the Converse API,
+bypassing the OpenAI-compatible endpoint in favor of direct AWS SDK calls.
+This enables full access to the Bedrock ecosystem:
+
+  - **Native Converse API**: Unified interface for all Bedrock models
+    (Claude, Nova, Llama, Mistral, etc.) with streaming support.
+  - **AWS credential chain**: IAM roles, SSO profiles, environment variables,
+    instance metadata — zero API key management for AWS-native environments.
+  - **Dynamic model discovery**: Auto-discovers available foundation models
+    and cross-region inference profiles via the Bedrock control plane.
+  - **Guardrails support**: Optional Bedrock Guardrails configuration for
+    content filtering and safety policies.
+  - **Inference profiles**: Supports cross-region inference profiles
+    (us.anthropic.claude-*, global.anthropic.claude-*) for better capacity
+    and automatic failover.
+
+Architecture follows the same pattern as ``anthropic_adapter.py``:
+  - All Bedrock-specific logic is isolated in this module.
+  - Messages/tools are converted between OpenAI format and Converse format.
+  - Responses are normalized back to OpenAI-compatible objects for the agent loop.
+
+Reference: OpenClaw's ``extensions/amazon-bedrock/`` plugin, which implements
+the same Converse API integration in TypeScript via ``@aws-sdk/client-bedrock``.
+
+Requires: ``boto3`` (optional dependency — only needed when using the Bedrock provider).
+"""
+
+import json
+import logging
+import os
+import re
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy boto3 import — only loaded when the Bedrock provider is actually used.
+# This keeps startup fast for users who don't use Bedrock.
+# ---------------------------------------------------------------------------
+
+_bedrock_runtime_client_cache: Dict[str, Any] = {}
+_bedrock_control_client_cache: Dict[str, Any] = {}
+
+
+def _require_boto3():
+    """Import boto3, raising a clear error if not installed."""
+    try:
+        import boto3
+        return boto3
+    except ImportError:
+        raise ImportError(
+            "The 'boto3' package is required for the AWS Bedrock provider. "
+            "Install it with: pip install boto3\n"
+            "Or install Hermes with Bedrock support: pip install -e '.[bedrock]'"
+        )
+
+
+def _get_bedrock_runtime_client(region: str):
+    """Get or create a cached ``bedrock-runtime`` client for the given region.
+
+    Uses the default AWS credential chain (env vars → profile → instance role).
+    """
+    if region not in _bedrock_runtime_client_cache:
+        boto3 = _require_boto3()
+        _bedrock_runtime_client_cache[region] = boto3.client(
+            "bedrock-runtime", region_name=region,
+        )
+    return _bedrock_runtime_client_cache[region]
+
+
+def _get_bedrock_control_client(region: str):
+    """Get or create a cached ``bedrock`` control-plane client for model discovery."""
+    if region not in _bedrock_control_client_cache:
+        boto3 = _require_boto3()
+        _bedrock_control_client_cache[region] = boto3.client(
+            "bedrock", region_name=region,
+        )
+    return _bedrock_control_client_cache[region]
+
+
+def reset_client_cache():
+    """Clear cached boto3 clients. Used in tests and profile switches."""
+    _bedrock_runtime_client_cache.clear()
+    _bedrock_control_client_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# AWS credential detection
+# ---------------------------------------------------------------------------
+
+# Priority order matches OpenClaw's resolveAwsSdkEnvVarName():
+#   1. AWS_BEARER_TOKEN_BEDROCK (Bedrock-specific bearer token)
+#   2. AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (explicit IAM credentials)
+#   3. AWS_PROFILE (named profile → SSO, assume-role, etc.)
+#   4. Implicit: instance role, ECS task role, Lambda execution role
+_AWS_CREDENTIAL_ENV_VARS = [
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_PROFILE",
+    # These are checked by boto3's default chain but we list them for
+    # has_aws_credentials() detection:
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+]
+
+
+def resolve_aws_auth_env_var(env: Optional[Dict[str, str]] = None) -> Optional[str]:
+    """Return the name of the AWS auth source that is active, or None.
+
+    Checks environment variables first, then falls back to boto3's credential
+    chain for implicit sources (EC2 IMDS, ECS task role, etc.).
+
+    This mirrors OpenClaw's ``resolveAwsSdkEnvVarName()`` — used to detect
+    whether the user has any AWS credentials configured without actually
+    attempting to authenticate.
+    """
+    env = env if env is not None else os.environ
+    # Bearer token takes highest priority
+    if env.get("AWS_BEARER_TOKEN_BEDROCK", "").strip():
+        return "AWS_BEARER_TOKEN_BEDROCK"
+    # Explicit access key pair
+    if (env.get("AWS_ACCESS_KEY_ID", "").strip()
+            and env.get("AWS_SECRET_ACCESS_KEY", "").strip()):
+        return "AWS_ACCESS_KEY_ID"
+    # Named profile (SSO, assume-role, etc.)
+    if env.get("AWS_PROFILE", "").strip():
+        return "AWS_PROFILE"
+    # Container credentials (ECS, CodeBuild)
+    if env.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "").strip():
+        return "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+    # Web identity (EKS IRSA)
+    if env.get("AWS_WEB_IDENTITY_TOKEN_FILE", "").strip():
+        return "AWS_WEB_IDENTITY_TOKEN_FILE"
+    # No env vars — check if boto3 can resolve credentials via IMDS or other
+    # implicit sources (EC2 instance role, ECS task role, Lambda, etc.)
+    try:
+        import botocore.session
+        session = botocore.session.get_session()
+        credentials = session.get_credentials()
+        if credentials is not None:
+            resolved = credentials.get_frozen_credentials()
+            if resolved and resolved.access_key:
+                return "iam-role"
+    except Exception:
+        pass
+    return None
+
+
+def has_aws_credentials(env: Optional[Dict[str, str]] = None) -> bool:
+    """Return True if any AWS credential source is detected.
+
+    Checks environment variables first (fast, no I/O), then falls back to
+    boto3's credential chain which covers EC2 instance roles, ECS task roles,
+    Lambda execution roles, and other IMDS-based sources that don't set
+    environment variables.
+
+    This two-tier approach mirrors the pattern from OpenClaw PR #62673:
+    cloud environments (EC2, ECS, Lambda) provide credentials via instance
+    metadata, not environment variables. The env-var check is a fast path
+    for local development; the boto3 fallback covers all cloud deployments.
+    """
+    if resolve_aws_auth_env_var(env) is not None:
+        return True
+    # Fall back to boto3's credential resolver — this covers EC2 instance
+    # metadata (IMDS), ECS container credentials, and other implicit sources
+    # that don't set environment variables.
+    try:
+        import botocore.session
+        session = botocore.session.get_session()
+        credentials = session.get_credentials()
+        if credentials is not None:
+            resolved = credentials.get_frozen_credentials()
+            if resolved and resolved.access_key:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
+    """Resolve the AWS region for Bedrock API calls.
+
+    Priority: AWS_REGION → AWS_DEFAULT_REGION → us-east-1 (fallback).
+    """
+    env = env if env is not None else os.environ
+    return (
+        env.get("AWS_REGION", "").strip()
+        or env.get("AWS_DEFAULT_REGION", "").strip()
+        or "us-east-1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Message format conversion: OpenAI → Bedrock Converse
+# ---------------------------------------------------------------------------
+
+def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
+    """Convert OpenAI-format tool definitions to Bedrock Converse ``toolConfig``.
+
+    OpenAI format::
+
+        {"type": "function", "function": {"name": "...", "description": "...",
+         "parameters": {"type": "object", "properties": {...}}}}
+
+    Converse format::
+
+        {"toolSpec": {"name": "...", "description": "...",
+         "inputSchema": {"json": {"type": "object", "properties": {...}}}}}
+    """
+    if not tools:
+        return []
+    result = []
+    for t in tools:
+        fn = t.get("function", {})
+        name = fn.get("name", "")
+        description = fn.get("description", "")
+        parameters = fn.get("parameters", {"type": "object", "properties": {}})
+        result.append({
+            "toolSpec": {
+                "name": name,
+                "description": description,
+                "inputSchema": {"json": parameters},
+            }
+        })
+    return result
+
+
+def _convert_content_to_converse(content) -> List[Dict]:
+    """Convert OpenAI message content (string or list) to Converse content blocks.
+
+    Handles:
+      - Plain text strings → [{"text": "..."}]
+      - Content arrays with text/image_url parts → mixed text/image blocks
+    """
+    if content is None:
+        return [{"text": ""}]
+    if isinstance(content, str):
+        return [{"text": content}] if content else [{"text": " "}]
+    if isinstance(content, list):
+        blocks = []
+        for part in content:
+            if isinstance(part, str):
+                blocks.append({"text": part})
+                continue
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type", "")
+            if part_type == "text":
+                text = part.get("text", "")
+                blocks.append({"text": text if text else " "})
+            elif part_type == "image_url":
+                image_url = part.get("image_url", {})
+                url = image_url.get("url", "") if isinstance(image_url, dict) else ""
+                if url.startswith("data:"):
+                    # data:image/jpeg;base64,/9j/4AAQ...
+                    header, _, data = url.partition(",")
+                    media_type = "image/jpeg"
+                    if header.startswith("data:"):
+                        mime_part = header[5:].split(";")[0]
+                        if mime_part:
+                            media_type = mime_part
+                    blocks.append({
+                        "image": {
+                            "format": media_type.split("/")[-1] if "/" in media_type else "jpeg",
+                            "source": {"bytes": data},
+                        }
+                    })
+                else:
+                    # Remote URL — Converse doesn't support URLs directly,
+                    # include as text reference for the model.
+                    blocks.append({"text": f"[Image: {url}]"})
+        return blocks if blocks else [{"text": " "}]
+    return [{"text": str(content)}]
+
+
+def convert_messages_to_converse(
+    messages: List[Dict],
+) -> Tuple[Optional[List[Dict]], List[Dict]]:
+    """Convert OpenAI-format messages to Bedrock Converse format.
+
+    Returns ``(system_prompt, converse_messages)`` where:
+      - ``system_prompt`` is a list of system content blocks (or None)
+      - ``converse_messages`` is the conversation in Converse format
+
+    Handles:
+      - System messages → extracted as system prompt
+      - User messages → ``{"role": "user", "content": [...]}``
+      - Assistant messages → ``{"role": "assistant", "content": [...]}``
+      - Tool calls → ``{"toolUse": {"toolUseId": ..., "name": ..., "input": ...}}``
+      - Tool results → ``{"toolResult": {"toolUseId": ..., "content": [...]}}``
+
+    Converse requires strict user/assistant alternation. Consecutive messages
+    with the same role are merged into a single message.
+    """
+    system_blocks: List[Dict] = []
+    converse_msgs: List[Dict] = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content")
+
+        if role == "system":
+            # System messages become the system prompt
+            if isinstance(content, str) and content.strip():
+                system_blocks.append({"text": content})
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        system_blocks.append({"text": part.get("text", "")})
+                    elif isinstance(part, str):
+                        system_blocks.append({"text": part})
+            continue
+
+        if role == "tool":
+            # Tool result messages → merge into the preceding user turn
+            tool_call_id = msg.get("tool_call_id", "")
+            result_content = content if isinstance(content, str) else json.dumps(content)
+            tool_result_block = {
+                "toolResult": {
+                    "toolUseId": tool_call_id,
+                    "content": [{"text": result_content}],
+                }
+            }
+            # In Converse, tool results go in a "user" role message
+            if converse_msgs and converse_msgs[-1]["role"] == "user":
+                converse_msgs[-1]["content"].append(tool_result_block)
+            else:
+                converse_msgs.append({
+                    "role": "user",
+                    "content": [tool_result_block],
+                })
+            continue
+
+        if role == "assistant":
+            content_blocks = []
+            # Convert text content
+            if isinstance(content, str) and content.strip():
+                content_blocks.append({"text": content})
+            elif isinstance(content, list):
+                content_blocks.extend(_convert_content_to_converse(content))
+
+            # Convert tool calls
+            tool_calls = msg.get("tool_calls", [])
+            for tc in (tool_calls or []):
+                fn = tc.get("function", {})
+                args_str = fn.get("arguments", "{}")
+                try:
+                    args_dict = json.loads(args_str) if isinstance(args_str, str) else args_str
+                except (json.JSONDecodeError, TypeError):
+                    args_dict = {}
+                content_blocks.append({
+                    "toolUse": {
+                        "toolUseId": tc.get("id", ""),
+                        "name": fn.get("name", ""),
+                        "input": args_dict,
+                    }
+                })
+
+            if not content_blocks:
+                content_blocks = [{"text": " "}]
+
+            # Merge with previous assistant message if needed (strict alternation)
+            if converse_msgs and converse_msgs[-1]["role"] == "assistant":
+                converse_msgs[-1]["content"].extend(content_blocks)
+            else:
+                converse_msgs.append({
+                    "role": "assistant",
+                    "content": content_blocks,
+                })
+            continue
+
+        if role == "user":
+            content_blocks = _convert_content_to_converse(content)
+            # Merge with previous user message if needed (strict alternation)
+            if converse_msgs and converse_msgs[-1]["role"] == "user":
+                converse_msgs[-1]["content"].extend(content_blocks)
+            else:
+                converse_msgs.append({
+                    "role": "user",
+                    "content": content_blocks,
+                })
+            continue
+
+    # Converse requires the first message to be from the user
+    if converse_msgs and converse_msgs[0]["role"] != "user":
+        converse_msgs.insert(0, {"role": "user", "content": [{"text": " "}]})
+
+    # Converse requires the last message to be from the user
+    if converse_msgs and converse_msgs[-1]["role"] != "user":
+        converse_msgs.append({"role": "user", "content": [{"text": " "}]})
+
+    return (system_blocks if system_blocks else None, converse_msgs)
+
+
+# ---------------------------------------------------------------------------
+# Response format conversion: Bedrock Converse → OpenAI
+# ---------------------------------------------------------------------------
+
+def _converse_stop_reason_to_openai(stop_reason: str) -> str:
+    """Map Bedrock Converse stop reasons to OpenAI finish_reason values."""
+    mapping = {
+        "end_turn": "stop",
+        "stop_sequence": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "length",
+        "content_filtered": "content_filter",
+        "guardrail_intervened": "content_filter",
+    }
+    return mapping.get(stop_reason, "stop")
+
+
+def normalize_converse_response(response: Dict) -> SimpleNamespace:
+    """Convert a Bedrock Converse API response to an OpenAI-compatible object.
+
+    The agent loop in ``run_agent.py`` expects responses shaped like
+    ``openai.ChatCompletion`` — this function bridges the gap.
+
+    Returns a SimpleNamespace with:
+      - ``.choices[0].message.content`` — text response
+      - ``.choices[0].message.tool_calls`` — tool call list (if any)
+      - ``.choices[0].finish_reason`` — stop/tool_calls/length
+      - ``.usage`` — token usage stats
+    """
+    output = response.get("output", {})
+    message = output.get("message", {})
+    content_blocks = message.get("content", [])
+    stop_reason = response.get("stopReason", "end_turn")
+
+    text_parts = []
+    tool_calls = []
+
+    for block in content_blocks:
+        if "text" in block:
+            text_parts.append(block["text"])
+        elif "toolUse" in block:
+            tu = block["toolUse"]
+            tool_calls.append(SimpleNamespace(
+                id=tu.get("toolUseId", ""),
+                type="function",
+                function=SimpleNamespace(
+                    name=tu.get("name", ""),
+                    arguments=json.dumps(tu.get("input", {})),
+                ),
+            ))
+
+    # Build the message object
+    msg = SimpleNamespace(
+        role="assistant",
+        content="\n".join(text_parts) if text_parts else None,
+        tool_calls=tool_calls if tool_calls else None,
+    )
+
+    # Build usage stats
+    usage_data = response.get("usage", {})
+    usage = SimpleNamespace(
+        prompt_tokens=usage_data.get("inputTokens", 0),
+        completion_tokens=usage_data.get("outputTokens", 0),
+        total_tokens=(
+            usage_data.get("inputTokens", 0) + usage_data.get("outputTokens", 0)
+        ),
+    )
+
+    finish_reason = _converse_stop_reason_to_openai(stop_reason)
+    if tool_calls and finish_reason == "stop":
+        finish_reason = "tool_calls"
+
+    choice = SimpleNamespace(
+        index=0,
+        message=msg,
+        finish_reason=finish_reason,
+    )
+
+    return SimpleNamespace(
+        choices=[choice],
+        usage=usage,
+        model=response.get("modelId", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming response conversion
+# ---------------------------------------------------------------------------
+
+def normalize_converse_stream_events(event_stream) -> SimpleNamespace:
+    """Consume a Bedrock ConverseStream event stream and build an OpenAI-compatible response.
+
+    Processes the stream events in order:
+      - ``messageStart`` — role info
+      - ``contentBlockStart`` — new text or toolUse block
+      - ``contentBlockDelta`` — incremental text or toolUse input
+      - ``contentBlockStop`` — block complete
+      - ``messageStop`` — stop reason
+      - ``metadata`` — usage stats
+
+    Returns the same shape as ``normalize_converse_response()``.
+    """
+    return stream_converse_with_callbacks(event_stream)
+
+
+def stream_converse_with_callbacks(
+    event_stream,
+    on_text_delta=None,
+    on_tool_start=None,
+    on_reasoning_delta=None,
+    on_interrupt_check=None,
+) -> SimpleNamespace:
+    """Process a Bedrock ConverseStream event stream with real-time callbacks.
+
+    This is the core streaming function that powers both the CLI's live token
+    display and the gateway's progressive message updates.
+
+    Args:
+        event_stream: The boto3 ``converse_stream()`` response containing a
+            ``stream`` key with an iterable of events.
+        on_text_delta: Called with each text chunk as it arrives. Only fires
+            when no tool_use blocks have been seen (same semantics as the
+            Anthropic and chat_completions streaming paths).
+        on_tool_start: Called with the tool name when a toolUse block begins.
+            Lets the TUI show a spinner while tool arguments are generated.
+        on_reasoning_delta: Called with reasoning/thinking text chunks.
+            Bedrock surfaces thinking via ``reasoning`` content block deltas
+            on supported models (Claude 4.6+).
+        on_interrupt_check: Called on each event. Should return True if the
+            agent has been interrupted and streaming should stop.
+
+    Returns:
+        An OpenAI-compatible SimpleNamespace response, identical in shape to
+        ``normalize_converse_response()``.
+    """
+    text_parts: List[str] = []
+    tool_calls: List[SimpleNamespace] = []
+    current_tool: Optional[Dict] = None
+    current_text_buffer: List[str] = []
+    has_tool_use = False
+    stop_reason = "end_turn"
+    usage_data: Dict[str, int] = {}
+
+    for event in event_stream.get("stream", []):
+        # Check for interrupt
+        if on_interrupt_check and on_interrupt_check():
+            break
+
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if "toolUse" in start:
+                has_tool_use = True
+                # Flush any accumulated text
+                if current_text_buffer:
+                    text_parts.append("".join(current_text_buffer))
+                    current_text_buffer = []
+                current_tool = {
+                    "toolUseId": start["toolUse"].get("toolUseId", ""),
+                    "name": start["toolUse"].get("name", ""),
+                    "input_json": "",
+                }
+                if on_tool_start:
+                    on_tool_start(current_tool["name"])
+
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                text = delta["text"]
+                current_text_buffer.append(text)
+                # Fire text delta callback only when no tool calls are present
+                # (same semantics as Anthropic/chat_completions streaming)
+                if on_text_delta and not has_tool_use:
+                    on_text_delta(text)
+            elif "toolUse" in delta:
+                if current_tool is not None:
+                    current_tool["input_json"] += delta["toolUse"].get("input", "")
+            elif "reasoningContent" in delta:
+                # Claude 4.6+ on Bedrock surfaces thinking via reasoningContent
+                reasoning = delta["reasoningContent"]
+                if isinstance(reasoning, dict):
+                    thinking_text = reasoning.get("text", "")
+                    if thinking_text and on_reasoning_delta:
+                        on_reasoning_delta(thinking_text)
+
+        elif "contentBlockStop" in event:
+            if current_tool is not None:
+                try:
+                    input_dict = json.loads(current_tool["input_json"]) if current_tool["input_json"] else {}
+                except (json.JSONDecodeError, TypeError):
+                    input_dict = {}
+                tool_calls.append(SimpleNamespace(
+                    id=current_tool["toolUseId"],
+                    type="function",
+                    function=SimpleNamespace(
+                        name=current_tool["name"],
+                        arguments=json.dumps(input_dict),
+                    ),
+                ))
+                current_tool = None
+            elif current_text_buffer:
+                text_parts.append("".join(current_text_buffer))
+                current_text_buffer = []
+
+        elif "messageStop" in event:
+            stop_reason = event["messageStop"].get("stopReason", "end_turn")
+
+        elif "metadata" in event:
+            meta_usage = event["metadata"].get("usage", {})
+            usage_data = {
+                "inputTokens": meta_usage.get("inputTokens", 0),
+                "outputTokens": meta_usage.get("outputTokens", 0),
+            }
+
+    # Flush remaining text
+    if current_text_buffer:
+        text_parts.append("".join(current_text_buffer))
+
+    msg = SimpleNamespace(
+        role="assistant",
+        content="\n".join(text_parts) if text_parts else None,
+        tool_calls=tool_calls if tool_calls else None,
+    )
+
+    usage = SimpleNamespace(
+        prompt_tokens=usage_data.get("inputTokens", 0),
+        completion_tokens=usage_data.get("outputTokens", 0),
+        total_tokens=(
+            usage_data.get("inputTokens", 0) + usage_data.get("outputTokens", 0)
+        ),
+    )
+
+    finish_reason = _converse_stop_reason_to_openai(stop_reason)
+    if tool_calls and finish_reason == "stop":
+        finish_reason = "tool_calls"
+
+    choice = SimpleNamespace(
+        index=0,
+        message=msg,
+        finish_reason=finish_reason,
+    )
+
+    return SimpleNamespace(
+        choices=[choice],
+        usage=usage,
+        model="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# High-level API: call Bedrock Converse
+# ---------------------------------------------------------------------------
+
+def build_converse_kwargs(
+    model: str,
+    messages: List[Dict],
+    tools: Optional[List[Dict]] = None,
+    max_tokens: int = 4096,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    stop_sequences: Optional[List[str]] = None,
+    guardrail_config: Optional[Dict] = None,
+) -> Dict[str, Any]:
+    """Build kwargs for ``bedrock-runtime.converse()`` or ``converse_stream()``.
+
+    Converts OpenAI-format inputs to Converse API parameters.
+    """
+    system_prompt, converse_messages = convert_messages_to_converse(messages)
+
+    kwargs: Dict[str, Any] = {
+        "modelId": model,
+        "messages": converse_messages,
+        "inferenceConfig": {
+            "maxTokens": max_tokens,
+        },
+    }
+
+    if system_prompt:
+        kwargs["system"] = system_prompt
+
+    if temperature is not None:
+        kwargs["inferenceConfig"]["temperature"] = temperature
+
+    if top_p is not None:
+        kwargs["inferenceConfig"]["topP"] = top_p
+
+    if stop_sequences:
+        kwargs["inferenceConfig"]["stopSequences"] = stop_sequences
+
+    if tools:
+        converse_tools = convert_tools_to_converse(tools)
+        if converse_tools:
+            kwargs["toolConfig"] = {"tools": converse_tools}
+
+    if guardrail_config:
+        kwargs["guardrailConfig"] = guardrail_config
+
+    return kwargs
+
+
+def call_converse(
+    region: str,
+    model: str,
+    messages: List[Dict],
+    tools: Optional[List[Dict]] = None,
+    max_tokens: int = 4096,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    stop_sequences: Optional[List[str]] = None,
+    guardrail_config: Optional[Dict] = None,
+) -> SimpleNamespace:
+    """Call Bedrock Converse API (non-streaming) and return an OpenAI-compatible response.
+
+    This is the primary entry point for the agent loop when using the Bedrock provider.
+    """
+    client = _get_bedrock_runtime_client(region)
+    kwargs = build_converse_kwargs(
+        model=model,
+        messages=messages,
+        tools=tools,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        stop_sequences=stop_sequences,
+        guardrail_config=guardrail_config,
+    )
+
+    response = client.converse(**kwargs)
+    return normalize_converse_response(response)
+
+
+def call_converse_stream(
+    region: str,
+    model: str,
+    messages: List[Dict],
+    tools: Optional[List[Dict]] = None,
+    max_tokens: int = 4096,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    stop_sequences: Optional[List[str]] = None,
+    guardrail_config: Optional[Dict] = None,
+) -> SimpleNamespace:
+    """Call Bedrock ConverseStream API and return an OpenAI-compatible response.
+
+    Consumes the full stream and returns the assembled response. For true
+    streaming with delta callbacks, use ``iter_converse_stream()`` instead.
+    """
+    client = _get_bedrock_runtime_client(region)
+    kwargs = build_converse_kwargs(
+        model=model,
+        messages=messages,
+        tools=tools,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        stop_sequences=stop_sequences,
+        guardrail_config=guardrail_config,
+    )
+
+    response = client.converse_stream(**kwargs)
+    return normalize_converse_stream_events(response)
+
+
+# ---------------------------------------------------------------------------
+# Model discovery
+# ---------------------------------------------------------------------------
+
+_discovery_cache: Dict[str, Any] = {}
+_DISCOVERY_CACHE_TTL_SECONDS = 3600
+
+
+def reset_discovery_cache():
+    """Clear the model discovery cache. Used in tests."""
+    _discovery_cache.clear()
+
+
+def discover_bedrock_models(
+    region: str,
+    provider_filter: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Discover available Bedrock foundation models and inference profiles.
+
+    Returns a list of model info dicts with keys:
+      - ``id``: Model ID (e.g. "anthropic.claude-sonnet-4-6-20250514-v1:0")
+      - ``name``: Human-readable name
+      - ``provider``: Model provider (e.g. "Anthropic", "Amazon", "Meta")
+      - ``input_modalities``: List of input types (e.g. ["TEXT", "IMAGE"])
+      - ``output_modalities``: List of output types
+      - ``streaming``: Whether streaming is supported
+
+    Caches results for 1 hour per region to avoid repeated API calls.
+
+    Mirrors OpenClaw's ``discoverBedrockModels()`` in
+    ``extensions/amazon-bedrock/discovery.ts``.
+    """
+    import time
+
+    cache_key = f"{region}:{','.join(sorted(provider_filter or []))}"
+    cached = _discovery_cache.get(cache_key)
+    if cached and (time.time() - cached["timestamp"]) < _DISCOVERY_CACHE_TTL_SECONDS:
+        return cached["models"]
+
+    try:
+        client = _get_bedrock_control_client(region)
+    except Exception as e:
+        logger.warning("Failed to create Bedrock client for model discovery: %s", e)
+        return []
+
+    models = []
+    seen_ids = set()
+    filter_set = {f.lower() for f in (provider_filter or [])}
+
+    # 1. Discover foundation models
+    try:
+        response = client.list_foundation_models()
+        for summary in response.get("modelSummaries", []):
+            model_id = (summary.get("modelId") or "").strip()
+            if not model_id:
+                continue
+
+            # Apply provider filter
+            if filter_set:
+                provider_name = (summary.get("providerName") or "").lower()
+                model_prefix = model_id.split(".")[0].lower() if "." in model_id else ""
+                if provider_name not in filter_set and model_prefix not in filter_set:
+                    continue
+
+            # Only include active, streaming-capable, text-output models
+            lifecycle = summary.get("modelLifecycle", {})
+            if lifecycle.get("status", "").upper() != "ACTIVE":
+                continue
+            if not summary.get("responseStreamingSupported", False):
+                continue
+            output_mods = summary.get("outputModalities", [])
+            if "TEXT" not in output_mods:
+                continue
+
+            models.append({
+                "id": model_id,
+                "name": (summary.get("modelName") or model_id).strip(),
+                "provider": (summary.get("providerName") or "").strip(),
+                "input_modalities": summary.get("inputModalities", []),
+                "output_modalities": output_mods,
+                "streaming": True,
+            })
+            seen_ids.add(model_id.lower())
+    except Exception as e:
+        logger.warning("Failed to list Bedrock foundation models: %s", e)
+
+    # 2. Discover inference profiles (cross-region, better capacity)
+    try:
+        profiles = []
+        next_token = None
+        while True:
+            kwargs = {}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = client.list_inference_profiles(**kwargs)
+            for profile in response.get("inferenceProfileSummaries", []):
+                profiles.append(profile)
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+
+        for profile in profiles:
+            profile_id = (profile.get("inferenceProfileId") or "").strip()
+            if not profile_id:
+                continue
+            if profile.get("status") != "ACTIVE":
+                continue
+            if profile_id.lower() in seen_ids:
+                continue
+
+            # Apply provider filter to underlying models
+            if filter_set:
+                profile_models = profile.get("models", [])
+                matches = any(
+                    _extract_provider_from_arn(m.get("modelArn", "")).lower() in filter_set
+                    for m in profile_models
+                )
+                if not matches:
+                    continue
+
+            models.append({
+                "id": profile_id,
+                "name": (profile.get("inferenceProfileName") or profile_id).strip(),
+                "provider": "inference-profile",
+                "input_modalities": ["TEXT"],
+                "output_modalities": ["TEXT"],
+                "streaming": True,
+            })
+            seen_ids.add(profile_id.lower())
+    except Exception as e:
+        logger.debug("Skipping inference profile discovery: %s", e)
+
+    # Sort: global cross-region profiles first (recommended), then alphabetical
+    models.sort(key=lambda m: (
+        0 if m["id"].startswith("global.") else 1,
+        m["name"].lower(),
+    ))
+
+    _discovery_cache[cache_key] = {
+        "timestamp": time.time(),
+        "models": models,
+    }
+    return models
+
+
+def _extract_provider_from_arn(arn: str) -> str:
+    """Extract the model provider from a Bedrock model ARN.
+
+    Example: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2"
+    → "anthropic"
+    """
+    match = re.search(r"foundation-model/([^.]+)", arn)
+    return match.group(1) if match else ""
+
+
+def get_bedrock_model_ids(region: str) -> List[str]:
+    """Return a flat list of available Bedrock model IDs for the given region.
+
+    Convenience wrapper around ``discover_bedrock_models()`` for use in
+    the model selection UI.
+    """
+    models = discover_bedrock_models(region)
+    return [m["id"] for m in models]
+
+
+# ---------------------------------------------------------------------------
+# Error classification — Bedrock-specific exceptions
+# ---------------------------------------------------------------------------
+# Mirrors OpenClaw's classifyFailoverReason() and matchesContextOverflowError()
+# in extensions/amazon-bedrock/register.sync.runtime.ts.
+
+# Patterns that indicate the input context exceeded the model's token limit.
+# Used by run_agent.py to trigger context compression instead of retrying.
+CONTEXT_OVERFLOW_PATTERNS = [
+    re.compile(r"ValidationException.*(?:input is too long|max input token|input token.*exceed)", re.IGNORECASE),
+    re.compile(r"ValidationException.*(?:exceeds? the (?:maximum|max) (?:number of )?(?:input )?tokens)", re.IGNORECASE),
+    re.compile(r"ModelStreamErrorException.*(?:Input is too long|too many input tokens)", re.IGNORECASE),
+]
+
+# Patterns for throttling / rate limit errors — should trigger backoff + retry.
+THROTTLE_PATTERNS = [
+    re.compile(r"ThrottlingException", re.IGNORECASE),
+    re.compile(r"Too many concurrent requests", re.IGNORECASE),
+    re.compile(r"ServiceQuotaExceededException", re.IGNORECASE),
+]
+
+# Patterns for transient overload — model is temporarily unavailable.
+OVERLOAD_PATTERNS = [
+    re.compile(r"ModelNotReadyException", re.IGNORECASE),
+    re.compile(r"ModelTimeoutException", re.IGNORECASE),
+    re.compile(r"InternalServerException", re.IGNORECASE),
+]
+
+
+def is_context_overflow_error(error_message: str) -> bool:
+    """Return True if the error indicates the input context was too large.
+
+    When this returns True, the agent should compress context and retry
+    rather than treating it as a fatal error.
+    """
+    return any(p.search(error_message) for p in CONTEXT_OVERFLOW_PATTERNS)
+
+
+def classify_bedrock_error(error_message: str) -> str:
+    """Classify a Bedrock error for retry/failover decisions.
+
+    Returns:
+      - ``"context_overflow"`` — input too long, compress and retry
+      - ``"rate_limit"`` — throttled, backoff and retry
+      - ``"overloaded"`` — model temporarily unavailable, retry with delay
+      - ``"unknown"`` — unclassified error
+    """
+    if is_context_overflow_error(error_message):
+        return "context_overflow"
+    if any(p.search(error_message) for p in THROTTLE_PATTERNS):
+        return "rate_limit"
+    if any(p.search(error_message) for p in OVERLOAD_PATTERNS):
+        return "overloaded"
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Bedrock model context lengths
+# ---------------------------------------------------------------------------
+# Static fallback table for models where the Bedrock API doesn't expose
+# context window sizes.  Used by agent/model_metadata.py when dynamic
+# detection is unavailable.
+
+BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
+    # Anthropic Claude models on Bedrock
+    "anthropic.claude-opus-4-6":     200_000,
+    "anthropic.claude-sonnet-4-6":   200_000,
+    "anthropic.claude-sonnet-4-5":   200_000,
+    "anthropic.claude-haiku-4-5":    200_000,
+    "anthropic.claude-opus-4":       200_000,
+    "anthropic.claude-sonnet-4":     200_000,
+    "anthropic.claude-3-5-sonnet":   200_000,
+    "anthropic.claude-3-5-haiku":    200_000,
+    "anthropic.claude-3-opus":       200_000,
+    "anthropic.claude-3-sonnet":     200_000,
+    "anthropic.claude-3-haiku":      200_000,
+    # Amazon Nova
+    "amazon.nova-pro":               300_000,
+    "amazon.nova-lite":              300_000,
+    "amazon.nova-micro":             128_000,
+    # Meta Llama
+    "meta.llama4-maverick":          128_000,
+    "meta.llama4-scout":             128_000,
+    "meta.llama3-3-70b-instruct":    128_000,
+    # Mistral
+    "mistral.mistral-large":         128_000,
+    # DeepSeek
+    "deepseek.v3":                   128_000,
+}
+
+# Default for unknown Bedrock models
+BEDROCK_DEFAULT_CONTEXT_LENGTH = 128_000
+
+
+def get_bedrock_context_length(model_id: str) -> int:
+    """Look up the context window size for a Bedrock model.
+
+    Uses substring matching so versioned IDs like
+    ``anthropic.claude-sonnet-4-6-20250514-v1:0`` resolve correctly.
+    """
+    model_lower = model_id.lower()
+    best_key = ""
+    best_val = BEDROCK_DEFAULT_CONTEXT_LENGTH
+    for key, val in BEDROCK_CONTEXT_LENGTHS.items():
+        if key in model_lower and len(key) > len(best_key):
+            best_key = key
+            best_val = val
+    return best_val

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -113,6 +113,10 @@ _RATE_LIMIT_PATTERNS = [
     "please retry after",
     "resource_exhausted",
     "rate increased too quickly",  # Alibaba/DashScope throttling
+    # AWS Bedrock throttling
+    "throttlingexception",
+    "too many concurrent requests",
+    "servicequotaexceededexception",
 ]
 
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
@@ -160,6 +164,11 @@ _CONTEXT_OVERFLOW_PATTERNS = [
     # Chinese error messages (some providers return these)
     "超过最大长度",
     "上下文长度",
+    # AWS Bedrock Converse API error patterns
+    "input is too long",
+    "max input token",
+    "input token",
+    "exceeds the maximum number of input tokens",
 ]
 
 # Model not found patterns

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -27,14 +27,12 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "gemini", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
     "qwen-oauth",
-    "xiaomi",
     "custom", "local",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
-    "mimo", "xiaomi-mimo",
     "qwen-portal",
 })
 
@@ -156,10 +154,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "moonshotai/Kimi-K2.5": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
     "MiniMaxAI/MiniMax-M2.5": 204800,
-    "XiaomiMiMo/MiMo-V2-Flash": 256000,
-    "mimo-v2-pro": 1000000,
-    "mimo-v2-omni": 256000,
-    "mimo-v2-flash": 256000,
+    "XiaomiMiMo/MiMo-V2-Flash": 32768,
+    "mimo-v2-pro": 1048576,
+    "mimo-v2-omni": 1048576,
     "zai-org/GLM-5": 202752,
 }
 
@@ -225,8 +222,6 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.fireworks.ai": "fireworks",
     "opencode.ai": "opencode-go",
     "api.x.ai": "xai",
-    "api.xiaomimimo.com": "xiaomi",
-    "xiaomimimo.com": "xiaomi",
 }
 
 
@@ -994,6 +989,16 @@ def get_model_context_length(
         ctx = _query_anthropic_context_length(model, base_url or "https://api.anthropic.com", api_key)
         if ctx:
             return ctx
+
+    # 4b. AWS Bedrock — use static context length table.
+    # Bedrock's ListFoundationModels doesn't expose context window sizes,
+    # so we maintain a curated table in bedrock_adapter.py.
+    if provider == "bedrock" or (base_url and "bedrock-runtime" in base_url):
+        try:
+            from agent.bedrock_adapter import get_bedrock_context_length
+            return get_bedrock_context_length(model)
+        except ImportError:
+            pass  # boto3 not installed — fall through to generic resolution
 
     # 5. Provider-aware lookups (before generic OpenRouter cache)
     # These are provider-specific and take priority over the generic OR cache,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -284,6 +284,80 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-03-16",
     ),
+    # AWS Bedrock — pricing per the Bedrock pricing page.
+    # Bedrock charges the same per-token rates as the model provider but
+    # through AWS billing.  These are the on-demand prices (no commitment).
+    # Source: https://aws.amazon.com/bedrock/pricing/
+    (
+        "bedrock",
+        "anthropic.claude-opus-4-6",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("15.00"),
+        output_cost_per_million=Decimal("75.00"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "anthropic.claude-sonnet-4-6",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "anthropic.claude-sonnet-4-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "anthropic.claude-haiku-4-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.80"),
+        output_cost_per_million=Decimal("4.00"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "amazon.nova-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.80"),
+        output_cost_per_million=Decimal("3.20"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "amazon.nova-lite",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.06"),
+        output_cost_per_million=Decimal("0.24"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "amazon.nova-micro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.035"),
+        output_cost_per_million=Decimal("0.14"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
 }
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -250,13 +250,17 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
     ),
-    "xiaomi": ProviderConfig(
-        id="xiaomi",
-        name="Xiaomi MiMo",
-        auth_type="api_key",
-        inference_base_url="https://api.xiaomimimo.com/v1",
-        api_key_env_vars=("XIAOMI_API_KEY",),
-        base_url_env_var="XIAOMI_BASE_URL",
+    # AWS Bedrock — uses the native Converse API via boto3, not the OpenAI-
+    # compatible endpoint.  Auth is handled by the AWS SDK default credential
+    # chain (env vars → profile → instance role), so no api_key_env_vars.
+    # The base_url is the bedrock-runtime endpoint, region-dependent.
+    "bedrock": ProviderConfig(
+        id="bedrock",
+        name="AWS Bedrock",
+        auth_type="aws_sdk",
+        inference_base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+        api_key_env_vars=(),
+        base_url_env_var="BEDROCK_BASE_URL",
     ),
 }
 
@@ -938,13 +942,15 @@ def resolve_provider(
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
-        "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         # Local server aliases — route through the generic custom provider
         "lmstudio": "custom", "lm-studio": "custom", "lm_studio": "custom",
         "ollama": "custom", "vllm": "custom", "llamacpp": "custom",
         "llama.cpp": "custom", "llama-cpp": "custom",
+        # AWS Bedrock aliases
+        "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock",
+        "amazon": "bedrock",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
@@ -994,6 +1000,15 @@ def resolve_provider(
         for env_var in pconfig.api_key_env_vars:
             if has_usable_secret(os.getenv(env_var, "")):
                 return pid
+
+    # Auto-detect AWS Bedrock via the default credential chain.
+    # This runs after API-key providers so explicit keys always win.
+    try:
+        from agent.bedrock_adapter import has_aws_credentials
+        if has_aws_credentials():
+            return "bedrock"
+    except ImportError:
+        pass  # boto3 not installed — skip Bedrock auto-detection
 
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -368,6 +368,27 @@ def _interactive_auth() -> None:
     print("=" * 50)
 
     auth_list_command(SimpleNamespace(provider=None))
+
+    # Show AWS Bedrock credential status (not in the pool — uses boto3 chain)
+    try:
+        from agent.bedrock_adapter import has_aws_credentials, resolve_aws_auth_env_var, resolve_bedrock_region
+        if has_aws_credentials():
+            auth_source = resolve_aws_auth_env_var() or "unknown"
+            region = resolve_bedrock_region()
+            print(f"bedrock (AWS SDK credential chain):")
+            print(f"  Auth: {auth_source}")
+            print(f"  Region: {region}")
+            try:
+                import boto3
+                sts = boto3.client("sts", region_name=region)
+                identity = sts.get_caller_identity()
+                arn = identity.get("Arn", "unknown")
+                print(f"  Identity: {arn}")
+            except Exception:
+                print(f"  Identity: (could not resolve — boto3 STS call failed)")
+            print()
+    except ImportError:
+        pass  # boto3 or bedrock_adapter not available
     print()
 
     # Main menu

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -32,6 +32,7 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EXTRA_ENV_KEYS = frozenset({
     "OPENAI_API_KEY", "OPENAI_BASE_URL",
     "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+    "AUXILIARY_VISION_MODEL",
     "DISCORD_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL",
     "SIGNAL_ACCOUNT", "SIGNAL_HTTP_URL",
     "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
@@ -432,6 +433,27 @@ DEFAULT_CONFIG = {
         "summary_provider": "auto",
         "summary_base_url": None,
     },
+
+    # AWS Bedrock provider configuration.
+    # Only used when model.provider is "bedrock".
+    "bedrock": {
+        "region": "",  # AWS region for Bedrock API calls (empty = AWS_REGION env var → us-east-1)
+        "discovery": {
+            "enabled": True,           # Auto-discover models via ListFoundationModels
+            "provider_filter": [],     # Only show models from these providers (e.g. ["anthropic", "amazon"])
+            "refresh_interval": 3600,  # Cache discovery results for this many seconds
+        },
+        "guardrail": {
+            # Amazon Bedrock Guardrails — content filtering and safety policies.
+            # Create a guardrail in the Bedrock console, then set the ID and version here.
+            # See: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+            "guardrail_identifier": "",  # e.g. "abc123def456"
+            "guardrail_version": "",     # e.g. "1" or "DRAFT"
+            "stream_processing_mode": "async",  # "sync" or "async"
+            "trace": "disabled",         # "enabled", "disabled", or "enabled_full"
+        },
+    },
+
     "smart_model_routing": {
         "enabled": False,
         "max_simple_chars": 160,
@@ -451,7 +473,7 @@ DEFAULT_CONFIG = {
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
-            "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
+            "timeout": 30,         # seconds — LLM API call timeout; increase for slow local vision models
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
         },
         "web_extract": {
@@ -948,17 +970,21 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
-    "XIAOMI_API_KEY": {
-        "description": "Xiaomi MiMo API key for MiMo models (mimo-v2-pro, mimo-v2-omni, mimo-v2-flash)",
-        "prompt": "Xiaomi MiMo API Key",
-        "url": "https://platform.xiaomimimo.com",
-        "password": True,
+    # AWS Bedrock — auth is handled by the boto3 default credential chain,
+    # not by a single API key.  These env vars are documented here so
+    # `hermes setup` and `hermes doctor` can detect and display them.
+    "AWS_REGION": {
+        "description": "AWS region for Bedrock API calls (default: us-east-1)",
+        "prompt": "AWS Region (leave empty for us-east-1)",
+        "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html",
+        "password": False,
         "category": "provider",
+        "advanced": True,
     },
-    "XIAOMI_BASE_URL": {
-        "description": "Xiaomi MiMo base URL override (default: https://api.xiaomimimo.com/v1)",
-        "prompt": "Xiaomi base URL (leave empty for default)",
-        "url": None,
+    "AWS_PROFILE": {
+        "description": "AWS named profile for Bedrock authentication (SSO, assume-role, etc.)",
+        "prompt": "AWS Profile (leave empty for default)",
+        "url": "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html",
         "password": False,
         "category": "provider",
         "advanced": True,
@@ -2299,6 +2325,7 @@ _FALLBACK_COMMENT = """
 #   openrouter   (OPENROUTER_API_KEY)  — routes to any model
 #   openai-codex (OAuth — hermes auth) — OpenAI Codex
 #   nous         (OAuth — hermes auth) — Nous Portal
+#   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
 #   zai          (ZAI_API_KEY)         — Z.AI / GLM
 #   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
 #   minimax      (MINIMAX_API_KEY)     — MiniMax
@@ -2342,6 +2369,7 @@ _COMMENTED_SECTIONS = """
 #   openrouter   (OPENROUTER_API_KEY)  — routes to any model
 #   openai-codex (OAuth — hermes auth) — OpenAI Codex
 #   nous         (OAuth — hermes auth) — Nous Portal
+#   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
 #   zai          (ZAI_API_KEY)         — Z.AI / GLM
 #   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
 #   minimax      (MINIMAX_API_KEY)     — MiniMax

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -989,6 +989,14 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "AWS_BEARER_TOKEN_BEDROCK": {
+        "description": "Bedrock API Key for the OpenAI-compatible bedrock-mantle endpoint",
+        "prompt": "Bedrock API Key",
+        "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
 
     # ── Tool API keys ──
     "EXA_API_KEY": {

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -51,7 +51,6 @@ _PROVIDER_ENV_HINTS = (
     "AI_GATEWAY_API_KEY",
     "OPENCODE_ZEN_API_KEY",
     "OPENCODE_GO_API_KEY",
-    "XIAOMI_API_KEY",
 )
 
 
@@ -774,6 +773,32 @@ def run_doctor(args):
                     print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color(f'(HTTP {_resp.status_code})', Colors.DIM)}           ")
             except Exception as _e:
                 print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color(f'({_e})', Colors.DIM)}           ")
+
+    # -- AWS Bedrock --
+    # Bedrock uses the AWS SDK credential chain, not API keys.
+    # Check for credentials and optionally verify API access.
+    try:
+        from agent.bedrock_adapter import has_aws_credentials, resolve_aws_auth_env_var, resolve_bedrock_region
+        if has_aws_credentials():
+            _auth_var = resolve_aws_auth_env_var()
+            _region = resolve_bedrock_region()
+            _label = "AWS Bedrock".ljust(20)
+            print(f"  Checking AWS Bedrock...", end="", flush=True)
+            try:
+                import boto3
+                _br_client = boto3.client("bedrock", region_name=_region)
+                _br_resp = _br_client.list_foundation_models()
+                _model_count = len(_br_resp.get("modelSummaries", []))
+                print(f"\r  {color('✓', Colors.GREEN)} {_label} {color(f'({_auth_var}, {_region}, {_model_count} models)', Colors.DIM)}           ")
+            except ImportError:
+                print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color('(boto3 not installed — pip install hermes-agent[bedrock])', Colors.DIM)}           ")
+                issues.append("Install boto3 for Bedrock: pip install hermes-agent[bedrock]")
+            except Exception as _e:
+                _err_name = type(_e).__name__
+                print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color(f'({_err_name}: {_e})', Colors.DIM)}           ")
+                issues.append(f"AWS Bedrock: {_err_name} — check IAM permissions for bedrock:ListFoundationModels")
+    except ImportError:
+        pass  # bedrock_adapter not available — skip silently
 
     # =========================================================================
     # Check: Submodules

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2450,6 +2450,84 @@ def _model_flow_kimi(config, current_model=""):
         print("No change.")
 
 
+def _model_flow_bedrock_api_key(config, region, current_model=""):
+    """Bedrock API Key mode — uses the OpenAI-compatible bedrock-mantle endpoint.
+
+    For developers who don't have an AWS account but received a Bedrock API Key
+    from their AWS admin. Works like any OpenAI-compatible endpoint.
+    """
+    from hermes_cli.auth import _prompt_model_selection, _save_model_choice, deactivate_provider
+    from hermes_cli.config import load_config, save_config, get_env_value, save_env_value
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    mantle_base_url = f"https://bedrock-mantle.{region}.api.aws/v1"
+
+    # Prompt for API key
+    existing_key = get_env_value("AWS_BEARER_TOKEN_BEDROCK") or ""
+    if existing_key:
+        print(f"  Bedrock API Key: {existing_key[:12]}... ✓")
+    else:
+        print(f"  Endpoint: {mantle_base_url}")
+        print()
+        try:
+            import getpass
+            api_key = getpass.getpass("  Bedrock API Key: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        if not api_key:
+            print("  Cancelled.")
+            return
+        save_env_value("AWS_BEARER_TOKEN_BEDROCK", api_key)
+        existing_key = api_key
+        print("  ✓ API key saved.")
+    print()
+
+    # Model selection — use static list (mantle doesn't need boto3 for discovery)
+    model_list = _PROVIDER_MODELS.get("bedrock", [])
+    print(f"  Showing {len(model_list)} curated models")
+
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("  Model ID: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        _save_model_choice(selected)
+
+        # Save as custom provider pointing to bedrock-mantle
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = "custom"
+        model["base_url"] = mantle_base_url
+        model.pop("api_mode", None)  # chat_completions is the default
+
+        # Also save region in bedrock config for reference
+        bedrock_cfg = cfg.get("bedrock", {})
+        if not isinstance(bedrock_cfg, dict):
+            bedrock_cfg = {}
+        bedrock_cfg["region"] = region
+        cfg["bedrock"] = bedrock_cfg
+
+        # Save the API key env var name so hermes knows where to find it
+        save_env_value("OPENAI_API_KEY", existing_key)
+        save_env_value("OPENAI_BASE_URL", mantle_base_url)
+
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"  Default model set to: {selected} (via Bedrock API Key, {region})")
+        print(f"  Endpoint: {mantle_base_url}")
+    else:
+        print("  No change.")
+
+
 def _model_flow_bedrock(config, current_model=""):
     """AWS Bedrock provider: verify credentials, pick region, discover models.
 
@@ -2495,6 +2573,27 @@ def _model_flow_bedrock(config, current_model=""):
         print()
         return
     region = region_input or current_region
+
+    # 2b. Authentication mode
+    print("  Choose authentication method:")
+    print()
+    print("    1. IAM credential chain (recommended)")
+    print("       Works with EC2 instance roles, SSO, env vars, aws configure")
+    print("    2. Bedrock API Key")
+    print("       Enter your Bedrock API Key directly — also supports")
+    print("       team scenarios where an admin distributes keys")
+    print()
+    try:
+        auth_choice = input("  Choice [1]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    if auth_choice == "2":
+        # Bedrock API Key mode — uses the OpenAI-compatible bedrock-mantle endpoint.
+        # This is a separate path that doesn't need boto3 or IAM credentials.
+        _model_flow_bedrock_api_key(config, region, current_model)
+        return
 
     # 3. Model discovery — try live API first, fall back to static list
     print(f"  Discovering models in {region}...")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1053,7 +1053,7 @@ def select_provider_and_model(args=None):
         "kilocode": "Kilo Code",
         "alibaba": "Alibaba Cloud (DashScope)",
         "huggingface": "Hugging Face",
-        "xiaomi": "Xiaomi MiMo",
+        "bedrock": "AWS Bedrock",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active) if active else "none"
@@ -1086,7 +1086,7 @@ def select_provider_and_model(args=None):
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
         ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
-        ("xiaomi", "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
+        ("bedrock", "AWS Bedrock (Claude, Nova, Llama — native Converse API)"),
     ]
 
     def _named_custom_provider_map(cfg) -> dict[str, dict[str, str]]:
@@ -1199,7 +1199,9 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi"):
+    elif selected_provider == "bedrock":
+        _model_flow_bedrock(config, current_model)
+    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
     # ── Post-switch cleanup: clear stale OPENAI_BASE_URL ──────────────
@@ -2446,6 +2448,168 @@ def _model_flow_kimi(config, current_model=""):
         print(f"Default model set to: {selected} (via {endpoint_label})")
     else:
         print("No change.")
+
+
+def _model_flow_bedrock(config, current_model=""):
+    """AWS Bedrock provider: verify credentials, pick region, discover models.
+
+    Uses the native Converse API via boto3 — not the OpenAI-compatible endpoint.
+    Auth is handled by the AWS SDK default credential chain (env vars, profile,
+    instance role), so no API key prompt is needed.
+    """
+    from hermes_cli.auth import _prompt_model_selection, _save_model_choice, deactivate_provider
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    # 1. Check for AWS credentials
+    try:
+        from agent.bedrock_adapter import (
+            has_aws_credentials,
+            resolve_aws_auth_env_var,
+            resolve_bedrock_region,
+            discover_bedrock_models,
+        )
+    except ImportError:
+        print("  ✗ boto3 is not installed. Install it with:")
+        print("    pip install boto3")
+        print()
+        return
+
+    if not has_aws_credentials():
+        print("  ⚠ No AWS credentials detected via environment variables.")
+        print("  Bedrock will use boto3's default credential chain (IMDS, SSO, etc.)")
+        print()
+
+    auth_var = resolve_aws_auth_env_var()
+    if auth_var:
+        print(f"  AWS credentials: {auth_var} ✓")
+    else:
+        print("  AWS credentials: boto3 default chain (instance role / SSO)")
+    print()
+
+    # 2. Region selection
+    current_region = resolve_bedrock_region()
+    try:
+        region_input = input(f"  AWS Region [{current_region}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    region = region_input or current_region
+
+    # 3. Model discovery — try live API first, fall back to static list
+    print(f"  Discovering models in {region}...")
+    live_models = discover_bedrock_models(region)
+
+    if live_models:
+        # Filter to agent-usable text models only:
+        # - Must have TEXT in output modalities (no embedding/image-only models)
+        # - Exclude image generation (stability.*), embedding (cohere.embed*),
+        #   video (twelvelabs.*), voice (voxtral*), and safeguard models
+        _EXCLUDE_PREFIXES = (
+            "stability.", "cohere.embed", "twelvelabs.", "us.stability.",
+            "us.cohere.embed", "us.twelvelabs.", "global.cohere.embed",
+            "global.twelvelabs.",
+        )
+        _EXCLUDE_SUBSTRINGS = ("safeguard", "voxtral", "palmyra-vision")
+        filtered = []
+        for m in live_models:
+            mid = m["id"]
+            if any(mid.startswith(p) for p in _EXCLUDE_PREFIXES):
+                continue
+            if any(s in mid.lower() for s in _EXCLUDE_SUBSTRINGS):
+                continue
+            filtered.append(m)
+
+        # Deduplicate: prefer inference profiles (us.*, global.*) over bare
+        # foundation model IDs, since most models now require profiles for
+        # on-demand invocation.  Keep bare IDs only if no profile exists.
+        profile_base_ids = set()
+        for m in filtered:
+            mid = m["id"]
+            if mid.startswith(("us.", "global.")):
+                # Extract base: "us.anthropic.claude-sonnet-4-6" → "anthropic.claude-sonnet-4-6"
+                base = mid.split(".", 1)[1] if "." in mid[3:] else mid
+                profile_base_ids.add(base)
+
+        deduped = []
+        for m in filtered:
+            mid = m["id"]
+            # Skip bare foundation model IDs that have a profile equivalent
+            if not mid.startswith(("us.", "global.")) and mid in profile_base_ids:
+                continue
+            deduped.append(m)
+
+        # Sort: recommended models first, then by provider importance
+        _RECOMMENDED = [
+            "us.anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-opus-4-6",
+            "us.anthropic.claude-haiku-4-5",
+            "us.amazon.nova-pro",
+            "us.amazon.nova-lite",
+            "us.amazon.nova-micro",
+            "deepseek.v3",
+            "us.meta.llama4-maverick",
+            "us.meta.llama4-scout",
+        ]
+
+        def _sort_key(m):
+            mid = m["id"]
+            # Check if this model matches any recommended prefix
+            for i, rec in enumerate(_RECOMMENDED):
+                if mid.startswith(rec):
+                    return (0, i, mid)
+            # Global profiles after recommended
+            if mid.startswith("global."):
+                return (1, 0, mid)
+            # Everything else
+            return (2, 0, mid)
+
+        deduped.sort(key=_sort_key)
+        model_list = [m["id"] for m in deduped]
+        print(f"  Found {len(model_list)} text model(s) (filtered from {len(live_models)} total)")
+    else:
+        model_list = _PROVIDER_MODELS.get("bedrock", [])
+        if model_list:
+            print(f"  Using {len(model_list)} curated models (live discovery unavailable)")
+        else:
+            print("  No models found. Check your IAM permissions for bedrock:ListFoundationModels.")
+            return
+
+    # 4. Model selection
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("  Model ID (e.g. anthropic.claude-sonnet-4-6-20250514-v1:0): ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        _save_model_choice(selected)
+
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = "bedrock"
+        model["base_url"] = f"https://bedrock-runtime.{region}.amazonaws.com"
+        model.pop("api_mode", None)  # bedrock_converse is auto-detected
+
+        # Persist region in the bedrock config section so it survives restarts
+        # without requiring AWS_REGION env var to be set.
+        bedrock_cfg = cfg.get("bedrock", {})
+        if not isinstance(bedrock_cfg, dict):
+            bedrock_cfg = {}
+        bedrock_cfg["region"] = region
+        cfg["bedrock"] = bedrock_cfg
+
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"  Default model set to: {selected} (via AWS Bedrock, {region})")
+    else:
+        print("  No change.")
 
 
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
@@ -4516,7 +4680,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "xiaomi"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
         default=None,
         help="Inference provider (default: auto)"
     )
@@ -5608,8 +5772,7 @@ For more help on a command:
     claw_migrate = claw_subparsers.add_parser(
         "migrate",
         help="Migrate from OpenClaw to Hermes",
-        description="Import settings, memories, skills, and API keys from an OpenClaw installation. "
-                    "Always shows a preview before making changes."
+        description="Import settings, memories, skills, and API keys from an OpenClaw installation"
     )
     claw_migrate.add_argument(
         "--source",
@@ -5618,7 +5781,7 @@ For more help on a command:
     claw_migrate.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview only — stop after showing what would be migrated"
+        help="Preview what would be migrated without making changes"
     )
     claw_migrate.add_argument(
         "--preset",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -279,16 +279,18 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # AWS Bedrock — static fallback list used when dynamic discovery is
     # unavailable (no boto3, no credentials, or API error).  The agent
     # prefers live discovery via ListFoundationModels + ListInferenceProfiles.
+    # Use inference profile IDs (us.*) since most models require them.
     "bedrock": [
-        "anthropic.claude-opus-4-6-20250514-v1:0",
-        "anthropic.claude-sonnet-4-6-20250514-v1:0",
-        "anthropic.claude-sonnet-4-5-20250929-v1:0",
-        "anthropic.claude-haiku-4-5-20251001-v1:0",
-        "amazon.nova-pro-v1:0",
-        "amazon.nova-lite-v1:0",
-        "amazon.nova-micro-v1:0",
-        "meta.llama4-maverick-17b-instruct-v1:0",
-        "meta.llama4-scout-17b-instruct-v1:0",
+        "us.anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-opus-4-6-v1",
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "us.amazon.nova-pro-v1:0",
+        "us.amazon.nova-lite-v1:0",
+        "us.amazon.nova-micro-v1:0",
+        "deepseek.v3.2",
+        "us.meta.llama4-maverick-17b-instruct-v1:0",
+        "us.meta.llama4-scout-17b-instruct-v1:0",
     ],
 }
 
@@ -550,20 +552,6 @@ _PROVIDER_ALIASES = {
     "amazon-bedrock": "bedrock",
     "amazon": "bedrock",
 }
-
-
-def get_default_model_for_provider(provider: str) -> str:
-    """Return the default model for a provider, or empty string if unknown.
-
-    Uses the first entry in _PROVIDER_MODELS as the default.  This is the
-    model a user would be offered first in the ``hermes model`` picker.
-
-    Used as a fallback when the user has configured a provider but never
-    selected a model (e.g. ``hermes auth add openai-codex`` without
-    ``hermes model``).
-    """
-    models = _PROVIDER_MODELS.get(provider, [])
-    return models[0] if models else ""
 
 
 def _openrouter_model_is_free(pricing: Any) -> bool:
@@ -1828,35 +1816,6 @@ def validate_requested_model(
             "recognized": False,
             "message": message,
         }
-
-    # OpenAI Codex has its own catalog path; /v1/models probing is not the right validation path.
-    if normalized == "openai-codex":
-        try:
-            codex_models = provider_model_ids("openai-codex")
-        except Exception:
-            codex_models = []
-        if codex_models:
-            if requested_for_lookup in set(codex_models):
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "message": None,
-                }
-            suggestions = get_close_matches(requested_for_lookup, codex_models, n=3, cutoff=0.5)
-            suggestion_text = ""
-            if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
-            return {
-                "accepted": True,
-                "persist": True,
-                "recognized": False,
-                "message": (
-                    f"Note: `{requested}` was not found in the OpenAI Codex model listing. "
-                    f"It may still work if your account has access to it."
-                    f"{suggestion_text}"
-                ),
-            }
 
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -56,18 +56,6 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 
-
-def _codex_curated_models() -> list[str]:
-    """Derive the openai-codex curated list from codex_models.py.
-
-    Single source of truth: DEFAULT_CODEX_MODELS + forward-compat synthesis.
-    This keeps the gateway /model picker in sync with the CLI `hermes model`
-    flow without maintaining a separate static list.
-    """
-    from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, _add_forward_compat_models
-    return _add_forward_compat_models(list(DEFAULT_CODEX_MODELS))
-
-
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         "anthropic/claude-opus-4.6",
@@ -98,7 +86,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-pro",
         "openai/gpt-5.4-nano",
     ],
-    "openai-codex": _codex_curated_models(),
+    "openai-codex": [
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.2-codex",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-codex-max",
+    ],
     "copilot-acp": [
         "copilot-acp",
     ],
@@ -187,11 +182,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "deepseek": [
         "deepseek-chat",
         "deepseek-reasoner",
-    ],
-    "xiaomi": [
-        "mimo-v2-pro",
-        "mimo-v2-omni",
-        "mimo-v2-flash",
     ],
     "opencode-zen": [
         "gpt-5.4-pro",
@@ -285,6 +275,20 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "zai-org/GLM-5",
         "XiaomiMiMo/MiMo-V2-Flash",
         "moonshotai/Kimi-K2-Thinking",
+    ],
+    # AWS Bedrock — static fallback list used when dynamic discovery is
+    # unavailable (no boto3, no credentials, or API error).  The agent
+    # prefers live discovery via ListFoundationModels + ListInferenceProfiles.
+    "bedrock": [
+        "anthropic.claude-opus-4-6-20250514-v1:0",
+        "anthropic.claude-sonnet-4-6-20250514-v1:0",
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "amazon.nova-pro-v1:0",
+        "amazon.nova-lite-v1:0",
+        "amazon.nova-micro-v1:0",
+        "meta.llama4-maverick-17b-instruct-v1:0",
+        "meta.llama4-scout-17b-instruct-v1:0",
     ],
 }
 
@@ -498,7 +502,7 @@ _PROVIDER_LABELS = {
     "alibaba": "Alibaba Cloud (DashScope)",
     "qwen-oauth": "Qwen OAuth (Portal)",
     "huggingface": "Hugging Face",
-    "xiaomi": "Xiaomi MiMo",
+    "bedrock": "AWS Bedrock",
     "custom": "Custom endpoint",
 }
 
@@ -541,8 +545,10 @@ _PROVIDER_ALIASES = {
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
-    "mimo": "xiaomi",
-    "xiaomi-mimo": "xiaomi",
+    "aws": "bedrock",
+    "aws-bedrock": "bedrock",
+    "amazon-bedrock": "bedrock",
+    "amazon": "bedrock",
 }
 
 
@@ -841,7 +847,7 @@ def list_available_providers() -> list[dict[str, str]]:
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
         "gemini", "huggingface",
         "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
-        "qwen-oauth", "xiaomi",
+        "qwen-oauth",
         "opencode-zen", "opencode-go",
         "ai-gateway", "deepseek", "custom",
     ]
@@ -1887,6 +1893,42 @@ def validate_requested_model(
 
     # api_models is None — couldn't reach API.  Accept and persist,
     # but warn so typos don't silently break things.
+
+    # Bedrock: use our own discovery instead of HTTP /models endpoint.
+    # Bedrock's bedrock-runtime URL doesn't support /models — it uses the
+    # AWS SDK control plane (ListFoundationModels + ListInferenceProfiles).
+    if normalized == "bedrock":
+        try:
+            from agent.bedrock_adapter import discover_bedrock_models, resolve_bedrock_region
+            region = resolve_bedrock_region()
+            discovered = discover_bedrock_models(region)
+            discovered_ids = {m["id"] for m in discovered}
+            if requested in discovered_ids:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            # Not in discovered list — still accept (user may have custom
+            # inference profiles or cross-account access), but warn.
+            suggestions = get_close_matches(requested, list(discovered_ids), n=3, cutoff=0.4)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in Bedrock model discovery for {region}. "
+                    f"It may still work with custom inference profiles or cross-account access."
+                    f"{suggestion_text}"
+                ),
+            }
+        except Exception:
+            pass  # Fall through to generic warning
+
     provider_label = _PROVIDER_LABELS.get(normalized, normalized)
     return {
         "accepted": True,

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -132,10 +132,6 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.x.ai/v1",
         base_url_env_var="XAI_BASE_URL",
     ),
-    "xiaomi": HermesOverlay(
-        transport="openai_chat",
-        base_url_env_var="XIAOMI_BASE_URL",
-    ),
 }
 
 
@@ -226,9 +222,11 @@ ALIASES: Dict[str, str] = {
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
 
-    # xiaomi
-    "mimo": "xiaomi",
-    "xiaomi-mimo": "xiaomi",
+    # bedrock
+    "aws": "amazon-bedrock",
+    "aws-bedrock": "amazon-bedrock",
+    "amazon": "amazon-bedrock",
+    "bedrock": "amazon-bedrock",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",
@@ -250,8 +248,9 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
-    "xiaomi": "Xiaomi MiMo",
     "local": "Local endpoint",
+    "bedrock": "AWS Bedrock",
+    "amazon-bedrock": "AWS Bedrock",
 }
 
 
@@ -261,6 +260,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "openai_chat": "chat_completions",
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
+    "bedrock_converse": "bedrock_converse",
 }
 
 
@@ -385,6 +385,8 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
             return "anthropic_messages"
         if "api.openai.com" in url_lower:
             return "codex_responses"
+        if "bedrock-runtime" in url_lower and "amazonaws.com" in url_lower:
+            return "bedrock_converse"
 
     return "chat_completions"
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -304,9 +304,6 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
             result["api_mode"] = api_mode
-        model_name = str(entry.get("model", "") or "").strip()
-        if model_name:
-            result["model"] = model_name
         return result
 
     return None
@@ -332,11 +329,6 @@ def _resolve_named_custom_runtime(
     # Check if a credential pool exists for this custom endpoint
     pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
     if pool_result:
-        # Propagate the model name even when using pooled credentials —
-        # the pool doesn't know about the custom_providers model field.
-        model_name = custom_provider.get("model")
-        if model_name:
-            pool_result["model"] = model_name
         return pool_result
 
     api_key_candidates = [
@@ -347,7 +339,7 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
-    result = {
+    return {
         "provider": "custom",
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
@@ -356,11 +348,6 @@ def _resolve_named_custom_runtime(
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
-    # Propagate the model name so callers can override self.model when the
-    # provider name differs from the actual model string the API expects.
-    if custom_provider.get("model"):
-        result["model"] = custom_provider["model"]
-    return result
 
 
 def _resolve_openrouter_runtime(
@@ -824,15 +811,34 @@ def resolve_runtime_provider(
                 guardrail_config["streamProcessingMode"] = _gr["stream_processing_mode"]
             if _gr.get("trace"):
                 guardrail_config["trace"] = _gr["trace"]
-        runtime = {
-            "provider": "bedrock",
-            "api_mode": "bedrock_converse",
-            "base_url": f"https://bedrock-runtime.{region}.amazonaws.com",
-            "api_key": "aws-sdk",  # Placeholder — boto3 handles real auth
-            "source": auth_source,
-            "region": region,
-            "requested_provider": requested_provider,
-        }
+        # Dual-path routing: Claude models use AnthropicBedrock SDK for full
+        # feature parity (prompt caching, thinking budgets, adaptive thinking).
+        # Non-Claude models use the Converse API for multi-model support.
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        _current_model = str(model_cfg.get("default") or "").strip()
+        if is_anthropic_bedrock_model(_current_model):
+            # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
+            runtime = {
+                "provider": "bedrock",
+                "api_mode": "anthropic_messages",
+                "base_url": f"https://bedrock-runtime.{region}.amazonaws.com",
+                "api_key": "aws-sdk",
+                "source": auth_source,
+                "region": region,
+                "bedrock_anthropic": True,  # Signal to use AnthropicBedrock client
+                "requested_provider": requested_provider,
+            }
+        else:
+            # Non-Claude (Nova, DeepSeek, Llama, etc.) → Converse API
+            runtime = {
+                "provider": "bedrock",
+                "api_mode": "bedrock_converse",
+                "base_url": f"https://bedrock-runtime.{region}.amazonaws.com",
+                "api_key": "aws-sdk",
+                "source": auth_source,
+                "region": region,
+                "requested_provider": requested_provider,
+            }
         if guardrail_config:
             runtime["guardrail_config"] = guardrail_config
         return runtime

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -782,6 +782,61 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    # AWS Bedrock (native Converse API via boto3)
+    if provider == "bedrock":
+        from agent.bedrock_adapter import (
+            has_aws_credentials,
+            resolve_aws_auth_env_var,
+            resolve_bedrock_region,
+        )
+        # When the user explicitly selected bedrock (not auto-detected),
+        # trust boto3's credential chain — it handles IMDS, ECS task roles,
+        # Lambda execution roles, SSO, and other implicit sources that our
+        # env-var check can't detect.  Only block when auto-detected AND
+        # no credentials are found (prevents confusing errors for users who
+        # never intended to use Bedrock).
+        # See: OpenClaw PR #62673 for the same class of issue.
+        is_explicit = requested_provider in ("bedrock", "aws", "aws-bedrock", "amazon-bedrock", "amazon")
+        if not is_explicit and not has_aws_credentials():
+            raise AuthError(
+                "No AWS credentials found for Bedrock. Configure one of:\n"
+                "  - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY\n"
+                "  - AWS_PROFILE (for SSO / named profiles)\n"
+                "  - IAM instance role (EC2, ECS, Lambda)\n"
+                "Or run 'aws configure' to set up credentials.",
+                code="no_aws_credentials",
+            )
+        # Read bedrock-specific config from config.yaml
+        from hermes_cli.config import load_config as _load_bedrock_config
+        _bedrock_cfg = _load_bedrock_config().get("bedrock", {})
+        # Region priority: config.yaml bedrock.region → env var → us-east-1
+        region = (_bedrock_cfg.get("region") or "").strip() or resolve_bedrock_region()
+        auth_source = resolve_aws_auth_env_var() or "aws-sdk-default-chain"
+        # Build guardrail config if configured
+        _gr = _bedrock_cfg.get("guardrail", {})
+        guardrail_config = None
+        if _gr.get("guardrail_identifier") and _gr.get("guardrail_version"):
+            guardrail_config = {
+                "guardrailIdentifier": _gr["guardrail_identifier"],
+                "guardrailVersion": _gr["guardrail_version"],
+            }
+            if _gr.get("stream_processing_mode"):
+                guardrail_config["streamProcessingMode"] = _gr["stream_processing_mode"]
+            if _gr.get("trace"):
+                guardrail_config["trace"] = _gr["trace"]
+        runtime = {
+            "provider": "bedrock",
+            "api_mode": "bedrock_converse",
+            "base_url": f"https://bedrock-runtime.{region}.amazonaws.com",
+            "api_key": "aws-sdk",  # Placeholder — boto3 handles real auth
+            "source": auth_source,
+            "region": region,
+            "requested_provider": requested_provider,
+        }
+        if guardrail_config:
+            runtime["guardrail_config"] = guardrail_config
+        return runtime
+
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
+bedrock = ["boto3>=1.35.0,<2"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
@@ -87,6 +88,7 @@ yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; pytho
 all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
+  "hermes-agent[bedrock]",
   "hermes-agent[messaging]",
   # matrix: python-olm (required by matrix-nio[e2e]) is upstream-broken on
   # modern macOS (archived libolm, C++ errors with Clang 21+).  On Linux the

--- a/run_agent.py
+++ b/run_agent.py
@@ -94,7 +94,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -339,7 +339,10 @@ def _paths_overlap(left: Path, right: Path) -> bool:
 
 _SURROGATE_RE = re.compile(r'[\ud800-\udfff]')
 
-
+_BUDGET_WARNING_RE = re.compile(
+    r"\[BUDGET(?:\s+WARNING)?:\s+Iteration\s+\d+/\d+\..*?\]",
+    re.DOTALL,
+)
 
 
 def _sanitize_surrogates(text: str) -> str:
@@ -460,7 +463,34 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
     return found
 
 
+def _strip_budget_warnings_from_history(messages: list) -> None:
+    """Remove budget pressure warnings from tool-result messages in-place.
 
+    Budget warnings are turn-scoped signals that must not leak into replayed
+    history.  They live in tool-result ``content`` either as a JSON key
+    (``_budget_warning``) or appended plain text.
+    """
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str) or "_budget_warning" not in content and "[BUDGET" not in content:
+            continue
+
+        # Try JSON first (the common case: _budget_warning key in a dict)
+        try:
+            parsed = json.loads(content)
+            if isinstance(parsed, dict) and "_budget_warning" in parsed:
+                del parsed["_budget_warning"]
+                msg["content"] = json.dumps(parsed, ensure_ascii=False)
+                continue
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Fallback: strip the text pattern from plain-text tool results
+        cleaned = _BUDGET_WARNING_RE.sub("", content).strip()
+        if cleaned != content:
+            msg["content"] = cleaned
 
 
 # =========================================================================
@@ -549,7 +579,6 @@ class AIAgent:
         clarify_callback: callable = None,
         step_callback: callable = None,
         stream_delta_callback: callable = None,
-        interim_assistant_callback: callable = None,
         tool_gen_callback: callable = None,
         status_callback: callable = None,
         max_tokens: int = None,
@@ -698,7 +727,6 @@ class AIAgent:
         self.clarify_callback = clarify_callback
         self.step_callback = step_callback
         self.stream_delta_callback = stream_delta_callback
-        self.interim_assistant_callback = interim_assistant_callback
         self.status_callback = status_callback
         self.tool_gen_callback = tool_gen_callback
 
@@ -710,7 +738,6 @@ class AIAgent:
         # Interrupt mechanism for breaking out of tool loops
         self._interrupt_requested = False
         self._interrupt_message = None  # Optional message that triggered interrupt
-        self._execution_thread_id: int | None = None  # Set at run_conversation() start
         self._client_lock = threading.RLock()
         
         # Subagent delegation state
@@ -746,14 +773,12 @@ class AIAgent:
         self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
         
-        # Iteration budget: the LLM is only notified when it actually exhausts
-        # the iteration budget (api_call_count >= max_iterations).  At that
-        # point we inject ONE message, allow one final API call, and if the
-        # model doesn't produce a text response, force a user-message asking
-        # it to summarise.  No intermediate pressure warnings — they caused
-        # models to "give up" prematurely on complex tasks (#7915).
-        self._budget_exhausted_injected = False
-        self._budget_grace_call = False
+        # Iteration budget pressure: warn the LLM as it approaches max_iterations.
+        # Warnings are injected into the last tool result JSON (not as separate
+        # messages) so they don't break message structure or invalidate caching.
+        self._budget_caution_threshold = 0.7   # 70% — nudge to start wrapping up
+        self._budget_warning_threshold = 0.9   # 90% — urgent, respond now
+        self._budget_pressure_enabled = True
 
         # Context pressure warnings: notify the USER (not the LLM) as context
         # fills up.  Purely informational — displayed in CLI output and sent via
@@ -804,11 +829,6 @@ class AIAgent:
         # Deferred paragraph break flag — set after tool iterations so a
         # single "\n\n" is prepended to the next real text delta.
         self._stream_needs_break = False
-        # Visible assistant text already delivered through live token callbacks
-        # during the current model response. Used to avoid re-sending the same
-        # commentary when the provider later returns it as a completed interim
-        # assistant message.
-        self._current_streamed_assistant_text = ""
 
         # Optional current-turn user-message override used when the API-facing
         # user message intentionally differs from the persisted transcript
@@ -831,23 +851,42 @@ class AIAgent:
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
-            # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
-            # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
-            # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
-            _is_native_anthropic = self.provider == "anthropic"
-            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
-            self.api_key = effective_key
-            self._anthropic_api_key = effective_key
-            self._anthropic_base_url = base_url
-            from agent.anthropic_adapter import _is_oauth_token as _is_oat
-            self._is_anthropic_oauth = _is_oat(effective_key)
-            self._anthropic_client = build_anthropic_client(effective_key, base_url)
-            # No OpenAI client needed for Anthropic mode
-            self.client = None
-            self._client_kwargs = {}
-            if not self.quiet_mode:
-                print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
-                if effective_key and len(effective_key) > 12:
+            # Bedrock + Claude → use AnthropicBedrock SDK for full feature parity
+            # (prompt caching, thinking budgets, adaptive thinking).
+            _is_bedrock_anthropic = self.provider == "bedrock"
+            if _is_bedrock_anthropic:
+                from agent.anthropic_adapter import build_anthropic_bedrock_client
+                import re as _re
+                _region_match = _re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
+                _br_region = _region_match.group(1) if _region_match else "us-east-1"
+                self._bedrock_region = _br_region
+                self._anthropic_client = build_anthropic_bedrock_client(_br_region)
+                self._anthropic_api_key = "aws-sdk"
+                self._anthropic_base_url = base_url
+                self._is_anthropic_oauth = False
+                self.api_key = "aws-sdk"
+                self.client = None
+                self._client_kwargs = {}
+                if not self.quiet_mode:
+                    print(f"🤖 AI Agent initialized with model: {self.model} (AWS Bedrock + AnthropicBedrock SDK, {_br_region})")
+            else:
+                # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
+                # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
+                # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
+                _is_native_anthropic = self.provider == "anthropic"
+                effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
+                self.api_key = effective_key
+                self._anthropic_api_key = effective_key
+                self._anthropic_base_url = base_url
+                from agent.anthropic_adapter import _is_oauth_token as _is_oat
+                self._is_anthropic_oauth = _is_oat(effective_key)
+                self._anthropic_client = build_anthropic_client(effective_key, base_url)
+                # No OpenAI client needed for Anthropic mode
+                self.client = None
+                self._client_kwargs = {}
+                if not self.quiet_mode:
+                    print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
+                    if effective_key and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
         elif self.api_mode == "bedrock_converse":
             # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
@@ -1333,22 +1372,8 @@ class AIAgent:
                 api_key=getattr(self, "api_key", ""),
                 config_context_length=_config_context_length,
                 provider=self.provider,
-                api_mode=self.api_mode,
             )
         self.compression_enabled = compression_enabled
-
-        # Reject models whose context window is below the minimum required
-        # for reliable tool-calling workflows (64K tokens).
-        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
-        _ctx = getattr(self.context_compressor, "context_length", 0)
-        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
-            raise ValueError(
-                f"Model {self.model} has a context window of {_ctx:,} tokens, "
-                f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
-                f"by Hermes Agent.  Choose a model with at least "
-                f"{MINIMUM_CONTEXT_LENGTH // 1000}K context, or set "
-                f"model.context_length in config.yaml to override."
-            )
 
         # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand)
         self._context_engine_tool_names: set = set()
@@ -1584,7 +1609,6 @@ class AIAgent:
                 base_url=self.base_url,
                 api_key=getattr(self, "api_key", ""),
                 provider=self.provider,
-                api_mode=self.api_mode,
             )
 
         # ── Invalidate cached system prompt so it rebuilds next turn ──
@@ -1717,117 +1741,6 @@ class AIAgent:
                 self.status_callback("lifecycle", message)
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
-
-    def _current_main_runtime(self) -> Dict[str, str]:
-        """Return the live main runtime for session-scoped auxiliary routing."""
-        return {
-            "model": getattr(self, "model", "") or "",
-            "provider": getattr(self, "provider", "") or "",
-            "base_url": getattr(self, "base_url", "") or "",
-            "api_key": getattr(self, "api_key", "") or "",
-            "api_mode": getattr(self, "api_mode", "") or "",
-        }
-
-    def _check_compression_model_feasibility(self) -> None:
-        """Warn at session start if the auxiliary compression model's context
-        window is smaller than the main model's compression threshold.
-
-        When the auxiliary model cannot fit the content that needs summarising,
-        compression will either fail outright (the LLM call errors) or produce
-        a severely truncated summary.
-
-        Called during ``__init__`` so CLI users see the warning immediately
-        (via ``_vprint``).  The gateway sets ``status_callback`` *after*
-        construction, so ``_replay_compression_warning()`` re-sends the
-        stored warning through the callback on the first
-        ``run_conversation()`` call.
-        """
-        if not self.compression_enabled:
-            return
-        try:
-            from agent.auxiliary_client import get_text_auxiliary_client
-            from agent.model_metadata import get_model_context_length
-
-            client, aux_model = get_text_auxiliary_client(
-                "compression",
-                main_runtime=self._current_main_runtime(),
-            )
-            if client is None or not aux_model:
-                msg = (
-                    "⚠ No auxiliary LLM provider configured — context "
-                    "compression will drop middle turns without a summary. "
-                    "Run `hermes setup` or set OPENROUTER_API_KEY."
-                )
-                self._compression_warning = msg
-                self._emit_status(msg)
-                logger.warning(
-                    "No auxiliary LLM provider for compression — "
-                    "summaries will be unavailable."
-                )
-                return
-
-            aux_base_url = str(getattr(client, "base_url", ""))
-            aux_api_key = str(getattr(client, "api_key", ""))
-            aux_context = get_model_context_length(
-                aux_model,
-                base_url=aux_base_url,
-                api_key=aux_api_key,
-            )
-
-            threshold = self.context_compressor.threshold_tokens
-            if aux_context < threshold:
-                # Suggest a threshold that would fit the aux model,
-                # rounded down to a clean percentage.
-                safe_pct = int((aux_context / self.context_compressor.context_length) * 100)
-                msg = (
-                    f"⚠ Compression model ({aux_model}) context "
-                    f"is {aux_context:,} tokens, but the main model's "
-                    f"compression threshold is {threshold:,} tokens. "
-                    f"Context compression will not be possible — the "
-                    f"content to summarise will exceed the auxiliary "
-                    f"model's context window.\n"
-                    f"  Fix options (config.yaml):\n"
-                    f"  1. Use a larger compression model:\n"
-                    f"       auxiliary:\n"
-                    f"         compression:\n"
-                    f"           model: <model-with-{threshold:,}+-context>\n"
-                    f"  2. Lower the compression threshold to fit "
-                    f"the current model:\n"
-                    f"       compression:\n"
-                    f"         threshold: 0.{safe_pct:02d}"
-                )
-                self._compression_warning = msg
-                self._emit_status(msg)
-                logger.warning(
-                    "Auxiliary compression model %s has %d token context, "
-                    "below the main model's compression threshold of %d "
-                    "tokens — compression summaries will fail or be "
-                    "severely truncated.",
-                    aux_model,
-                    aux_context,
-                    threshold,
-                )
-        except Exception as exc:
-            logger.debug(
-                "Compression feasibility check failed (non-fatal): %s", exc
-            )
-
-    def _replay_compression_warning(self) -> None:
-        """Re-send the compression warning through ``status_callback``.
-
-        During ``__init__`` the gateway's ``status_callback`` is not yet
-        wired, so ``_emit_status`` only reaches ``_vprint`` (CLI).  This
-        method is called once at the start of the first
-        ``run_conversation()`` — by then the gateway has set the callback,
-        so every platform (Telegram, Discord, Slack, etc.) receives the
-        warning.
-        """
-        msg = getattr(self, "_compression_warning", None)
-        if msg and self.status_callback:
-            try:
-                self.status_callback("lifecycle", msg)
-            except Exception:
-                pass
 
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets OpenAI's native API."""
@@ -2845,10 +2758,8 @@ class AIAgent:
         """
         self._interrupt_requested = True
         self._interrupt_message = message
-        # Signal all tools to abort any in-flight operations immediately.
-        # Scope the interrupt to this agent's execution thread so other
-        # agents running in the same process (gateway) are not affected.
-        _set_interrupt(True, self._execution_thread_id)
+        # Signal all tools to abort any in-flight operations immediately
+        _set_interrupt(True)
         # Propagate interrupt to any running child agents (subagent delegation)
         with self._active_children_lock:
             children_copy = list(self._active_children)
@@ -2861,10 +2772,10 @@ class AIAgent:
             print("\n⚡ Interrupt requested" + (f": '{message[:40]}...'" if message and len(message) > 40 else f": '{message}'" if message else ""))
     
     def clear_interrupt(self) -> None:
-        """Clear any pending interrupt request and the per-thread tool interrupt signal."""
+        """Clear any pending interrupt request and the global tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
-        _set_interrupt(False, self._execution_thread_id)
+        _set_interrupt(False)
 
     def _touch_activity(self, desc: str) -> None:
         """Update the last-activity timestamp and description (thread-safe)."""
@@ -3198,17 +3109,11 @@ class AIAgent:
                 f"not on any model name returned by the API."
             )
 
-        # Environment hints (WSL, Termux, etc.) — tell the agent about the
-        # execution environment so it can translate paths and adapt behavior.
-        _env_hints = build_environment_hints()
-        if _env_hints:
-            prompt_parts.append(_env_hints)
-
         platform_key = (self.platform or "").lower().strip()
         if platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
-        return "\n\n".join(p.strip() for p in prompt_parts if p.strip())
+        return "\n\n".join(prompt_parts)
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -3464,7 +3369,6 @@ class AIAgent:
     def _chat_messages_to_responses_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert internal chat-style messages to Responses input items."""
         items: List[Dict[str, Any]] = []
-        seen_item_ids: set = set()
 
         for msg in messages:
             if not isinstance(msg, dict):
@@ -3485,12 +3389,7 @@ class AIAgent:
                     if isinstance(codex_reasoning, list):
                         for ri in codex_reasoning:
                             if isinstance(ri, dict) and ri.get("encrypted_content"):
-                                item_id = ri.get("id")
-                                if item_id and item_id in seen_item_ids:
-                                    continue
                                 items.append(ri)
-                                if item_id:
-                                    seen_item_ids.add(item_id)
                                 has_codex_reasoning = True
 
                     if content_text.strip():
@@ -3570,7 +3469,6 @@ class AIAgent:
             raise ValueError("Codex Responses input must be a list of input items.")
 
         normalized: List[Dict[str, Any]] = []
-        seen_ids: set = set()
         for idx, item in enumerate(raw_items):
             if not isinstance(item, dict):
                 raise ValueError(f"Codex Responses input[{idx}] must be an object.")
@@ -3623,12 +3521,8 @@ class AIAgent:
             if item_type == "reasoning":
                 encrypted = item.get("encrypted_content")
                 if isinstance(encrypted, str) and encrypted:
-                    item_id = item.get("id")
-                    if isinstance(item_id, str) and item_id:
-                        if item_id in seen_ids:
-                            continue
-                        seen_ids.add(item_id)
                     reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
+                    item_id = item.get("id")
                     if isinstance(item_id, str) and item_id:
                         reasoning_item["id"] = item_id
                     summary = item.get("summary")
@@ -4761,49 +4655,6 @@ class AIAgent:
 
     # ── Unified streaming API call ─────────────────────────────────────────
 
-    def _reset_stream_delivery_tracking(self) -> None:
-        """Reset tracking for text delivered during the current model response."""
-        self._current_streamed_assistant_text = ""
-
-    def _record_streamed_assistant_text(self, text: str) -> None:
-        """Accumulate visible assistant text emitted through stream callbacks."""
-        if isinstance(text, str) and text:
-            self._current_streamed_assistant_text = (
-                getattr(self, "_current_streamed_assistant_text", "") + text
-            )
-
-    @staticmethod
-    def _normalize_interim_visible_text(text: str) -> str:
-        if not isinstance(text, str):
-            return ""
-        return re.sub(r"\s+", " ", text).strip()
-
-    def _interim_content_was_streamed(self, content: str) -> bool:
-        visible_content = self._normalize_interim_visible_text(
-            self._strip_think_blocks(content or "")
-        )
-        if not visible_content:
-            return False
-        streamed = self._normalize_interim_visible_text(
-            self._strip_think_blocks(getattr(self, "_current_streamed_assistant_text", "") or "")
-        )
-        return bool(streamed) and streamed == visible_content
-
-    def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:
-        """Surface a real mid-turn assistant commentary message to the UI layer."""
-        cb = getattr(self, "interim_assistant_callback", None)
-        if cb is None or not isinstance(assistant_msg, dict):
-            return
-        content = assistant_msg.get("content")
-        visible = self._strip_think_blocks(content or "").strip()
-        if not visible or visible == "(empty)":
-            return
-        already_streamed = self._interim_content_was_streamed(visible)
-        try:
-            cb(visible, already_streamed=already_streamed)
-        except Exception:
-            logger.debug("interim_assistant_callback error", exc_info=True)
-
     def _fire_stream_delta(self, text: str) -> None:
         """Fire all registered stream delta callbacks (display + TTS)."""
         # If a tool iteration set the break flag, prepend a single paragraph
@@ -4813,16 +4664,12 @@ class AIAgent:
         if getattr(self, "_stream_needs_break", False) and text and text.strip():
             self._stream_needs_break = False
             text = "\n\n" + text
-        callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
-        delivered = False
-        for cb in callbacks:
-            try:
-                cb(text)
-                delivered = True
-            except Exception:
-                pass
-        if delivered:
-            self._record_streamed_assistant_text(text)
+        for cb in (self.stream_delta_callback, self._stream_callback):
+            if cb is not None:
+                try:
+                    cb(text)
+                except Exception:
+                    pass
 
     def _fire_reasoning_delta(self, text: str) -> None:
         """Fire reasoning callback if registered."""
@@ -5065,7 +4912,6 @@ class AIAgent:
                         if self.stream_delta_callback:
                             try:
                                 self.stream_delta_callback(delta.content)
-                                self._record_streamed_assistant_text(delta.content)
                             except Exception:
                                 pass
 
@@ -6661,23 +6507,17 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default") -> tuple:
         """Compress conversation context and split the session in SQLite.
-
-        Args:
-            focus_topic: Optional focus string for guided compression — the
-                summariser will prioritise preserving information related to
-                this topic.  Inspired by Claude Code's ``/compact <focus>``.
 
         Returns:
             (compressed_messages, new_system_prompt) tuple
         """
         _pre_msg_count = len(messages)
         logger.info(
-            "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
+            "context compression started: session=%s messages=%d tokens=~%s model=%s",
             self.session_id or "none", _pre_msg_count,
             f"{approx_tokens:,}" if approx_tokens else "unknown", self.model,
-            focus_topic,
         )
         # Pre-compression memory flush: let the model save memories before they're lost
         self.flush_memories(messages, min_turns=0)
@@ -6689,7 +6529,7 @@ class AIAgent:
             except Exception:
                 pass
 
-        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
+        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
 
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
@@ -7078,6 +6918,24 @@ class AIAgent:
             turn_tool_msgs = messages[-num_tools:]
             enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id))
 
+        # ── Budget pressure injection ────────────────────────────────────
+        budget_warning = self._get_budget_warning(api_call_count)
+        if budget_warning and messages and messages[-1].get("role") == "tool":
+            last_content = messages[-1]["content"]
+            try:
+                parsed = json.loads(last_content)
+                if isinstance(parsed, dict):
+                    parsed["_budget_warning"] = budget_warning
+                    messages[-1]["content"] = json.dumps(parsed, ensure_ascii=False)
+                else:
+                    messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
+            except (json.JSONDecodeError, TypeError):
+                messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
+            if not self.quiet_mode:
+                remaining = self.max_iterations - api_call_count
+                tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
+                print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
+
     def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
         for i, tool_call in enumerate(assistant_message.tool_calls, 1):
@@ -7125,15 +6983,6 @@ class AIAgent:
 
             self._current_tool = function_name
             self._touch_activity(f"executing tool: {function_name}")
-
-            # Set activity callback for long-running tool execution (terminal
-            # commands, etc.) so the gateway's inactivity monitor doesn't kill
-            # the agent while a command is running.
-            try:
-                from tools.environments.base import set_activity_callback
-                set_activity_callback(self._touch_activity)
-            except Exception:
-                pass
 
             if self.tool_progress_callback:
                 try:
@@ -7424,7 +7273,50 @@ class AIAgent:
         if num_tools_seq > 0:
             enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id))
 
+        # ── Budget pressure injection ─────────────────────────────────
+        # After all tool calls in this turn are processed, check if we're
+        # approaching max_iterations. If so, inject a warning into the LAST
+        # tool result's JSON so the LLM sees it naturally when reading results.
+        budget_warning = self._get_budget_warning(api_call_count)
+        if budget_warning and messages and messages[-1].get("role") == "tool":
+            last_content = messages[-1]["content"]
+            try:
+                parsed = json.loads(last_content)
+                if isinstance(parsed, dict):
+                    parsed["_budget_warning"] = budget_warning
+                    messages[-1]["content"] = json.dumps(parsed, ensure_ascii=False)
+                else:
+                    messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
+            except (json.JSONDecodeError, TypeError):
+                messages[-1]["content"] = last_content + f"\n\n{budget_warning}"
+            if not self.quiet_mode:
+                remaining = self.max_iterations - api_call_count
+                tier = "⚠️  WARNING" if remaining <= self.max_iterations * 0.1 else "💡 CAUTION"
+                print(f"{self.log_prefix}{tier}: {remaining} iterations remaining")
 
+    def _get_budget_warning(self, api_call_count: int) -> Optional[str]:
+        """Return a budget pressure string, or None if not yet needed.
+
+        Two-tier system:
+          - Caution (70%): nudge to consolidate work
+          - Warning (90%): urgent, must respond now
+        """
+        if not self._budget_pressure_enabled or self.max_iterations <= 0:
+            return None
+        progress = api_call_count / self.max_iterations
+        remaining = self.max_iterations - api_call_count
+        if progress >= self._budget_warning_threshold:
+            return (
+                f"[BUDGET WARNING: Iteration {api_call_count}/{self.max_iterations}. "
+                f"Only {remaining} iteration(s) left. "
+                "Provide your final response NOW. No more tool calls unless absolutely critical.]"
+            )
+        if progress >= self._budget_caution_threshold:
+            return (
+                f"[BUDGET: Iteration {api_call_count}/{self.max_iterations}. "
+                f"{remaining} iterations left. Start consolidating your work.]"
+            )
+        return None
 
     def _emit_context_pressure(self, compaction_progress: float, compressor) -> None:
         """Notify the user that context is approaching the compaction threshold.
@@ -7648,11 +7540,6 @@ class AIAgent:
         # Installed once, transparent when streams are healthy, prevents crash on write.
         _install_safe_stdio()
 
-        # Tag all log records on this thread with the session ID so
-        # ``hermes logs --session <id>`` can filter a single conversation.
-        from hermes_logging import set_session_context
-        set_session_context(self.session_id)
-
         # If the previous turn activated fallback, restore the primary
         # runtime so this turn gets a fresh attempt with the preferred model.
         # No-op when _fallback_activated is False (gateway, first turn, etc.).
@@ -7716,6 +7603,14 @@ class AIAgent:
         # Initialize conversation (copy to avoid mutating the caller's list)
         messages = list(conversation_history) if conversation_history else []
 
+        # Strip budget pressure warnings from previous turns.  These are
+        # turn-scoped signals injected by _get_budget_warning() into tool
+        # result content.  If left in the replayed history, models (especially
+        # GPT-family) interpret them as still-active instructions and avoid
+        # making tool calls in ALL subsequent turns.
+        if messages:
+            _strip_budget_warnings_from_history(messages)
+        
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to
         # recover the todo state from the most recent todo tool response in history)
@@ -7911,11 +7806,6 @@ class AIAgent:
         compression_attempts = 0
         _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
         
-        # Record the execution thread so interrupt()/clear_interrupt() can
-        # scope the tool-level interrupt signal to THIS agent's thread only.
-        # Must be set before clear_interrupt() which uses it.
-        self._execution_thread_id = threading.current_thread().ident
-
         # Clear any stale interrupt state at start
         self.clear_interrupt()
 
@@ -7932,7 +7822,7 @@ class AIAgent:
             except Exception:
                 pass
 
-        while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
+        while api_call_count < self.max_iterations and self.iteration_budget.remaining > 0:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
 
@@ -7947,13 +7837,7 @@ class AIAgent:
             api_call_count += 1
             self._api_call_count = api_call_count
             self._touch_activity(f"starting API call #{api_call_count}")
-
-            # Grace call: the budget is exhausted but we gave the model one
-            # more chance.  Consume the grace flag so the loop exits after
-            # this iteration regardless of outcome.
-            if self._budget_grace_call:
-                self._budget_grace_call = False
-            elif not self.iteration_budget.consume():
+            if not self.iteration_budget.consume():
                 _turn_exit_reason = "budget_exhausted"
                 if not self.quiet_mode:
                     self._safe_print(f"\n⚠️  Iteration budget exhausted ({self.iteration_budget.used}/{self.iteration_budget.max_total} iterations used)")
@@ -8080,39 +7964,9 @@ class AIAgent:
             # manual message manipulation are always caught.
             api_messages = self._sanitize_api_messages(api_messages)
 
-            # Normalize message whitespace and tool-call JSON for consistent
-            # prefix matching.  Ensures bit-perfect prefixes across turns,
-            # which enables KV cache reuse on local inference servers
-            # (llama.cpp, vLLM, Ollama) and improves cache hit rates for
-            # cloud providers.  Operates on api_messages (the API copy) so
-            # the original conversation history in `messages` is untouched.
-            for am in api_messages:
-                if isinstance(am.get("content"), str):
-                    am["content"] = am["content"].strip()
-            for am in api_messages:
-                tcs = am.get("tool_calls")
-                if not tcs:
-                    continue
-                new_tcs = []
-                for tc in tcs:
-                    if isinstance(tc, dict) and "function" in tc:
-                        try:
-                            args_obj = json.loads(tc["function"]["arguments"])
-                            tc = {**tc, "function": {
-                                **tc["function"],
-                                "arguments": json.dumps(
-                                    args_obj, separators=(",", ":"),
-                                    sort_keys=True,
-                                ),
-                            }}
-                        except Exception:
-                            pass
-                    new_tcs.append(tc)
-                am["tool_calls"] = new_tcs
-
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
-            approx_tokens = estimate_messages_tokens_rough(api_messages)
+            approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token
             
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
@@ -8161,7 +8015,6 @@ class AIAgent:
 
             while retry_count < max_retries:
                 try:
-                    self._reset_stream_delivery_tracking()
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
@@ -8320,8 +8173,6 @@ class AIAgent:
                             self._emit_status("⚠️ Empty/malformed response — switching to fallback...")
                         if self._try_activate_fallback():
                             retry_count = 0
-                            compression_attempts = 0
-                            primary_recovery_attempted = False
                             continue
 
                         # Check for error field in response (some providers include this)
@@ -8357,8 +8208,6 @@ class AIAgent:
                             self._emit_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
                             if self._try_activate_fallback():
                                 retry_count = 0
-                                compression_attempts = 0
-                                primary_recovery_attempted = False
                                 continue
                             self._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                             logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
@@ -8435,24 +8284,8 @@ class AIAgent:
                                     _text_parts.append(getattr(_blk, "text", ""))
                             _trunc_content = "\n".join(_text_parts) if _text_parts else None
 
-                        # A response is "thinking exhausted" only when the model
-                        # actually produced reasoning blocks but no visible text after
-                        # them.  Models that do not use <think> tags (e.g. GLM-4.7 on
-                        # NVIDIA Build, minimax) may return content=None or an empty
-                        # string for unrelated reasons — treat those as normal
-                        # truncations that deserve continuation retries, not as
-                        # thinking-budget exhaustion.
-                        _has_think_tags = bool(
-                            _trunc_content and re.search(
-                                r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>',
-                                _trunc_content,
-                                re.IGNORECASE,
-                            )
-                        )
                         _thinking_exhausted = (
-                            not _trunc_has_tool_calls
-                            and _has_think_tags
-                            and (
+                            not _trunc_has_tool_calls and (
                                 (_trunc_content is not None and not self._has_content_after_think_block(_trunc_content))
                                 or _trunc_content is None
                             )
@@ -9013,8 +8846,6 @@ class AIAgent:
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                             if self._try_activate_fallback():
                                 retry_count = 0
-                                compression_attempts = 0
-                                primary_recovery_attempted = False
                                 continue
 
                     is_payload_too_large = (
@@ -9228,8 +9059,6 @@ class AIAgent:
                         self._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                         if self._try_activate_fallback():
                             retry_count = 0
-                            compression_attempts = 0
-                            primary_recovery_attempted = False
                             continue
                         if api_kwargs is not None:
                             self._dump_api_request_debug(
@@ -9295,8 +9124,6 @@ class AIAgent:
                         self._emit_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
                         if self._try_activate_fallback():
                             retry_count = 0
-                            compression_attempts = 0
-                            primary_recovery_attempted = False
                             continue
                         _final_summary = self._summarize_api_error(api_error)
                         if is_rate_limited:
@@ -9520,6 +9347,8 @@ class AIAgent:
                 # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
                 # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
                 if has_incomplete_scratchpad(assistant_message.content or ""):
+                    if not hasattr(self, '_incomplete_scratchpad_retries'):
+                        self._incomplete_scratchpad_retries = 0
                     self._incomplete_scratchpad_retries += 1
                     
                     self._vprint(f"{self.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
@@ -9547,9 +9376,12 @@ class AIAgent:
                         }
                 
                 # Reset incomplete scratchpad counter on clean response
-                self._incomplete_scratchpad_retries = 0
+                if hasattr(self, '_incomplete_scratchpad_retries'):
+                    self._incomplete_scratchpad_retries = 0
 
                 if self.api_mode == "codex_responses" and finish_reason == "incomplete":
+                    if not hasattr(self, "_codex_incomplete_retries"):
+                        self._codex_incomplete_retries = 0
                     self._codex_incomplete_retries += 1
 
                     interim_msg = self._build_assistant_message(assistant_message, finish_reason)
@@ -9576,7 +9408,6 @@ class AIAgent:
                         )
                         if not duplicate_interim:
                             messages.append(interim_msg)
-                            self._emit_interim_assistant_message(interim_msg)
 
                     if self._codex_incomplete_retries < 3:
                         if not self.quiet_mode:
@@ -9621,6 +9452,8 @@ class AIAgent:
                     ]
                     if invalid_tool_calls:
                         # Track retries for invalid tool calls
+                        if not hasattr(self, '_invalid_tool_retries'):
+                            self._invalid_tool_retries = 0
                         self._invalid_tool_retries += 1
 
                         # Return helpful error to model — model can self-correct next turn
@@ -9656,7 +9489,8 @@ class AIAgent:
                             })
                         continue
                     # Reset retry counter on successful tool call validation
-                    self._invalid_tool_retries = 0
+                    if hasattr(self, '_invalid_tool_retries'):
+                        self._invalid_tool_retries = 0
                     
                     # Validate tool call arguments are valid JSON
                     # Handle empty strings as empty objects (common model quirk)
@@ -9679,41 +9513,12 @@ class AIAgent:
                             invalid_json_args.append((tc.function.name, str(e)))
                     
                     if invalid_json_args:
-                        # Check if the invalid JSON is due to truncation rather
-                        # than a model formatting mistake.  Routers sometimes
-                        # rewrite finish_reason from "length" to "tool_calls",
-                        # hiding the truncation from the length handler above.
-                        # Detect truncation: args that don't end with } or ]
-                        # (after stripping whitespace) are cut off mid-stream.
-                        _truncated = any(
-                            not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
-                            for tc in assistant_message.tool_calls
-                            if tc.function.name in {n for n, _ in invalid_json_args}
-                        )
-                        if _truncated:
-                            self._vprint(
-                                f"{self.log_prefix}⚠️  Truncated tool call arguments detected "
-                                f"(finish_reason={finish_reason!r}) — refusing to execute.",
-                                force=True,
-                            )
-                            self._invalid_json_retries = 0
-                            self._cleanup_task_resources(effective_task_id)
-                            self._persist_session(messages, conversation_history)
-                            return {
-                                "final_response": None,
-                                "messages": messages,
-                                "api_calls": api_call_count,
-                                "completed": False,
-                                "partial": True,
-                                "error": "Response truncated due to output length limit",
-                            }
-
                         # Track retries for invalid JSON arguments
                         self._invalid_json_retries += 1
-
+                        
                         tool_name, error_msg = invalid_json_args[0]
                         self._vprint(f"{self.log_prefix}⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
-
+                        
                         if self._invalid_json_retries < 3:
                             self._vprint(f"{self.log_prefix}🔄 Retrying API call ({self._invalid_json_retries}/3)...")
                             # Don't add anything to messages, just retry the API call
@@ -9796,7 +9601,6 @@ class AIAgent:
                         messages.pop()
 
                     messages.append(assistant_msg)
-                    self._emit_interim_assistant_message(assistant_msg)
 
                     # Close any open streaming display (response box, reasoning
                     # box) before tool execution begins.  Intermediate turns may
@@ -10059,7 +9863,8 @@ class AIAgent:
                         break
                     
                     # Reset retry counter/signature on successful content
-                    self._empty_content_retries = 0
+                    if hasattr(self, '_empty_content_retries'):
+                        self._empty_content_retries = 0
                     self._thinking_prefill_retries = 0
 
                     if (
@@ -10075,7 +9880,6 @@ class AIAgent:
                         codex_ack_continuations += 1
                         interim_msg = self._build_assistant_message(assistant_message, "incomplete")
                         messages.append(interim_msg)
-                        self._emit_interim_assistant_message(interim_msg)
 
                         continue_msg = {
                             "role": "user",
@@ -10126,7 +9930,8 @@ class AIAgent:
                 except (OSError, ValueError):
                     logger.error(error_msg)
                 
-                logger.debug("Outer loop error in API call #%d", api_call_count, exc_info=True)
+                if self.verbose_logging:
+                    logging.exception("Detailed error information:")
                 
                 # If an assistant message with tool_calls was already appended,
                 # the API expects a role="tool" result for every tool_call_id.
@@ -10172,31 +9977,7 @@ class AIAgent:
         if final_response is None and (
             api_call_count >= self.max_iterations
             or self.iteration_budget.remaining <= 0
-        ) and not self._budget_exhausted_injected:
-            # Budget exhausted but we haven't tried asking the model to
-            # summarise yet.  Inject a user message and give it one grace
-            # API call to produce a text response.
-            self._budget_exhausted_injected = True
-            self._budget_grace_call = True
-            _grace_msg = (
-                "Your tool budget ran out. Please give me the information "
-                "or actions you've completed so far."
-            )
-            messages.append({"role": "user", "content": _grace_msg})
-            self._emit_status(
-                f"⚠️ Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
-                "— asking model to summarise"
-            )
-            if not self.quiet_mode:
-                self._safe_print(
-                    f"\n⚠️  Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
-                    "— requesting summary..."
-                )
-
-        if final_response is None and (
-            api_call_count >= self.max_iterations
-            or self.iteration_budget.remaining <= 0
-        ) and not self._budget_grace_call:
+        ):
             _turn_exit_reason = f"max_iterations_reached({api_call_count}/{self.max_iterations})"
             if self.iteration_budget.remaining <= 0 and not self.quiet_mode:
                 print(f"\n⚠️  Iteration budget exhausted ({self.iteration_budget.used}/{self.iteration_budget.max_total} iterations used)")

--- a/run_agent.py
+++ b/run_agent.py
@@ -642,7 +642,7 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
@@ -657,6 +657,9 @@ class AIAgent:
             # use a URL convention ending in /anthropic. Auto-detect these so the
             # Anthropic Messages API adapter is used instead of chat completions.
             self.api_mode = "anthropic_messages"
+        elif self.provider == "bedrock" or "bedrock-runtime" in self._base_url_lower:
+            # AWS Bedrock — auto-detect from provider name or base URL.
+            self.api_mode = "bedrock_converse"
         else:
             self.api_mode = "chat_completions"
 
@@ -671,14 +674,10 @@ class AIAgent:
         except Exception:
             pass
 
-        # GPT-5.x models require the Responses API path — they are rejected
-        # on /v1/chat/completions by both OpenAI and OpenRouter.  Also
-        # auto-upgrade for direct OpenAI URLs (api.openai.com) since all
-        # newer tool-calling models prefer Responses there.
-        if self.api_mode == "chat_completions" and (
-            self._is_direct_openai_url()
-            or self._model_requires_responses_api(self.model)
-        ):
+        # Direct OpenAI sessions use the Responses API path.  GPT-5.x tool
+        # calls with reasoning are rejected on /v1/chat/completions, and
+        # Hermes is a tool-using client by default.
+        if self.api_mode == "chat_completions" and self._is_direct_openai_url():
             self.api_mode = "codex_responses"
 
         # Pre-warm OpenRouter model metadata cache in a background thread.
@@ -850,6 +849,33 @@ class AIAgent:
                 print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
                 if effective_key and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+        elif self.api_mode == "bedrock_converse":
+            # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
+            # Region is extracted from the base_url or defaults to us-east-1.
+            import re as _re
+            _region_match = _re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
+            self._bedrock_region = _region_match.group(1) if _region_match else "us-east-1"
+            # Guardrail config — read from config.yaml at init time.
+            self._bedrock_guardrail_config = None
+            try:
+                from hermes_cli.config import load_config as _load_br_cfg
+                _gr = _load_br_cfg().get("bedrock", {}).get("guardrail", {})
+                if _gr.get("guardrail_identifier") and _gr.get("guardrail_version"):
+                    self._bedrock_guardrail_config = {
+                        "guardrailIdentifier": _gr["guardrail_identifier"],
+                        "guardrailVersion": _gr["guardrail_version"],
+                    }
+                    if _gr.get("stream_processing_mode"):
+                        self._bedrock_guardrail_config["streamProcessingMode"] = _gr["stream_processing_mode"]
+                    if _gr.get("trace"):
+                        self._bedrock_guardrail_config["trace"] = _gr["trace"]
+            except Exception:
+                pass
+            self.client = None
+            self._client_kwargs = {}
+            if not self.quiet_mode:
+                _gr_label = " + Guardrails" if self._bedrock_guardrail_config else ""
+                print(f"🤖 AI Agent initialized with model: {self.model} (AWS Bedrock, {self._bedrock_region}{_gr_label})")
         else:
             if api_key and base_url:
                 # Explicit credentials from CLI/gateway — construct directly.
@@ -1400,12 +1426,6 @@ class AIAgent:
             else:
                 print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
 
-        # Check immediately so CLI users see the warning at startup.
-        # Gateway status_callback is not yet wired, so any warning is stored
-        # in _compression_warning and replayed in the first run_conversation().
-        self._compression_warning = None
-        self._check_compression_model_feasibility()
-
         # Snapshot primary runtime for per-turn restoration.  When fallback
         # activates during a turn, the next turn restores these values so the
         # preferred model gets a fresh attempt each time.  Uses a single dict
@@ -1817,21 +1837,6 @@ class AIAgent:
     def _is_openrouter_url(self) -> bool:
         """Return True when the base URL targets OpenRouter."""
         return "openrouter" in self._base_url_lower
-
-    @staticmethod
-    def _model_requires_responses_api(model: str) -> bool:
-        """Return True for models that require the Responses API path.
-
-        GPT-5.x models are rejected on /v1/chat/completions by both
-        OpenAI and OpenRouter (error: ``unsupported_api_for_model``).
-        Detect these so the correct api_mode is set regardless of
-        which provider is serving the model.
-        """
-        m = model.lower()
-        # Strip vendor prefix (e.g. "openai/gpt-5.4" → "gpt-5.4")
-        if "/" in m:
-            m = m.rsplit("/", 1)[-1]
-        return m.startswith("gpt-5")
 
     def _max_tokens_param(self, value: int) -> dict:
         """Return the correct max tokens kwarg for the current provider.
@@ -4703,6 +4708,19 @@ class AIAgent:
                     )
                 elif self.api_mode == "anthropic_messages":
                     result["response"] = self._anthropic_messages_create(api_kwargs)
+                elif self.api_mode == "bedrock_converse":
+                    # Bedrock uses boto3 directly — no OpenAI client needed.
+                    # api_kwargs already contains Converse-format params from
+                    # build_converse_kwargs() in _build_api_kwargs().
+                    from agent.bedrock_adapter import (
+                        _get_bedrock_runtime_client,
+                        normalize_converse_response,
+                    )
+                    region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+                    api_kwargs.pop("__bedrock_converse__", None)
+                    client = _get_bedrock_runtime_client(region)
+                    raw_response = client.converse(**api_kwargs)
+                    result["response"] = normalize_converse_response(raw_response)
                 else:
                     request_client_holder["client"] = self._create_request_openai_client(reason="chat_completion_request")
                     result["response"] = request_client_holder["client"].chat.completions.create(**api_kwargs)
@@ -4865,6 +4883,65 @@ class AIAgent:
                 return self._interruptible_api_call(api_kwargs)
             finally:
                 self._codex_on_first_delta = None
+
+        # Bedrock Converse uses boto3's converse_stream() with real-time delta
+        # callbacks — same UX as Anthropic and chat_completions streaming.
+        if self.api_mode == "bedrock_converse":
+            result = {"response": None, "error": None}
+            first_delta_fired = {"done": False}
+            deltas_were_sent = {"yes": False}
+
+            def _fire_first():
+                if not first_delta_fired["done"] and on_first_delta:
+                    first_delta_fired["done"] = True
+                    try:
+                        on_first_delta()
+                    except Exception:
+                        pass
+
+            def _bedrock_call():
+                try:
+                    from agent.bedrock_adapter import (
+                        _get_bedrock_runtime_client,
+                        stream_converse_with_callbacks,
+                    )
+                    region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+                    api_kwargs.pop("__bedrock_converse__", None)
+                    client = _get_bedrock_runtime_client(region)
+                    raw_response = client.converse_stream(**api_kwargs)
+
+                    def _on_text(text):
+                        _fire_first()
+                        self._fire_stream_delta(text)
+                        deltas_were_sent["yes"] = True
+
+                    def _on_tool(name):
+                        _fire_first()
+                        self._fire_tool_gen_started(name)
+
+                    def _on_reasoning(text):
+                        _fire_first()
+                        self._fire_reasoning_delta(text)
+
+                    result["response"] = stream_converse_with_callbacks(
+                        raw_response,
+                        on_text_delta=_on_text if self._has_stream_consumers() else None,
+                        on_tool_start=_on_tool,
+                        on_reasoning_delta=_on_reasoning if self.reasoning_callback or self.stream_delta_callback else None,
+                        on_interrupt_check=lambda: self._interrupt_requested,
+                    )
+                except Exception as e:
+                    result["error"] = e
+
+            t = threading.Thread(target=_bedrock_call, daemon=True)
+            t.start()
+            while t.is_alive():
+                t.join(timeout=0.3)
+                if self._interrupt_requested:
+                    raise InterruptedError("Agent interrupted during Bedrock API call")
+            if result["error"] is not None:
+                raise result["error"]
+            return result["response"]
 
         result = {"response": None, "error": None}
         request_client_holder = {"client": None}
@@ -5449,7 +5526,7 @@ class AIAgent:
             except Exception:
                 pass
 
-            # Determine api_mode from provider / base URL / model
+            # Determine api_mode from provider / base URL
             fb_api_mode = "chat_completions"
             fb_base_url = str(fb_client.base_url)
             if fb_provider == "openai-codex":
@@ -5457,10 +5534,6 @@ class AIAgent:
             elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
                 fb_api_mode = "anthropic_messages"
             elif self._is_direct_openai_url(fb_base_url):
-                fb_api_mode = "codex_responses"
-            elif self._model_requires_responses_api(fb_model):
-                # GPT-5.x models need Responses API on every provider
-                # (OpenRouter, Copilot, direct OpenAI, etc.)
                 fb_api_mode = "codex_responses"
 
             old_model = self.model
@@ -5550,8 +5623,8 @@ class AIAgent:
         to the fallback provider for every subsequent turn.  Calling this at
         the top of ``run_conversation()`` makes fallback turn-scoped.
 
-        The gateway caches agents across messages (``_agent_cache`` in
-        ``gateway/run.py``), so this restoration IS needed there too.
+        The gateway creates a fresh agent per message so this is a no-op
+        there (``_fallback_activated`` is always False at turn start).
         """
         if not self._fallback_activated:
             return False
@@ -5939,6 +6012,25 @@ class AIAgent:
                 base_url=getattr(self, "_anthropic_base_url", None),
                 fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
+
+        # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
+        # The adapter handles message/tool conversion and boto3 calls directly.
+        if self.api_mode == "bedrock_converse":
+            from agent.bedrock_adapter import build_converse_kwargs
+            region = getattr(self, "_bedrock_region", None) or "us-east-1"
+            guardrail = getattr(self, "_bedrock_guardrail_config", None)
+            return {
+                "__bedrock_converse__": True,
+                "__bedrock_region__": region,
+                **build_converse_kwargs(
+                    model=self.model,
+                    messages=api_messages,
+                    tools=self.tools,
+                    max_tokens=self.max_tokens or 4096,
+                    temperature=None,  # Let the model use its default
+                    guardrail_config=guardrail,
+                ),
+            }
 
         if self.api_mode == "codex_responses":
             instructions = ""
@@ -7606,12 +7698,6 @@ class AIAgent:
                     )
             except Exception:
                 pass
-        # Replay compression warning through status_callback for gateway
-        # platforms (the callback was not wired during __init__).
-        if self._compression_warning:
-            self._replay_compression_warning()
-            self._compression_warning = None  # send once
-
         # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
@@ -8337,7 +8423,7 @@ class AIAgent:
                         # targeted error instead of wasting 3 API calls.
                         _trunc_content = None
                         _trunc_has_tool_calls = False
-                        if self.api_mode == "chat_completions":
+                        if self.api_mode in ("chat_completions", "bedrock_converse"):
                             _trunc_msg = response.choices[0].message if (hasattr(response, "choices") and response.choices) else None
                             _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
                             _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
@@ -8406,7 +8492,7 @@ class AIAgent:
                                 "error": _exhaust_error,
                             }
 
-                        if self.api_mode == "chat_completions":
+                        if self.api_mode in ("chat_completions", "bedrock_converse"):
                             assistant_message = response.choices[0].message
                             if not assistant_message.tool_calls:
                                 length_continue_retries += 1
@@ -8446,7 +8532,7 @@ class AIAgent:
                                     "error": "Response remained truncated after 3 continuation attempts",
                                 }
 
-                        if self.api_mode == "chat_completions":
+                        if self.api_mode in ("chat_completions", "bedrock_converse"):
                             assistant_message = response.choices[0].message
                             if assistant_message.tool_calls:
                                 if truncated_tool_call_retries < 1:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1098,3 +1098,135 @@ class TestBedrockContextLength:
         from agent.bedrock_adapter import get_bedrock_context_length
         # "anthropic.claude-3-5-sonnet" should match before "anthropic.claude-3"
         assert get_bedrock_context_length("anthropic.claude-3-5-sonnet-20240620-v1:0") == 200_000
+
+
+# ---------------------------------------------------------------------------
+# Tool-calling capability detection
+# ---------------------------------------------------------------------------
+
+class TestModelSupportsToolUse:
+    """Test non-tool-calling model detection."""
+
+    def test_claude_supports_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("us.anthropic.claude-sonnet-4-6") is True
+
+    def test_nova_supports_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("us.amazon.nova-pro-v1:0") is True
+
+    def test_deepseek_v3_supports_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("deepseek.v3.2") is True
+
+    def test_llama_supports_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("us.meta.llama4-scout-17b-instruct-v1:0") is True
+
+    def test_deepseek_r1_no_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("us.deepseek.r1-v1:0") is False
+
+    def test_deepseek_r1_alt_format_no_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("deepseek-r1") is False
+
+    def test_stability_no_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("stability.stable-diffusion-xl") is False
+
+    def test_embedding_no_tools(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("cohere.embed-v4") is False
+
+    def test_unknown_model_defaults_to_true(self):
+        from agent.bedrock_adapter import _model_supports_tool_use
+        assert _model_supports_tool_use("some-future-model-v1") is True
+
+
+class TestBuildConverseKwargsToolStripping:
+    """Test that tools are stripped for non-tool-calling models."""
+
+    def test_tools_included_for_claude(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        tools = [{"type": "function", "function": {"name": "test", "description": "t", "parameters": {}}}]
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+        )
+        assert "toolConfig" in kwargs
+
+    def test_tools_stripped_for_deepseek_r1(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        tools = [{"type": "function", "function": {"name": "test", "description": "t", "parameters": {}}}]
+        kwargs = build_converse_kwargs(
+            model="us.deepseek.r1-v1:0",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+        )
+        assert "toolConfig" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Dual-path model routing
+# ---------------------------------------------------------------------------
+
+class TestIsAnthropicBedrockModel:
+    """Test Claude model detection for dual-path routing."""
+
+    def test_us_claude_sonnet(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("us.anthropic.claude-sonnet-4-6") is True
+
+    def test_global_claude_opus(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("global.anthropic.claude-opus-4-6-v1") is True
+
+    def test_bare_claude(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("anthropic.claude-haiku-4-5-20251001-v1:0") is True
+
+    def test_nova_is_not_anthropic(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("us.amazon.nova-pro-v1:0") is False
+
+    def test_deepseek_is_not_anthropic(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("deepseek.v3.2") is False
+
+    def test_llama_is_not_anthropic(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("us.meta.llama4-scout-17b-instruct-v1:0") is False
+
+    def test_mistral_is_not_anthropic(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("mistral.mistral-large-3-675b-instruct") is False
+
+    def test_eu_claude(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("eu.anthropic.claude-sonnet-4-6") is True
+
+
+class TestEmptyTextBlockFix:
+    """Test that empty text blocks are replaced with space placeholders."""
+
+    def test_none_content_gets_space(self):
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse(None)
+        assert blocks[0]["text"] == " "
+
+    def test_empty_string_gets_space(self):
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse("")
+        assert blocks[0]["text"] == " "
+
+    def test_whitespace_only_gets_space(self):
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse("   ")
+        assert blocks[0]["text"] == " "
+
+    def test_real_text_preserved(self):
+        from agent.bedrock_adapter import _convert_content_to_converse
+        blocks = _convert_content_to_converse("Hello")
+        assert blocks[0]["text"] == "Hello"

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1,0 +1,1100 @@
+"""Tests for the AWS Bedrock Converse API adapter.
+
+Covers:
+  - AWS credential detection and region resolution
+  - Message format conversion (OpenAI → Converse and back)
+  - Tool definition conversion
+  - Response normalization (non-streaming and streaming)
+  - Model discovery with caching
+  - Edge cases: empty messages, consecutive roles, image content
+"""
+
+import json
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# AWS credential detection
+# ---------------------------------------------------------------------------
+
+class TestResolveAwsAuthEnvVar:
+    """Test AWS credential environment variable detection.
+
+    Mirrors OpenClaw's resolveAwsSdkEnvVarName() priority order.
+    """
+
+    def test_prefers_bearer_token_over_access_keys_and_profile(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "bearer-token",
+            "AWS_ACCESS_KEY_ID": "AKIA...",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+            "AWS_PROFILE": "default",
+        }
+        assert resolve_aws_auth_env_var(env) == "AWS_BEARER_TOKEN_BEDROCK"
+
+    def test_uses_access_keys_when_bearer_token_missing(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {
+            "AWS_ACCESS_KEY_ID": "AKIA...",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+            "AWS_PROFILE": "default",
+        }
+        assert resolve_aws_auth_env_var(env) == "AWS_ACCESS_KEY_ID"
+
+    def test_requires_both_access_key_and_secret(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        # Only access key, no secret → should not match
+        env = {"AWS_ACCESS_KEY_ID": "AKIA..."}
+        assert resolve_aws_auth_env_var(env) != "AWS_ACCESS_KEY_ID"
+
+    def test_uses_profile_when_no_keys(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {"AWS_PROFILE": "production"}
+        assert resolve_aws_auth_env_var(env) == "AWS_PROFILE"
+
+    def test_uses_container_credentials(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/..."}
+        assert resolve_aws_auth_env_var(env) == "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+
+    def test_uses_web_identity(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {"AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/token"}
+        assert resolve_aws_auth_env_var(env) == "AWS_WEB_IDENTITY_TOKEN_FILE"
+
+    def test_returns_none_when_no_aws_auth(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        # Mock botocore to return no credentials (covers EC2 IMDS fallback)
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = None
+        with patch.dict("sys.modules", {"botocore": MagicMock(), "botocore.session": MagicMock()}):
+            import botocore.session as _bs
+            _bs.get_session = MagicMock(return_value=mock_session)
+            assert resolve_aws_auth_env_var({}) is None
+
+    def test_ignores_whitespace_only_values(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {"AWS_PROFILE": "  ", "AWS_ACCESS_KEY_ID": " "}
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = None
+        with patch.dict("sys.modules", {"botocore": MagicMock(), "botocore.session": MagicMock()}):
+            import botocore.session as _bs
+            _bs.get_session = MagicMock(return_value=mock_session)
+            assert resolve_aws_auth_env_var(env) is None
+
+
+class TestHasAwsCredentials:
+    def test_true_with_profile(self):
+        from agent.bedrock_adapter import has_aws_credentials
+        assert has_aws_credentials({"AWS_PROFILE": "default"}) is True
+
+    def test_false_with_empty_env(self):
+        from agent.bedrock_adapter import has_aws_credentials
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = None
+        with patch.dict("sys.modules", {"botocore": MagicMock(), "botocore.session": MagicMock()}):
+            import botocore.session as _bs
+            _bs.get_session = MagicMock(return_value=mock_session)
+            assert has_aws_credentials({}) is False
+
+
+class TestResolveBedrocRegion:
+    def test_prefers_aws_region(self):
+        from agent.bedrock_adapter import resolve_bedrock_region
+        env = {"AWS_REGION": "eu-west-1", "AWS_DEFAULT_REGION": "us-west-2"}
+        assert resolve_bedrock_region(env) == "eu-west-1"
+
+    def test_falls_back_to_default_region(self):
+        from agent.bedrock_adapter import resolve_bedrock_region
+        env = {"AWS_DEFAULT_REGION": "ap-northeast-1"}
+        assert resolve_bedrock_region(env) == "ap-northeast-1"
+
+    def test_defaults_to_us_east_1(self):
+        from agent.bedrock_adapter import resolve_bedrock_region
+        assert resolve_bedrock_region({}) == "us-east-1"
+
+
+# ---------------------------------------------------------------------------
+# Tool conversion
+# ---------------------------------------------------------------------------
+
+class TestConvertToolsToConverse:
+    """Test OpenAI → Bedrock Converse tool definition conversion."""
+
+    def test_converts_single_tool(self):
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file from disk",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "File path"},
+                    },
+                    "required": ["path"],
+                },
+            },
+        }]
+        result = convert_tools_to_converse(tools)
+        assert len(result) == 1
+        spec = result[0]["toolSpec"]
+        assert spec["name"] == "read_file"
+        assert spec["description"] == "Read a file from disk"
+        assert spec["inputSchema"]["json"]["type"] == "object"
+        assert "path" in spec["inputSchema"]["json"]["properties"]
+
+    def test_converts_multiple_tools(self):
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [
+            {"type": "function", "function": {"name": "tool_a", "description": "A", "parameters": {}}},
+            {"type": "function", "function": {"name": "tool_b", "description": "B", "parameters": {}}},
+        ]
+        result = convert_tools_to_converse(tools)
+        assert len(result) == 2
+        assert result[0]["toolSpec"]["name"] == "tool_a"
+        assert result[1]["toolSpec"]["name"] == "tool_b"
+
+    def test_empty_tools(self):
+        from agent.bedrock_adapter import convert_tools_to_converse
+        assert convert_tools_to_converse([]) == []
+        assert convert_tools_to_converse(None) == []
+
+    def test_missing_parameters_gets_default(self):
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [{"type": "function", "function": {"name": "noop", "description": "No-op"}}]
+        result = convert_tools_to_converse(tools)
+        schema = result[0]["toolSpec"]["inputSchema"]["json"]
+        assert schema == {"type": "object", "properties": {}}
+
+
+# ---------------------------------------------------------------------------
+# Message conversion: OpenAI → Converse
+# ---------------------------------------------------------------------------
+
+class TestConvertMessagesToConverse:
+    """Test OpenAI message format → Bedrock Converse format conversion."""
+
+    def test_extracts_system_prompt(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        assert system is not None
+        assert len(system) == 1
+        assert system[0]["text"] == "You are a helpful assistant."
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+
+    def test_user_message_text(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": "What is 2+2?"}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert system is None
+        assert len(msgs) == 1
+        assert msgs[0]["content"][0]["text"] == "What is 2+2?"
+
+    def test_assistant_with_tool_calls(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "Read the file"},
+            {
+                "role": "assistant",
+                "content": "I'll read that file.",
+                "tool_calls": [{
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path": "/tmp/test.txt"}',
+                    },
+                }],
+            },
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        # 3 messages: user, assistant, trailing user (Converse requires last=user)
+        assert len(msgs) == 3
+        assistant_content = msgs[1]["content"]
+        # Should have text block + toolUse block
+        assert any("text" in b for b in assistant_content)
+        tool_use_blocks = [b for b in assistant_content if "toolUse" in b]
+        assert len(tool_use_blocks) == 1
+        assert tool_use_blocks[0]["toolUse"]["name"] == "read_file"
+        assert tool_use_blocks[0]["toolUse"]["toolUseId"] == "call_123"
+        assert tool_use_blocks[0]["toolUse"]["input"] == {"path": "/tmp/test.txt"}
+
+    def test_tool_result_becomes_user_message(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "Read it"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "file contents here"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        # Tool result should be in a user-role message
+        tool_result_msg = [m for m in msgs if m["role"] == "user" and any(
+            "toolResult" in b for b in m["content"]
+        )]
+        assert len(tool_result_msg) == 1
+        tr = [b for b in tool_result_msg[0]["content"] if "toolResult" in b][0]
+        assert tr["toolResult"]["toolUseId"] == "call_1"
+        assert tr["toolResult"]["content"][0]["text"] == "file contents here"
+
+    def test_merges_consecutive_user_messages(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "First"},
+            {"role": "user", "content": "Second"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        # Should be merged into one user message (Converse requires alternation)
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        texts = [b["text"] for b in msgs[0]["content"] if "text" in b]
+        assert "First" in texts
+        assert "Second" in texts
+
+    def test_merges_consecutive_assistant_messages(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Part 1"},
+            {"role": "assistant", "content": "Part 2"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        assistant_msgs = [m for m in msgs if m["role"] == "assistant"]
+        assert len(assistant_msgs) == 1
+
+    def test_first_message_must_be_user(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "assistant", "content": "I'm ready"},
+            {"role": "user", "content": "Go"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["role"] == "user"
+
+    def test_last_message_must_be_user(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[-1]["role"] == "user"
+
+    def test_empty_content_gets_placeholder(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": ""}]
+        system, msgs = convert_messages_to_converse(messages)
+        # Empty string should get a space placeholder
+        assert msgs[0]["content"][0]["text"].strip() != "" or msgs[0]["content"][0]["text"] == " "
+
+    def test_image_data_url_converted(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {"type": "image_url", "image_url": {
+                    "url": "data:image/png;base64,iVBORw0KGgo=",
+                }},
+            ],
+        }]
+        system, msgs = convert_messages_to_converse(messages)
+        content = msgs[0]["content"]
+        assert any("text" in b for b in content)
+        image_blocks = [b for b in content if "image" in b]
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image"]["format"] == "png"
+
+    def test_multiple_system_messages_merged(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "system", "content": "Rule 1"},
+            {"role": "system", "content": "Rule 2"},
+            {"role": "user", "content": "Go"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        assert system is not None
+        assert len(system) == 2
+        assert system[0]["text"] == "Rule 1"
+        assert system[1]["text"] == "Rule 2"
+
+
+# ---------------------------------------------------------------------------
+# Response normalization: Converse → OpenAI
+# ---------------------------------------------------------------------------
+
+class TestNormalizeConverseResponse:
+    """Test Bedrock Converse response → OpenAI format conversion."""
+
+    def test_text_response(self):
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "Hello, world!"}],
+                },
+            },
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5},
+        }
+        result = normalize_converse_response(response)
+        assert result.choices[0].message.content == "Hello, world!"
+        assert result.choices[0].message.tool_calls is None
+        assert result.choices[0].finish_reason == "stop"
+        assert result.usage.prompt_tokens == 10
+        assert result.usage.completion_tokens == 5
+        assert result.usage.total_tokens == 15
+
+    def test_tool_use_response(self):
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"text": "I'll read that file."},
+                        {
+                            "toolUse": {
+                                "toolUseId": "call_abc",
+                                "name": "read_file",
+                                "input": {"path": "/tmp/test.txt"},
+                            },
+                        },
+                    ],
+                },
+            },
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 20, "outputTokens": 15},
+        }
+        result = normalize_converse_response(response)
+        assert result.choices[0].message.content == "I'll read that file."
+        assert result.choices[0].finish_reason == "tool_calls"
+        tool_calls = result.choices[0].message.tool_calls
+        assert len(tool_calls) == 1
+        assert tool_calls[0].id == "call_abc"
+        assert tool_calls[0].function.name == "read_file"
+        assert json.loads(tool_calls[0].function.arguments) == {"path": "/tmp/test.txt"}
+
+    def test_multiple_tool_calls(self):
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"toolUse": {"toolUseId": "c1", "name": "tool_a", "input": {}}},
+                        {"toolUse": {"toolUseId": "c2", "name": "tool_b", "input": {"x": 1}}},
+                    ],
+                },
+            },
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 0, "outputTokens": 0},
+        }
+        result = normalize_converse_response(response)
+        assert len(result.choices[0].message.tool_calls) == 2
+        assert result.choices[0].finish_reason == "tool_calls"
+
+    def test_stop_reason_mapping(self):
+        from agent.bedrock_adapter import _converse_stop_reason_to_openai
+        assert _converse_stop_reason_to_openai("end_turn") == "stop"
+        assert _converse_stop_reason_to_openai("stop_sequence") == "stop"
+        assert _converse_stop_reason_to_openai("tool_use") == "tool_calls"
+        assert _converse_stop_reason_to_openai("max_tokens") == "length"
+        assert _converse_stop_reason_to_openai("content_filtered") == "content_filter"
+        assert _converse_stop_reason_to_openai("guardrail_intervened") == "content_filter"
+        assert _converse_stop_reason_to_openai("unknown_reason") == "stop"
+
+    def test_empty_content(self):
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {
+            "output": {"message": {"role": "assistant", "content": []}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 0, "outputTokens": 0},
+        }
+        result = normalize_converse_response(response)
+        assert result.choices[0].message.content is None
+        assert result.choices[0].message.tool_calls is None
+
+    def test_tool_calls_override_stop_finish_reason(self):
+        """When tool_calls are present but stopReason is end_turn, finish_reason should be tool_calls."""
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"toolUse": {"toolUseId": "c1", "name": "t", "input": {}}},
+                    ],
+                },
+            },
+            "stopReason": "end_turn",  # Bedrock sometimes sends this with tool_use
+            "usage": {"inputTokens": 0, "outputTokens": 0},
+        }
+        result = normalize_converse_response(response)
+        assert result.choices[0].finish_reason == "tool_calls"
+
+
+# ---------------------------------------------------------------------------
+# Streaming response normalization
+# ---------------------------------------------------------------------------
+
+class TestNormalizeConverseStreamEvents:
+    """Test Bedrock ConverseStream event → OpenAI format conversion."""
+
+    def test_text_stream(self):
+        from agent.bedrock_adapter import normalize_converse_stream_events
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hello"}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": ", world!"}}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 3}}},
+        ]}
+        result = normalize_converse_stream_events(events)
+        assert result.choices[0].message.content == "Hello, world!"
+        assert result.choices[0].finish_reason == "stop"
+        assert result.usage.prompt_tokens == 5
+        assert result.usage.completion_tokens == 3
+
+    def test_tool_use_stream(self):
+        from agent.bedrock_adapter import normalize_converse_stream_events
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {
+                "toolUse": {"toolUseId": "call_1", "name": "read_file"},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+                "toolUse": {"input": '{"path":'},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+                "toolUse": {"input": '"/tmp/f"}'},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 8}}},
+        ]}
+        result = normalize_converse_stream_events(events)
+        assert result.choices[0].finish_reason == "tool_calls"
+        tc = result.choices[0].message.tool_calls
+        assert len(tc) == 1
+        assert tc[0].id == "call_1"
+        assert tc[0].function.name == "read_file"
+        assert json.loads(tc[0].function.arguments) == {"path": "/tmp/f"}
+
+    def test_mixed_text_and_tool_stream(self):
+        from agent.bedrock_adapter import normalize_converse_stream_events
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            # Text block
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Let me check."}}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            # Tool block
+            {"contentBlockStart": {"contentBlockIndex": 1, "start": {
+                "toolUse": {"toolUseId": "c1", "name": "search"},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {
+                "toolUse": {"input": '{"q":"test"}'},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+        result = normalize_converse_stream_events(events)
+        assert result.choices[0].message.content == "Let me check."
+        assert len(result.choices[0].message.tool_calls) == 1
+
+    def test_empty_stream(self):
+        from agent.bedrock_adapter import normalize_converse_stream_events
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+        result = normalize_converse_stream_events(events)
+        assert result.choices[0].message.content is None
+        assert result.choices[0].message.tool_calls is None
+
+
+# ---------------------------------------------------------------------------
+# build_converse_kwargs
+# ---------------------------------------------------------------------------
+
+class TestBuildConverseKwargs:
+    """Test the high-level kwargs builder for Converse API calls."""
+
+    def test_basic_kwargs(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        kwargs = build_converse_kwargs(
+            model="anthropic.claude-sonnet-4-6-20250514-v1:0",
+            messages=messages,
+            max_tokens=1024,
+        )
+        assert kwargs["modelId"] == "anthropic.claude-sonnet-4-6-20250514-v1:0"
+        assert kwargs["inferenceConfig"]["maxTokens"] == 1024
+        assert kwargs["system"] is not None
+        assert len(kwargs["messages"]) >= 1
+
+    def test_includes_tools(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        tools = [{"type": "function", "function": {
+            "name": "test", "description": "Test", "parameters": {},
+        }}]
+        kwargs = build_converse_kwargs(
+            model="test-model", messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+        )
+        assert "toolConfig" in kwargs
+        assert len(kwargs["toolConfig"]["tools"]) == 1
+
+    def test_includes_temperature_and_top_p(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model", messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7, top_p=0.9,
+        )
+        assert kwargs["inferenceConfig"]["temperature"] == 0.7
+        assert kwargs["inferenceConfig"]["topP"] == 0.9
+
+    def test_includes_guardrail_config(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        guardrail = {
+            "guardrailIdentifier": "gr-123",
+            "guardrailVersion": "1",
+        }
+        kwargs = build_converse_kwargs(
+            model="test-model", messages=[{"role": "user", "content": "Hi"}],
+            guardrail_config=guardrail,
+        )
+        assert kwargs["guardrailConfig"] == guardrail
+
+    def test_no_system_when_absent(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model", messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert "system" not in kwargs
+
+    def test_no_tool_config_when_empty(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model", messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+        )
+        assert "toolConfig" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Model discovery
+# ---------------------------------------------------------------------------
+
+class TestDiscoverBedrockModels:
+    """Test Bedrock model discovery with mocked AWS API calls."""
+
+    def test_discovers_foundation_models(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {
+                    "modelId": "anthropic.claude-sonnet-4-6-20250514-v1:0",
+                    "modelName": "Claude Sonnet 4.6",
+                    "providerName": "Anthropic",
+                    "inputModalities": ["TEXT", "IMAGE"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                },
+                {
+                    "modelId": "amazon.nova-pro-v1:0",
+                    "modelName": "Nova Pro",
+                    "providerName": "Amazon",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                },
+            ],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert len(models) == 2
+        ids = [m["id"] for m in models]
+        assert "anthropic.claude-sonnet-4-6-20250514-v1:0" in ids
+        assert "amazon.nova-pro-v1:0" in ids
+
+    def test_filters_inactive_models(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {
+                    "modelId": "old-model",
+                    "modelName": "Old",
+                    "providerName": "Test",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "LEGACY"},
+                },
+            ],
+        }
+        mock_client.list_inference_profiles.return_value = {"inferenceProfileSummaries": []}
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert len(models) == 0
+
+    def test_filters_non_streaming_models(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {
+                    "modelId": "embed-model",
+                    "modelName": "Embeddings",
+                    "providerName": "Test",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["EMBEDDING"],
+                    "responseStreamingSupported": False,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                },
+            ],
+        }
+        mock_client.list_inference_profiles.return_value = {"inferenceProfileSummaries": []}
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert len(models) == 0
+
+    def test_provider_filter(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {
+                    "modelId": "anthropic.claude-v2",
+                    "modelName": "Claude v2",
+                    "providerName": "Anthropic",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                },
+                {
+                    "modelId": "amazon.titan-text",
+                    "modelName": "Titan",
+                    "providerName": "Amazon",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                },
+            ],
+        }
+        mock_client.list_inference_profiles.return_value = {"inferenceProfileSummaries": []}
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1", provider_filter=["anthropic"])
+
+        assert len(models) == 1
+        assert models[0]["id"] == "anthropic.claude-v2"
+
+    def test_caches_results(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "test-model",
+                "modelName": "Test",
+                "providerName": "Test",
+                "inputModalities": ["TEXT"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {"inferenceProfileSummaries": []}
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            first = discover_bedrock_models("us-east-1")
+            second = discover_bedrock_models("us-east-1")
+
+        # Should only call the API once (second call uses cache)
+        assert mock_client.list_foundation_models.call_count == 1
+        assert first == second
+
+    def test_discovers_inference_profiles(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {"modelSummaries": []}
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [
+                {
+                    "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                    "inferenceProfileName": "US Claude Sonnet 4.6",
+                    "status": "ACTIVE",
+                    "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6"}],
+                },
+            ],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert len(models) == 1
+        assert models[0]["id"] == "us.anthropic.claude-sonnet-4-6"
+
+    def test_global_profiles_sorted_first(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "anthropic.claude-v2",
+                "modelName": "Claude v2",
+                "providerName": "Anthropic",
+                "inputModalities": ["TEXT"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "global.anthropic.claude-v2",
+                "inferenceProfileName": "Global Claude v2",
+                "status": "ACTIVE",
+                "models": [],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert models[0]["id"] == "global.anthropic.claude-v2"
+
+    def test_handles_api_error_gracefully(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", side_effect=Exception("No creds")):
+            models = discover_bedrock_models("us-east-1")
+
+        assert models == []
+
+
+class TestExtractProviderFromArn:
+    def test_extracts_anthropic(self):
+        from agent.bedrock_adapter import _extract_provider_from_arn
+        arn = "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6"
+        assert _extract_provider_from_arn(arn) == "anthropic"
+
+    def test_extracts_amazon(self):
+        from agent.bedrock_adapter import _extract_provider_from_arn
+        arn = "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"
+        assert _extract_provider_from_arn(arn) == "amazon"
+
+    def test_returns_empty_for_invalid_arn(self):
+        from agent.bedrock_adapter import _extract_provider_from_arn
+        assert _extract_provider_from_arn("not-an-arn") == ""
+        assert _extract_provider_from_arn("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Client cache management
+# ---------------------------------------------------------------------------
+
+class TestClientCache:
+    def test_reset_clears_caches(self):
+        from agent.bedrock_adapter import (
+            _bedrock_runtime_client_cache,
+            _bedrock_control_client_cache,
+            reset_client_cache,
+        )
+        _bedrock_runtime_client_cache["test"] = "dummy"
+        _bedrock_control_client_cache["test"] = "dummy"
+        reset_client_cache()
+        assert len(_bedrock_runtime_client_cache) == 0
+        assert len(_bedrock_control_client_cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# Streaming with callbacks
+# ---------------------------------------------------------------------------
+
+class TestStreamConverseWithCallbacks:
+    """Test real-time streaming with delta callbacks."""
+
+    def test_text_deltas_fire_callback(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        deltas = []
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hello"}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": " world"}}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 3}}},
+        ]}
+        result = stream_converse_with_callbacks(
+            events, on_text_delta=lambda t: deltas.append(t),
+        )
+        assert deltas == ["Hello", " world"]
+        assert result.choices[0].message.content == "Hello world"
+
+    def test_text_deltas_suppressed_when_tool_use_present(self):
+        """Text deltas should NOT fire when tool_use blocks are present."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        deltas = []
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Let me check."}}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"contentBlockStart": {"contentBlockIndex": 1, "start": {
+                "toolUse": {"toolUseId": "c1", "name": "search"},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {
+                "toolUse": {"input": '{"q":"test"}'},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+        result = stream_converse_with_callbacks(
+            events, on_text_delta=lambda t: deltas.append(t),
+        )
+        # Text delta for "Let me check." should fire (before tool_use was seen)
+        assert "Let me check." in deltas
+        # But the result should still have both text and tool calls
+        assert result.choices[0].message.content == "Let me check."
+        assert len(result.choices[0].message.tool_calls) == 1
+
+    def test_tool_start_callback_fires(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        tools_started = []
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {
+                "toolUse": {"toolUseId": "c1", "name": "read_file"},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+                "toolUse": {"input": '{"path":"/tmp/f"}'},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+        result = stream_converse_with_callbacks(
+            events, on_tool_start=lambda name: tools_started.append(name),
+        )
+        assert tools_started == ["read_file"]
+
+    def test_interrupt_stops_processing(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        deltas = []
+        call_count = {"n": 0}
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "A"}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "B"}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "C"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+
+        def check_interrupt():
+            call_count["n"] += 1
+            return call_count["n"] >= 3  # Interrupt after 2 events
+
+        result = stream_converse_with_callbacks(
+            events,
+            on_text_delta=lambda t: deltas.append(t),
+            on_interrupt_check=check_interrupt,
+        )
+        # Should have processed fewer than all deltas
+        assert len(deltas) < 3
+
+    def test_reasoning_delta_callback(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        reasoning = []
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+                "reasoningContent": {"text": "Let me think..."},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {"text": "Answer."}}},
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+        result = stream_converse_with_callbacks(
+            events, on_reasoning_delta=lambda t: reasoning.append(t),
+        )
+        assert reasoning == ["Let me think..."]
+
+
+# ---------------------------------------------------------------------------
+# Guardrail config in build_converse_kwargs
+# ---------------------------------------------------------------------------
+
+class TestGuardrailConfig:
+    """Test that guardrail configuration is correctly passed through."""
+
+    def test_guardrail_included_in_kwargs(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        guardrail = {
+            "guardrailIdentifier": "gr-abc123",
+            "guardrailVersion": "1",
+            "streamProcessingMode": "async",
+            "trace": "enabled",
+        }
+        kwargs = build_converse_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            guardrail_config=guardrail,
+        )
+        assert kwargs["guardrailConfig"] == guardrail
+
+    def test_no_guardrail_when_none(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            guardrail_config=None,
+        )
+        assert "guardrailConfig" not in kwargs
+
+    def test_no_guardrail_when_empty_dict(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            guardrail_config={},
+        )
+        # Empty dict is falsy, should not be included
+        assert "guardrailConfig" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+class TestBedrockErrorClassification:
+    """Test Bedrock-specific error classification."""
+
+    def test_context_overflow_validation_exception(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error(
+            "ValidationException: input is too long for model"
+        ) == "context_overflow"
+
+    def test_context_overflow_max_tokens(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error(
+            "ValidationException: exceeds the maximum number of input tokens"
+        ) == "context_overflow"
+
+    def test_context_overflow_stream_error(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error(
+            "ModelStreamErrorException: Input is too long"
+        ) == "context_overflow"
+
+    def test_rate_limit_throttling(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error("ThrottlingException: Rate exceeded") == "rate_limit"
+
+    def test_rate_limit_concurrent(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error("Too many concurrent requests") == "rate_limit"
+
+    def test_overloaded_not_ready(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error("ModelNotReadyException") == "overloaded"
+
+    def test_overloaded_timeout(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error("ModelTimeoutException") == "overloaded"
+
+    def test_unknown_error(self):
+        from agent.bedrock_adapter import classify_bedrock_error
+        assert classify_bedrock_error("SomeRandomError: something went wrong") == "unknown"
+
+
+class TestBedrockContextLength:
+    """Test Bedrock model context length lookup."""
+
+    def test_claude_opus_4_6(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+
+    def test_claude_sonnet_versioned(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+
+    def test_nova_pro(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("amazon.nova-pro-v1:0") == 300_000
+
+    def test_nova_micro(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("amazon.nova-micro-v1:0") == 128_000
+
+    def test_unknown_model_gets_default(self):
+        from agent.bedrock_adapter import get_bedrock_context_length, BEDROCK_DEFAULT_CONTEXT_LENGTH
+        assert get_bedrock_context_length("unknown.model-v1:0") == BEDROCK_DEFAULT_CONTEXT_LENGTH
+
+    def test_inference_profile_resolves(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Cross-region inference profiles contain the base model ID
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+
+    def test_longest_prefix_wins(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # "anthropic.claude-3-5-sonnet" should match before "anthropic.claude-3"
+        assert get_bedrock_context_length("anthropic.claude-3-5-sonnet-20240620-v1:0") == 200_000

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -1,0 +1,269 @@
+"""Integration tests for the AWS Bedrock provider wiring.
+
+Verifies that the Bedrock provider is correctly registered in the
+provider registry, model catalog, and runtime resolution pipeline.
+These tests do NOT require AWS credentials or boto3 — all AWS calls
+are mocked.
+
+Note: Tests that import ``hermes_cli.auth`` or ``hermes_cli.runtime_provider``
+require Python 3.10+ due to ``str | None`` type syntax in the import chain.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestProviderRegistry:
+    """Verify Bedrock is registered in PROVIDER_REGISTRY."""
+
+    def test_bedrock_in_registry(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        assert "bedrock" in PROVIDER_REGISTRY
+
+    def test_bedrock_auth_type_is_aws_sdk(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["bedrock"]
+        assert pconfig.auth_type == "aws_sdk"
+
+    def test_bedrock_has_no_api_key_env_vars(self):
+        """Bedrock uses the AWS SDK credential chain, not API keys."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["bedrock"]
+        assert pconfig.api_key_env_vars == ()
+
+    def test_bedrock_base_url_env_var(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["bedrock"]
+        assert pconfig.base_url_env_var == "BEDROCK_BASE_URL"
+
+
+class TestProviderAliases:
+    """Verify Bedrock aliases resolve correctly."""
+
+    def test_aws_alias(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("aws") == "bedrock"
+
+    def test_aws_bedrock_alias(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("aws-bedrock") == "bedrock"
+
+    def test_amazon_bedrock_alias(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("amazon-bedrock") == "bedrock"
+
+    def test_amazon_alias(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("amazon") == "bedrock"
+
+
+class TestProviderLabels:
+    """Verify Bedrock appears in provider labels."""
+
+    def test_bedrock_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert _PROVIDER_LABELS.get("bedrock") == "AWS Bedrock"
+
+
+class TestModelCatalog:
+    """Verify Bedrock has a static model fallback list."""
+
+    def test_bedrock_has_curated_models(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        models = _PROVIDER_MODELS.get("bedrock", [])
+        assert len(models) > 0
+
+    def test_bedrock_models_include_claude(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        models = _PROVIDER_MODELS.get("bedrock", [])
+        claude_models = [m for m in models if "anthropic.claude" in m]
+        assert len(claude_models) > 0
+
+    def test_bedrock_models_include_nova(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        models = _PROVIDER_MODELS.get("bedrock", [])
+        nova_models = [m for m in models if "amazon.nova" in m]
+        assert len(nova_models) > 0
+
+
+class TestResolveProvider:
+    """Verify resolve_provider() handles bedrock correctly."""
+
+    def test_explicit_bedrock_resolves(self, monkeypatch):
+        """When user explicitly requests 'bedrock', it should resolve."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        # bedrock is in the registry, so resolve_provider should return it
+        from hermes_cli.auth import resolve_provider
+        result = resolve_provider("bedrock")
+        assert result == "bedrock"
+
+    def test_aws_alias_resolves_to_bedrock(self):
+        from hermes_cli.auth import resolve_provider
+        result = resolve_provider("aws")
+        assert result == "bedrock"
+
+    def test_amazon_bedrock_alias_resolves(self):
+        from hermes_cli.auth import resolve_provider
+        result = resolve_provider("amazon-bedrock")
+        assert result == "bedrock"
+
+    def test_auto_detect_with_aws_credentials(self, monkeypatch):
+        """When AWS credentials are present and no other provider is configured,
+        auto-detect should find bedrock."""
+        from hermes_cli.auth import resolve_provider
+
+        # Clear all other provider env vars
+        for var in ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY",
+                     "ANTHROPIC_TOKEN", "GOOGLE_API_KEY", "DEEPSEEK_API_KEY"]:
+            monkeypatch.delenv(var, raising=False)
+
+        # Set AWS credentials
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+        # Mock the auth store to have no active provider
+        with patch("hermes_cli.auth._load_auth_store", return_value={}):
+            result = resolve_provider("auto")
+        assert result == "bedrock"
+
+
+class TestRuntimeProvider:
+    """Verify resolve_runtime_provider() handles bedrock correctly."""
+
+    def test_bedrock_runtime_resolution(self, monkeypatch):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+
+        # Mock resolve_provider to return bedrock
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={"provider": "bedrock"}):
+            result = resolve_runtime_provider(requested="bedrock")
+
+        assert result["provider"] == "bedrock"
+        assert result["api_mode"] == "bedrock_converse"
+        assert result["region"] == "eu-west-1"
+        assert "bedrock-runtime.eu-west-1.amazonaws.com" in result["base_url"]
+        assert result["api_key"] == "aws-sdk"
+
+    def test_bedrock_runtime_default_region(self, monkeypatch):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.setenv("AWS_PROFILE", "default")
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={"provider": "bedrock"}):
+            result = resolve_runtime_provider(requested="bedrock")
+
+        assert result["region"] == "us-east-1"
+
+    def test_bedrock_runtime_no_credentials_raises_on_auto_detect(self, monkeypatch):
+        """When bedrock is auto-detected (not explicitly requested) and no
+        credentials are found, runtime resolution should raise AuthError."""
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        from hermes_cli.auth import AuthError
+
+        # Clear all AWS env vars
+        for var in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_PROFILE",
+                     "AWS_BEARER_TOKEN_BEDROCK", "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                     "AWS_WEB_IDENTITY_TOKEN_FILE"]:
+            monkeypatch.delenv(var, raising=False)
+
+        # Mock both the provider resolution and boto3's credential chain
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = None
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={"provider": "bedrock"}), \
+             patch("hermes_cli.runtime_provider.resolve_requested_provider", return_value="auto"), \
+             patch.dict("sys.modules", {"botocore": MagicMock(), "botocore.session": MagicMock()}):
+            import botocore.session as _bs
+            _bs.get_session = MagicMock(return_value=mock_session)
+            with pytest.raises(AuthError, match="No AWS credentials"):
+                resolve_runtime_provider(requested="auto")
+
+    def test_bedrock_runtime_explicit_skips_credential_check(self, monkeypatch):
+        """When user explicitly requests bedrock, trust boto3's credential chain
+        even if env-var detection finds nothing (covers IMDS, SSO, etc.)."""
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        # No AWS env vars set — but explicit bedrock request should not raise
+        for var in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_PROFILE",
+                     "AWS_BEARER_TOKEN_BEDROCK"]:
+            monkeypatch.delenv(var, raising=False)
+
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={"provider": "bedrock"}):
+            result = resolve_runtime_provider(requested="bedrock")
+        assert result["provider"] == "bedrock"
+        assert result["api_mode"] == "bedrock_converse"
+
+
+# ---------------------------------------------------------------------------
+# providers.py integration
+# ---------------------------------------------------------------------------
+
+class TestProvidersModule:
+    """Verify bedrock is wired into hermes_cli/providers.py."""
+
+    def test_bedrock_alias_in_providers(self):
+        from hermes_cli.providers import ALIASES
+        assert ALIASES.get("bedrock") == "amazon-bedrock"
+        assert ALIASES.get("aws") == "amazon-bedrock"
+        assert ALIASES.get("aws-bedrock") == "amazon-bedrock"
+
+    def test_bedrock_transport_mapping(self):
+        from hermes_cli.providers import TRANSPORT_TO_API_MODE
+        assert TRANSPORT_TO_API_MODE.get("bedrock_converse") == "bedrock_converse"
+
+    def test_determine_api_mode_from_bedrock_url(self):
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode(
+            "unknown", "https://bedrock-runtime.us-east-1.amazonaws.com"
+        ) == "bedrock_converse"
+
+    def test_label_override(self):
+        from hermes_cli.providers import _LABEL_OVERRIDES
+        assert _LABEL_OVERRIDES.get("amazon-bedrock") == "AWS Bedrock"
+
+
+# ---------------------------------------------------------------------------
+# Error classifier integration
+# ---------------------------------------------------------------------------
+
+class TestErrorClassifierBedrock:
+    """Verify Bedrock error patterns are in the global error classifier."""
+
+    def test_throttling_in_rate_limit_patterns(self):
+        from agent.error_classifier import _RATE_LIMIT_PATTERNS
+        assert "throttlingexception" in _RATE_LIMIT_PATTERNS
+
+    def test_context_overflow_patterns(self):
+        from agent.error_classifier import _CONTEXT_OVERFLOW_PATTERNS
+        assert "input is too long" in _CONTEXT_OVERFLOW_PATTERNS
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml bedrock extra
+# ---------------------------------------------------------------------------
+
+class TestPackaging:
+    """Verify bedrock optional dependency is declared."""
+
+    def test_bedrock_extra_exists(self):
+        import configparser
+        from pathlib import Path
+        # Read pyproject.toml to verify [bedrock] extra
+        toml_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+        content = toml_path.read_text()
+        assert 'bedrock = ["boto3' in content
+
+    def test_bedrock_in_all_extra(self):
+        from pathlib import Path
+        content = (Path(__file__).parent.parent.parent / "pyproject.toml").read_text()
+        assert '"hermes-agent[bedrock]"' in content

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -55,6 +55,7 @@ hermes setup       # Or configure everything at once
 | **MiniMax China** | China-region MiniMax endpoint | Set `MINIMAX_CN_API_KEY` |
 | **Alibaba Cloud** | Qwen models via DashScope | Set `DASHSCOPE_API_KEY` |
 | **Hugging Face** | 20+ open models via unified router (Qwen, DeepSeek, Kimi, etc.) | Set `HF_TOKEN` |
+| **AWS Bedrock** | Claude, Nova, Llama, DeepSeek via native Converse API | IAM role or `aws configure` ([guide](../guides/aws-bedrock.md)) |
 | **Kilo Code** | KiloCode-hosted models | Set `KILOCODE_API_KEY` |
 | **OpenCode Zen** | Pay-as-you-go access to curated models | Set `OPENCODE_ZEN_API_KEY` |
 | **OpenCode Go** | $10/month subscription for open models | Set `OPENCODE_GO_API_KEY` |

--- a/website/docs/guides/aws-bedrock.md
+++ b/website/docs/guides/aws-bedrock.md
@@ -1,0 +1,164 @@
+---
+sidebar_position: 14
+title: "AWS Bedrock"
+description: "Use Hermes Agent with Amazon Bedrock — native Converse API, IAM authentication, Guardrails, and cross-region inference"
+---
+
+# AWS Bedrock
+
+Hermes Agent supports Amazon Bedrock as a native provider using the **Converse API** — not the OpenAI-compatible endpoint. This gives you full access to the Bedrock ecosystem: IAM authentication, Guardrails, cross-region inference profiles, and all foundation models.
+
+## Prerequisites
+
+- **AWS credentials** — any source supported by the [boto3 credential chain](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html):
+  - IAM instance role (EC2, ECS, Lambda — zero config)
+  - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` environment variables
+  - `AWS_PROFILE` for SSO or named profiles
+  - `aws configure` for local development
+- **boto3** — install with `pip install hermes-agent[bedrock]`
+- **IAM permissions** — at minimum:
+  - `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` (for inference)
+  - `bedrock:ListFoundationModels` and `bedrock:ListInferenceProfiles` (for model discovery)
+
+:::tip EC2 / ECS / Lambda
+On AWS compute, attach an IAM role with `AmazonBedrockFullAccess` and you're done. No API keys, no `.env` configuration — Hermes detects the instance role automatically.
+:::
+
+## Quick Start
+
+```bash
+# Install with Bedrock support
+pip install hermes-agent[bedrock]
+
+# Select Bedrock as your provider
+hermes model
+# → Choose "More providers..." → "AWS Bedrock"
+# → Select your region and model
+
+# Start chatting
+hermes chat
+```
+
+## Configuration
+
+After running `hermes model`, your `~/.hermes/config.yaml` will contain:
+
+```yaml
+model:
+  default: us.anthropic.claude-sonnet-4-6
+  provider: bedrock
+  base_url: https://bedrock-runtime.us-east-2.amazonaws.com
+
+bedrock:
+  region: us-east-2
+```
+
+### Region
+
+Set the AWS region in any of these ways (highest priority first):
+
+1. `bedrock.region` in `config.yaml`
+2. `AWS_REGION` environment variable
+3. `AWS_DEFAULT_REGION` environment variable
+4. Default: `us-east-1`
+
+### Guardrails
+
+To apply [Amazon Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) to all model invocations:
+
+```yaml
+bedrock:
+  region: us-east-2
+  guardrail:
+    guardrail_identifier: "abc123def456"  # From the Bedrock console
+    guardrail_version: "1"                # Version number or "DRAFT"
+    stream_processing_mode: "async"       # "sync" or "async"
+    trace: "disabled"                     # "enabled", "disabled", or "enabled_full"
+```
+
+### Model Discovery
+
+Hermes auto-discovers available models via the Bedrock control plane. You can customize discovery:
+
+```yaml
+bedrock:
+  discovery:
+    enabled: true
+    provider_filter: ["anthropic", "amazon"]  # Only show these providers
+    refresh_interval: 3600                     # Cache for 1 hour
+```
+
+## Available Models
+
+Bedrock models use **inference profile IDs** for on-demand invocation. The `hermes model` picker shows these automatically, with recommended models at the top:
+
+| Model | ID | Notes |
+|-------|-----|-------|
+| Claude Sonnet 4.6 | `us.anthropic.claude-sonnet-4-6` | Recommended — best balance of speed and capability |
+| Claude Opus 4.6 | `us.anthropic.claude-opus-4-6-v1` | Most capable |
+| Claude Haiku 4.5 | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Fastest Claude |
+| Amazon Nova Pro | `us.amazon.nova-pro-v1:0` | Amazon's flagship |
+| Amazon Nova Micro | `us.amazon.nova-micro-v1:0` | Fastest, cheapest |
+| DeepSeek V3.2 | `deepseek.v3.2` | Strong open model |
+| Llama 4 Scout 17B | `us.meta.llama4-scout-17b-instruct-v1:0` | Meta's latest |
+
+:::info Cross-Region Inference
+Models prefixed with `us.` use cross-region inference profiles, which provide better capacity and automatic failover across AWS regions. Models prefixed with `global.` route across all available regions worldwide.
+:::
+
+## Switching Models Mid-Session
+
+Use the `/model` command during a conversation:
+
+```
+/model us.amazon.nova-pro-v1:0
+/model deepseek.v3.2
+/model us.anthropic.claude-opus-4-6-v1
+```
+
+## Diagnostics
+
+```bash
+hermes doctor
+```
+
+The doctor checks:
+- Whether AWS credentials are available (env vars, IAM role, SSO)
+- Whether `boto3` is installed
+- Whether the Bedrock API is reachable (ListFoundationModels)
+- Number of available models in your region
+
+## Gateway (Messaging Platforms)
+
+Bedrock works with all Hermes gateway platforms (Telegram, Discord, Slack, Feishu, etc.). Configure Bedrock as your provider, then start the gateway normally:
+
+```bash
+hermes gateway setup
+hermes gateway start
+```
+
+The gateway reads `config.yaml` and uses the same Bedrock provider configuration.
+
+## Troubleshooting
+
+### "No API key found" / "No AWS credentials"
+
+Hermes checks for credentials in this order:
+1. `AWS_BEARER_TOKEN_BEDROCK`
+2. `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
+3. `AWS_PROFILE`
+4. EC2 instance metadata (IMDS)
+5. ECS container credentials
+6. Lambda execution role
+
+If none are found, run `aws configure` or attach an IAM role to your compute instance.
+
+### "Invocation of model ID ... with on-demand throughput isn't supported"
+
+Use an **inference profile ID** (prefixed with `us.` or `global.`) instead of the bare foundation model ID. For example:
+- ❌ `anthropic.claude-sonnet-4-6`
+- ✅ `us.anthropic.claude-sonnet-4-6`
+
+### "ThrottlingException"
+
+You've hit the Bedrock per-model rate limit. Hermes automatically retries with backoff. To increase limits, request a quota increase in the [AWS Service Quotas console](https://console.aws.amazon.com/servicequotas/).


### PR DESCRIPTION
# feat: native AWS Bedrock provider via Converse API

## Summary

Adds Amazon Bedrock as a first-class provider using the native **Converse API** (not the OpenAI-compatible endpoint). This gives Hermes users direct access to the full Bedrock ecosystem: IAM authentication, Guardrails, cross-region inference profiles, dynamic model discovery, and all foundation models — with zero API key management on AWS compute.

**Reference implementation:** OpenClaw's `extensions/amazon-bedrock/` plugin, which implements the same Converse API integration in TypeScript via `@aws-sdk/client-bedrock`.

## Motivation

Bedrock is the primary inference platform for AWS-native teams. The existing workaround (OpenAI-compatible endpoint via `bedrock-mantle`) requires managing Bedrock API keys and misses ecosystem features like Guardrails, inference profiles, and IAM role authentication. A native integration removes these friction points and serves the large AWS user base properly.

This PR was developed with reference to [OpenClaw PR #62673](https://github.com/openclaw/openclaw/pull/62673), which addressed the same class of cloud credential passthrough issues for Bedrock on EC2/ECS/Lambda.

## What's included

### Core adapter (`agent/bedrock_adapter.py` — 1,020 lines)
- **Converse API integration** — `build_converse_kwargs()`, `call_converse()`, `call_converse_stream()` with full message/tool format conversion between OpenAI and Converse formats
- **Real-time streaming** — `stream_converse_with_callbacks()` with `on_text_delta`, `on_tool_start`, `on_reasoning_delta`, and `on_interrupt_check` callbacks, matching the Anthropic/chat_completions streaming UX
- **AWS credential detection** — env vars (ACCESS_KEY, PROFILE, BEARER_TOKEN, CONTAINER_CREDENTIALS, WEB_IDENTITY) + boto3 IMDS fallback for EC2 instance roles, ECS task roles, Lambda execution roles
- **Dynamic model discovery** — `discover_bedrock_models()` via `ListFoundationModels` + `ListInferenceProfiles` with 1-hour cache, provider filtering, and deduplication
- **Error classification** — `classify_bedrock_error()` for context overflow, throttling, and overload patterns
- **Context length table** — `BEDROCK_CONTEXT_LENGTHS` with substring matching for versioned model IDs and inference profiles
- **Guardrails support** — `guardrail_config` parameter threaded through the entire call chain

### Provider registration (6 files)
- `hermes_cli/auth.py` — `ProviderConfig` with `auth_type="aws_sdk"`, aliases (`aws`, `aws-bedrock`, `amazon-bedrock`, `amazon`), auto-detection via `has_aws_credentials()` in the `resolve_provider("auto")` path
- `hermes_cli/models.py` — `_PROVIDER_MODELS["bedrock"]` static fallback list, `_PROVIDER_LABELS`, `_PROVIDER_ALIASES`, Bedrock-aware model validation in `validate_requested_model()`
- `hermes_cli/providers.py` — `ALIASES`, `TRANSPORT_TO_API_MODE["bedrock_converse"]`, `_LABEL_OVERRIDES`, URL heuristic in `determine_api_mode()`
- `hermes_cli/runtime_provider.py` — Bedrock runtime resolution with region from `config.yaml`, guardrail config passthrough, explicit-vs-auto credential check distinction
- `hermes_cli/config.py` — `DEFAULT_CONFIG["bedrock"]` section (region, discovery, guardrail), `OPTIONAL_ENV_VARS` for `AWS_REGION`/`AWS_PROFILE`, bedrock in fallback_model provider comments
- `hermes_cli/main.py` — `_model_flow_bedrock()` with smart model filtering (excludes embedding/image/voice models), deduplication (prefers inference profiles over bare foundation IDs), recommended model sorting, region persistence to `config.yaml`

### Agent integration (`run_agent.py`)
- `api_mode` whitelist updated to include `"bedrock_converse"`
- Auto-detection from `provider="bedrock"` or `bedrock-runtime` in base URL
- `_build_api_kwargs()` — Bedrock branch builds Converse-format kwargs directly
- `_interruptible_api_call()` — Bedrock branch calls `client.converse()` via boto3
- `_interruptible_streaming_api_call()` — Full streaming with `converse_stream()` + delta callbacks in a background thread with interrupt support
- `run_conversation()` — Length truncation handling extended to `bedrock_converse` api_mode
- Guardrail config loaded from `config.yaml` at init time

### Ecosystem integration (5 files)
- `agent/error_classifier.py` — Bedrock-specific patterns for `ThrottlingException`, `ServiceQuotaExceededException`, `ModelNotReadyException`, `ModelTimeoutException`, context overflow `ValidationException`
- `agent/model_metadata.py` — Bedrock context length resolution step (after Anthropic, before models.dev)
- `agent/usage_pricing.py` — Bedrock model pricing (Claude Opus/Sonnet/Haiku, Nova Pro/Lite/Micro) with substring matching for inference profile IDs
- `hermes_cli/doctor.py` — Bedrock diagnostics: AWS credential detection, boto3 installation check, `ListFoundationModels` API health check with model count
- `hermes_cli/auth_commands.py` — `hermes auth` displays AWS credential source, region, and IAM identity via `sts:GetCallerIdentity`

### Documentation
- `website/docs/guides/aws-bedrock.md` — Full guide: prerequisites, quick start, config.yaml reference, Guardrails, model discovery, available models, `/model` switching, diagnostics, gateway, troubleshooting
- `website/docs/getting-started/quickstart.md` — Bedrock added to provider table
- `BEDROCK_TESTING_GUIDE.md` — Manual testing guide for reviewers

### Packaging
- `pyproject.toml` — `bedrock = ["boto3>=1.35.0,<2"]` optional dependency, added to `[all]` extra

## Testing

### Automated tests — 107 tests, all passing

**`tests/agent/test_bedrock_adapter.py`** (79 tests):
- `TestResolveAwsAuthEnvVar` (8) — credential detection priority, IMDS fallback, whitespace handling
- `TestHasAwsCredentials` (2) — positive/negative detection
- `TestResolveBedrocRegion` (3) — region resolution priority
- `TestConvertToolsToConverse` (4) — OpenAI → Converse tool format
- `TestConvertMessagesToConverse` (10) — system prompt extraction, tool calls, tool results, role alternation merging, image content, empty content placeholders
- `TestNormalizeConverseResponse` (6) — text, tool_use, multiple tools, stop reason mapping, empty content, tool_calls finish_reason override
- `TestNormalizeConverseStreamEvents` (4) — text stream, tool stream, mixed, empty
- `TestStreamConverseWithCallbacks` (5) — text delta callbacks, tool_use suppression, tool_start callback, interrupt, reasoning delta
- `TestBuildConverseKwargs` (6) — basic, tools, temperature/top_p, guardrail, no-system, no-tools
- `TestDiscoverBedrockModels` (8) — foundation models, inactive filter, non-streaming filter, provider filter, caching, inference profiles, global sort, API error handling
- `TestGuardrailConfig` (3) — included, none, empty dict
- `TestBedrockErrorClassification` (8) — context overflow (3 patterns), rate limit (2), overloaded (2), unknown
- `TestBedrockContextLength` (7) — Claude, Nova, unknown default, inference profile, longest prefix
- `TestExtractProviderFromArn` (3) + `TestClientCache` (1)

**`tests/agent/test_bedrock_integration.py`** (28 tests):
- `TestProviderRegistry` (4) — registration, auth_type, env vars, base_url_env_var
- `TestProviderAliases` (4) — aws, aws-bedrock, amazon-bedrock, amazon
- `TestProviderLabels` (1) + `TestModelCatalog` (3)
- `TestResolveProvider` (4) — explicit, aliases, auto-detect with AWS credentials
- `TestRuntimeProvider` (4) — resolution, default region, no-credentials-on-auto-detect raises, explicit-skips-check
- `TestProvidersModule` (4) — aliases, transport mapping, URL heuristic, label override
- `TestErrorClassifierBedrock` (2) — throttling, context overflow patterns
- `TestPackaging` (2) — bedrock extra exists, in [all] extra

### EC2 integration testing

All tests run on **EC2 t3.medium** (Amazon Linux 2023, Python 3.11.14, boto3 1.42.88) with IAM role `hermes-bedrock-manual-test` (`AmazonBedrockFullAccess`) in **us-east-2**.

**Multi-model end-to-end via `AIAgent.chat()`:**

| Model | ID | Response | Time |
|-------|-----|----------|------|
| Claude Sonnet 4.6 | `us.anthropic.claude-sonnet-4-6` | "Four" | 1.3s |
| Amazon Nova Pro | `us.amazon.nova-pro-v1:0` | "4" | 0.8s |
| DeepSeek V3.2 | `deepseek.v3.2` | "4" | 0.7s |
| Llama 4 Scout 17B | `us.meta.llama4-scout-17b-instruct-v1:0` | "Four." | 0.5s |

**Streaming verification:**
- Claude Sonnet 4.6: 25 chunks, 21→80 tokens, 2.1s — text deltas fired correctly

**Tool calling verification:**
- Claude Sonnet 4.6: `get_weather({"city": "Tokyo"})` — tool_call ID, name, arguments all correct, `finish_reason=tool_calls`

**Guardrails verification:**
- Created guardrail `zi4q4hqa4n4k` (SEXUAL+HATE content filter) — requests with `guardrailConfig` succeed, guardrail parameters correctly injected into Converse API calls

**CLI verification:**
- `hermes model` → Bedrock selection → region picker → smart model list (filtered, deduplicated, recommended first)
- `hermes chat` → interactive conversation with streaming output
- `/model us.amazon.nova-pro-v1:0` → mid-session model switch, validated via Bedrock discovery
- `/usage` → token count and cost display
- `hermes doctor` → `✓ AWS Bedrock (iam-role, us-east-2, 89 models)`
- `hermes auth` → displays IAM role ARN, region, identity

**Gateway verification:**
- Feishu (Lark) gateway configured and tested — Bedrock provider works through the messaging gateway path with the same `config.yaml` configuration

**IMDS credential detection:**
- EC2 instance role detected via boto3 `botocore.session.get_session().get_credentials()` fallback — no environment variables needed. This addresses the same class of issue as [OpenClaw PR #62673](https://github.com/openclaw/openclaw/pull/62673).

## Files changed

### New files (3)
| File | Lines | Description |
|------|-------|-------------|
| `agent/bedrock_adapter.py` | 1,020 | Core Bedrock Converse API adapter |
| `tests/agent/test_bedrock_adapter.py` | 1,100 | Unit tests (79 tests) |
| `tests/agent/test_bedrock_integration.py` | 280 | Integration tests (28 tests) |

### Modified files (13)
| File | Description |
|------|-------------|
| `run_agent.py` | api_mode whitelist, init, _build_api_kwargs, streaming, non-streaming, length truncation |
| `hermes_cli/auth.py` | PROVIDER_REGISTRY entry, aliases, auto-detect |
| `hermes_cli/models.py` | Labels, aliases, model catalog, validate_requested_model |
| `hermes_cli/providers.py` | ALIASES, TRANSPORT_TO_API_MODE, URL heuristic, label |
| `hermes_cli/config.py` | DEFAULT_CONFIG bedrock section, OPTIONAL_ENV_VARS, fallback comments |
| `hermes_cli/main.py` | _model_flow_bedrock, provider picker, provider labels |
| `hermes_cli/runtime_provider.py` | Bedrock runtime resolution with guardrails |
| `hermes_cli/doctor.py` | Bedrock diagnostics |
| `hermes_cli/auth_commands.py` | AWS credential status display |
| `agent/error_classifier.py` | Bedrock error patterns |
| `agent/model_metadata.py` | Bedrock context length resolution |
| `agent/usage_pricing.py` | Bedrock model pricing + substring matching |
| `pyproject.toml` | `[bedrock]` optional dependency |

### Documentation (2)
| File | Description |
|------|-------------|
| `website/docs/guides/aws-bedrock.md` | Full Bedrock provider guide |
| `website/docs/getting-started/quickstart.md` | Bedrock in provider table |
