### PR TITLE
fix: surface session DB flush failures instead of silently swallowing them

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1050,6 +1050,7 @@ class AIAgent:
         self._session_db = session_db
         self._parent_session_id = parent_session_id
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
+        self._db_flush_failed = False  # tracks whether a flush attempt failed
         if self._session_db:
             try:
                 self._session_db.create_session(
@@ -2248,8 +2249,19 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                 )
             self._last_flushed_db_idx = len(messages)
+            # Clear the failure flag on successful flush
+            if self._db_flush_failed:
+                logger.info("Session DB flush recovered after previous failure")
+                self._db_flush_failed = False
         except Exception as e:
-            logger.warning("Session DB append_message failed: %s", e)
+            self._db_flush_failed = True
+            logger.error(
+                "Session DB flush failed: %s (%d messages at risk). "
+                "Messages may still be in JSONL — prefer JSONL on resume if "
+                "conversation appears incomplete.",
+                e,
+                len(messages) - self._last_flushed_db_idx,
+            )
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """


### PR DESCRIPTION
Closes #8038.

## Summary
_flush_messages_to_session_db() was silently swallowing all persistence errors with only a WARNING log. This fix:

1. Adds `_db_flush_failed` flag to track persistence failures
2. Changes logger.warning to logger.error with context about messages at risk
3. Logs recovery message on successful flush after failure
4. Informs users that JSONL may contain more complete data after flush failure

## Why
High severity bug — messages can be silently lost from SQLite on exit. Users have no indication persistence failed.