### PR TITLE
fix(discord): channel name matching and flush pending sends on shutdown

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -671,6 +671,42 @@ class DiscordAdapter(BasePlatformAdapter):
             self._release_platform_lock()
             return False
 
+    async def cancel_background_tasks(self) -> None:
+        """Cancel background tasks, but first flush any pending text-batch sends.
+
+        The base-class implementation only cancels tasks in self._background_tasks.
+        Discord keeps its own _pending_text_batch_tasks dict for the message-merge
+        logic, and those tasks are NOT in _background_tasks.  On shutdown/restart
+        this caused a race where in-flight response deliveries were cancelled before
+        Discord had a chance to actually send them, resulting in silent dropped
+        messages visible to the user as tool-log-only replies with no text.
+
+        Fix: await all pending text-batch tasks (give them a short deadline to flush)
+        before delegating to the base cancel.
+        """
+        pending = list(self._pending_text_batch_tasks.values())
+        if pending:
+            logger.info(
+                "[%s] Flushing %d pending text-batch task(s) before shutdown",
+                self.name, len(pending),
+            )
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*pending, return_exceptions=True),
+                    timeout=8.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[%s] Text-batch flush timed out; cancelling remaining tasks",
+                    self.name,
+                )
+                for task in pending:
+                    if not task.done():
+                        task.cancel()
+        self._pending_text_batch_tasks.clear()
+        self._pending_text_batches.clear()
+        await super().cancel_background_tasks()
+
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
         # Clean up all active voice connections before closing the client
@@ -2224,31 +2260,44 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
+            channel_keys = {str(message.channel.id)}
+            channel_name = str(getattr(message.channel, "name", "")).strip()
+            if channel_name:
+                channel_keys.add(channel_name)
+                channel_keys.add(f"#{channel_name}")
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
+                channel_keys.add(parent_channel_id)
+                parent_channel = None
+                try:
+                    parent_channel = message.channel.parent if isinstance(message.channel, discord.Thread) else None
+                except Exception:
+                    parent_channel = None
+                parent_name = str(getattr(parent_channel, "name", "")).strip() if parent_channel else ""
+                if parent_name:
+                    channel_keys.add(parent_name)
+                    channel_keys.add(f"#{parent_name}")
 
             # Check allowed channels - if set, only respond in these channels
             allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
             if allowed_channels_raw:
                 allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
-                if not (channel_ids & allowed_channels):
-                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
+                if not ((channel_ids & allowed_channels) or (channel_keys & allowed_channels)):
+                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_keys)
                     return
 
             # Check ignored channels - never respond even when mentioned
             ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
             ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
-            if channel_ids & ignored_channels:
-                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
+            if channel_keys & ignored_channels:
+                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_keys)
                 return
 
             free_channels_raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
-            if parent_channel_id:
-                channel_ids.add(parent_channel_id)
 
             require_mention = os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
-            is_free_channel = bool(channel_ids & free_channels)
+            is_free_channel = bool(channel_keys & free_channels)
 
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
@@ -2270,7 +2319,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels)
+            skip_thread = bool((channel_ids & no_thread_channels) or (channel_keys & no_thread_channels))
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             if auto_thread and not skip_thread:
                 thread = await self._auto_create_thread(message)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -839,10 +839,8 @@ class DiscordAdapter(BasePlatformAdapter):
                         if hasattr(message.channel, "parent_id") and message.channel.parent_id:
                             _parent_id = str(message.channel.parent_id)
                         _free_channels = adapter_self._discord_free_response_channels()
-                        _channel_ids = {_channel_id}
-                        if _parent_id:
-                            _channel_ids.add(_parent_id)
-                        if "*" not in _free_channels and not (_channel_ids & _free_channels):
+                        _channel_keys = adapter_self._discord_channel_keys(message, _parent_id)
+                        if "*" not in _free_channels and not (_channel_keys & _free_channels):
                             return
 
                 await self._handle_message(message)
@@ -901,6 +899,42 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
             self._release_platform_lock()
             return False
