### PR TITLE
fix(api-server): keep chat-completions SSE OpenAI-compatible

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -644,37 +644,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
-            def _on_tool_progress(event_type, name, preview, args, **kwargs):
-                """Send tool progress as a separate SSE event.
-
-                Previously, progress markers like ``⏰ list`` were injected
-                directly into ``delta.content``.  OpenAI-compatible frontends
-                (Open WebUI, LobeChat, …) store ``delta.content`` verbatim as
-                the assistant message and send it back on subsequent requests.
-                After enough turns the model learns to *emit* the markers as
-                plain text instead of issuing real tool calls — silently
-                hallucinating tool results.  See #6972.
-
-                The fix: push a tagged tuple ``("__tool_progress__", payload)``
-                onto the stream queue.  The SSE writer emits it as a custom
-                ``event: hermes.tool.progress`` line that compliant frontends
-                can render for UX but will *not* persist into conversation
-                history.  Clients that don't understand the custom event type
-                silently ignore it per the SSE specification.
-                """
-                if event_type != "tool.started":
-                    return
-                if name.startswith("_"):
-                    return
-                from agent.display import get_tool_emoji
-                emoji = get_tool_emoji(name)
-                label = preview or name
-                _stream_q.put(("__tool_progress__", {
-                    "tool": name,
-                    "emoji": emoji,
-                    "label": label,
-                }))
-
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             agent_ref = [None]
@@ -684,7 +653,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
+                # Chat-completions streaming must stay strictly OpenAI-shaped.
+                # Structured progress belongs on /v1/runs/{run_id}/events.
+                tool_progress_callback=None,
                 agent_ref=agent_ref,
             ))
 
@@ -791,28 +762,14 @@ class APIServerAdapter(BasePlatformAdapter):
             await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
             last_activity = time.monotonic()
 
-            # Helper — route a queue item to the correct SSE event.
+            # Helper — emit a normal OpenAI chat delta chunk.
             async def _emit(item):
-                """Write a single queue item to the SSE stream.
-
-                Plain strings are sent as normal ``delta.content`` chunks.
-                Tagged tuples ``("__tool_progress__", payload)`` are sent
-                as a custom ``event: hermes.tool.progress`` SSE event so
-                frontends can display them without storing the markers in
-                conversation history.  See #6972.
-                """
-                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
-                    event_data = json.dumps(item[1])
-                    await response.write(
-                        f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
-                    )
-                else:
-                    content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
-                    }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -502,8 +502,8 @@ class TestChatCompletionsEndpoint:
                 assert " about it..." in body
 
     @pytest.mark.asyncio
-    async def test_stream_includes_tool_progress(self, adapter):
-        """tool_progress_callback fires → progress appears as custom SSE event, not in delta.content."""
+    async def test_stream_ignores_tool_progress_for_chat_completions(self, adapter):
+        """Chat-completions SSE should stay OpenAI-shaped even when tools run."""
         import asyncio
 
         app = _create_app(adapter)
@@ -511,9 +511,7 @@ class TestChatCompletionsEndpoint:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 tp_cb = kwargs.get("tool_progress_callback")
-                # Simulate tool progress before streaming content
-                if tp_cb:
-                    tp_cb("tool.started", "terminal", "ls -la", {"command": "ls -la"})
+                assert tp_cb is None
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Here are the files.")
@@ -534,32 +532,15 @@ class TestChatCompletionsEndpoint:
                 assert resp.status == 200
                 body = await resp.text()
                 assert "[DONE]" in body
