### PR TITLE
feat(cli): prompt to update Hermes before launch

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -523,10 +523,13 @@ DEFAULT_CONFIG = {
     },
 
     "startup": {
-        # When true, `hermes` checks whether the current git checkout is behind
-        # origin/main before launching chat. If the checkout is clean and on
-        # main, Hermes runs the normal update flow first, then re-execs itself
-        # so the interactive session starts on the freshly updated code.
+        # Startup update policy for git checkouts:
+        # - "ask" (default UX): prompt before launching when updates exist
+        # - "auto": update immediately before launching
+        # - "off": never check/apply launch-time updates
+        # Back-compat: older configs may still use boolean auto_update_on_launch
+        # where true => "auto" and false => "off".
+        "update_on_launch": "ask",
         "auto_update_on_launch": False,
     },
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -522,6 +522,14 @@ DEFAULT_CONFIG = {
         "platforms": {},  # Per-platform display overrides: {"telegram": {"tool_progress": "all"}, "slack": {"tool_progress": "off"}}
     },
 
+    "startup": {
+        # When true, `hermes` checks whether the current git checkout is behind
+        # origin/main before launching chat. If the checkout is clean and on
+        # main, Hermes runs the normal update flow first, then re-execs itself
+        # so the interactive session starts on the freshly updated code.
+        "auto_update_on_launch": False,
+    },
+
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
@@ -707,7 +715,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 16,
+    "_config_version": 17,
 }
 
 # =============================================================================
@@ -1563,7 +1571,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
+    "agent", "terminal", "display", "startup", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
 }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -281,11 +281,11 @@ def _has_any_provider_configured() -> bool:
 
 
 def _maybe_auto_update_before_chat_launch() -> None:
-    """Auto-update on CLI launch when enabled and safe to do so.
+    """Handle startup update policy before launching interactive chat.
 
-    This is intentionally conservative: only auto-update a clean checkout on
+    Safe-guards are intentionally conservative: only act on a clean checkout on
     ``main``. If the repo is dirty, detached, on a feature branch, or the check
