### PR TITLE
fix(delegation): prefer disk config over stale runtime defaults in long-lived processes

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1281,52 +1281,65 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 class TestLoadConfigMerge(unittest.TestCase):
     """Tests for _load_config disk-first + runtime-fill behavior."""
 
+    _DEFAULT_DELEGATION = {
+        "model": "",
+        "provider": "",
+        "base_url": "",
+        "api_key": "",
+        "max_iterations": 50,
+        "reasoning_effort": "",
+    }
+
     def test_disk_config_used_when_runtime_empty(self):
         mock_cli = MagicMock()
         mock_cli.CLI_CONFIG = {"delegation": {}}
         with patch.dict(sys.modules, {"cli": mock_cli}):
-            with patch("hermes_cli.config.load_config") as mock_load_config:
-                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
-                from tools.delegate_tool import _load_config
-                cfg = _load_config()
-                self.assertEqual(cfg["model"], "glm-5.1")
-                self.assertEqual(cfg["provider"], "zai-customize")
+            with patch("hermes_cli.config.DEFAULT_CONFIG", {"delegation": self._DEFAULT_DELEGATION}):
+                with patch("hermes_cli.config.read_raw_config") as mock_raw:
+                    mock_raw.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                    from tools.delegate_tool import _load_config
+                    cfg = _load_config()
+                    self.assertEqual(cfg["model"], "glm-5.1")
+                    self.assertEqual(cfg["provider"], "zai-customize")
 
     def test_runtime_fills_missing_keys(self):
         mock_cli = MagicMock()
         mock_cli.CLI_CONFIG = {"delegation": {"max_iterations": 50, "reasoning_effort": "low"}}
         with patch.dict(sys.modules, {"cli": mock_cli}):
-            with patch("hermes_cli.config.load_config") as mock_load_config:
-                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
-                from tools.delegate_tool import _load_config
-                cfg = _load_config()
-                self.assertEqual(cfg["model"], "glm-5.1")
-                self.assertEqual(cfg["provider"], "zai-customize")
-                self.assertEqual(cfg["max_iterations"], 50)
-                self.assertEqual(cfg["reasoning_effort"], "low")
+            with patch("hermes_cli.config.DEFAULT_CONFIG", {"delegation": self._DEFAULT_DELEGATION}):
+                with patch("hermes_cli.config.read_raw_config") as mock_raw:
+                    mock_raw.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                    from tools.delegate_tool import _load_config
+                    cfg = _load_config()
+                    self.assertEqual(cfg["model"], "glm-5.1")
+                    self.assertEqual(cfg["provider"], "zai-customize")
+                    self.assertEqual(cfg["max_iterations"], 50)
+                    self.assertEqual(cfg["reasoning_effort"], "low")
 
     def test_runtime_does_not_override_disk(self):
         mock_cli = MagicMock()
         mock_cli.CLI_CONFIG = {"delegation": {"model": "glm-4.7", "max_iterations": 99}}
         with patch.dict(sys.modules, {"cli": mock_cli}):
-            with patch("hermes_cli.config.load_config") as mock_load_config:
-                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
-                from tools.delegate_tool import _load_config
-                cfg = _load_config()
-                self.assertEqual(cfg["model"], "glm-5.1")  # disk wins
-                self.assertEqual(cfg["provider"], "zai-customize")
-                self.assertEqual(cfg["max_iterations"], 99)  # runtime fills missing
+            with patch("hermes_cli.config.DEFAULT_CONFIG", {"delegation": self._DEFAULT_DELEGATION}):
+                with patch("hermes_cli.config.read_raw_config") as mock_raw:
+                    mock_raw.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                    from tools.delegate_tool import _load_config
+                    cfg = _load_config()
+                    self.assertEqual(cfg["model"], "glm-5.1")  # disk wins
+                    self.assertEqual(cfg["provider"], "zai-customize")
+                    self.assertEqual(cfg["max_iterations"], 99)  # runtime fills missing
 
     def test_empty_runtime_values_ignored(self):
         mock_cli = MagicMock()
         mock_cli.CLI_CONFIG = {"delegation": {"model": "", "provider": None}}
         with patch.dict(sys.modules, {"cli": mock_cli}):
