### PR TITLE
fix(bluebubbles): remove invalid webhook event and include auth token in URL

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -54,7 +54,7 @@ _TAPBACK_REMOVED = {
 }
 
 # Webhook event types that carry user messages
-_MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_MESSAGE_EVENTS = {"new-message", "updated-message"}
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -222,7 +222,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         host = self.webhook_host
         if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
             host = "localhost"
-        return f"http://{host}:{self.webhook_port}{self.webhook_path}"
+        base = f"http://{host}:{self.webhook_port}{self.webhook_path}"
+        if self.password:
+            from urllib.parse import urlencode
+            return f"{base}?{urlencode({'password': self.password})}"
+        return base
 
     async def _find_registered_webhooks(self, url: str) -> list:
         """Return list of BB webhook entries matching *url*."""
@@ -257,7 +261,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message", "message"],
+            "events": ["new-message", "updated-message"],
         }
 
         try:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -385,6 +385,21 @@ class TestBlueBubblesWebhookUrl:
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")
         assert "192.168.1.50" in adapter._webhook_url
 
+    def test_password_included_in_url(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert "password=secret" in adapter._webhook_url
+
+    def test_no_password_omits_query_string(self, monkeypatch):
+        monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+        monkeypatch.delenv("BLUEBUBBLES_PASSWORD", raising=False)
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={"server_url": "http://localhost:1234", "password": ""},
+        )
+        adapter = BlueBubblesAdapter(cfg)
+        assert "?" not in adapter._webhook_url
+
 
 class TestBlueBubblesWebhookRegistration:
     """Tests for _register_webhook, _unregister_webhook, _find_registered_webhooks."""
@@ -482,6 +497,25 @@ class TestBlueBubblesWebhookRegistration:
             adapter._register_webhook()
         )
         assert ok is True
+
+    def test_register_events_exclude_invalid_message(self, monkeypatch):
+        """Webhook registration must not include invalid 'message' event."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = self._mock_client(
+            get_response={"status": 200, "data": []},
+            post_response={"status": 200, "data": {"id": 44}},
+        )
+        captured = {}
+        orig_api_post = adapter._api_post
+        async def _capture_post(path, payload):
+            captured.update(payload)
+            return {"status": 200, "data": {"id": 44}}
+        adapter._api_post = _capture_post
+        asyncio.get_event_loop().run_until_complete(adapter._register_webhook())
+        assert "message" not in captured.get("events", [])
+        assert "new-message" in captured.get("events", [])
+        assert "updated-message" in captured.get("events", [])
 
     def test_register_accepts_201(self, monkeypatch):
         """BB might return 201 Created — must still succeed."""


### PR DESCRIPTION
## Summary

- Removes invalid `"message"` event from webhook registration payload — only `"new-message"` and `"updated-message"` are valid BlueBubbles events. The invalid event caused HTTP 400 on every gateway start.
- Appends `?password=<token>` to the webhook URL registered with the BB server, so incoming callbacks include the auth token. Previously all webhooks were rejected with 401 because the handler checks `request.query.get("password")` but the registered URL never included it.
- Cleans up the `_MESSAGE_EVENTS` constant to match.

Fixes #7495

## Test plan

- [x] `test_password_included_in_url` — verifies webhook URL includes password query param
- [x] `test_no_password_omits_query_string` — verifies no query string when password is empty
- [x] `test_register_events_exclude_invalid_message` — verifies POST payload only contains valid events
- [x] Full BlueBubbles test suite: 48/48 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)