### PR TITLE
security: cache HERMES_YOLO_MODE at import time to prevent subprocess bypass

### DIFF
--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -57,6 +57,7 @@ class TestYoloMode:
     def test_dangerous_command_approved_in_yolo_mode(self, monkeypatch):
         """With HERMES_YOLO_MODE, dangerous commands are auto-approved."""
         monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setattr("tools.approval._YOLO_AT_STARTUP", True)
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         monkeypatch.setenv("HERMES_SESSION_KEY", "test-session")
 
@@ -67,6 +68,7 @@ class TestYoloMode:
     def test_yolo_mode_works_for_all_patterns(self, monkeypatch):
         """Yolo mode bypasses all dangerous patterns, not just some."""
         monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setattr("tools.approval._YOLO_AT_STARTUP", True)
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
 
         dangerous_commands = [
@@ -85,6 +87,7 @@ class TestYoloMode:
     def test_combined_guard_bypasses_yolo_mode(self, monkeypatch):
         """The new combined guard should preserve yolo bypass semantics."""
         monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setattr("tools.approval._YOLO_AT_STARTUP", True)
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
 
         called = {"value": False}

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -72,6 +72,10 @@ _SENSITIVE_WRITE_TARGET = (
 # Dangerous command patterns
 # =========================================================================
 
+# Snapshot YOLO mode at import time so subprocesses cannot export it
+# to bypass approval in later commands within the same session.
+_YOLO_AT_STARTUP = bool(os.getenv("HERMES_YOLO_MODE"))
+
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
@@ -600,7 +604,7 @@ def check_dangerous_command(command: str, env_type: str,
 
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
-    if os.getenv("HERMES_YOLO_MODE") or is_current_session_yolo_enabled():
+    if _YOLO_AT_STARTUP or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
@@ -703,7 +707,7 @@ def check_all_command_guards(command: str, env_type: str,
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
-    if os.getenv("HERMES_YOLO_MODE") or is_current_session_yolo_enabled() or approval_mode == "off":
+    if _YOLO_AT_STARTUP or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
     is_cli = os.getenv("HERMES_INTERACTIVE")


### PR DESCRIPTION
HERMES_YOLO_MODE was read via `os.getenv()` on every approval check. A persistent shell session could `export HERMES_YOLO_MODE=1` and bypass approval for all subsequent commands. Now cached as `_YOLO_AT_STARTUP` at module import time. 9 lines across `tools/approval.py` and 3 test updates. Ref #4170. Split from #4168.