### PR TITLE
fix(discord): resolve reply context for referenced messages

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2208,6 +2208,77 @@ class DiscordAdapter(BasePlatformAdapter):
             self._bot_participated_threads.add(thread_id)
             self._save_participated_threads()
 
+    def _summarize_referenced_message(self, referenced: Any) -> Optional[str]:
+        """Return text context for a referenced Discord message.
+
+        Prefer plain text content. If the referenced message has no text, fall
+        back to a concise attachment/embed summary so reply context still has a
+        useful anchor.
+        """
+        if not referenced:
+            return None
+
+        content = (getattr(referenced, "content", None) or "").strip()
+        if content:
+            return content
+
+        parts = []
+        author = getattr(referenced, "author", None)
+        author_name = (
+            getattr(author, "display_name", None)
+            or getattr(author, "name", None)
+            or ""
+        )
+
+        attachments = list(getattr(referenced, "attachments", None) or [])
+        if attachments:
+            attachment_labels = []
+            for att in attachments[:3]:
+                filename = getattr(att, "filename", None) or "attachment"
+                content_type = getattr(att, "content_type", None) or "file"
+                attachment_labels.append(f"{filename} ({content_type})")
+            extra = "" if len(attachments) <= 3 else f" +{len(attachments) - 3} more"
+            parts.append(
+                f"Referenced message had {len(attachments)} attachment(s): "
+                f"{', '.join(attachment_labels)}{extra}"
+            )
+
+        embeds = list(getattr(referenced, "embeds", None) or [])
+        if embeds:
+            parts.append(f"Referenced message had {len(embeds)} embed(s)")
+
+        if not parts:
+            return None
+        prefix = f"{author_name}: " if author_name else ""
+        return prefix + " | ".join(parts)
+
+    async def _resolve_referenced_message_text(self, message: DiscordMessage) -> tuple[Optional[str], Optional[str]]:
+        """Resolve Discord reply metadata into (reply_to_message_id, reply_to_text)."""
+        reference = getattr(message, "reference", None)
+        reference_message_id = getattr(reference, "message_id", None) if reference else None
+        if not reference_message_id:
+            return None, None
+
+        reply_to_message_id = str(reference_message_id)
+        referenced = getattr(reference, "resolved", None)
+        if referenced is None:
+            fetch_channel = getattr(message, "channel", None)
+            channel_id = getattr(reference, "channel_id", None)
+            if channel_id and self._client:
+                fetch_channel = self._client.get_channel(int(channel_id)) or fetch_channel
+                if fetch_channel is None:
+                    try:
+                        fetch_channel = await self._client.fetch_channel(int(channel_id))
+                    except Exception:
+                        fetch_channel = getattr(message, "channel", None)
+            if fetch_channel and hasattr(fetch_channel, "fetch_message"):
+                try:
+                    referenced = await fetch_channel.fetch_message(int(reference_message_id))
+                except Exception as e:
+                    logger.debug("[%s] Could not fetch referenced Discord message %s: %s", self.name, reference_message_id, e)
+
+        return reply_to_message_id, self._summarize_referenced_message(referenced)
+
     async def _handle_message(self, message: DiscordMessage) -> None:
         """Handle incoming Discord messages."""
         # In server channels (not DMs), require the bot to be @mentioned
@@ -2345,27 +2416,30 @@ class DiscordAdapter(BasePlatformAdapter):
                     ext = "." + content_type.split("/")[-1].split(";")[0]
                     if ext not in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
                         ext = ".jpg"
-                    cached_path = await cache_image_from_url(att.url, ext=ext)
+                    image_url = getattr(att, "proxy_url", None) or att.url
+                    cached_path = await cache_image_from_url(image_url, ext=ext)
                     media_urls.append(cached_path)
                     media_types.append(content_type)
                     print(f"[Discord] Cached user image: {cached_path}", flush=True)
                 except Exception as e:
                     print(f"[Discord] Failed to cache image attachment: {e}", flush=True)
-                    # Fall back to the CDN URL if caching fails
-                    media_urls.append(att.url)
+                    # Fall back to the proxy/CDN URL if caching fails
+                    media_urls.append(getattr(att, "proxy_url", None) or att.url)
                     media_types.append(content_type)
             elif content_type.startswith("audio/"):
                 try:
                     ext = "." + content_type.split("/")[-1].split(";")[0]
                     if ext not in (".ogg", ".mp3", ".wav", ".webm", ".m4a"):
                         ext = ".ogg"
-                    cached_path = await cache_audio_from_url(att.url, ext=ext)
+                    audio_url = getattr(att, "proxy_url", None) or att.url
+                    cached_path = await cache_audio_from_url(audio_url, ext=ext)
                     media_urls.append(cached_path)
                     media_types.append(content_type)
                     print(f"[Discord] Cached user audio: {cached_path}", flush=True)
                 except Exception as e:
                     print(f"[Discord] Failed to cache audio attachment: {e}", flush=True)
