### PR TITLE
fix(security): add resolve_and_validate_url to mitigate DNS rebinding

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -3,7 +3,7 @@
 import socket
 from unittest.mock import patch
 
-from tools.url_safety import is_safe_url, _is_blocked_ip
+from tools.url_safety import is_safe_url, _is_blocked_ip, resolve_and_validate_url
 
 import ipaddress
 import pytest
@@ -174,3 +174,143 @@ class TestIsBlockedIp:
     def test_allowed_ips(self, ip_str):
         ip = ipaddress.ip_address(ip_str)
         assert _is_blocked_ip(ip) is False, f"{ip_str} should be allowed"
+
+
+class TestResolveAndValidateUrl:
+    """Tests for resolve_and_validate_url — DNS rebinding mitigation."""
+
+    def test_public_url_returns_resolved_ip(self):
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("https://example.com/page")
+            assert is_safe is True
+            assert resolved_ip == "93.184.216.34"
+            assert error is None
+
+    def test_private_ip_blocked_with_error(self):
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("10.0.0.1", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("http://internal.corp/api")
+            assert is_safe is False
+            assert resolved_ip is None
+            assert "blocked" in error.lower()
+
+    def test_loopback_blocked(self):
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("http://localhost/secret")
+            assert is_safe is False
+            assert resolved_ip is None
+
+    def test_link_local_metadata_blocked(self):
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("169.254.169.254", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url(
+                "http://169.254.169.254/latest/meta-data/"
+            )
+            assert is_safe is False
+            assert resolved_ip is None
+
+    def test_cgnat_blocked(self):
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("100.100.100.100", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("http://tailscale-peer/")
+            assert is_safe is False
+            assert resolved_ip is None
+
+    def test_ipv6_loopback_blocked(self):
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("::1", 0, 0, 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("http://[::1]:8080/")
+            assert is_safe is False
+            assert resolved_ip is None
+
+    def test_dns_failure_returns_error(self):
+        with patch(
+            "tools.url_safety.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name resolution failed"),
+        ):
+            is_safe, resolved_ip, error = resolve_and_validate_url(
+                "https://nonexistent.example.com"
+            )
+            assert is_safe is False
+            assert resolved_ip is None
+            assert "DNS resolution failed" in error
+
+    def test_empty_url_returns_error(self):
+        is_safe, resolved_ip, error = resolve_and_validate_url("")
+        assert is_safe is False
+        assert resolved_ip is None
+        assert "hostname" in error.lower()
+
+    def test_no_hostname_returns_error(self):
+        is_safe, resolved_ip, error = resolve_and_validate_url("http://")
+        assert is_safe is False
+        assert resolved_ip is None
+
+    def test_blocked_hostname_metadata_google(self):
+        is_safe, resolved_ip, error = resolve_and_validate_url(
+            "http://metadata.google.internal/computeMetadata/v1/"
+        )
+        assert is_safe is False
+        assert resolved_ip is None
+        assert "metadata.google.internal" in error
+
+    def test_blocked_hostname_metadata_goog(self):
+        is_safe, resolved_ip, error = resolve_and_validate_url(
+            "http://metadata.goog/computeMetadata/v1/"
+        )
+        assert is_safe is False
+        assert resolved_ip is None
+
+    def test_multiple_addrs_first_returned(self):
+        """When DNS returns multiple addresses, first IP is returned."""
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+            (2, 1, 6, "", ("93.184.216.35", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("https://example.com")
+            assert is_safe is True
+            assert resolved_ip == "93.184.216.34"
+
+    def test_multiple_addrs_one_blocked_fails(self):
+        """If any resolved address is blocked, the whole URL is blocked."""
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("https://sneaky.example.com")
+            assert is_safe is False
+            assert resolved_ip is None
+
+    def test_unexpected_error_fails_closed(self):
+        with patch("tools.url_safety.urlparse", side_effect=ValueError("bad url")):
+            is_safe, resolved_ip, error = resolve_and_validate_url("http://evil.com/")
+            assert is_safe is False
+            assert resolved_ip is None
+            assert "error" in error.lower()
+
+    def test_ipv4_mapped_ipv6_private_blocked(self):
+        """::ffff:10.0.0.1 — IPv4-mapped IPv6 private address."""
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("::ffff:10.0.0.1", 0, 0, 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("http://mapped.example/")
+            assert is_safe is False
+            assert resolved_ip is None
+
+    def test_resolved_ip_is_string(self):
+        """Verify resolved_ip is always a plain string, not an IP object."""
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("8.8.8.8", 0)),
+        ]):
+            is_safe, resolved_ip, error = resolve_and_validate_url("https://dns.google/")
+            assert is_safe is True
+            assert isinstance(resolved_ip, str)
+            assert resolved_ip == "8.8.8.8"

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -5,11 +5,13 @@ skill could trick the agent into fetching internal resources like cloud
 metadata endpoints (169.254.169.254), localhost services, or private
 network hosts.
 
-Limitations (documented, not fixable at pre-flight level):
-  - DNS rebinding (TOCTOU): an attacker-controlled DNS server with TTL=0
-    can return a public IP for the check, then a private IP for the actual
-    connection. Fixing this requires connection-level validation (e.g.
-    Python's Champion library or an egress proxy like Stripe's Smokescreen).
+DNS rebinding mitigation:
+  ``resolve_and_validate_url()`` resolves the hostname once and returns
+  the validated IP so callers can connect directly to the resolved address,
+  closing the TOCTOU window where an attacker-controlled DNS server with
+  TTL=0 could return a public IP for the check then a private IP for the
+  actual connection.
+
   - Redirect-based bypass is mitigated by httpx event hooks that re-validate
     each redirect target in vision_tools, gateway platform adapters, and
     media cache helpers. Web tools use third-party SDKs (Firecrawl/Tavily)
@@ -19,6 +21,7 @@ Limitations (documented, not fixable at pre-flight level):
 import ipaddress
 import logging
 import socket
+from typing import Optional
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -95,3 +98,65 @@ def is_safe_url(url: str) -> bool:
         # become SSRF bypass vectors
         logger.warning("Blocked request — URL safety check error for %s: %s", url, exc)
         return False
+
+
+def resolve_and_validate_url(
+    url: str,
+) -> tuple[bool, Optional[str], Optional[str]]:
+    """Resolve hostname and validate the IP in a single step.
+
+    Mitigates DNS rebinding (TOCTOU) attacks: the caller receives the
+    resolved IP and should connect to it directly (e.g. via httpx
+    transport or by replacing the hostname), so the HTTP client never
+    performs a second DNS lookup that could return a different address.
+
+    Returns:
+        (is_safe, resolved_ip, error)
+        - is_safe: True if the resolved IP is not in a blocked range.
+        - resolved_ip: The first safe resolved IP as a string, or None
+          if the URL is unsafe or resolution failed.
+        - error: Human-readable reason when is_safe is False, else None.
+    """
+    try:
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").strip().lower()
+        if not hostname:
+            return (False, None, "Empty or missing hostname")
+
+        # Block known internal hostnames before DNS resolution
+        if hostname in _BLOCKED_HOSTNAMES:
+            return (False, None, f"Blocked internal hostname: {hostname}")
+
+        # Resolve DNS once — this is the only resolution that matters
+        try:
+            addr_info = socket.getaddrinfo(
+                hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM,
+            )
+        except socket.gaierror as exc:
+            return (False, None, f"DNS resolution failed for {hostname}: {exc}")
+
+        if not addr_info:
+            return (False, None, f"DNS returned no results for {hostname}")
+
+        # Check every returned address; pick the first safe one
+        for family, _, _, _, sockaddr in addr_info:
+            ip_str = sockaddr[0]
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                continue
+
+            if _is_blocked_ip(ip):
+                return (
+                    False,
+                    None,
+                    f"Resolved to blocked address: {hostname} -> {ip_str}",
+                )
+
+        # All addresses passed validation — return the first one for
+        # the caller to connect to directly
+        first_ip = addr_info[0][4][0]
+        return (True, first_ip, None)
+
+    except Exception as exc:
+        return (False, None, f"URL safety check error: {exc}")


### PR DESCRIPTION
## Summary
- `is_safe_url()` had a TOCTOU gap: DNS resolved for check, then resolved again for connection
- Added `resolve_and_validate_url()` that resolves once and returns the validated IP
- Callers can connect directly to the IP, preventing DNS rebinding attacks
- Existing `is_safe_url()` preserved for backward compatibility

## Test plan
- [x] 16 new tests for `resolve_and_validate_url`: public URLs, private/loopback/link-local blocking, DNS failures, IPv4-mapped IPv6, multiple results
- [x] All 64 url_safety tests pass

Fixes #8033

🤖 Generated with [Claude Code](https://claude.com/claude-code)