### PR TITLE
fix: make transcript rewrite atomic to prevent data loss on crash

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -13,6 +13,7 @@ import logging
 import os
 import json
 import re
+import tempfile
 import threading
 import uuid
 from pathlib import Path
@@ -968,35 +969,38 @@ class SessionStore:
     
     def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.
-        
+
         Used by /retry, /undo, and /compress to persist modified conversation history.
         Rewrites both SQLite and legacy JSONL storage.
         """
-        # SQLite: clear old messages and re-insert
+        # SQLite: atomic clear+reinsert in a single transaction
         if self._db:
             try:
-                self._db.clear_messages(session_id)
-                for msg in messages:
-                    role = msg.get("role", "unknown")
-                    self._db.append_message(
-                        session_id=session_id,
-                        role=role,
-                        content=msg.get("content"),
-                        tool_name=msg.get("tool_name"),
-                        tool_calls=msg.get("tool_calls"),
-                        tool_call_id=msg.get("tool_call_id"),
-                        reasoning=msg.get("reasoning") if role == "assistant" else None,
-                        reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                        codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    )
+                self._db.rewrite_messages(session_id, messages)
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
-        
-        # JSONL: overwrite the file
+
+        # JSONL: atomic write via temp file + os.replace
         transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "w", encoding="utf-8") as f:
-            for msg in messages:
-                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        transcript_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(transcript_path.parent),
+            prefix=f".{transcript_path.stem}_",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                for msg in messages:
+                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, transcript_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1172,6 +1172,59 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def rewrite_messages(self, session_id: str, messages: list) -> None:
+        """Atomically replace all messages for a session.
+
+        Runs DELETE + re-INSERT inside a single ``_execute_write`` transaction
+        so that a crash mid-rewrite rolls back to the original messages rather
+        than leaving a partially-written (or empty) transcript.
+        """
+        # Pre-serialize structured fields outside the transaction to minimise
+        # time spent holding the write lock.
+        prepared = []
+        total_tool_calls = 0
+        for msg in messages:
+            role = msg.get("role", "unknown")
+            tool_calls = msg.get("tool_calls")
+            tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+            reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
+            codex_items = msg.get("codex_reasoning_items") if role == "assistant" else None
+            n_tc = 0
+            if tool_calls is not None:
+                n_tc = len(tool_calls) if isinstance(tool_calls, list) else 1
+            total_tool_calls += n_tc
+            prepared.append((
+                session_id,
+                role,
+                msg.get("content"),
+                msg.get("tool_call_id"),
+                tool_calls_json,
+                msg.get("tool_name"),
+                time.time(),
+                None,  # token_count
+                None,  # finish_reason
+                msg.get("reasoning") if role == "assistant" else None,
+                json.dumps(reasoning_details) if reasoning_details else None,
+                json.dumps(codex_items) if codex_items else None,
+            ))
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM messages WHERE session_id = ?", (session_id,)
+            )
+            conn.executemany(
+                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                   tool_calls, tool_name, timestamp, token_count, finish_reason,
+                   reasoning, reasoning_details, codex_reasoning_items)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                prepared,
+            )
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                (len(prepared), total_tool_calls, session_id),
+            )
+        self._execute_write(_do)
+
     def delete_session(self, session_id: str) -> bool:
         """Delete a session and all its messages.
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1010,3 +1010,55 @@ class TestRewriteTranscriptPreservesReasoning:
         assert after[0].get("reasoning") == "I need to think step by step."
         assert after[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
         assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
+
+
+class TestRewriteTranscriptAtomicity:
+    """rewrite_transcript must use atomic operations (#8029)."""
+
+    def test_sqlite_rewrite_is_atomic(self, tmp_path):
+        """DB rewrite should use rewrite_messages (single transaction)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "test.db")
+        session_id = "atomic-test"
+        db.create_session(session_id=session_id, source="cli")
+
+        # Insert original messages
+        db.append_message(session_id=session_id, role="user", content="original-1")
+        db.append_message(session_id=session_id, role="assistant", content="original-2")
+
+        # Rewrite atomically
+        new_messages = [
+            {"role": "user", "content": "compressed"},
+        ]
+        db.rewrite_messages(session_id, new_messages)
+
+        rows = db.get_messages_as_conversation(session_id)
+        assert len(rows) == 1
+        assert rows[0]["content"] == "compressed"
+
+    def test_jsonl_rewrite_preserves_original_on_error(self, tmp_path):
+        """If JSONL write fails, original file should remain intact."""
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None
+        store._loaded = True
+
+        session_id = "atomic-jsonl"
+        store.append_to_transcript(session_id, {"role": "user", "content": "keep me"})
+
+        # Verify original exists
+        path = store.get_transcript_path(session_id)
+        assert path.exists()
+        original_content = path.read_text()
+        assert "keep me" in original_content
+
+        # Force os.replace to fail by making tempfile creation succeed
+        # but os.replace raise an error
+        with patch("gateway.session.os.replace", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                store.rewrite_transcript(session_id, [{"role": "user", "content": "new"}])
+
+        # Original file should be untouched
+        assert path.read_text() == original_content


### PR DESCRIPTION
## Summary

- Add `SessionDB.rewrite_messages()` that runs DELETE + all INSERTs inside a single `_execute_write()` transaction — a crash during rewrite rolls back to the original messages instead of leaving an empty or partial transcript
- Use `tempfile` + `fsync` + `os.replace` for JSONL rewrites — a crash mid-write preserves the original file intact
- Replaces the previous non-atomic `clear_messages()` + N × `append_message()` sequence in `rewrite_transcript()`

## Test plan

- [x] `test_sqlite_rewrite_is_atomic` — verifies `rewrite_messages` works end-to-end
- [x] `test_jsonl_rewrite_preserves_original_on_error` — verifies original JSONL file survives when `os.replace` fails
- [x] `test_reasoning_survives_rewrite` — existing regression test still passes
- [x] All 62 session tests pass, all 9 dedup tests pass

Closes #8029

🤖 Generated with [Claude Code](https://claude.com/claude-code)