### PR TITLE
fix(agent): force 429 classification for RateLimitError + rate-limit cooldown on primary restore

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -251,6 +251,9 @@ def classify_api_error(
     """
     status_code = _extract_status_code(error)
     error_type = type(error).__name__
+    # ^ Copilot/GitHub Models RateLimitError may not set .status_code; force 429.
+    if status_code is None and error_type == "RateLimitError":
+        status_code = 429
     body = _extract_error_body(error)
     error_code = _extract_error_code(body)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5195,7 +5195,7 @@ class AIAgent:
 
     # ── Provider fallback ──────────────────────────────────────────────────
 
-    def _try_activate_fallback(self) -> bool:
+    def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
         """Switch to the next fallback model/provider in the chain.
 
         Called when the current model is failing after retries.  Swaps the
@@ -5207,6 +5207,8 @@ class AIAgent:
         auth resolution and client construction — no duplicated provider→key
         mappings.
         """
+        if reason in (FailoverReason.rate_limit, FailoverReason.billing):
+            self._rate_limited_until = time.monotonic() + 60
         if self._fallback_index >= len(self._fallback_chain):
             return False
 
@@ -5349,6 +5351,9 @@ class AIAgent:
         """
         if not self._fallback_activated:
             return False
+
+        if getattr(self, "_rate_limited_until", 0) > time.monotonic():
+            return False  # primary still in rate-limit cooldown, stay on fallback
 
         rt = self._primary_runtime
         try:
@@ -8690,7 +8695,7 @@ class AIAgent:
                         pool_may_recover = pool is not None and pool.has_available()
                         if not pool_may_recover:
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")
-                            if self._try_activate_fallback():
+                            if self._try_activate_fallback(reason=classified.reason):
                                 retry_count = 0
                                 continue
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5208,7 +5208,14 @@ class AIAgent:
         mappings.
         """
         if reason in (FailoverReason.rate_limit, FailoverReason.billing):
-            self._rate_limited_until = time.monotonic() + 60
+            # Only start cooldown when leaving the primary provider.  If we're
+            # already on a fallback and chain-switching, the primary wasn't the
+            # source of the 429 so the cooldown should not be reset/extended.
+            fallback_already_active = bool(getattr(self, "_fallback_activated", False))
+            current_provider = (getattr(self, "provider", "") or "").strip().lower()
+            primary_provider = ((self._primary_runtime or {}).get("provider") or "").strip().lower()
+            if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
+                self._rate_limited_until = time.monotonic() + 60
         if self._fallback_index >= len(self._fallback_chain):
             return False
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -807,3 +807,38 @@ class TestAdversarialEdgeCases:
         )
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.model_not_found
+
+
+# ── Test: RateLimitError without status_code (Copilot/GitHub Models) ──────────
+
+class TestRateLimitErrorWithoutStatusCode:
+    """Regression tests for the Copilot/GitHub Models edge case where the
+    OpenAI SDK raises RateLimitError but does not populate .status_code."""
+
+    def _make_rate_limit_error(self, status_code=None):
+        """Create an exception whose class name is 'RateLimitError' with
+        an optionally missing status_code, mirroring the OpenAI SDK shape."""
+        cls = type("RateLimitError", (Exception,), {})
+        e = cls("You have exceeded your rate limit.")
+        e.status_code = status_code  # None simulates the Copilot case
+        return e
+
+    def test_rate_limit_error_without_status_code_classified_as_rate_limit(self):
+        """RateLimitError with status_code=None must classify as rate_limit."""
+        e = self._make_rate_limit_error(status_code=None)
+        result = classify_api_error(e, provider="copilot", model="gpt-4o")
+        assert result.reason == FailoverReason.rate_limit
+
+    def test_rate_limit_error_with_status_code_429_classified_as_rate_limit(self):
+        """RateLimitError that does set status_code=429 still classifies correctly."""
+        e = self._make_rate_limit_error(status_code=429)
+        result = classify_api_error(e, provider="copilot", model="gpt-4o")
+        assert result.reason == FailoverReason.rate_limit
+
+    def test_other_error_without_status_code_not_forced_to_rate_limit(self):
+        """A non-RateLimitError with missing status_code must NOT be forced to 429."""
+        cls = type("APIError", (Exception,), {})
+        e = cls("something went wrong")
+        e.status_code = None
+        result = classify_api_error(e, provider="copilot", model="gpt-4o")
+        assert result.reason != FailoverReason.rate_limit

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -446,3 +446,85 @@ class TestRestoreInRunConversation:
         assert agent._fallback_index == 0
         assert agent.provider == "custom"
         assert agent.base_url == "https://my-llm.example.com/v1"
+
+
+# =============================================================================
+# Rate-limit cooldown gate
+# =============================================================================
+
+class TestRateLimitCooldown:
+    """Verify _restore_primary_runtime() respects the 60s rate-limit cooldown."""
+
+    def test_restore_blocked_during_cooldown(self):
+        """While _rate_limited_until is in the future, restore returns False."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+
+        assert agent._fallback_activated is True
+
+        # Manually set cooldown well into the future
+        agent._rate_limited_until = time.monotonic() + 60
+
+        result = agent._restore_primary_runtime()
+        assert result is False
+        assert agent._fallback_activated is True  # still on fallback
+
+    def test_restore_allowed_after_cooldown_expires(self):
+        """Once the cooldown window passes, restore proceeds normally."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+
+        assert agent._fallback_activated is True
+
+        # Cooldown already expired
+        agent._rate_limited_until = time.monotonic() - 1
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False
+
+    def test_cooldown_set_on_rate_limit_reason(self):
+        """_try_activate_fallback with rate_limit reason sets _rate_limited_until."""
+        from run_agent import FailoverReason
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        )
+        before = time.monotonic()
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
+
+        assert hasattr(agent, "_rate_limited_until")
+        assert agent._rate_limited_until > before + 50  # ~60s from now
+
+    def test_cooldown_not_set_when_already_on_fallback(self):
+        """Chain-switching while already on fallback must not reset cooldown."""
+        from run_agent import FailoverReason
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "openrouter", "model": "model-a"},
+                {"provider": "anthropic", "model": "model-b"},
+            ],
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            # First call: leaving primary → cooldown should be set
+            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
+            first_cooldown = getattr(agent, "_rate_limited_until", 0)
+
+            # Second call: already on fallback (provider != primary) → cooldown must not advance
+            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
+            second_cooldown = getattr(agent, "_rate_limited_until", 0)
+
+        # second call should not have extended the cooldown
+        assert second_cooldown == first_cooldown


### PR DESCRIPTION
## What does this PR do?

Two related bugs prevented `fallback_providers` from activating when the primary provider (e.g. GitHub Copilot/GitHub Models) returns a 429 rate limit error.

**Bug 1 — Copilot `RateLimitError` missing `status_code`**

The OpenAI SDK's `RateLimitError` raised by the GitHub Models endpoint does not always set `.status_code` on the exception. `_extract_status_code()` returns `None`, so `classify_api_error()` falls through to message-pattern matching. If the error body doesn't contain a recognisable pattern, `reason` becomes `unknown` and the `is_rate_limited` guard in `run_agent.py` never fires — fallback is skipped entirely.

**Bug 2 — `_restore_primary_runtime()` resets fallback every turn**

In long-lived CLI sessions, `_restore_primary_runtime()` is called at the top of every turn and unconditionally swaps back to the primary provider. When the primary is rate-limited, the very next user turn hits 429 again, activates fallback again, and the cycle repeats indefinitely. The fallback never stays stable.

## Related Issue

Related: #7385 (status bar shows wrong model after fallback), #7230 (fallback not triggered on auth failure)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` (line 254-256): After `_extract_status_code()`, if `status_code is None` and the exception class name is `RateLimitError`, force `status_code = 429`. Covers all OpenAI-SDK-based providers where the SDK raises `RateLimitError` without setting `.status_code`.

- `run_agent.py` — `_try_activate_fallback()`: accepts an optional `reason` parameter. When `reason` is `rate_limit` or `billing`, sets `self._rate_limited_until = time.monotonic() + 60`.

- `run_agent.py` — `_restore_primary_runtime()`: checks `_rate_limited_until` before restoring the primary. If the primary is still in cooldown, returns `False` — session stays on fallback for the rest of the cooldown window.

- `run_agent.py` — rate-limit call site: passes `reason=classified.reason` into `_try_activate_fallback()` to propagate the rate-limit reason into the cooldown logic.

## How to Test

1. Configure `config.yaml` with Copilot as primary and Anthropic as fallback:

```yaml
model:
  provider: copilot
fallback_providers:
  - provider: anthropic
    model: claude-sonnet-4-6
```

2. Exhaust the Copilot rate limit (or mock a `RateLimitError` without `.status_code`)
3. Before fix: fallback never activates; next turn immediately retries Copilot and hits 429 again
4. After fix: fallback activates on first 429, stays on Anthropic for ~60 seconds, then probes primary again

To test Fix 1 in isolation:

```python
from agent.error_classifier import classify_api_error, FailoverReason
class RateLimitError(Exception): pass
e = RateLimitError("rate limit exceeded")
result = classify_api_error(e, provider="copilot", model="gpt-4o")
assert result.reason == FailoverReason.rate_limit
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicate found
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` — all tests pass except one pre-existing unrelated failure (`test_429_rate_limit_is_retried_and_recovers` fails due to `AttributeError: GatewayRunner has no attribute _session_model_overrides` — confirmed failing on `main` before these changes)
- [x] Tested on macOS 15

### Documentation & Housekeeping

- [x] N/A — no config keys added, no docs changed
- [x] Cross-platform: `time.monotonic()` is cross-platform; no OS-specific calls
