### PR TITLE
fix(gateway): restore RedactingFormatter import

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8470,6 +8470,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # verbosity=1    (-v):         INFO and above
     # verbosity=2+   (-vv/-vvv):   DEBUG
     if verbosity is not None:
+        from agent.redact import RedactingFormatter
+
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
         _stderr_handler.setLevel(_stderr_level)


### PR DESCRIPTION
## Summary
- Restore the stderr logging import in `gateway/run.py` so gateway startup no longer crashes on `RedactingFormatter`.

## Verification
- `python -m pytest tests/gateway/test_runner_startup_failures.py -q`
