### PR TITLE
fix(cli): add ChatConsole.status compatibility for /skills search

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1355,6 +1355,19 @@ class ChatConsole:
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 
+    @contextmanager
+    def status(self, *_args, **_kwargs):
+        """Provide a no-op Rich-compatible status context.
+
+        Some slash command helpers use ``console.status(...)`` when running in
+        the standalone CLI. Interactive chat routes those helpers through
+        ``ChatConsole()``, which historically only implemented ``print()``.
+        Returning a silent context manager keeps slash commands compatible
+        without duplicating the higher-level busy indicator already shown by
+        ``HermesCLI._busy_command()``.
+        """
+        yield self
+
 # ASCII Art - HERMES-AGENT logo (full width, single line - requires ~95 char terminal)
 HERMES_AGENT_LOGO = """[bold #FFD700]██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗       █████╗  ██████╗ ███████╗███╗   ██╗████████╗[/]
 [bold #FFD700]██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝      ██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝[/]

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,8 +1,10 @@
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 from rich.console import Console
 
+from cli import ChatConsole
 from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
 
 
@@ -177,6 +179,21 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():
+    results = [type("R", (), {
+        "name": "kubernetes",
+        "description": "Cluster orchestration",
+        "source": "skills.sh",
+        "trust_level": "community",
+        "identifier": "skills-sh/example/kubernetes",
+    })()]
+
+    with patch("tools.skills_hub.unified_search", return_value=results), \
+         patch("tools.skills_hub.create_source_router", return_value={}), \
+         patch("tools.skills_hub.GitHubAuth"):
+        handle_skills_slash("/skills search kubernetes", console=ChatConsole())
 
 
 def test_do_install_scans_with_resolved_identifier(monkeypatch, tmp_path, hub_env):


### PR DESCRIPTION
## Summary

Salvage of #7888 by @ktutumi. Cherry-picked onto current main.

Fixes a crash when using `/skills search <query>` in the interactive CLI:
```
Error: 'ChatConsole' object has no attribute 'status'
```

`hermes_cli/skills_hub.py` uses `console.status(...)` (introduced in #7301), but the interactive CLI passes `ChatConsole` which only implemented `print()`.

## Changes

- Add `ChatConsole.status()` as a no-op `@contextmanager` (silent because `_busy_command()` already shows progress)
- Add regression test exercising the `/skills search` path with `ChatConsole`

## Test plan

```
python -m pytest tests/hermes_cli/test_skills_hub.py -q  # 10 passed
```

Credit: @ktutumi (original author, commit preserved)