### PR TITLE
fix: renumber repeated ordered list markers in final responses

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1895,6 +1895,55 @@ class AIAgent:
         content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
         return content
 
+    def _renumber_repeated_ordered_list_markers(self, content: str) -> str:
+        """Fix ordered lists where every visible item was emitted as 1./1)/1、."""
+        if not content or "1" not in content:
+            return content or ""
+
+        fence_pattern = re.compile(r'```[\s\S]*?```')
+        fence_stash = []
+
+        def _stash_fence(match):
+            fence_stash.append(match.group(0))
+            return f"\x00CODEBLOCK{len(fence_stash)-1}\x00"
+
+        working = fence_pattern.sub(_stash_fence, content)
+        lines = working.splitlines()
+        out = []
+        i = 0
+        pattern = re.compile(r'^(?P<indent>\s*)(?P<num>\d+)(?P<marker>[\.)、])(?P<rest>(?:\s+.*|\S.*))$')
+
+        while i < len(lines):
+            match = pattern.match(lines[i])
+            if not match:
+                out.append(lines[i])
+                i += 1
+                continue
+
+            start = i
+            base_indent = match.group('indent')
+            marker = match.group('marker')
+            block = []
+
+            while i < len(lines):
+                current = pattern.match(lines[i])
+                if not current:
+                    break
+                if current.group('indent') != base_indent or current.group('marker') != marker:
+                    break
+                block.append(current)
+                i += 1
+
+            nums = [m.group('num') for m in block]
+            if len(block) >= 2 and all(n == '1' for n in nums):
+                for idx, item in enumerate(block, start=1):
+                    out.append(f"{item.group('indent')}{idx}{item.group('marker')}{item.group('rest')}")
+            else:
+                out.extend(lines[start:i])
+
+        renumbered = "\n".join(out)
+        return re.sub(r'\x00CODEBLOCK(\d+)\x00', lambda m: fence_stash[int(m.group(1))], renumbered)
+
     def _looks_like_codex_intermediate_ack(
         self,
         user_message: str,
@@ -10065,6 +10114,7 @@ class AIAgent:
                     
                     # Strip <think> blocks from user-facing response (keep raw in messages for trajectory)
                     final_response = self._strip_think_blocks(final_response).strip()
+                    final_response = self._renumber_repeated_ordered_list_markers(final_response)
                     
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
 

--- a/tests/test_repeated_ordered_list_renumber.py
+++ b/tests/test_repeated_ordered_list_renumber.py
@@ -1,0 +1,53 @@
+from run_agent import AIAgent
+
+
+def _agent():
+    return AIAgent.__new__(AIAgent)
+
+
+def test_renumber_repeated_dot_markers():
+    agent = _agent()
+    text = "1. a\n1. b\n1. c"
+    assert agent._renumber_repeated_ordered_list_markers(text) == "1. a\n2. b\n3. c"
+
+
+def test_renumber_repeated_paren_markers():
+    agent = _agent()
+    text = "1) a\n1) b"
+    assert agent._renumber_repeated_ordered_list_markers(text) == "1) a\n2) b"
+
+
+def test_renumber_repeated_cjk_markers():
+    agent = _agent()
+    text = "1、甲\n1、乙\n1、丙"
+    assert agent._renumber_repeated_ordered_list_markers(text) == "1、甲\n2、乙\n3、丙"
+
+
+def test_leave_non_repeated_or_mixed_numbering_unchanged():
+    agent = _agent()
+    text = "1. a\n2. b\n1. c"
+    assert agent._renumber_repeated_ordered_list_markers(text) == text
+
+
+def test_leave_single_item_unchanged():
+    agent = _agent()
+    text = "1. only"
+    assert agent._renumber_repeated_ordered_list_markers(text) == text
+
+
+def test_leave_blank_line_separated_lists_unchanged():
+    agent = _agent()
+    text = "1. a\n\n1. b"
+    assert agent._renumber_repeated_ordered_list_markers(text) == text
+
+
+def test_renumber_nested_list_by_indent_block_only():
+    agent = _agent()
+    text = "1. parent\n  1. child a\n  1. child b"
+    assert agent._renumber_repeated_ordered_list_markers(text) == "1. parent\n  1. child a\n  2. child b"
+
+
+def test_leave_fenced_code_block_unchanged():
+    agent = _agent()
+    text = "```\n1. code\n1. still code\n```"
+    assert agent._renumber_repeated_ordered_list_markers(text) == text


### PR DESCRIPTION
## Summary
- renumber contiguous ordered-list blocks when every item is emitted as `1.` / `1)` / `1、`
- apply the fix at the final response output path so CLI, Web UI, and API all benefit
- preserve fenced code blocks and avoid changing mixed-numbered or single-item lists

## Tests
- `source venv/bin/activate && python -m pytest tests/test_repeated_ordered_list_renumber.py tests/run_agent/test_run_agent.py -q`
