### PR TITLE
fix: accept context_window as alias for context_length in config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1694,7 +1694,7 @@ def init_agent(
 
     # Read explicit context_length override from model config
     if isinstance(_model_cfg, dict):
-        _config_context_length = _model_cfg.get("context_length")
+        _config_context_length = _model_cfg.get("context_length") or _model_cfg.get("context_window")
     else:
         _config_context_length = None
     if _config_context_length is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3142,7 +3142,7 @@ class GatewayRunner:
                         _hyg_model = _model_cfg.get("default") or _model_cfg.get("model") or _hyg_model
                         # Read explicit context_length override from model config
                         # (same as run_agent.py lines 995-1005)
-                        _raw_ctx = _model_cfg.get("context_length")
+                        _raw_ctx = _model_cfg.get("context_length") or _model_cfg.get("context_window")
                         if _raw_ctx is not None:
                             try:
                                 _hyg_config_context_length = int(_raw_ctx)
@@ -3712,7 +3712,7 @@ class GatewayRunner:
                     data = _info_yaml.safe_load(f) or {}
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
-                    raw_ctx = model_cfg.get("context_length")
+                    raw_ctx = model_cfg.get("context_length") or model_cfg.get("context_window")
                     if raw_ctx is not None:
                         try:
                             config_context_length = int(raw_ctx)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10963,7 +10963,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _msg_cfg = _load_gateway_config()
                     _msg_model_cfg = _msg_cfg.get("model", {})
                     if isinstance(_msg_model_cfg, dict):
-                        _msg_raw_ctx = _msg_model_cfg.get("context_length")
+                        _msg_raw_ctx = _msg_model_cfg.get("context_length") or _msg_model_cfg.get("context_window")
                         if _msg_raw_ctx is not None:
                             _msg_config_ctx = int(_msg_raw_ctx)
                     try:
@@ -11464,7 +11464,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _hyg_model = _model_cfg.get("default") or _model_cfg.get("model") or _hyg_model
                         # Read explicit context_length override from model config
                         # (same as run_agent.py lines 995-1005)
-                        _raw_ctx = _model_cfg.get("context_length")
+                        _raw_ctx = _model_cfg.get("context_length") or _model_cfg.get("context_window")
                         if _raw_ctx is not None:
                             try:
                                 _hyg_config_context_length = int(_raw_ctx)
@@ -11524,7 +11524,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 if isinstance(_cp_models, dict):
                                     _cp_model_cfg = _cp_models.get(_hyg_model, {})
                                     if isinstance(_cp_model_cfg, dict):
-                                        _cp_ctx = _cp_model_cfg.get("context_length")
+                                        _cp_ctx = _cp_model_cfg.get("context_length") or _cp_model_cfg.get("context_window")
                                         if _cp_ctx is not None:
                                             _hyg_config_context_length = int(_cp_ctx)
                                 break
@@ -12771,7 +12771,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if data:
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
-                    raw_ctx = model_cfg.get("context_length")
+                    raw_ctx = model_cfg.get("context_length") or model_cfg.get("context_window")
                     if raw_ctx is not None:
                         try:
                             config_context_length = int(raw_ctx)
@@ -12799,7 +12799,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         cp_models = cp.get("models") or {}
                         # Match provider model to current model
                         if cp_model and cp_model == model:
-                            raw_cp_ctx = cp.get("context_length")
+                            raw_cp_ctx = cp.get("context_length") or cp.get("context_window")
                             if raw_cp_ctx is not None:
                                 try:
                                     config_context_length = int(raw_cp_ctx)
@@ -12810,7 +12810,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if isinstance(cp_models, dict):
                             model_entry = cp_models.get(model)
                             if isinstance(model_entry, dict):
-                                model_ctx = model_entry.get("context_length")
+                                model_ctx = model_entry.get("context_length") or model_entry.get("context_window")
                             else:
                                 model_ctx = model_entry
                             if model_ctx is not None and isinstance(model_ctx, (int, float)):
@@ -16304,6 +16304,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # Add more here as new baked-at-construction config settings are added.
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
         ("model", "context_length"),
+        ("model", "context_window"),
         ("model", "max_tokens"),
         ("compression", "enabled"),
         ("compression", "threshold"),

--- a/run_agent.py
+++ b/run_agent.py
@@ -1249,7 +1249,7 @@ class AIAgent:
         # Read explicit context_length override from model config
         _model_cfg = _agent_cfg.get("model", {})
         if isinstance(_model_cfg, dict):
-            _config_context_length = _model_cfg.get("context_length")
+            _config_context_length = _model_cfg.get("context_length") or _model_cfg.get("context_window")
         else:
             _config_context_length = None
         if _config_context_length is not None:


### PR DESCRIPTION
## Bug

The config reader in `run_agent.py` and `gateway/run.py` only checks `model.context_length`, silently ignoring `model.context_window` — a common key name that is already accepted by the API response parser in `model_metadata.py` (`_CONTEXT_LENGTH_KEYS`).

Users who set `context_window: 1000000` in their config.yaml get silently ignored and fall through to the 128K probe default, causing premature context compression warnings at ~50% of the actual configured window.

## Fix

Accept `context_window` as a fallback in the three config-reading locations:

- `run_agent.py` — main agent init
- `gateway/run.py` — hygiene session context resolution
- `gateway/run.py` — `/model` status command

Each location now reads:
```python
_model_cfg.get("context_length") or _model_cfg.get("context_window")
```

## Related

- #5173 — different root cause (stale Codex cache), same symptom
- #5089 — custom_providers per-model context_length not picked up by status banner

This PR covers the top-level `model:` block key mismatch specifically.