### PR TITLE
fix(security): apply SSRF URL validation to local browser backend

### DIFF
--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -1,12 +1,7 @@
-"""Tests that browser_navigate SSRF checks respect local-backend mode and
-the allow_private_urls setting.
+"""Tests that browser_navigate SSRF checks apply to ALL browser backends.
 
-Local backends (Camofox, headless Chromium without a cloud provider) skip
-SSRF checks entirely — the agent already has full local-network access via
-the terminal tool.
-
-Cloud backends (Browserbase, BrowserUse) enforce SSRF by default.  Users
-can opt out for cloud mode via ``browser.allow_private_urls: true``.
+SSRF protection blocks private/internal addresses for both cloud and local
+backends.  Users can opt out via ``browser.allow_private_urls: true``.
 """
 
 import json
@@ -84,12 +79,23 @@ class TestPreNavigationSsrf:
 
         assert result["success"] is True
 
-    # -- Local mode: SSRF skipped ----------------------------------------------
+    # -- Local mode: SSRF now enforced -----------------------------------------
 
-    def test_local_allows_private_url(self, monkeypatch, _common_patches):
-        """Local backends skip SSRF — private URLs are always allowed."""
+    def test_local_blocks_private_url(self, monkeypatch, _common_patches):
+        """Local backends now enforce SSRF — private URLs are blocked."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
+
+        result = json.loads(browser_tool.browser_navigate(self.PRIVATE_URL))
+
+        assert result["success"] is False
+        assert "private or internal address" in result["error"]
+
+    def test_local_allows_private_url_when_setting_true(self, monkeypatch, _common_patches):
+        """Local backends allow private URLs when allow_private_urls is True."""
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: True)
         monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
 
         result = json.loads(browser_tool.browser_navigate(self.PRIVATE_URL))
@@ -97,7 +103,7 @@ class TestPreNavigationSsrf:
         assert result["success"] is True
 
     def test_local_allows_public_url(self, monkeypatch, _common_patches):
-        """Local backends pass public URLs too (sanity check)."""
+        """Local backends pass public URLs (sanity check)."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
         monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
@@ -105,6 +111,32 @@ class TestPreNavigationSsrf:
         result = json.loads(browser_tool.browser_navigate("https://example.com"))
 
         assert result["success"] is True
+
+    # -- Local mode: specific internal IPs blocked -----------------------------
+
+    @pytest.mark.parametrize(
+        "url,label",
+        [
+            ("http://169.254.169.254/latest/meta-data/", "AWS metadata endpoint"),
+            ("http://10.0.0.1/admin", "10.x private network"),
+            ("http://10.255.255.255/secret", "10.x private network (high end)"),
+            ("http://127.0.0.1:9090/metrics", "localhost"),
+            ("http://192.168.1.1/router", "192.168.x private network"),
+            ("http://172.16.0.1/internal", "172.16.x private network"),
+        ],
+    )
+    def test_local_blocks_specific_internal_ips(
+        self, monkeypatch, _common_patches, url, label
+    ):
+        """Local backend blocks navigation to {label} ({url})."""
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda u: False)
+
+        result = json.loads(browser_tool.browser_navigate(url))
+
+        assert result["success"] is False, f"Expected {label} ({url}) to be blocked"
+        assert "private or internal address" in result["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -121,14 +153,14 @@ class TestIsLocalBackend:
         assert browser_tool._is_local_backend() is True
 
     def test_no_cloud_provider_is_local(self, monkeypatch):
-        """No cloud provider configured → local backend."""
+        """No cloud provider configured -> local backend."""
         monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
 
         assert browser_tool._is_local_backend() is True
 
     def test_cloud_provider_is_not_local(self, monkeypatch):
-        """Cloud provider configured and not Camofox → NOT local."""
+        """Cloud provider configured and not Camofox -> NOT local."""
         monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: "bb")
 
@@ -199,12 +231,30 @@ class TestPostRedirectSsrf:
         assert result["success"] is True
         assert result["url"] == self.PRIVATE_FINAL_URL
 
-    # -- Local mode: redirect SSRF skipped -------------------------------------
+    # -- Local mode: redirect SSRF now enforced --------------------------------
 
-    def test_local_allows_redirect_to_private(self, monkeypatch, _common_patches):
-        """Redirects to private addresses pass in local mode."""
+    def test_local_blocks_redirect_to_private(self, monkeypatch, _common_patches):
+        """Redirects to private addresses are now blocked in local mode."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(
+            browser_tool, "_is_safe_url", lambda url: "192.168" not in url,
+        )
+        monkeypatch.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _make_browser_result(url=self.PRIVATE_FINAL_URL),
+        )
+
+        result = json.loads(browser_tool.browser_navigate(self.PUBLIC_URL))
+
+        assert result["success"] is False
+        assert "redirect landed on a private/internal address" in result["error"]
+
+    def test_local_allows_redirect_to_private_when_setting_true(self, monkeypatch, _common_patches):
+        """Redirects to private addresses pass in local mode with allow_private_urls."""
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: True)
         monkeypatch.setattr(
             browser_tool, "_is_safe_url", lambda url: "192.168" not in url,
         )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -329,12 +329,8 @@ def _is_local_mode() -> bool:
 def _is_local_backend() -> bool:
     """Return True when the browser runs locally (no cloud provider).
 
-    SSRF protection is only meaningful for cloud backends (Browserbase,
-    BrowserUse) where the agent could reach internal resources on a remote
-    machine.  For local backends — Camofox, or the built-in headless
-    Chromium without a cloud provider — the user already has full terminal
-    and network access on the same machine, so the check adds no security
-    value.
+    Returns True for Camofox mode or when no cloud provider is configured
+    (built-in headless Chromium).
     """
     return _is_camofox_mode() or _get_cloud_provider() is None
 
