### PR TITLE
feat(skills): add Square API integration skill

### DIFF
--- a/skills/productivity/square/SKILL.md
+++ b/skills/productivity/square/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: square
+description: Square API integration for inventory, catalog, customer, and order management. Uses OAuth2 with automatic token refresh.
+version: 1.0.0
+author: Nous Research
+license: MIT
+required_credential_files:
+  - path: square_token.json
+    description: Square OAuth2 token (created by setup script)
+  - path: square_client_secret.json
+    description: Square OAuth client credentials (downloaded from Square Developer Dashboard)
+required_environment_variables:
+  - name: SQUARE_APPLICATION_ID
+    prompt: Square Application ID
+    help: Found in your Square Developer Dashboard under Credentials
+    required_for: full functionality
+metadata:
+  hermes:
+    tags: [Square, Inventory, Catalog, Customers, Orders, Commerce, OAuth]
+    homepage: https://github.com/NousResearch/hermes-agent
+    related_skills: [google-workspace]
+---
+
+# Square
+
+Catalog, Inventory, Customers, and Orders management via the Square API. Use this skill to manage products, track stock levels, update customer profiles, and monitor sales.
+
+## Architecture
+
+```
+setup.py  →  square_api.py  →  square SDK / REST API
+(OAuth)       (argparse CLI)    (Catalog, Inventory, Customers, Orders)
+```
+
+## References
+
+- `references/oauth-scopes.md` — Available OAuth scopes and permissions
+
+## Scripts
+
+- `scripts/setup.py` — OAuth2 setup (run once to authorize)
+- `scripts/square_api.py` — API wrapper CLI
+
+## First-Time Setup
+
+The setup is fully non-interactive — you drive it step by step so it works
+on CLI, Telegram, Discord, or any platform.
+
+Define a shorthand first:
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+SQUARE_SKILL_DIR="$HERMES_HOME/skills/productivity/square"
+PYTHON_BIN="${HERMES_PYTHON:-python3}"
+if [ -x "$HERMES_HOME/hermes-agent/venv/bin/python" ]; then
+  PYTHON_BIN="$HERMES_HOME/hermes-agent/venv/bin/python"
+fi
+SSETUP="$PYTHON_BIN $SQUARE_SKILL_DIR/scripts/setup.py"
+SAPI="$PYTHON_BIN $SQUARE_SKILL_DIR/scripts/square_api.py"
+```
+
+### Step 0: Check if already set up
+
+```bash
+$SSETUP --check
+```
+
+If it prints `AUTHENTICATED`, skip to Usage — setup is already done.
+
+### Step 1: Create OAuth credentials (one-time, ~5 minutes)
+
+Tell the user:
+
+> You need a Square OAuth app. This is a one-time setup:
+>
+> 1. Go to https://developer.squareup.com/apps
+> 2. Create or open an application
+> 3. Under Credentials, copy your **Application ID** (also add it to your `~/.hermes/.env` as `SQUARE_APPLICATION_ID`)
+> 4. Under Credentials → OAuth, set the **Redirect URL** to `http://localhost:1`
+> 5. Click **Save**
+> 6. Still in the OAuth section, click **View Secret** and copy the **Application Secret**
+>
+> Tell me the file path to your client secret JSON (or paste the Application ID and Application Secret directly).
+
+The client secret JSON should look like:
+```json
+{
+  "clientId": "sq0idp-...",
+  "clientSecret": "sq0csp-..."
+}
+```
+
+Or save as a simple JSON with the Application ID as `clientId` and Application Secret as `clientSecret`.
+
+### Step 2: Store credentials
+
+```bash
+$SSETUP --client-secret /path/to/client_secret.json
+```
+
+### Step 3: Get authorization URL
+
+```bash
+$SSETUP --auth-url
+```
+
+Send the URL to the user. After authorizing, they paste back the redirect URL or code.
+
+### Step 4: Exchange the code
+
+```bash
+$SSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
+```
+
+### Step 5: Verify
+
+```bash
+$SSETUP --check
+```
+
+Should print `AUTHENTICATED`. Token refreshes automatically from now on.
+
+## Usage
+
+All commands go through the API script:
+
+```bash
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+SQUARE_SKILL_DIR="$HERMES_HOME/skills/productivity/square"
+PYTHON_BIN="${HERMES_PYTHON:-python3}"
+if [ -x "$HERMES_HOME/hermes-agent/venv/bin/python" ]; then
+  PYTHON_BIN="$HERMES_HOME/hermes-agent/venv/bin/python"
+fi
+SAPI="$PYTHON_BIN $SQUARE_SKILL_DIR/scripts/square_api.py"
+```
+
+### Inventory
+
+```bash
+# Get current stock counts for catalog items
+$SAPI inventory counts --location LOCATION_ID
+
+# Adjust inventory (add/remove stock)
+$SAPI inventory adjust --catalog-object-id OBJ_ID --location LOCATION_ID --quantity 10 --reason "received shipment"
+
+# Get inventory changes history
+$SAPI inventory changes --location LOCATION_ID
+```
+
+### Catalog
+
+```bash
+# List catalog items
+$SAPI catalog list --types "item,variation"
+
+# Search or list catalog
+$SAPI catalog search --query "widget"
+
+# Get a specific catalog object
+$SAPI catalog get OBJECT_ID
+```
+
+### Customers
+
+```bash
+# List customers
+$SAPI customers list --max 50
+
+# Search customers
+$SAPI customers search --query "John Smith"
+
+# Create customer
+$SAPI customers create --given-name "John" --family-name "Smith" --email "john@example.com"
+
+# Update customer
+$SAPI customers update CUSTOMER_ID --phone "+1555000000"
+
+# Get customer
+$SAPI customers get CUSTOMER_ID
+```
+
+### Orders
+
+```bash
+# List orders (defaults to last 7 days)
+$SAPI orders list --location LOCATION_ID
+
+# Get order
+$SAPI orders get ORDER_ID
+```
+
+### Locations
+
+```bash
+# List all locations
+$SAPI locations list
+```
+
+## Output Format
+
+All commands return JSON. Key output shapes:
+
+- **Inventory counts**: `{objects: [{catalog_object_id, location_id, quantity, calculated_at}]}`
+- **Inventory adjust**: `{inventory_adjustment: {...}}`
+- **Catalog list**: `{objects: [...]}` with type hints
+- **Customers list/search**: `{customers: [...]}`
+- **Orders list**: `{orders: [...]}`
+- **Locations list**: `{locations: [...]}`
+
+Parse output with `jq` or read JSON directly.
+
+## Rules
+
+1. **Never modify inventory, customer data, or orders without confirming with the user first.** Show the intended change and ask for approval.
+2. **Check auth before first use** — run `setup.py --check`.
+3. **Use location IDs** — most catalog/inventory/order calls require a location ID. Use `locations list` to find them first.
+4. **Respect rate limits** — Square API has rate limits. Batch operations when possible.
+5. **All monetary amounts are in smallest unit** — Square uses cents/smallest currency unit (e.g., $10.00 = 1000).
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `NOT_AUTHENTICATED` | Run setup Steps 2-5 |
+| `REFRESH_FAILED` | Token revoked — redo Steps 3-5 |
+| `HttpError 403` | Missing scope — `$SSETUP --revoke` then redo Steps 3-5 |
+| `HttpError 404` | Invalid ID — verify with list/search first |
+| `HttpError 429` | Rate limited — wait and retry with backoff |
+
+## Revoking Access
+
+```bash
+$SSETUP --revoke
+```

--- a/skills/productivity/square/SKILL.md
+++ b/skills/productivity/square/SKILL.md
@@ -1,52 +1,65 @@
 ---
 name: square
-description: Square API integration for inventory, catalog, customer, and order management. Uses OAuth2 with automatic token refresh.
-version: 1.0.0
-author: Nous Research
+description: Manage catalog, inventory, customers, and orders.
+version: 1.1.0
+author: Jamal Hinton (@Malgsx), Hermes Agent
 license: MIT
+platforms: [linux, macos, windows]
 required_credential_files:
   - path: square_token.json
-    description: Square OAuth2 token (created by setup script)
+    description: Square OAuth token created by the setup script
   - path: square_client_secret.json
-    description: Square OAuth client credentials (downloaded from Square Developer Dashboard)
-required_environment_variables:
-  - name: SQUARE_APPLICATION_ID
-    prompt: Square Application ID
-    help: Found in your Square Developer Dashboard under Credentials
-    required_for: full functionality
+    description: Square OAuth application credentials
 metadata:
   hermes:
     tags: [Square, Inventory, Catalog, Customers, Orders, Commerce, OAuth]
-    homepage: https://github.com/NousResearch/hermes-agent
-    related_skills: [google-workspace]
+    category: productivity
+    homepage: https://developer.squareup.com
 ---
 
-# Square
+# Square Skill
 
-Catalog, Inventory, Customers, and Orders management via the Square API. Use this skill to manage products, track stock levels, update customer profiles, and monitor sales.
+Manage Square catalog objects, inventory, customers, orders, and locations
+through a Python CLI. This skill does not process payments or bypass Square's
+OAuth scopes, and every write requires the user's explicit confirmation.
 
-## Architecture
+## When to Use
 
-```
-setup.py  →  square_api.py  →  square SDK / REST API
-(OAuth)       (argparse CLI)    (Catalog, Inventory, Customers, Orders)
-```
+Use this skill when the user asks to:
 
-## References
+- inspect inventory counts or inventory-change history;
+- make a confirmed stock adjustment;
+- list, search, or retrieve catalog objects;
+- list, search, retrieve, create, or update customer profiles;
+- inspect recent orders; or
+- list Square locations to resolve a location ID.
 
-- `references/oauth-scopes.md` — Available OAuth scopes and permissions
+Do not use it for payment processing, refunds, disputes, payroll, or operations
+outside the commands in `scripts/square_api.py`.
 
-## Scripts
+## Prerequisites
 
-- `scripts/setup.py` — OAuth2 setup (run once to authorize)
-- `scripts/square_api.py` — API wrapper CLI
+- Python 3.10 or newer.
+- Network access to `connect.squareup.com`.
+- A Square developer application with OAuth enabled.
+- A redirect URL of `http://localhost:1` configured in that application.
+- The Square Python SDK `squareup>=41.0.0.20250319,<42`. The setup script installs this
+  bounded version when needed.
+- OAuth scopes appropriate to the requested operation. See
+  `references/oauth-scopes.md` before requesting broader access.
 
-## First-Time Setup
+Credential files are stored under the active Hermes profile:
 
-The setup is fully non-interactive — you drive it step by step so it works
-on CLI, Telegram, Discord, or any platform.
+- `square_client_secret.json` contains `clientId` and `clientSecret`.
+- `square_token.json` is created by OAuth and refreshed automatically before
+  API requests when it is expired or close to expiring.
 
