### PR TITLE
fix: update activity tracker during Codex Responses streaming

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4240,6 +4240,7 @@ class AIAgent:
             collected_output_items: list = []
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
+                    self._touch_activity("receiving Codex stream response")
                     for event in stream:
                         if self._interrupt_requested:
                             break
@@ -4249,6 +4250,7 @@ class AIAgent:
                             delta_text = getattr(event, "delta", "")
                             if delta_text:
                                 self._codex_streamed_text_parts.append(delta_text)
+                                self._touch_activity("receiving Codex stream response")
                             if delta_text and not has_tool_calls:
                                 if not first_delta_fired:
                                     first_delta_fired = True
@@ -4266,6 +4268,7 @@ class AIAgent:
                             reasoning_text = getattr(event, "delta", "")
                             if reasoning_text:
                                 self._fire_reasoning_delta(reasoning_text)
+                                self._touch_activity("receiving Codex reasoning")
                         # Collect completed output items — some backends
                         # (chatgpt.com/backend-api/codex) stream valid items
                         # via response.output_item.done but the SDK's
@@ -4368,6 +4371,7 @@ class AIAgent:
                 event_type = getattr(event, "type", None)
                 if not event_type and isinstance(event, dict):
                     event_type = event.get("type")
+                self._touch_activity("receiving Codex fallback stream response")
 
                 # Collect output items and text deltas for backfill
                 if event_type == "response.output_item.done":

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1197,3 +1197,53 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     assert reasoning_ids.count("rs_xyz") == 1
     assert reasoning_ids.count("rs_zzz") == 1
     assert len(reasoning_items) == 2
+
+
+def test_codex_stream_updates_activity_tracker(monkeypatch):
+    """Regression for #7794: Codex stream events must update _touch_activity."""
+    agent = _build_agent(monkeypatch)
+
+    text_event = SimpleNamespace(type="response.output_text.delta", delta="hello")
+    reasoning_event = SimpleNamespace(type="response.reasoning.delta", delta="thinking")
+
+    class _StreamWithEvents:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def __iter__(self):
+            yield text_event
+            yield reasoning_event
+        def get_final_response(self):
+            return _codex_message_response("done")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=lambda **kw: _StreamWithEvents())
+    )
+
+    initial_ts = agent._last_activity_ts
+    agent._run_codex_stream(_codex_request_kwargs())
+    assert agent._last_activity_ts > initial_ts
+    assert "Codex" in agent._last_activity_desc
+
+
+def test_codex_fallback_stream_updates_activity_tracker(monkeypatch):
+    """Regression for #7794: Codex fallback stream must also update activity."""
+    agent = _build_agent(monkeypatch)
+
+    events = [
+        SimpleNamespace(type="response.output_text.delta", delta="hi"),
+        SimpleNamespace(
+            type="response.completed",
+            response=_codex_message_response("result"),
+        ),
+    ]
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kw: iter(events))
+    )
+
+    initial_ts = agent._last_activity_ts
+    agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert agent._last_activity_ts > initial_ts
+    assert "Codex" in agent._last_activity_desc


### PR DESCRIPTION
## Summary

- Adds `_touch_activity()` calls in `_run_codex_stream()` and `_run_codex_create_stream_fallback()` so the cron inactivity tracker stays fresh during active Codex Responses streaming.
- Without this fix, the activity description stays stale at "starting API call #N" even while stream events are flowing, causing the cron inactivity timeout to kill active jobs.
- Touch points: stream entry, text deltas, reasoning deltas, and fallback stream loop.

Fixes #7794

## Test plan

- [x] `test_codex_stream_updates_activity_tracker` — verifies `_last_activity_ts` and `_last_activity_desc` are updated during stream
- [x] `test_codex_fallback_stream_updates_activity_tracker` — same for the create(stream=True) fallback path
- [x] Full Codex Responses test suite: 42/42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)