### PR TITLE
security: block cloud provider credentials and git credential prompts in subprocesses

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -100,11 +100,33 @@ def _build_provider_env_blocklist() -> frozenset:
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
         "DAYTONA_API_KEY",
+        # Cloud provider credentials.
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_SECURITY_TOKEN",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "KUBECONFIG",
+        "DOCKER_HOST",
+        "DOCKER_CERT_PATH",
+        "NPM_TOKEN",
+        "PYPI_TOKEN",
+        "SSH_AUTH_SOCK",
+        "GPG_AGENT_INFO",
     })
     return frozenset(blocked)
 
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+
+
+# Git hardening: disable credential prompts in all subprocesses.
+_GIT_HARDENING_VARS = {
+    "GIT_TERMINAL_PROMPT": "0",
+}
 
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
@@ -135,6 +157,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     if _profile_home:
         sanitized["HOME"] = _profile_home
 
+    # Apply git hardening
+    sanitized.update(_GIT_HARDENING_VARS)
     return sanitized
 
 


### PR DESCRIPTION
Block cloud provider credentials (AWS, Azure, GCP, Kubernetes, Docker, npm, PyPI, SSH agent, GPG) from leaking to agent subprocesses. Set GIT_TERMINAL_PROMPT=0 to prevent git credential prompts on clone. 24 lines in `tools/environments/local.py`. Ref #4170. Split from #4168 for easier review.