### PR TITLE
feat: add generic MCP presets with Stitch shortcut

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5113,6 +5113,8 @@ For more help on a command:
     mcp_add_p.add_argument("--command", help="Stdio command (e.g. npx)")
     mcp_add_p.add_argument("--args", nargs="*", default=[], help="Arguments for stdio command")
     mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
+    mcp_add_p.add_argument("--preset", choices=["stitch"], help="Known MCP preset (e.g. Google Stitch)")
+    mcp_add_p.add_argument("--env", nargs="*", default=[], help="Environment variables for stdio servers (KEY=VALUE)")
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -9,7 +9,6 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 """
 
 import asyncio
-import getpass
 import logging
 import os
 import re
@@ -27,6 +26,17 @@ from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
+
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+_MCP_PRESETS: Dict[str, Dict[str, Any]] = {
+    "stitch": {
+        "command": "npx",
+        "args": ["-y", "@_davideast/stitch-mcp", "proxy"],
+        "display_name": "Google Stitch",
+    },
+}
 
 
 # ─── UI Helpers ───────────────────────────────────────────────────────────────
@@ -109,6 +119,59 @@ def _env_key_for_server(name: str) -> str:
     return f"MCP_{name.upper().replace('-', '_')}_API_KEY"
 
 
+def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
+    """Parse ``KEY=VALUE`` strings from CLI args into an env dict."""
+    parsed: Dict[str, str] = {}
+    for item in raw_env or []:
+        text = str(item or "").strip()
+        if not text:
+            continue
+        if "=" not in text:
+            raise ValueError(f"Invalid --env value '{text}' (expected KEY=VALUE)")
+        key, value = text.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"Invalid --env value '{text}' (missing variable name)")
+        if not _ENV_VAR_NAME_RE.match(key):
+            raise ValueError(f"Invalid --env variable name '{key}'")
+        parsed[key] = value
+    return parsed
+
+
+def _apply_mcp_preset(
+    name: str,
+    *,
+    preset_name: Optional[str],
+    url: Optional[str],
+    command: Optional[str],
+    cmd_args: List[str],
+    server_config: Dict[str, Any],
+) -> tuple[Optional[str], Optional[str], List[str], bool]:
+    """Apply a known MCP preset when transport details were omitted."""
+    if not preset_name:
+        return url, command, cmd_args, False
+
+    preset = _MCP_PRESETS.get(preset_name)
+    if not preset:
+        raise ValueError(f"Unknown MCP preset: {preset_name}")
+
+    if url or command:
+        return url, command, cmd_args, False
+
+    url = preset.get("url")
+    command = preset.get("command")
+    cmd_args = list(preset.get("args") or [])
+
+    if url:
+        server_config["url"] = url
+    if command:
+        server_config["command"] = command
+    if cmd_args:
+        server_config["args"] = cmd_args
+
+    return url, command, cmd_args, True
+
+
 # ─── Discovery (temporary connect) ───────────────────────────────────────────
 
 def _probe_single_server(
@@ -177,13 +240,35 @@ def cmd_mcp_add(args):
     command = getattr(args, "command", None)
     cmd_args = getattr(args, "args", None) or []
     auth_type = getattr(args, "auth", None)
+    preset_name = getattr(args, "preset", None)
+    raw_env = getattr(args, "env", None)
+
+    server_config: Dict[str, Any] = {}
+    try:
+        explicit_env = _parse_env_assignments(raw_env)
+        url, command, cmd_args, _preset_applied = _apply_mcp_preset(
+            name,
+            preset_name=preset_name,
+            url=url,
+            command=command,
+            cmd_args=list(cmd_args),
+            server_config=server_config,
+        )
+    except ValueError as exc:
+        _error(str(exc))
+        return
+
+    if url and explicit_env:
+        _error("--env is only supported for stdio MCP servers (--command or stdio presets)")
+        return
 
     # Validate transport
     if not url and not command:
-        _error("Must specify --url <endpoint> or --command <cmd>")
+        _error("Must specify --url <endpoint>, --command <cmd>, or --preset <name>")
         _info("Examples:")
         _info('  hermes mcp add ink --url "https://mcp.ml.ink/mcp"')
         _info('  hermes mcp add github --command npx --args @modelcontextprotocol/server-github')
+        _info('  hermes mcp add stitch --preset stitch')
         return
 
     # Check if server already exists
@@ -194,13 +279,15 @@ def cmd_mcp_add(args):
             return
 
     # Build initial config
-    server_config: Dict[str, Any] = {}
     if url:
         server_config["url"] = url
     else:
         server_config["command"] = command
         if cmd_args:
             server_config["args"] = cmd_args
+        if explicit_env:
+            server_config["env"] = explicit_env
+
 
     # ── Authentication ────────────────────────────────────────────────
 
@@ -638,6 +725,7 @@ def mcp_command(args):
         _info("hermes mcp serve                              Run as MCP server")
         _info("hermes mcp add <name> --url <endpoint>        Add an MCP server")
         _info("hermes mcp add <name> --command <cmd>         Add a stdio server")
+        _info("hermes mcp add stitch --preset stitch        Add the Google Stitch proxy preset")
         _info("hermes mcp remove <name>                      Remove a server")
         _info("hermes mcp list                               List servers")
         _info("hermes mcp test <name>                        Test connection")

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -46,6 +46,8 @@ def _make_args(**kwargs):
         "command": None,
         "args": None,
         "auth": None,
+        "preset": None,
+        "env": None,
         "mcp_action": None,
     }
     defaults.update(kwargs)
@@ -268,6 +270,129 @@ class TestMcpAdd:
 
         config = load_config()
         assert config["mcp_servers"]["broken"]["enabled"] is False
+
+    def test_add_stdio_server_with_env(self, tmp_path, capsys, monkeypatch):
+        """Stdio servers can persist explicit environment variables."""
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            assert config["env"] == {
+                "STITCH_USE_SYSTEM_GCLOUD": "1",
+                "DEBUG": "true",
+            }
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="github",
+            command="npx",
+            args=["@mcp/github"],
+            env=["STITCH_USE_SYSTEM_GCLOUD=1", "DEBUG=true"],
+        ))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        srv = config["mcp_servers"]["github"]
+        assert srv["env"] == {
+            "STITCH_USE_SYSTEM_GCLOUD": "1",
+            "DEBUG": "true",
+        }
+
+    def test_add_stdio_server_rejects_invalid_env_name(self, capsys):
+        """Invalid environment variable names are rejected up front."""
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="github",
+            command="npx",
+            args=["@mcp/github"],
+            env=["BAD-NAME=value"],
+        ))
+        out = capsys.readouterr().out
+        assert "Invalid --env variable name" in out
+
+    def test_add_http_server_rejects_env_flag(self, capsys):
+        """The --env flag is only valid for stdio transports."""
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="ink",
+            url="https://mcp.ml.ink/mcp",
+            env=["DEBUG=true"],
+        ))
+        out = capsys.readouterr().out
+        assert "only supported for stdio MCP servers" in out
+
+    def test_add_stitch_preset(self, tmp_path, capsys, monkeypatch):
+        """The Stitch preset only fills in the stdio transport."""
+        fake_tools = [FakeTool("build_site", "Builds a site from a project")]
+
+        def mock_probe(name, config, **kw):
+            assert name == "stitch"
+            assert config["command"] == "npx"
+            assert config["args"] == ["-y", "@_davideast/stitch-mcp", "proxy"]
+            assert "env" not in config
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_add(_make_args(name="stitch", preset="stitch"))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+
+        config = read_raw_config()
+        srv = config["mcp_servers"]["stitch"]
+        assert srv["command"] == "npx"
+        assert srv["args"] == ["-y", "@_davideast/stitch-mcp", "proxy"]
+        assert "env" not in srv
+
+    def test_stitch_preset_does_not_override_explicit_command(self, tmp_path, capsys, monkeypatch):
+        """Explicit transports win over presets."""
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            assert config["command"] == "uvx"
+            assert config["args"] == ["custom-server"]
+            assert "env" not in config
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_add(_make_args(
+            name="custom-stitch",
+            preset="stitch",
+            command="uvx",
+            args=["custom-server"],
+        ))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+
+        config = read_raw_config()
+        srv = config["mcp_servers"]["custom-stitch"]
+        assert srv["command"] == "uvx"
+        assert srv["args"] == ["custom-server"]
+        assert "env" not in srv
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add generic `--preset` support to `hermes mcp add`
- add generic `--env KEY=VALUE` support for stdio MCP servers
- ship a first preset for Google Stitch via `@_davideast/stitch-mcp proxy`
- validate env var names and reject `--env` for HTTP MCP servers
- ensure explicit `--command`/`--url` overrides preset transport defaults

## Why

Hermes already supports external MCP servers well, but adding common servers still requires users to remember the exact stdio command and arguments.

This change keeps Hermes general-purpose while making common MCP integrations easier to configure. Stitch is added as a preset, not as a native integration, so Hermes stays architecture-neutral and continues to rely on standard MCP server configuration.

## Example

```bash
hermes mcp add stitch --preset stitch
```

Optional stdio env variables can also be passed explicitly:

```bash
hermes mcp add stitch --preset stitch --env STITCH_USE_SYSTEM_GCLOUD=1
```

If a transport is already specified, the preset does not override it:

```bash
hermes mcp add custom --preset stitch --command uvx --args custom-server
```

## Verified end-to-end

Tested with a real Stitch API key on a temporary HERMES_HOME:

- `hermes mcp add stitch --preset stitch --env STITCH_API_KEY=<key>`:
  - connected to Stitch MCP proxy
  - discovered 12 tools
  - saved config with correct `npx` + `@_davideast/stitch-mcp proxy` + env
- `hermes mcp test stitch`:
  - reconnected successfully
  - rediscovered the same 12 tools
- `create_project`:
  - created a project in Stitch
- `generate_screen_from_text`:
  - generated a landing page screen
- `get_screen`:
  - returned the `htmlCode.downloadUrl`
- `curl` to download the HTML:
  - downloaded a 20KB valid `text/html` document

No secret was stored in code or repo; the key was injected via env var only during the test session.

## Test Plan

```bash
pytest -c /dev/null tests/hermes_cli/test_mcp_config.py tests/test_mcp_serve.py -q
```

## Notes

- the preset mechanism is generic and extensible (add more presets in `_MCP_PRESETS`)
- no Stitch-specific auth or login flow is embedded in Hermes
- environment variables for stdio servers are validated (`^[A-Za-z_][A-Za-z0-9_]*$`)
- `--env` with HTTP servers is explicitly rejected