### PR TITLE
fix(gateway): use source.thread_id instead of undefined event in queued response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7053,7 +7053,7 @@ class GatewayRunner:
                     if first_response and not _already_streamed:
                         try:
                             await adapter.send(source.chat_id, first_response,
-                                               metadata=getattr(event, "metadata", None))
+                                               metadata={"thread_id": source.thread_id} if source.thread_id else None)
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                 # else: interrupted — discard the interrupted response ("Operation


### PR DESCRIPTION
## Bug

In `_run_agent()`, the pending message handler references `event` which is not defined in that scope — it only exists in the caller (`_handle_message()` and similar). This causes a `NameError` when sending the first response before processing a queued follow-up message.

```python
# BROKEN — event is undefined in _run_agent scope
await adapter.send(source.chat_id, first_response,
                   metadata=getattr(event, "metadata", None))
```

This crashes the pending message queue, breaking multi-image handling and queued follow-ups in Telegram threads.

## Fix

Replace with the established pattern already used at lines 2625, 2810, 3678, 4410, 4566:

```python
metadata={"thread_id": source.thread_id} if source.thread_id else None
```

`source` (SessionSource) is a parameter of `_run_agent()`, so it's always available.

## Impact

- 1 line changed
- No behavior change for non-thread contexts (returns None, same as before)
- Fixes thread routing for queued responses (correctly passes thread_id to adapter.send)