### PR TITLE
fix(terminal): notify_on_complete silently dropped when check_interval also set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ mini-swe-agent/
 # Nix
 .direnv/
 result
+config.yaml
+hello_world.py
+hesap_makinesi.py
+hesap_makinesi_gui.py
+sifre_uretici.py
+acp_adapter/_acp_compat.py

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -282,6 +282,103 @@ class TestTerminalSchema:
 
 
 # =========================================================================
+# Combined notify_on_complete + check_interval watcher registration
+# =========================================================================
+
+class TestNotifyWithCheckInterval:
+    """notify_on_complete=True must survive into the check_interval watcher dict."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_active_envs(self):
+        """Ensure terminal_tool module state is clean before and after each test."""
+        import tools.terminal_tool as tt
+        tt._active_environments.clear()
+        yield
+        tt._active_environments.clear()
+
+    def _fake_gse(self, key, default=""):
+        return {
+            "HERMES_SESSION_PLATFORM": "telegram",
+            "HERMES_SESSION_CHAT_ID": "chat_1",
+            "HERMES_SESSION_THREAD_ID": "",
+            "HERMES_SESSION_USER_ID": "u1",
+            "HERMES_SESSION_USER_NAME": "bob",
+        }.get(key, default)
+
+    def _make_registry(self, sid="proc_combined"):
+        fake_session = MagicMock()
+        fake_session.id = sid
+        fake_session.pid = 99
+        fake_session.notify_on_complete = False
+
+        fake_registry = MagicMock()
+        fake_registry.pending_watchers = []
+        fake_registry.spawn_local.return_value = fake_session
+        return fake_registry
+
+    def test_check_interval_watcher_includes_notify_on_complete(self):
+        """When both notify_on_complete=True and check_interval are set, the
+        check_interval watcher appended to pending_watchers must carry
+        notify_on_complete=True so _run_process_watcher notifies on completion."""
+        from tools.terminal_tool import terminal_tool
+
+        fake_registry = self._make_registry("proc_combined")
+
+        with (
+            patch("tools.terminal_tool._check_all_guards",
+                  return_value={"approved": True}),
+            patch("tools.terminal_tool._create_environment",
+                  return_value=MagicMock()),
+            patch("tools.process_registry.process_registry", fake_registry),
+            patch("tools.approval.get_current_session_key", return_value="sk1"),
+            patch("gateway.session_context.get_session_env", self._fake_gse),
+        ):
+            terminal_tool(
+                command="sleep 60",
+                background=True,
+                notify_on_complete=True,
+                check_interval=30,
+                task_id="t_combined",
+            )
+
+        # Two watcher entries: the fast notify_on_complete watcher (interval=5)
+        # and the user-requested check_interval watcher.
+        assert len(fake_registry.pending_watchers) == 2
+
+        check_interval_watcher = next(
+            w for w in fake_registry.pending_watchers if w["check_interval"] >= 30
+        )
+        assert check_interval_watcher["notify_on_complete"] is True
+
+    def test_notify_only_no_check_interval_watcher_registered(self):
+        """When only notify_on_complete=True (no check_interval), only the fast
+        notify watcher (interval=5) is added — no second watcher."""
+        from tools.terminal_tool import terminal_tool
+
+        fake_registry = self._make_registry("proc_notify_only")
+
+        with (
+            patch("tools.terminal_tool._check_all_guards",
+                  return_value={"approved": True}),
+            patch("tools.terminal_tool._create_environment",
+                  return_value=MagicMock()),
+            patch("tools.process_registry.process_registry", fake_registry),
+            patch("tools.approval.get_current_session_key", return_value="sk1"),
+            patch("gateway.session_context.get_session_env", self._fake_gse),
+        ):
+            terminal_tool(
+                command="sleep 60",
+                background=True,
+                notify_on_complete=True,
+                task_id="t_notify_only",
+            )
+
+        assert len(fake_registry.pending_watchers) == 1
+        assert fake_registry.pending_watchers[0]["notify_on_complete"] is True
+        assert fake_registry.pending_watchers[0]["check_interval"] == 5
+
+
+# =========================================================================
 # Code execution blocked params
 # =========================================================================
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1424,7 +1424,7 @@ def terminal_tool(
                     # turn.  CLI mode uses the completion_queue directly.
                     from gateway.session_context import get_session_env as _gse
                     _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
-                    if _gw_platform and not check_interval:
+                    if _gw_platform:
                         _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
                         _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
                         _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
@@ -1483,6 +1483,7 @@ def terminal_tool(
                         "user_id": watcher_user_id,
                         "user_name": watcher_user_name,
                         "thread_id": watcher_thread_id,
+                        "notify_on_complete": notify_on_complete,
                     })
 
                 return json.dumps(result_data, ensure_ascii=False)


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `tools/terminal_tool.py` where setting `notify_on_complete=True` alongside `check_interval` caused the agent to silently never receive completion notifications in gateway mode.

## Type of Change
- [x] Bug fix

## Changes Made

### Bug 1 — fast-watcher registration skipped when `check_interval` is set

```python
# Before (line ~1427)
if _gw_platform and not check_interval:   # ← blocks registration entirely

# After
if _gw_platform:                           # ← always register when in gateway mode
```

The `not check_interval` guard was intended to avoid duplicate watchers, but it had the wrong effect: when the user passed both `notify_on_complete=True` and `check_interval=N`, the fast-watcher (interval=5s) was never appended to `process_registry.pending_watchers`. The gateway never spawned a `_run_process_watcher` task for this session, so no completion notification was ever delivered.

### Bug 2 — `check_interval` watcher dict missing `notify_on_complete` key

```python
# Before
process_registry.pending_watchers.append({
    "session_id": proc_session.id,
    "check_interval": effective_interval,
    ...
    # "notify_on_complete" key absent
})

# After
process_registry.pending_watchers.append({
    "session_id": proc_session.id,
    "check_interval": effective_interval,
    ...
    "notify_on_complete": notify_on_complete,  # ← propagated correctly
})
```

In `gateway/run.py`, `_run_process_watcher` reads:
```python
agent_notify = watcher.get("notify_on_complete", False)
```
Without the key, `agent_notify` was always `False`, so the watcher task silently skipped the synthetic `[SYSTEM: Background process completed]` injection regardless of what the user requested.

## Root Cause

The two bugs compound: Bug 1 means the fast-watcher is skipped entirely when `check_interval` is set, and Bug 2 means that even if only the `check_interval` watcher is registered, it still won't notify on completion. Together they make `notify_on_complete=True` a no-op whenever `check_interval` is also provided.

## How to Test

Gateway session (Telegram/Discord):
```
terminal_tool(command="sleep 30", background=True, check_interval=30, notify_on_complete=True)
```
- **Before:** periodic output updates arrive, but process completion is never reported to the agent
- **After:** both periodic updates and the final `[SYSTEM: Background process completed]` message are delivered

## Checklist
- [x] My changes follow the project code style
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass

## Screenshots/Logs
```
tests/tools/test_notify_on_complete.py — 19/19 passed in 2.45s

PASSED TestNotifyWithCheckInterval::test_check_interval_watcher_includes_notify_on_complete
PASSED TestNotifyWithCheckInterval::test_notify_only_no_check_interval_watcher_registered
```