### PR TITLE
fix(gateway): pass reply_to to streaming messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7401,6 +7401,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=event_message_id,
                         )
                         _stream_delta_cb = _stream_consumer.on_delta
                         stream_consumer_holder[0] = _stream_consumer

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -66,11 +66,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self._reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -499,6 +501,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self._reply_to,
                     metadata=self.metadata,
                 )
                 if result.success and result.message_id:


### PR DESCRIPTION
## Summary

When using streaming mode, the GatewayStreamConsumer was not passing the original message ID to the platform adapter's send() method. This caused the reply_to_mode configuration (off/first/all) to have no effect on streaming responses.

## Changes

- Add `reply_to` parameter to `GatewayStreamConsumer.__init__`
- Pass `reply_to` when sending the first streaming message
- Pass `event_message_id` from `gateway/run.py` when creating the consumer

## Testing

- All 25 tests in `tests/gateway/test_stream_consumer.py` pass
- Manual testing confirmed streaming messages now correctly reply to the original message based on `reply_to_mode` setting

Fixes #7934