### PR TITLE
fix: move _last_content_with_tools fallback after retry mechanisms

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9450,7 +9450,12 @@ class AIAgent:
                             clean = self._strip_think_blocks(turn_content).strip()
                             if clean:
                                 self._vprint(f"  ┊ 💬 {clean}")
-                    
+                    else:
+                        # Tool-call turn with no real content — clear stale
+                        # fallback capture so it doesn't persist across many
+                        # turns and surface as a misleading final response.
+                        self._last_content_with_tools = None
+
                     # Pop thinking-only prefill message(s) before appending
                     # (tool-call path — same rationale as the final-response path).
                     while (
@@ -9576,30 +9581,6 @@ class AIAgent:
                     
                     # Check if response only has think block with no actual content after it
                     if not self._has_content_after_think_block(final_response):
-                        # If the previous turn already delivered real content alongside
-                        # tool calls (e.g. "You're welcome!" + memory save), the model
-                        # has nothing more to say. Use the earlier content immediately
-                        # instead of wasting API calls on retries that won't help.
-                        fallback = getattr(self, '_last_content_with_tools', None)
-                        if fallback:
-                            _turn_exit_reason = "fallback_prior_turn_content"
-                            logger.info("Empty follow-up after tool calls — using prior turn content as final response")
-                            self._emit_status("↻ Empty response after tool calls — using earlier content as final answer")
-                            self._last_content_with_tools = None
-                            self._empty_content_retries = 0
-                            for i in range(len(messages) - 1, -1, -1):
-                                msg = messages[i]
-                                if msg.get("role") == "assistant" and msg.get("tool_calls"):
-                                    tool_names = []
-                                    for tc in msg["tool_calls"]:
-                                        if not tc or not isinstance(tc, dict): continue
-                                        fn = tc.get("function", {})
-                                        tool_names.append(fn.get("name", "unknown"))
-                                    msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
-                                    break
-                            final_response = self._strip_think_blocks(fallback).strip()
-                            self._response_was_previewed = True
-                            break
 
                         # ── Thinking-only prefill continuation ──────────
                         # The model produced structured reasoning (via API
@@ -9684,6 +9665,31 @@ class AIAgent:
                                     self.model, self.provider,
                                 )
                                 continue
+
+                        # ── Last resort: use prior turn content ──────
+                        # If the previous turn already delivered real content alongside
+                        # tool calls (e.g. "You're welcome!" + memory save), the model
+                        # has nothing more to say. Use the earlier content as a last
+                        # resort after all retry mechanisms are exhausted.
+                        fallback = getattr(self, '_last_content_with_tools', None)
+                        if fallback:
+                            _turn_exit_reason = "fallback_prior_turn_content"
+                            logger.info("Empty follow-up after tool calls — using prior turn content as final response (retries exhausted)")
+                            self._emit_status("↻ Retries exhausted — using earlier content as final answer")
+                            self._last_content_with_tools = None
+                            for i in range(len(messages) - 1, -1, -1):
+                                msg = messages[i]
+                                if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                                    tool_names = []
+                                    for tc in msg["tool_calls"]:
+                                        if not tc or not isinstance(tc, dict): continue
+                                        fn = tc.get("function", {})
+                                        tool_names.append(fn.get("name", "unknown"))
+                                    msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
+                                    break
+                            final_response = self._strip_think_blocks(fallback).strip()
+                            self._response_was_previewed = True
+                            break
 
                         # Exhausted retries and fallback chain (or no
                         # fallback configured).  Fall through to the

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2170,6 +2170,117 @@ class TestRunConversation:
         assert result["final_response"] == "Done!"
 
 