+
+    async def cancel_background_tasks(self) -> None:
+        """Cancel background tasks, but first flush any pending text-batch sends.
+
+        The base-class implementation only cancels tasks in self._background_tasks.
+        Discord keeps its own _pending_text_batch_tasks dict for the message-merge
+        logic, and those tasks are NOT in _background_tasks. On shutdown/restart
+        this caused a race where in-flight response deliveries were cancelled before
+        Discord had a chance to actually send them, resulting in silent dropped
+        messages visible to the user as tool-log-only replies with no text.
+
+        Fix: await all pending text-batch tasks (give them a short deadline to flush)
+        before delegating to the base cancel.
+        """
+        pending = list(self._pending_text_batch_tasks.values())
+        if pending:
+            logger.info(
+                "[%s] Flushing %d pending text-batch task(s) before shutdown",
+                self.name, len(pending),
+            )
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*pending, return_exceptions=True),
+                    timeout=8.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[%s] Text-batch flush timed out; cancelling remaining tasks",
+                    self.name,
+                )
+                for task in pending:
+                    if not task.done():
+                        task.cancel()
+        self._pending_text_batch_tasks.clear()
+        self._pending_text_batches.clear()
+        await super().cancel_background_tasks()
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
@@ -3675,7 +3709,7 @@ class DiscordAdapter(BasePlatformAdapter):
         )
 
     def _discord_free_response_channels(self) -> set:
-        """Return Discord channel IDs where no bot mention is required.
+        """Return Discord channel IDs/names where no bot mention is required.
 
         A single ``"*"`` entry (either from a list or a comma-separated
         string) is preserved in the returned set so callers can short-circuit
@@ -3696,6 +3730,38 @@ class DiscordAdapter(BasePlatformAdapter):
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
+
+    def _discord_channel_keys(self, message: Any, parent_channel_id: Optional[str] = None) -> set[str]:
+        """Return channel identifiers accepted by Discord channel config gates.
+
+        Users commonly configure channels by Discord snowflake ID, bare name, or
+        ``#name``. Include the current channel and, for threads, the parent
+        channel so free-response/no-thread/allow/ignore rules work with either
+        form.
+        """
+        channel = getattr(message, "channel", None)
+        keys: set[str] = set()
+
+        channel_id = getattr(channel, "id", None)
+        if channel_id is not None:
+            keys.add(str(channel_id))
+
+        channel_name = str(getattr(channel, "name", "")).strip()
+        if channel_name:
+            keys.add(channel_name)
+            keys.add(f"#{channel_name}")
+
+        parent_id = parent_channel_id or getattr(channel, "parent_id", None)
+        if parent_id:
+            keys.add(str(parent_id))
+
+        parent_channel = getattr(channel, "parent", None)
+        parent_name = str(getattr(parent_channel, "name", "")).strip() if parent_channel else ""
+        if parent_name:
+            keys.add(parent_name)
+            keys.add(f"#{parent_name}")
+
+        return keys
 
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
@@ -4532,25 +4598,24 @@ class DiscordAdapter(BasePlatformAdapter):
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
+            channel_keys = self._discord_channel_keys(message, parent_channel_id)
 
             # Check allowed channels - if set, only respond in these channels
             allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
             if allowed_channels_raw:
                 allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
-                if "*" not in allowed_channels and not (channel_ids & allowed_channels):
-                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
+                if "*" not in allowed_channels and not (channel_keys & allowed_channels):
+                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_keys)
                     return
 
             # Check ignored channels - never respond even when mentioned
             ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
             ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
-            if "*" in ignored_channels or (channel_ids & ignored_channels):
-                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
+            if "*" in ignored_channels or (channel_keys & ignored_channels):
+                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_keys)
                 return
 
             free_channels = self._discord_free_response_channels()
-            if parent_channel_id:
-                channel_ids.add(parent_channel_id)
 
             require_mention = self._discord_require_mention()
             # Voice-linked text channels act as free-response while voice is active.
@@ -4560,7 +4625,7 @@ class DiscordAdapter(BasePlatformAdapter):
             is_voice_linked_channel = current_channel_id in voice_linked_ids
             is_free_channel = (
                 "*" in free_channels
-                or bool(channel_ids & free_channels)
+                or bool(channel_keys & free_channels)
                 or is_voice_linked_channel
             )
 
