### PR TITLE
fix: add threading locks to model metadata caches

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -7,6 +7,7 @@ and run_agent.py for pre-flight context checks.
 import logging
 import os
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -67,9 +68,11 @@ def _strip_provider_prefix(model: str) -> str:
 _model_metadata_cache: Dict[str, Dict[str, Any]] = {}
 _model_metadata_cache_time: float = 0
 _MODEL_CACHE_TTL = 3600
+_model_metadata_lock = threading.Lock()
 _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
+_endpoint_metadata_lock = threading.Lock()
 
 # Descending tiers for context length probing when the model is unknown.
 # We start at 128K (a safe default for most modern models) and step down
@@ -428,36 +431,37 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
     """Fetch model metadata from OpenRouter (cached for 1 hour)."""
     global _model_metadata_cache, _model_metadata_cache_time
 
-    if not force_refresh and _model_metadata_cache and (time.time() - _model_metadata_cache_time) < _MODEL_CACHE_TTL:
-        return _model_metadata_cache
+    with _model_metadata_lock:
+        if not force_refresh and _model_metadata_cache and (time.time() - _model_metadata_cache_time) < _MODEL_CACHE_TTL:
+            return _model_metadata_cache
 
-    try:
-        response = requests.get(OPENROUTER_MODELS_URL, timeout=10)
-        response.raise_for_status()
-        data = response.json()
+        try:
+            response = requests.get(OPENROUTER_MODELS_URL, timeout=10)
+            response.raise_for_status()
+            data = response.json()
 
-        cache = {}
-        for model in data.get("data", []):
-            model_id = model.get("id", "")
-            entry = {
-                "context_length": model.get("context_length", 128000),
-                "max_completion_tokens": model.get("top_provider", {}).get("max_completion_tokens", 4096),
-                "name": model.get("name", model_id),
-                "pricing": model.get("pricing", {}),
-            }
-            _add_model_aliases(cache, model_id, entry)
-            canonical = model.get("canonical_slug", "")
-            if canonical and canonical != model_id:
-                _add_model_aliases(cache, canonical, entry)
+            cache = {}
+            for model in data.get("data", []):
+                model_id = model.get("id", "")
+                entry = {
+                    "context_length": model.get("context_length", 128000),
+                    "max_completion_tokens": model.get("top_provider", {}).get("max_completion_tokens", 4096),
+                    "name": model.get("name", model_id),
+                    "pricing": model.get("pricing", {}),
+                }
+                _add_model_aliases(cache, model_id, entry)
+                canonical = model.get("canonical_slug", "")
+                if canonical and canonical != model_id:
+                    _add_model_aliases(cache, canonical, entry)
 
-        _model_metadata_cache = cache
-        _model_metadata_cache_time = time.time()
-        logger.debug("Fetched metadata for %s models from OpenRouter", len(cache))
-        return cache
+            _model_metadata_cache = cache
+            _model_metadata_cache_time = time.time()
+            logger.debug("Fetched metadata for %s models from OpenRouter", len(cache))
+            return cache
 
