### PR TITLE
fix(cron): pass skip_context_files=True to AIAgent in run_job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -722,6 +722,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             provider_sort=pr.get("sort"),
             disabled_toolsets=["cronjob", "messaging", "clarify"],
             quiet_mode=True,
+            skip_context_files=True,  # Don't inject SOUL.md/AGENTS.md from scheduler cwd
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",
             session_id=_cron_session_id,


### PR DESCRIPTION
## Summary

Cron jobs were missing `skip_context_files=True` when constructing the AIAgent in `run_job()`. This meant the cron agent would auto-inject AGENTS.md, SOUL.md, or .cursorrules from the scheduler's working directory (typically the hermes-agent install dir) into the system prompt — wasting tokens and potentially confusing the agent with irrelevant project-specific instructions.

`batch_runner.py` and `gateway/builtin_hooks/boot_md.py` already pass this flag for the same reason. This aligns cron with the established pattern for autonomous/headless agent runs.

## Changes

- `cron/scheduler.py`: Added `skip_context_files=True` to the AIAgent constructor in `run_job()`

## Test plan

- `python -m pytest tests/cron/ -o 'addopts=' -q` — 168 passed, 4 skipped