@@ -4586,7 +4651,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -409,6 +409,74 @@ async def test_discord_reply_message_skips_auto_thread(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discord_free_response_matches_channel_name(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "cypher")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=123, name="cypher"),
+        content="name-configured channel without mention",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "name-configured channel without mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_matches_hash_channel_name(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "#cypher")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=123, name="cypher"),
+        content="hash-name-configured channel without mention",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_parent_channel_name_matches_thread_gates(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "#cypher")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    parent = FakeTextChannel(channel_id=123, name="cypher")
+    thread = FakeThread(channel_id=456, name="topic", parent=parent)
+    message = make_message(channel=thread, content="thread message without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.thread_id == "456"
+
+
+@pytest.mark.asyncio
+async def test_discord_no_thread_matches_channel_name(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "cypher")
+
+    adapter._auto_create_thread = AsyncMock()
+    message = make_message(channel=FakeTextChannel(channel_id=123, name="cypher"), content="hello")
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
 async def test_discord_auto_thread_can_be_disabled(adapter, monkeypatch):
     """Setting auto_thread to false skips thread creation."""
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")

--- a/tests/gateway/test_discord_pending_text_batch_shutdown.py
+++ b/tests/gateway/test_discord_pending_text_batch_shutdown.py
@@ -1,0 +1,75 @@
+"""Regression guard for Discord text-batch flush during gateway shutdown."""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_cancel_background_tasks_awaits_pending_text_batch_before_clearing():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    flushed = asyncio.Event()
+
+    async def pending_flush():
+        await asyncio.sleep(0)
+        flushed.set()
+
+    task = asyncio.create_task(pending_flush())
+    adapter._pending_text_batch_tasks["chat"] = task
+    adapter._pending_text_batches["chat"] = MessageEvent(
+        text="pending",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.DISCORD, chat_id="chat", chat_type="group"),
+    )
+
+    await adapter.cancel_background_tasks()
+
+    assert flushed.is_set()
+    assert task.done()
+    assert adapter._pending_text_batch_tasks == {}
+    assert adapter._pending_text_batches == {}


### PR DESCRIPTION
## Summary

Two bug fixes to the Discord gateway adapter discovered and patched in production use.

---

### Fix 1: Channel name matching for free-response, allowed, ignored, and no-thread channels

**Problem:** Config values like `free_response_channels: cypher` were silently ignored because the adapter only matched against numeric channel IDs (`channel_ids` set). If a user configured channel names or `#name` forms, none of the gates (`is_free_channel`, `skip_thread`, allowed/ignored checks) would trigger.

**Fix:** Build a `channel_keys` set alongside `channel_ids` that includes:
- the numeric channel ID (existing)
- the channel name string (new)
- the `#channel-name` form (new)
- same for parent channels in threads

All gate checks now use `channel_keys` for name-form matching and `channel_ids` for ID matching.

---

### Fix 2: Flush pending text-batch tasks before shutdown to prevent dropped messages

**Problem:** `DiscordAdapter` maintains its own `_pending_text_batch_tasks` dict for merging rapid successive Discord message chunks (the 2000-char split logic). These tasks were **not** added to `self._background_tasks` (the base class list). As a result, `cancel_background_tasks()` in the base class never awaited them on gateway restart or shutdown.

This created a race condition: on restart, the gateway would call `cancel_background_tasks()` then `disconnect()` (closing the Discord client) while in-flight response delivery tasks were still pending. The tasks would be killed by the event loop without completing, causing **silent dropped messages** — users saw only tool-log activity with no text response body.

**Fix:** Override `cancel_background_tasks()` in `DiscordAdapter` to await all pending `_pending_text_batch_tasks` (with an 8-second deadline) before delegating to `super().cancel_background_tasks()`. If the deadline is exceeded, remaining tasks are cancelled gracefully.

---

## Testing

Both fixes were validated in production on a Discord gateway instance running `claude-sonnet-4-6` via Anthropic. The dropped-message race was reproducible on every gateway restart when a response was in-flight; after the fix, responses land correctly even through restarts.