-    fails, Hermes skips auto-update and continues launching normally.
+    fails, Hermes skips startup updating and continues launching normally.
     """
     from hermes_cli.config import is_managed, load_config
 
@@ -301,7 +301,17 @@ def _maybe_auto_update_before_chat_launch() -> None:
         return
 
     startup_cfg = config.get("startup") if isinstance(config, dict) else None
-    if not isinstance(startup_cfg, dict) or not startup_cfg.get("auto_update_on_launch", False):
+    policy = "ask"
+    if isinstance(startup_cfg, dict):
+        raw_policy = startup_cfg.get("update_on_launch")
+        if isinstance(raw_policy, str) and raw_policy.strip().lower() in {"ask", "auto", "off"}:
+            policy = raw_policy.strip().lower()
+        elif startup_cfg.get("auto_update_on_launch") is True:
+            policy = "auto"
+        elif startup_cfg.get("auto_update_on_launch") is False and "update_on_launch" not in startup_cfg:
+            policy = "off"
+
+    if policy == "off":
         return
 
     try:
@@ -332,7 +342,7 @@ def _maybe_auto_update_before_chat_launch() -> None:
 
     if current_branch != "main":
         print(
-            f"↻ Auto-update skipped: checkout is on '{current_branch or 'unknown'}', not 'main'."
+            f"↻ Startup update skipped: checkout is on '{current_branch or 'unknown'}', not 'main'."
         )
         return
 
@@ -349,15 +359,32 @@ def _maybe_auto_update_before_chat_launch() -> None:
         return
 
     if (status_result.stdout or "").strip():
-        print("↻ Auto-update skipped: local changes detected in the repo.")
+        print("↻ Startup update skipped: local changes detected in the repo.")
         return
 
-    print(f"↻ Auto-update: found {behind} new commit(s); updating before launch...")
+    if policy == "ask":
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            print("↻ Hermes update available, but startup prompt skipped in non-interactive mode.")
+            return
+        try:
+            reply = input(
+                f"↻ Hermes update available ({behind} commit{'s' if behind != 1 else ''}). "
+                "Update before launch? [Y/n] "
+            ).strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            reply = "n"
+        if reply not in ("", "y", "yes"):
+            print("↻ Skipping startup update and launching current checkout.")
+            return
+
+    elif policy == "auto":
+        print(f"↻ Auto-update: found {behind} new commit(s); updating before launch...")
+
     try:
         cmd_update(argparse.Namespace(gateway=False, auto_startup=True))
     except SystemExit as exc:
         if exc.code not in (0, None):
-            print("⚠ Auto-update failed; continuing with the current checkout.")
+            print("⚠ Startup update failed; continuing with the current checkout.")
         return
 
     print("↻ Restarting Hermes on the updated checkout...")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -280,6 +280,91 @@ def _has_any_provider_configured() -> bool:
     return False
 
 
+def _maybe_auto_update_before_chat_launch() -> None:
+    """Auto-update on CLI launch when enabled and safe to do so.
+
+    This is intentionally conservative: only auto-update a clean checkout on
+    ``main``. If the repo is dirty, detached, on a feature branch, or the check
+    fails, Hermes skips auto-update and continues launching normally.
+    """
+    from hermes_cli.config import is_managed, load_config
+
+    if os.environ.get("HERMES_AUTO_UPDATE_REEXECED") == "1":
+        return
+
+    if is_managed():
+        return
+
+    try:
+        config = load_config()
+    except Exception:
+        return
+
+    startup_cfg = config.get("startup") if isinstance(config, dict) else None
+    if not isinstance(startup_cfg, dict) or not startup_cfg.get("auto_update_on_launch", False):
+        return
+
+    try:
+        from hermes_cli.banner import check_for_updates
+        behind = check_for_updates()
+    except Exception:
+        return
+
+    if not behind or behind <= 0:
+        return
+
+    git_cmd = ["git"]
+    if sys.platform == "win32":
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+
+    try:
+        branch_result = subprocess.run(
+            git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+        current_branch = (branch_result.stdout or "").strip()
+    except Exception:
+        return
+
+    if current_branch != "main":
+        print(
+            f"↻ Auto-update skipped: checkout is on '{current_branch or 'unknown'}', not 'main'."
+        )
+        return
+
+    try:
+        status_result = subprocess.run(
+            git_cmd + ["status", "--porcelain"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except Exception:
+        return
+
+    if (status_result.stdout or "").strip():
+        print("↻ Auto-update skipped: local changes detected in the repo.")
+        return
+
+    print(f"↻ Auto-update: found {behind} new commit(s); updating before launch...")
+    try:
+        cmd_update(argparse.Namespace(gateway=False, auto_startup=True))
+    except SystemExit as exc:
+        if exc.code not in (0, None):
+            print("⚠ Auto-update failed; continuing with the current checkout.")
+        return
+
+    print("↻ Restarting Hermes on the updated checkout...")
+    os.environ["HERMES_AUTO_UPDATE_REEXECED"] = "1"
+    os.execv(sys.executable, [sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]])
+
+
 def _session_browse_picker(sessions: list) -> Optional[str]:
     """Interactive curses-based session browser with live search filtering.
 
@@ -719,6 +804,11 @@ def cmd_chat(args):
         print()
         print("You can run 'hermes setup' at any time to configure.")
         sys.exit(1)
+
+    try:
+        _maybe_auto_update_before_chat_launch()
+    except Exception:
+        pass
 
     # Start update check in background (runs while other init happens)
     try:
@@ -3560,6 +3650,7 @@ def cmd_update(args):
         return
 
     gateway_mode = getattr(args, "gateway", False)
+    auto_startup = getattr(args, "auto_startup", False)
     # In gateway mode, use file-based IPC for prompts instead of stdin
     gw_input_fn = (lambda prompt, default="": _gateway_prompt(prompt, default)) if gateway_mode else None
     
@@ -3871,7 +3962,11 @@ def cmd_update(args):
                 print(f"  ℹ️  {len(missing_config)} new config option(s) available")
             
             print()
-            if gateway_mode:
+            if auto_startup:
+                print("  ℹ Startup auto-update mode: skipping interactive config migration prompt.")
+                print("    Run 'hermes config migrate' later to review new options.")
+                response = "n"
+            elif gateway_mode:
                 response = _gateway_prompt(
                     "Would you like to configure new options now? [Y/n]", "n"
                 ).strip().lower()

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -171,7 +171,63 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
     assert not (default_home / ".update_check").exists()
 
 
