### PR TITLE
docs: add Docker-to-host local LLM connection guide

### DIFF
--- a/website/docs/guides/local-llm-on-mac.md
+++ b/website/docs/guides/local-llm-on-mac.md
@@ -222,7 +222,7 @@ Select **Custom endpoint** and follow the prompts. It will ask for the base URL 
 
 ## Timeouts
 
-Hermes automatically detects local endpoints (localhost, LAN IPs) and relaxes its streaming timeouts. No configuration needed for most setups.
+Hermes automatically detects local endpoints (localhost, LAN IPs, and container-to-host DNS names like `host.docker.internal`, `host.containers.internal`, and `host.lima.internal`) and relaxes its streaming timeouts. No configuration needed for most setups — including when Hermes runs inside Docker and connects to a host-side LLM server.
 
 If you still hit timeout errors (e.g. very large contexts on slow hardware), you can override the streaming read timeout:
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -111,6 +111,30 @@ services:
 
 Start with `docker compose up -d` and view logs with `docker compose logs -f hermes`.
 
+## Connecting to local LLMs on the host
+
+If you run a local LLM server (Ollama, llama.cpp, omlx, vLLM) on the host machine while Hermes runs inside a container, use the special DNS name that resolves to the host:
+
+| Runtime | Host DNS name |
+|---------|---------------|
+| Docker Desktop (macOS / Windows) | `host.docker.internal` |
+| Docker with `--network=host` (Linux) | `localhost` (network is shared) |
+| Podman | `host.containers.internal` |
+| Lima / Colima (macOS) | `host.lima.internal` |
+
+Configure the endpoint via `hermes model` → **Custom endpoint**:
+
+```sh
+docker run -it --rm \
+  -v ~/.hermes:/opt/data \
+  nousresearch/hermes-agent model
+# When prompted for the base URL, enter:
+#   http://host.docker.internal:8080/v1   (llama.cpp default)
+#   http://host.docker.internal:11434/v1  (Ollama default)
+```
+
+Hermes auto-detects all of these hostnames as local endpoints and relaxes streaming timeouts accordingly — no manual timeout configuration needed. See the [Run Local LLMs on Mac](/docs/guides/local-llm-on-mac#timeouts) guide for timeout details.
+
 ## Resource limits
 
 The Hermes container needs moderate resources. Recommended minimums:


### PR DESCRIPTION
## Summary

Documents behavior added in #7950 (`is_local_endpoint` Docker/Podman/Lima DNS support) that was missing from user-facing docs.

**docker.md** — new section "Connecting to local LLMs on the host":
- Hostname table for Docker Desktop, Podman, Lima/Colima, and `--network=host`
- Config example (`hermes model` with `host.docker.internal` URL)
- Notes that Hermes auto-detects these as local endpoints (relaxed timeouts)

**local-llm-on-mac.md** — updated Timeouts auto-detection description to mention container-to-host DNS names (`host.docker.internal`, `host.containers.internal`, `host.lima.internal`).

Fixes #7963

## Why

Users running Hermes inside Docker with a local LLM on the host (Ollama, llama.cpp, omlx, vLLM) have no docs guidance on which hostname to use or that auto-detection works. `localhost` from inside Docker points to the container, not the host — this is a common gotcha that the new section addresses directly.