### PR TITLE
fix: strip provider prefix from model name in /model command

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -650,6 +650,24 @@ def switch_model(
                 api_key = "no-key-required"
 
     # --- Normalize model name for target provider ---
+    # If the model still has a provider/ prefix and the target provider wasn't
+    # explicitly resolved, extract the prefix as the provider so normalization
+    # can strip it.  Handles cases where the model is not in the curated list
+    # and detect_provider_for_model() returned None.  (#7922)
+    # Skip for aggregator providers where vendor/model is the expected format.
+    if (
+        "/" in new_model
+        and not explicit_provider
+        and not resolved_alias
+        and not is_aggregator(target_provider)
+    ):
+        prefix, bare = new_model.split("/", 1)
+        if bare:
+            from hermes_cli.models import _PROVIDER_MODELS, _PROVIDER_ALIASES
+            canonical = _PROVIDER_ALIASES.get(prefix.lower(), prefix.lower())
+            if canonical in _PROVIDER_MODELS:
+                target_provider = canonical
+                new_model = bare
     new_model = normalize_model_for_provider(new_model, target_provider)
 
     # --- Validate ---

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -130,10 +130,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemma-4-26b-it",
     ],
     "zai": [
+        "glm-5.1",
         "glm-5",
         "glm-5-turbo",
         "glm-4.7",
+        "glm-4.6",
         "glm-4.5",
+        "glm-4.5-air",
         "glm-4.5-flash",
     ],
     "xai": [

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -102,3 +102,30 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.new_model == "rotator-openrouter-coding"
     assert result.base_url == "http://127.0.0.1:4141/v1"
     assert result.api_key == "no-key-required"
+
+
+def test_switch_model_strips_provider_prefix_for_unlisted_model(monkeypatch):
+    """Regression for #7922: zai/glm-5.1 should strip prefix even if not in curated list."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "zai-key",
+            "base_url": "https://api.z.ai/api/coding/paas/v4/",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="zai/glm-5.1",
+        current_provider="auto",
+        current_model="gpt-4o",
+        current_base_url="",
+        current_api_key="some-key",
+    )
+
+    assert result.success is True
+    assert result.new_model == "glm-5.1"
+    assert result.target_provider == "zai"


### PR DESCRIPTION
## Summary

- When switching to a non-curated model via `/model zai/glm-5.1`, the `zai/` prefix was stored verbatim in the session override, causing the provider API to reject it with HTTP 400 ("Unknown Model"). This happened because `detect_provider_for_model()` returned None for models not in the curated list, so `normalize_model_for_provider()` didn't know which prefix to strip.
- Adds a fallback check before normalization: if the model contains a `/` prefix matching a known provider (via `_PROVIDER_MODELS` or `_PROVIDER_ALIASES`), extract it as the target provider and strip the prefix. Skips this for aggregator providers (OpenRouter etc.) where `vendor/model` is the expected slug format.
- Updates the stale Z.AI curated model list with `glm-5.1`, `glm-4.6`, and `glm-4.5-air`.

Fixes #7922

## Test plan

- [x] `test_switch_model_strips_provider_prefix_for_unlisted_model` — verifies `zai/glm-5.1` becomes `glm-5.1` with provider `zai`
- [x] All model switch tests: 4/4 passed
- [x] All model normalize tests: 23/23 passed
- [x] All variant tag preservation tests: 12/12 passed (no regression for aggregator slugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)