### PR TITLE
feat: add Real Sports delivery orchestration skill

### DIFF
--- a/skills/productivity/real-sports-delivery/SKILL.md
+++ b/skills/productivity/real-sports-delivery/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: real-sports-delivery
+description: Orchestrate the Real Sports extractor with Hermes — run extraction, validate ai-ready.json freshness, generate delivery-ready picks, and post results to Discord. Treats the extractor repo as the source of truth and keeps Hermes focused on orchestration.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [RealSports, Extraction, Discord, Cron, Orchestration, Automation]
+    related_skills: [github-pr-workflow, hermes-agent]
+prerequisites:
+  commands: [hermes, npm, node, python3, git]
+---
+
+# Real Sports Delivery Orchestration
+
+Use this skill when you want Hermes to orchestrate the `real-extractor` repo rather than re-implement the scraper. The extraction repo remains the source of truth for authentication, extraction, normalization, and `ai-ready.json` generation.
+
+## What this skill does
+
+1. Runs or reuses the extractor output in a configured `real-extractor` checkout.
+2. Verifies that `data/normalized/<date>/ai-ready.json` exists and is fresh.
+3. Invokes Hermes with a focused prompt that tells it to read the extracted JSON, generate delivery-ready picks, and post them through the configured Discord/messaging tools.
+4. Supports dry runs so you can validate the workflow without sending anything.
+5. Gives you a clean cron-friendly entrypoint for scheduled runs.
+
+## Default configuration
+
+Set the extractor checkout path with one of:
+
+- `REALSPORTS_EXTRACTOR_DIR`
+- `--extractor-dir /absolute/path/to/real-extractor`
+
+If neither is provided, the helper script will fail fast and tell you what to set.
+
+## Quick start
+
+```bash
+# Validate the workflow without posting
+python3 "$SKILL_DIR/scripts/run_real_sports_delivery.py" \
+  --extractor-dir ~/src/real-extractor \
+  --dry-run
+
+# Run extraction and hand off to Hermes for delivery
+python3 "$SKILL_DIR/scripts/run_real_sports_delivery.py" \
+  --extractor-dir ~/src/real-extractor
+```
+
+## Recommended workflow
+
+### 1) Keep the extractor repo separate
+
+The extractor repo should continue to own:
+
+- browser auth
+- site scraping
+- normalization
+- `picks.json`
+- `ai-ready.json`
+
+Do not duplicate that logic in Hermes.
+
+### 2) Let Hermes own orchestration
+
+Hermes should:
+
+- decide whether to re-run extraction
+- validate freshness and target date
+- read `ai-ready.json`
+- generate the delivery summary
+- post to Discord when the messaging tool is available
+- report failures clearly
+
+### 3) Schedule it with cron
+
+A cron job can attach this skill and call the helper script directly, or ask Hermes to execute the workflow as a scheduled task.
+
+Example pattern:
+
+```bash
+hermes cron create "0 8 * * *" \
+  "Run the Real Sports delivery workflow from the configured extractor checkout." \
+  --skill real-sports-delivery \
+  --deliver discord
+```
+
+## Pitfalls
+
+- **No `HASS_TOKEN` equivalent here** — this workflow depends on the extractor auth file in the extractor repo and whatever Discord/messaging setup Hermes already has.
+- **Freshness matters** — if the `ai-ready.json` timestamp is stale, rerun extraction first.
+- **Do not hardcode repo paths** — use `REALSPORTS_EXTRACTOR_DIR` or the script flag.
+- **Keep delivery logic out of the extractor repo** — the goal is to keep that repository lean.
+
+## Verification
+
+A good run should confirm:
+
+- the extractor repo exists and has `.auth/realsports-auth.json`
+- `npm run extract` succeeds when requested
+- `ai-ready.json` exists for the expected target date
+- Hermes can read the JSON and produce a structured delivery result
+- Discord posting succeeds or fails with a specific, actionable error
+
+## Notes
+
+This skill is intentionally Hermes-side only. It does not replace the extractor. It wraps the extractor so Hermes can manage scheduling, delivery, retries, and future improvements.