-def test_auto_update_before_chat_launch_runs_update_and_reexec(monkeypatch):
+def test_startup_update_prompt_accepts_and_reexecs(monkeypatch):
+    import hermes_cli.main as main
+
+    monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "chat"])
+    monkeypatch.setattr(main, "__file__", "/tmp/hermes_cli/main.py")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+    branch = MagicMock(returncode=0, stdout="main\n")
+    clean = MagicMock(returncode=0, stdout="")
+
+    with patch("hermes_cli.config.is_managed", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"update_on_launch": "ask"}}), \
+         patch("hermes_cli.banner.check_for_updates", return_value=2), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[branch, clean]) as mock_run, \
+         patch("builtins.input", return_value="y"), \
+         patch.object(main, "cmd_update") as mock_update, \
+         patch("hermes_cli.main.os.execv") as mock_execv:
+        main._maybe_auto_update_before_chat_launch()
+
+    mock_update.assert_called_once()
+    update_args = mock_update.call_args.args[0]
+    assert update_args.gateway is False
+    assert update_args.auto_startup is True
+    mock_execv.assert_called_once_with(
+        sys.executable,
+        [sys.executable, str(Path("/tmp/hermes_cli/main.py").resolve()), "chat"],
+    )
+    assert os.environ["HERMES_AUTO_UPDATE_REEXECED"] == "1"
+    assert mock_run.call_count == 2
+
+
+def test_startup_update_prompt_decline_skips_update(monkeypatch):
+    import hermes_cli.main as main
+
+    monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+    branch = MagicMock(returncode=0, stdout="main\n")
+    clean = MagicMock(returncode=0, stdout="")
+
+    with patch("hermes_cli.config.is_managed", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"update_on_launch": "ask"}}), \
+         patch("hermes_cli.banner.check_for_updates", return_value=2), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[branch, clean]), \
+         patch("builtins.input", return_value="n"), \
+         patch.object(main, "cmd_update") as mock_update, \
+         patch("hermes_cli.main.os.execv") as mock_execv:
+        main._maybe_auto_update_before_chat_launch()
+
+    mock_update.assert_not_called()
+    mock_execv.assert_not_called()
+
+
+def test_startup_auto_policy_runs_update_and_reexec(monkeypatch):
     import hermes_cli.main as main
 
     monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
@@ -182,7 +238,7 @@ def test_auto_update_before_chat_launch_runs_update_and_reexec(monkeypatch):
     clean = MagicMock(returncode=0, stdout="")
 
     with patch("hermes_cli.config.is_managed", return_value=False), \
-         patch("hermes_cli.config.load_config", return_value={"startup": {"auto_update_on_launch": True}}), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"update_on_launch": "auto"}}), \
          patch("hermes_cli.banner.check_for_updates", return_value=2), \
          patch("hermes_cli.main.subprocess.run", side_effect=[branch, clean]) as mock_run, \
          patch.object(main, "cmd_update") as mock_update, \
@@ -201,7 +257,24 @@ def test_auto_update_before_chat_launch_runs_update_and_reexec(monkeypatch):
     assert mock_run.call_count == 2
 
 
-def test_auto_update_before_chat_launch_skips_dirty_repo(monkeypatch):
+def test_startup_update_off_skips_update(monkeypatch):
+    import hermes_cli.main as main
+
+    monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
+
+    with patch("hermes_cli.config.is_managed", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"update_on_launch": "off"}}), \
+         patch("hermes_cli.banner.check_for_updates") as mock_check, \
+         patch.object(main, "cmd_update") as mock_update, \
+         patch("hermes_cli.main.os.execv") as mock_execv:
+        main._maybe_auto_update_before_chat_launch()
+
+    mock_check.assert_not_called()
+    mock_update.assert_not_called()
+    mock_execv.assert_not_called()
+
+
+def test_startup_update_skips_dirty_repo(monkeypatch):
     import hermes_cli.main as main
 
     monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
@@ -210,7 +283,7 @@ def test_auto_update_before_chat_launch_skips_dirty_repo(monkeypatch):
     dirty = MagicMock(returncode=0, stdout=" M cli.py\n")
 
     with patch("hermes_cli.config.is_managed", return_value=False), \
-         patch("hermes_cli.config.load_config", return_value={"startup": {"auto_update_on_launch": True}}), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"update_on_launch": "auto"}}), \
          patch("hermes_cli.banner.check_for_updates", return_value=3), \
          patch("hermes_cli.main.subprocess.run", side_effect=[branch, dirty]), \
          patch.object(main, "cmd_update") as mock_update, \

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import threading
 import time
 from pathlib import Path