-    except Exception as e:
-        logging.warning(f"Failed to fetch model metadata from OpenRouter: {e}")
-        return _model_metadata_cache or {}
+        except Exception as e:
+            logging.warning(f"Failed to fetch model metadata from OpenRouter: {e}")
+            return _model_metadata_cache or {}
 
 
 def fetch_endpoint_model_metadata(
@@ -474,81 +478,82 @@ def fetch_endpoint_model_metadata(
     if not normalized or _is_openrouter_base_url(normalized):
         return {}
 
-    if not force_refresh:
-        cached = _endpoint_model_metadata_cache.get(normalized)
-        cached_at = _endpoint_model_metadata_cache_time.get(normalized, 0)
-        if cached is not None and (time.time() - cached_at) < _ENDPOINT_MODEL_CACHE_TTL:
-            return cached
+    with _endpoint_metadata_lock:
+        if not force_refresh:
+            cached = _endpoint_model_metadata_cache.get(normalized)
+            cached_at = _endpoint_model_metadata_cache_time.get(normalized, 0)
+            if cached is not None and (time.time() - cached_at) < _ENDPOINT_MODEL_CACHE_TTL:
+                return cached
 
-    candidates = [normalized]
-    if normalized.endswith("/v1"):
-        alternate = normalized[:-3].rstrip("/")
-    else:
-        alternate = normalized + "/v1"
-    if alternate and alternate not in candidates:
-        candidates.append(alternate)
+        candidates = [normalized]
+        if normalized.endswith("/v1"):
+            alternate = normalized[:-3].rstrip("/")
+        else:
+            alternate = normalized + "/v1"
+        if alternate and alternate not in candidates:
+            candidates.append(alternate)
 
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-    last_error: Optional[Exception] = None
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        last_error: Optional[Exception] = None
 
-    for candidate in candidates:
-        url = candidate.rstrip("/") + "/models"
-        try:
-            response = requests.get(url, headers=headers, timeout=10)
-            response.raise_for_status()
-            payload = response.json()
-            cache: Dict[str, Dict[str, Any]] = {}
-            for model in payload.get("data", []):
-                if not isinstance(model, dict):
-                    continue
-                model_id = model.get("id")
-                if not model_id:
-                    continue
-                entry: Dict[str, Any] = {"name": model.get("name", model_id)}
-                context_length = _extract_context_length(model)
-                if context_length is not None:
-                    entry["context_length"] = context_length
-                max_completion_tokens = _extract_max_completion_tokens(model)
-                if max_completion_tokens is not None:
-                    entry["max_completion_tokens"] = max_completion_tokens
-                pricing = _extract_pricing(model)
-                if pricing:
-                    entry["pricing"] = pricing
-                _add_model_aliases(cache, model_id, entry)
+        for candidate in candidates:
+            url = candidate.rstrip("/") + "/models"
+            try:
+                response = requests.get(url, headers=headers, timeout=10)
+                response.raise_for_status()
+                payload = response.json()
+                cache: Dict[str, Dict[str, Any]] = {}
+                for model in payload.get("data", []):
+                    if not isinstance(model, dict):
+                        continue
+                    model_id = model.get("id")
+                    if not model_id:
+                        continue
+                    entry: Dict[str, Any] = {"name": model.get("name", model_id)}
+                    context_length = _extract_context_length(model)
+                    if context_length is not None:
+                        entry["context_length"] = context_length
+                    max_completion_tokens = _extract_max_completion_tokens(model)
+                    if max_completion_tokens is not None:
+                        entry["max_completion_tokens"] = max_completion_tokens
+                    pricing = _extract_pricing(model)
+                    if pricing:
+                        entry["pricing"] = pricing
+                    _add_model_aliases(cache, model_id, entry)
 
-            # If this is a llama.cpp server, query /props for actual allocated context
-            is_llamacpp = any(
-                m.get("owned_by") == "llamacpp"
-                for m in payload.get("data", []) if isinstance(m, dict)
-            )
-            if is_llamacpp:
-                try:
-                    # Try /v1/props first (current llama.cpp); fall back to /props for older builds
-                    base = candidate.rstrip("/").replace("/v1", "")
-                    props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5)
-                    if not props_resp.ok:
-                        props_resp = requests.get(base + "/props", headers=headers, timeout=5)
-                    if props_resp.ok:
-                        props = props_resp.json()
-                        gen_settings = props.get("default_generation_settings", {})
-                        n_ctx = gen_settings.get("n_ctx")
-                        model_alias = props.get("model_alias", "")
-                        if n_ctx and model_alias and model_alias in cache:
-                            cache[model_alias]["context_length"] = n_ctx
-                except Exception:
-                    pass
+                # If this is a llama.cpp server, query /props for actual allocated context
+                is_llamacpp = any(
+                    m.get("owned_by") == "llamacpp"
+                    for m in payload.get("data", []) if isinstance(m, dict)
+                )
+                if is_llamacpp:
+                    try:
+                        # Try /v1/props first (current llama.cpp); fall back to /props for older builds
+                        base = candidate.rstrip("/").replace("/v1", "")
+                        props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5)
+                        if not props_resp.ok:
+                            props_resp = requests.get(base + "/props", headers=headers, timeout=5)
+                        if props_resp.ok:
+                            props = props_resp.json()
+                            gen_settings = props.get("default_generation_settings", {})
+                            n_ctx = gen_settings.get("n_ctx")
+                            model_alias = props.get("model_alias", "")
+                            if n_ctx and model_alias and model_alias in cache:
+                                cache[model_alias]["context_length"] = n_ctx
+                    except Exception:
+                        pass
 
-            _endpoint_model_metadata_cache[normalized] = cache
-            _endpoint_model_metadata_cache_time[normalized] = time.time()
-            return cache
-        except Exception as exc:
-            last_error = exc
+                _endpoint_model_metadata_cache[normalized] = cache
+                _endpoint_model_metadata_cache_time[normalized] = time.time()
+                return cache
+            except Exception as exc:
+                last_error = exc
 
-    if last_error:
-        logger.debug("Failed to fetch model metadata from %s/models: %s", normalized, last_error)
-    _endpoint_model_metadata_cache[normalized] = {}
-    _endpoint_model_metadata_cache_time[normalized] = time.time()
-    return {}
+        if last_error:
+            logger.debug("Failed to fetch model metadata from %s/models: %s", normalized, last_error)
+        _endpoint_model_metadata_cache[normalized] = {}
+        _endpoint_model_metadata_cache_time[normalized] = time.time()
+        return {}
 
 
 def _get_context_cache_path() -> Path:

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -22,6 +22,7 @@ import difflib
 import json
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,6 +40,7 @@ _MODELS_DEV_CACHE_TTL = 3600  # 1 hour in-memory
 # In-memory cache
 _models_dev_cache: Dict[str, Any] = {}
 _models_dev_cache_time: float = 0