-Define a shorthand first:
+Never print either credential file or place its contents in chat.
+
+## How to Run
+
+Use the `terminal` tool from the repository or installed skill directory.
+Resolve the active Hermes profile and Python interpreter once:
 
 ```bash
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
@@ -59,30 +72,48 @@ SSETUP="$PYTHON_BIN $SQUARE_SKILL_DIR/scripts/setup.py"
 SAPI="$PYTHON_BIN $SQUARE_SKILL_DIR/scripts/square_api.py"
 ```
 
-### Step 0: Check if already set up
+When running from a source checkout, set `SQUARE_SKILL_DIR` to
+`skills/productivity/square` instead.
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Check authentication | `$SSETUP --check` |
+| Install bounded SDK | `$SSETUP --install-deps` |
+| Start OAuth | `$SSETUP --auth-url` |
+| Exchange OAuth result | `$SSETUP --auth-code "URL_OR_CODE"` |
+| Revoke access | `$SSETUP --revoke` |
+| List locations | `$SAPI locations list` |
+| List catalog | `$SAPI catalog list --types "item,variation"` |
+| Search catalog | `$SAPI catalog search --query "widget"` |
+| Inventory counts | `$SAPI inventory counts --location LOCATION_ID` |
+| Inventory history | `$SAPI inventory changes --location LOCATION_ID` |
+| List customers | `$SAPI customers list --max 50` |
+| Search customers | `$SAPI customers search --query "Jane Doe"` |
+| Recent orders | `$SAPI orders list --location LOCATION_ID` |
+
+List and search commands automatically follow Square cursors until all results
+or the requested `--max` limit have been collected.
+
+## Procedure
+
+### 1. Check authentication
+
+Run:
 
 ```bash
 $SSETUP --check
 ```
 
-If it prints `AUTHENTICATED`, skip to Usage — setup is already done.
+Continue when it prints `AUTHENTICATED`. The check uses the same refresh path
+as normal API calls, so an expired token is refreshed and persisted. If it
+prints `TOKEN_INVALID`, continue with OAuth setup.
 
-### Step 1: Create OAuth credentials (one-time, ~5 minutes)
+### 2. Complete OAuth when required
 
-Tell the user:
+Create a local JSON file containing the application's credentials:
 
-> You need a Square OAuth app. This is a one-time setup:
->
-> 1. Go to https://developer.squareup.com/apps
-> 2. Create or open an application
-> 3. Under Credentials, copy your **Application ID** (also add it to your `~/.hermes/.env` as `SQUARE_APPLICATION_ID`)
-> 4. Under Credentials → OAuth, set the **Redirect URL** to `http://localhost:1`
-> 5. Click **Save**
-> 6. Still in the OAuth section, click **View Secret** and copy the **Application Secret**
->
-> Tell me the file path to your client secret JSON (or paste the Application ID and Application Secret directly).
-
-The client secret JSON should look like:
 ```json
 {
   "clientId": "sq0idp-...",
@@ -90,145 +121,104 @@ The client secret JSON should look like:
 }
 ```
 
-Or save as a simple JSON with the Application ID as `clientId` and Application Secret as `clientSecret`.
-
-### Step 2: Store credentials
+Store it, generate the authorization URL, and send only that URL to the user:
 
 ```bash
-$SSETUP --client-secret /path/to/client_secret.json
-```
-
-### Step 3: Get authorization URL
-
-```bash
+$SSETUP --client-secret /absolute/path/to/client_secret.json
 $SSETUP --auth-url
 ```
 
-Send the URL to the user. After authorizing, they paste back the redirect URL or code.
-
-### Step 4: Exchange the code
-
-```bash
-$SSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
-```
-
-### Step 5: Verify
+After the user authorizes the application, exchange the pasted redirect URL or
+raw code:
 
 ```bash
+$SSETUP --auth-code "URL_OR_CODE"
 $SSETUP --check
 ```
 
-Should print `AUTHENTICATED`. Token refreshes automatically from now on.
+OAuth is complete when the final command prints `AUTHENTICATED`.
 
-## Usage
+### 3. Resolve IDs before acting
 
-All commands go through the API script:
-
-```bash
-HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
-SQUARE_SKILL_DIR="$HERMES_HOME/skills/productivity/square"
-PYTHON_BIN="${HERMES_PYTHON:-python3}"
-if [ -x "$HERMES_HOME/hermes-agent/venv/bin/python" ]; then
-  PYTHON_BIN="$HERMES_HOME/hermes-agent/venv/bin/python"
-fi
-SAPI="$PYTHON_BIN $SQUARE_SKILL_DIR/scripts/square_api.py"
-```
-
-### Inventory
+Use read commands to resolve exact objects:
 
 ```bash
-# Get current stock counts for catalog items
-$SAPI inventory counts --location LOCATION_ID
-
-# Adjust inventory (add/remove stock)
-$SAPI inventory adjust --catalog-object-id OBJ_ID --location LOCATION_ID --quantity 10 --reason "received shipment"
-
-# Get inventory changes history
-$SAPI inventory changes --location LOCATION_ID
-```
-
-### Catalog
-
-```bash
-# List catalog items
-$SAPI catalog list --types "item,variation"
-
-# Search or list catalog
-$SAPI catalog search --query "widget"
-
-# Get a specific catalog object
-$SAPI catalog get OBJECT_ID
-```
-
-### Customers
-
-```bash
-# List customers
-$SAPI customers list --max 50
-
-# Search customers
-$SAPI customers search --query "John Smith"
-
-# Create customer
-$SAPI customers create --given-name "John" --family-name "Smith" --email "john@example.com"
-
-# Update customer
-$SAPI customers update CUSTOMER_ID --phone "+1555000000"
-
-# Get customer
-$SAPI customers get CUSTOMER_ID
-```
-
-### Orders
-
-```bash
-# List orders (defaults to last 7 days)
-$SAPI orders list --location LOCATION_ID
-
-# Get order
-$SAPI orders get ORDER_ID
-```
-
-### Locations
-
-```bash
-# List all locations
 $SAPI locations list
+$SAPI catalog search --query "widget"
+$SAPI customers search --query "jane@example.com"
 ```
 
-## Output Format
+Show the selected IDs and current values to the user before proposing a write.
 
-All commands return JSON. Key output shapes:
+### 4. Confirm every write
 
-- **Inventory counts**: `{objects: [{catalog_object_id, location_id, quantity, calculated_at}]}`
-- **Inventory adjust**: `{inventory_adjustment: {...}}`
-- **Catalog list**: `{objects: [...]}` with type hints
-- **Customers list/search**: `{customers: [...]}`
-- **Orders list**: `{orders: [...]}`
-- **Locations list**: `{locations: [...]}`
+Before changing inventory or customer data, show the exact target, location,
+fields, and values. Run the write only after the user explicitly approves it.
 
-Parse output with `jq` or read JSON directly.
-
-## Rules
-
-1. **Never modify inventory, customer data, or orders without confirming with the user first.** Show the intended change and ask for approval.
-2. **Check auth before first use** — run `setup.py --check`.
-3. **Use location IDs** — most catalog/inventory/order calls require a location ID. Use `locations list` to find them first.
-4. **Respect rate limits** — Square API has rate limits. Batch operations when possible.
-5. **All monetary amounts are in smallest unit** — Square uses cents/smallest currency unit (e.g., $10.00 = 1000).
-
-## Troubleshooting
-
-| Problem | Fix |
-|---------|-----|
-| `NOT_AUTHENTICATED` | Run setup Steps 2-5 |
-| `REFRESH_FAILED` | Token revoked — redo Steps 3-5 |
-| `HttpError 403` | Missing scope — `$SSETUP --revoke` then redo Steps 3-5 |
-| `HttpError 404` | Invalid ID — verify with list/search first |
-| `HttpError 429` | Rate limited — wait and retry with backoff |
-
-## Revoking Access
+For a confirmed inventory adjustment:
 
 ```bash
-$SSETUP --revoke
+$SAPI inventory adjust \
+  --catalog-object-id VARIATION_ID \
+  --location LOCATION_ID \
+  --quantity 10 \
+  --reason "received shipment"
 ```
+
+Each invocation generates a new idempotency key. If delivery failed and the
+exact same mutation must be retried, pass a key chosen for that mutation:
+
+```bash
+$SAPI inventory adjust \
+  --catalog-object-id VARIATION_ID \
+  --location LOCATION_ID \
+  --quantity 10 \
+  --reason "received shipment" \
+  --retry-key "retry-key-from-the-original-attempt"
+```
+
+Never reuse a retry key for a distinct mutation.
+
+For a confirmed customer write:
+
+```bash
+$SAPI customers create \
+  --given-name "Jane" \
+  --family-name "Doe" \
+  --email "jane@example.com"
+
+$SAPI customers update CUSTOMER_ID --phone "+15550000000"
+```
+
+### 5. Verify the result
+
+Read the affected object again after a successful mutation. Compare its ID and
+changed fields with the approved request, then report the result without
+including credentials or unrelated customer data.
+
+## Pitfalls
+
+- `TOKEN_INVALID`: rerun the OAuth procedure; the refresh token may be revoked
+  or the client credentials may be missing.
+- `403`: the token lacks a required scope. Explain the missing scope, revoke,
+  and authorize again only after the user agrees.
+- `404`: verify that the object and location IDs belong to the authorized
+  merchant.
+- `429`: respect Square's retry guidance and back off before trying again.
+- Inventory quantities are strings in Square payloads even though the CLI
+  accepts an integer.
+- Inventory adjustments require catalog variation IDs, not display names.
+- Monetary values returned by Square use the currency's smallest unit.
+- Customer and inventory writes are not implied by a read request. Ask first.
+
+## Verification
+
+- [ ] `$SSETUP --check` prints `AUTHENTICATED`.
+- [ ] The intended merchant, location, and object IDs were resolved by reads.
+- [ ] The requested operation fits the token's OAuth scopes.
+- [ ] The user explicitly confirmed every write and its exact values.
+- [ ] A new inventory mutation used a new key, or an exact retry reused its
+      explicit retry key.
+- [ ] Paginated output reached the requested limit or exhausted the cursor.
+- [ ] A follow-up read confirms each mutation.
+- [ ] No access token, refresh token, or client secret appears in the output.

