### PR TITLE
fix(gateway): TypeError in suspend_recently_active on startup

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -809,7 +809,7 @@ class SessionStore:
         """
         import time as _time
 
-        cutoff = _time.time() - max_age_seconds
+        cutoff = datetime.fromtimestamp(_time.time() - max_age_seconds)
         count = 0
         with self._lock:
             self._ensure_loaded_locked()


### PR DESCRIPTION
## Problem

On gateway startup, `suspend_recently_active()` crashes with:

```
TypeError: ">=" not supported between instances of "datetime.datetime" and "float"
```

The `cutoff` variable is computed as a `float` (epoch seconds from `time.time()`) but compared against `entry.updated_at` which is a `datetime` object.

## Fix

Wrap `cutoff` with `datetime.fromtimestamp()` so both sides of the comparison are `datetime` objects.

## Repro

1. Have a session with recent `updated_at` timestamp
2. Restart the gateway
3. Warning appears: `Session suspension on startup failed`