-            with patch("hermes_cli.config.load_config") as mock_load_config:
-                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
-                from tools.delegate_tool import _load_config
-                cfg = _load_config()
-                self.assertEqual(cfg["model"], "glm-5.1")
-                self.assertEqual(cfg["provider"], "zai-customize")
+            with patch("hermes_cli.config.DEFAULT_CONFIG", {"delegation": self._DEFAULT_DELEGATION}):
+                with patch("hermes_cli.config.read_raw_config") as mock_raw:
+                    mock_raw.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                    from tools.delegate_tool import _load_config
+                    cfg = _load_config()
+                    self.assertEqual(cfg["model"], "glm-5.1")
+                    self.assertEqual(cfg["provider"], "zai-customize")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1278,5 +1278,56 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
 
 
+class TestLoadConfigMerge(unittest.TestCase):
+    """Tests for _load_config disk-first + runtime-fill behavior."""
+
+    def test_disk_config_used_when_runtime_empty(self):
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {"delegation": {}}
+        with patch.dict(sys.modules, {"cli": mock_cli}):
+            with patch("hermes_cli.config.load_config") as mock_load_config:
+                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                from tools.delegate_tool import _load_config
+                cfg = _load_config()
+                self.assertEqual(cfg["model"], "glm-5.1")
+                self.assertEqual(cfg["provider"], "zai-customize")
+
+    def test_runtime_fills_missing_keys(self):
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {"delegation": {"max_iterations": 50, "reasoning_effort": "low"}}
+        with patch.dict(sys.modules, {"cli": mock_cli}):
+            with patch("hermes_cli.config.load_config") as mock_load_config:
+                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                from tools.delegate_tool import _load_config
+                cfg = _load_config()
+                self.assertEqual(cfg["model"], "glm-5.1")
+                self.assertEqual(cfg["provider"], "zai-customize")
+                self.assertEqual(cfg["max_iterations"], 50)
+                self.assertEqual(cfg["reasoning_effort"], "low")
+
+    def test_runtime_does_not_override_disk(self):
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {"delegation": {"model": "glm-4.7", "max_iterations": 99}}
+        with patch.dict(sys.modules, {"cli": mock_cli}):
+            with patch("hermes_cli.config.load_config") as mock_load_config:
+                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                from tools.delegate_tool import _load_config
+                cfg = _load_config()
+                self.assertEqual(cfg["model"], "glm-5.1")  # disk wins
+                self.assertEqual(cfg["provider"], "zai-customize")
+                self.assertEqual(cfg["max_iterations"], 99)  # runtime fills missing
+
+    def test_empty_runtime_values_ignored(self):
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {"delegation": {"model": "", "provider": None}}
+        with patch.dict(sys.modules, {"cli": mock_cli}):
+            with patch("hermes_cli.config.load_config") as mock_load_config:
+                mock_load_config.return_value = {"delegation": {"model": "glm-5.1", "provider": "zai-customize"}}
+                from tools.delegate_tool import _load_config
+                cfg = _load_config()
+                self.assertEqual(cfg["model"], "glm-5.1")
+                self.assertEqual(cfg["provider"], "zai-customize")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -928,10 +928,12 @@ def _load_config() -> dict:
     long-running processes (gateway, cron) from using stale runtime defaults
     that mask edits made to config.yaml after startup.
     """
-    disk_cfg = {}
+    from hermes_cli.config import DEFAULT_CONFIG, read_raw_config
+
+    defaults = dict(DEFAULT_CONFIG.get("delegation", {}))
+    raw_disk = {}
     try:
-        from hermes_cli.config import load_config
-        disk_cfg = load_config().get("delegation", {}) or {}
+        raw_disk = read_raw_config().get("delegation", {}) or {}
     except Exception:
         pass
 
@@ -942,12 +944,15 @@ def _load_config() -> dict:
     except Exception:
         pass
 
-    # Prefer disk config; runtime only fills missing keys so that
-    # CLI_CONFIG defaults (e.g. max_iterations) do not overwrite
-    # newer config.yaml edits in long-lived processes.
-    merged = dict(disk_cfg)
+    # Start from defaults, overlay raw disk config.
+    # We use read_raw_config() instead of load_config() because load_config()
+    # deep-merges DEFAULT_CONFIG, so keys like max_iterations always appear
+    # "present" even when the user never set them in config.yaml. By tracking
+    # raw disk keys explicitly, runtime can still fill truly missing values.
+    merged = dict(defaults)
+    merged.update(raw_disk)
     for k, v in runtime_cfg.items():
-        if k not in merged and v not in (None, ""):
+        if k not in raw_disk and v not in (None, ""):
             merged[k] = v
     return merged
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -921,26 +921,35 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from persistent config, falling back to runtime.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Disk config (config.yaml) is authoritative. Runtime config (cli.py
+    CLI_CONFIG) is only used to fill keys missing from disk. This prevents
+    long-running processes (gateway, cron) from using stale runtime defaults
+    that mask edits made to config.yaml after startup.
     """
-    try:
-        from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
-        if cfg:
-            return cfg
-    except Exception:
-        pass
+    disk_cfg = {}
     try:
         from hermes_cli.config import load_config
-        full = load_config()
-        return full.get("delegation", {})
+        disk_cfg = load_config().get("delegation", {}) or {}
     except Exception:
-        return {}
+        pass
+
+    runtime_cfg = {}
+    try:
+        from cli import CLI_CONFIG
+        runtime_cfg = CLI_CONFIG.get("delegation", {}) or {}
+    except Exception:
+        pass
+
+    # Prefer disk config; runtime only fills missing keys so that
+    # CLI_CONFIG defaults (e.g. max_iterations) do not overwrite
+    # newer config.yaml edits in long-lived processes.
+    merged = dict(disk_cfg)
+    for k, v in runtime_cfg.items():
+        if k not in merged and v not in (None, ""):
+            merged[k] = v
+    return merged
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In long-running processes (gateway, cron), \`_load_config()\` in \`tools/delegate_tool.py\` checked runtime \`CLI_CONFIG\` first and returned it immediately when non-empty. This meant any edits to \`config.yaml\` (e.g. changing \`delegation.model\`) were ignored after process startup, because the runtime snapshot was frozen.

## Fix

Make disk config (\`config.yaml\`) authoritative. Runtime config (\`CLI_CONFIG\`) is now only used to fill keys that are *missing* from disk, preventing stale runtime defaults from masking newer edits.

## Changes

- \`tools/delegate_tool.py\`: rewrite \`_load_config()\` to prefer disk config.
- \`tests/tools/test_delegate.py\`: add 4 unit tests covering disk-only, runtime-fill, runtime-no-override, and empty-runtime scenarios.

## Verification


cd /Users/mac/.hermes/hermes-agent && source venv/bin/activate && python -m pytest tests/tools/test_delegate.py -q
# 71 passed