--- a/skills/productivity/real-sports-delivery/references/extractor-contract.md
+++ b/skills/productivity/real-sports-delivery/references/extractor-contract.md
@@ -1,0 +1,27 @@
+# Real Sports extractor contract
+
+This skill treats the extractor repo as a black box and relies on a few stable files and behaviors.
+
+## Required files
+
+- `.auth/realsports-auth.json` — extractor auth captured by `npm run auth`
+- `data/normalized/<date>/ai-ready.json` — delivery input for Hermes
+- `data/normalized/<date>/picks.json` — richer debug artifact for humans
+
+## ai-ready.json fields
+
+The delivery workflow only relies on a small contract:
+
+- `targetDate` — the site day the file belongs to
+- `extractedAt` — ISO-8601 timestamp used for freshness checks
+- `posts` — the list Hermes should read and turn into a delivery summary
+
+## Fallback compatibility
+
+For local testing, the helper script also accepts a root-level `ai-ready.json` if the normalized directory is absent. When that fallback is used, the helper still validates `targetDate` and `extractedAt` before invoking Hermes.
+
+## Operational notes
+
+- The extractor repo is responsible for auth and extraction.
+- Hermes is responsible for orchestration, delivery, and retries.
+- The helper script does not try to infer picks from raw site data; it only hands off the extracted JSON to Hermes.

