### PR TITLE
fix(gateway): KV cache flush on session reset for llama-server

### DIFF
--- a/gateway/llamacpp_slots.py
+++ b/gateway/llamacpp_slots.py
@@ -1,0 +1,71 @@
+"""llama-server KV-cache slot erasure for session reset."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def erase_all_slots(base_url: str) -> bool:
+    """Erase KV-cache slots on llama-server to prevent context bleed.
+    
+    Probes GET /slots to detect llama-server capability, then erases all
+    slots to ensure clean session state after /new or /reset command.
+    
+    Args:
+        base_url: Base URL of the LLM server (e.g., http://localhost:8080)
+        
+    Returns:
+        True if llama-server detected and erasure attempted, False otherwise
+    """
+    import httpx
+    
+    # Normalize base_url - remove trailing slash for consistent API calls
+    base = base_url.rstrip("/")
+    
+    try:
+        # Probe for llama-server capability via GET /slots
+        # This endpoint is unique to llama-server and not present in other backends
+        slots_response = httpx.get(f"{base}/slots", timeout=2.0)
+        
+        # If 404 or 501, this is not llama-server - skip erasure
+        if slots_response.status_code in (404, 501):
+            logger.debug("llama-server not detected at %s (status %d), skipping slot erasure", 
+                        base_url, slots_response.status_code)
+            return False
+        
+        # Parse slots response
+        slots_data = slots_response.json()
+        if not isinstance(slots_data, list):
+            logger.debug("Unexpected /slots response format: %s", slots_data)
+            return False
+        
+        # Erase ALL slots to prevent cross-slot context bleed
+        # This is critical for --parallel N deployments where multiple slots exist
+        for slot_info in slots_data:
+            slot_id = slot_info.get("id")
+            if slot_id is None:
+                continue
+            
+            try:
+                erase_response = httpx.post(
+                    f"{base}/slots/{slot_id}?action=erase",
+                    timeout=2.0
+                )
+                if erase_response.status_code != 200:
+                    logger.debug("Failed to erase slot %d (status %d)", 
+                                slot_id, erase_response.status_code)
+            except httpx.HTTPError as e:
+                logger.debug("Failed to erase slot %d: %s", slot_id, e)
+        
+        logger.debug("Successfully erased %d slots on llama-server", len(slots_data))
+        return True
+        
+    except httpx.HTTPError as e:
+        # Network error or timeout - assume not llama-server
+        logger.debug("Failed to probe llama-server at %s: %s", base_url, e)
+        return False
+    except Exception as e:
+        # Any other error - assume not llama-server
+        logger.debug("Unexpected error probing llama-server: %s", e)
+        return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3786,6 +3786,16 @@ class GatewayRunner:
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 
+        # Flush llama-server KV-cache to prevent context bleed
+        try:
+            from gateway.llamacpp_slots import erase_all_slots
+            runtime = _resolve_runtime_agent_kwargs()
+            base_url = runtime.get("base_url")
+            if base_url:
+                erase_all_slots(base_url)
+        except Exception as e:
+            logger.debug("KV-cache flush failed: %s", e)
+
         # Clear any session-scoped model override so the next agent picks up
         # the configured default instead of the previously switched model.
         self._session_model_overrides.pop(session_key, None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5965,6 +5965,15 @@ class AIAgent:
         if self._is_qwen_portal():
             extra_body["vl_high_resolution_images"] = True
 
+        # Detect first turn - add cache_prompt: false as universal fallback
+        # This prevents KV-cache context bleed on llama-server when slot erasure fails
+        _turn_count = sum(1 for msg in api_messages if msg.get("role") == "user")
+        if _turn_count == 1 and "cache_prompt" not in (extra_body or {}):
+            if extra_body is None:
+                extra_body = {"cache_prompt": False}
+            else:
+                extra_body["cache_prompt"] = False
+
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 


### PR DESCRIPTION
## What Changed and Why
This fix addresses a gap in session reset behavior when using llama-server as the LLM backend. Previously, when `/new` or `/reset` was issued, the llama-server's KV-cache was not flushed, causing context bleed across sessions.
### The Problem
- llama-server maintains per-slot KV-caches for prompt caching
- Session rotation in Hermes only cleared the conversation history, not the server-side cache
- This caused the model to "remember" previous sessions, leading to hallucinated context
### The Solution
Three-layer fix to ensure complete session isolation:
1. **New module `gateway/llamacpp_slots.py`** - Probes llama-server for slot capability and erases all slots
   - Uses capability-based detection (GET /slots probe) rather than IP-based detection
   - Cloud providers and other LLM backends are unaffected (they return 404 on GET /slots)
2. **Modified `gateway/run.py`** - Calls `erase_all_slots()` after session rotation
   - Ensures server-side cache is cleared when `/new` or `/reset` is issued
3. **Modified `run_agent.py`** - Sends `cache_prompt=false` on first turn of new session
   - Prevents the first message from being cached in a fresh session
## How to Test
### Reproduction Steps for the Bug
1. Start Hermes with llama-server backend (local or remote)
2. Have a conversation about a specific topic (e.g., "explain quantum physics")
3. Issue `/new` or `/reset` command
4. Start a new conversation on a different topic
5. **Before fix:** Model may reference quantum physics or previous context
6. **After fix:** Model has no memory of previous session
### Verification
```bash
# Test that the module imports correctly
python -c "from gateway.llamacpp_slots import erase_all_slots; print('OK')"
# Test with llama-server
Start hermes
Say to Hermes: "Remember this: test value 123"
Run command: "/new"
Say to Hermes:  "What was the test value?"  # Should not know
Related Issues
This fix addresses the session isolation gap for llama-server backends. The capability-based detection ensures compatibility with:
- Local llama-server instances
- Remote llama.cpp deployments
- Cloud providers (Anthropic, OpenAI, OpenRouter) - unaffected, return 404 on GET /slots
---
Technical Details:
- Branch: fix/kv-cache-flush-on-session-reset
- Files changed: 3 (90 insertions)
- No breaking changes - backward compatible with all LLM backends