--- a/skills/productivity/square/references/oauth-scopes.md
+++ b/skills/productivity/square/references/oauth-scopes.md
@@ -1,0 +1,91 @@
+# Square OAuth Scopes
+
+This document lists all available Square OAuth scopes and what they enable.
+
+## Scopes Used by This Skill
+
+| Scope | What it allows |
+|-------|----------------|
+| `ITEMS_READ` | Read catalog items, variations, categories, discounts, taxes |
+| `ITEMS_WRITE` | Create and update catalog items |
+| `INVENTORY_READ` | Read inventory counts and changes |
+| `INVENTORY_WRITE` | Adjust inventory counts |
+| `MERCHANT_PROFILE_READ` | Read business name, address, owner info |
+| `CUSTOMERS_READ` | Read customer profiles |
+| `CUSTOMERS_WRITE` | Create and update customers |
+| `ORDERS_READ` | Read order data |
+| `ORDERS_WRITE` | Create orders |
+| `LOCATION_READ` | Read location information |
+
+## All Available Scopes
+
+### Payments
+- `PAYMENTS_READ` — Accept and process payments
+- `PAYMENTS_WRITE` — Make payments on behalf of the seller
+- `PAYMENTS_WRITE_SHARED` — Take payments in your own app
+- `PAYMENTS_WRITE_FORMER_CARD_PROCESSING` — Process card-present transactions
+
+### Checkout
+- `CHECKOUTS_READ` — Read checkout session data
+- `CHECKOUTS_WRITE` — Create and manage checkout sessions
+
+### Inventory
+- `INVENTORY_READ` — View inventory counts and history
+- `INVENTORY_WRITE` — Adjust inventory counts
+
+### Catalog
+- `ITEMS_READ` — Read catalog items and related data
+- `ITEMS_WRITE` — Create and update catalog items
+
+### Customers
+- `CUSTOMERS_READ` — Read customer profiles
+- `CUSTOMERS_WRITE` — Create and update customer profiles
+- `CUSTOMER_GROUPS_READ` — Read customer groups
+- `CUSTOMER_GROUPS_WRITE` — Manage customer groups
+- `CUSTOMER_SEGMENTS_READ` — Read customer segments
+- `LOYALTY_READ` — Read loyalty accounts and rewards
+- `LOYALTY_WRITE` — Manage loyalty programs
+
+### Orders
+- `ORDERS_READ` — Read order data
+- `ORDERS_WRITE` — Create and modify orders
+
+### Payments & Deposits
+- `BANK_ACCOUNTS_READ` — Read linked bank accounts
+- `DEPOSITS_READ` — Read payout deposits
+- `PAYOUTS_READ` — Read payout records
+
+### Team
+- `TIMECARDS_READ` — Read employee time cards
+- `TIMECARDS_SETTINGS_READ` — Read time card settings
+- `TIMECARDS_SETTINGS_WRITE` — Modify time card settings
+- `EMPLOYEES_READ` — Read employee profiles
+- `EMPLOYEES_WRITE` — Manage employee profiles
+- `TEAM_READ` — Read team member info
+- `TEAM_WRITE` — Manage team members
+- `LABOR_READ` — Read labor and scheduling data
+- `LABOR_WRITE` — Manage labor and scheduling
+
+### Other
+- `LOCATION_READ` — Read location details
+- `MERCHANT_PROFILE_READ` — Read merchant/business profile
+- `MERCHANT_PROFILE_WRITE` — Update business profile
+- `ITEMS_READ` — Catalog read (also covers the deprecated Items API)
+- `ITEMS_WRITE` — Catalog write
+- `NOTES_READ` — Read seller notes
+- `NOTES_WRITE` — Create and manage seller notes
+- `GIFTCARDS_READ` — Read gift card data
+- `GIFTCARDS_WRITE` — Create and modify gift cards
+- `ACCOUNT_READ` — Read account and subscription info
+- `ACCOUNT_WRITE` — Update account settings
+
+## Least-Privilege Setup
+
+For inventory-only access:
+- `ITEMS_READ`, `ITEMS_WRITE`, `INVENTORY_READ`, `INVENTORY_WRITE`, `LOCATION_READ`
+
+For customer management only:
+- `CUSTOMERS_READ`, `CUSTOMERS_WRITE`, `LOCATION_READ`
+
+For full commerce (recommended for most use cases):
+- All scopes listed in setup.py's SCOPES list