-                # Tool progress must appear as a custom SSE event, not in
-                # delta.content — prevents model from learning to imitate
-                # markers instead of calling tools (#6972).
-                assert "event: hermes.tool.progress" in body
-                assert '"tool": "terminal"' in body
-                assert '"label": "ls -la"' in body
-                # The progress marker must NOT appear inside any
-                # chat.completion.chunk delta.content field.
-                import json as _json
-                for line in body.splitlines():
-                    if line.startswith("data: ") and line.strip() != "data: [DONE]":
-                        try:
-                            chunk = _json.loads(line[len("data: "):])
-                        except _json.JSONDecodeError:
-                            continue
-                        if chunk.get("object") == "chat.completion.chunk":
-                            for choice in chunk.get("choices", []):
-                                content = choice.get("delta", {}).get("content", "")
-                                # Tool emoji markers must never leak into content
-                                assert "ls -la" not in content or content == "Here are the files."
+                assert "event: hermes.tool.progress" not in body
+                assert '"tool": "terminal"' not in body
+                assert '"label": "ls -la"' not in body
                 # Final content must also be present
                 assert "Here are the files." in body
 
     @pytest.mark.asyncio
-    async def test_stream_tool_progress_skips_internal_events(self, adapter):
-        """Internal events (name starting with _) are not streamed."""
+    async def test_stream_tool_progress_is_not_serialized_into_chat_chunks(self, adapter):
+        """Tool progress must not leak into chat-completions stream content."""
         import asyncio
 
         app = _create_app(adapter)
@@ -567,9 +548,7 @@ class TestChatCompletionsEndpoint:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 tp_cb = kwargs.get("tool_progress_callback")
-                if tp_cb:
-                    tp_cb("tool.started", "_thinking", "some internal state", {})
-                    tp_cb("tool.started", "web_search", "Python docs", {"query": "Python docs"})
+                assert tp_cb is None
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Found it.")
@@ -589,12 +568,10 @@ class TestChatCompletionsEndpoint:
                 )
                 assert resp.status == 200
                 body = await resp.text()
-                # Internal _thinking event should NOT appear anywhere
-                assert "some internal state" not in body
-                # Real tool progress should appear as custom SSE event
-                assert "event: hermes.tool.progress" in body
-                assert '"tool": "web_search"' in body
-                assert '"label": "Python docs"' in body
+                assert "event: hermes.tool.progress" not in body
+                assert '"tool": "web_search"' not in body
+                assert '"label": "Python docs"' not in body
+                assert "Found it." in body
 
     @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):


### PR DESCRIPTION
## What does this PR do?

This keeps the OpenAI-compatible /v1/chat/completions SSE stream strictly OpenAI-shaped again.

Recent API-server changes fixed the silent-stream problem during long tool runs, but /v1/chat/completions was also emitting custom hermes.tool.progress SSE payloads. Some OpenAI-style clients appear to parse those payloads as if they were normal chat-completions chunks, which can break streaming on strict clients.

This change keeps the keepalive behavior but removes custom tool-progress SSE events from the chat-completions stream. Structured tool progress still belongs on /v1/runs/{run_id}/events.

## Related Issue

https://discord.com/channels/1053877538025386074/1492545538015367198/1492663624601440296

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- stop passing a tool-progress callback into /v1/chat/completions streaming
- remove custom hermes.tool.progress SSE serialization from the chat-completions stream
- keep idle-stream keepalive behavior intact
- update API-server tests to assert that chat-completions streaming stays OpenAI-compatible and does not emit custom tool-progress events

## How to Test

source venv/bin/activate
python -m pytest tests/gateway/test_api_server.py -q
python -m pytest tests/gateway/test_sse_agent_cancel.py -q

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I searched for existing PRs before creating this one.
- [x] I added tests for the bug fix.
- [ ] I ran pytest tests/ -q and all tests passed.

Notes:
- focused API-server tests passed:
  - tests/gateway/test_api_server.py -> 107 passed
  - tests/gateway/test_sse_agent_cancel.py -> 6 passed
- full suite on current main + this patch finished at 75 failed, 10616 passed, 33 skipped in 593.63s
- one tests/gateway/test_api_server.py::TestAdapterInit::test_default_config failure appeared in the xdist full-suite run, but it passed cleanly in isolated rerun immediately afterward
