### PR TITLE
fix(gateway): use source.thread_id instead of undefined event in queued response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8131,7 +8131,7 @@ class GatewayRunner:
                     if first_response and not _already_streamed:
                         try:
                             await adapter.send(source.chat_id, first_response,
-                                               metadata=getattr(event, "metadata", None))
+                                               metadata={"thread_id": source.thread_id} if source.thread_id else None)
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                 # else: interrupted — discard the interrupted response ("Operation


### PR DESCRIPTION
## Summary

Salvage of PR #7926 by @willy-scr — cherry-picked onto current main.

Fixes a `NameError` in `_run_agent()` where `event` is referenced but doesn't exist in that scope. The line tries `getattr(event, "metadata", None)` but `_run_agent`'s parameters are `(self, message, context_prompt, history, source, session_id, session_key, _interrupt_depth, event_message_id)` — no `event`.

This crashes the pending message queue when the agent sends a first response before processing a queued follow-up, breaking multi-image handling and queued follow-ups in Telegram threads.

## Fix

Replaced with the established pattern already used at 5 other sites in gateway/run.py:
```python
metadata={"thread_id": source.thread_id} if source.thread_id else None
```

## Changes
- 1 file changed, 1 insertion, 1 deletion
- Contributor authorship preserved via cherry-pick

## Test plan
- Gateway test suite: 2478 passed (23 pre-existing failures, identical on main)