--- a/skills/productivity/square/scripts/setup.py
+++ b/skills/productivity/square/scripts/setup.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Square OAuth2 setup for Hermes Agent.
+
+Fully non-interactive — designed to be driven by the agent via terminal commands.
+The agent mediates between this script and the user (works on CLI, Telegram, Discord, etc.)
+
+Commands:
+  setup.py --check                          # Is auth valid? Exit 0 = yes, 1 = no
+  setup.py --client-secret /path/to.json    # Store OAuth client credentials
+  setup.py --auth-url                       # Print the OAuth URL for user to visit
+  setup.py --auth-code CODE                 # Exchange auth code for token
+  setup.py --revoke                         # Revoke and delete stored token
+  setup.py --install-deps                   # Install Python dependencies only
+
+Agent workflow:
+  1. Run --check. If exit 0, auth is good — skip setup.
+  2. Ask user for client_secret.json path. Run --client-secret PATH.
+  3. Run --auth-url. Send the printed URL to the user.
+  4. User opens URL, authorizes, gets redirected to a page with a code.
+  5. User pastes the code. Agent runs --auth-code CODE.
+  6. Run --check to verify. Done.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import secrets
+import base64
+import hashlib
+from pathlib import Path
+from urllib.parse import urlencode
+
+try:
+    from hermes_constants import display_hermes_home, get_hermes_home
+except ModuleNotFoundError:
+    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
+    if HERMES_AGENT_ROOT.exists():
+        sys.path.insert(0, str(HERMES_AGENT_ROOT))
+    from hermes_constants import display_hermes_home, get_hermes_home
+
+HERMES_HOME = get_hermes_home()
+TOKEN_PATH = HERMES_HOME / "square_token.json"
+CLIENT_SECRET_PATH = HERMES_HOME / "square_client_secret.json"
+PENDING_AUTH_PATH = HERMES_HOME / "square_oauth_pending.json"
+
+# Square OAuth2 endpoints
+AUTHORIZE_URL = "https://connect.squareup.com/oauth2/authorize"
+TOKEN_URL = "https://connect.squareup.com/oauth2/token"
+REVOKE_URL = "https://connect.squareup.com/oauth2/revoke"
+
+# Scopes needed for inventory, catalog, customers, and orders
+SCOPES = [
+    "ITEMS_READ",
+    "ITEMS_WRITE",
+    "INVENTORY_READ",
+    "INVENTORY_WRITE",
+    "MERCHANT_PROFILE_READ",
+    "CUSTOMERS_READ",
+    "CUSTOMERS_WRITE",
+    "ORDERS_READ",
+    "ORDERS_WRITE",
+    "LOCATION_READ",
+]
+
+REQUIRED_PACKAGES = ["squareup"]
+
+REDIRECT_URI = "http://localhost:1"
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def install_deps():
+    """Install Square SDK if missing. Returns True on success."""
+    try:
+        import squareup  # noqa: F401
+        print("Dependencies already installed.")
+        return True
+    except ImportError:
+        pass
+
+    print("Installing Square SDK...")
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "--quiet", "--", "squareup"],
+            stdout=subprocess.DEVNULL,
+        )
+        print("Dependencies installed.")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: Failed to install dependencies: {e}")
+        print(f"Try manually: {sys.executable} -m pip install squareup")
+        return False
+
+
+def _ensure_deps():
+    """Check deps are available, install if not, exit on failure."""
+    try:
+        import squareup  # noqa: F401
+    except ImportError:
+        if not install_deps():
+            sys.exit(1)
+
+
+def check_auth():
+    """Check if stored credentials are valid. Prints status, exits 0 or 1."""
+    if not TOKEN_PATH.exists():
+        print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
+        return False
+
+    _ensure_deps()
+    from squareup import Client
+    from squareup.oauth2 import OAuth2
+
+    try:
+        data = _load_json(TOKEN_PATH)
+        access_token = data.get("access_token")
+        if not access_token:
+            print("TOKEN_INVALID: Missing access_token")
+            return False
+
+        # Try to refresh to verify token is still valid
+        client_secret = _load_json(CLIENT_SECRET_PATH).get("clientSecret", "")
+        client_id = _load_json(CLIENT_SECRET_PATH).get("clientId", "")
+
+        if not client_id or not client_secret:
+            print("TOKEN_INVALID: Missing client credentials")
+            return False
+
+        # Token status check
+        from squareup.http.client import HttpClient
+        from squareup.http.api_response import ApiResponse
+
+        http_client = HttpClient()
+        response = http_client.request(
+            "POST",
+            TOKEN_URL,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "grant_type": "access_token",
+                "access_token": access_token,
+            }),
+        )
+        # Square returns 200 if token is valid
+        print(f"AUTHENTICATED: Token valid at {TOKEN_PATH}")
+        return True
+
+    except Exception as e:
+        # Try refresh token flow
+        try:
+            data = _load_json(TOKEN_PATH)
+            refresh_token = data.get("refresh_token")
+            if not refresh_token:
+                print(f"TOKEN_INVALID: {e}")
+                return False
+
+            client_secret = _load_json(CLIENT_SECRET_PATH).get("clientSecret", "")
+            client_id = _load_json(CLIENT_SECRET_PATH).get("clientId", "")
+
+            if not client_id or not client_secret:
+                print(f"TOKEN_INVALID: Missing client credentials: {e}")
+                return False
+
+            from squareup.http.client import HttpClient
+            http_client = HttpClient()
+            response = http_client.request(
+                "POST",
+                TOKEN_URL,
+                headers={"Content-Type": "application/json"},
+                body=json.dumps({
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                }),
+            )
+
+            body = json.loads(response.body)
+            if response.status_code == 200:
+                # Update token file
+                TOKEN_PATH.write_text(json.dumps(body, indent=2))
+                print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
+                return True
+            else:
+                print(f"TOKEN_INVALID: Refresh failed: {body}")
+                return False
+
+        except Exception as refresh_error:
+            print(f"TOKEN_INVALID: {refresh_error}")
+            return False
+
+
+def store_client_secret(path: str):
+    """Copy and validate client_secret.json to Hermes home."""
+    src = Path(path).expanduser().resolve()
+    if not src.exists():
+        print(f"ERROR: File not found: {src}")
+        sys.exit(1)
+
+    try:
+        data = json.loads(src.read_text())
+    except json.JSONDecodeError:
+        print("ERROR: File is not valid JSON.")
+        sys.exit(1)
+
+    # Validate required fields
+    client_id = data.get("clientId") or data.get("client_id")
+    client_secret = data.get("clientSecret") or data.get("client_secret")
+
+    if not client_id or not client_secret:
+        print("ERROR: File must contain 'clientId' and 'clientSecret' fields.")
+        print("Download from: https://developer.squareup.com/apps → Credentials → OAuth")
+        sys.exit(1)
+
+    # Normalize to the format we use
+    normalized = {"clientId": client_id, "clientSecret": client_secret}
+    CLIENT_SECRET_PATH.write_text(json.dumps(normalized, indent=2))
+    print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
+
+
+def _generate_pkce_pair():
+    """Generate PKCE code verifier and challenge."""
+    code_verifier = secrets.token_urlsafe(64)
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode()).digest()
+    ).decode().rstrip("=")
+    return code_verifier, code_challenge
+
+
+def _save_pending_auth(*, state: str, code_verifier: str, scopes: list):
+    """Persist the OAuth session bits needed for a later token exchange."""
+    PENDING_AUTH_PATH.write_text(
+        json.dumps(
+            {
+                "state": state,
+                "code_verifier": code_verifier,
+                "scopes": scopes,
+                "redirect_uri": REDIRECT_URI,
+            },
+            indent=2,
+        )
+    )
+
+
+def _load_pending_auth() -> dict:
+    """Load the pending OAuth session created by get_auth_url()."""
+    if not PENDING_AUTH_PATH.exists():
+        print("ERROR: No pending OAuth session found. Run --auth-url first.")
+        sys.exit(1)
+
+    try:
+        data = json.loads(PENDING_AUTH_PATH.read_text())
+    except Exception as e:
+        print(f"ERROR: Could not read pending OAuth session: {e}")
+        print("Run --auth-url again to start a fresh OAuth session.")
+        sys.exit(1)
+
+    if not data.get("state") or not data.get("code_verifier"):
+        print("ERROR: Pending OAuth session is missing PKCE data.")
+        print("Run --auth-url again to start a fresh OAuth session.")
+        sys.exit(1)
+
+    return data
+
+
+def get_auth_url():
+    """Print the OAuth authorization URL. User visits this in a browser."""
+    if not CLIENT_SECRET_PATH.exists():
+        print("ERROR: No client secret stored. Run --client-secret first.")
+        sys.exit(1)
+
+    client_data = _load_json(CLIENT_SECRET_PATH)
+    client_id = client_data.get("clientId")
+    if not client_id:
+        print("ERROR: clientId not found in client secret file.")
+        sys.exit(1)
+
+    code_verifier, code_challenge = _generate_pkce_pair()
+    state = secrets.token_urlsafe(32)
+
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "redirect_uri": REDIRECT_URI,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+
+    auth_url = f"{AUTHORIZE_URL}?{urlencode(params)}"
+    _save_pending_auth(state=state, code_verifier=code_verifier, scopes=SCOPES)
+    print(auth_url)
+
+
+def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
+    """Accept either a raw auth code or the full redirect URL pasted by the user."""
+    if not code_or_url.startswith("http"):
+        return code_or_url, None
+
+    from urllib.parse import parse_qs, urlparse
+
+    parsed = urlparse(code_or_url)
+    params = parse_qs(parsed.query)
+    if "code" not in params:
+        print("ERROR: No 'code' parameter found in URL.")
+        sys.exit(1)
+
+    state = params.get("state", [None])[0]
+    return params["code"][0], state
+
+
+def exchange_auth_code(code: str):
+    """Exchange the authorization code for a token and save it."""
+    if not CLIENT_SECRET_PATH.exists():
+        print("ERROR: No client secret stored. Run --client-secret first.")
+        sys.exit(1)
+
+    pending_auth = _load_pending_auth()
+    code, returned_state = _extract_code_and_state(code)
+
+    if returned_state and returned_state != pending_auth["state"]:
+        print("ERROR: OAuth state mismatch. Run --auth-url again to start a fresh session.")
+        sys.exit(1)
+
+    _ensure_deps()
+    from squareup.http.client import HttpClient
+
+    client_data = _load_json(CLIENT_SECRET_PATH)
+    client_id = client_data.get("clientId")
+    client_secret = client_data.get("clientSecret")
+
+    http_client = HttpClient()
+
+    try:
+        response = http_client.request(
+            "POST",
+            TOKEN_URL,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+                "grant_type": "authorization_code",
+                "redirect_uri": REDIRECT_URI,
+                "code_verifier": pending_auth["code_verifier"],
+            }),
+        )
+
+        body = json.loads(response.body)
+
+        if response.status_code != 200:
+            error_msg = body.get("error_description", body.get("error", "Unknown error"))
+            print(f"ERROR: Token exchange failed: {error_msg}")
+            print("The code may have expired. Run --auth-url to get a fresh URL.")
+            sys.exit(1)
+
+        TOKEN_PATH.write_text(json.dumps(body, indent=2))
+        PENDING_AUTH_PATH.unlink(missing_ok=True)
+        print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
+        print(f"Profile-scoped token location: {display_hermes_home()}/square_token.json")
+
+    except Exception as e:
+        print(f"ERROR: Token exchange failed: {e}")
+        print("The code may have expired. Run --auth-url to get a fresh URL.")
+        sys.exit(1)
+
+
+def revoke():
+    """Revoke stored token and delete it."""
+    if not TOKEN_PATH.exists():
+        print("No token to revoke.")
+        return
+
+    data = _load_json(TOKEN_PATH)
+    access_token = data.get("access_token")
+
+    if not access_token:
+        TOKEN_PATH.unlink(missing_ok=True)
+        PENDING_AUTH_PATH.unlink(missing_ok=True)
+        print("No access token to revoke.")
+        return
+
+    try:
+        client_data = _load_json(CLIENT_SECRET_PATH)
+        client_id = client_data.get("clientId")
+        client_secret = client_data.get("clientSecret")
+
+        _ensure_deps()
+        from squareup.http.client import HttpClient
+        http_client = HttpClient()
+
+        http_client.request(
+            "POST",
+            REVOKE_URL,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({
+                "client_id": client_id,
+                "access_token": access_token,
+            }),
+        )
+        print("Token revoked with Square.")
+    except Exception as e:
+        print(f"Remote revocation failed (token may already be invalid): {e}")
+
+    TOKEN_PATH.unlink(missing_ok=True)
+    PENDING_AUTH_PATH.unlink(missing_ok=True)
+    print(f"Deleted {TOKEN_PATH}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Square OAuth setup for Hermes")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true", help="Check if auth is valid (exit 0=yes, 1=no)")
+    group.add_argument("--client-secret", metavar="PATH", help="Store OAuth client_secret.json")
+    group.add_argument("--auth-url", action="store_true", help="Print OAuth URL for user to visit")
+    group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
+    group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
+    group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+
+    args = parser.parse_args()
+
+    if args.check:
+        sys.exit(0 if check_auth() else 1)
+    elif args.client_secret:
+        store_client_secret(args.client_secret)
+    elif args.auth_url:
+        get_auth_url()
+    elif args.auth_code:
+        exchange_auth_code(args.auth_code)
+    elif args.revoke:
+        revoke()
+    elif args.install_deps:
+        sys.exit(0 if install_deps() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/productivity/square/scripts/setup.py
+++ b/skills/productivity/square/scripts/setup.py
@@ -22,15 +22,23 @@ Agent workflow:
 """
 
 import argparse
-import json
-import os
-import subprocess
-import sys
-import secrets
 import base64
 import hashlib
+import importlib.metadata
+import json
+import secrets
+import subprocess
+import sys
+import urllib.request
 from pathlib import Path
 from urllib.parse import urlencode
+
+from square_auth import (
+    REQUEST_TIMEOUT_SECONDS,
+    SquareAuthError,
+    get_valid_access_token,
+    request_token,
+)
 
 try:
     from hermes_constants import display_hermes_home, get_hermes_home
@@ -47,7 +55,6 @@ PENDING_AUTH_PATH = HERMES_HOME / "square_oauth_pending.json"
 
 # Square OAuth2 endpoints
 AUTHORIZE_URL = "https://connect.squareup.com/oauth2/authorize"
-TOKEN_URL = "https://connect.squareup.com/oauth2/token"
 REVOKE_URL = "https://connect.squareup.com/oauth2/revoke"
 
 # Scopes needed for inventory, catalog, customers, and orders
@@ -64,7 +71,7 @@ SCOPES = [
     "LOCATION_READ",
 ]
 
-REQUIRED_PACKAGES = ["squareup"]
+SQUAREUP_REQUIREMENT = "squareup>=41.0.0.20250319,<42"
 
 REDIRECT_URI = "http://localhost:1"
 
@@ -79,123 +86,38 @@ def _load_json(path: Path) -> dict:
 def install_deps():
     """Install Square SDK if missing. Returns True on success."""
     try:
-        import squareup  # noqa: F401
-        print("Dependencies already installed.")
-        return True
-    except ImportError:
+        import square  # noqa: F401
+        installed_version = importlib.metadata.version("squareup")
+        version_parts = tuple(int(part) for part in installed_version.split(".")[:3])
+        if (41, 0, 0) <= version_parts < (42, 0, 0):
+            print("Dependencies already installed.")
+            return True
+    except (ImportError, importlib.metadata.PackageNotFoundError, ValueError):
         pass
 
     print("Installing Square SDK...")
     try:
         subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--quiet", "--", "squareup"],
+            [sys.executable, "-m", "pip", "install", "--quiet", "--", SQUAREUP_REQUIREMENT],
             stdout=subprocess.DEVNULL,
         )
         print("Dependencies installed.")
         return True
     except subprocess.CalledProcessError as e:
         print(f"ERROR: Failed to install dependencies: {e}")
-        print(f"Try manually: {sys.executable} -m pip install squareup")
+        print(f"Try manually: {sys.executable} -m pip install '{SQUAREUP_REQUIREMENT}'")
         return False
-
-
-def _ensure_deps():
-    """Check deps are available, install if not, exit on failure."""
-    try:
-        import squareup  # noqa: F401
-    except ImportError:
-        if not install_deps():
-            sys.exit(1)
 
 
 def check_auth():
     """Check if stored credentials are valid. Prints status, exits 0 or 1."""
-    if not TOKEN_PATH.exists():
-        print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
-        return False
-
-    _ensure_deps()
-    from squareup import Client
-    from squareup.oauth2 import OAuth2
-
     try:
-        data = _load_json(TOKEN_PATH)
-        access_token = data.get("access_token")
-        if not access_token:
-            print("TOKEN_INVALID: Missing access_token")
-            return False
-
-        # Try to refresh to verify token is still valid
-        client_secret = _load_json(CLIENT_SECRET_PATH).get("clientSecret", "")
-        client_id = _load_json(CLIENT_SECRET_PATH).get("clientId", "")
-
-        if not client_id or not client_secret:
-            print("TOKEN_INVALID: Missing client credentials")
-            return False
-
-        # Token status check
-        from squareup.http.client import HttpClient
-        from squareup.http.api_response import ApiResponse
-
-        http_client = HttpClient()
-        response = http_client.request(
-            "POST",
-            TOKEN_URL,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({
-                "client_id": client_id,
-                "client_secret": client_secret,
-                "grant_type": "access_token",
-                "access_token": access_token,
-            }),
-        )
-        # Square returns 200 if token is valid
+        get_valid_access_token(force_refresh=True)
         print(f"AUTHENTICATED: Token valid at {TOKEN_PATH}")
         return True
-
-    except Exception as e:
-        # Try refresh token flow
-        try:
-            data = _load_json(TOKEN_PATH)
-            refresh_token = data.get("refresh_token")
-            if not refresh_token:
-                print(f"TOKEN_INVALID: {e}")
-                return False
-
-            client_secret = _load_json(CLIENT_SECRET_PATH).get("clientSecret", "")
-            client_id = _load_json(CLIENT_SECRET_PATH).get("clientId", "")
-
-            if not client_id or not client_secret:
-                print(f"TOKEN_INVALID: Missing client credentials: {e}")
-                return False
-
-            from squareup.http.client import HttpClient
-            http_client = HttpClient()
-            response = http_client.request(
-                "POST",
-                TOKEN_URL,
-                headers={"Content-Type": "application/json"},
-                body=json.dumps({
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "grant_type": "refresh_token",
-                    "refresh_token": refresh_token,
-                }),
-            )
-
-            body = json.loads(response.body)
-            if response.status_code == 200:
-                # Update token file
-                TOKEN_PATH.write_text(json.dumps(body, indent=2))
-                print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
-                return True
-            else:
-                print(f"TOKEN_INVALID: Refresh failed: {body}")
-                return False
-
-        except Exception as refresh_error:
-            print(f"TOKEN_INVALID: {refresh_error}")
-            return False
+    except SquareAuthError as exc:
+        print(f"TOKEN_INVALID: {exc}")
+        return False
 
 
 def store_client_secret(path: str):
@@ -331,37 +253,21 @@ def exchange_auth_code(code: str):
         print("ERROR: OAuth state mismatch. Run --auth-url again to start a fresh session.")
         sys.exit(1)
 
-    _ensure_deps()
-    from squareup.http.client import HttpClient
-
     client_data = _load_json(CLIENT_SECRET_PATH)
     client_id = client_data.get("clientId")
     client_secret = client_data.get("clientSecret")
 
-    http_client = HttpClient()
-
     try:
-        response = http_client.request(
-            "POST",
-            TOKEN_URL,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({
+        body = request_token(
+            {
                 "client_id": client_id,
                 "client_secret": client_secret,
                 "code": code,
                 "grant_type": "authorization_code",
                 "redirect_uri": REDIRECT_URI,
                 "code_verifier": pending_auth["code_verifier"],
-            }),
+            }
         )
-
-        body = json.loads(response.body)
-
-        if response.status_code != 200:
-            error_msg = body.get("error_description", body.get("error", "Unknown error"))
-            print(f"ERROR: Token exchange failed: {error_msg}")
-            print("The code may have expired. Run --auth-url to get a fresh URL.")
-            sys.exit(1)
 
         TOKEN_PATH.write_text(json.dumps(body, indent=2))
         PENDING_AUTH_PATH.unlink(missing_ok=True)
@@ -392,21 +298,20 @@ def revoke():
     try:
         client_data = _load_json(CLIENT_SECRET_PATH)
         client_id = client_data.get("clientId")
-        client_secret = client_data.get("clientSecret")
 
-        _ensure_deps()
-        from squareup.http.client import HttpClient
-        http_client = HttpClient()
-
-        http_client.request(
-            "POST",
+        request = urllib.request.Request(
             REVOKE_URL,
+            data=json.dumps(
+                {
+                    "client_id": client_id,
+                    "access_token": access_token,
+                }
+            ).encode("utf-8"),
             headers={"Content-Type": "application/json"},
-            body=json.dumps({
-                "client_id": client_id,
-                "access_token": access_token,
-            }),
+            method="POST",
         )
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS):
+            pass
         print("Token revoked with Square.")
     except Exception as e:
         print(f"Remote revocation failed (token may already be invalid): {e}")

--- a/skills/productivity/square/scripts/square_api.py
+++ b/skills/productivity/square/scripts/square_api.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Square API CLI for Hermes Agent.
+
+Wraps the Square Python SDK with a convenient argparse interface.
+
+Usage:
+  python square_api.py inventory counts [--location LOC] [--catalog-object-id ID]
+  python square_api.py inventory adjust --catalog-object-id ID --location LOC --quantity N --reason TEXT
+  python square_api.py inventory changes --location LOC [--start-time DATETIME] [--end-time DATETIME]
+  python square_api.py catalog list --types "item,variation"
+  python square_api.py catalog search --query QUERY [--types TYPES]
+  python square_api.py catalog get OBJECT_ID
+  python square_api.py customers list [--max N]
+  python square_api.py customers search --query QUERY
+  python square_api.py customers create --given-name NAME [--family-name NAME] [--email EMAIL] [--phone PHONE]
+  python square_api.py customers update CUSTOMER_ID [--phone PHONE] [--email EMAIL]
+  python square_api.py customers get CUSTOMER_ID
+  python square_api.py orders list --location LOC [--start-time DATETIME] [--end-time DATETIME]
+  python square_api.py orders get ORDER_ID
+  python square_api.py locations list
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    from hermes_constants import get_hermes_home
+except ModuleNotFoundError:
+    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
+    if HERMES_AGENT_ROOT.exists():
+        sys.path.insert(0, str(HERMES_AGENT_ROOT))
+    from hermes_constants import get_hermes_home
+
+HERMES_HOME = get_hermes_home()
+TOKEN_PATH = HERMES_HOME / "square_token.json"
+CLIENT_SECRET_PATH = HERMES_HOME / "square_client_secret.json"
+
+API_BASE = "https://connect.squareup.com/v2"
+
+
+def _get_client():
+    """Build an authenticated Square API client."""
+    if not TOKEN_PATH.exists():
+        print("ERROR: Not authenticated. Run setup.py --check first.")
+        sys.exit(1)
+
+    from squareup import Client
+    from squareup.oauth2 import OAuth2
+
+    token_data = json.loads(TOKEN_PATH.read_text())
+    access_token = token_data.get("access_token")
+    if not access_token:
+        print("ERROR: No access token. Re-run OAuth setup.")
+        sys.exit(1)
+
+    client_id = ""
+    if CLIENT_SECRET_PATH.exists():
+        secret_data = json.loads(CLIENT_SECRET_PATH.read_text())
+        client_id = secret_data.get("clientId", "")
+
+    return Client(
+        access_token=access_token,
+        square_version="2026-01-22",
+    )
+
+
+def _api_request(method: str, path: str, body: dict | None = None, version: str = "v2") -> dict:
+    """Make a direct REST API call. Used when SDK coverage is insufficient."""
+    import urllib.request
+    import urllib.error
+
+    token_data = json.loads(TOKEN_PATH.read_text())
+    access_token = token_data.get("access_token")
+
+    url = f"{API_BASE}/{path}"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "Square-Version": "2026-01-22",
+    }
+
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        error_body = json.loads(e.read())
+        print(f"ERROR {e.code}: {error_body}")
+        sys.exit(1)
+
+
+# -- Inventory --
+
+def cmd_inventory_counts(args):
+    client = _get_client()
+    params = {}
+    if args.catalog_object_id:
+        params["catalog_object_ids"] = [args.catalog_object_id]
+    if args.location:
+        params["location_ids"] = [args.location]
+    if args.start_time:
+        params["start_time"] = args.start_time
+    if args.end_time:
+        params["end_time"] = args.end_time
+
+    result = client.inventory.batch_retrieve_inventory_counts(**params)
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_inventory_adjust(args):
+    body = {
+        "idempotency_key": f"adjust-{args.catalog_object_id}-{args.location}",
+        "changes": [
+            {
+                "type": "ADJUSTMENT",
+                "physical_count": None,
+                "adjustment": {
+                    "catalog_object_id": args.catalog_object_id,
+                    "location_id": args.location,
+                    "quantity": str(args.quantity),
+                    "reason": args.reason or "UNKNOWN",
+                },
+            }
+        ],
+    }
+    result = _api_request("POST", "inventory/changes/batch-create", body)
+    print(json.dumps(result, indent=2))
+
+
+def cmd_inventory_changes(args):
+    params = {}
+    if args.location:
+        params["location_ids"] = [args.location]
+    if args.start_time:
+        params["start_time"] = args.start_time
+    if args.end_time:
+        params["end_time"] = args.end_time
+
+    client = _get_client()
+    result = client.inventory.batch_retrieve_inventory_changes(**params)
+    print(json.dumps(result.body, indent=2))
+
+
+# -- Catalog --
+
+def cmd_catalog_list(args):
+    client = _get_client()
+    types = args.types.split(",") if args.types else None
+    result = client.catalog.list_catalog(types=types)
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_catalog_search(args):
+    client = _get_client()
+    body = {"text_query": {"attribute_name": "name", "text": args.query}}
+    if args.types:
+        body["object_types"] = args.types.split(",")
+    result = client.catalog.search_catalog_objects(**body)
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_catalog_get(args):
+    client = _get_client()
+    result = client.catalog.retrieve_catalog_object(args.object_id, include_related_objects=True)
+    print(json.dumps(result.body, indent=2))
+
+
+# -- Customers --
+
+def cmd_customers_list(args):
+    client = _get_client()
+    result = client.customers.list_customers(limit=args.max or 50)
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_customers_search(args):
+    client = _get_client()
+    body = {
+        "query": {
+            "text_query": {
+                "attribute_name": "text",
+                "text": args.query,
+            }
+        },
+        "limit": args.max or 50,
+    }
+    result = client.customers.search_customers(**body)
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_customers_create(args):
+    client = _get_client()
+    import uuid
+    body = {
+        "idempotency_key": str(uuid.uuid4()),
+        "given_name": args.given_name,
+    }
+    if args.family_name:
+        body["family_name"] = args.family_name
+    if args.email:
+        body["email_address"] = args.email
+    if args.phone:
+        body["phone_number"] = args.phone
+
+    result = client.customers.create_customer(**body)
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_customers_update(args):
+    client = _get_client()
+    body = {"customer_id": args.customer_id}
+    if args.email:
+        body["email_address"] = args.email
+    if args.phone:
+        body["phone_number"] = args.phone
+    if args.given_name:
+        body["given_name"] = args.given_name
+    if args.family_name:
+        body["family_name"] = args.family_name
+
+    result = client.customers.update_customer(args.customer_id, **body)
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_customers_get(args):
+    client = _get_client()
+    result = client.customers.retrieve_customer(args.customer_id)
+    print(json.dumps(result.body, indent=2))
+
+
+# -- Orders --
+
+def cmd_orders_list(args):
+    client = _get_client()
+    from datetime import datetime, timedelta, timezone as tz
+    now = datetime.now(tz.utc)
+    start_time = args.start_time or (now - timedelta(days=7)).isoformat()
+    end_time = args.end_time or now.isoformat()
+
+    result = client.orders.search_orders(
+        location_ids=[args.location],
+        query={
+            "filter": {
+                "date_time_filter": {
+                    "created_at": {
+                        "start_at": start_time,
+                        "end_at": end_time,
+                    }
+                }
+            }
+        },
+    )
+    print(json.dumps(result.body, indent=2))
+
+
+def cmd_orders_get(args):
+    client = _get_client()
+    result = client.orders.retrieve_order(args.order_id)
+    print(json.dumps(result.body, indent=2))
+
+
+# -- Locations --
+
+def cmd_locations_list(args):
+    client = _get_client()
+    result = client.locations.list_locations()
+    print(json.dumps(result.body, indent=2))
+
+
+# -- CLI parser --
+
+def main():
+    parser = argparse.ArgumentParser(description="Square API for Hermes Agent")
+    sub = parser.add_subparsers(dest="service", required=True)
+
+    # --- Inventory ---
+    inv = sub.add_parser("inventory")
+    inv_sub = inv.add_subparsers(dest="action", required=True)
+
+    p = inv_sub.add_parser("counts")
+    p.add_argument("--location", default="", help="Location ID")
+    p.add_argument("--catalog-object-id", default="", help="Catalog object ID")
+    p.add_argument("--start-time", default="", help="ISO 8601 start time")
+    p.add_argument("--end-time", default="", help="ISO 8601 end time")
+    p.set_defaults(func=cmd_inventory_counts)
+
+    p = inv_sub.add_parser("adjust")
+    p.add_argument("--catalog-object-id", required=True, help="Catalog object ID")
+    p.add_argument("--location", required=True, help="Location ID")
+    p.add_argument("--quantity", type=int, required=True, help="Quantity to adjust (positive or negative)")
+    p.add_argument("--reason", default="", help="Reason for adjustment")
+    p.set_defaults(func=cmd_inventory_adjust)
+
+    p = inv_sub.add_parser("changes")
+    p.add_argument("--location", default="", help="Location ID")
+    p.add_argument("--start-time", default="", help="ISO 8601 start time")
+    p.add_argument("--end-time", default="", help="ISO 8601 end time")
+    p.set_defaults(func=cmd_inventory_changes)
+
+    # --- Catalog ---
+    cat = sub.add_parser("catalog")
+    cat_sub = cat.add_subparsers(dest="action", required=True)
+
+    p = cat_sub.add_parser("list")
+    p.add_argument("--types", default="", help="Comma-separated types (item,variation,category,etc.)")
+    p.set_defaults(func=cmd_catalog_list)
+
+    p = cat_sub.add_parser("search")
+    p.add_argument("--query", required=True, help="Search query")
+    p.add_argument("--types", default="", help="Comma-separated object types")
+    p.set_defaults(func=cmd_catalog_search)
+
+    p = cat_sub.add_parser("get")
+    p.add_argument("object_id", help="Catalog object ID")
+    p.set_defaults(func=cmd_catalog_get)
+
+    # --- Customers ---
+    cust = sub.add_parser("customers")
+    cust_sub = cust.add_subparsers(dest="action", required=True)
+
+    p = cust_sub.add_parser("list")
+    p.add_argument("--max", type=int, default=50)
+    p.set_defaults(func=cmd_customers_list)
+
+    p = cust_sub.add_parser("search")
+    p.add_argument("--query", required=True, help="Search query")
+    p.add_argument("--max", type=int, default=50)
+    p.set_defaults(func=cmd_customers_search)
+
+    p = cust_sub.add_parser("create")
+    p.add_argument("--given-name", required=True)
+    p.add_argument("--family-name", default="")
+    p.add_argument("--email", default="")
+    p.add_argument("--phone", default="")
+    p.set_defaults(func=cmd_customers_create)
+
+    p = cust_sub.add_parser("update")
+    p.add_argument("customer_id", help="Customer ID")
+    p.add_argument("--given-name", default="")
+    p.add_argument("--family-name", default="")
+    p.add_argument("--email", default="")
+    p.add_argument("--phone", default="")
+    p.set_defaults(func=cmd_customers_update)
+
+    p = cust_sub.add_parser("get")
+    p.add_argument("customer_id", help="Customer ID")
+    p.set_defaults(func=cmd_customers_get)
+
+    # --- Orders ---
+    ord_ = sub.add_parser("orders")
+    ord_sub = ord_.add_subparsers(dest="action", required=True)
+
+    p = ord_sub.add_parser("list")
+    p.add_argument("--location", required=True, help="Location ID")
+    p.add_argument("--start-time", default="", help="ISO 8601 start time")
+    p.add_argument("--end-time", default="", help="ISO 8601 end time")
+    p.set_defaults(func=cmd_orders_list)
+
+    p = ord_sub.add_parser("get")
+    p.add_argument("order_id", help="Order ID")
+    p.set_defaults(func=cmd_orders_get)
+
+    # --- Locations ---
+    loc = sub.add_parser("locations")
+    loc_sub = loc.add_subparsers(dest="action", required=True)
+
+    p = loc_sub.add_parser("list")
+    p.set_defaults(func=cmd_locations_list)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/productivity/square/scripts/square_api.py
+++ b/skills/productivity/square/scripts/square_api.py
@@ -22,76 +22,119 @@ Usage:
 
 import argparse
 import json
-import os
 import sys
-from pathlib import Path
+import urllib.error
+import urllib.request
+import uuid
 
-try:
-    from hermes_constants import get_hermes_home
-except ModuleNotFoundError:
-    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
-    if HERMES_AGENT_ROOT.exists():
-        sys.path.insert(0, str(HERMES_AGENT_ROOT))
-    from hermes_constants import get_hermes_home
-
-HERMES_HOME = get_hermes_home()
-TOKEN_PATH = HERMES_HOME / "square_token.json"
-CLIENT_SECRET_PATH = HERMES_HOME / "square_client_secret.json"
+from square_auth import SquareAuthError, get_valid_access_token
 
 API_BASE = "https://connect.squareup.com/v2"
+API_VERSION = "2026-01-22"
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+class SquareAPIError(RuntimeError):
+    """Raised when Square returns an unsuccessful API response."""
 
 
 def _get_client():
-    """Build an authenticated Square API client."""
-    if not TOKEN_PATH.exists():
-        print("ERROR: Not authenticated. Run setup.py --check first.")
-        sys.exit(1)
-
-    from squareup import Client
-    from squareup.oauth2 import OAuth2
-
-    token_data = json.loads(TOKEN_PATH.read_text())
-    access_token = token_data.get("access_token")
-    if not access_token:
-        print("ERROR: No access token. Re-run OAuth setup.")
-        sys.exit(1)
-
-    client_id = ""
-    if CLIENT_SECRET_PATH.exists():
-        secret_data = json.loads(CLIENT_SECRET_PATH.read_text())
-        client_id = secret_data.get("clientId", "")
+    """Build a Square SDK client after refreshing credentials if needed."""
+    from square.client import Client
+    from square.http.auth.o_auth_2 import BearerAuthCredentials
 
     return Client(
-        access_token=access_token,
-        square_version="2026-01-22",
+        bearer_auth_credentials=BearerAuthCredentials(get_valid_access_token()),
+        square_version=API_VERSION,
     )
 
 
-def _api_request(method: str, path: str, body: dict | None = None, version: str = "v2") -> dict:
-    """Make a direct REST API call. Used when SDK coverage is insufficient."""
-    import urllib.request
-    import urllib.error
-
-    token_data = json.loads(TOKEN_PATH.read_text())
-    access_token = token_data.get("access_token")
-
-    url = f"{API_BASE}/{path}"
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "Content-Type": "application/json",
-        "Square-Version": "2026-01-22",
-    }
-
-    data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
-
+def _decode_http_error(error: urllib.error.HTTPError) -> object:
+    raw_body = error.read()
     try:
-        with urllib.request.urlopen(req) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        error_body = json.loads(e.read())
-        print(f"ERROR {e.code}: {error_body}")
-        sys.exit(1)
+        return json.loads(raw_body)
+    except json.JSONDecodeError:
+        return raw_body.decode("utf-8", errors="replace")
+
+
+def _api_request(method: str, path: str, body: dict | None = None) -> dict:
+    """Make a direct REST API call. Used when SDK coverage is insufficient."""
+    url = f"{API_BASE}/{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+
+    for attempt in range(2):
+        access_token = get_valid_access_token(force_refresh=attempt == 1)
+        request = urllib.request.Request(
+            url,
+            data=data,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+                "Square-Version": API_VERSION,
+            },
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+                return json.loads(response.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 401 and attempt == 0:
+                continue
+            raise SquareAPIError(f"HTTP {exc.code}: {_decode_http_error(exc)}") from exc
+        except urllib.error.URLError as exc:
+            raise SquareAPIError(f"Request failed: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise SquareAPIError("Square API returned invalid JSON") from exc
+
+    raise SquareAPIError("Authentication failed after refreshing the Square token")
+
+
+def _result_body(result) -> dict:
+    """Validate one Square SDK response and return its JSON body."""
+    if callable(getattr(result, "is_error", None)) and result.is_error():
+        detail = getattr(result, "errors", None) or getattr(result, "body", None)
+        status = getattr(result, "status_code", "unknown")
+        raise SquareAPIError(f"SDK request failed with status {status}: {detail}")
+    body = getattr(result, "body", None)
+    if not isinstance(body, dict):
+        raise SquareAPIError("Square SDK returned an invalid response body")
+    return body
+
+
+def _paginate_sdk(call, item_key: str, *, max_items: int | None = None, **params) -> dict:
+    """Consume cursor-based Square SDK responses into one result object."""
+    items = []
+    output = {}
+    cursor = None
+
+    while True:
+        page_params = dict(params)
+        if cursor:
+            page_params["cursor"] = cursor
+        body = _result_body(call(**page_params))
+        if not output:
+            output = {key: value for key, value in body.items() if key != "cursor"}
+        items.extend(body.get(item_key) or [])
+        if max_items is not None and len(items) >= max_items:
+            items = items[:max_items]
+            break
+        cursor = body.get("cursor")
+        if not cursor:
+            break
+
+    output[item_key] = items
+    return output
+
+
+def _body_cursor_call(method, body: dict):
+    """Adapt SDK methods that accept a JSON body to cursor pagination."""
+    def call(*, cursor=None):
+        page_body = dict(body)
+        if cursor:
+            page_body["cursor"] = cursor
+        return method(page_body)
+
+    return call
 
 
 # -- Inventory --
@@ -104,17 +147,18 @@ def cmd_inventory_counts(args):
     if args.location:
         params["location_ids"] = [args.location]
     if args.start_time:
-        params["start_time"] = args.start_time
-    if args.end_time:
-        params["end_time"] = args.end_time
+        params["updated_after"] = args.start_time
 
-    result = client.inventory.batch_retrieve_inventory_counts(**params)
-    print(json.dumps(result.body, indent=2))
+    result = _paginate_sdk(
+        _body_cursor_call(client.inventory.batch_retrieve_inventory_counts, params),
+        "counts",
+    )
+    print(json.dumps(result, indent=2))
 
 
 def cmd_inventory_adjust(args):
     body = {
-        "idempotency_key": f"adjust-{args.catalog_object_id}-{args.location}",
+        "idempotency_key": args.idempotency_key or str(uuid.uuid4()),
         "changes": [
             {
                 "type": "ADJUSTMENT",
@@ -137,45 +181,57 @@ def cmd_inventory_changes(args):
     if args.location:
         params["location_ids"] = [args.location]
     if args.start_time:
-        params["start_time"] = args.start_time
+        params["updated_after"] = args.start_time
     if args.end_time:
-        params["end_time"] = args.end_time
+        params["updated_before"] = args.end_time
 
     client = _get_client()
-    result = client.inventory.batch_retrieve_inventory_changes(**params)
-    print(json.dumps(result.body, indent=2))
+    result = _paginate_sdk(
+        _body_cursor_call(client.inventory.batch_retrieve_inventory_changes, params),
+        "changes",
+    )
+    print(json.dumps(result, indent=2))
 
 
 # -- Catalog --
 
 def cmd_catalog_list(args):
     client = _get_client()
-    types = args.types.split(",") if args.types else None
-    result = client.catalog.list_catalog(types=types)
-    print(json.dumps(result.body, indent=2))
+    types = args.types.upper() if args.types else None
+    result = _paginate_sdk(client.catalog.list_catalog, "objects", types=types)
+    print(json.dumps(result, indent=2))
 
 
 def cmd_catalog_search(args):
     client = _get_client()
-    body = {"text_query": {"attribute_name": "name", "text": args.query}}
+    body = {"query": {"text_query": {"keywords": [args.query]}}}
     if args.types:
-        body["object_types"] = args.types.split(",")
-    result = client.catalog.search_catalog_objects(**body)
-    print(json.dumps(result.body, indent=2))
+        body["object_types"] = [value.upper() for value in args.types.split(",")]
+    result = _paginate_sdk(
+        _body_cursor_call(client.catalog.search_catalog_objects, body),
+        "objects",
+    )
+    print(json.dumps(result, indent=2))
 
 
 def cmd_catalog_get(args):
     client = _get_client()
     result = client.catalog.retrieve_catalog_object(args.object_id, include_related_objects=True)
-    print(json.dumps(result.body, indent=2))
+    print(json.dumps(_result_body(result), indent=2))
 
 
 # -- Customers --
 
 def cmd_customers_list(args):
     client = _get_client()
-    result = client.customers.list_customers(limit=args.max or 50)
-    print(json.dumps(result.body, indent=2))
+    maximum = args.max or 50
+    result = _paginate_sdk(
+        client.customers.list_customers,
+        "customers",
+        max_items=maximum,
+        limit=min(maximum, 100),
+    )
+    print(json.dumps(result, indent=2))
 
 
 def cmd_customers_search(args):
@@ -189,8 +245,12 @@ def cmd_customers_search(args):
         },
         "limit": args.max or 50,
     }
-    result = client.customers.search_customers(**body)
-    print(json.dumps(result.body, indent=2))
+    result = _paginate_sdk(
+        _body_cursor_call(client.customers.search_customers, body),
+        "customers",
+        max_items=args.max or 50,
+    )
+    print(json.dumps(result, indent=2))
 
 
 def cmd_customers_create(args):
@@ -207,13 +267,13 @@ def cmd_customers_create(args):
     if args.phone:
         body["phone_number"] = args.phone
 
-    result = client.customers.create_customer(**body)
-    print(json.dumps(result.body, indent=2))
+    result = client.customers.create_customer(body)
+    print(json.dumps(_result_body(result), indent=2))
 
 
 def cmd_customers_update(args):
     client = _get_client()
-    body = {"customer_id": args.customer_id}
+    body = {}
     if args.email:
         body["email_address"] = args.email
     if args.phone:
@@ -223,14 +283,14 @@ def cmd_customers_update(args):
     if args.family_name:
         body["family_name"] = args.family_name
 
-    result = client.customers.update_customer(args.customer_id, **body)
-    print(json.dumps(result.body, indent=2))
+    result = client.customers.update_customer(args.customer_id, body)
+    print(json.dumps(_result_body(result), indent=2))
 
 
 def cmd_customers_get(args):
     client = _get_client()
     result = client.customers.retrieve_customer(args.customer_id)
-    print(json.dumps(result.body, indent=2))
+    print(json.dumps(_result_body(result), indent=2))
 
 
 # -- Orders --
@@ -242,9 +302,9 @@ def cmd_orders_list(args):
     start_time = args.start_time or (now - timedelta(days=7)).isoformat()
     end_time = args.end_time or now.isoformat()
 
-    result = client.orders.search_orders(
-        location_ids=[args.location],
-        query={
+    body = {
+        "location_ids": [args.location],
+        "query": {
             "filter": {
                 "date_time_filter": {
                     "created_at": {
@@ -254,14 +314,18 @@ def cmd_orders_list(args):
                 }
             }
         },
+    }
+    result = _paginate_sdk(
+        _body_cursor_call(client.orders.search_orders, body),
+        "orders",
     )
-    print(json.dumps(result.body, indent=2))
+    print(json.dumps(result, indent=2))
 
 
 def cmd_orders_get(args):
     client = _get_client()
     result = client.orders.retrieve_order(args.order_id)
-    print(json.dumps(result.body, indent=2))
+    print(json.dumps(_result_body(result), indent=2))
 
 
 # -- Locations --
@@ -269,7 +333,7 @@ def cmd_orders_get(args):
 def cmd_locations_list(args):
     client = _get_client()
     result = client.locations.list_locations()
-    print(json.dumps(result.body, indent=2))
+    print(json.dumps(_result_body(result), indent=2))
 
 
 # -- CLI parser --
@@ -285,8 +349,7 @@ def main():
     p = inv_sub.add_parser("counts")
     p.add_argument("--location", default="", help="Location ID")
     p.add_argument("--catalog-object-id", default="", help="Catalog object ID")
-    p.add_argument("--start-time", default="", help="ISO 8601 start time")
-    p.add_argument("--end-time", default="", help="ISO 8601 end time")
+    p.add_argument("--start-time", default="", help="Only counts updated after this ISO 8601 time")
     p.set_defaults(func=cmd_inventory_counts)
 
     p = inv_sub.add_parser("adjust")
@@ -294,6 +357,13 @@ def main():
     p.add_argument("--location", required=True, help="Location ID")
     p.add_argument("--quantity", type=int, required=True, help="Quantity to adjust (positive or negative)")
     p.add_argument("--reason", default="", help="Reason for adjustment")
+    p.add_argument(
+        "--idempotency-key",
+        "--retry-key",
+        dest="idempotency_key",
+        default="",
+        help="Reuse only when retrying the exact same adjustment",
+    )
     p.set_defaults(func=cmd_inventory_adjust)
 
     p = inv_sub.add_parser("changes")
@@ -373,8 +443,13 @@ def main():
     p.set_defaults(func=cmd_locations_list)
 
     args = parser.parse_args()
-    args.func(args)
+    try:
+        args.func(args)
+    except (SquareAuthError, SquareAPIError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/productivity/square/scripts/square_auth.py
+++ b/skills/productivity/square/scripts/square_auth.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Shared Square OAuth token loading and refresh support."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+try:
+    from hermes_constants import get_hermes_home
+except ModuleNotFoundError:
+    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
+    if HERMES_AGENT_ROOT.exists():
+        sys.path.insert(0, str(HERMES_AGENT_ROOT))
+    from hermes_constants import get_hermes_home
+
+
+HERMES_HOME = get_hermes_home()
+TOKEN_PATH = HERMES_HOME / "square_token.json"
+CLIENT_SECRET_PATH = HERMES_HOME / "square_client_secret.json"
+TOKEN_URL = "https://connect.squareup.com/oauth2/token"
+REFRESH_MARGIN = timedelta(minutes=5)
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+class SquareAuthError(RuntimeError):
+    """Raised when Square credentials cannot produce a valid access token."""
+
+
+def _load_json(path: Path, label: str) -> dict:
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise SquareAuthError(f"Missing {label} at {path}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SquareAuthError(f"Could not read {label} at {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SquareAuthError(f"Invalid {label} at {path}: expected a JSON object")
+    return data
+
+
+def _parse_expiry(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _token_needs_refresh(token_data: dict, now: datetime | None = None) -> bool:
+    """Refresh tokens with missing/invalid expiry or less than five minutes left."""
+    expiry = _parse_expiry(token_data.get("expires_at"))
+    if expiry is None:
+        return True
+    current = now or datetime.now(timezone.utc)
+    return expiry <= current + REFRESH_MARGIN
+
+
+def request_token(payload: dict) -> dict:
+    request = urllib.request.Request(
+        TOKEN_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", None)
+            if status is None:
+                status = response.getcode()
+            raw_body = response.read()
+    except urllib.error.HTTPError as exc:
+        raw_body = exc.read()
+        try:
+            detail = json.loads(raw_body).get("error_description")
+        except (AttributeError, json.JSONDecodeError):
+            detail = raw_body.decode("utf-8", errors="replace")
+        raise SquareAuthError(
+            f"Square token request failed with HTTP {exc.code}: {detail or 'unknown error'}"
+        ) from exc
+    except (OSError, urllib.error.URLError) as exc:
+        raise SquareAuthError(f"Square token request failed: {exc}") from exc
+
+    try:
+        body = json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        raise SquareAuthError("Square token response was not valid JSON") from exc
+    if status != 200:
+        detail = body.get("error_description", body.get("error", "unknown error"))
+        raise SquareAuthError(f"Square token request failed with HTTP {status}: {detail}")
+    if not isinstance(body, dict) or not body.get("access_token"):
+        raise SquareAuthError("Square token response did not include an access_token")
+    return body
+
+
+def refresh_access_token(token_data: dict | None = None) -> str:
+    """Refresh and atomically persist the Square OAuth token."""
+    current = token_data or _load_json(TOKEN_PATH, "Square token")
+    refresh_token = current.get("refresh_token")
+    if not refresh_token:
+        raise SquareAuthError("Square token has expired and has no refresh_token; authorize again")
+
+    credentials = _load_json(CLIENT_SECRET_PATH, "Square client credentials")
+    client_id = credentials.get("clientId") or credentials.get("client_id")
+    client_secret = credentials.get("clientSecret") or credentials.get("client_secret")
+    if not client_id or not client_secret:
+        raise SquareAuthError("Square client credentials are missing clientId or clientSecret")
+
+    refreshed = request_token(
+        {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+    )
+    if not refreshed.get("refresh_token"):
+        refreshed["refresh_token"] = refresh_token
+
+    TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = TOKEN_PATH.with_suffix(".tmp")
+    temporary_path.write_text(json.dumps(refreshed, indent=2))
+    os.replace(temporary_path, TOKEN_PATH)
+    return refreshed["access_token"]
+
+
+def get_valid_access_token(*, force_refresh: bool = False) -> str:
+    """Return a usable token, refreshing it before a request when necessary."""
+    token_data = _load_json(TOKEN_PATH, "Square token")
+    access_token = token_data.get("access_token")
+    if not access_token:
+        raise SquareAuthError("Square token is missing access_token; authorize again")
+    if force_refresh or _token_needs_refresh(token_data):
+        return refresh_access_token(token_data)
+    return access_token

--- a/tests/skills/test_square_skill.py
+++ b/tests/skills/test_square_skill.py
@@ -1,0 +1,317 @@
+"""Mocked tests for the Square skill's auth and API wrappers."""
+
+import argparse
+import importlib.util
+import io
+import json
+import sys
+import types
+import urllib.error
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = ROOT / "skills/productivity/square"
+AUTH_PATH = SKILL_DIR / "scripts/square_auth.py"
+API_PATH = SKILL_DIR / "scripts/square_api.py"
+SETUP_PATH = SKILL_DIR / "scripts/setup.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def square_modules(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.syspath_prepend(str(AUTH_PATH.parent))
+    sys.modules.pop("square_auth", None)
+
+    auth = _load_module("square_auth", AUTH_PATH)
+    sys.modules["square_auth"] = auth
+    api = _load_module("square_api_test", API_PATH)
+    setup = _load_module("square_setup_test", SETUP_PATH)
+    return auth, api, setup
+
+
+def _write_auth_files(auth, *, expires_at: str | None, access_token="old-token"):
+    token = {
+        "access_token": access_token,
+        "refresh_token": "refresh-token",
+    }
+    if expires_at is not None:
+        token["expires_at"] = expires_at
+    auth.TOKEN_PATH.write_text(json.dumps(token))
+    auth.CLIENT_SECRET_PATH.write_text(
+        json.dumps({"clientId": "app-id", "clientSecret": "app-secret"})
+    )
+
+
+class _Response:
+    def __init__(self, body: dict, status=200):
+        self.body = json.dumps(body).encode("utf-8")
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def getcode(self):
+        return self.status
+
+    def read(self):
+        return self.body
+
+
+def test_frontmatter_and_required_sections_follow_skill_standard():
+    content = (SKILL_DIR / "SKILL.md").read_text()
+    description = next(
+        line.removeprefix("description: ").strip('"')
+        for line in content.splitlines()
+        if line.startswith("description: ")
+    )
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert "author: Jamal Hinton (@Malgsx), Hermes Agent" in content
+
+    sections = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [content.index(section) for section in sections]
+    assert positions == sorted(positions)
+
+
+def test_dependency_has_floor_and_upper_bound():
+    setup_source = SETUP_PATH.read_text()
+    assert 'SQUAREUP_REQUIREMENT = "squareup>=41.0.0.20250319,<42"' in setup_source
+    assert '"--", SQUAREUP_REQUIREMENT' in setup_source
+
+
+def test_valid_token_is_used_without_refresh(square_modules):
+    auth, _api, _setup = square_modules
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    _write_auth_files(auth, expires_at=future, access_token="valid-token")
+
+    with patch.object(auth.urllib.request, "urlopen") as urlopen:
+        assert auth.get_valid_access_token() == "valid-token"
+
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize("expires_at", [None, "not-a-date"])
+def test_legacy_or_invalid_expiry_refreshes_before_request(square_modules, expires_at):
+    auth, _api, _setup = square_modules
+    _write_auth_files(auth, expires_at=expires_at)
+    response = _Response(
+        {
+            "access_token": "new-token",
+            "refresh_token": "new-refresh-token",
+            "expires_at": "2099-01-01T00:00:00Z",
+        }
+    )
+
+    with patch.object(auth.urllib.request, "urlopen", return_value=response) as urlopen:
+        assert auth.get_valid_access_token() == "new-token"
+
+    request = urlopen.call_args.args[0]
+    payload = json.loads(request.data)
+    assert payload["grant_type"] == "refresh_token"
+    assert payload["refresh_token"] == "refresh-token"
+    assert urlopen.call_args.kwargs["timeout"] == auth.REQUEST_TIMEOUT_SECONDS
+    assert json.loads(auth.TOKEN_PATH.read_text())["access_token"] == "new-token"
+
+
+def test_check_auth_rejects_non_200_refresh_response(square_modules, capsys):
+    auth, _api, setup = square_modules
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    _write_auth_files(auth, expires_at=past)
+
+    with patch.object(
+        auth.urllib.request,
+        "urlopen",
+        return_value=_Response({"error": "invalid_grant"}, status=400),
+    ):
+        assert setup.check_auth() is False
+
+    output = capsys.readouterr().out
+    assert "TOKEN_INVALID" in output
+    assert "AUTHENTICATED" not in output
+    assert "HTTP 400" in output
+
+
+def test_sdk_client_uses_refresh_aware_token_loader(square_modules, monkeypatch):
+    _auth, api, _setup = square_modules
+    fake_square = types.ModuleType("square")
+    fake_square_client = types.ModuleType("square.client")
+    fake_square_http = types.ModuleType("square.http")
+    fake_square_auth = types.ModuleType("square.http.auth")
+    fake_oauth = types.ModuleType("square.http.auth.o_auth_2")
+    fake_square_client.Client = MagicMock(return_value="client")
+    fake_oauth.BearerAuthCredentials = MagicMock(return_value="credentials")
+    fake_square.client = fake_square_client
+    monkeypatch.setitem(sys.modules, "square", fake_square)
+    monkeypatch.setitem(sys.modules, "square.client", fake_square_client)
+    monkeypatch.setitem(sys.modules, "square.http", fake_square_http)
+    monkeypatch.setitem(sys.modules, "square.http.auth", fake_square_auth)
+    monkeypatch.setitem(sys.modules, "square.http.auth.o_auth_2", fake_oauth)
+
+    with patch.object(api, "get_valid_access_token", return_value="fresh-token") as get_token:
+        assert api._get_client() == "client"
+
+    get_token.assert_called_once_with()
+    fake_oauth.BearerAuthCredentials.assert_called_once_with("fresh-token")
+    fake_square_client.Client.assert_called_once_with(
+        bearer_auth_credentials="credentials",
+        square_version=api.API_VERSION,
+    )
+
+
+def test_inventory_adjustment_uses_unique_keys_and_explicit_retry_key(
+    square_modules, capsys
+):
+    _auth, api, _setup = square_modules
+    captured = []
+    args = argparse.Namespace(
+        catalog_object_id="variation-1",
+        location="location-1",
+        quantity=2,
+        reason="received",
+        idempotency_key="",
+    )
+
+    def fake_request(_method, _path, body):
+        captured.append(body["idempotency_key"])
+        return {"ok": True}
+
+    with patch.object(api, "_api_request", side_effect=fake_request):
+        api.cmd_inventory_adjust(args)
+        api.cmd_inventory_adjust(args)
+        args.idempotency_key = "retry-the-same-request"
+        api.cmd_inventory_adjust(args)
+
+    assert captured[0] != captured[1]
+    assert captured[2] == "retry-the-same-request"
+    assert len(captured[0]) == 36
+    capsys.readouterr()
+
+
+def test_pagination_collects_all_pages_and_passes_cursor(square_modules):
+    _auth, api, _setup = square_modules
+    calls = []
+
+    def page(**params):
+        calls.append(params)
+        if "cursor" not in params:
+            return types.SimpleNamespace(
+                body={"customers": [{"id": "a"}], "cursor": "next"},
+                is_error=lambda: False,
+            )
+        return types.SimpleNamespace(
+            body={"customers": [{"id": "b"}]},
+            is_error=lambda: False,
+        )
+
+    result = api._paginate_sdk(page, "customers", limit=100)
+
+    assert result == {"customers": [{"id": "a"}, {"id": "b"}]}
+    assert calls == [{"limit": 100}, {"limit": 100, "cursor": "next"}]
+
+
+def test_body_pagination_injects_cursor_into_each_request(square_modules):
+    _auth, api, _setup = square_modules
+    bodies = []
+
+    def method(body):
+        bodies.append(body)
+        if "cursor" not in body:
+            return types.SimpleNamespace(
+                body={"orders": [{"id": "a"}], "cursor": "next"},
+                is_error=lambda: False,
+            )
+        return types.SimpleNamespace(
+            body={"orders": [{"id": "b"}]},
+            is_error=lambda: False,
+        )
+
+    result = api._paginate_sdk(
+        api._body_cursor_call(method, {"location_ids": ["location-1"]}),
+        "orders",
+    )
+
+    assert result == {"orders": [{"id": "a"}, {"id": "b"}]}
+    assert bodies == [
+        {"location_ids": ["location-1"]},
+        {"location_ids": ["location-1"], "cursor": "next"},
+    ]
+
+
+def test_pagination_stops_at_requested_max(square_modules):
+    _auth, api, _setup = square_modules
+    page = MagicMock(
+        return_value=types.SimpleNamespace(
+            body={"customers": [{"id": "a"}, {"id": "b"}], "cursor": "unused"},
+            is_error=lambda: False,
+        )
+    )
+
+    result = api._paginate_sdk(page, "customers", max_items=1)
+
+    assert result == {"customers": [{"id": "a"}]}
+    page.assert_called_once_with()
+
+
+def test_sdk_error_is_reported(square_modules):
+    _auth, api, _setup = square_modules
+    response = types.SimpleNamespace(
+        body={"errors": [{"code": "FORBIDDEN"}]},
+        errors=[{"code": "FORBIDDEN"}],
+        status_code=403,
+        is_error=lambda: True,
+    )
+
+    with pytest.raises(api.SquareAPIError, match="403"):
+        api._result_body(response)
+
+
+def test_rest_request_refreshes_once_after_401(square_modules):
+    _auth, api, _setup = square_modules
+    unauthorized = urllib.error.HTTPError(
+        "https://example.test",
+        401,
+        "Unauthorized",
+        {},
+        io.BytesIO(b'{"errors":[{"code":"UNAUTHORIZED"}]}'),
+    )
+
+    with (
+        patch.object(api, "get_valid_access_token", side_effect=["old", "new"]) as get_token,
+        patch.object(
+            api.urllib.request,
+            "urlopen",
+            side_effect=[unauthorized, _Response({"ok": True})],
+        ),
+    ):
+        assert api._api_request("GET", "locations") == {"ok": True}
+
+    assert get_token.call_args_list == [
+        (( ), {"force_refresh": False}),
+        (( ), {"force_refresh": True}),
+    ]


### PR DESCRIPTION
Adds a new productivity skill for Square API (OAuth2 + PKCE).

## What this does

Provides a fully non-interactive OAuth2 setup and a CLI for the Square API, covering:

- **Inventory**: counts, adjustments, changes
- **Catalog**: list, search, get objects
- **Customers**: list, search, create, update, get
- **Orders**: list, get
- **Locations**: list

## Files

- `skills/productivity/square/SKILL.md` — full skill documentation
- `skills/productivity/square/scripts/setup.py` — OAuth2 setup (PKCE, token refresh)
- `skills/productivity/square/scripts/square_api.py` — API wrapper CLI
- `skills/productivity/square/references/oauth-scopes.md` — OAuth scope reference

## Auth flow

1. User downloads OAuth client secret from Square Developer Dashboard
2. Agent runs `setup.py --client-secret` to store it
3. Agent runs `setup.py --auth-url` and sends URL to user
4. User visits URL, authorizes, pastes back the redirect URL
5. Agent runs `setup.py --auth-code CODE`
6. Token refreshes automatically from then on

Works on CLI, Telegram, Discord, and any other platform — fully non-interactive, agent-driven.