+class TestLastContentWithToolsFallback:
+    """Verify _last_content_with_tools fallback only fires after retries are exhausted.
+
+    Regression for #7968: the fallback used to bypass empty-response retries,
+    causing silent agent loop termination when the model returned empty content
+    after a tool-call turn that included text.
+    """
+
+    def _setup_agent(self, agent):
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.base_url = "http://127.0.0.1:1234/v1"
+
+    def test_retries_before_fallback_on_empty_followup(self, agent):
+        """Empty follow-up after content+tools retries before using prior content."""
+        self._setup_agent(agent)
+        # Turn 1: model produces content + tool call
+        tc = _mock_tool_call(name="web_search", arguments='{"query":"test"}')
+        content_with_tools_resp = _mock_response(
+            content="Task 4 done! Now starting task 5:",
+            finish_reason="stop",
+            tool_calls=[tc],
+        )
+        # Turn 2-4: model returns empty (should retry 3 times)
+        empty_resp = _mock_response(content=None, finish_reason="stop")
+        # Turn 5: model produces real content on 3rd retry
+        real_resp = _mock_response(content="Here is task 5 result.", finish_reason="stop")
+
+        agent.client.chat.completions.create.side_effect = [
+            content_with_tools_resp,  # content + tools
+            empty_resp,               # 1st empty (retry 1)
+            empty_resp,               # 2nd empty (retry 2)
+            real_resp,                # 3rd attempt: real content
+        ]
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}'),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("do tasks 4 and 5")
+        # Must get the real follow-up, NOT the stale "Task 4 done!" fallback
+        assert result["final_response"] == "Here is task 5 result."
+        assert result["api_calls"] == 4
+
+    def test_fallback_used_after_all_retries_exhausted(self, agent):
+        """When all retries fail, _last_content_with_tools is used as last resort."""
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments='{"query":"test"}')
+        content_with_tools_resp = _mock_response(
+            content="Here is your answer!",
+            finish_reason="stop",
+            tool_calls=[tc],
+        )
+        empty_resp = _mock_response(content=None, finish_reason="stop")
+
+        agent.client.chat.completions.create.side_effect = [
+            content_with_tools_resp,  # content + tools
+            empty_resp,               # retry 1
+            empty_resp,               # retry 2
+            empty_resp,               # retry 3
+            empty_resp,               # all exhausted
+        ]
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}'),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("answer me")
+        # After exhausting retries, fallback to prior content
+        assert result["final_response"] == "Here is your answer!"
+
+    def test_stale_fallback_cleared_on_tool_only_turn(self, agent):
+        """_last_content_with_tools is cleared when a tool-only turn follows."""
+        self._setup_agent(agent)
+        # Turn 1: content + tools
+        tc1 = _mock_tool_call(name="web_search", arguments='{"query":"setup"}')
+        content_tools_resp = _mock_response(
+            content="Stale content from turn 1",
+            finish_reason="stop",
+            tool_calls=[tc1],
+        )
+        # Turn 2: tool-only turn (no content) — should clear the fallback
+        tc2 = _mock_tool_call(name="web_search", arguments='{"query":"test"}')
+        tools_only_resp = _mock_response(
+            content=None,
+            finish_reason="stop",
+            tool_calls=[tc2],
+        )
+        # Turn 3: final response
+        final_resp = _mock_response(content="Fresh result.", finish_reason="stop")
+
+        agent.client.chat.completions.create.side_effect = [
+            content_tools_resp,  # content + tools (captures fallback)
+            tools_only_resp,     # tools only (clears fallback)
+            final_resp,          # final response
+        ]
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}'),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("do research")
+        assert result["final_response"] == "Fresh result."
+
+
 class TestRetryExhaustion:
     """Regression: retry_count > max_retries was dead code (off-by-one).
 


### PR DESCRIPTION
## Summary

- Moves the `_last_content_with_tools` fallback to fire **after** all retry mechanisms (thinking-prefill retry, empty-content retry ×3, fallback provider), instead of before them. Previously the fallback short-circuited retries, causing silent mid-task termination with stale content.
- Clears stale `_last_content_with_tools` on tool-only turns (no real content) to prevent old content from persisting across many turns.
- Adds 3 tests covering: retries fire before fallback, fallback fires after retries exhausted, stale capture cleared on tool-only turns.

Fixes #7968

## Test plan

- [x] `TestLastContentWithToolsFallback::test_retries_before_fallback_on_empty_followup` — verifies retries produce fresh content before fallback is consulted
- [x] `TestLastContentWithToolsFallback::test_fallback_used_after_all_retries_exhausted` — verifies fallback IS used when all retries return empty
- [x] `TestLastContentWithToolsFallback::test_stale_fallback_cleared_on_tool_only_turn` — verifies tool-only turn clears stale capture
- [x] Full `test_run_agent.py` suite: 251/251 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)