@@ -168,3 +169,53 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()
+
+
+def test_auto_update_before_chat_launch_runs_update_and_reexec(monkeypatch):
+    import hermes_cli.main as main
+
+    monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "chat"])
+    monkeypatch.setattr(main, "__file__", "/tmp/hermes_cli/main.py")
+
+    branch = MagicMock(returncode=0, stdout="main\n")
+    clean = MagicMock(returncode=0, stdout="")
+
+    with patch("hermes_cli.config.is_managed", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"auto_update_on_launch": True}}), \
+         patch("hermes_cli.banner.check_for_updates", return_value=2), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[branch, clean]) as mock_run, \
+         patch.object(main, "cmd_update") as mock_update, \
+         patch("hermes_cli.main.os.execv") as mock_execv:
+        main._maybe_auto_update_before_chat_launch()
+
+    mock_update.assert_called_once()
+    update_args = mock_update.call_args.args[0]
+    assert update_args.gateway is False
+    assert update_args.auto_startup is True
+    mock_execv.assert_called_once_with(
+        sys.executable,
+        [sys.executable, str(Path("/tmp/hermes_cli/main.py").resolve()), "chat"],
+    )
+    assert os.environ["HERMES_AUTO_UPDATE_REEXECED"] == "1"
+    assert mock_run.call_count == 2
+
+
+def test_auto_update_before_chat_launch_skips_dirty_repo(monkeypatch):
+    import hermes_cli.main as main
+
+    monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
+
+    branch = MagicMock(returncode=0, stdout="main\n")
+    dirty = MagicMock(returncode=0, stdout=" M cli.py\n")
+
+    with patch("hermes_cli.config.is_managed", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"auto_update_on_launch": True}}), \
+         patch("hermes_cli.banner.check_for_updates", return_value=3), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[branch, dirty]), \
+         patch.object(main, "cmd_update") as mock_update, \
+         patch("hermes_cli.main.os.execv") as mock_execv:
+        main._maybe_auto_update_before_chat_launch()
+
+    mock_update.assert_not_called()
+    mock_execv.assert_not_called()

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -274,6 +274,45 @@ def test_startup_update_off_skips_update(monkeypatch):
     mock_execv.assert_not_called()
 
 
+def test_startup_update_legacy_true_maps_to_auto(monkeypatch):
+    import hermes_cli.main as main
+
+    monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "chat"])
+    monkeypatch.setattr(main, "__file__", "/tmp/hermes_cli/main.py")
+
+    branch = MagicMock(returncode=0, stdout="main\n")
+    clean = MagicMock(returncode=0, stdout="")
+
+    with patch("hermes_cli.config.is_managed", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"auto_update_on_launch": True}}), \
+         patch("hermes_cli.banner.check_for_updates", return_value=1), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[branch, clean]), \
+         patch.object(main, "cmd_update") as mock_update, \
+         patch("hermes_cli.main.os.execv") as mock_execv:
+        main._maybe_auto_update_before_chat_launch()
+
+    mock_update.assert_called_once()
+    mock_execv.assert_called_once()
+
+
+def test_startup_update_legacy_false_maps_to_off(monkeypatch):
+    import hermes_cli.main as main
+
+    monkeypatch.delenv("HERMES_AUTO_UPDATE_REEXECED", raising=False)
+
+    with patch("hermes_cli.config.is_managed", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={"startup": {"auto_update_on_launch": False}}), \
+         patch("hermes_cli.banner.check_for_updates") as mock_check, \
+         patch.object(main, "cmd_update") as mock_update, \
+         patch("hermes_cli.main.os.execv") as mock_execv:
+        main._maybe_auto_update_before_chat_launch()
+
+    mock_check.assert_not_called()
+    mock_update.assert_not_called()
+    mock_execv.assert_not_called()
+
+
 def test_startup_update_skips_dirty_repo(monkeypatch):
     import hermes_cli.main as main
 


### PR DESCRIPTION
## Summary
- add a startup update policy for interactive Hermes launches
- default the UX to prompting before launch when the local checkout is behind `origin/main`
- preserve safe skips for dirty repos, non-`main` branches, managed installs, and non-git installs
- keep backward compatibility with older boolean `startup.auto_update_on_launch` configs

## Behavior
- `startup.update_on_launch: ask` → prompt before launch when updates are available
- `startup.update_on_launch: auto` → update immediately before launch
- `startup.update_on_launch: off` → disable launch-time updates
- legacy `auto_update_on_launch: true/false` still maps to `auto/off`

## Test Plan
- [x] `python3 -m pytest -o addopts='' tests/hermes_cli/test_update_check.py -q`
- [x] `python3 -m py_compile hermes_cli/config.py hermes_cli/main.py tests/hermes_cli/test_update_check.py`
- [x] `gitleaks detect` on `origin/main...HEAD` diff reported no leaks
