### PR TITLE
fix: use weakref for ProcessSession.env_ref to allow environment GC

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -635,3 +635,57 @@ class TestProcessToolHandler:
         from tools.process_registry import _handle_process
         result = json.loads(_handle_process({"action": "unknown_action"}))
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# env_ref weakref (#8041)
+# ---------------------------------------------------------------------------
+
+class TestEnvRefWeakref:
+    """Verify env_ref uses weakref and allows GC of environment objects."""
+
+    def test_env_ref_is_weakref(self):
+        """ProcessSession.env_ref should be a weakref when set via spawn_in_env."""
+        import weakref
+
+        class DummyEnv:
+            def execute(self, cmd, timeout=5):
+                return {"output": ""}
+
+        env = DummyEnv()
+        session = ProcessSession(
+            id="proc_weakref_test",
+            command="echo test",
+            started_at=time.time(),
+            env_ref=weakref.ref(env),
+            pid_scope="sandbox",
+        )
+        # Dereferencing the weakref should return the original object
+        assert session.env_ref() is env
+
+        # After deleting the strong reference, weakref should return None
+        del env
+        assert session.env_ref() is None
+
+    def test_kill_handles_dead_weakref(self, registry):
+        """kill_process should handle case where env has been garbage collected."""
+        import weakref
+
+        env = MagicMock()
+        session = ProcessSession(
+            id="proc_dead_env",
+            command="echo test",
+            task_id="t1",
+            started_at=time.time(),
+            env_ref=weakref.ref(env),
+            pid=12345,
+            pid_scope="sandbox",
+        )
+        registry._running["proc_dead_env"] = session
+
+        # Drop the strong reference — env_ref() now returns None
+        del env
+
+        # kill should not crash when the environment is gone
+        result = registry.kill_process("proc_dead_env")
+        assert result is not None

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -39,6 +39,7 @@ import subprocess
 import threading
 import time
 import uuid
+import weakref
 
 _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _sanitize_subprocess_env
@@ -418,7 +419,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=cwd,
             started_at=time.time(),
-            env_ref=env,
+            env_ref=weakref.ref(env),
             pid_scope="sandbox",
         )
 
@@ -777,7 +778,9 @@ class ProcessRegistry:
                     session.process.kill()
             elif session.env_ref and session.pid:
                 # Non-local -- kill inside sandbox
-                session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
+                env = session.env_ref()
+                if env is not None:
+                    env.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
             elif session.detached and session.pid_scope == "host" and session.pid:
                 if not self._is_host_pid_alive(session.pid):
                     with session._lock:


### PR DESCRIPTION
## Summary

- Change `ProcessSession.env_ref` from strong reference to `weakref.ref` so environment objects (Docker/SSH/Modal) can be garbage collected after the process exits, instead of being held for 30 minutes in `_finished` dict
- Update `kill_process` to dereference the weakref and gracefully handle the case where the environment has been collected

## Test plan

- [x] `test_env_ref_is_weakref` — verifies weakref allows GC when strong refs are released
- [x] `test_kill_handles_dead_weakref` — verifies kill_process doesn't crash when environment is gone
- [x] All 44 existing process_registry tests pass

Closes #8041

🤖 Generated with [Claude Code](https://claude.com/claude-code)