### PR TITLE
fix(security): scope credential pool view for delegated subagents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1007,15 +1007,17 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
 
 class TestChildCredentialLeasing(unittest.TestCase):
     def test_run_single_child_acquires_and_releases_lease(self):
-        from tools.delegate_tool import _run_single_child
+        from tools.delegate_tool import _run_single_child, ScopedCredentialView
 
         leased_entry = MagicMock()
         leased_entry.id = "cred-b"
 
+        original_pool = MagicMock()
+        original_pool.acquire_lease.return_value = "cred-b"
+        original_pool.current.return_value = leased_entry
+
         child = MagicMock()
-        child._credential_pool = MagicMock()
-        child._credential_pool.acquire_lease.return_value = "cred-b"
-        child._credential_pool.current.return_value = leased_entry
+        child._credential_pool = original_pool
         child.run_conversation.return_value = {
             "final_response": "done",
             "completed": True,
@@ -1032,17 +1034,22 @@ class TestChildCredentialLeasing(unittest.TestCase):
         )
 
         self.assertEqual(result["status"], "completed")
-        child._credential_pool.acquire_lease.assert_called_once_with()
+        original_pool.acquire_lease.assert_called_once_with()
         child._swap_credential.assert_called_once_with(leased_entry)
-        child._credential_pool.release_lease.assert_called_once_with("cred-b")
+        # After leasing, child._credential_pool is replaced with ScopedCredentialView
+        self.assertIsInstance(child._credential_pool, ScopedCredentialView)
+        # Release happens on the original pool (captured before replacement)
+        original_pool.release_lease.assert_called_once_with("cred-b")
 
     def test_run_single_child_releases_lease_after_failure(self):
         from tools.delegate_tool import _run_single_child
 
+        original_pool = MagicMock()
+        original_pool.acquire_lease.return_value = "cred-a"
+        original_pool.current.return_value = MagicMock(id="cred-a")
+
         child = MagicMock()
-        child._credential_pool = MagicMock()
-        child._credential_pool.acquire_lease.return_value = "cred-a"
-        child._credential_pool.current.return_value = MagicMock(id="cred-a")
+        child._credential_pool = original_pool
         child.run_conversation.side_effect = RuntimeError("boom")
 
         result = _run_single_child(
@@ -1053,7 +1060,8 @@ class TestChildCredentialLeasing(unittest.TestCase):
         )
 
         self.assertEqual(result["status"], "error")
-        child._credential_pool.release_lease.assert_called_once_with("cred-a")
+        # Release happens on the original pool even after failure
+        original_pool.release_lease.assert_called_once_with("cred-a")
 
 
 class TestDelegateHeartbeat(unittest.TestCase):

