### PR TITLE
feat(cli): add /editor compose command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5124,6 +5124,8 @@ class HermesCLI:
                     _cprint(f"  Queued for the next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
                 else:
                     _cprint(f"  Queued: {payload[:80]}{'...' if len(payload) > 80 else ''}")
+        elif canonical == "editor":
+            self._handle_editor_command(cmd_original)
         elif canonical == "skin":
             self._handle_skin_command(cmd_original)
         elif canonical == "voice":
@@ -5258,6 +5260,63 @@ class HermesCLI:
             self._pending_input.put(msg)
         else:
             ChatConsole().print("[bold red]Plan mode unavailable: input queue not initialized[/]")
+
+    def _handle_editor_command(self, cmd: str):
+        """Handle /editor — compose a message in the user's external editor."""
+        import shlex
+        import subprocess
+
+        editor = os.getenv("EDITOR") or os.getenv("VISUAL")
+        if not editor:
+            for candidate in ("nano", "vim", "vi", "code", "notepad"):
+                if shutil.which(candidate):
+                    editor = candidate
+                    break
+
+        if not editor:
+            _cprint("  No editor found. Set $EDITOR or $VISUAL first.")
+            return
+
+        if not hasattr(self, "_pending_input"):
+            _cprint("  Editor unavailable: input queue not initialized.")
+            return
+
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                suffix=".md",
+                prefix="hermes-editor-",
+                delete=False,
+            ) as handle:
+                temp_path = Path(handle.name)
+
+            argv = shlex.split(editor, posix=os.name != "nt")
+            if not argv:
+                _cprint("  Editor command is empty. Set $EDITOR or $VISUAL first.")
+                return
+
+            _cprint(f"  Opening {editor}... Save and close to send, leave empty to cancel.")
+            subprocess.call([*argv, str(temp_path)])
+
+            content = temp_path.read_text(encoding="utf-8")
+            if not content.strip():
+                _cprint("  Editor closed without content.")
+                return
+
+            self._pending_input.put(content)
+            _cprint(f"  Queued {len(content)} characters from editor.")
+        except FileNotFoundError:
+            _cprint(f"  Editor not found: {editor}")
+        except Exception as exc:
+            _cprint(f"  Editor command failed: {exc}")
+        finally:
+            if temp_path is not None:
+                try:
+                    temp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
     
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -83,6 +83,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<question>"),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
                aliases=("q",), args_hint="<prompt>"),
+    CommandDef("editor", "Compose a message in your external editor", "Session",
+               aliases=("edit",)),
     CommandDef("status", "Show session info", "Session"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/tests/cli/test_cli_editor_command.py
+++ b/tests/cli/test_cli_editor_command.py
@@ -1,0 +1,88 @@
+"""Regression tests for the /editor CLI command."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    queued = []
+
+    class _Queue:
+        def put(self, value):
+            queued.append(value)
+
+    cli_obj._pending_input = _Queue()
+    return cli_obj, queued
+
+
+def test_process_command_editor_dispatches_to_handler():
+    cli_obj, _ = _make_cli()
+
+    with patch.object(cli_obj, "_handle_editor_command", create=True) as mock_handler:
+        assert cli_obj.process_command("/editor") is True
+
+    mock_handler.assert_called_once_with("/editor")
+
+
+def test_process_command_edit_alias_dispatches_to_handler():
+    cli_obj, _ = _make_cli()
+
+    with patch.object(cli_obj, "_handle_editor_command", create=True) as mock_handler:
+        assert cli_obj.process_command("/edit") is True
+
+    mock_handler.assert_called_once_with("/edit")
+
+
+def test_handle_editor_command_queues_editor_contents(monkeypatch):
+    cli_obj, queued = _make_cli()
+    captured = {}
+
+    monkeypatch.setenv("EDITOR", "code --wait")
+
+    def fake_call(argv):
+        captured["argv"] = argv
+        path = Path(argv[-1])
+        path.write_text("Draft from editor\n", encoding="utf-8")
+        return 0
+
+    with patch("subprocess.call", side_effect=fake_call), \
+         patch("cli._cprint"):
+        cli_obj._handle_editor_command("/editor")
+
+    assert queued == ["Draft from editor\n"]
+    assert captured["argv"][:2] == ["code", "--wait"]
+    assert captured["argv"][-1].endswith(".md")
+
+
+def test_handle_editor_command_skips_empty_content(monkeypatch):
+    cli_obj, queued = _make_cli()
+
+    monkeypatch.setenv("EDITOR", "vim")
+
+    def fake_call(argv):
+        Path(argv[-1]).write_text(" \n", encoding="utf-8")
+        return 0
+
+    with patch("subprocess.call", side_effect=fake_call), \
+         patch("cli._cprint") as mock_print:
+        cli_obj._handle_editor_command("/editor")
+
+    assert queued == []
+    assert any("without content" in str(call.args[0]) for call in mock_print.call_args_list)
+
+
+def test_handle_editor_command_reports_missing_editor(monkeypatch):
+    cli_obj, queued = _make_cli()
+
+    monkeypatch.delenv("EDITOR", raising=False)
+    monkeypatch.delenv("VISUAL", raising=False)
+
+    with patch("shutil.which", return_value=None), \
+         patch("cli._cprint") as mock_print:
+        cli_obj._handle_editor_command("/editor")
+
+    assert queued == []
+    assert any("No editor found" in str(call.args[0]) for call in mock_print.call_args_list)

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -96,6 +96,7 @@ class TestResolveCommand:
 
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
+        assert resolve_command("edit").name == "editor"
         assert resolve_command("reset").name == "new"
         assert resolve_command("q").name == "quit"
         assert resolve_command("exit").name == "quit"
@@ -132,6 +133,7 @@ class TestDerivedDicts:
 
     def test_commands_dict_includes_aliases(self):
         assert "/bg" in COMMANDS
+        assert "/edit" in COMMANDS
         assert "/reset" in COMMANDS
         assert "/q" in COMMANDS
         assert "/exit" in COMMANDS


### PR DESCRIPTION
Summary
Adds an explicit /editor command with /edit alias so long prompts can be composed in the user's external editor and then queued back into the normal CLI input path.

This is a fresh rebased pass on the command-oriented approach from issue #7262.

Changes
- register /editor with /edit alias in the central command registry
- dispatch /editor through HermesCLI.process_command()
- add _handle_editor_command() to resolve the editor from EDITOR/VISUAL with local fallbacks, open a temp file via subprocess.call(), read the saved content back, and queue it through _pending_input
- treat empty editor output as cancel
- add regression tests for dispatch, alias resolution, editor argv handling, content queueing, and missing-editor behavior

Test plan
- venv/bin/python -m pytest tests/cli/test_cli_editor_command.py -o addopts='' -q
- venv/bin/python -m pytest tests/hermes_cli/test_commands.py -o addopts='' -q

Closes #7262