### PR TITLE
feat(model-picker): group custom_providers by name into a single row per provider

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -900,7 +900,17 @@ def list_authenticated_providers(
             })
 
     # --- 4. Saved custom providers from config ---
+    # Each ``custom_providers`` entry represents one model under a named
+    # provider. Entries sharing the same provider name are grouped into a
+    # single picker row so that e.g. four Ollama Cloud entries
+    # (qwen3-coder, glm-5.1, kimi-k2, minimax-m2.7) appear as one
+    # "Ollama Cloud" row with four models inside instead of four
+    # duplicate "Ollama Cloud" rows. Entries with distinct provider names
+    # still produce separate rows (e.g. Ollama Cloud vs Moonshot).
     if custom_providers and isinstance(custom_providers, list):
+        from collections import OrderedDict
+
+        groups: "OrderedDict[str, dict]" = OrderedDict()
         for entry in custom_providers:
             if not isinstance(entry, dict):
                 continue
@@ -916,23 +926,28 @@ def list_authenticated_providers(
                 continue
 
             slug = custom_provider_slug(display_name)
+            if slug not in groups:
+                groups[slug] = {
+                    "name": display_name,
+                    "api_url": api_url,
+                    "models": [],
+                }
+            default_model = (entry.get("model") or "").strip()
+            if default_model and default_model not in groups[slug]["models"]:
+                groups[slug]["models"].append(default_model)
+
+        for slug, grp in groups.items():
             if slug in seen_slugs:
                 continue
-
-            models_list = []
-            default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
-
             results.append({
                 "slug": slug,
-                "name": display_name,
+                "name": grp["name"],
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
-                "total_models": len(models_list),
+                "models": grp["models"],
+                "total_models": len(grp["models"]),
                 "source": "user-config",
-                "api_url": api_url,
+                "api_url": grp["api_url"],
             })
             seen_slugs.add(slug)
 


### PR DESCRIPTION
## Summary

The ``/model`` picker currently renders **one row per ``custom_providers`` entry**. When several entries share the same provider name (e.g. four ``ollama-cloud`` entries for ``qwen3-coder``, ``glm-5.1``, ``kimi-k2``, ``minimax-m2.7``), users see **four separate ""Ollama Cloud"" rows** in the picker, which is confusing UX — there is only one Ollama Cloud provider, so there should be one row containing four models.

This PR groups ``custom_providers`` entries that share the same provider name into a single picker row, while keeping entries with distinct names as separate rows.

### Before

\`\`\`
custom_providers:
  - name: Ollama Cloud
    base_url: https://ollama.com/v1
    model: qwen3-coder:480b-cloud
  - name: Ollama Cloud
    base_url: https://ollama.com/v1
    model: glm-5.1:cloud
  - name: Ollama Cloud
    base_url: https://ollama.com/v1
    model: kimi-k2.5
  - name: Ollama Cloud
    base_url: https://ollama.com/v1
    model: minimax-m2.7:cloud
  - name: Moonshot
    base_url: https://api.moonshot.ai/v1
    model: kimi-k2-thinking
\`\`\`

picker:

\`\`\`
1. Ollama Cloud      qwen3-coder:480b-cloud
2. Ollama Cloud      glm-5.1:cloud
3. Ollama Cloud      kimi-k2.5
4. Ollama Cloud      minimax-m2.7:cloud
5. Moonshot          kimi-k2-thinking
\`\`\`

### After

\`\`\`
1. Ollama Cloud      qwen3-coder:480b-cloud, glm-5.1:cloud, kimi-k2.5, minimax-m2.7:cloud
2. Moonshot          kimi-k2-thinking
\`\`\`

Each provider gets one row, and the picker drills into the model list when the user selects it — same as the curated providers (Anthropic, OpenAI, etc.) already do.

## Implementation

Replaces the single-pass loop in ``list_authenticated_providers()`` (``hermes_cli/model_switch.py``) with a two-pass approach:

1. **First pass:** build an ``OrderedDict`` keyed by ``custom_provider_slug(name)``, accumulating ``models`` per group while preserving discovery order.
2. **Second pass:** iterate the groups and append one result row per group, skipping any slug that already appeared in an earlier provider source (the existing ``seen_slugs`` guard is preserved).

Insertion order is preserved via ``OrderedDict``, so providers and their models still appear in the order the user listed them in ``custom_providers``. No new dependencies.

### What's preserved

- **``seen_slugs`` skip logic** — providers already registered by an earlier source (curated providers, user-defined endpoints) still take precedence over ``custom_providers`` entries with the same slug.
- **The ``not display_name or not api_url`` skip** — entries missing either field are still ignored.
- **All field parsing** — ``base_url`` / ``url`` / ``api`` precedence is unchanged.
- **The sort order** — ``current provider first, then by model count descending`` still applies, so the user's active provider always floats to the top and the grouped row's higher ``total_models`` correctly reflects the new behaviour.

## Files

- ``hermes_cli/model_switch.py`` — single function (``list_authenticated_providers``), 25 inserted / 10 removed.

## Test plan

- [x] Manual run of ``/model`` against a config with multiple ``Ollama Cloud`` entries shows one grouped row instead of four duplicates.
- [x] Distinct provider names (Ollama Cloud + Moonshot) still produce separate rows.
- [x] Insertion order is preserved across both passes.
- [x] Existing ``seen_slugs`` precedence still applies — ``custom_providers`` entries do not override curated providers with the same slug.
- [x] Syntax + import smoke test (``ast.parse`` + ``from hermes_cli.model_switch import list_authenticated_providers``).
- [ ] Happy to add a unit test against ``list_authenticated_providers`` if reviewers want one before merge — the function is pure (config in, list out), so a test against a synthetic config dict is straightforward.

## Related PRs

This builds naturally on top of #7261 (``custom_providers`` list schema support) and #7267 (hide providers with no curated LLM models). Both are still open. This PR does not depend on either being merged first — it stands alone against current ``main``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)