### PR TITLE
fix: defer redact_secrets env snapshot to first call

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -13,9 +13,20 @@ import re
 
 logger = logging.getLogger(__name__)
 
-# Snapshot at import time so runtime env mutations (e.g. LLM-generated
-# `export HERMES_REDACT_SECRETS=false`) cannot disable redaction mid-session.
-_REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "").lower() not in ("0", "false", "no", "off")
+# Frozen on first call (not import time) so config.yaml has a chance to
+# set HERMES_REDACT_SECRETS before we snapshot.  Once frozen, runtime env
+# mutations (e.g. LLM-generated `export HERMES_REDACT_SECRETS=false`)
+# cannot disable redaction mid-session.
+_REDACT_ENABLED: bool | None = None
+
+
+def _is_redact_enabled() -> bool:
+    global _REDACT_ENABLED
+    if _REDACT_ENABLED is None:
+        _REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "").lower() not in (
+            "0", "false", "no", "off",
+        )
+    return _REDACT_ENABLED
 
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
@@ -122,7 +133,7 @@ def redact_sensitive_text(text: str) -> str:
         text = str(text)
     if not text:
         return text
-    if not _REDACT_ENABLED:
+    if not _is_redact_enabled():
         return text
 
     # Known prefixes (sk-, ghp_, etc.)


### PR DESCRIPTION
## Summary

`_REDACT_ENABLED` in `agent/redact.py` is captured at **import time**, but both `cli.py` and `gateway/run.py` set `HERMES_REDACT_SECRETS` via `os.environ` **after** the module is already imported (during config load). This means `security.redact_secrets: false` in config.yaml is silently ignored — secrets are always redacted regardless of config.

## Fix

Lazy-initialize `_REDACT_ENABLED` on first call to `redact_sensitive_text()` instead of at import time. Once frozen, runtime env mutations (e.g. LLM-generated `export`) still cannot disable redaction mid-session — same security guarantee as before.

## Reproduction

1. Set `security.redact_secrets: false` in `~/.hermes/config.yaml`
2. Send a message containing an API key pattern (e.g. `sk-1234567890abcdef1234567890`)
3. Observe the key is still redacted in tool output despite config

## Test plan

- [x] `security.redact_secrets: false` → secrets pass through unredacted
- [x] Default (no config) → secrets are redacted as before
- [x] All 43 existing redact tests pass
- [x] LLM-generated `export HERMES_REDACT_SECRETS=false` after first call has no effect (frozen)