### PR TITLE
fix(gateway): add missing RedactingFormatter import in start_gateway

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8470,6 +8470,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # verbosity=1    (-v):         INFO and above
     # verbosity=2+   (-vv/-vvv):   DEBUG
     if verbosity is not None:
+        from agent.redact import RedactingFormatter
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
         _stderr_handler.setLevel(_stderr_level)


### PR DESCRIPTION
## Summary

- `start_gateway()` in `gateway/run.py` uses `RedactingFormatter` to set up an optional stderr log handler, but the name was never imported in that scope
- This causes a `NameError: name 'RedactingFormatter' is not defined` at startup whenever `verbosity is not None` (the default code path), preventing the gateway service from starting

## Fix

Added a lazy local import `from agent.redact import RedactingFormatter` at the point of use, consistent with the pattern already used in `hermes_logging.py` (lines 220 and 273).

## Test plan

- [ ] Run `python -m hermes_cli.main gateway run` and confirm the gateway starts without `NameError`
- [ ] Run with `-v` and `-vv` flags to exercise the verbosity branches
- [ ] Run with `-q` / `--quiet` (verbosity=None) to confirm the import is not reached and still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)