### PR TITLE
fix(delegate): allow delegation to local endpoints without API key

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -855,12 +855,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         api_key = (
             configured_api_key
             or os.getenv("OPENAI_API_KEY", "").strip()
+            or "no-key-required"  # local servers (Ollama, vLLM, llama.cpp) don't need keys
         )
-        if not api_key:
-            raise ValueError(
-                "Delegation base_url is configured but no API key was found. "
-                "Set delegation.api_key or OPENAI_API_KEY."
-            )
 
         base_lower = configured_base_url.lower()
         provider = "custom"


### PR DESCRIPTION
Local servers (Ollama, vLLM, llama.cpp) don't require API keys. The main model resolution handles this with `"no-key-required"` (`runtime_provider.py:348`), but delegation hard-fails with `ValueError` when `delegation.api_key` is null and no `OPENAI_API_KEY` is set. Applies the same fallback so users can delegate to local endpoints without setting a dummy key. 1 insertion, 5 deletions.