### PR TITLE
feat: standardize message whitespace and JSON formatting

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3190,7 +3190,7 @@ class AIAgent:
         if platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
-        return "\n\n".join(prompt_parts)
+        return "\n\n".join(p.strip() for p in prompt_parts if p.strip())
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -7975,6 +7975,36 @@ class AIAgent:
             # gated on context_compressor — so orphans from session loading or
             # manual message manipulation are always caught.
             api_messages = self._sanitize_api_messages(api_messages)
+
+            # Normalize message whitespace and tool-call JSON for consistent
+            # prefix matching.  Ensures bit-perfect prefixes across turns,
+            # which enables KV cache reuse on local inference servers
+            # (llama.cpp, vLLM, Ollama) and improves cache hit rates for
+            # cloud providers.  Operates on api_messages (the API copy) so
+            # the original conversation history in `messages` is untouched.
+            for am in api_messages:
+                if isinstance(am.get("content"), str):
+                    am["content"] = am["content"].strip()
+            for am in api_messages:
+                tcs = am.get("tool_calls")
+                if not tcs:
+                    continue
+                new_tcs = []
+                for tc in tcs:
+                    if isinstance(tc, dict) and "function" in tc:
+                        try:
+                            args_obj = json.loads(tc["function"]["arguments"])
+                            tc = {**tc, "function": {
+                                **tc["function"],
+                                "arguments": json.dumps(
+                                    args_obj, separators=(",", ":"),
+                                    sort_keys=True,
+                                ),
+                            }}
+                        except Exception:
+                            pass
+                    new_tcs.append(tc)
+                am["tool_calls"] = new_tcs
 
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)


### PR DESCRIPTION
## Summary

Salvaged from PR #7875 by @waxinz. Normalizes `api_messages` before each API call for consistent prefix matching across turns:

1. **System prompt parts** — strip leading/trailing whitespace and filter empties before joining
2. **Message content** — strip leading/trailing whitespace from all content strings
3. **Tool-call arguments** — normalize to compact sorted JSON (`separators=(',',':')`, `sort_keys=True`)

This enables KV cache reuse on local inference servers (llama.cpp, vLLM, Ollama) — the contributor reports prompt eval dropping from ~30s to <100ms on a 27B model with 50k+ context. Also benefits cloud provider cache hit rates.

## Fix from original PR

The original PR mutated tool-call arguments in-place through shared references (shallow copy). Since `api_messages` is built with `msg.copy()` (shallow), the nested `tool_calls[].function` dicts are shared with the original `messages` history. The fix creates new dicts via spread (`{**tc, "function": {**tc["function"], ...}}`) so the original conversation history is never mutated.

## Test plan

- E2E verified: content stripping, JSON normalization, original history preservation, idempotency, malformed JSON passthrough
- `tests/run_agent/test_agent_guardrails.py` — 29 passed
- `tests/run_agent/test_context_pressure.py` — 31 passed
- `tests/run_agent/test_session_meta_filtering.py` — passed
- `tests/agent/test_prompt_builder.py` + `test_prompt_caching.py` — 127 passed
- `tests/gateway/test_agent_cache.py` — passed