+_models_dev_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -216,41 +218,42 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
     """
     global _models_dev_cache, _models_dev_cache_time
 
-    # Check in-memory cache
-    if (
-        not force_refresh
-        and _models_dev_cache
-        and (time.time() - _models_dev_cache_time) < _MODELS_DEV_CACHE_TTL
-    ):
+    with _models_dev_lock:
+        # Check in-memory cache
+        if (
+            not force_refresh
+            and _models_dev_cache
+            and (time.time() - _models_dev_cache_time) < _MODELS_DEV_CACHE_TTL
+        ):
+            return _models_dev_cache
+
+        # Try network fetch
+        try:
+            response = requests.get(MODELS_DEV_URL, timeout=15)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, dict) and data:
+                _models_dev_cache = data
+                _models_dev_cache_time = time.time()
+                _save_disk_cache(data)
+                logger.debug(
+                    "Fetched models.dev registry: %d providers, %d total models",
+                    len(data),
+                    sum(len(p.get("models", {})) for p in data.values() if isinstance(p, dict)),
+                )
+                return data
+        except Exception as e:
+            logger.debug("Failed to fetch models.dev: %s", e)
+
+        # Fall back to disk cache — use a short TTL (5 min) so we retry
+        # the network fetch soon instead of serving stale data for a full hour.
+        if not _models_dev_cache:
+            _models_dev_cache = _load_disk_cache()
+            if _models_dev_cache:
+                _models_dev_cache_time = time.time() - _MODELS_DEV_CACHE_TTL + 300
+                logger.debug("Loaded models.dev from disk cache (%d providers)", len(_models_dev_cache))
+
         return _models_dev_cache
-
-    # Try network fetch
-    try:
-        response = requests.get(MODELS_DEV_URL, timeout=15)
-        response.raise_for_status()
-        data = response.json()
-        if isinstance(data, dict) and data:
-            _models_dev_cache = data
-            _models_dev_cache_time = time.time()
-            _save_disk_cache(data)
-            logger.debug(
-                "Fetched models.dev registry: %d providers, %d total models",
-                len(data),
-                sum(len(p.get("models", {})) for p in data.values() if isinstance(p, dict)),
-            )
-            return data
-    except Exception as e:
-        logger.debug("Failed to fetch models.dev: %s", e)
-
-    # Fall back to disk cache — use a short TTL (5 min) so we retry
-    # the network fetch soon instead of serving stale data for a full hour.
-    if not _models_dev_cache:
-        _models_dev_cache = _load_disk_cache()
-        if _models_dev_cache:
-            _models_dev_cache_time = time.time() - _MODELS_DEV_CACHE_TTL + 300
-            logger.debug("Loaded models.dev from disk cache (%d providers)", len(_models_dev_cache))
-
-    return _models_dev_cache
 
 
 def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -709,3 +709,55 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# Thread safety (#8039)
+# =========================================================================
+
+class TestFetchThreadSafety:
+    """Verify concurrent fetch_model_metadata calls don't race."""
+
+    def test_concurrent_fetch_uses_lock(self):
+        """Two threads calling fetch_model_metadata should serialize via lock."""
+        import threading
+        from agent import model_metadata
+
+        results = []
+        call_count = {"n": 0}
+        original_cache = model_metadata._model_metadata_cache
+        original_time = model_metadata._model_metadata_cache_time
+
+        def mock_get(*args, **kwargs):
+            call_count["n"] += 1
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"data": [{"id": "test/model", "context_length": 8192, "name": "Test"}]}
+            return resp
+
+        try:
+            # Clear cache to force fetch
+            model_metadata._model_metadata_cache = {}
+            model_metadata._model_metadata_cache_time = 0
+
+            with patch("agent.model_metadata.requests.get", side_effect=mock_get):
+                barrier = threading.Barrier(2)
+
+                def fetch():
+                    barrier.wait()
+                    result = fetch_model_metadata(force_refresh=True)
+                    results.append(result)
+
+                t1 = threading.Thread(target=fetch)
+                t2 = threading.Thread(target=fetch)
+                t1.start()
+                t2.start()
+                t1.join(timeout=10)
+                t2.join(timeout=10)
+
+            assert len(results) == 2
+            # Both should return valid dicts
+            assert all(isinstance(r, dict) for r in results)
+        finally:
+            model_metadata._model_metadata_cache = original_cache
+            model_metadata._model_metadata_cache_time = original_time


### PR DESCRIPTION
## Summary

- Add `threading.Lock` around `fetch_model_metadata()` and `fetch_endpoint_model_metadata()` in `agent/model_metadata.py`
- Add `threading.Lock` around `fetch_models_dev()` in `agent/models_dev.py`
- Prevents data races when the background pre-warm thread (`run_agent.py:687`) overlaps with concurrent metadata lookups from gateway sessions

Follows the existing pattern in `auxiliary_client.py` (`_client_cache_lock`).

## Test plan

- [x] `test_concurrent_fetch_uses_lock` — two threads race on `fetch_model_metadata(force_refresh=True)`, both complete without error
- [x] All 100 existing model_metadata tests pass

Closes #8039

🤖 Generated with [Claude Code](https://claude.com/claude-code)