-                    media_urls.append(att.url)
+                    fallback_audio_url = getattr(att, "proxy_url", None) or att.url
+                    media_urls.append(fallback_audio_url)
                     media_types.append(content_type)
             else:
                 # Document attachments: download, cache, and optionally inject text
@@ -2435,6 +2509,8 @@ class DiscordAdapter(BasePlatformAdapter):
         if not event_text or not event_text.strip():
             event_text = "(The user sent a message with no text content)"
 
+        reply_to_message_id, reply_to_text = await self._resolve_referenced_message_text(message)
+
         event = MessageEvent(
             text=event_text,
             message_type=msg_type,
@@ -2443,7 +2519,8 @@ class DiscordAdapter(BasePlatformAdapter):
             message_id=str(message.id),
             media_urls=media_urls,
             media_types=media_types,
-            reply_to_message_id=str(message.reference.message_id) if message.reference else None,
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
             timestamp=message.created_at,
         )
 

--- a/tests/gateway/test_discord_reply_context.py
+++ b/tests/gateway/test_discord_reply_context.py
@@ -1,0 +1,128 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.MessageType = SimpleNamespace(default="default", reply="reply")
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+def _make_adapter():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter.handle_message = AsyncMock()
+    adapter._client = MagicMock()
+    adapter._client.user = object()
+    return adapter
+
+
+def _base_message():
+    guild = SimpleNamespace(name="Guild")
+    channel = SimpleNamespace(id=123, name="general", guild=guild, topic=None)
+    author = SimpleNamespace(id=1, display_name="yake", name="yake", bot=False)
+    return SimpleNamespace(
+        id=999,
+        channel=channel,
+        author=author,
+        content="current reply",
+        attachments=[],
+        created_at=None,
+        mentions=[],
+        type="reply",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_message_uses_resolved_reply_text():
+    adapter = _make_adapter()
+    message = _base_message()
+    referenced = SimpleNamespace(
+        content="quoted text from resolved message",
+        attachments=[],
+        author=SimpleNamespace(display_name="Alice"),
+    )
+    message.reference = SimpleNamespace(message_id=111, resolved=referenced)
+
+    await adapter._handle_message(message)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.reply_to_message_id == "111"
+    assert event.reply_to_text == "quoted text from resolved message"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_fetches_reply_text_when_resolved_missing():
+    adapter = _make_adapter()
+    message = _base_message()
+    fetched = SimpleNamespace(
+        content="fetched quoted text",
+        attachments=[],
+        author=SimpleNamespace(display_name="Bob"),
+    )
+    async def _fetch_message(message_id):
+        assert message_id == 222
+        return fetched
+    message.channel.fetch_message = _fetch_message
+    message.reference = SimpleNamespace(message_id=222, resolved=None, channel_id=123)
+
+    await adapter._handle_message(message)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.reply_to_message_id == "222"
+    assert event.reply_to_text == "fetched quoted text"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_builds_reply_text_from_attachments_when_no_text():
+    adapter = _make_adapter()
+    message = _base_message()
+    attachment = SimpleNamespace(filename="design.png", content_type="image/png")
+    referenced = SimpleNamespace(
+        content="   ",
+        attachments=[attachment],
+        author=SimpleNamespace(display_name="Carol"),
+    )
+    message.reference = SimpleNamespace(message_id=333, resolved=referenced)
+
+    await adapter._handle_message(message)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.reply_to_message_id == "333"
+    assert "design.png" in (event.reply_to_text or "")
+    assert "attachment" in (event.reply_to_text or "")


### PR DESCRIPTION
## Summary
- resolve Discord reply context into `reply_to_text` so referenced messages reach the agent prompt
- prefer `message.reference.resolved` and fall back to `fetch_message(reference.message_id)` when Discord omits the resolved payload
- add a concise attachment/embed fallback summary when the referenced message has no plain-text content
- add regression tests covering resolved replies, fetch fallback, and attachment-only replies

## Problem
Hermes already has a gateway-level reply-context injection path in `gateway/run.py`, but Discord only populated `reply_to_message_id` and never filled `reply_to_text`.

That meant Discord replies often reached the model without the quoted content, especially when the referenced message was outside the current in-memory history window.

## Why this approach
This follows the standard Discord / discord.py pattern:
1. prefer the already-resolved referenced message when available
2. fetch the referenced message on demand when Discord does not include it
3. degrade gracefully when the referenced message only contains attachments or embeds

This keeps the fix local to the Discord adapter, preserves the existing cross-platform `MessageEvent` contract, and reuses the existing reply-context injection logic already used by other platforms.

## Testing
- added `tests/gateway/test_discord_reply_context.py`
- syntax-checked locally with `python3 -m compileall gateway/platforms/discord.py tests/gateway/test_discord_reply_context.py`

## Notes
This PR intentionally does not change Discord's primary message routing or session model. It only restores parity with Hermes' existing reply-context design used by other adapters.
