### PR TITLE
fix: deduplicate reasoning items in Responses API input

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3105,6 +3105,7 @@ class AIAgent:
     def _chat_messages_to_responses_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert internal chat-style messages to Responses input items."""
         items: List[Dict[str, Any]] = []
+        seen_item_ids: set = set()
 
         for msg in messages:
             if not isinstance(msg, dict):
@@ -3125,7 +3126,12 @@ class AIAgent:
                     if isinstance(codex_reasoning, list):
                         for ri in codex_reasoning:
                             if isinstance(ri, dict) and ri.get("encrypted_content"):
+                                item_id = ri.get("id")
+                                if item_id and item_id in seen_item_ids:
+                                    continue
                                 items.append(ri)
+                                if item_id:
+                                    seen_item_ids.add(item_id)
                                 has_codex_reasoning = True
 
                     if content_text.strip():
@@ -3205,6 +3211,7 @@ class AIAgent:
             raise ValueError("Codex Responses input must be a list of input items.")
 
         normalized: List[Dict[str, Any]] = []
+        seen_ids: set = set()
         for idx, item in enumerate(raw_items):
             if not isinstance(item, dict):
                 raise ValueError(f"Codex Responses input[{idx}] must be an object.")
@@ -3257,8 +3264,12 @@ class AIAgent:
             if item_type == "reasoning":
                 encrypted = item.get("encrypted_content")
                 if isinstance(encrypted, str) and encrypted:
-                    reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
                     item_id = item.get("id")
+                    if isinstance(item_id, str) and item_id:
+                        if item_id in seen_ids:
+                            continue
+                        seen_ids.add(item_id)
+                    reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
                     if isinstance(item_id, str) and item_id:
                         reasoning_item["id"] = item_id
                     summary = item.get("summary")


### PR DESCRIPTION
## Summary
- Reasoning items (`rs_*` IDs) from `codex_reasoning_items` were replayed without deduplication in `_chat_messages_to_responses_input()`, causing HTTP 400 "Duplicate item found" errors from the OpenAI Responses API in multi-turn conversations
- Added `seen_item_ids` / `seen_ids` tracking in both `_chat_messages_to_responses_input()` and `_preflight_codex_input_items()` to skip already-added reasoning items by their ID

## Root Cause
When a conversation spans multiple turns with `finish_reason="incomplete"`, the same reasoning item ID can appear in multiple historical messages' `codex_reasoning_items`. The conversion function iterated all messages and appended these items without checking for duplicates, resulting in:
```
Duplicate item found with id rs_0ab337766a203f600169da493cd324819ba05d09435f047288.
Remove duplicate items from your input and try again.
```

## Changes
- `_chat_messages_to_responses_input()` (L3105): track `seen_item_ids` set, skip reasoning items whose ID was already added
- `_preflight_codex_input_items()` (L3209): defensive dedup in the preflight validation layer as a second safety net

## Test plan
- [ ] Verify multi-turn conversations with codex reasoning no longer produce HTTP 400 duplicate item errors
- [ ] Verify reasoning chains remain coherent after dedup (first occurrence is kept, subsequent duplicates skipped)
- [ ] Verify single-turn conversations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)