--- a/tests/tools/test_delegate_scoped_credential.py
+++ b/tests/tools/test_delegate_scoped_credential.py
@@ -1,0 +1,323 @@
+"""Tests for ScopedCredentialView -- credential isolation for subagents.
+
+Verifies that child agents receive a restricted view of the credential pool
+that only exposes the single leased credential, blocking pool-wide iteration,
+status resets, and credential mutations.
+"""
+
+import json
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.delegate_tool import ScopedCredentialView, _run_single_child
+
+
+def _make_mock_parent(depth=0):
+    """Create a mock parent agent with the fields delegate_task expects."""
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _make_mock_pool_entry(entry_id="cred-a", label="test-key"):
+    """Create a mock PooledCredential entry."""
+    entry = MagicMock()
+    entry.id = entry_id
+    entry.label = label
+    entry.runtime_api_key = f"sk-{entry_id}"
+    entry.runtime_base_url = "https://example.com/v1"
+    return entry
+
+
+class TestScopedCredentialViewSelect:
+    """select() returns only the leased credential."""
+
+    def test_select_returns_leased_entry(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.select()
+        assert result is entry
+
+    def test_current_returns_leased_entry(self):
+        entry = _make_mock_pool_entry("cred-b")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.current()
+        assert result is entry
+
+    def test_peek_returns_leased_entry(self):
+        entry = _make_mock_pool_entry("cred-c")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.peek()
+        assert result is entry
+
+
+class TestScopedCredentialViewIteration:
+    """Pool-wide iteration is blocked -- only the leased entry is visible."""
+
+    def test_entries_returns_single_entry_list(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.entries()
+        assert result == [entry]
+        assert len(result) == 1
+
+    def test_entries_with_none_entry_returns_empty(self):
+        pool = MagicMock()
+        view = ScopedCredentialView(None, pool)
+
+        result = view.entries()
+        assert result == []
+
+    def test_has_credentials_true_when_entry_present(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        assert view.has_credentials() is True
+
+    def test_has_credentials_false_when_no_entry(self):
+        pool = MagicMock()
+        view = ScopedCredentialView(None, pool)
+
+        assert view.has_credentials() is False
+
+    def test_has_available_true_when_entry_present(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        assert view.has_available() is True
+
+    def test_has_available_false_when_no_entry(self):
+        pool = MagicMock()
+        view = ScopedCredentialView(None, pool)
+
+        assert view.has_available() is False
+
+
+class TestScopedCredentialViewRotation:
+    """rotate() is a no-op that returns the same entry."""
+
+    def test_rotate_returns_same_entry(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.rotate()
+        assert result is entry
+
+    def test_mark_exhausted_and_rotate_returns_same_entry(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.mark_exhausted_and_rotate(status_code=429)
+        assert result is entry
+
+    def test_rotate_does_not_call_pool(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        view.rotate()
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        pool.select.assert_not_called()
+
+
+class TestScopedCredentialViewBlocked:
+    """Pool-wide mutation operations are blocked."""
+
+    def test_reset_statuses_raises(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        with pytest.raises(PermissionError, match="statuses"):
+            view.reset_statuses()
+
+    def test_remove_index_raises(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        with pytest.raises(PermissionError, match="remove"):
+            view.remove_index(1)
+
+    def test_add_entry_raises(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        with pytest.raises(PermissionError, match="add"):
+            view.add_entry(MagicMock())
+
+
+class TestScopedCredentialViewLease:
+    """Lease operations delegate to the underlying pool."""
+
+    def test_acquire_lease_delegates_to_pool(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        pool.acquire_lease.return_value = "cred-a"
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.acquire_lease()
+        pool.acquire_lease.assert_called_once_with(credential_id="cred-a")
+        assert result == "cred-a"
+
+    def test_acquire_lease_with_explicit_id_delegates(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        pool.acquire_lease.return_value = "cred-x"
+        view = ScopedCredentialView(entry, pool)
+
+        result = view.acquire_lease(credential_id="cred-x")
+        pool.acquire_lease.assert_called_once_with(credential_id="cred-x")
+        assert result == "cred-x"
+
+    def test_release_lease_delegates_to_pool(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        view = ScopedCredentialView(entry, pool)
+
+        view.release_lease("cred-a")
+        pool.release_lease.assert_called_once_with("cred-a")
+
+    def test_provider_delegates_to_pool(self):
+        entry = _make_mock_pool_entry("cred-a")
+        pool = MagicMock()
+        pool.provider = "openrouter"
+        view = ScopedCredentialView(entry, pool)
+
+        assert view.provider == "openrouter"
+
+
+class TestScopedViewDoesNotExposeOtherCredentials:
+    """End-to-end: a scoped view over a pool with multiple entries only
+    exposes the single leased credential."""
+
+    def test_multi_credential_pool_scoped_to_one(self):
+        cred_a = _make_mock_pool_entry("cred-a", "key-alpha")
+        cred_b = _make_mock_pool_entry("cred-b", "key-beta")
+        cred_c = _make_mock_pool_entry("cred-c", "key-gamma")
+
+        pool = MagicMock()
+        pool.entries.return_value = [cred_a, cred_b, cred_c]
+        pool.provider = "openrouter"
+
+        # Scope to cred_b only
+        view = ScopedCredentialView(cred_b, pool)
+
+        # select/current/peek all return cred_b
+        assert view.select() is cred_b
+        assert view.current() is cred_b
+        assert view.peek() is cred_b
+
+        # entries() shows only cred_b, not the full pool
+        assert view.entries() == [cred_b]
+        assert cred_a not in view.entries()
+        assert cred_c not in view.entries()
+
+        # rotate returns same
+        assert view.rotate() is cred_b
+
+
+class TestRunSingleChildUsesScoped:
+    """_run_single_child wraps the pool in ScopedCredentialView."""
+
+    def test_child_gets_scoped_view_after_lease(self):
+        """After leasing, child._credential_pool should be a ScopedCredentialView,
+        not the original full pool."""
+        leased_entry = _make_mock_pool_entry("cred-b")
+
+        full_pool = MagicMock()
+        full_pool.acquire_lease.return_value = "cred-b"
+        full_pool.current.return_value = leased_entry
+
+        child = MagicMock()
+        child._credential_pool = full_pool
+        child.tool_progress_callback = None
+
+        # Track what _credential_pool is set to during run_conversation
+        captured_pool = {}
+
+        def capture_pool(**kwargs):
+            captured_pool["pool"] = child._credential_pool
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = capture_pool
+
+        _run_single_child(
+            task_index=0,
+            goal="Test scoped view assignment",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        pool_during_run = captured_pool["pool"]
+        assert isinstance(pool_during_run, ScopedCredentialView)
+        assert pool_during_run.select() is leased_entry
+        assert pool_during_run.current() is leased_entry
+        assert pool_during_run.entries() == [leased_entry]
+
+    def test_lease_released_on_real_pool_after_scoped(self):
+        """release_lease should be called on the real pool, not lost
+        when child._credential_pool is replaced with scoped view."""
+        leased_entry = _make_mock_pool_entry("cred-a")
+
+        full_pool = MagicMock()
+        full_pool.acquire_lease.return_value = "cred-a"
+        full_pool.current.return_value = leased_entry
+
+        child = MagicMock()
+        child._credential_pool = full_pool
+        child.tool_progress_callback = None
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        _run_single_child(
+            task_index=0,
+            goal="Test release after scoped",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        # The real pool's release_lease must be called
+        full_pool.release_lease.assert_called_once_with("cred-a")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -39,6 +39,79 @@ _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 
 
+class ScopedCredentialView:
+    """A restricted view over a single leased credential.
+
+    Subagents receive this instead of the full ``CredentialPool`` so they
+    can only see and use the one credential that was leased to them.
+    Pool-wide iteration, status inspection, and rotation are blocked.
+
+    ``select()`` always returns the leased entry.
+    ``rotate()`` is a no-op that returns the same entry (subagents should
+    not trigger cross-credential rotation).
+    ``acquire_lease`` / ``release_lease`` delegate to the underlying pool
+    so the parent's lease bookkeeping stays consistent.
+    """
+
+    def __init__(self, entry, pool):
+        self._entry = entry
+        self._pool = pool
+
+    # --- Allowed: credential access ---
+
+    def select(self):
+        """Return the single leased credential."""
+        return self._entry
+
+    def current(self):
+        """Return the single leased credential."""
+        return self._entry
+
+    def has_credentials(self) -> bool:
+        return self._entry is not None
+
+    def has_available(self) -> bool:
+        return self._entry is not None
+
+    def rotate(self, **_kwargs):
+        """No-op rotation -- subagents stay pinned to their lease."""
+        return self._entry
+
+    def mark_exhausted_and_rotate(self, **_kwargs):
+        """No-op -- subagents cannot mark credentials exhausted pool-wide."""
+        return self._entry
+
+    # --- Allowed: lease lifecycle (delegates to real pool) ---
+
+    def acquire_lease(self, credential_id=None):
+        return self._pool.acquire_lease(credential_id=credential_id or self._entry.id)
+
+    def release_lease(self, credential_id):
+        return self._pool.release_lease(credential_id)
+
+    # --- Blocked: pool-wide visibility ---
+
+    def entries(self):
+        """Return only the leased credential, not the full pool."""
+        return [self._entry] if self._entry is not None else []
+
+    def peek(self):
+        return self._entry
+
+    def reset_statuses(self):
+        raise PermissionError("Subagents cannot reset pool-wide credential statuses")
+
+    def remove_index(self, index):
+        raise PermissionError("Subagents cannot remove credentials from the pool")
+
+    def add_entry(self, entry):
+        raise PermissionError("Subagents cannot add credentials to the pool")
+
+    @property
+    def provider(self):
+        return self._pool.provider
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -411,8 +484,13 @@ def _run_single_child(
         if leased_cred_id is not None:
             try:
                 leased_entry = child_pool.current()
-                if leased_entry is not None and hasattr(child, '_swap_credential'):
-                    child._swap_credential(leased_entry)
+                if leased_entry is not None:
+                    # Replace the child's pool reference with a scoped view
+                    # so the subagent can only see its own leased credential,
+                    # not the parent's full credential pool.
+                    child._credential_pool = ScopedCredentialView(leased_entry, child_pool)
+                    if hasattr(child, '_swap_credential'):
+                        child._swap_credential(leased_entry)
             except Exception as exc:
                 logger.debug("Failed to bind child to leased credential: %s", exc)
 


### PR DESCRIPTION
## Summary
- Subagents received the parent's full credential pool, exposing ALL API keys
- Added `ScopedCredentialView` wrapper that only exposes the leased credential
- `select()`/`current()`/`peek()` return only the leased entry
- `entries()` returns single-element list
- `rotate()` is a no-op; `reset_statuses()`/`remove_index()`/`add_entry()` raise `PermissionError`
- Lease operations delegate to the real pool for proper bookkeeping

## Test plan
- [x] 22 new tests covering all scoped view methods, lease delegation, multi-credential isolation
- [x] 2 existing tests updated for scoped view behavior
- [x] All 94 delegate tests pass

Fixes #8037

🤖 Generated with [Claude Code](https://claude.com/claude-code)