### PR TITLE
fix(agent): route Anthropic fast mode via extra_body

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1230,9 +1230,13 @@ def build_anthropic_kwargs(
     When *base_url* points to a third-party Anthropic-compatible endpoint,
     thinking block signatures are stripped (they are Anthropic-proprietary).
 
-    When *fast_mode* is True, adds ``speed: "fast"`` and the fast-mode beta
-    header for ~2.5x faster output throughput on Opus 4.6.  Currently only
-    supported on native Anthropic endpoints (not third-party compatible ones).
+    When *fast_mode* is True, adds ``speed: "fast"`` via ``extra_body`` plus
+    the fast-mode beta header for ~2.5x faster output throughput on Opus 4.6.
+    Anthropic's stable Python SDK exposes ``extra_body`` for undocumented
+    request params; passing ``speed`` as a top-level kwarg only works on the
+    beta helper surface, not ``client.messages.create()`` / ``.stream()``.
+    Fast mode is currently only supported on native Anthropic endpoints (not
+    third-party compatible ones).
     """
     system, anthropic_messages = convert_messages_to_anthropic(messages, base_url=base_url)
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
@@ -1334,10 +1338,15 @@ def build_anthropic_kwargs(
 
     # ── Fast mode (Opus 4.6 only) ────────────────────────────────────
     # Adds speed:"fast" + the fast-mode beta header for ~2.5x output speed.
+    # Route speed through extra_body because Anthropic's stable SDK surface
+    # accepts undocumented request params there, while top-level speed is only
+    # typed on client.beta.messages.* in newer SDK releases.
     # Only for native Anthropic endpoints — third-party providers would
     # reject the unknown beta header and speed parameter.
     if fast_mode and not _is_third_party_anthropic_endpoint(base_url):
-        kwargs["speed"] = "fast"
+        extra_body = dict(kwargs.get("extra_body") or {})
+        extra_body["speed"] = "fast"
+        kwargs["extra_body"] = extra_body
         # Build extra_headers with ALL applicable betas (the per-request
         # extra_headers override the client-level anthropic-beta header).
         betas = list(_common_betas_for_base_url(base_url))

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1076,6 +1076,67 @@ class TestBuildAnthropicKwargs:
         )
         assert kwargs["max_tokens"] == 64_000
 
+    def test_fast_mode_uses_extra_body_not_top_level_speed(self):
+        from agent.anthropic_adapter import _FAST_MODE_BETA
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            fast_mode=True,
+        )
+        assert kwargs["extra_body"] == {"speed": "fast"}
+        assert "speed" not in kwargs
+        assert _FAST_MODE_BETA in kwargs["extra_headers"]["anthropic-beta"]
+
+    def test_fast_mode_kwargs_work_with_current_sdk(self):
+        anthropic = pytest.importorskip("anthropic")
+        httpx = pytest.importorskip("httpx")
+        from agent.anthropic_adapter import _FAST_MODE_BETA
+
+        captured = {}
+
+        def handler(request):
+            captured["url"] = str(request.url)
+            captured["headers"] = dict(request.headers)
+            captured["body"] = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "model": "claude-opus-4-6",
+                    "stop_reason": "end_turn",
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+                headers={"request-id": "req_test"},
+            )
+
+        client = anthropic.Anthropic(
+            api_key="test",
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            max_tokens=16,
+            reasoning_config=None,
+            fast_mode=True,
+        )
+
+        response = client.messages.create(**kwargs)
+
+        assert response.content[0].text == "ok"
+        assert captured["url"].endswith("/v1/messages")
+        assert captured["body"]["speed"] == "fast"
+        assert _FAST_MODE_BETA in captured["headers"]["anthropic-beta"]
+
 
 # ---------------------------------------------------------------------------
 # Model output limit lookup

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -369,7 +369,8 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
             reasoning_config=None,
             fast_mode=True,
         )
-        assert kwargs.get("speed") == "fast"
+        assert kwargs.get("extra_body", {}).get("speed") == "fast"
+        assert "speed" not in kwargs
         assert "extra_headers" in kwargs
         assert _FAST_MODE_BETA in kwargs["extra_headers"].get("anthropic-beta", "")
 
@@ -385,6 +386,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
             fast_mode=False,
         )
         assert "speed" not in kwargs
+        assert "extra_body" not in kwargs
         assert "extra_headers" not in kwargs
 
     def test_fast_mode_skipped_for_third_party_endpoint(self):
@@ -401,6 +403,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         )
         # Third-party endpoints should NOT get speed or fast-mode beta
         assert "speed" not in kwargs
+        assert "extra_body" not in kwargs
         assert "extra_headers" not in kwargs
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the native Anthropic fast-mode request shape introduced in #7037.

`/fast fast` stores `{"speed": "fast"}` in `request_overrides`, and the Anthropic adapter was forwarding that as a top-level `speed=` kwarg. On the stable Anthropic Python SDK, `client.messages.create()` and `client.messages.stream()` do not accept top-level `speed`; both surfaces accept undocumented body params through `extra_body`. The old shape fails locally with `TypeError` before a request is sent.

This PR keeps the fix at the adapter boundary:

- route fast mode as `extra_body["speed"] = "fast"`
- preserve the fast-mode beta header
- keep third-party Anthropic-compatible endpoints excluded from fast mode

`extra_body` is the right fix because `build_anthropic_kwargs()` already owns Anthropic-specific request shaping, and the SDK exposes `extra_body` on both the current release (`0.93.0`) and the repo's minimum supported floor (`0.39.0`).

## Related Issue

Regression from #7037.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`: move fast-mode `speed` from a top-level kwarg to `extra_body`, with SDK-compatibility notes in the docstring/comments
- `tests/agent/test_anthropic_adapter.py`: add a real SDK-boundary regression test using `anthropic` + `httpx.MockTransport` to verify `"speed": "fast"` is serialized into the JSON body
- `tests/cli/test_fast_command.py`: update fast-mode assertions to expect `extra_body`, and keep the third-party endpoint exclusion coverage

## How to Test

1. Activate the project environment:
   `source /home/mruhf/.hermes/hermes-agent/venv/bin/activate`
2. Run the focused regression suites:
   `python -m pytest tests/cli/test_fast_command.py -q`
   `python -m pytest tests/agent/test_anthropic_adapter.py -q`
   `python -m pytest tests/cli/test_fast_command.py tests/agent/test_anthropic_adapter.py -q`
   `python -m pytest tests/agent/test_minimax_provider.py -q`
   `python -m pytest tests/gateway/test_fast_command.py -q`
3. Verify the old and new request shapes against the current Anthropic SDK:
   - old shape: `client.messages.create(..., speed="fast")` and `client.messages.stream(..., speed="fast")` raise `TypeError`
   - patched shape: `build_anthropic_kwargs(..., fast_mode=True)` succeeds and sends `"speed": "fast"` in the JSON body

Additional note:
- `python -m pytest tests/ -q` currently fails on this worktree with unrelated pre-existing failures outside this PR's scope; the focused suites above are green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0-106-generic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Manual SDK verification on `anthropic==0.93.0`:

```text
Messages.create() got an unexpected keyword argument 'speed'
Messages.stream() got an unexpected keyword argument 'speed'
```

Patched adapter verification:

```text
response_text ok
body_speed fast
header_has_fast_beta True
top_level_speed_in_kwargs False
```