--- a/skills/productivity/real-sports-delivery/scripts/run_real_sports_delivery.py
+++ b/skills/productivity/real-sports-delivery/scripts/run_real_sports_delivery.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Hermes-side orchestration for the Real Sports extractor.
+
+This helper keeps the extractor repo as the source of truth and uses Hermes
+for the delivery/orchestration layer:
+
+1. optionally run `npm run extract`
+2. locate and validate `ai-ready.json`
+3. invoke `hermes chat` with a focused delivery prompt
+4. let Hermes use its configured tools to post the result
+
+Usage:
+  python run_real_sports_delivery.py --extractor-dir ~/src/real-extractor
+  python run_real_sports_delivery.py --extractor-dir ~/src/real-extractor --skip-extract
+  python run_real_sports_delivery.py --extractor-dir ~/src/real-extractor --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_STALE_MS = 36 * 60 * 60 * 1000
+DEFAULT_TOOLSETS = "file,terminal,send_message"
+
+
+@dataclass(frozen=True)
+class AiReady:
+    path: Path
+    payload: dict
+
+
+def _die(message: str, code: int = 1) -> None:
+    print(f"[real-sports] {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _extractor_dir_from_args(args: argparse.Namespace) -> Path:
+    raw = args.extractor_dir or os.getenv("REALSPORTS_EXTRACTOR_DIR", "")
+    if not raw:
+        _die(
+            "Set REALSPORTS_EXTRACTOR_DIR or pass --extractor-dir /absolute/path/to/real-extractor."
+        )
+    extractor_dir = Path(raw).expanduser().resolve()
+    if not extractor_dir.is_dir():
+        _die(f"Extractor directory not found: {extractor_dir}")
+    return extractor_dir
+
+
+def _auth_file(extractor_dir: Path) -> Path:
+    return extractor_dir / ".auth" / "realsports-auth.json"
+
+
+def _ai_ready_dir(extractor_dir: Path, target_date: Optional[str] = None) -> Path:
+    if target_date:
+        return extractor_dir / "data" / "normalized" / target_date
+    return extractor_dir / "data" / "normalized"
+
+
+def _load_ai_ready(path: Path) -> AiReady:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        _die(f"Missing ai-ready JSON: {path}")
+    return AiReady(path=path, payload=payload)
+
+
+def _latest_ai_ready(extractor_dir: Path, target_date: Optional[str] = None) -> AiReady:
+    base = _ai_ready_dir(extractor_dir, target_date)
+    if target_date:
+        path = base / "ai-ready.json"
+        if path.is_file():
+            return _load_ai_ready(path)
+
+        fallback = extractor_dir / "ai-ready.json"
+        if fallback.is_file():
+            ai = _load_ai_ready(fallback)
+            if ai.payload.get("targetDate") == target_date:
+                return ai
+        _die(f"Missing ai-ready JSON for {target_date}: expected {path} (or compatible root ai-ready.json)")
+
+    candidates = sorted(
+        base.glob("*/ai-ready.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if candidates:
+        return _load_ai_ready(candidates[0])
+
+    fallback = extractor_dir / "ai-ready.json"
+    if fallback.is_file():
+        return _load_ai_ready(fallback)
+
+    _die(f"No ai-ready.json files found under {base} or at {fallback}")
+
+
+def _validate_ai_ready(ai: AiReady, expected_date: Optional[str], max_stale_ms: int) -> None:
+    payload = ai.payload
+    target_date = payload.get("targetDate")
+    extracted_at = payload.get("extractedAt")
+    if not isinstance(target_date, str) or not target_date:
+        _die(f"ai-ready.json is missing a valid targetDate: {ai.path}")
+    if expected_date and target_date != expected_date:
+        _die(
+            f"ai-ready.json targetDate {target_date!r} does not match expected {expected_date!r}: {ai.path}"
+        )
+    if not isinstance(extracted_at, str) or not extracted_at:
+        _die(f"ai-ready.json is missing a valid extractedAt timestamp: {ai.path}")
+
+    try:
+        extracted_ts = datetime.fromisoformat(extracted_at.replace("Z", "+00:00"))
+    except ValueError:
+        _die(f"ai-ready.json extractedAt is not ISO-8601: {extracted_at!r}")
+
+    if extracted_ts.tzinfo is None:
+        extracted_ts = extracted_ts.replace(tzinfo=timezone.utc)
+    age_ms = int((datetime.now(timezone.utc) - extracted_ts.astimezone(timezone.utc)).total_seconds() * 1000)
+    if age_ms > max_stale_ms:
+        hours = max_stale_ms / 3_600_000
+        _die(
+            f"ai-ready.json looks stale ({age_ms / 3_600_000:.1f}h old, max {hours:.1f}h): {ai.path}"
+        )
+
+
+def _run(cmd: list[str], cwd: Path, env: Optional[dict[str, str]] = None) -> None:
+    result = subprocess.run(cmd, cwd=str(cwd), env=env, text=True)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def _run_extract(extractor_dir: Path) -> None:
+    auth_path = _auth_file(extractor_dir)
+    if not auth_path.is_file():
+        _die(
+            f"Missing auth file: {auth_path}. Run `npm run auth` in the extractor repo first."
+        )
+    print(f"[real-sports] Running extraction in {extractor_dir}")
+    _run(["npm", "run", "extract"], cwd=extractor_dir)
+
+
+def _hermes_prompt(extractor_dir: Path, ai: AiReady, toolsets: str) -> str:
+    return (
+        "You are Hermes orchestrating the Real Sports delivery workflow. "
+        "The extractor repo is the source of truth; do not modify it. "
+        f"Read the delivery input from `{ai.path}` and generate the final delivery-ready picks output. "
+        "Use the file tool to inspect the JSON, summarize only what is present, and do not invent picks. "
+        "If the send_message tool is available in this session, post the final result to the configured Discord target. "
+        "If the messaging tool is unavailable or posting fails, explain exactly what is missing. "
+        f"Extractor repo: `{extractor_dir}`. "
+        f"Available toolsets requested for this run: `{toolsets}`."
+    )
+
+
+def _invoke_hermes(args: argparse.Namespace, extractor_dir: Path, ai: AiReady) -> None:
+    hermes_bin = args.hermes_bin or os.getenv("HERMES_BIN", "hermes")
+    toolsets = args.toolsets or os.getenv("REALSPORTS_TOOLSETS", DEFAULT_TOOLSETS)
+    prompt = _hermes_prompt(extractor_dir, ai, toolsets)
+    cmd = [hermes_bin, "chat", "-t", toolsets]
+    if args.model:
+        cmd.extend(["-m", args.model])
+    if args.provider:
+        cmd.extend(["--provider", args.provider])
+    cmd.extend(["-q", prompt])
+
+    print("[real-sports] Invoking Hermes delivery session:")
+    print("[real-sports] ", " ".join(cmd[:4]), "...", sep="")
+    _run(cmd, cwd=_repo_root())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Hermes-side orchestration for the Real Sports extractor")
+    parser.add_argument("--extractor-dir", help="Path to the real-extractor checkout")
+    parser.add_argument("--date", help="Target date folder under data/normalized/YYYY-MM-DD")
+    parser.add_argument("--skip-extract", action="store_true", help="Reuse existing ai-ready.json")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and print the Hermes command without running it")
+    parser.add_argument("--max-stale-ms", type=int, default=DEFAULT_STALE_MS, help="Maximum allowed age for ai-ready.json")
+    parser.add_argument("--hermes-bin", help="Hermes executable name or path (default: hermes)")
+    parser.add_argument("--toolsets", help=f"Hermes toolsets to request (default: {DEFAULT_TOOLSETS})")
+    parser.add_argument("--model", help="Optional Hermes model override")
+    parser.add_argument("--provider", help="Optional Hermes provider override")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    extractor_dir = _extractor_dir_from_args(args)
+
+    if not args.skip_extract:
+        _run_extract(extractor_dir)
+
+    ai = _latest_ai_ready(extractor_dir, args.date)
+    _validate_ai_ready(ai, args.date, args.max_stale_ms)
+
+    if args.dry_run:
+        toolsets = args.toolsets or os.getenv("REALSPORTS_TOOLSETS", DEFAULT_TOOLSETS)
+        print("[real-sports] Dry run OK")
+        print(f"[real-sports] ai-ready: {ai.path}")
+        print("[real-sports] Hermes prompt:")
+        print(_hermes_prompt(extractor_dir, ai, toolsets))
+        return
+
+    _invoke_hermes(args, extractor_dir, ai)
+
+
+if __name__ == "__main__":
+    main()

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -242,6 +242,7 @@ Skills for document creation, presentations, spreadsheets, and other productivit
 | `linear` | Manage Linear issues, projects, and teams via the GraphQL API. Create, update, search, and organize issues. | `productivity/linear` |
 | `nano-pdf` | Edit PDFs with natural-language instructions using the nano-pdf CLI. Modify text, fix typos, update titles, and make content changes to specific pages without manual editing. | `productivity/nano-pdf` |
 | `notion` | Notion API for creating and managing pages, databases, and blocks via curl. Search, create, update, and query Notion workspaces directly from the terminal. | `productivity/notion` |
+| `real-sports-delivery` | Orchestrate the Real Sports extractor with Hermes: run extraction, validate ai-ready.json freshness, hand off delivery to Hermes, and post the result to Discord. Treats the extractor repo as the source of truth. | `productivity/real-sports-delivery` |
 | `ocr-and-documents` | Extract text from PDFs and scanned documents. Use web_extract for remote URLs, pymupdf for local text-based PDFs, marker-pdf for OCR/scanned docs. For DOCX use python-docx, for PPTX see the powerpoint skill. | `productivity/ocr-and-documents` |
 | `powerpoint` | "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in a… | `productivity/powerpoint` |
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -86,6 +86,19 @@ cronjob(
 
 This is useful when you want a scheduled agent to inherit reusable workflows without stuffing the full skill text into the cron prompt itself.
 
+A good real-world example is the Real Sports delivery workflow:
+
+```python
+cronjob(
+    action="create",
+    skills=["real-sports-delivery"],
+    prompt="Run the Real Sports delivery workflow from the configured extractor checkout.",
+    schedule="0 8 * * *",
+    name="Real Sports picks",
+    deliver="discord",
+)
+```
+
 ## Editing jobs
 
 You do not need to delete and recreate jobs just to change them.


### PR DESCRIPTION
## Summary\n- Add a Hermes-side Real Sports orchestration skill\n- Include a helper script that can validate ai-ready.json and hand off delivery to Hermes\n- Document the extractor-as-source-of-truth workflow\n- Add a cron example using the new skill\n\n## Validation\n- python3 -m py_compile skills/productivity/real-sports-delivery/scripts/run_real_sports_delivery.py\n- Dry-run the helper against the sample extractor artifact\n\n## Notes\nThis keeps the extractor repo focused on scraping/normalization while Hermes owns delivery orchestration and future automation.