@@ -1294,11 +1290,10 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         })
 
     # SSRF protection — block private/internal addresses before navigating.
-    # Skipped for local backends (Camofox, headless Chromium without a cloud
-    # provider) because the agent already has full local network access via
-    # the terminal tool.  Can also be opted out for cloud mode via
-    # ``browser.allow_private_urls`` in config.
-    if not _is_local_backend() and not _allow_private_urls() and not _is_safe_url(url):
+    # Applied to ALL backends (cloud and local) to prevent prompt-injection
+    # attacks from reaching internal services like cloud metadata endpoints.
+    # Can be opted out via ``browser.allow_private_urls`` in config.
+    if not _allow_private_urls() and not _is_safe_url(url):
         return json.dumps({
             "success": False,
             "error": "Blocked: URL targets a private or internal address",
@@ -1340,8 +1335,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         # Post-redirect SSRF check — if the browser followed a redirect to a
         # private/internal address, block the result so the model can't read
         # internal content via subsequent browser_snapshot calls.
-        # Skipped for local backends (same rationale as the pre-nav check).
-        if not _is_local_backend() and not _allow_private_urls() and final_url and final_url != url and not _is_safe_url(final_url):
+        if not _allow_private_urls() and final_url and final_url != url and not _is_safe_url(final_url):
             # Navigate away to a blank page to prevent snapshot leaks
             _run_browser_command(effective_task_id, "open", ["about:blank"], timeout=10)
             return json.dumps({


### PR DESCRIPTION
## Summary
- SSRF checks via `is_safe_url()` were only applied to cloud browser backends (Browserbase)
- Local browsers (the default) could navigate to internal IPs and cloud metadata endpoints
- Removed `_is_local_backend()` guard from both pre-navigation and post-redirect checks
- `allow_private_urls` opt-out setting still honored

## Test plan
- [x] 6 new parametrized tests for specific internal IPs (169.254.169.254, 10.x, 127.0.0.1, 192.168.x, 172.16.x)
- [x] 2 existing tests updated to match new behavior
- [x] 2 new tests for `allow_private_urls` opt-out in local mode
- [x] All 99 browser tests pass across 9 test files

Fixes #8034

🤖 Generated with [Claude Code](https://claude.com/claude-code)