### PR TITLE
fix(gateway): use datetime cutoff in suspend_recently_active

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -807,9 +807,7 @@ class SessionStore:
         to avoid resetting long-idle sessions that are harmless to resume.
         Returns the number of sessions that were suspended.
         """
-        import time as _time
-
-        cutoff = _time.time() - max_age_seconds
+        cutoff = _now() - timedelta(seconds=max_age_seconds)
         count = 0
         with self._lock:
             self._ensure_loaded_locked()

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -12,6 +12,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
 )
+from gateway.session import SessionEntry
 
 
 class TestSessionSourceRoundtrip:
@@ -1010,3 +1011,58 @@ class TestRewriteTranscriptPreservesReasoning:
         assert after[0].get("reasoning") == "I need to think step by step."
         assert after[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
         assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
+
+
+class TestSuspendRecentlyActive:
+    """suspend_recently_active must compare datetime to datetime, not float."""
+
+    @pytest.fixture()
+    def store(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            s = SessionStore(sessions_dir=tmp_path, config=config)
+        s._db = None
+        s._loaded = True
+        return s
+
+    def test_suspends_recent_session(self, store):
+        from datetime import datetime, timedelta
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=now - timedelta(seconds=30),
+            updated_at=now - timedelta(seconds=30),
+        )
+        store._entries = {"k1": entry}
+        count = store.suspend_recently_active(max_age_seconds=120)
+        assert count == 1
+        assert entry.suspended is True
+
+    def test_skips_old_session(self, store):
+        from datetime import datetime, timedelta
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=now - timedelta(hours=1),
+            updated_at=now - timedelta(hours=1),
+        )
+        store._entries = {"k1": entry}
+        count = store.suspend_recently_active(max_age_seconds=120)
+        assert count == 0
+        assert entry.suspended is False
+
+    def test_no_type_error(self, store):
+        """Regression: must not raise 'datetime >= float' TypeError."""
+        from datetime import datetime, timedelta
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=now,
+            updated_at=now,
+        )
+        store._entries = {"k1": entry}
+        # Should not raise TypeError
+        store.suspend_recently_active(max_age_seconds=120)


### PR DESCRIPTION
## Summary

- `suspend_recently_active()` compared `entry.updated_at` (a `datetime`) to `time.time() - max_age_seconds` (a `float`), raising `TypeError: '>=' not supported between instances of 'datetime.datetime' and 'float'` on every gateway startup.
- Replaces the float cutoff with `_now() - timedelta(seconds=max_age_seconds)` so the comparison is `datetime >= datetime`.
- Adds 3 tests: suspends recent session, skips old session, and regression test for no TypeError.

Fixes #7966

## Test plan

- [x] `test_suspends_recent_session` — session updated 30s ago is suspended (within 120s window)
- [x] `test_skips_old_session` — session updated 1h ago is not suspended
- [x] `test_no_type_error` — regression: no datetime >= float TypeError
- [x] Full session test suite: 63/63 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)